### PR TITLE
Extract topic store write path

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -930,6 +930,32 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("serializes mixed concurrent writes before notifying subscribers", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("a", "open", 10, 1), order("b", "open", 20, 2)]);
+      const subscription = yield* engine.subscribe("orders", {});
+      const take = yield* makeEventReader(subscription);
+      yield* take(1);
+
+      yield* Effect.all(
+        [
+          engine.patch("orders", "a", { price: 30 }),
+          engine.delete("orders", "b"),
+          engine.publish("orders", order("c", "closed", 40, 3)),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      yield* take(3);
+      const fresh = yield* engine.snapshot("orders", {});
+      expect(fresh.version).toBe(4);
+      expect(rowIds(fresh.rows)).toEqual(["a", "c"]);
+      expect(fresh.rows).toEqual([order("a", "open", 30, 1), order("c", "closed", 40, 3)]);
+      yield* subscription.close();
+    }),
+  );
+
   it.effect("idempotent subscription close removes active subscribers from health", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -12,22 +12,28 @@ import type {
   StringFieldKey,
   TopicRow,
 } from "@view-server/config";
-import { Effect, Schema, Semaphore, Stream } from "effect";
+import { Effect, Schema, Stream } from "effect";
 import {
   collectColumnLiveViewEngineHealth,
   type ColumnLiveViewEngineHealth,
-  type HealthTopicStoreState,
 } from "./engine-health.js";
-import { makeLiveSubscription, type LiveTopicSubscriber } from "./live-subscription.js";
+import { makeLiveSubscription } from "./live-subscription.js";
 import {
   evaluateCompiledRawQuery,
   InvalidQueryError,
   prepareRawQuery,
-  rawQueryCompilerMetadata,
   type QueryEvaluation,
-  type RawQueryCompilerMetadata,
 } from "./raw-query-compiler.js";
-import { cloneRow, fieldValue } from "./row-values.js";
+import {
+  closeTopicStoreSubscriptions,
+  deleteTopicStoreRow,
+  notifyTopicStoreSubscribers,
+  patchTopicStoreRow,
+  publishTopicStoreRow,
+  publishTopicStoreRows,
+  resetTopicStore,
+  TopicStore,
+} from "./topic-store.js";
 
 export { InvalidQueryError } from "./raw-query-compiler.js";
 export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health.js";
@@ -259,40 +265,11 @@ export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
 type RowObject = object;
 const defaultSubscriptionQueueCapacity = 1_024;
 
-class TopicStore<Row extends RowObject> implements HealthTopicStoreState<Row> {
-  readonly rows = new Map<string, Row>();
-  readonly subscribers = new Set<LiveTopicSubscriber<Row>>();
-  readonly mutationSemaphore = Semaphore.makeUnsafe(1);
-  version = 0;
-  maxQueueDepth = 0;
-  backpressureEvents = 0;
-
-  constructor(
-    readonly topic: string,
-    readonly schema: Schema.Decoder<object>,
-    readonly keyField: string,
-    readonly rawQueryMetadata: RawQueryCompilerMetadata,
-  ) {}
-}
-
 const isGroupedQuery = (query: unknown): boolean =>
   typeof query === "object" &&
   query !== null &&
   !Array.isArray(query) &&
   ("groupBy" in query || "aggregates" in query);
-
-const safeCloneRow = Effect.fn("ColumnLiveViewEngine.safeCloneRow")(function* <
-  Row extends RowObject,
->(store: TopicStore<Row>, row: Row) {
-  return yield* Effect.try({
-    try: () => cloneRow(row),
-    catch: (cause) =>
-      InvalidRowError.make({
-        topic: store.topic,
-        message: String(cause),
-      }),
-  });
-});
 
 const liveQueryResult = <Row extends RowObject>(
   evaluation: QueryEvaluation<Row>,
@@ -302,33 +279,11 @@ const liveQueryResult = <Row extends RowObject>(
   version: evaluation.version,
 });
 
-const decodeRow = Effect.fn("ColumnLiveViewEngine.decodeRow")(function* <Row extends RowObject>(
-  store: TopicStore<Row>,
-  row: RowObject,
-) {
-  return yield* Effect.try({
-    try: () => Schema.decodeUnknownSync(store.schema)(row) as Row,
-    catch: (cause) =>
-      InvalidRowError.make({
-        topic: store.topic,
-        message: String(cause),
-      }),
+const invalidRow = (topic: string, message: string) =>
+  new InvalidRowError({
+    topic,
+    message,
   });
-});
-
-const rowKey = Effect.fn("ColumnLiveViewEngine.rowKey")(function* <Row extends RowObject>(
-  store: TopicStore<Row>,
-  row: Row,
-) {
-  const key = fieldValue(row, store.keyField);
-  if (typeof key !== "string") {
-    return yield* InvalidRowError.make({
-      topic: store.topic,
-      message: `Key field ${store.keyField} must decode to a string.`,
-    });
-  }
-  return key;
-});
 
 class InMemoryColumnLiveViewEngine<
   Topics extends DecodableTopicDefinitions,
@@ -352,12 +307,7 @@ class InMemoryColumnLiveViewEngine<
       const definition = config.topics[topic];
       this.stores.set(
         topic,
-        new TopicStore<AnyTopicRow<Topics>>(
-          topic,
-          definition.schema,
-          definition.key,
-          rawQueryCompilerMetadata(definition.schema),
-        ),
+        new TopicStore<AnyTopicRow<Topics>>(topic, definition.schema, definition.key),
       );
     }
   }
@@ -387,19 +337,11 @@ class InMemoryColumnLiveViewEngine<
     });
   }
 
