### PR TITLE
Ignore inherited topic definitions

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -1644,6 +1644,27 @@ describe("ColumnLiveViewEngine validation and health", () => {
     }),
   );
 
+  it.effect("creates stores only for own topic definitions", () =>
+    Effect.gen(function* () {
+      const topicsWithInheritedDefinition: Record<string, Topics["orders"]> = Object.create({
+        inherited: viewServer.topics.orders,
+      });
+      topicsWithInheritedDefinition["orders"] = viewServer.topics.orders;
+
+      const engine = yield* createColumnLiveViewEngine({
+        topics: topicsWithInheritedDefinition,
+      });
+      const health = yield* engine.health();
+      expect(Object.keys(health.topics)).toEqual(["orders"]);
+
+      const inherited = yield* Effect.flip(engine.snapshot("inherited", {}));
+      expect(inherited).toMatchObject({
+        _tag: "InvalidTopicError",
+        topic: "inherited",
+      });
+    }),
+  );
+
   it.effect("falls back to the default queue capacity when configured capacity is invalid", () =>
     Effect.gen(function* () {
       const engine = yield* createColumnLiveViewEngine({

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -349,6 +349,9 @@ class InMemoryColumnLiveViewEngine<
         ? configuredCapacity
         : defaultSubscriptionQueueCapacity;
     for (const topic in config.topics) {
+      if (!Object.hasOwn(config.topics, topic)) {
+        continue;
+      }
       const definition = config.topics[topic];
       this.stores.set(
         topic,


### PR DESCRIPTION
## Summary
- guard topic config iteration with Object.hasOwn so inherited enumerable properties are ignored
- add regression proving inherited topic definitions do not create stores and remain invalid topics

## Context
Fixes the post-merge review comment on PR #6: for...in over config.topics could register inherited enumerable topic definitions.

## Validation
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error
- vp run --filter @view-server/column-live-view-engine test
- pnpm run ready
- policy scan: no as any/as unknown/as never, direct vitest imports, console.*, node assert/test, or Date usage in engine/config