### PR TITLE
Extract engine health aggregation

### DIFF
--- a/packages/column-live-view-engine/src/engine-health.ts
+++ b/packages/column-live-view-engine/src/engine-health.ts
@@ -1,0 +1,89 @@
+import type { LiveTopicSubscriber } from "./live-subscription.js";
+import { Effect } from "effect";
+
+type RowObject = object;
+
+export type ColumnLiveViewTopicHealth = {
+  readonly status: "ready" | "degraded";
+  readonly rowCount: number;
+  readonly version: number;
+  readonly activeSubscriptions: number;
+  readonly queuedEvents: number;
+  readonly maxQueueDepth: number;
+  readonly backpressureEvents: number;
+};
+
+export type ColumnLiveViewEngineHealth<Topics extends object = Record<string, object>> = {
+  readonly status: "ready" | "stopping";
+  readonly version: number;
+  readonly topics: Readonly<Record<Extract<keyof Topics, string>, ColumnLiveViewTopicHealth>>;
+  readonly activeSubscriptions: number;
+  readonly queuedEvents: number;
+  readonly maxQueueDepth: number;
+  readonly backpressureEvents: number;
+};
+
+export type HealthTopicStoreState<Row extends RowObject> = {
+  readonly rows: ReadonlyMap<string, Row>;
+  readonly subscribers: ReadonlySet<LiveTopicSubscriber<Row>>;
+  readonly version: number;
+  readonly maxQueueDepth: number;
+  readonly backpressureEvents: number;
+};
+
+export type EngineHealthRuntimeState = {
+  readonly version: () => number;
+  readonly closed: () => boolean;
+};
+
+export const collectColumnLiveViewEngineHealth = Effect.fn("ColumnLiveViewEngine.health.collect")(
+  function* <Topics extends object, Row extends RowObject>(
+    stores: ReadonlyMap<Extract<keyof Topics, string>, HealthTopicStoreState<Row>>,
+    engineState: EngineHealthRuntimeState,
+  ) {
+    const topics = {} as Record<Extract<keyof Topics, string>, ColumnLiveViewTopicHealth>;
+    let activeSubscriptions = 0;
+    let queuedEvents = 0;
+    let maxQueueDepth = 0;
+    let backpressureEvents = 0;
+    const closed = engineState.closed();
+    const engineVersion = engineState.version();
+
+    for (const [topic, store] of stores) {
+      activeSubscriptions += store.subscribers.size;
+      let topicQueuedEvents = 0;
+      let topicMaxQueueDepth = store.maxQueueDepth;
+      let topicBackpressureEvents = store.backpressureEvents;
+
+      for (const subscriber of store.subscribers) {
+        const subscriberQueueDepth = yield* subscriber.queuedEvents;
+        topicQueuedEvents += subscriberQueueDepth;
+        topicMaxQueueDepth = Math.max(topicMaxQueueDepth, subscriber.maxQueueDepth);
+        topicBackpressureEvents += subscriber.backpressureEvents;
+      }
+
+      queuedEvents += topicQueuedEvents;
+      maxQueueDepth = Math.max(maxQueueDepth, topicMaxQueueDepth);
+      backpressureEvents += topicBackpressureEvents;
+      topics[topic] = {
+        status: closed ? "degraded" : "ready",
+        rowCount: store.rows.size,
+        version: store.version,
+        activeSubscriptions: store.subscribers.size,
+        queuedEvents: topicQueuedEvents,
+        maxQueueDepth: topicMaxQueueDepth,
+        backpressureEvents: topicBackpressureEvents,
+      };
+    }
+
+    return {
+      status: closed ? "stopping" : "ready",
+      version: engineVersion,
+      topics,
+      activeSubscriptions,
+      queuedEvents,
+      maxQueueDepth,
+      backpressureEvents,
+    } satisfies ColumnLiveViewEngineHealth<Topics>;
+  },
+);

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -1622,6 +1622,28 @@ describe("ColumnLiveViewEngine validation and health", () => {
     }),
   );
 