-  private notifySubscribers<Row extends RowObject>(store: TopicStore<Row>): Effect.Effect<void> {
-    return Effect.gen(function* () {
-      for (const subscriber of store.subscribers) {
-        yield* subscriber.notify(store);
-      }
-    });
-  }
-
   private commit<Row extends RowObject>(store: TopicStore<Row>): Effect.Effect<void> {
     return Effect.gen({ self: this }, function* () {
       store.version += 1;
       this.engineVersion += 1;
-      yield* this.notifySubscribers(store);
+      yield* notifyTopicStoreSubscribers(store);
     });
   }
 
@@ -407,14 +349,8 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      const decoded = yield* decodeRow(store, row);
-      const key = yield* rowKey(store, decoded);
-      const cloned = yield* safeCloneRow(store, decoded);
-      yield* store.mutationSemaphore.withPermits(1)(
-        Effect.gen({ self: this }, function* () {
-          store.rows.set(key, cloned);
-          yield* this.commit(store);
-        }),
+      yield* publishTopicStoreRow(store, row, invalidRow, (committedStore) =>
+        this.commit(committedStore),
       );
     });
   };
@@ -423,21 +359,8 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      const decodedRows = yield* Effect.forEach(rows, (row) => decodeRow(store, row));
-      const keyedRows = yield* Effect.forEach(decodedRows, (row) =>
-        Effect.gen(function* () {
-          const key = yield* rowKey(store, row);
-          const cloned = yield* safeCloneRow(store, row);
-          return { key, row: cloned };
-        }),
-      );
-      yield* store.mutationSemaphore.withPermits(1)(
-        Effect.gen({ self: this }, function* () {
-          for (const { key, row } of keyedRows) {
-            store.rows.set(key, row);
-          }
-          yield* this.commit(store);
-        }),
+      yield* publishTopicStoreRows(store, rows, invalidRow, (committedStore) =>
+        this.commit(committedStore),
       );
     });
   };
@@ -446,27 +369,8 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      yield* store.mutationSemaphore.withPermits(1)(
-        Effect.gen({ self: this }, function* () {
-          const current = store.rows.get(key);
-          if (current === undefined) {
-            return yield* InvalidRowError.make({
-              topic,
-              message: `Cannot patch missing key: ${key}`,
-            });
-          }
-          const decoded = yield* decodeRow(store, { ...current, ...patch });
-          const decodedKey = yield* rowKey(store, decoded);
-          if (decodedKey !== key) {
-            return yield* InvalidRowError.make({
-              topic,
-              message: "Patch must not change the row key.",
-            });
-          }
-          const cloned = yield* safeCloneRow(store, decoded);
-          store.rows.set(key, cloned);
-          yield* this.commit(store);
-        }),
+      yield* patchTopicStoreRow(store, key, patch, invalidRow, (committedStore) =>
+        this.commit(committedStore),
       );
     });
   };
