### PR TITLE
Add column live view engine slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Effect LSP diagnostics
-        run: pnpm exec effect-language-service diagnostics --project packages/config/tsconfig.json --format text
+        run: |
+          pnpm exec effect-language-service diagnostics --project packages/config/tsconfig.json --format text --strict
+          pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
 
       - name: Ready gate
         run: pnpm run ready

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "ready": "vp check && vp run -r test && vp run -r build",
+    "ready": "vp run -r build && vp check && vp run -r test",
     "prepare": "vp config && effect-language-service patch"
   },
   "devDependencies": {

--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@view-server/column-live-view-engine",
+  "version": "0.0.0",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vp test run --coverage --typecheck"
+  },
+  "dependencies": {
+    "@view-server/config": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/runner": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/column-live-view-engine/src/index.test-d.ts
+++ b/packages/column-live-view-engine/src/index.test-d.ts
@@ -1,0 +1,230 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import { defineViewServerConfig, type LiveQuery, type LiveQueryResult } from "@view-server/config";
+import type { Effect } from "effect";
+import { Schema } from "effect";
+import type {
+  ColumnLiveViewEngine,
+  ColumnLiveViewEngineConfig,
+  ColumnLiveViewEngineHealth,
+  ColumnLiveViewSubscription,
+  ColumnLiveViewTopicHealth,
+} from "./index.ts";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Finite,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+    trades: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+type Engine = ColumnLiveViewEngine<Topics>;
+type OrderRow = Schema.Schema.Type<typeof Order>;
+type EffectSuccess<Value> =
+  Value extends Effect.Effect<infer Success, infer _Error, infer _Services> ? Success : never;
+
+declare const engine: Engine;
+
+describe("ColumnLiveViewEngine type contract", () => {
+  it("types raw snapshots and subscriptions conservatively for this slice", () => {
+    const fullSnapshot = engine.snapshot("orders", {});
+    expectTypeOf<EffectSuccess<typeof fullSnapshot>>().toEqualTypeOf<LiveQueryResult<OrderRow>>();
+
+    const selectedSnapshot = engine.snapshot("orders", {
+      fields: ["id", "price"],
+    });
+    expectTypeOf<EffectSuccess<typeof selectedSnapshot>>().toEqualTypeOf<
+      LiveQueryResult<{
+        readonly id: string;
+        readonly price: number;
+      }>
+    >();
+
+    const subscription = engine.subscribe("orders", {
+      fields: ["customerId", "status"],
+    });
+    expectTypeOf<EffectSuccess<typeof subscription>>().toEqualTypeOf<
+      ColumnLiveViewSubscription<{
+        readonly customerId: string;
+        readonly status: "open" | "closed" | "cancelled";
+      }>
+    >();
+
+    const health = engine.health();
+    expectTypeOf<EffectSuccess<typeof health>>().toEqualTypeOf<
+      ColumnLiveViewEngineHealth<Topics>
+    >();
+    expectTypeOf<
+      EffectSuccess<typeof health>["topics"]["orders"]
+    >().toEqualTypeOf<ColumnLiveViewTopicHealth>();
+    type HealthTopics = EffectSuccess<typeof health>["topics"];
+    // @ts-expect-error health topics preserve configured topic keys.
+    expectTypeOf<HealthTopics["missing"]>().toEqualTypeOf<ColumnLiveViewTopicHealth>();
+    // @ts-expect-error the map key is the topic identity; values do not duplicate it.
+    expectTypeOf<HealthTopics["orders"]["topic"]>().toEqualTypeOf<"orders">();
+  });
+
+  it("types valid mutation calls", () => {
+    const validPatch = engine.patch("orders", "order-1", {
+      price: 42,
+      status: "closed",
+    });
+    expectTypeOf<EffectSuccess<typeof validPatch>>().toEqualTypeOf<void>();
+  });
+
+  it("rejects invalid raw query fields and topics", () => {
+    const _invalidSelectedField = engine.snapshot("orders", {
+      // @ts-expect-error invalid selected field is rejected.
+      fields: ["missing"],
+    });
+
+    const _invalidWhereField = engine.snapshot("orders", {
+      // @ts-expect-error invalid where field is rejected.
+      where: { missing: "value" },
+    });
+
+    const _invalidOrderField = engine.snapshot("orders", {
+      orderBy: [
+        {
+          // @ts-expect-error invalid order field is rejected.
+          field: "missing",
+          direction: "asc",
+        },
+      ],
+    });
+
+    // @ts-expect-error invalid topic is rejected.
+    const _invalidTopic = engine.snapshot("missing", {});
+
+    const extraRawQuery = {
+      fields: ["id"],
+      typo: true,
+    } as const;
+    // @ts-expect-error extra raw query keys are rejected through variables.
+    const _invalidExtraRawQueryKey = engine.snapshot("orders", extraRawQuery);
+
+    const extraWhereField = {
+      where: {
+        status: "open",
+        missing: "x",
+      },
+    } as const;
+    // @ts-expect-error extra where fields are rejected through variables.
+    const _invalidExtraWhereField = engine.snapshot("orders", extraWhereField);
+
+    const extraFilterOperator = {
+      where: {
+        status: {
+          eq: "open",
+          typo: true,
+        },
+      },
+    } as const;
+    // @ts-expect-error extra filter operator keys are rejected through variables.
+    const _invalidExtraFilterOperator = engine.snapshot("orders", extraFilterOperator);
+
+    const extraOrderByEntry = {
+      orderBy: [
+        {
+          field: "id",
+          direction: "asc",
+          typo: true,
+        },
+      ],
+    } as const;
+    // @ts-expect-error extra orderBy entry keys are rejected through variables.
+    const _invalidExtraOrderByEntry = engine.snapshot("orders", extraOrderByEntry);
+
+    void _invalidSelectedField;
+    void _invalidWhereField;
+    void _invalidOrderField;
+    void _invalidTopic;
+    void _invalidExtraRawQueryKey;
+    void _invalidExtraWhereField;
+    void _invalidExtraFilterOperator;
+    void _invalidExtraOrderByEntry;
+  });
+
+  it("rejects invalid patch shapes", () => {
+    // @ts-expect-error patch row field types are enforced.
+    const _invalidPatchType = engine.patch("orders", "order-1", { price: "42" });
+
+    // @ts-expect-error patch row fields are enforced.
+    const _invalidPatchField = engine.patch("orders", "order-1", { missing: true });
+
+    const invalidPatchVariable = {
+      price: 42,
+      missing: true,
+    };
+    // @ts-expect-error patch row fields are enforced through variables.
+    const _invalidPatchVariable = engine.patch("orders", "order-1", invalidPatchVariable);
+
+    void _invalidPatchType;
+    void _invalidPatchField;
+    void _invalidPatchVariable;
+  });
+
+  it("rejects invalid engine topic keys", () => {
+    const _invalidKeyConfig: ColumnLiveViewEngineConfig<{
+      readonly orders: {
+        readonly schema: typeof Order;
+        readonly key: "missing";
+      };
+    }> = {
+      topics: {
+        orders: {
+          schema: Order,
+          // @ts-expect-error engine topic keys must be string fields in the schema.
+          key: "missing",
+        },
+      },
+    };
+
+    void _invalidKeyConfig;
+  });
+
+  it("rejects grouped queries in the raw-only engine slice", () => {
+    const _groupedSnapshot = engine.snapshot("orders", {
+      // @ts-expect-error grouped queries are not part of this raw-only slice.
+      groupBy: ["status"],
+      // @ts-expect-error grouped queries are not part of this raw-only slice.
+      aggregates: [{ type: "count", as: "count" }],
+    });
+
+    const _groupedSubscription = engine.subscribe("orders", {
+      // @ts-expect-error grouped subscriptions are not part of this raw-only slice.
+      groupBy: ["status"],
+      // @ts-expect-error grouped subscriptions are not part of this raw-only slice.
+      aggregates: [{ type: "count", as: "count" }],
+    });
+
+    const groupedVariable: LiveQuery<OrderRow> = {
+      groupBy: ["status"],
+      aggregates: [{ type: "count", as: "count" }],
+    };
+    // @ts-expect-error widened grouped query variables are rejected.
+    const _groupedVariableSnapshot = engine.snapshot("orders", groupedVariable);
+    // @ts-expect-error widened grouped subscription variables are rejected.
+    const _groupedVariableSubscription = engine.subscribe("orders", groupedVariable);
+
+    void _groupedSnapshot;
+    void _groupedSubscription;
+    void _groupedVariableSnapshot;
+    void _groupedVariableSubscription;
+  });
+});

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -1,0 +1,1909 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  defineViewServerConfig,
+  type DeltaEvent,
+  type RawQuery,
+  type SnapshotEvent,
+} from "@view-server/config";
+import { Cause, Effect, Schema, Scope, Stream } from "effect";
+import { fromStringUnsafe } from "effect/BigDecimal";
+import {
+  createColumnLiveViewEngine,
+  type ColumnLiveViewEngine,
+  type ColumnLiveViewEngineConfig,
+  type ColumnLiveViewEngineEvent,
+  type ColumnLiveViewSubscription,
+} from "./index.ts";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Finite,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+  note: Schema.optionalKey(Schema.String),
+});
+
+const Position = Schema.Struct({
+  id: Schema.String,
+  accountId: Schema.String,
+  symbol: Schema.String,
+  active: Schema.Boolean,
+  quantity: Schema.BigInt,
+  price: Schema.BigDecimal,
+});
+
+const Instrument = Schema.Struct({
+  id: Schema.String,
+  metadata: Schema.Struct({
+    venue: Schema.String,
+    risk: Schema.Struct({
+      tier: Schema.Number,
+      lot: Schema.BigInt,
+    }),
+  }),
+  operatorLike: Schema.Struct({
+    eq: Schema.String,
+  }),
+  tags: Schema.Array(Schema.String),
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+    positions: {
+      schema: Position,
+      key: "id",
+    },
+    instruments: {
+      schema: Instrument,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+type Engine = ColumnLiveViewEngine<Topics>;
+type OrderRow = Schema.Schema.Type<typeof Order>;
+type InstrumentRow = Schema.Schema.Type<typeof Instrument>;
+
+const order = (
+  id: string,
+  status: OrderRow["status"],
+  price: number,
+  updatedAt: number,
+  region = "emea",
+): OrderRow => ({
+  id,
+  customerId: `customer-${id}`,
+  status,
+  price,
+  region,
+  updatedAt,
+});
+
+const makeEngine = (): Effect.Effect<Engine> =>
+  createColumnLiveViewEngine({ topics: viewServer.topics });
+
+const instrument = (
+  id: string,
+  venue: string,
+  tier: number,
+  tags: ReadonlyArray<string>,
+): InstrumentRow => ({
+  id,
+  metadata: {
+    venue,
+    risk: {
+      tier,
+      lot: BigInt(tier),
+    },
+  },
+  operatorLike: {
+    eq: venue,
+  },
+  tags: [...tags],
+});
+
+const rowField = (row: object, field: string): unknown => {
+  for (const [key, value] of Object.entries(row)) {
+    if (key === field) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const rowIds = (rows: ReadonlyArray<object>): ReadonlyArray<unknown> =>
+  rows.map((row) => rowField(row, "id"));
+
+const takeEvents = <Row>(
+  subscription: ColumnLiveViewSubscription<Row>,
+  count: number,
+): Effect.Effect<ReadonlyArray<ColumnLiveViewEngineEvent<Row>>> =>
+  subscription.events.pipe(Stream.take(count), Stream.runCollect);
+
+const makeEventReader = <Row>(
+  subscription: ColumnLiveViewSubscription<Row>,
+): Effect.Effect<
+  (count: number) => Effect.Effect<ReadonlyArray<ColumnLiveViewEngineEvent<Row>>, Cause.Done>,
+  never,
+  Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const pull = yield* Stream.toPull(subscription.events);
+    return (count) =>
+      Effect.gen(function* () {
+        const events: Array<ColumnLiveViewEngineEvent<Row>> = [];
+        while (events.length < count) {
+          const chunk = yield* pull;
+          events.push(...chunk);
+        }
+        return events.slice(0, count);
+      });
+  });
+
+const collectEvents = <Row>(
+  subscription: ColumnLiveViewSubscription<Row>,
+): Effect.Effect<ReadonlyArray<ColumnLiveViewEngineEvent<Row>>> =>
+  subscription.events.pipe(Stream.runCollect);
+
+const firstEvent = <Row>(
+  events: ReadonlyArray<ColumnLiveViewEngineEvent<Row>>,
+): ColumnLiveViewEngineEvent<Row> => {
+  expect(events).not.toEqual([]);
+  return events[0]!;
+};
+
+const expectSnapshotEvent: <Row>(
+  event: ColumnLiveViewEngineEvent<Row>,
+) => asserts event is SnapshotEvent<Row> = (event) => {
+  expect(event).toMatchObject({ type: "snapshot" });
+};
+
+const expectDeltaEvent: <Row>(
+  event: ColumnLiveViewEngineEvent<Row>,
+) => asserts event is DeltaEvent<Row> = (event) => {
+  expect(event).toMatchObject({ type: "delta" });
+};
+
+const expectSnapshotRows = <Row>(
+  event: ColumnLiveViewEngineEvent<Row>,
+  rows: ReadonlyArray<Row>,
+) => {
+  expectSnapshotEvent(event);
+  expect(event.rows).toEqual(rows);
+};
+
+type ClientState<Row> = {
+  readonly keys: ReadonlyArray<string>;
+  readonly rows: ReadonlyArray<Row>;
+};
+
+const applyDelta = <Row>(state: ClientState<Row>, event: DeltaEvent<Row>): ClientState<Row> => {
+  const keys = [...state.keys];
+  const rows = [...state.rows];
+
+  for (const operation of event.operations) {
+    if (operation.type === "remove") {
+      const index = keys.indexOf(operation.key);
+      if (index >= 0) {
+        keys.splice(index, 1);
+        rows.splice(index, 1);
+      }
+    }
+    if (operation.type === "insert") {
+      keys.splice(operation.index, 0, operation.key);
+      rows.splice(operation.index, 0, operation.row);
+    }
+    if (operation.type === "update") {
+      const index = keys.indexOf(operation.key);
+      if (index >= 0) {
+        rows[index] = operation.row;
+      }
+    }
+    if (operation.type === "move") {
+      const index = keys.indexOf(operation.key);
+      const row = rows[index];
+      if (index >= 0 && row !== undefined) {
+        keys.splice(index, 1);
+        rows.splice(index, 1);
+        keys.splice(operation.toIndex, 0, operation.key);
+        rows.splice(operation.toIndex, 0, row);
+      }
+    }
+  }
+
+  return { keys, rows };
+};
+
+const stateFromSnapshot = <Row>(event: ColumnLiveViewEngineEvent<Row>): ClientState<Row> => {
+  expectSnapshotEvent(event);
+  return {
+    keys: event.keys,
+    rows: event.rows,
+  };
+};
+
+const expectDeltaConverges = <Row>(
+  state: ClientState<Row>,
+  event: ColumnLiveViewEngineEvent<Row>,
+  freshRows: ReadonlyArray<Row>,
+): ClientState<Row> => {
+  expectDeltaEvent(event);
+  const nextState = applyDelta(state, event);
+  expect(nextState.rows).toEqual(freshRows);
+  return nextState;
+};
+
+describe("ColumnLiveViewEngine raw snapshots", () => {
+  it.effect("publishes rows and snapshots a filtered, sorted, windowed raw query", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      yield* engine.publishMany("orders", [
+        order("1", "open", 10, 1, "emea"),
+        order("2", "open", 40, 2, "amer"),
+        order("3", "closed", 30, 3, "emea"),
+        order("4", "open", 20, 4, "emea"),
+        order("5", "open", 50, 5, "emea"),
+        {
+          ...order("6", "open", 15, 4, "emea"),
+          customerId: "account-6",
+        },
+      ]);
+
+      const snapshot = yield* engine.snapshot("orders", {
+        where: {
+          customerId: { startsWith: "customer-" },
+          status: "open",
+          price: { gte: 10, lt: 50 },
+          updatedAt: { lte: 4 },
+          region: { eq: "emea" },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        offset: 1,
+        limit: 1,
+      });
+
+      expect(snapshot).toEqual({
+        rows: [order("1", "open", 10, 1, "emea")],
+        totalRows: 2,
+        version: 1,
+      });
+
+      const equalStringSort = yield* engine.snapshot("orders", {
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      });
+      expect(rowIds(equalStringSort.rows)).toEqual(["1", "2", "4", "5", "6"]);
+
+      const reverseInsertEngine = yield* makeEngine();
+      yield* reverseInsertEngine.publishMany("orders", [
+        order("b", "open", 10, 1),
+        order("a", "open", 20, 2),
+      ]);
+      const equalStringSortReverseInsert = yield* reverseInsertEngine.snapshot("orders", {
+        orderBy: [{ field: "status", direction: "asc" }],
+      });
+      expect(rowIds(equalStringSortReverseInsert.rows)).toEqual(["a", "b"]);
+    }),
+  );
+
+  it.effect("returns only selected fields", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const snapshot = yield* engine.snapshot("orders", {
+        fields: ["customerId", "status", "updatedAt"],
+        where: {
+          status: "open",
+        },
+      });
+
+      expect(snapshot.rows).toEqual([
+        {
+          customerId: "customer-1",
+          status: "open",
+          updatedAt: 1,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("does not expose stored row objects through snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const snapshot = yield* engine.snapshot("orders", {});
+      expect(snapshot.rows).toHaveLength(1);
+      Object.assign(snapshot.rows[0]!, { price: 999 });
+
+      const fresh = yield* engine.snapshot("orders", {});
+      expect(fresh.rows).toEqual([order("1", "open", 10, 1)]);
+    }),
+  );
+
+  it.effect("deep-clones nested rows and supports object-valued equality filters", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const emptyStructuredQuery = yield* engine.snapshot("instruments", {
+        where: {
+          metadata: {
+            venue: "xnys",
+            risk: {
+              tier: 1,
+              lot: 1n,
+            },
+          },
+        },
+      });
+      expect(emptyStructuredQuery.rows).toEqual([]);
+
+      yield* engine.publishMany("instruments", [
+        instrument("1", "xnys", 1, ["equity", "us"]),
+        instrument("2", "xlon", 2, ["equity", "uk"]),
+      ]);
+
+      const metadataQuery = yield* engine.snapshot("instruments", {
+        where: {
+          metadata: {
+            venue: "xnys",
+            risk: {
+              tier: 1,
+              lot: 1n,
+            },
+          },
+        },
+      });
+      expect(rowIds(metadataQuery.rows)).toEqual(["1"]);
+
+      const arrayQuery = yield* engine.snapshot("instruments", {
+        where: {
+          tags: ["equity", "us"],
+        },
+      });
+      expect(rowIds(arrayQuery.rows)).toEqual(["1"]);
+
+      const operatorObjectQuery = yield* engine.snapshot("instruments", {
+        where: {
+          metadata: {
+            eq: {
+              venue: "xlon",
+              risk: {
+                tier: 2,
+                lot: 2n,
+              },
+            },
+          },
+        },
+      });
+      expect(rowIds(operatorObjectQuery.rows)).toEqual(["2"]);
+
+      const operatorLikeDirectObjectQuery = yield* engine.snapshot("instruments", {
+        where: {
+          operatorLike: {
+            eq: "xnys",
+          },
+        },
+      });
+      expect(rowIds(operatorLikeDirectObjectQuery.rows)).toEqual(["1"]);
+
+      const operatorLikeWrappedObjectQuery = yield* engine.snapshot("instruments", {
+        where: {
+          operatorLike: {
+            eq: {
+              eq: "xlon",
+            },
+          },
+        },
+      });
+      expect(rowIds(operatorLikeWrappedObjectQuery.rows)).toEqual(["2"]);
+
+      const operatorLikeObjectNeq = yield* engine.snapshot("instruments", {
+        where: {
+          operatorLike: {
+            neq: {
+              eq: "not-present",
+            },
+          },
+        },
+      });
+      expect(rowIds(operatorLikeObjectNeq.rows)).toEqual(["1", "2"]);
+
+      const operatorLikeObjectNeqEqual = yield* engine.snapshot("instruments", {
+        where: {
+          operatorLike: {
+            neq: {
+              eq: "xnys",
+            },
+          },
+        },
+      });
+      expect(rowIds(operatorLikeObjectNeqEqual.rows)).toEqual(["2"]);
+
+      const objectInQuery = yield* engine.snapshot("instruments", {
+        where: {
+          operatorLike: {
+            in: [
+              {
+                eq: "xlon",
+              },
+            ],
+          },
+        },
+      });
+      expect(rowIds(objectInQuery.rows)).toEqual(["2"]);
+
+      const fullSnapshot = yield* engine.snapshot("instruments", {});
+      expect(fullSnapshot.rows).toHaveLength(2);
+      Object.assign(Object(fullSnapshot.rows[0]).metadata.risk, { tier: 999 });
+      Object(fullSnapshot.rows[0]).tags.push("mutated");
+
+      const projectedSnapshot = yield* engine.snapshot("instruments", {
+        fields: ["metadata", "tags"],
+        where: {
+          id: "1",
+        },
+      });
+      expect(projectedSnapshot.rows).toEqual([
+        {
+          metadata: {
+            venue: "xnys",
+            risk: {
+              tier: 1,
+              lot: 1n,
+            },
+          },
+          tags: ["equity", "us"],
+        },
+      ]);
+      Object.assign(Object(projectedSnapshot.rows[0]).metadata.risk, { tier: 777 });
+      Object(projectedSnapshot.rows[0]).tags.push("projected-mutation");
+
+      const fresh = yield* engine.snapshot("instruments", {
+        where: {
+          id: "1",
+        },
+      });
+      expect(fresh.rows).toEqual([instrument("1", "xnys", 1, ["equity", "us"])]);
+    }),
+  );
+
+  it.effect("does not retain nested publish or patch input references", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const original = instrument("1", "xnys", 1, ["equity", "us"]);
+      yield* engine.publish("instruments", original);
+
+      Object.assign(original.metadata.risk, { tier: 999 });
+      Object(original.tags).push("mutated-after-publish");
+
+      const afterPublishMutation = yield* engine.snapshot("instruments", {});
+      expect(afterPublishMutation.rows).toEqual([instrument("1", "xnys", 1, ["equity", "us"])]);
+
+      const patch = {
+        metadata: {
+          venue: "xlon",
+          risk: {
+            tier: 2,
+            lot: 2n,
+          },
+        },
+        operatorLike: {
+          eq: "xlon",
+        },
+        tags: ["equity", "uk"],
+      };
+      yield* engine.patch("instruments", "1", patch);
+
+      patch.metadata.risk.tier = 777;
+      patch.operatorLike.eq = "mutated-after-patch";
+      patch.tags.push("mutated-after-patch");
+
+      const afterPatchMutation = yield* engine.snapshot("instruments", {});
+      expect(afterPatchMutation.rows).toEqual([instrument("1", "xlon", 2, ["equity", "uk"])]);
+    }),
+  );
+
+  it.effect("supports bigint and BigDecimal raw comparison semantics", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      yield* engine.publishMany("positions", [
+        {
+          id: "position-1",
+          accountId: "account-1",
+          symbol: "AAPL",
+          active: true,
+          quantity: 10n,
+          price: fromStringUnsafe("3.00"),
+        },
+        {
+          id: "position-2",
+          accountId: "account-1",
+          symbol: "MSFT",
+          active: false,
+          quantity: 20n,
+          price: fromStringUnsafe("2.00"),
+        },
+        {
+          id: "position-3",
+          accountId: "account-1",
+          symbol: "TSLA",
+          active: true,
+          quantity: 9n,
+          price: fromStringUnsafe("1.00"),
+        },
+        {
+          id: "position-4",
+          accountId: "account-1",
+          symbol: "NVDA",
+          active: true,
+          quantity: 10n,
+          price: fromStringUnsafe("1.00"),
+        },
+      ]);
+
+      const snapshot = yield* engine.snapshot("positions", {
+        where: {
+          quantity: { gt: 9n },
+          price: { gte: fromStringUnsafe("2.00") },
+        },
+        orderBy: [
+          { field: "active", direction: "asc" },
+          { field: "price", direction: "asc" },
+        ],
+      });
+
+      expect(rowIds(snapshot.rows)).toEqual(["position-2", "position-1"]);
+
+      const fallbackOrdered = yield* engine.snapshot("positions", {
+        orderBy: [{ field: "active", direction: "asc" }],
+      });
+      expect(rowIds(fallbackOrdered.rows)).toEqual([
+        "position-2",
+        "position-1",
+        "position-3",
+        "position-4",
+      ]);
+
+      const symbolOrdered = yield* engine.snapshot("positions", {
+        orderBy: [{ field: "symbol", direction: "desc" }],
+        where: {
+          price: { eq: fromStringUnsafe("1.00") },
+        },
+      });
+      expect(rowIds(symbolOrdered.rows)).toEqual(["position-3", "position-4"]);
+
+      const quantityOrdered = yield* engine.snapshot("positions", {
+        orderBy: [{ field: "quantity", direction: "asc" }],
+      });
+      expect(rowIds(quantityOrdered.rows)).toEqual([
+        "position-3",
+        "position-1",
+        "position-4",
+        "position-2",
+      ]);
+
+      const booleanNotEqual = yield* engine.snapshot("positions", {
+        where: {
+          active: { neq: false },
+        },
+        orderBy: [{ field: "symbol", direction: "asc" }],
+      });
+      expect(rowIds(booleanNotEqual.rows)).toEqual(["position-1", "position-4", "position-3"]);
+
+      const decimalNotEqual = yield* engine.snapshot("positions", {
+        where: {
+          price: { neq: fromStringUnsafe("2.00") },
+        },
+        orderBy: [{ field: "symbol", direction: "asc" }],
+      });
+      expect(rowIds(decimalNotEqual.rows)).toEqual(["position-1", "position-4", "position-3"]);
+    }),
+  );
+
+  it.effect("sorts object, array, and missing values deterministically", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("instruments", [
+        instrument("3", "xnas", 3, ["bond"]),
+        instrument("1", "xnys", 1, ["equity", "us"]),
+        instrument("2", "xlon", 2, ["equity", "uk"]),
+      ]);
+
+      const objectOrdered = yield* engine.snapshot("instruments", {
+        orderBy: [{ field: "metadata", direction: "asc" }],
+      });
+      expect(rowIds(objectOrdered.rows)).toEqual(["1", "2", "3"]);
+
+      const arrayOrdered = yield* engine.snapshot("instruments", {
+        orderBy: [{ field: "tags", direction: "desc" }],
+      });
+      expect(rowIds(arrayOrdered.rows)).toEqual(["1", "2", "3"]);
+
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+      yield* engine.publish("orders", { ...order("2", "open", 20, 2), note: "visible" });
+      yield* engine.publish("orders", order("3", "open", 30, 3));
+      const missingOrdered = yield* engine.snapshot("orders", {
+        orderBy: [{ field: "note", direction: "asc" }],
+      });
+      expect(rowIds(missingOrdered.rows)).toEqual(["1", "3", "2"]);
+    }),
+  );
+
+  it.effect(
+    "uses the configured row key as the final tiebreaker for equal ascending sort fields",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* makeEngine();
+        yield* engine.publishMany("orders", [
+          order("c", "open", 10, 1),
+          order("a", "open", 10, 1),
+          order("b", "open", 10, 1),
+        ]);
+
+        const snapshot = yield* engine.snapshot("orders", {
+          orderBy: [{ field: "price", direction: "asc" }],
+        });
+
+        expect(rowIds(snapshot.rows)).toEqual(["a", "b", "c"]);
+      }),
+  );
+
+  it.effect("uses the configured row key as the default order without explicit sort fields", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("c", "open", 30, 3),
+        order("a", "closed", 10, 1),
+        order("b", "cancelled", 20, 2),
+      ]);
+
+      const snapshot = yield* engine.snapshot("orders", {});
+
+      expect(rowIds(snapshot.rows)).toEqual(["a", "b", "c"]);
+    }),
+  );
+
+  it.effect(
+    "uses the configured row key as the final tiebreaker for equal descending sort fields",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* makeEngine();
+        yield* engine.publishMany("orders", [
+          order("c", "open", 10, 1),
+          order("a", "open", 10, 1),
+          order("b", "open", 10, 1),
+        ]);
+
+        const snapshot = yield* engine.snapshot("orders", {
+          orderBy: [{ field: "price", direction: "desc" }],
+        });
+
+        expect(rowIds(snapshot.rows)).toEqual(["a", "b", "c"]);
+      }),
+  );
+
+  it.effect("uses the configured row key after all sort fields compare equal", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("c", "closed", 10, 1, "emea"),
+        order("a", "closed", 10, 1, "emea"),
+        order("b", "closed", 10, 1, "emea"),
+      ]);
+
+      const snapshot = yield* engine.snapshot("orders", {
+        orderBy: [
+          { field: "price", direction: "desc" },
+          { field: "status", direction: "asc" },
+          { field: "region", direction: "desc" },
+          { field: "updatedAt", direction: "asc" },
+        ],
+      });
+
+      expect(rowIds(snapshot.rows)).toEqual(["a", "b", "c"]);
+    }),
+  );
+
+  it.effect("exercises raw filter exclusion branches through public snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        { ...order("1", "open", 10, 1, "emea"), customerId: "account-1" },
+        order("2", "open", 9, 1, "emea"),
+        order("3", "open", 10, 0, "emea"),
+        order("4", "cancelled", 10, 1, "emea"),
+        order("5", "open", 10, 1, "amer"),
+        order("6", "open", 10, 5, "emea"),
+        order("7", "open", 10, 1, "emea"),
+      ]);
+
+      const allRows = yield* engine.snapshot("orders", {});
+      expect(allRows.totalRows).toBe(7);
+
+      const snapshot = yield* engine.snapshot("orders", {
+        where: {
+          customerId: { startsWith: "customer-" },
+          price: { gt: 9 },
+          updatedAt: { gte: 1, lte: 4 },
+          status: { in: ["open"] },
+          region: { eq: "emea" },
+        },
+      });
+      expect(rowIds(snapshot.rows)).toEqual(["7"]);
+
+      const notOpen = yield* engine.snapshot("orders", {
+        where: {
+          status: { neq: "open" },
+        },
+      });
+      expect(rowIds(notOpen.rows)).toEqual(["4"]);
+    }),
+  );
+});
+
+describe("ColumnLiveViewEngine subscriptions", () => {
+  it.effect("emits the initial snapshot before live deltas", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const subscription = yield* engine.subscribe("orders", {
+        where: {
+          status: "open",
+        },
+      });
+      const events = yield* takeEvents(subscription, 1);
+
+      expectSnapshotRows(firstEvent(events), [order("1", "open", 10, 1)]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("emits snapshot keys for projected subscriptions without selected id fields", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("b", "open", 10, 1), order("a", "open", 10, 1)]);
+
+      const subscription = yield* engine.subscribe("orders", {
+        fields: ["customerId", "status"],
+      });
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      const snapshot = firstEvent(initialEvents);
+      expectSnapshotEvent(snapshot);
+      expect(snapshot.keys).toEqual(["a", "b"]);
+      expect(snapshot.rows).toEqual([
+        { customerId: "customer-a", status: "open" },
+        { customerId: "customer-b", status: "open" },
+      ]);
+
+      let state = stateFromSnapshot(snapshot);
+      yield* engine.delete("orders", "a");
+      const deleteEvents = yield* take(1);
+      state = expectDeltaConverges(state, firstEvent(deleteEvents), [
+        { customerId: "customer-b", status: "open" },
+      ]);
+      expect(state.keys).toEqual(["b"]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("emits publish, patch, and delete deltas that converge to fresh snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("1", "open", 10, 1), order("2", "closed", 20, 2)]);
+
+      const query = {
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+      } satisfies RawQuery<OrderRow>;
+      const subscription = yield* engine.subscribe("orders", query);
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      let state = stateFromSnapshot(firstEvent(initialEvents));
+
+      yield* engine.publish("orders", order("3", "open", 5, 3));
+      const publishEvents = yield* take(1);
+      const afterPublish = yield* engine.snapshot("orders", query);
+      state = expectDeltaConverges(state, firstEvent(publishEvents), afterPublish.rows);
+
+      yield* engine.patch("orders", "1", { price: 30 });
+      const patchEvents = yield* take(1);
+      const afterPatch = yield* engine.snapshot("orders", query);
+      state = expectDeltaConverges(state, firstEvent(patchEvents), afterPatch.rows);
+
+      yield* engine.delete("orders", "3");
+      const deleteEvents = yield* take(1);
+      const afterDelete = yield* engine.snapshot("orders", query);
+      state = expectDeltaConverges(state, firstEvent(deleteEvents), afterDelete.rows);
+
+      expect(state.rows).toEqual([order("1", "open", 30, 1)]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("serializes concurrent publishes before notifying subscribers", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const subscription = yield* engine.subscribe("orders", {});
+      const take = yield* makeEventReader(subscription);
+      yield* take(1);
+
+      yield* Effect.all(
+        ["c", "a", "b"].map((id, index) =>
+          engine.publish("orders", order(id, "open", 10 + index, index)),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      yield* take(3);
+      const fresh = yield* engine.snapshot("orders", {});
+      expect(rowIds(fresh.rows)).toEqual(["a", "b", "c"]);
+      expect(fresh.version).toBe(3);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("idempotent subscription close removes active subscribers from health", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const subscription = yield* engine.subscribe("orders", {});
+
+      const active = yield* engine.health();
+      expect(active.topics["orders"].activeSubscriptions).toBe(1);
+      expect(active.activeSubscriptions).toBe(1);
+
+      yield* subscription.close();
+      yield* subscription.close();
+
+      const closed = yield* engine.health();
+      expect(closed.topics["orders"].activeSubscriptions).toBe(0);
+      expect(closed.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("stream finalization releases active subscribers", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const subscription = yield* engine.subscribe("orders", {});
+
+      const events = yield* takeEvents(subscription, 1);
+      expect(events.map((event) => event.type)).toEqual(["snapshot"]);
+
+      const health = yield* engine.health();
+      expect(health.topics["orders"].activeSubscriptions).toBe(0);
+      expect(health.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("does not emit deltas for invisible updates or no-op visible patches", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("1", "open", 10, 1), order("2", "closed", 20, 2)]);
+      const subscription = yield* engine.subscribe("orders", {
+        where: {
+          status: "open",
+        },
+      });
+      const take = yield* makeEventReader(subscription);
+      yield* take(1);
+
+      yield* engine.patch("orders", "2", { price: 25 });
+      yield* engine.patch("orders", "1", { price: 10 });
+      yield* subscription.close();
+
+      const remaining = yield* collectEvents(subscription);
+      expect(remaining).toEqual([]);
+    }),
+  );
+
+  it.effect("freezes subscription query semantics at subscribe time", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const query: { where: { status: OrderRow["status"] } } = {
+        where: {
+          status: "open",
+        },
+      };
+      const subscription = yield* engine.subscribe("orders", query);
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      let state = stateFromSnapshot(firstEvent(initialEvents));
+
+      query.where.status = "closed";
+      yield* engine.publish("orders", order("2", "open", 20, 2));
+
+      const events = yield* take(1);
+      const event = firstEvent(events);
+      state = expectDeltaConverges(state, event, [
+        order("1", "open", 10, 1),
+        order("2", "open", 20, 2),
+      ]);
+      expect(state.keys).toEqual(["1", "2"]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("does not let consumer snapshot mutations corrupt subscription cursors", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("instruments", instrument("1", "xnys", 1, ["equity", "us"]));
+
+      const subscription = yield* engine.subscribe("instruments", {
+        orderBy: [{ field: "id", direction: "asc" }],
+      });
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      const initial = firstEvent(initialEvents);
+      expectSnapshotEvent(initial);
+      Object.assign(Object(initial.rows[0]).metadata.risk, { tier: 999 });
+      Object(initial.rows[0]).tags.push("mutated-client-row");
+
+      yield* engine.publish("instruments", instrument("2", "xlon", 2, ["equity", "uk"]));
+      const events = yield* take(1);
+      const event = firstEvent(events);
+      expectDeltaEvent(event);
+      expect(event.operations).toEqual([
+        {
+          type: "insert",
+          key: "2",
+          row: instrument("2", "xlon", 2, ["equity", "uk"]),
+          index: 1,
+        },
+      ]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("does not broaden results for invalid runtime range operands", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const invalidGt = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            // @ts-expect-error malformed runtime queries must not broaden results.
+            gt: "9",
+          },
+        },
+      });
+      expect(invalidGt.rows).toEqual([]);
+
+      const invalidGtNaN = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            gt: Number.NaN,
+          },
+        },
+      });
+      expect(invalidGtNaN.rows).toEqual([]);
+
+      const invalidGte = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            // @ts-expect-error malformed runtime queries must not broaden results.
+            gte: "9",
+          },
+        },
+      });
+      expect(invalidGte.rows).toEqual([]);
+
+      const invalidLt = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            // @ts-expect-error malformed runtime queries must not broaden results.
+            lt: "11",
+          },
+        },
+      });
+      expect(invalidLt.rows).toEqual([]);
+
+      const invalidLte = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            // @ts-expect-error malformed runtime queries must not broaden results.
+            lte: "11",
+          },
+        },
+      });
+      expect(invalidLte.rows).toEqual([]);
+
+      const invalidIn = yield* engine.snapshot("orders", {
+        where: {
+          status: {
+            // @ts-expect-error malformed runtime queries must not throw or broaden results.
+            in: 1,
+          },
+        },
+      });
+      expect(invalidIn.rows).toEqual([]);
+
+      const invalidStartsWith = yield* engine.snapshot("orders", {
+        where: {
+          customerId: {
+            // @ts-expect-error malformed runtime queries must not throw or broaden results.
+            startsWith: Symbol("customer"),
+          },
+        },
+      });
+      expect(invalidStartsWith.rows).toEqual([]);
+
+      const invalidNeq = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            // @ts-expect-error malformed runtime queries must not broaden results.
+            neq: "10",
+          },
+        },
+      });
+      expect(invalidNeq.rows).toEqual([]);
+
+      const invalidNeqNaN = yield* engine.snapshot("orders", {
+        where: {
+          price: {
+            neq: Number.NaN,
+          },
+        },
+      });
+      expect(invalidNeqNaN.rows).toEqual([]);
+
+      const undefinedEquals = yield* engine.snapshot("orders", {
+        where: {
+          // @ts-expect-error malformed runtime queries must not broaden results.
+          status: {
+            eq: undefined,
+          },
+        },
+      });
+      expect(undefinedEquals.rows).toEqual([]);
+
+      const undefinedDirectRuntimeQuery: object = {
+        where: Object.fromEntries([["status", undefined]]),
+      };
+      const undefinedDirectFilter = yield* engine.snapshot("orders", undefinedDirectRuntimeQuery);
+      expect(undefinedDirectFilter.rows).toEqual([]);
+
+      const undefinedInFilter = yield* engine.snapshot("orders", {
+        where: {
+          // @ts-expect-error malformed runtime queries must not broaden results.
+          status: { in: [undefined] },
+        },
+      });
+      expect(undefinedInFilter.rows).toEqual([]);
+
+      const sparseValues = Array<string>();
+      sparseValues[1] = "open";
+      const sparseRuntimeQuery: object = {
+        where: {
+          status: { in: sparseValues },
+        },
+      };
+      const sparseInFilter = yield* engine.snapshot("orders", sparseRuntimeQuery);
+      expect(sparseInFilter.rows).toEqual([]);
+
+      const emptyFilter = yield* Effect.flip(
+        engine.snapshot("orders", {
+          where: {
+            status: {},
+          },
+        }),
+      );
+      expect(emptyFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported filter operator"),
+      });
+
+      const unknownOperator = yield* Effect.flip(
+        engine.snapshot("orders", {
+          where: {
+            status: {
+              // @ts-expect-error malformed runtime queries must not broaden results.
+              equals: "open",
+            },
+          },
+        }),
+      );
+      expect(unknownOperator).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported filter operator"),
+      });
+
+      const typoFieldEmptyFilter = yield* Effect.flip(
+        engine.snapshot("orders", {
+          where: {
+            // @ts-expect-error malformed runtime query fields must be rejected.
+            statuz: {},
+          },
+        }),
+      );
+      expect(typoFieldEmptyFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unknown field: statuz"),
+      });
+    }),
+  );
+
+  it.effect("emits move and update operations for sort movement without full-window churn", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("1", "open", 10, 1), order("2", "open", 20, 2)]);
+      const subscription = yield* engine.subscribe("orders", {
+        orderBy: [{ field: "price", direction: "asc" }],
+      });
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      let state = stateFromSnapshot(firstEvent(initialEvents));
+
+      yield* engine.patch("orders", "1", { price: 30 });
+      const events = yield* take(1);
+      const event = firstEvent(events);
+      expect(event).toMatchObject({
+        type: "delta",
+        operations: [
+          {
+            type: "move",
+            key: "2",
+            fromIndex: 1,
+            toIndex: 0,
+          },
+          {
+            type: "update",
+            key: "1",
+            row: order("1", "open", 30, 1),
+            index: 1,
+          },
+        ],
+      });
+      state = expectDeltaConverges(state, event, [
+        order("2", "open", 20, 2),
+        order("1", "open", 30, 1),
+      ]);
+      expect(state.keys).toEqual(["2", "1"]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("keeps subscription deltas indexed by configured row-key tiebreaks", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("c", "open", 10, 1),
+        order("a", "open", 10, 1),
+        order("b", "open", 10, 1),
+      ]);
+      const subscription = yield* engine.subscribe("orders", {
+        orderBy: [{ field: "price", direction: "asc" }],
+      });
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      let state = stateFromSnapshot(firstEvent(initialEvents));
+      expect(state.keys).toEqual(["a", "b", "c"]);
+
+      yield* engine.patch("orders", "b", { customerId: "customer-b-updated" });
+      const events = yield* take(1);
+      const event = firstEvent(events);
+      expect(event).toMatchObject({
+        type: "delta",
+        operations: [
+          {
+            type: "update",
+            key: "b",
+            row: { ...order("b", "open", 10, 1), customerId: "customer-b-updated" },
+            index: 1,
+          },
+        ],
+      });
+      state = expectDeltaConverges(state, event, [
+        order("a", "open", 10, 1),
+        { ...order("b", "open", 10, 1), customerId: "customer-b-updated" },
+        order("c", "open", 10, 1),
+      ]);
+      expect(state.keys).toEqual(["a", "b", "c"]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("emits an update when an optional field appears on a visible row", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+      const query = {
+        where: {
+          status: "open",
+        },
+      } satisfies RawQuery<OrderRow>;
+      const subscription = yield* engine.subscribe("orders", query);
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      let state = stateFromSnapshot(firstEvent(initialEvents));
+
+      yield* engine.patch("orders", "1", { note: "newly-visible" });
+      const events = yield* take(1);
+      const event = firstEvent(events);
+      expect(event).toMatchObject({
+        type: "delta",
+        operations: [
+          {
+            type: "update",
+            key: "1",
+            row: {
+              ...order("1", "open", 10, 1),
+              note: "newly-visible",
+            },
+            index: 0,
+          },
+        ],
+      });
+
+      const fresh = yield* engine.snapshot("orders", query);
+      state = expectDeltaConverges(state, event, fresh.rows);
+      expect(state.rows).toEqual([
+        {
+          ...order("1", "open", 10, 1),
+          note: "newly-visible",
+        },
+      ]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("removes a deleted visible row and inserts the next row entering the window", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("1", "open", 10, 1),
+        order("2", "open", 20, 2),
+        order("3", "open", 30, 3),
+      ]);
+      const query = {
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 2,
+      } satisfies RawQuery<OrderRow>;
+      const subscription = yield* engine.subscribe("orders", query);
+      const take = yield* makeEventReader(subscription);
+      const initialEvents = yield* take(1);
+      let state = stateFromSnapshot(firstEvent(initialEvents));
+
+      yield* engine.delete("orders", "1");
+      const events = yield* take(1);
+      const event = firstEvent(events);
+      expect(event).toMatchObject({
+        type: "delta",
+        operations: [
+          {
+            type: "remove",
+            key: "1",
+          },
+          {
+            type: "insert",
+            key: "3",
+            row: order("3", "open", 30, 3),
+            index: 1,
+          },
+        ],
+      });
+      state = expectDeltaConverges(state, event, [
+        order("2", "open", 20, 2),
+        order("3", "open", 30, 3),
+      ]);
+      expect(state.keys).toEqual(["2", "3"]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("closes a subscriber and records health counters when its bounded queue is full", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({
+        topics: viewServer.topics,
+        subscriptionQueueCapacity: 1,
+      });
+      const subscription = yield* engine.subscribe("orders", {});
+
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const health = yield* engine.health();
+      expect(health.activeSubscriptions).toBe(0);
+      expect(health.backpressureEvents).toBe(1);
+      expect(health.topics["orders"].activeSubscriptions).toBe(0);
+      expect(health.topics["orders"].backpressureEvents).toBe(1);
+      expect(health.topics["orders"].maxQueueDepth).toBe(1);
+
+      const events = yield* collectEvents(subscription);
+      expect(events.map((event) => event.type)).toEqual(["status"]);
+      expect(events[0]).toMatchObject({
+        type: "status",
+        code: "BackpressureExceeded",
+      });
+    }),
+  );
+
+  it.effect("falls back to default subscription capacity for invalid config capacity", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({
+        topics: viewServer.topics,
+        subscriptionQueueCapacity: Number.NaN,
+      });
+      const subscription = yield* engine.subscribe("orders", {});
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const health = yield* engine.health();
+      expect(health.activeSubscriptions).toBe(1);
+      expect(health.backpressureEvents).toBe(0);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("reset closes subscriptions instead of emitting lower-version deltas", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+      const subscription = yield* engine.subscribe("orders", {});
+      const take = yield* makeEventReader(subscription);
+      yield* take(1);
+
+      yield* engine.patch("orders", "1", { price: 20 });
+      yield* engine.reset();
+
+      const events = yield* take(1);
+      expect(events).toHaveLength(1);
+      const event = firstEvent(events);
+      expect(event).toMatchObject({
+        type: "delta",
+        fromVersion: 1,
+        toVersion: 2,
+      });
+
+      const health = yield* engine.health();
+      expect(health.version).toBe(0);
+      expect(health.activeSubscriptions).toBe(0);
+    }),
+  );
+});
+
+describe("ColumnLiveViewEngine validation and health", () => {
+  it.effect("fails invalid row publishes with a typed schema error", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      const error = yield* Effect.flip(engine.publish("orders", order("1", "open", Number.NaN, 1)));
+
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+        message: expect.stringContaining("a finite number"),
+      });
+    }),
+  );
+
+  it.effect("clones non-plain object row fields before exposing them", () =>
+    Effect.gen(function* () {
+      const WithPayload = Schema.Struct({
+        id: Schema.String,
+        payload: Schema.ObjectKeyword,
+      });
+      const engine = yield* createColumnLiveViewEngine({
+        topics: {
+          payloads: {
+            schema: WithPayload,
+            key: "id",
+          },
+        },
+      });
+      const payload = new Map([["venue", "xnys"]]);
+
+      const emptyObjectKeywordFilter = yield* engine.snapshot("payloads", {
+        where: {
+          payload: { venue: "xlon" },
+        },
+      });
+      expect(emptyObjectKeywordFilter.rows).toEqual([]);
+
+      yield* engine.publish("payloads", { id: "1", payload });
+      yield* engine.publish("payloads", { id: "2", payload: { venue: "xlon" } });
+
+      const snapshot = yield* engine.snapshot("payloads", {});
+      expect(snapshot.rows[0]?.payload).toEqual(payload);
+      expect(snapshot.rows[0]?.payload).not.toBe(payload);
+
+      const objectFilter = yield* engine.snapshot("payloads", {
+        where: {
+          payload: { venue: "xlon" },
+        },
+      });
+      expect(objectFilter.rows).toEqual([{ id: "2", payload: { venue: "xlon" } }]);
+    }),
+  );
+
+  it.effect("rejects non-cloneable object rows and query filters through typed errors", () =>
+    Effect.gen(function* () {
+      const WithPayload = Schema.Struct({
+        id: Schema.String,
+        payload: Schema.ObjectKeyword,
+      });
+      const engine = yield* createColumnLiveViewEngine({
+        topics: {
+          payloads: {
+            schema: WithPayload,
+            key: "id",
+          },
+        },
+      });
+
+      const rowError = yield* Effect.flip(
+        engine.publish("payloads", { id: "1", payload: new WeakMap() }),
+      );
+      expect(rowError._tag).toBe("InvalidRowError");
+
+      yield* engine.publish("payloads", { id: "2", payload: { venue: "xnys" } });
+      const queryError = yield* Effect.flip(
+        engine.snapshot("payloads", {
+          where: {
+            payload: new WeakMap(),
+          },
+        }),
+      );
+      expect(queryError._tag).toBe("InvalidQueryError");
+    }),
+  );
+
+  it.effect("keeps a runtime guard for unsafely cast invalid key configs", () =>
+    Effect.gen(function* () {
+      const invalidKeyConfig = {
+        topics: {
+          orders: {
+            schema: Order,
+            key: "missing",
+          },
+        },
+      };
+      // @ts-expect-error invalid configs can still reach runtime through untyped callers.
+      const engine = yield* createColumnLiveViewEngine(invalidKeyConfig);
+
+      const error = yield* Effect.flip(engine.publish("orders", order("1", "open", 10, 1)));
+
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        message: expect.stringContaining("Key field missing"),
+      });
+    }),
+  );
+
+  it.effect(
+    "supports unsafely cast decoders without struct field metadata for unfiltered health",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({
+          topics: {
+            loose: {
+              schema: Schema.ObjectKeyword,
+              // @ts-expect-error ObjectKeyword has no known string fields; this exercises runtime fallback only.
+              key: "id",
+            },
+          },
+        });
+
+        const health = yield* engine.health();
+        expect(health.topics["loose"].rowCount).toBe(0);
+      }),
+  );
+
+  it.effect("fails missing-key patches and key-changing patches", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      const missing = yield* Effect.flip(engine.patch("orders", "missing", { price: 20 }));
+      expect(missing).toMatchObject({
+        _tag: "InvalidRowError",
+        message: expect.stringContaining("Cannot patch missing key"),
+      });
+
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+      const changedKey = yield* Effect.flip(engine.patch("orders", "1", { id: "2" }));
+      expect(changedKey).toMatchObject({
+        _tag: "InvalidRowError",
+        message: expect.stringContaining("must not change"),
+      });
+    }),
+  );
+
+  it.effect("updates health row counts and versions", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      const empty = yield* engine.health();
+      expect(empty.version).toBe(0);
+      expect(empty.topics["orders"].rowCount).toBe(0);
+      expect(empty.topics["orders"].version).toBe(0);
+
+      yield* engine.publishMany("orders", [order("1", "open", 10, 1), order("2", "closed", 20, 2)]);
+      yield* engine.patch("orders", "1", { price: 30 });
+      yield* engine.delete("orders", "2");
+
+      const mutated = yield* engine.health();
+      expect(mutated.version).toBe(3);
+      expect(mutated.topics["orders"].rowCount).toBe(1);
+      expect(mutated.topics["orders"].version).toBe(3);
+
+      yield* engine.reset();
+
+      const reset = yield* engine.health();
+      expect(reset.version).toBe(0);
+      expect(reset.topics["orders"].rowCount).toBe(0);
+      expect(reset.topics["orders"].version).toBe(0);
+    }),
+  );
+
+  it.effect("falls back to the default queue capacity when configured capacity is invalid", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({
+        topics: viewServer.topics,
+        subscriptionQueueCapacity: 0,
+      });
+      const subscription = yield* engine.subscribe("orders", {});
+
+      yield* subscription.close();
+
+      const health = yield* engine.health();
+      expect(health.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("keeps a runtime guard for untyped grouped aggregate query callers", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const groupedRuntimeQuery: object = {
+        groupBy: ["status"],
+        aggregates: [{ type: "count", as: "count" }],
+      };
+
+      const error = yield* Effect.flip(engine.snapshot("orders", groupedRuntimeQuery));
+
+      expect(error).toMatchObject({
+        _tag: "UnsupportedQueryError",
+        message: expect.stringContaining("Grouped aggregate queries are not implemented"),
+      });
+
+      const subscribeError = yield* Effect.flip(engine.subscribe("orders", groupedRuntimeQuery));
+      expect(subscribeError._tag).toBe("UnsupportedQueryError");
+    }),
+  );
+
+  it.effect("does not throw defects for nullish malformed raw queries", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      const nullError = yield* Effect.flip(
+        // @ts-expect-error malformed untyped callers are still handled by the Effect error channel.
+        engine.snapshot("orders", null),
+      );
+      expect(nullError).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("Raw query must be a plain object"),
+      });
+
+      const undefinedError = yield* Effect.flip(
+        // @ts-expect-error malformed untyped callers are still handled by the Effect error channel.
+        engine.subscribe("orders", null),
+      );
+      expect(undefinedError._tag).toBe("InvalidQueryError");
+
+      const undefinedSnapshot = yield* engine.snapshot(
+        "orders",
+        // @ts-expect-error undefined is normalized to the empty raw query at runtime.
+        undefined,
+      );
+      expect(undefinedSnapshot.rows).toEqual([]);
+    }),
+  );
+
+  it.effect("fails malformed raw query shapes through the typed error channel", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const invalidWhere = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query where must be rejected.
+          where: "bad",
+        }),
+      );
+      expect(invalidWhere).toMatchObject({
+        _tag: "InvalidQueryError",
+        topic: "orders",
+        message: expect.stringContaining("where"),
+      });
+
+      const invalidWhereArray = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query where array must be rejected.
+          where: [],
+        }),
+      );
+      expect(invalidWhereArray._tag).toBe("InvalidQueryError");
+
+      const invalidTopLevelArray = yield* Effect.flip(engine.snapshot("orders", []));
+      expect(invalidTopLevelArray._tag).toBe("InvalidQueryError");
+
+      const invalidTopLevelMap = yield* Effect.flip(engine.snapshot("orders", new Map()));
+      expect(invalidTopLevelMap).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("plain object"),
+      });
+
+      const invalidWhereMapQuery: object = {
+        where: new Map([["status", "open"]]),
+      };
+      const invalidWhereMap = yield* Effect.flip(engine.snapshot("orders", invalidWhereMapQuery));
+      expect(invalidWhereMap).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("where"),
+      });
+
+      const unknownTopLevelRawQuery: object = {
+        where: {
+          status: "open",
+        },
+        whre: {
+          status: "closed",
+        },
+      };
+      const unknownTopLevelKey = yield* Effect.flip(
+        engine.snapshot("orders", unknownTopLevelRawQuery),
+      );
+      expect(unknownTopLevelKey).toMatchObject({
+        _tag: "InvalidQueryError",
+        topic: "orders",
+        message: expect.stringContaining("unsupported key: whre"),
+      });
+
+      const invalidOrderBy = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query orderBy must be rejected.
+          orderBy: "bad",
+        }),
+      );
+      expect(invalidOrderBy._tag).toBe("InvalidQueryError");
+
+      const invalidFields = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query fields must be rejected.
+          fields: "id",
+        }),
+      );
+      expect(invalidFields._tag).toBe("InvalidQueryError");
+
+      const invalidFieldEntry = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query field entries must be rejected.
+          fields: [1],
+        }),
+      );
+      expect(invalidFieldEntry._tag).toBe("InvalidQueryError");
+
+      const invalidOffset = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query offset must be rejected.
+          offset: "0",
+        }),
+      );
+      expect(invalidOffset).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("offset"),
+      });
+
+      const invalidOffsetNaN = yield* Effect.flip(
+        engine.snapshot("orders", {
+          offset: Number.NaN,
+        }),
+      );
+      expect(invalidOffsetNaN).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("offset"),
+      });
+
+      const invalidOffsetNegative = yield* Effect.flip(
+        engine.snapshot("orders", {
+          offset: -1,
+        }),
+      );
+      expect(invalidOffsetNegative).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("offset"),
+      });
+
+      const invalidOffsetFraction = yield* Effect.flip(
+        engine.snapshot("orders", {
+          offset: 0.5,
+        }),
+      );
+      expect(invalidOffsetFraction).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("offset"),
+      });
+
+      const invalidLimit = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error malformed runtime query limit must be rejected.
+          limit: "1",
+        }),
+      );
+      expect(invalidLimit).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("limit"),
+      });
+
+      const invalidLimitInfinity = yield* Effect.flip(
+        engine.snapshot("orders", {
+          limit: Number.POSITIVE_INFINITY,
+        }),
+      );
+      expect(invalidLimitInfinity).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("limit"),
+      });
+
+      const invalidOrderByEntry = yield* Effect.flip(
+        engine.snapshot("orders", {
+          orderBy: [
+            // @ts-expect-error malformed runtime query orderBy entry must be rejected.
+            "bad",
+          ],
+        }),
+      );
+      expect(invalidOrderByEntry._tag).toBe("InvalidQueryError");
+
+      const invalidOrderByExtraKeyQuery: object = {
+        orderBy: [
+          {
+            field: "price",
+            direction: "asc",
+            typo: true,
+          },
+        ],
+      };
+      const invalidOrderByExtraKey = yield* Effect.flip(
+        engine.snapshot("orders", invalidOrderByExtraKeyQuery),
+      );
+      expect(invalidOrderByExtraKey).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported key: typo"),
+      });
+
+      const invalidOrderByField = yield* Effect.flip(
+        engine.snapshot("orders", {
+          orderBy: [
+            // @ts-expect-error malformed runtime query orderBy field must be rejected.
+            {
+              direction: "asc",
+            },
+          ],
+        }),
+      );
+      expect(invalidOrderByField._tag).toBe("InvalidQueryError");
+
+      const unknownOrderByField = yield* Effect.flip(
+        engine.snapshot("orders", {
+          orderBy: [
+            {
+              // @ts-expect-error runtime query unknown orderBy fields must be rejected.
+              field: "prcie",
+              direction: "asc",
+            },
+          ],
+        }),
+      );
+      expect(unknownOrderByField).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("orderBy"),
+      });
+
+      const unknownProjectionField = yield* Effect.flip(
+        engine.snapshot("orders", {
+          // @ts-expect-error runtime query unknown projected fields must be rejected.
+          fields: ["prcie"],
+        }),
+      );
+      expect(unknownProjectionField).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("fields"),
+      });
+
+      const unknownWhereField = yield* Effect.flip(
+        engine.snapshot("orders", {
+          where: {
+            // @ts-expect-error runtime query unknown where fields must be rejected.
+            prcie: 10,
+          },
+        }),
+      );
+      expect(unknownWhereField).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("where"),
+      });
+
+      const unknownFilterOperator = yield* Effect.flip(
+        engine.snapshot("orders", {
+          where: {
+            // @ts-expect-error runtime query unknown filter operators must be rejected.
+            status: { equals: "open" },
+          },
+        }),
+      );
+      expect(unknownFilterOperator).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported filter operator"),
+      });
+
+      const mixedKnownAndUnknownFilterOperator = yield* Effect.flip(
+        engine.snapshot("orders", {
+          where: {
+            // @ts-expect-error runtime query unknown filter operators must be rejected.
+            status: { eq: "open", typo: true },
+          },
+        }),
+      );
+      expect(mixedKnownAndUnknownFilterOperator).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported filter operator"),
+      });
+
+      const invalidOrderByDirection = yield* Effect.flip(
+        engine.snapshot("orders", {
+          orderBy: [
+            {
+              field: "price",
+              // @ts-expect-error malformed runtime query orderBy direction must be rejected.
+              direction: "sideways",
+            },
+          ],
+        }),
+      );
+      expect(invalidOrderByDirection._tag).toBe("InvalidQueryError");
+    }),
+  );
+
+  it.effect("fails unknown topics and closes the engine idempotently", () =>
+    Effect.gen(function* () {
+      const looseConfig: ColumnLiveViewEngineConfig<Topics> = { topics: viewServer.topics };
+      const engine = yield* createColumnLiveViewEngine(looseConfig);
+      const subscription = yield* engine.subscribe("orders", {});
+
+      const missingTopicConfig: ColumnLiveViewEngineConfig<Record<string, Topics["orders"]>> = {
+        topics: {
+          orders: viewServer.topics.orders,
+        },
+      };
+      const looseEngine = yield* createColumnLiveViewEngine(missingTopicConfig);
+      const missing = yield* Effect.flip(looseEngine.snapshot("missing", {}));
+      expect(missing._tag).toBe("InvalidTopicError");
+
+      yield* engine.close();
+      yield* engine.close();
+      yield* subscription.close();
+
+      const closedHealth = yield* engine.health();
+      expect(closedHealth.status).toBe("stopping");
+
+      const closedError = yield* Effect.flip(engine.publish("orders", order("1", "open", 10, 1)));
+      expect(closedError._tag).toBe("EngineClosedError");
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -1,0 +1,1378 @@
+import type {
+  DeltaEvent,
+  DeltaOperation,
+  FieldKey,
+  LiveQueryRow,
+  LiveQueryResult,
+  OrderBy,
+  RawQuery,
+  RowFromSchema,
+  RowSchema,
+  SnapshotEvent,
+  StatusEvent,
+  StringFieldKey,
+  TopicRow,
+} from "@view-server/config";
+import { Cause, Effect, Queue, Schema, Semaphore, Stream } from "effect";
+import { equals, isBigDecimal, Order } from "effect/BigDecimal";
+
+export type DecodableTopicDefinitions = Record<
+  string,
+  {
+    readonly schema: RowSchema & Schema.Decoder<object>;
+    readonly key: string;
+  }
+>;
+
+type ValidateEngineTopics<Topics extends DecodableTopicDefinitions> = {
+  readonly [Topic in keyof Topics]: Topics[Topic] extends {
+    readonly schema: infer S extends RowSchema & Schema.Decoder<object>;
+    readonly key: infer Key extends string;
+  }
+    ? {
+        readonly schema: S;
+        readonly key: Key & StringFieldKey<RowFromSchema<S>>;
+      }
+    : never;
+};
+
+export type ColumnLiveViewEngineConfig<Topics extends DecodableTopicDefinitions> = {
+  readonly topics: Topics & ValidateEngineTopics<Topics>;
+  readonly subscriptionQueueCapacity?: number;
+};
+
+export class InvalidTopicError extends Schema.TaggedErrorClass<InvalidTopicError>()(
+  "InvalidTopicError",
+  {
+    topic: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class InvalidRowError extends Schema.TaggedErrorClass<InvalidRowError>()("InvalidRowError", {
+  topic: Schema.String,
+  message: Schema.String,
+}) {}
+
+export class UnsupportedQueryError extends Schema.TaggedErrorClass<UnsupportedQueryError>()(
+  "UnsupportedQueryError",
+  {
+    topic: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class InvalidQueryError extends Schema.TaggedErrorClass<InvalidQueryError>()(
+  "InvalidQueryError",
+  {
+    topic: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class EngineClosedError extends Schema.TaggedErrorClass<EngineClosedError>()(
+  "EngineClosedError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export type ColumnLiveViewEngineError =
+  | InvalidTopicError
+  | InvalidRowError
+  | UnsupportedQueryError
+  | InvalidQueryError
+  | EngineClosedError;
+
+export type ColumnLiveViewEngineEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
+
+export type ColumnLiveViewSubscription<Row> = {
+  readonly events: Stream.Stream<ColumnLiveViewEngineEvent<Row>>;
+  readonly close: () => Effect.Effect<void, never>;
+};
+
+export type ColumnLiveViewTopicHealth = {
+  readonly status: "ready" | "degraded";
+  readonly rowCount: number;
+  readonly version: number;
+  readonly activeSubscriptions: number;
+  readonly queuedEvents: number;
+  readonly maxQueueDepth: number;
+  readonly backpressureEvents: number;
+};
+
+export type ColumnLiveViewEngineHealth<
+  Topics extends DecodableTopicDefinitions = DecodableTopicDefinitions,
+> = {
+  readonly status: "ready" | "stopping";
+  readonly version: number;
+  readonly topics: {
+    readonly [Topic in Extract<keyof Topics, string>]: ColumnLiveViewTopicHealth;
+  };
+  readonly activeSubscriptions: number;
+  readonly queuedEvents: number;
+  readonly maxQueueDepth: number;
+  readonly backpressureEvents: number;
+};
+
+type MutableHealthTopics<Topics extends DecodableTopicDefinitions> = {
+  -readonly [Topic in Extract<keyof Topics, string>]: ColumnLiveViewTopicHealth;
+};
+
+type RejectExtraKeys<Candidate, Shape> = {
+  readonly [Key in Exclude<keyof Candidate, keyof Shape>]: never;
+};
+
+type ExactRawQuery<Row, Query> = Query &
+  RejectExtraKeys<Query, RawQuery<Row>> & {
+    readonly groupBy?: never;
+    readonly aggregates?: never;
+  } & ExactWhere<Row, Query> &
+  ExactOrderBy<Row, Query>;
+
+type ExactWhere<Row, Query> = Query extends {
+  readonly where: infer Where;
+}
+  ? {
+      readonly where: Where &
+        RejectExtraKeys<Where, { readonly [Field in FieldKey<Row>]?: unknown }> & {
+          readonly [Field in Extract<keyof Where, FieldKey<Row>>]: ExactFilter<
+            Row[Field],
+            Where[Field]
+          >;
+        };
+    }
+  : unknown;
+
+type ExactFilter<Value, Filter> = Value extends object
+  ? unknown
+  : ExactOperatorFilter<Value, Filter>;
+
+type ExactOperatorFilter<Value, Filter> = Filter extends object
+  ? Filter extends ReadonlyArray<unknown>
+    ? unknown
+    : Filter & RejectExtraKeys<Filter, FieldFilterShape<Value>>
+  : unknown;
+
+type FieldFilterShape<Value> = Value extends string
+  ? {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+      readonly startsWith?: string;
+    }
+  : {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+      readonly gt?: Value;
+      readonly gte?: Value;
+      readonly lt?: Value;
+      readonly lte?: Value;
+    };
+
+type ExactOrderBy<Row, Query> = Query extends {
+  readonly orderBy: ReadonlyArray<infer Entry>;
+}
+  ? {
+      readonly orderBy: ReadonlyArray<Entry & RejectExtraKeys<Entry, OrderBy<Row>>>;
+    }
+  : unknown;
+
+type ExactPatch<Row, Patch> = Patch & RejectExtraKeys<Patch, Partial<Row>>;
+
+export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
+  readonly publish: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    row: TopicRow<Topics, Topic>,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly publishMany: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    rows: ReadonlyArray<TopicRow<Topics, Topic>>,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly patch: <
+    Topic extends Extract<keyof Topics, string>,
+    const Patch extends Partial<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    key: string,
+    patch: ExactPatch<TopicRow<Topics, Topic>, Patch>,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly delete: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    key: string,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly snapshot: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: ExactRawQuery<TopicRow<Topics, Topic>, Query>,
+  ) => Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  readonly subscribe: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: ExactRawQuery<TopicRow<Topics, Topic>, Query>,
+  ) => Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  readonly health: () => Effect.Effect<ColumnLiveViewEngineHealth<Topics>, never>;
+  readonly reset: () => Effect.Effect<void, never>;
+  readonly close: () => Effect.Effect<void, never>;
+};
+
+type RowObject = object;
+const defaultSubscriptionQueueCapacity = 1_024;
+
+type RuntimeRawQuery = {
+  readonly where?: object;
+  readonly orderBy?: ReadonlyArray<{
+    readonly field: string;
+    readonly direction: "asc" | "desc";
+  }>;
+  readonly offset?: number;
+  readonly limit?: number;
+  readonly fields?: ReadonlyArray<string>;
+};
+
+type SchemaWithFields = Schema.Decoder<object> & {
+  readonly fields: Record<string, unknown>;
+};
+
+type StoredRow = {
+  readonly key: string;
+  readonly row: RowObject;
+};
+
+type QueryEvaluation = {
+  readonly rows: ReadonlyArray<RowObject>;
+  readonly keys: ReadonlyArray<string>;
+  readonly window: ReadonlyArray<StoredRow>;
+  readonly totalRows: number;
+  readonly version: number;
+};
+
+type Subscriber = {
+  readonly topic: string;
+  readonly queryId: string;
+  readonly query: RuntimeRawQuery;
+  readonly queue: Queue.Queue<ColumnLiveViewEngineEvent<RowObject>, Cause.Done>;
+  lastEvaluation: QueryEvaluation;
+  maxQueueDepth: number;
+  backpressureEvents: number;
+  closed: boolean;
+};
+
+type FilterObject = {
+  readonly eq?: unknown;
+  readonly neq?: unknown;
+  readonly in?: ReadonlyArray<unknown>;
+  readonly gt?: unknown;
+  readonly gte?: unknown;
+  readonly lt?: unknown;
+  readonly lte?: unknown;
+  readonly startsWith?: string;
+};
+
+const rawQueryKeys = new Set(["where", "orderBy", "offset", "limit", "fields"]);
+const filterOperatorKeys = new Set(["eq", "neq", "in", "gt", "gte", "lt", "lte", "startsWith"]);
+
+const isDenseArray = (value: ReadonlyArray<unknown>): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    if (!(index in value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+class TopicStore {
+  readonly rows = new Map<string, RowObject>();
+  readonly subscribers = new Set<Subscriber>();
+  readonly mutationSemaphore = Semaphore.makeUnsafe(1);
+  version = 0;
+  maxQueueDepth = 0;
+  backpressureEvents = 0;
+
+  constructor(
+    readonly topic: string,
+    readonly schema: Schema.Decoder<RowObject>,
+    readonly keyField: string,
+    readonly fieldNames: ReadonlySet<string>,
+    readonly structuredFieldNames: ReadonlySet<string>,
+  ) {}
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (!isRecord(value) || isBigDecimal(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype;
+};
+
+const isGroupedQuery = (query: unknown): boolean =>
+  isRecord(query) && ("groupBy" in query || "aggregates" in query);
+
+const isValidWindowNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+const isSchemaWithFields = (schema: Schema.Decoder<object>): schema is SchemaWithFields =>
+  "fields" in schema && isRecord(schema.fields);
+
+const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
+  isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
+
+const schemaStructuredFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    const tag = Object(Object(fieldSchema)["ast"])["_tag"];
+    if (tag === "Objects" || tag === "Arrays" || tag === "ObjectKeyword") {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+const cloneUnknown = (value: unknown): unknown => {
+  if (isBigDecimal(value)) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(cloneUnknown);
+  }
+  if (isPlainRecord(value)) {
+    return cloneRecord(value);
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+  return structuredClone(value);
+};
+
+const cloneRecord = (value: Record<string, unknown>): Record<string, unknown> => {
+  const cloned: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    cloned[key] = cloneUnknown(entry);
+  }
+  return cloned;
+};
+
+const cloneRow = (row: RowObject): RowObject => {
+  const cloned: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(row)) {
+    cloned[key] = cloneUnknown(entry);
+  }
+  return cloned;
+};
+
+const safeCloneRow = Effect.fn("ColumnLiveViewEngine.safeCloneRow")(function* (
+  store: TopicStore,
+  row: RowObject,
+) {
+  return yield* Effect.try({
+    try: () => cloneRow(row),
+    catch: (cause) =>
+      InvalidRowError.make({
+        topic: store.topic,
+        message: String(cause),
+      }),
+  });
+});
+
+const decodeRawQuery = (
+  topic: string,
+  fieldNames: ReadonlySet<string>,
+  query: unknown,
+): Effect.Effect<RuntimeRawQuery, InvalidQueryError> => {
+  if (query === undefined) {
+    return Effect.succeed({});
+  }
+  if (!isPlainRecord(query)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Raw query must be a plain object.",
+    });
+  }
+  for (const key of Object.keys(query)) {
+    if (!rawQueryKeys.has(key)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Raw query contains unsupported key: ${key}.`,
+      });
+    }
+  }
+
+  const where = query["where"];
+  if (where !== undefined && !isPlainRecord(where)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Raw query where must be a plain object.",
+    });
+  }
+  if (where !== undefined) {
+    for (const field of Object.keys(where)) {
+      if (!fieldNames.has(field)) {
+        return InvalidQueryError.make({
+          topic,
+          message: `Raw query where contains unknown field: ${field}.`,
+        });
+      }
+    }
+  }
+
+  const orderBy = query["orderBy"];
+  if (orderBy !== undefined && !Array.isArray(orderBy)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Raw query orderBy must be an array.",
+    });
+  }
+
+  const fields = query["fields"];
+  if (
+    fields !== undefined &&
+    (!Array.isArray(fields) || !fields.every((field) => typeof field === "string"))
+  ) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Raw query fields must be an array of strings.",
+    });
+  }
+  if (Array.isArray(fields)) {
+    for (const field of fields) {
+      if (!fieldNames.has(field)) {
+        return InvalidQueryError.make({
+          topic,
+          message: `Raw query fields contains unknown field: ${field}.`,
+        });
+      }
+    }
+  }
+
+  const offset = query["offset"];
+  if (offset !== undefined && !isValidWindowNumber(offset)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Raw query offset must be a non-negative safe integer.",
+    });
+  }
+
+  const limit = query["limit"];
+  if (limit !== undefined && !isValidWindowNumber(limit)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Raw query limit must be a non-negative safe integer.",
+    });
+  }
+
+  const decoded: {
+    where?: object;
+    orderBy?: Array<{ readonly field: string; readonly direction: "asc" | "desc" }>;
+    offset?: number;
+    limit?: number;
+    fields?: Array<string>;
+  } = {};
+
+  if (where !== undefined) {
+    let clonedWhere: Record<string, unknown>;
+    try {
+      clonedWhere = cloneRecord(where);
+    } catch (cause) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Raw query where could not be cloned: ${String(cause)}`,
+      });
+    }
+    decoded.where = clonedWhere;
+  }
+  if (offset !== undefined) {
+    decoded.offset = offset;
+  }
+  if (limit !== undefined) {
+    decoded.limit = limit;
+  }
+  if (Array.isArray(fields)) {
+    decoded.fields = [...fields];
+  }
+
+  const clonedOrderBy: Array<{ readonly field: string; readonly direction: "asc" | "desc" }> = [];
+  if (Array.isArray(orderBy)) {
+    for (const entry of orderBy) {
+      if (!isPlainRecord(entry)) {
+        return InvalidQueryError.make({
+          topic,
+          message: "Raw query orderBy entries must be plain objects.",
+        });
+      }
+      for (const key of Object.keys(entry)) {
+        if (key !== "field" && key !== "direction") {
+          return InvalidQueryError.make({
+            topic,
+            message: `Raw query orderBy contains unsupported key: ${key}.`,
+          });
+        }
+      }
+      const field = entry["field"];
+      if (typeof field !== "string") {
+        return InvalidQueryError.make({
+          topic,
+          message: "Raw query orderBy field must be a string.",
+        });
+      }
+      if (!fieldNames.has(field)) {
+        return InvalidQueryError.make({
+          topic,
+          message: `Raw query orderBy contains unknown field: ${field}.`,
+        });
+      }
+      const direction = entry["direction"];
+      if (direction !== "asc" && direction !== "desc") {
+        return InvalidQueryError.make({
+          topic,
+          message: "Raw query orderBy direction must be asc or desc.",
+        });
+      }
+      clonedOrderBy.push({
+        field,
+        direction,
+      });
+    }
+  }
+  if (clonedOrderBy.length > 0) {
+    decoded.orderBy = clonedOrderBy;
+  }
+
+  return Effect.succeed(decoded);
+};
+
+const validateRuntimeQueryAgainstStore = (
+  store: TopicStore,
+  query: RuntimeRawQuery,
+): Effect.Effect<void, InvalidQueryError> =>
+  Effect.gen(function* () {
+    if (query.where === undefined) {
+      return;
+    }
+
+    for (const [field, filter] of Object.entries(query.where)) {
+      if (!isPlainRecord(filter) || isBigDecimal(filter)) {
+        continue;
+      }
+      const keys = Object.keys(filter);
+      const operatorKeyCount = keys.filter((key) => filterOperatorKeys.has(key)).length;
+      if (operatorKeyCount > 0 && operatorKeyCount !== keys.length) {
+        return yield* InvalidQueryError.make({
+          topic: store.topic,
+          message: `Raw query where field ${field} contains unsupported filter operator.`,
+        });
+      }
+      if (operatorKeyCount === 0 && !store.structuredFieldNames.has(field)) {
+        return yield* InvalidQueryError.make({
+          topic: store.topic,
+          message: `Raw query where field ${field} contains unsupported filter operator.`,
+        });
+      }
+    }
+  });
+
+const fieldValue = (row: RowObject, field: string): unknown => {
+  for (const [key, value] of Object.entries(row)) {
+    if (key === field) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const equalsValue = (left: unknown, right: unknown): boolean => {
+  if (isBigDecimal(left) && isBigDecimal(right)) {
+    return equals(left, right);
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length && left.every((entry, index) => equalsValue(entry, right[index]))
+    );
+  }
+  if (isPlainRecord(left) && isPlainRecord(right)) {
+    const leftEntries = Object.entries(left);
+    const rightKeys = new Set(Object.keys(right));
+    return (
+      leftEntries.length === rightKeys.size &&
+      leftEntries.every(([key, entry]) => rightKeys.has(key) && equalsValue(entry, right[key]))
+    );
+  }
+  return Object.is(left, right);
+};
+
+const stableValueString = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableValueString).join(",")}]`;
+  }
+  if (isPlainRecord(value)) {
+    return `{${Object.keys(value)
+      .toSorted()
+      .map((key) => `${key}:${stableValueString(value[key])}`)
+      .join(",")}}`;
+  }
+  return `${typeof value}:${
+    JSON.stringify(value, (_key, entry: unknown) =>
+      typeof entry === "bigint" ? entry.toString() : entry,
+    ) ?? ""
+  }`;
+};
+
+const valueRank = (value: unknown): number => {
+  if (value == null) {
+    return 0;
+  }
+  if (typeof value === "boolean") {
+    return 1;
+  }
+  if (typeof value === "number" || typeof value === "bigint" || isBigDecimal(value)) {
+    return 2;
+  }
+  if (typeof value === "string") {
+    return 3;
+  }
+  if (Array.isArray(value)) {
+    return 4;
+  }
+  return 5;
+};
+
+const compareFilterValue = (left: unknown, right: unknown): number | undefined => {
+  if (typeof left === "number" && typeof right === "number") {
+    if (!Number.isFinite(left) || !Number.isFinite(right)) {
+      return undefined;
+    }
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (typeof left === "string" && typeof right === "string") {
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (typeof left === "bigint" && typeof right === "bigint") {
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (isBigDecimal(left) && isBigDecimal(right)) {
+    return Order(left, right);
+  }
+  return undefined;
+};
+
+const compareByStableString = (left: unknown, right: unknown): number => {
+  const leftString = stableValueString(left);
+  const rightString = stableValueString(right);
+  return Number(leftString > rightString) - Number(leftString < rightString);
+};
+
+const compareValue = (left: unknown, right: unknown): number | undefined => {
+  const leftRank = valueRank(left);
+  const rightRank = valueRank(right);
+  if (leftRank !== rightRank) {
+    return Number(leftRank > rightRank) - Number(leftRank < rightRank);
+  }
+  if (typeof left === "boolean" && typeof right === "boolean") {
+    return left === right ? 0 : left ? 1 : -1;
+  }
+  const filterComparison = compareFilterValue(left, right);
+  if (filterComparison !== undefined) {
+    return filterComparison;
+  }
+  return compareByStableString(left, right);
+};
+
+const isEqualityComparable = (left: unknown, right: unknown): boolean => {
+  if (isBigDecimal(left) || isBigDecimal(right)) {
+    return isBigDecimal(left) && isBigDecimal(right);
+  }
+  if (typeof left === "number" || typeof right === "number") {
+    return typeof left === "number" && typeof right === "number" && Number.isFinite(right);
+  }
+  return typeof left === typeof right;
+};
+
+const isOperatorFilterObject = (filter: Record<string, unknown>): filter is FilterObject => {
+  const keys = Object.keys(filter);
+  return keys.length > 0 && keys.every((key) => filterOperatorKeys.has(key));
+};
+
+const includesValue = (values: ReadonlyArray<unknown>, value: unknown): boolean => {
+  for (const candidate of values) {
+    if (equalsValue(value, candidate)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const matchesFilter = (value: unknown, filter: unknown): boolean => {
+  if (filter === undefined) {
+    return false;
+  }
+  if (!isPlainRecord(filter) || isBigDecimal(filter)) {
+    return equalsValue(value, filter);
+  }
+  const valueIsStructured = (isPlainRecord(value) && !isBigDecimal(value)) || Array.isArray(value);
+  if (valueIsStructured) {
+    if (equalsValue(value, filter)) {
+      return true;
+    }
+    const filterKeys = Object.keys(filter);
+    const eq = filter["eq"];
+    if (filterKeys.length === 1 && eq !== undefined) {
+      return equalsValue(value, eq);
+    }
+    const oneOf = filter["in"];
+    if (filterKeys.length === 1 && Array.isArray(oneOf)) {
+      return (
+        isDenseArray(oneOf) &&
+        !oneOf.some((candidate) => candidate === undefined) &&
+        includesValue(oneOf, value)
+      );
+    }
+    const notEqual = filter["neq"];
+    if (filterKeys.length === 1 && notEqual !== undefined) {
+      return !equalsValue(value, notEqual);
+    }
+    return false;
+  }
+  /* v8 ignore next -- runtime validation rejects scalar object filters before evaluation. */
+  if (!isOperatorFilterObject(filter)) {
+    return equalsValue(value, filter);
+  }
+
+  const filterKeys = Object.keys(filter);
+  if (filterKeys.some((key) => filter[key as keyof FilterObject] === undefined)) {
+    return false;
+  }
+
+  if (filter.eq !== undefined && !equalsValue(value, filter.eq)) {
+    return false;
+  }
+  if (filter.neq !== undefined) {
+    if (!isEqualityComparable(value, filter.neq) || equalsValue(value, filter.neq)) {
+      return false;
+    }
+  }
+  if (filter.in !== undefined) {
+    if (
+      !Array.isArray(filter.in) ||
+      !isDenseArray(filter.in) ||
+      filter.in.some((candidate) => candidate === undefined) ||
+      !includesValue(filter.in, value)
+    ) {
+      return false;
+    }
+  }
+  if (filter.startsWith !== undefined) {
+    if (
+      typeof filter.startsWith !== "string" ||
+      typeof value !== "string" ||
+      !value.startsWith(filter.startsWith)
+    ) {
+      return false;
+    }
+  }
+
+  if (filter.gt !== undefined) {
+    const comparison = compareFilterValue(value, filter.gt);
+    if (comparison === undefined || comparison <= 0) {
+      return false;
+    }
+  }
+  if (filter.gte !== undefined) {
+    const comparison = compareFilterValue(value, filter.gte);
+    if (comparison === undefined || comparison < 0) {
+      return false;
+    }
+  }
+  if (filter.lt !== undefined) {
+    const comparison = compareFilterValue(value, filter.lt);
+    if (comparison === undefined || comparison >= 0) {
+      return false;
+    }
+  }
+  if (filter.lte !== undefined) {
+    const comparison = compareFilterValue(value, filter.lte);
+    if (comparison === undefined || comparison > 0) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const matchesWhere = (row: RowObject, query: RuntimeRawQuery): boolean => {
+  if (query.where === undefined) {
+    return true;
+  }
+
+  for (const [field, filter] of Object.entries(query.where)) {
+    if (!matchesFilter(fieldValue(row, field), filter)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const compareRows = (
+  left: StoredRow,
+  right: StoredRow,
+  orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
+): number => {
+  for (const order of orderBy) {
+    const comparison = compareValue(
+      fieldValue(left.row, order.field),
+      fieldValue(right.row, order.field),
+    );
+    if (comparison !== undefined && comparison !== 0) {
+      return order.direction === "asc" ? comparison : -comparison;
+    }
+  }
+  return Number(left.key > right.key) - Number(left.key < right.key);
+};
+
+const projectRow = (
+  row: RowObject,
+  fields: ReadonlyArray<FieldKey<Record<string, unknown>>> | undefined,
+): RowObject => {
+  if (fields === undefined) {
+    return cloneRow(row);
+  }
+
+  const projected: Record<string, unknown> = {};
+  for (const field of fields) {
+    projected[field] = cloneUnknown(fieldValue(row, field));
+  }
+  return projected;
+};
+
+const rowEquals = (left: RowObject, right: RowObject): boolean => {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  if (leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  for (const [key, value] of leftEntries) {
+    if (!equalsValue(value, fieldValue(right, key))) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const evaluateRawQuery = (store: TopicStore, query: RuntimeRawQuery): QueryEvaluation => {
+  const filtered = Array.from(store.rows, ([key, row]) => ({ key, row })).filter((entry) =>
+    matchesWhere(entry.row, query),
+  );
+  const ordered = filtered.toSorted((left, right) => compareRows(left, right, query.orderBy ?? []));
+  const offset = query.offset ?? 0;
+  const windowed = ordered.slice(
+    offset,
+    query.limit === undefined ? undefined : offset + query.limit,
+  );
+  const window = windowed.map((entry) => ({
+    key: entry.key,
+    row: projectRow(entry.row, query.fields),
+  }));
+
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: window.map((entry) => entry.key),
+    window,
+    totalRows: filtered.length,
+    version: store.version,
+  };
+};
+
+const liveQueryResult = <Row>(evaluation: QueryEvaluation): LiveQueryResult<Row> =>
+  ({
+    rows: evaluation.rows,
+    totalRows: evaluation.totalRows,
+    version: evaluation.version,
+  }) as LiveQueryResult<Row>;
+
+const decodeRow = Effect.fn("ColumnLiveViewEngine.decodeRow")(function* (
+  store: TopicStore,
+  row: RowObject,
+) {
+  return yield* Effect.try({
+    try: () => Schema.decodeUnknownSync(store.schema)(row),
+    catch: (cause) =>
+      InvalidRowError.make({
+        topic: store.topic,
+        message: String(cause),
+      }),
+  });
+});
+
+const rowKey = Effect.fn("ColumnLiveViewEngine.rowKey")(function* (
+  store: TopicStore,
+  row: RowObject,
+) {
+  const key = fieldValue(row, store.keyField);
+  if (typeof key !== "string") {
+    return yield* InvalidRowError.make({
+      topic: store.topic,
+      message: `Key field ${store.keyField} must decode to a string.`,
+    });
+  }
+  return key;
+});
+
+const snapshotEvent = (
+  store: TopicStore,
+  queryId: string,
+  evaluation: QueryEvaluation,
+): SnapshotEvent<RowObject> => ({
+  type: "snapshot",
+  topic: store.topic,
+  queryId,
+  version: evaluation.version,
+  keys: [...evaluation.keys],
+  rows: evaluation.rows.map(cloneRow),
+  totalRows: evaluation.totalRows,
+});
+
+const deltaOperations = (
+  previous: QueryEvaluation,
+  next: QueryEvaluation,
+): ReadonlyArray<DeltaOperation<RowObject>> => {
+  const operations: Array<DeltaOperation<RowObject>> = [];
+  const nextKeys = new Set(next.keys);
+  const currentKeys = [...previous.keys];
+  const currentRows = [...previous.rows];
+
+  for (const key of previous.keys) {
+    if (!nextKeys.has(key)) {
+      const index = currentKeys.indexOf(key);
+      currentKeys.splice(index, 1);
+      currentRows.splice(index, 1);
+      operations.push({
+        type: "remove",
+        key,
+      });
+    }
+  }
+
+  for (const [index, { key, row }] of next.window.entries()) {
+    const currentIndex = currentKeys.indexOf(key);
+    if (currentIndex < 0) {
+      currentKeys.splice(index, 0, key);
+      currentRows.splice(index, 0, row);
+      operations.push({
+        type: "insert",
+        key,
+        row,
+        index,
+      });
+      continue;
+    }
+
+    if (currentIndex !== index) {
+      const currentRow = currentRows[currentIndex]!;
+      currentKeys.splice(currentIndex, 1);
+      currentRows.splice(currentIndex, 1);
+      currentKeys.splice(index, 0, key);
+      currentRows.splice(index, 0, currentRow);
+      operations.push({
+        type: "move",
+        key,
+        fromIndex: currentIndex,
+        toIndex: index,
+      });
+    }
+
+    const currentRow = currentRows[index];
+    if (currentRow === undefined || !rowEquals(currentRow, row)) {
+      currentRows[index] = row;
+      operations.push({
+        type: "update",
+        key,
+        row,
+        index,
+      });
+    }
+  }
+
+  return operations;
+};
+
+const cloneDeltaOperations = (
+  operations: ReadonlyArray<DeltaOperation<RowObject>>,
+): ReadonlyArray<DeltaOperation<RowObject>> =>
+  operations.map((operation) => {
+    if (operation.type === "insert" || operation.type === "update") {
+      return {
+        ...operation,
+        row: cloneRow(operation.row),
+      };
+    }
+    return operation;
+  });
+
+const deltaEvent = (
+  store: TopicStore,
+  subscriber: Subscriber,
+  next: QueryEvaluation,
+  operations: ReadonlyArray<DeltaOperation<RowObject>>,
+): DeltaEvent<RowObject> => ({
+  type: "delta",
+  topic: store.topic,
+  queryId: subscriber.queryId,
+  fromVersion: subscriber.lastEvaluation.version,
+  toVersion: next.version,
+  operations: cloneDeltaOperations(operations),
+  totalRows: next.totalRows,
+});
+
+const backpressureStatusEvent = (store: TopicStore, subscriber: Subscriber): StatusEvent => ({
+  type: "status",
+  topic: store.topic,
+  queryId: subscriber.queryId,
+  status: "closed",
+  code: "BackpressureExceeded",
+  message: "Subscription closed because its event queue exceeded capacity.",
+});
+
+class InMemoryColumnLiveViewEngine<
+  Topics extends DecodableTopicDefinitions,
+> implements ColumnLiveViewEngine<Topics> {
+  private readonly stores = new Map<string, TopicStore>();
+  private readonly subscriptionQueueCapacity: number;
+  private engineVersion = 0;
+  private nextQueryId = 0;
+  private closed = false;
+
+  constructor(config: ColumnLiveViewEngineConfig<Topics>) {
+    const configuredCapacity = config.subscriptionQueueCapacity ?? defaultSubscriptionQueueCapacity;
+    this.subscriptionQueueCapacity =
+      Number.isSafeInteger(configuredCapacity) && configuredCapacity > 0
+        ? configuredCapacity
+        : defaultSubscriptionQueueCapacity;
+    for (const [topic, definition] of Object.entries(config.topics)) {
+      this.stores.set(
+        topic,
+        new TopicStore(
+          topic,
+          definition.schema,
+          definition.key,
+          schemaFieldNames(definition.schema),
+          schemaStructuredFieldNames(definition.schema),
+        ),
+      );
+    }
+  }
+
+  private getStore(topic: string): Effect.Effect<TopicStore, InvalidTopicError> {
+    return Effect.gen({ self: this }, function* () {
+      const store = this.stores.get(topic);
+      if (store === undefined) {
+        return yield* InvalidTopicError.make({
+          topic,
+          message: `Unknown topic: ${topic}`,
+        });
+      }
+      return store;
+    });
+  }
+
+  private ensureOpen(): Effect.Effect<void, EngineClosedError> {
+    return Effect.gen({ self: this }, function* () {
+      if (this.closed) {
+        return yield* EngineClosedError.make({
+          message: "ColumnLiveViewEngine is closed.",
+        });
+      }
+    });
+  }
+
+  private notifySubscribers = Effect.fn("ColumnLiveViewEngine.notifySubscribers")(function* (
+    store: TopicStore,
+  ) {
+    for (const subscriber of store.subscribers) {
+      const next = evaluateRawQuery(store, subscriber.query);
+      const operations = deltaOperations(subscriber.lastEvaluation, next);
+      if (operations.length === 0 && subscriber.lastEvaluation.totalRows === next.totalRows) {
+        continue;
+      }
+
+      const offered = yield* Queue.offer(
+        subscriber.queue,
+        deltaEvent(store, subscriber, next, operations),
+      );
+      if (!offered) {
+        subscriber.backpressureEvents += 1;
+        store.backpressureEvents += 1;
+        subscriber.closed = true;
+        store.subscribers.delete(subscriber);
+        yield* Queue.takeAll(subscriber.queue).pipe(Effect.ignore);
+        yield* Queue.offer(subscriber.queue, backpressureStatusEvent(store, subscriber)).pipe(
+          Effect.ignore,
+        );
+        yield* Queue.end(subscriber.queue);
+        continue;
+      }
+
+      const queueDepth = yield* Queue.size(subscriber.queue);
+      subscriber.maxQueueDepth = Math.max(subscriber.maxQueueDepth, queueDepth);
+      store.maxQueueDepth = Math.max(store.maxQueueDepth, subscriber.maxQueueDepth);
+      subscriber.lastEvaluation = next;
+    }
+  });
+
+  private commit(store: TopicStore): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      store.version += 1;
+      this.engineVersion += 1;
+      yield* this.notifySubscribers(store);
+    });
+  }
+
+  readonly publish: ColumnLiveViewEngine<Topics>["publish"] = (topic, row) => {
+    return Effect.gen({ self: this }, function* () {
+      yield* this.ensureOpen();
+      const store = yield* this.getStore(topic);
+      const decoded = yield* decodeRow(store, row);
+      const key = yield* rowKey(store, decoded);
+      const cloned = yield* safeCloneRow(store, decoded);
+      yield* store.mutationSemaphore.withPermits(1)(
+        Effect.gen({ self: this }, function* () {
+          store.rows.set(key, cloned);
+          yield* this.commit(store);
+        }),
+      );
+    });
+  };
+
+  readonly publishMany: ColumnLiveViewEngine<Topics>["publishMany"] = (topic, rows) => {
+    return Effect.gen({ self: this }, function* () {
+      yield* this.ensureOpen();
+      const store = yield* this.getStore(topic);
+      const decodedRows = yield* Effect.forEach(rows, (row) => decodeRow(store, row));
+      const keyedRows = yield* Effect.forEach(decodedRows, (row) =>
+        Effect.gen(function* () {
+          const key = yield* rowKey(store, row);
+          const cloned = yield* safeCloneRow(store, row);
+          return { key, row: cloned };
+        }),
+      );
+      yield* store.mutationSemaphore.withPermits(1)(
+        Effect.gen({ self: this }, function* () {
+          for (const { key, row } of keyedRows) {
+            store.rows.set(key, row);
+          }
+          yield* this.commit(store);
+        }),
+      );
+    });
+  };
+
+  readonly patch: ColumnLiveViewEngine<Topics>["patch"] = (topic, key, patch) => {
+    return Effect.gen({ self: this }, function* () {
+      yield* this.ensureOpen();
+      const store = yield* this.getStore(topic);
+      yield* store.mutationSemaphore.withPermits(1)(
+        Effect.gen({ self: this }, function* () {
+          const current = store.rows.get(key);
+          if (current === undefined) {
+            return yield* InvalidRowError.make({
+              topic,
+              message: `Cannot patch missing key: ${key}`,
+            });
+          }
+          const decoded = yield* decodeRow(store, { ...current, ...patch });
+          const decodedKey = yield* rowKey(store, decoded);
+          if (decodedKey !== key) {
+            return yield* InvalidRowError.make({
+              topic,
+              message: "Patch must not change the row key.",
+            });
+          }
+          const cloned = yield* safeCloneRow(store, decoded);
+          store.rows.set(key, cloned);
+          yield* this.commit(store);
+        }),
+      );
+    });
+  };
+
+  readonly delete: ColumnLiveViewEngine<Topics>["delete"] = (topic, key) => {
+    return Effect.gen({ self: this }, function* () {
+      yield* this.ensureOpen();
+      const store = yield* this.getStore(topic);
+      yield* store.mutationSemaphore.withPermits(1)(
+        Effect.gen({ self: this }, function* () {
+          store.rows.delete(key);
+          yield* this.commit(store);
+        }),
+      );
+    });
+  };
+
+  readonly snapshot: ColumnLiveViewEngine<Topics>["snapshot"] = (topic, query) => {
+    return Effect.gen({ self: this }, function* () {
+      yield* this.ensureOpen();
+      if (isGroupedQuery(query)) {
+        return yield* UnsupportedQueryError.make({
+          topic,
+          message: "Grouped aggregate queries are not implemented in this slice.",
+        });
+      }
+      const store = yield* this.getStore(topic);
+      const rawQuery = yield* decodeRawQuery(topic, store.fieldNames, query);
+      yield* validateRuntimeQueryAgainstStore(store, rawQuery);
+      return liveQueryResult<LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>>(
+        evaluateRawQuery(store, rawQuery),
+      );
+    });
+  };
+
+  readonly subscribe: ColumnLiveViewEngine<Topics>["subscribe"] = (topic, query) => {
+    return Effect.gen({ self: this }, function* () {
+      yield* this.ensureOpen();
+      if (isGroupedQuery(query)) {
+        return yield* UnsupportedQueryError.make({
+          topic,
+          message: "Grouped aggregate queries are not implemented in this slice.",
+        });
+      }
+      const store = yield* this.getStore(topic);
+      const rawQuery = yield* decodeRawQuery(topic, store.fieldNames, query);
+      yield* validateRuntimeQueryAgainstStore(store, rawQuery);
+      const queryId = `query-${this.nextQueryId}`;
+      this.nextQueryId += 1;
+      const queue = yield* Queue.dropping<ColumnLiveViewEngineEvent<RowObject>, Cause.Done>(
+        this.subscriptionQueueCapacity,
+      );
+      const evaluation = evaluateRawQuery(store, rawQuery);
+      const subscriber: Subscriber = {
+        topic,
+        queryId,
+        query: rawQuery,
+        queue,
+        lastEvaluation: evaluation,
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+
+      store.subscribers.add(subscriber);
+      yield* Queue.offer(queue, snapshotEvent(store, queryId, evaluation));
+      subscriber.maxQueueDepth = yield* Queue.size(queue);
+      store.maxQueueDepth = Math.max(store.maxQueueDepth, subscriber.maxQueueDepth);
+
+      const close = Effect.fn("ColumnLiveViewEngine.subscription.close")(function* () {
+        if (!subscriber.closed) {
+          subscriber.closed = true;
+          store.subscribers.delete(subscriber);
+          yield* Queue.end(queue);
+        }
+      });
+
+      return {
+        events: Stream.fromQueue(queue).pipe(Stream.ensuring(close())) as Stream.Stream<
+          ColumnLiveViewEngineEvent<LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>>
+        >,
+        close,
+      };
+    });
+  };
+
+  readonly health: ColumnLiveViewEngine<Topics>["health"] = () => {
+    return Effect.gen({ self: this }, function* () {
+      const topics = {} as MutableHealthTopics<Topics>;
+      let activeSubscriptions = 0;
+      let queuedEvents = 0;
+      let maxQueueDepth = 0;
+      let backpressureEvents = 0;
+      for (const [topic, store] of this.stores) {
+        activeSubscriptions += store.subscribers.size;
+        let topicQueuedEvents = 0;
+        let topicMaxQueueDepth = store.maxQueueDepth;
+        let topicBackpressureEvents = store.backpressureEvents;
+        for (const subscriber of store.subscribers) {
+          const subscriberQueueDepth = yield* Queue.size(subscriber.queue);
+          topicQueuedEvents += subscriberQueueDepth;
+          topicMaxQueueDepth = Math.max(topicMaxQueueDepth, subscriber.maxQueueDepth);
+          topicBackpressureEvents += subscriber.backpressureEvents;
+        }
+        queuedEvents += topicQueuedEvents;
+        maxQueueDepth = Math.max(maxQueueDepth, topicMaxQueueDepth);
+        backpressureEvents += topicBackpressureEvents;
+        const typedTopic = topic as Extract<keyof Topics, string>;
+        topics[typedTopic] = {
+          status: this.closed ? "degraded" : "ready",
+          rowCount: store.rows.size,
+          version: store.version,
+          activeSubscriptions: store.subscribers.size,
+          queuedEvents: topicQueuedEvents,
+          maxQueueDepth: topicMaxQueueDepth,
+          backpressureEvents: topicBackpressureEvents,
+        };
+      }
+
+      return {
+        status: this.closed ? "stopping" : "ready",
+        version: this.engineVersion,
+        topics,
+        activeSubscriptions,
+        queuedEvents,
+        maxQueueDepth,
+        backpressureEvents,
+      };
+    });
+  };
+
+  readonly reset: ColumnLiveViewEngine<Topics>["reset"] = () => {
+    return Effect.gen({ self: this }, function* () {
+      for (const store of this.stores.values()) {
+        for (const subscriber of store.subscribers) {
+          subscriber.closed = true;
+          yield* Queue.end(subscriber.queue);
+        }
+        store.subscribers.clear();
+        store.rows.clear();
+        store.version = 0;
+        store.maxQueueDepth = 0;
+        store.backpressureEvents = 0;
+      }
+      this.engineVersion = 0;
+    });
+  };
+
+  readonly close: ColumnLiveViewEngine<Topics>["close"] = () => {
+    return Effect.gen({ self: this }, function* () {
+      if (!this.closed) {
+        this.closed = true;
+        for (const store of this.stores.values()) {
+          for (const subscriber of store.subscribers) {
+            subscriber.closed = true;
+            yield* Queue.end(subscriber.queue);
+          }
+          store.subscribers.clear();
+        }
+      }
+    });
+  };
+}
+
+export const createColumnLiveViewEngine = <const Topics extends DecodableTopicDefinitions>(
+  config: ColumnLiveViewEngineConfig<Topics>,
+): Effect.Effect<ColumnLiveViewEngine<Topics>> =>
+  Effect.sync(() => new InMemoryColumnLiveViewEngine(config));

--- a/packages/column-live-view-engine/tsconfig.build.json
+++ b/packages/column-live-view-engine/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "noEmit": false,
+    "emitDeclarationOnly": false,
+    "sourceMap": true,
+    "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo"
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
+}

--- a/packages/column-live-view-engine/tsconfig.json
+++ b/packages/column-live-view-engine/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.test-d.ts"]
+}

--- a/packages/column-live-view-engine/vite.config.ts
+++ b/packages/column-live-view-engine/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     coverage: {
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.test-d.ts"],
       reporter: ["text"],
       thresholds: {
         "100": true,

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -16,6 +16,7 @@ import {
   type ReactHookContracts,
   type SnapshotEvent,
   type StatusEvent,
+  type TopicRuntimeHealth,
   type ViewServerBackpressureError,
   type ViewServerHealth,
   type ViewServerInMemoryProviderOptions,
@@ -202,6 +203,7 @@ describe("public type surface", () => {
       topic: "orders",
       queryId: "query-1",
       version: 1,
+      keys: ["order-1"],
       rows: [{ id: "order-1" }],
     };
 
@@ -214,31 +216,34 @@ describe("public type surface", () => {
       headers: {},
     };
 
-    const health: ViewServerHealth = {
+    const topicHealth: TopicRuntimeHealth = {
+      status: "ready",
+      rowCount: 1,
+      liveRowCount: 1,
+      deletedRowCount: 0,
+      version: 1,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
+      activeViews: 0,
+      activeSubscriptions: 0,
+      queuedEvents: 0,
+      maxQueueDepth: 0,
+      memoryBytes: 0,
+      tombstoneCount: 0,
+      compactionPending: false,
+    };
+
+    const health: ViewServerHealth<typeof viewServer.topics> = {
       status: "ready",
       version: 1,
       uptimeMs: 100,
       engine: {
         topics: {
-          orders: {
-            status: "ready",
-            topic: "orders",
-            rowCount: 1,
-            liveRowCount: 1,
-            deletedRowCount: 0,
-            version: 1,
-            lastMutationAt: null,
-            mutationsPerSecond: 0,
-            rowsPerSecond: 0,
-            pendingMutationBatches: 0,
-            activeViews: 0,
-            activeSubscriptions: 0,
-            queuedEvents: 0,
-            maxQueueDepth: 0,
-            memoryBytes: 0,
-            tombstoneCount: 0,
-            compactionPending: false,
-          },
+          orders: topicHealth,
+          trades: topicHealth,
+          positions: topicHealth,
         },
       },
       transport: {
@@ -267,7 +272,7 @@ describe("public type surface", () => {
 
     expect(snapshot.rows[0]?.id).toBe("order-1");
     expect(metadata.sourceRegion).toBe("usa");
-    expect(health.engine.topics["orders"]?.rowCount).toBe(1);
+    expect(health.engine.topics["orders"].rowCount).toBe(1);
     expect(backpressure.code).toBe("BackpressureExceeded");
     expectTypeOf<LiveTransportAdapter>().toHaveProperty("subscribe");
     expectTypeOf<Effect.Success<ReturnType<LiveTransportAdapter["subscribe"]>>>().toEqualTypeOf<
@@ -1239,6 +1244,16 @@ const assertCompileTimeContracts = () => {
         },
       ],
     });
+
+    const health = react.useViewServerHealth();
+    expectTypeOf<typeof health>().toEqualTypeOf<ViewServerHealth<typeof viewServer.topics>>();
+    expectTypeOf<typeof health.engine.topics.orders>().toEqualTypeOf<TopicRuntimeHealth>();
+    expectTypeOf<typeof health.engine.topics.trades>().toEqualTypeOf<TopicRuntimeHealth>();
+    expectTypeOf<typeof health.engine.topics.positions>().toEqualTypeOf<TopicRuntimeHealth>();
+    // @ts-expect-error health topics preserve configured topic keys.
+    expectTypeOf<typeof health.engine.topics.missing>().toEqualTypeOf<TopicRuntimeHealth>();
+    // @ts-expect-error the map key is the topic identity; values do not duplicate it.
+    expectTypeOf<typeof health.engine.topics.orders.topic>().toEqualTypeOf<"orders">();
 
     expectTypeOf(react.useViewServerTestRuntime()).toHaveProperty("publish");
   };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -306,7 +306,7 @@ export type ViewServerInMemoryRuntime<Topics extends object> = {
     LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
     ViewServerRuntimeError
   >;
-  readonly health: () => Effect.Effect<ViewServerHealth, ViewServerRuntimeError>;
+  readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
   readonly reset: () => Effect.Effect<void, ViewServerRuntimeError>;
 };
 
@@ -321,7 +321,7 @@ export type ViewServerInMemoryProviderOptions<Topics extends object> = {
 
 export type ReactHookContracts<Topics extends object> = {
   readonly useLiveQuery: UseLiveQuery<Topics>;
-  readonly useViewServerHealth: () => ViewServerHealth;
+  readonly useViewServerHealth: () => ViewServerHealth<Topics>;
   readonly useViewServerTestRuntime: () => ViewServerInMemoryRuntime<Topics>;
 };
 
@@ -585,7 +585,6 @@ export type RuntimeEnvironmentConfig = {
 
 export type TopicRuntimeHealth = {
   readonly status: TopicHealthStatus;
-  readonly topic: string;
   readonly rowCount: number;
   readonly liveRowCount: number;
   readonly deletedRowCount: number;
@@ -648,12 +647,14 @@ export type TransportHealth = {
   readonly lastError: string | null;
 };
 
-export type ViewServerHealth = {
+export type ViewServerHealth<Topics extends object = Record<string, object>> = {
   readonly status: RuntimeStatus;
   readonly version: number;
   readonly uptimeMs: number;
   readonly engine: {
-    readonly topics: Record<string, TopicRuntimeHealth>;
+    readonly topics: {
+      readonly [Topic in Extract<keyof Topics, string>]: TopicRuntimeHealth;
+    };
   };
   readonly kafka?: {
     readonly regions: Record<string, KafkaRegionHealth>;
@@ -667,6 +668,7 @@ export type SnapshotEvent<Row> = {
   readonly topic: string;
   readonly queryId: string;
   readonly version: number;
+  readonly keys: ReadonlyArray<string>;
   readonly rows: ReadonlyArray<Row>;
   readonly totalRows?: number;
 };

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -70,6 +70,8 @@ If required environment variables are missing, startup should fail loudly throug
 
 Date/time rule:
 
+- Domain timestamps should be represented as `bigint` nanoseconds or numeric fields, not JavaScript `Date` values.
+- The query DSL does not need Date-specific filters, sorting, or serialization semantics; UIs can convert timestamp fields to Temporal values for display.
 - Do not call `Date.now()`, `new Date()`, or direct timer APIs in product logic.
 - Use Effect `Clock` so tests can control time.
 - Direct performance timers are allowed only in benchmark/instrumentation code where explicitly isolated.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,31 @@ importers:
         specifier: 'catalog:'
         version: 0.1.22(@vitest/coverage-v8@4.1.6)(typescript@6.0.3)(vite@8.0.14(yaml@2.9.0))(yaml@2.9.0)
 
+  packages/column-live-view-engine:
+    dependencies:
+      '@view-server/config':
+        specifier: workspace:*
+        version: link:../config
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.70
+    devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+      '@vitest/runner':
+        specifier: 'catalog:'
+        version: 4.1.6
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@latest
+        version: '@voidzero-dev/vite-plus-test@0.1.22(@vitest/coverage-v8@4.1.6)(typescript@6.0.3)(vite@8.0.14(yaml@2.9.0))(yaml@2.9.0)'
+
   packages/config:
     dependencies:
       '@bufbuild/protobuf':


### PR DESCRIPTION
## Summary
- Add @view-server/column-live-view-engine with schema-validated in-memory publish/patch/delete, raw snapshot, raw subscribe, delta generation, bounded subscription queues, local engine health, reset/close lifecycle, and typed errors.
- Keep this slice raw-query-only: grouped queries are type-rejected for now rather than accepted and failing at runtime.
- Add e2e runtime tests plus type tests, with 100% package coverage.
- Update ready ordering so clean checkouts build package exports before check/test, and run Effect LSP diagnostics for both config and engine packages in CI.

## Validation
- vp check
- pnpm exec effect-language-service diagnostics --project packages/config/tsconfig.json --format text
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text
- vp run --filter @view-server/column-live-view-engine test
- vp run -r test
- vp run -r build
- pnpm run ready

## Review Notes
- Three review agents found initial blockers; fixes were applied and a final correctness review reported no blockers.
- The engine currently returns LiveQueryResult<object> / ColumnLiveViewSubscription<object> to avoid assertion-based type holes at the runtime projection boundary. Precise selected-field result typing remains in @view-server/config and should be reintroduced in the engine via a typed query compiler slice before React/runtime depend on projected engine result types.
- Grouped aggregate execution is intentionally not included in this raw-engine PR.