+  it.effect("reads health state when the returned Effect is executed", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const delayedMutatedHealth = engine.health();
+
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+
+      const mutated = yield* delayedMutatedHealth;
+      expect(mutated.status).toBe("ready");
+      expect(mutated.version).toBe(1);
+      expect(mutated.topics["orders"].rowCount).toBe(1);
+      expect(mutated.topics["orders"].version).toBe(1);
+
+      const delayedClosedHealth = engine.health();
+      yield* engine.close();
+
+      const closed = yield* delayedClosedHealth;
+      expect(closed.status).toBe("stopping");
+      expect(closed.topics["orders"].status).toBe("degraded");
+    }),
+  );
+
   it.effect("falls back to the default queue capacity when configured capacity is invalid", () =>
     Effect.gen(function* () {
       const engine = yield* createColumnLiveViewEngine({

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -13,6 +13,11 @@ import type {
   TopicRow,
 } from "@view-server/config";
 import { Effect, Schema, Semaphore, Stream } from "effect";
+import {
+  collectColumnLiveViewEngineHealth,
+  type ColumnLiveViewEngineHealth,
+  type HealthTopicStoreState,
+} from "./engine-health.js";
 import { makeLiveSubscription, type LiveTopicSubscriber } from "./live-subscription.js";
 import {
   evaluateCompiledRawQuery,
@@ -25,6 +30,7 @@ import {
 import { cloneRow, fieldValue } from "./row-values.js";
 
 export { InvalidQueryError } from "./raw-query-compiler.js";
+export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health.js";
 
 export type DecodableTopicDefinitions = Record<
   string,
@@ -91,34 +97,6 @@ export type ColumnLiveViewEngineEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row
 export type ColumnLiveViewSubscription<Row> = {
   readonly events: Stream.Stream<ColumnLiveViewEngineEvent<Row>>;
   readonly close: () => Effect.Effect<void, never>;
-};
-
-export type ColumnLiveViewTopicHealth = {
-  readonly status: "ready" | "degraded";
-  readonly rowCount: number;
-  readonly version: number;
-  readonly activeSubscriptions: number;
-  readonly queuedEvents: number;
-  readonly maxQueueDepth: number;
-  readonly backpressureEvents: number;
-};
-
-export type ColumnLiveViewEngineHealth<
-  Topics extends DecodableTopicDefinitions = DecodableTopicDefinitions,
-> = {
-  readonly status: "ready" | "stopping";
-  readonly version: number;
-  readonly topics: {
-    readonly [Topic in Extract<keyof Topics, string>]: ColumnLiveViewTopicHealth;
-  };
-  readonly activeSubscriptions: number;
-  readonly queuedEvents: number;
-  readonly maxQueueDepth: number;
-  readonly backpressureEvents: number;
-};
-
-type MutableHealthTopics<Topics extends DecodableTopicDefinitions> = {
-  -readonly [Topic in Extract<keyof Topics, string>]: ColumnLiveViewTopicHealth;
 };
 
 type AnyTopicRow<Topics extends DecodableTopicDefinitions> = TopicRow<
@@ -281,7 +259,7 @@ export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
 type RowObject = object;
 const defaultSubscriptionQueueCapacity = 1_024;
 
-class TopicStore<Row extends RowObject> {
+class TopicStore<Row extends RowObject> implements HealthTopicStoreState<Row> {
   readonly rows = new Map<string, Row>();
   readonly subscribers = new Set<LiveTopicSubscriber<Row>>();
   readonly mutationSemaphore = Semaphore.makeUnsafe(1);
@@ -355,7 +333,10 @@ const rowKey = Effect.fn("ColumnLiveViewEngine.rowKey")(function* <Row extends R
 class InMemoryColumnLiveViewEngine<
   Topics extends DecodableTopicDefinitions,
 > implements ColumnLiveViewEngine<Topics> {
-  private readonly stores = new Map<string, TopicStore<AnyTopicRow<Topics>>>();
+  private readonly stores = new Map<
+    Extract<keyof Topics, string>,
+    TopicStore<AnyTopicRow<Topics>>
+  >();
   private readonly subscriptionQueueCapacity: number;
   private engineVersion = 0;
   private nextQueryId = 0;
@@ -367,7 +348,8 @@ class InMemoryColumnLiveViewEngine<
       Number.isSafeInteger(configuredCapacity) && configuredCapacity > 0
         ? configuredCapacity
         : defaultSubscriptionQueueCapacity;
-    for (const [topic, definition] of Object.entries(config.topics)) {
+    for (const topic in config.topics) {
+      const definition = config.topics[topic];
       this.stores.set(
         topic,
         new TopicStore<AnyTopicRow<Topics>>(
@@ -556,47 +538,9 @@ class InMemoryColumnLiveViewEngine<
   };
 
   readonly health: ColumnLiveViewEngine<Topics>["health"] = () => {
-    return Effect.gen({ self: this }, function* () {
-      const topics = {} as MutableHealthTopics<Topics>;
-      let activeSubscriptions = 0;
-      let queuedEvents = 0;
-      let maxQueueDepth = 0;
-      let backpressureEvents = 0;
-      for (const [topic, store] of this.stores) {
-        activeSubscriptions += store.subscribers.size;
-        let topicQueuedEvents = 0;
-        let topicMaxQueueDepth = store.maxQueueDepth;
-        let topicBackpressureEvents = store.backpressureEvents;
-        for (const subscriber of store.subscribers) {
-          const subscriberQueueDepth = yield* subscriber.queuedEvents;
-          topicQueuedEvents += subscriberQueueDepth;
-          topicMaxQueueDepth = Math.max(topicMaxQueueDepth, subscriber.maxQueueDepth);
-          topicBackpressureEvents += subscriber.backpressureEvents;
-        }
-        queuedEvents += topicQueuedEvents;
-        maxQueueDepth = Math.max(maxQueueDepth, topicMaxQueueDepth);
-        backpressureEvents += topicBackpressureEvents;
-        const typedTopic = topic as Extract<keyof Topics, string>;
-        topics[typedTopic] = {
-          status: this.closed ? "degraded" : "ready",
-          rowCount: store.rows.size,
-          version: store.version,
-          activeSubscriptions: store.subscribers.size,
-          queuedEvents: topicQueuedEvents,
-          maxQueueDepth: topicMaxQueueDepth,
-          backpressureEvents: topicBackpressureEvents,
-        };
-      }
-
-      return {
-        status: this.closed ? "stopping" : "ready",
-        version: this.engineVersion,
-        topics,
-        activeSubscriptions,
-        queuedEvents,
-        maxQueueDepth,
-        backpressureEvents,
-      };
+    return collectColumnLiveViewEngineHealth<Topics, AnyTopicRow<Topics>>(this.stores, {
+      version: () => this.engineVersion,
+      closed: () => this.closed,
     });
   };
 


### PR DESCRIPTION
## Summary
- extract column live view engine health types and aggregation into engine-health.ts
- keep index.ts focused on engine lifecycle, mutation, subscription, and public API orchestration
- preserve typed health topics and queue/backpressure counters
- add regression coverage for health Effect laziness after publish/close

## Validation
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error
- vp run --filter @view-server/column-live-view-engine test
- pnpm run ready
- policy scan: no as any/as unknown/as never, direct vitest imports, console.*, node assert/test, or Date usage in engine/config

## Review
- runtime reviewer found and verified fix for delayed health Effect state capture
- Effect/testing reviewer accepted the remaining localized generic accumulator assertion as unavoidable without any/unknown/never
- architecture reviewer found no blockers; noted this is an in-memory health module, not a future runtime adapter seam
- final validation green with 100% coverage including engine-health.ts