@@ -475,12 +379,7 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      yield* store.mutationSemaphore.withPermits(1)(
-        Effect.gen({ self: this }, function* () {
-          store.rows.delete(key);
-          yield* this.commit(store);
-        }),
-      );
+      yield* deleteTopicStoreRow(store, key, (committedStore) => this.commit(committedStore));
     });
   };
 
@@ -547,15 +446,7 @@ class InMemoryColumnLiveViewEngine<
   readonly reset: ColumnLiveViewEngine<Topics>["reset"] = () => {
     return Effect.gen({ self: this }, function* () {
       for (const store of this.stores.values()) {
-        for (const subscriber of store.subscribers) {
-          subscriber.closed = true;
-          yield* subscriber.end;
-        }
-        store.subscribers.clear();
-        store.rows.clear();
-        store.version = 0;
-        store.maxQueueDepth = 0;
-        store.backpressureEvents = 0;
+        yield* resetTopicStore(store);
       }
       this.engineVersion = 0;
     });
@@ -566,11 +457,7 @@ class InMemoryColumnLiveViewEngine<
       if (!this.closed) {
         this.closed = true;
         for (const store of this.stores.values()) {
-          for (const subscriber of store.subscribers) {
-            subscriber.closed = true;
-            yield* subscriber.end;
-          }
-          store.subscribers.clear();
+          yield* closeTopicStoreSubscriptions(store);
         }
       }
     });

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,0 +1,184 @@
+import { Effect, Schema, Semaphore } from "effect";
+import type { HealthTopicStoreState } from "./engine-health.js";
+import type { LiveTopicStoreState, LiveTopicSubscriber } from "./live-subscription.js";
+import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler.js";
+import { cloneRow, fieldValue } from "./row-values.js";
+
+type RowObject = object;
+
+export type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
+
+export type CommitTopicStore = <Row extends RowObject>(
+  store: TopicStore<Row>,
+) => Effect.Effect<void>;
+
+export class TopicStore<Row extends RowObject>
+  implements HealthTopicStoreState<Row>, LiveTopicStoreState<Row>
+{
+  readonly rows = new Map<string, Row>();
+  readonly subscribers = new Set<LiveTopicSubscriber<Row>>();
+  readonly mutationSemaphore = Semaphore.makeUnsafe(1);
+  readonly rawQueryMetadata: RawQueryCompilerMetadata;
+  version = 0;
+  maxQueueDepth = 0;
+  backpressureEvents = 0;
+
+  constructor(
+    readonly topic: string,
+    readonly schema: Schema.Decoder<object>,
+    readonly keyField: string,
+  ) {
+    this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
+  }
+}
+
+export const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.notify")(
+  function* <Row extends RowObject>(store: TopicStore<Row>) {
+    for (const subscriber of store.subscribers) {
+      yield* subscriber.notify(store);
+    }
+  },
+);
+
+export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* <
+  Row extends RowObject,
+>(store: TopicStore<Row>) {
+  for (const subscriber of store.subscribers) {
+    subscriber.closed = true;
+    yield* subscriber.end;
+  }
+  store.subscribers.clear();
+  store.rows.clear();
+  store.version = 0;
+  store.maxQueueDepth = 0;
+  store.backpressureEvents = 0;
+});
+
+export const closeTopicStoreSubscriptions = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.closeSubscriptions",
+)(function* <Row extends RowObject>(store: TopicStore<Row>) {
+  for (const subscriber of store.subscribers) {
+    subscriber.closed = true;
+    yield* subscriber.end;
+  }
+  store.subscribers.clear();
+});
+
+const safeCloneRow = Effect.fn("ColumnLiveViewEngine.topicStore.safeCloneRow")(function* <
+  Row extends RowObject,
+  Error,
+>(store: TopicStore<Row>, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
+  return yield* Effect.try({
+    try: () => cloneRow(row),
+    catch: (cause) => invalidRow(store.topic, String(cause)),
+  });
+});
+
+const decodeRow = Effect.fn("ColumnLiveViewEngine.topicStore.decodeRow")(function* <
+  Row extends RowObject,
+  Error,
+>(store: TopicStore<Row>, row: RowObject, invalidRow: InvalidRowErrorFactory<Error>) {
+  return yield* Effect.try({
+    try: () => Schema.decodeUnknownSync(store.schema)(row) as Row,
+    catch: (cause) => invalidRow(store.topic, String(cause)),
+  });
+});
+
+const rowKey = Effect.fn("ColumnLiveViewEngine.topicStore.rowKey")(function* <
+  Row extends RowObject,
+  Error,
+>(store: TopicStore<Row>, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
+  const key = fieldValue(row, store.keyField);
+  if (typeof key !== "string") {
+    return yield* Effect.fail(
+      invalidRow(store.topic, `Key field ${store.keyField} must decode to a string.`),
+    );
+  }
+  return key;
+});
+
+export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.publish")(function* <
+  Row extends RowObject,
+  Error,
+>(
+  store: TopicStore<Row>,
+  row: Row,
+  invalidRow: InvalidRowErrorFactory<Error>,
+  commit: CommitTopicStore,
+) {
+  const decoded = yield* decodeRow(store, row, invalidRow);
+  const key = yield* rowKey(store, decoded, invalidRow);
+  const cloned = yield* safeCloneRow(store, decoded, invalidRow);
+  yield* store.mutationSemaphore.withPermits(1)(
+    Effect.gen(function* () {
+      store.rows.set(key, cloned);
+      yield* commit(store);
+    }),
+  );
+});
+
+export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.publishMany")(
+  function* <Row extends RowObject, Error>(
+    store: TopicStore<Row>,
+    rows: ReadonlyArray<Row>,
+    invalidRow: InvalidRowErrorFactory<Error>,
+    commit: CommitTopicStore,
+  ) {
+    const decodedRows = yield* Effect.forEach(rows, (row) => decodeRow(store, row, invalidRow));
+    const keyedRows = yield* Effect.forEach(decodedRows, (row) =>
+      Effect.gen(function* () {
+        const key = yield* rowKey(store, row, invalidRow);
+        const cloned = yield* safeCloneRow(store, row, invalidRow);
+        return { key, row: cloned };
+      }),
+    );
+    yield* store.mutationSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        for (const { key, row } of keyedRows) {
+          store.rows.set(key, row);
+        }
+        yield* commit(store);
+      }),
+    );
+  },
+);
+
+export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.patch")(function* <
+  Row extends RowObject,
+  Patch extends Partial<Row>,
+  Error,
+>(
+  store: TopicStore<Row>,
+  key: string,
+  patch: Patch,
+  invalidRow: InvalidRowErrorFactory<Error>,
+  commit: CommitTopicStore,
+) {
+  yield* store.mutationSemaphore.withPermits(1)(
+    Effect.gen(function* () {
+      const current = store.rows.get(key);
+      if (current === undefined) {
+        return yield* Effect.fail(invalidRow(store.topic, `Cannot patch missing key: ${key}`));
+      }
+      const decoded = yield* decodeRow(store, { ...current, ...patch }, invalidRow);
+      const decodedKey = yield* rowKey(store, decoded, invalidRow);
+      if (decodedKey !== key) {
+        return yield* Effect.fail(invalidRow(store.topic, "Patch must not change the row key."));
+      }
+      const cloned = yield* safeCloneRow(store, decoded, invalidRow);
+      store.rows.set(key, cloned);
+      yield* commit(store);
+    }),
+  );
+});
+
+export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.delete")(function* <
+  Row extends RowObject,
+>(store: TopicStore<Row>, key: string, commit: CommitTopicStore) {
+  yield* store.mutationSemaphore.withPermits(1)(
+    Effect.gen(function* () {
+      store.rows.delete(key);
+      yield* commit(store);
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- extract concrete in-memory TopicStore and write-path mechanics into topic-store.ts
- move row decode/key/clone, publish/publishMany/patch/delete, subscriber notification, reset, and close-subscription helpers out of index.ts
- keep index.ts focused on public API wiring, store lookup, commit version bump, query compilation, health, and lifecycle orchestration
- add mixed concurrent write regression for patch/delete/publish serialization and subscriber notification

## Validation
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error
- vp run --filter @view-server/column-live-view-engine test
- pnpm run ready
- policy scan: no as any/as unknown/as never, direct vitest imports, console.*, node assert/test, or Date usage in engine/config

## Review
- runtime reviewer found no blockers; write semantics, reset/close, cloning, and version/notification behavior preserved
- Effect/testing reviewer found no blockers; error channels and TaggedErrorClass construction are clean
- architecture reviewer found no blockers; topic-store.ts has real Depth/Locality as a concrete in-memory module, not a future provider seam
- final validation green with 100% coverage including topic-store.ts