### PR TITLE
Extract engine contract types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "ready": "vp run -r build && vp check && vp run -r test",
+    "check:package-exports": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/check-package-exports.ts && node --experimental-strip-types scripts/check-package-exports.ts",
+    "ready": "vp run -r build && pnpm run check:package-exports && vp check && vp run -r test",
     "prepare": "vp config && effect-language-service patch"
   },
   "devDependencies": {
     "@effect/language-service": "catalog:",
+    "@view-server/column-live-view-engine": "workspace:*",
+    "@view-server/config": "workspace:*",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
   },

--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "vp pack",
     "test": "vp test run --coverage --typecheck"
   },
   "dependencies": {

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -13,8 +13,8 @@ import type {
   TopicRow,
 } from "@view-server/config";
 import type { Effect, Schema, Stream } from "effect";
-import type { ColumnLiveViewEngineHealth } from "./engine-health.ts";
-import type { ColumnLiveViewEngineError } from "./engine-errors.ts";
+import type { ColumnLiveViewEngineHealth } from "./engine-health";
+import type { ColumnLiveViewEngineError } from "./engine-errors";
 
 export type DecodableTopicDefinitions = Record<
   string,

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- public type contract only */
 import type {
   DeltaEvent,
   FieldKey,

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -13,8 +13,8 @@ import type {
   TopicRow,
 } from "@view-server/config";
 import type { Effect, Schema, Stream } from "effect";
-import type { ColumnLiveViewEngineHealth } from "./engine-health.js";
-import type { ColumnLiveViewEngineError } from "./engine-errors.js";
+import type { ColumnLiveViewEngineHealth } from "./engine-health.ts";
+import type { ColumnLiveViewEngineError } from "./engine-errors.ts";
 
 export type DecodableTopicDefinitions = Record<
   string,

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -1,0 +1,207 @@
+/* v8 ignore file -- public type contract only */
+import type {
+  DeltaEvent,
+  FieldKey,
+  LiveQueryRow,
+  LiveQueryResult,
+  OrderBy,
+  RawQuery,
+  RowFromSchema,
+  RowSchema,
+  SnapshotEvent,
+  StatusEvent,
+  StringFieldKey,
+  TopicRow,
+} from "@view-server/config";
+import type { Effect, Schema, Stream } from "effect";
+import type { ColumnLiveViewEngineHealth } from "./engine-health.js";
+import type { ColumnLiveViewEngineError } from "./engine-errors.js";
+
+export type DecodableTopicDefinitions = Record<
+  string,
+  {
+    readonly schema: RowSchema & Schema.Decoder<object>;
+    readonly key: string;
+  }
+>;
+
+type ValidateEngineTopics<Topics extends DecodableTopicDefinitions> = {
+  readonly [Topic in keyof Topics]: Topics[Topic] extends {
+    readonly schema: infer S extends RowSchema & Schema.Decoder<object>;
+    readonly key: infer Key extends string;
+  }
+    ? {
+        readonly schema: S;
+        readonly key: Key & StringFieldKey<RowFromSchema<S>>;
+      }
+    : never;
+};
+
+export type ColumnLiveViewEngineConfig<Topics extends DecodableTopicDefinitions> = {
+  readonly topics: Topics & ValidateEngineTopics<Topics>;
+  readonly subscriptionQueueCapacity?: number;
+};
+
+export type ColumnLiveViewEngineEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
+
+export type ColumnLiveViewSubscription<Row> = {
+  readonly events: Stream.Stream<ColumnLiveViewEngineEvent<Row>>;
+  readonly close: () => Effect.Effect<void, never>;
+};
+
+export type AnyTopicRow<Topics extends DecodableTopicDefinitions> = TopicRow<
+  Topics,
+  Extract<keyof Topics, string>
+>;
+
+type RejectExtraKeys<Candidate, Shape> = {
+  readonly [Key in Exclude<keyof Candidate, keyof Shape>]: never;
+};
+
+type IsUnion<Value, Candidate = Value> = Value extends unknown
+  ? [Candidate] extends [Value]
+    ? false
+    : true
+  : false;
+
+type TupleHasUnionElement<Tuple extends ReadonlyArray<unknown>> = Tuple extends readonly [
+  infer Head,
+  ...infer Tail,
+]
+  ? IsUnion<Head> extends true
+    ? true
+    : TupleHasUnionElement<Tail>
+  : false;
+
+type ExactRawQuery<Row, Query> = Query &
+  RejectExtraKeys<Query, RawQuery<Row>> & {
+    readonly groupBy?: never;
+    readonly aggregates?: never;
+  } & ExactWhere<Row, Query> &
+  ExactOrderBy<Row, Query> &
+  RejectDynamicRawFields<Row, Query>;
+
+type RejectDynamicRawFields<Row, Query> = "fields" extends keyof Query
+  ? Query extends { readonly fields?: infer Fields }
+    ? NonNullable<Fields> extends ReadonlyArray<unknown>
+      ? undefined extends Query["fields"]
+        ? {
+            readonly fields: never;
+          }
+        : IsUnion<NonNullable<Fields>> extends true
+          ? {
+              readonly fields: never;
+            }
+          : number extends NonNullable<Fields>["length"]
+            ? {
+                readonly fields: never;
+              }
+            : TupleHasUnionElement<NonNullable<Fields>> extends true
+              ? {
+                  readonly fields: never;
+                }
+              : NonNullable<Fields>[number] extends FieldKey<Row>
+                ? unknown
+                : {
+                    readonly fields: never;
+                  }
+      : unknown
+    : unknown
+  : unknown;
+
+type ExactWhere<Row, Query> = Query extends {
+  readonly where: infer Where;
+}
+  ? {
+      readonly where: Where &
+        RejectExtraKeys<Where, { readonly [Field in FieldKey<Row>]?: unknown }> & {
+          readonly [Field in Extract<keyof Where, FieldKey<Row>>]: ExactFilter<
+            Row[Field],
+            Where[Field]
+          >;
+        };
+    }
+  : unknown;
+
+type ExactFilter<Value, Filter> = Value extends object
+  ? unknown
+  : ExactOperatorFilter<Value, Filter>;
+
+type ExactOperatorFilter<Value, Filter> = Filter extends object
+  ? Filter extends ReadonlyArray<unknown>
+    ? unknown
+    : Filter & RejectExtraKeys<Filter, FieldFilterShape<Value>>
+  : unknown;
+
+type FieldFilterShape<Value> = Value extends string
+  ? {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+      readonly startsWith?: string;
+    }
+  : {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+      readonly gt?: Value;
+      readonly gte?: Value;
+      readonly lt?: Value;
+      readonly lte?: Value;
+    };
+
+type ExactOrderBy<Row, Query> = Query extends {
+  readonly orderBy: ReadonlyArray<infer Entry>;
+}
+  ? {
+      readonly orderBy: ReadonlyArray<Entry & RejectExtraKeys<Entry, OrderBy<Row>>>;
+    }
+  : unknown;
+
+type ExactPatch<Row, Patch> = Patch & RejectExtraKeys<Patch, Partial<Row>>;
+
+export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
+  readonly publish: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    row: TopicRow<Topics, Topic>,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly publishMany: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    rows: ReadonlyArray<TopicRow<Topics, Topic>>,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly patch: <
+    Topic extends Extract<keyof Topics, string>,
+    const Patch extends Partial<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    key: string,
+    patch: ExactPatch<TopicRow<Topics, Topic>, Patch>,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly delete: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    key: string,
+  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
+  readonly snapshot: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: ExactRawQuery<TopicRow<Topics, Topic>, Query>,
+  ) => Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  readonly subscribe: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: ExactRawQuery<TopicRow<Topics, Topic>, Query>,
+  ) => Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  readonly health: () => Effect.Effect<ColumnLiveViewEngineHealth<Topics>, never>;
+  readonly reset: () => Effect.Effect<void, never>;
+  readonly close: () => Effect.Effect<void, never>;
+};

--- a/packages/column-live-view-engine/src/engine-errors.ts
+++ b/packages/column-live-view-engine/src/engine-errors.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import type { InvalidQueryError } from "./raw-query-compiler.ts";
+import type { InvalidQueryError } from "./raw-query-compiler";
 
 export class InvalidTopicError extends Schema.TaggedErrorClass<InvalidTopicError>()(
   "InvalidTopicError",

--- a/packages/column-live-view-engine/src/engine-errors.ts
+++ b/packages/column-live-view-engine/src/engine-errors.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import type { InvalidQueryError } from "./raw-query-compiler.js";
+import type { InvalidQueryError } from "./raw-query-compiler.ts";
 
 export class InvalidTopicError extends Schema.TaggedErrorClass<InvalidTopicError>()(
   "InvalidTopicError",

--- a/packages/column-live-view-engine/src/engine-errors.ts
+++ b/packages/column-live-view-engine/src/engine-errors.ts
@@ -1,0 +1,37 @@
+import { Schema } from "effect";
+import type { InvalidQueryError } from "./raw-query-compiler.js";
+
+export class InvalidTopicError extends Schema.TaggedErrorClass<InvalidTopicError>()(
+  "InvalidTopicError",
+  {
+    topic: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class InvalidRowError extends Schema.TaggedErrorClass<InvalidRowError>()("InvalidRowError", {
+  topic: Schema.String,
+  message: Schema.String,
+}) {}
+
+export class UnsupportedQueryError extends Schema.TaggedErrorClass<UnsupportedQueryError>()(
+  "UnsupportedQueryError",
+  {
+    topic: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class EngineClosedError extends Schema.TaggedErrorClass<EngineClosedError>()(
+  "EngineClosedError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export type ColumnLiveViewEngineError =
+  | InvalidTopicError
+  | InvalidRowError
+  | UnsupportedQueryError
+  | InvalidQueryError
+  | EngineClosedError;

--- a/packages/column-live-view-engine/src/engine-health.ts
+++ b/packages/column-live-view-engine/src/engine-health.ts
@@ -1,4 +1,4 @@
-import type { LiveTopicSubscriber } from "./live-subscription.ts";
+import type { LiveTopicSubscriber } from "./live-subscription";
 import { Effect } from "effect";
 
 type RowObject = object;

--- a/packages/column-live-view-engine/src/engine-health.ts
+++ b/packages/column-live-view-engine/src/engine-health.ts
@@ -1,4 +1,4 @@
-import type { LiveTopicSubscriber } from "./live-subscription.js";
+import type { LiveTopicSubscriber } from "./live-subscription.ts";
 import { Effect } from "effect";
 
 type RowObject = object;

--- a/packages/column-live-view-engine/src/index.test-d.ts
+++ b/packages/column-live-view-engine/src/index.test-d.ts
@@ -16,7 +16,7 @@ import type {
   ColumnLiveViewEngineHealth,
   ColumnLiveViewSubscription,
   ColumnLiveViewTopicHealth,
-} from "./index.ts";
+} from "./index";
 
 const Order = Schema.Struct({
   id: Schema.String,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -17,7 +17,7 @@ import {
   type ColumnLiveViewEngineConfig,
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
-} from "./index.ts";
+} from "./index";
 
 const Order = Schema.Struct({
   id: Schema.String,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -9,6 +9,10 @@ import { Cause, Effect, Schema, Scope, Stream } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
 import {
   createColumnLiveViewEngine,
+  EngineClosedError,
+  InvalidRowError,
+  InvalidTopicError,
+  UnsupportedQueryError,
   type ColumnLiveViewEngine,
   type ColumnLiveViewEngineConfig,
   type ColumnLiveViewEngineEvent,
@@ -1487,6 +1491,7 @@ describe("ColumnLiveViewEngine validation and health", () => {
         topic: "orders",
         message: expect.stringContaining("a finite number"),
       });
+      expect(error).toBeInstanceOf(InvalidRowError);
     }),
   );
 
@@ -1720,6 +1725,7 @@ describe("ColumnLiveViewEngine validation and health", () => {
         _tag: "UnsupportedQueryError",
         message: expect.stringContaining("Grouped aggregate queries are not implemented"),
       });
+      expect(error).toBeInstanceOf(UnsupportedQueryError);
 
       const subscribeError = yield* Effect.flip(engine.subscribe("orders", groupedRuntimeQuery));
       expect(subscribeError._tag).toBe("UnsupportedQueryError");
@@ -2036,6 +2042,7 @@ describe("ColumnLiveViewEngine validation and health", () => {
       const looseEngine = yield* createColumnLiveViewEngine(missingTopicConfig);
       const missing = yield* Effect.flip(looseEngine.snapshot("missing", {}));
       expect(missing._tag).toBe("InvalidTopicError");
+      expect(missing).toBeInstanceOf(InvalidTopicError);
 
       yield* engine.close();
       yield* engine.close();
@@ -2046,6 +2053,7 @@ describe("ColumnLiveViewEngine validation and health", () => {
 
       const closedError = yield* Effect.flip(engine.publish("orders", order("1", "open", 10, 1)));
       expect(closedError._tag).toBe("EngineClosedError");
+      expect(closedError).toBeInstanceOf(EngineClosedError);
     }),
   );
 });

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -5,20 +5,20 @@ import type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
   DecodableTopicDefinitions,
-} from "./engine-contract.ts";
+} from "./engine-contract";
 import {
   EngineClosedError,
   InvalidRowError,
   InvalidTopicError,
   UnsupportedQueryError,
-} from "./engine-errors.ts";
-import { collectColumnLiveViewEngineHealth } from "./engine-health.ts";
-import { makeLiveSubscription } from "./live-subscription.ts";
+} from "./engine-errors";
+import { collectColumnLiveViewEngineHealth } from "./engine-health";
+import { makeLiveSubscription } from "./live-subscription";
 import {
   evaluateCompiledRawQuery,
   prepareRawQuery,
   type QueryEvaluation,
-} from "./raw-query-compiler.ts";
+} from "./raw-query-compiler";
 import {
   closeTopicStoreSubscriptions,
   deleteTopicStoreRow,
@@ -28,24 +28,24 @@ import {
   publishTopicStoreRows,
   resetTopicStore,
   TopicStore,
-} from "./topic-store.ts";
+} from "./topic-store";
 
-export { InvalidQueryError } from "./raw-query-compiler.ts";
+export { InvalidQueryError } from "./raw-query-compiler";
 export {
   EngineClosedError,
   InvalidRowError,
   InvalidTopicError,
   UnsupportedQueryError,
-} from "./engine-errors.ts";
-export type { ColumnLiveViewEngineError } from "./engine-errors.ts";
+} from "./engine-errors";
+export type { ColumnLiveViewEngineError } from "./engine-errors";
 export type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
   ColumnLiveViewEngineEvent,
   ColumnLiveViewSubscription,
   DecodableTopicDefinitions,
-} from "./engine-contract.ts";
-export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health.ts";
+} from "./engine-contract";
+export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health";
 
 type RowObject = object;
 const defaultSubscriptionQueueCapacity = 1_024;

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -5,20 +5,20 @@ import type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
   DecodableTopicDefinitions,
-} from "./engine-contract.js";
+} from "./engine-contract.ts";
 import {
   EngineClosedError,
   InvalidRowError,
   InvalidTopicError,
   UnsupportedQueryError,
-} from "./engine-errors.js";
-import { collectColumnLiveViewEngineHealth } from "./engine-health.js";
-import { makeLiveSubscription } from "./live-subscription.js";
+} from "./engine-errors.ts";
+import { collectColumnLiveViewEngineHealth } from "./engine-health.ts";
+import { makeLiveSubscription } from "./live-subscription.ts";
 import {
   evaluateCompiledRawQuery,
   prepareRawQuery,
   type QueryEvaluation,
-} from "./raw-query-compiler.js";
+} from "./raw-query-compiler.ts";
 import {
   closeTopicStoreSubscriptions,
   deleteTopicStoreRow,
@@ -28,24 +28,24 @@ import {
   publishTopicStoreRows,
   resetTopicStore,
   TopicStore,
-} from "./topic-store.js";
+} from "./topic-store.ts";
 
-export { InvalidQueryError } from "./raw-query-compiler.js";
+export { InvalidQueryError } from "./raw-query-compiler.ts";
 export {
   EngineClosedError,
   InvalidRowError,
   InvalidTopicError,
   UnsupportedQueryError,
-} from "./engine-errors.js";
-export type { ColumnLiveViewEngineError } from "./engine-errors.js";
+} from "./engine-errors.ts";
+export type { ColumnLiveViewEngineError } from "./engine-errors.ts";
 export type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
   ColumnLiveViewEngineEvent,
   ColumnLiveViewSubscription,
   DecodableTopicDefinitions,
-} from "./engine-contract.js";
-export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health.js";
+} from "./engine-contract.ts";
+export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health.ts";
 
 type RowObject = object;
 const defaultSubscriptionQueueCapacity = 1_024;

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -22,7 +22,6 @@ import {
 import {
   closeTopicStoreSubscriptions,
   deleteTopicStoreRow,
-  notifyTopicStoreSubscribers,
   patchTopicStoreRow,
   publishTopicStoreRow,
   publishTopicStoreRows,
@@ -95,7 +94,9 @@ class InMemoryColumnLiveViewEngine<
       const definition = config.topics[topic];
       this.stores.set(
         topic,
-        new TopicStore<AnyTopicRow<Topics>>(topic, definition.schema, definition.key),
+        new TopicStore<AnyTopicRow<Topics>>(topic, definition.schema, definition.key, () => {
+          this.engineVersion += 1;
+        }),
       );
     }
   }
@@ -125,21 +126,11 @@ class InMemoryColumnLiveViewEngine<
     });
   }
 
-  private commit<Row extends RowObject>(store: TopicStore<Row>): Effect.Effect<void> {
-    return Effect.gen({ self: this }, function* () {
-      store.version += 1;
-      this.engineVersion += 1;
-      yield* notifyTopicStoreSubscribers(store);
-    });
-  }
-
   readonly publish: ColumnLiveViewEngine<Topics>["publish"] = (topic, row) => {
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      yield* publishTopicStoreRow(store, row, invalidRow, (committedStore) =>
-        this.commit(committedStore),
-      );
+      yield* publishTopicStoreRow(store, row, invalidRow);
     });
   };
 
@@ -147,9 +138,7 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      yield* publishTopicStoreRows(store, rows, invalidRow, (committedStore) =>
-        this.commit(committedStore),
-      );
+      yield* publishTopicStoreRows(store, rows, invalidRow);
     });
   };
 
@@ -157,9 +146,7 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      yield* patchTopicStoreRow(store, key, patch, invalidRow, (committedStore) =>
-        this.commit(committedStore),
-      );
+      yield* patchTopicStoreRow(store, key, patch, invalidRow);
     });
   };
 
@@ -167,7 +154,7 @@ class InMemoryColumnLiveViewEngine<
     return Effect.gen({ self: this }, function* () {
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
-      yield* deleteTopicStoreRow(store, key, (committedStore) => this.commit(committedStore));
+      yield* deleteTopicStoreRow(store, key);
     });
   };
 

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -1,26 +1,21 @@
+import type { LiveQueryRow, LiveQueryResult, TopicRow } from "@view-server/config";
+import { Effect } from "effect";
 import type {
-  DeltaEvent,
-  FieldKey,
-  LiveQueryRow,
-  LiveQueryResult,
-  OrderBy,
-  RawQuery,
-  RowFromSchema,
-  RowSchema,
-  SnapshotEvent,
-  StatusEvent,
-  StringFieldKey,
-  TopicRow,
-} from "@view-server/config";
-import { Effect, Schema, Stream } from "effect";
+  AnyTopicRow,
+  ColumnLiveViewEngine,
+  ColumnLiveViewEngineConfig,
+  DecodableTopicDefinitions,
+} from "./engine-contract.js";
 import {
-  collectColumnLiveViewEngineHealth,
-  type ColumnLiveViewEngineHealth,
-} from "./engine-health.js";
+  EngineClosedError,
+  InvalidRowError,
+  InvalidTopicError,
+  UnsupportedQueryError,
+} from "./engine-errors.js";
+import { collectColumnLiveViewEngineHealth } from "./engine-health.js";
 import { makeLiveSubscription } from "./live-subscription.js";
 import {
   evaluateCompiledRawQuery,
-  InvalidQueryError,
   prepareRawQuery,
   type QueryEvaluation,
 } from "./raw-query-compiler.js";
@@ -36,231 +31,21 @@ import {
 } from "./topic-store.js";
 
 export { InvalidQueryError } from "./raw-query-compiler.js";
+export {
+  EngineClosedError,
+  InvalidRowError,
+  InvalidTopicError,
+  UnsupportedQueryError,
+} from "./engine-errors.js";
+export type { ColumnLiveViewEngineError } from "./engine-errors.js";
+export type {
+  ColumnLiveViewEngine,
+  ColumnLiveViewEngineConfig,
+  ColumnLiveViewEngineEvent,
+  ColumnLiveViewSubscription,
+  DecodableTopicDefinitions,
+} from "./engine-contract.js";
 export type { ColumnLiveViewEngineHealth, ColumnLiveViewTopicHealth } from "./engine-health.js";
-
-export type DecodableTopicDefinitions = Record<
-  string,
-  {
-    readonly schema: RowSchema & Schema.Decoder<object>;
-    readonly key: string;
-  }
->;
-
-type ValidateEngineTopics<Topics extends DecodableTopicDefinitions> = {
-  readonly [Topic in keyof Topics]: Topics[Topic] extends {
-    readonly schema: infer S extends RowSchema & Schema.Decoder<object>;
-    readonly key: infer Key extends string;
-  }
-    ? {
-        readonly schema: S;
-        readonly key: Key & StringFieldKey<RowFromSchema<S>>;
-      }
-    : never;
-};
-
-export type ColumnLiveViewEngineConfig<Topics extends DecodableTopicDefinitions> = {
-  readonly topics: Topics & ValidateEngineTopics<Topics>;
-  readonly subscriptionQueueCapacity?: number;
-};
-
-export class InvalidTopicError extends Schema.TaggedErrorClass<InvalidTopicError>()(
-  "InvalidTopicError",
-  {
-    topic: Schema.String,
-    message: Schema.String,
-  },
-) {}
-
-export class InvalidRowError extends Schema.TaggedErrorClass<InvalidRowError>()("InvalidRowError", {
-  topic: Schema.String,
-  message: Schema.String,
-}) {}
-
-export class UnsupportedQueryError extends Schema.TaggedErrorClass<UnsupportedQueryError>()(
-  "UnsupportedQueryError",
-  {
-    topic: Schema.String,
-    message: Schema.String,
-  },
-) {}
-
-export class EngineClosedError extends Schema.TaggedErrorClass<EngineClosedError>()(
-  "EngineClosedError",
-  {
-    message: Schema.String,
-  },
-) {}
-
-export type ColumnLiveViewEngineError =
-  | InvalidTopicError
-  | InvalidRowError
-  | UnsupportedQueryError
-  | InvalidQueryError
-  | EngineClosedError;
-
-export type ColumnLiveViewEngineEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
-
-export type ColumnLiveViewSubscription<Row> = {
-  readonly events: Stream.Stream<ColumnLiveViewEngineEvent<Row>>;
-  readonly close: () => Effect.Effect<void, never>;
-};
-
-type AnyTopicRow<Topics extends DecodableTopicDefinitions> = TopicRow<
-  Topics,
-  Extract<keyof Topics, string>
->;
-
-type RejectExtraKeys<Candidate, Shape> = {
-  readonly [Key in Exclude<keyof Candidate, keyof Shape>]: never;
-};
-
-type IsUnion<Value, Candidate = Value> = Value extends unknown
-  ? [Candidate] extends [Value]
-    ? false
-    : true
-  : false;
-
-type TupleHasUnionElement<Tuple extends ReadonlyArray<unknown>> = Tuple extends readonly [
-  infer Head,
-  ...infer Tail,
-]
-  ? IsUnion<Head> extends true
-    ? true
-    : TupleHasUnionElement<Tail>
-  : false;
-
-type ExactRawQuery<Row, Query> = Query &
-  RejectExtraKeys<Query, RawQuery<Row>> & {
-    readonly groupBy?: never;
-    readonly aggregates?: never;
-  } & ExactWhere<Row, Query> &
-  ExactOrderBy<Row, Query> &
-  RejectDynamicRawFields<Row, Query>;
-
-type RejectDynamicRawFields<Row, Query> = "fields" extends keyof Query
-  ? Query extends { readonly fields?: infer Fields }
-    ? NonNullable<Fields> extends ReadonlyArray<unknown>
-      ? undefined extends Query["fields"]
-        ? {
-            readonly fields: never;
-          }
-        : IsUnion<NonNullable<Fields>> extends true
-          ? {
-              readonly fields: never;
-            }
-          : number extends NonNullable<Fields>["length"]
-            ? {
-                readonly fields: never;
-              }
-            : TupleHasUnionElement<NonNullable<Fields>> extends true
-              ? {
-                  readonly fields: never;
-                }
-              : NonNullable<Fields>[number] extends FieldKey<Row>
-                ? unknown
-                : {
-                    readonly fields: never;
-                  }
-      : unknown
-    : unknown
-  : unknown;
-
-type ExactWhere<Row, Query> = Query extends {
-  readonly where: infer Where;
-}
-  ? {
-      readonly where: Where &
-        RejectExtraKeys<Where, { readonly [Field in FieldKey<Row>]?: unknown }> & {
-          readonly [Field in Extract<keyof Where, FieldKey<Row>>]: ExactFilter<
-            Row[Field],
-            Where[Field]
-          >;
-        };
-    }
-  : unknown;
-
-type ExactFilter<Value, Filter> = Value extends object
-  ? unknown
-  : ExactOperatorFilter<Value, Filter>;
-
-type ExactOperatorFilter<Value, Filter> = Filter extends object
-  ? Filter extends ReadonlyArray<unknown>
-    ? unknown
-    : Filter & RejectExtraKeys<Filter, FieldFilterShape<Value>>
-  : unknown;
-
-type FieldFilterShape<Value> = Value extends string
-  ? {
-      readonly eq?: Value;
-      readonly neq?: Value;
-      readonly in?: ReadonlyArray<Value>;
-      readonly startsWith?: string;
-    }
-  : {
-      readonly eq?: Value;
-      readonly neq?: Value;
-      readonly in?: ReadonlyArray<Value>;
-      readonly gt?: Value;
-      readonly gte?: Value;
-      readonly lt?: Value;
-      readonly lte?: Value;
-    };
-
-type ExactOrderBy<Row, Query> = Query extends {
-  readonly orderBy: ReadonlyArray<infer Entry>;
-}
-  ? {
-      readonly orderBy: ReadonlyArray<Entry & RejectExtraKeys<Entry, OrderBy<Row>>>;
-    }
-  : unknown;
-
-type ExactPatch<Row, Patch> = Patch & RejectExtraKeys<Patch, Partial<Row>>;
-
-export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
-  readonly publish: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    row: TopicRow<Topics, Topic>,
-  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
-  readonly publishMany: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    rows: ReadonlyArray<TopicRow<Topics, Topic>>,
-  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
-  readonly patch: <
-    Topic extends Extract<keyof Topics, string>,
-    const Patch extends Partial<TopicRow<Topics, Topic>>,
-  >(
-    topic: Topic,
-    key: string,
-    patch: ExactPatch<TopicRow<Topics, Topic>, Patch>,
-  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
-  readonly delete: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    key: string,
-  ) => Effect.Effect<void, ColumnLiveViewEngineError>;
-  readonly snapshot: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends RawQuery<TopicRow<Topics, Topic>>,
-  >(
-    topic: Topic,
-    query: ExactRawQuery<TopicRow<Topics, Topic>, Query>,
-  ) => Effect.Effect<
-    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ColumnLiveViewEngineError
-  >;
-  readonly subscribe: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends RawQuery<TopicRow<Topics, Topic>>,
-  >(
-    topic: Topic,
-    query: ExactRawQuery<TopicRow<Topics, Topic>, Query>,
-  ) => Effect.Effect<
-    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ColumnLiveViewEngineError
-  >;
-  readonly health: () => Effect.Effect<ColumnLiveViewEngineHealth<Topics>, never>;
-  readonly reset: () => Effect.Effect<void, never>;
-  readonly close: () => Effect.Effect<void, never>;
-};
 
 type RowObject = object;
 const defaultSubscriptionQueueCapacity = 1_024;

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -4,8 +4,8 @@ import {
   evaluateCompiledRawQuery,
   type CompiledRawQuery,
   type QueryEvaluation,
-} from "./raw-query-compiler.ts";
-import { cloneRow, rowsEqual } from "./row-values.ts";
+} from "./raw-query-compiler";
+import { cloneRow, rowsEqual } from "./row-values";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -4,8 +4,8 @@ import {
   evaluateCompiledRawQuery,
   type CompiledRawQuery,
   type QueryEvaluation,
-} from "./raw-query-compiler.js";
-import { cloneRow, rowsEqual } from "./row-values.js";
+} from "./raw-query-compiler.ts";
+import { cloneRow, rowsEqual } from "./row-values.ts";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -9,7 +9,7 @@ import {
   isPlainRecord,
   isRecord,
   valuesEqual,
-} from "./row-values.ts";
+} from "./row-values";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -9,7 +9,7 @@ import {
   isPlainRecord,
   isRecord,
   valuesEqual,
-} from "./row-values.js";
+} from "./row-values.ts";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -454,7 +454,6 @@ const matchesFilter = (value: unknown, filter: unknown): boolean => {
     }
     return eq !== undefined || oneOf !== undefined || notEqual !== undefined;
   }
-  /* v8 ignore next -- runtime validation rejects scalar object filters before evaluation. */
   if (!isOperatorFilterObject(filter)) {
     return valuesEqual(value, filter);
   }

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,8 +1,8 @@
 import { Effect, Schema, Semaphore } from "effect";
-import type { HealthTopicStoreState } from "./engine-health.ts";
-import type { LiveTopicStoreState, LiveTopicSubscriber } from "./live-subscription.ts";
-import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler.ts";
-import { cloneRow, fieldValue } from "./row-values.ts";
+import type { HealthTopicStoreState } from "./engine-health";
+import type { LiveTopicStoreState, LiveTopicSubscriber } from "./live-subscription";
+import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
+import { cloneRow, fieldValue } from "./row-values";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,8 +1,8 @@
 import { Effect, Schema, Semaphore } from "effect";
-import type { HealthTopicStoreState } from "./engine-health.js";
-import type { LiveTopicStoreState, LiveTopicSubscriber } from "./live-subscription.js";
-import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler.js";
-import { cloneRow, fieldValue } from "./row-values.js";
+import type { HealthTopicStoreState } from "./engine-health.ts";
+import type { LiveTopicStoreState, LiveTopicSubscriber } from "./live-subscription.ts";
+import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler.ts";
+import { cloneRow, fieldValue } from "./row-values.ts";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -8,10 +8,6 @@ type RowObject = object;
 
 export type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
 
-export type CommitTopicStore = <Row extends RowObject>(
-  store: TopicStore<Row>,
-) => Effect.Effect<void>;
-
 export class TopicStore<Row extends RowObject>
   implements HealthTopicStoreState<Row>, LiveTopicStoreState<Row>
 {
@@ -27,18 +23,21 @@ export class TopicStore<Row extends RowObject>
     readonly topic: string,
     readonly schema: Schema.Decoder<object>,
     readonly keyField: string,
+    readonly onCommit: () => void,
   ) {
     this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
   }
 }
 
-export const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.notify")(
-  function* <Row extends RowObject>(store: TopicStore<Row>) {
-    for (const subscriber of store.subscribers) {
-      yield* subscriber.notify(store);
-    }
-  },
-);
+const commitTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.commit")(function* <
+  Row extends RowObject,
+>(store: TopicStore<Row>) {
+  store.version += 1;
+  store.onCommit();
+  for (const subscriber of store.subscribers) {
+    yield* subscriber.notify(store);
+  }
+});
 
 export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* <
   Row extends RowObject,
@@ -100,19 +99,14 @@ const rowKey = Effect.fn("ColumnLiveViewEngine.topicStore.rowKey")(function* <
 export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.publish")(function* <
   Row extends RowObject,
   Error,
->(
-  store: TopicStore<Row>,
-  row: Row,
-  invalidRow: InvalidRowErrorFactory<Error>,
-  commit: CommitTopicStore,
-) {
+>(store: TopicStore<Row>, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
   const decoded = yield* decodeRow(store, row, invalidRow);
   const key = yield* rowKey(store, decoded, invalidRow);
   const cloned = yield* safeCloneRow(store, decoded, invalidRow);
   yield* store.mutationSemaphore.withPermits(1)(
     Effect.gen(function* () {
       store.rows.set(key, cloned);
-      yield* commit(store);
+      yield* commitTopicStore(store);
     }),
   );
 });
@@ -122,7 +116,6 @@ export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.
     store: TopicStore<Row>,
     rows: ReadonlyArray<Row>,
     invalidRow: InvalidRowErrorFactory<Error>,
-    commit: CommitTopicStore,
   ) {
     const decodedRows = yield* Effect.forEach(rows, (row) => decodeRow(store, row, invalidRow));
     const keyedRows = yield* Effect.forEach(decodedRows, (row) =>
@@ -137,7 +130,7 @@ export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.
         for (const { key, row } of keyedRows) {
           store.rows.set(key, row);
         }
-        yield* commit(store);
+        yield* commitTopicStore(store);
       }),
     );
   },
@@ -147,13 +140,7 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
   Row extends RowObject,
   Patch extends Partial<Row>,
   Error,
->(
-  store: TopicStore<Row>,
-  key: string,
-  patch: Patch,
-  invalidRow: InvalidRowErrorFactory<Error>,
-  commit: CommitTopicStore,
-) {
+>(store: TopicStore<Row>, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
   yield* store.mutationSemaphore.withPermits(1)(
     Effect.gen(function* () {
       const current = store.rows.get(key);
@@ -167,18 +154,18 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
       }
       const cloned = yield* safeCloneRow(store, decoded, invalidRow);
       store.rows.set(key, cloned);
-      yield* commit(store);
+      yield* commitTopicStore(store);
     }),
   );
 });
 
 export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.delete")(function* <
   Row extends RowObject,
->(store: TopicStore<Row>, key: string, commit: CommitTopicStore) {
+>(store: TopicStore<Row>, key: string) {
   yield* store.mutationSemaphore.withPermits(1)(
     Effect.gen(function* () {
       store.rows.delete(key);
-      yield* commit(store);
+      yield* commitTopicStore(store);
     }),
   );
 });

--- a/packages/column-live-view-engine/tsconfig.build.json
+++ b/packages/column-live-view-engine/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "noEmit": false,
     "emitDeclarationOnly": false,
     "sourceMap": true,

--- a/packages/column-live-view-engine/tsconfig.build.json
+++ b/packages/column-live-view-engine/tsconfig.build.json
@@ -1,8 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
-    "rewriteRelativeImportExtensions": true,
     "noEmit": false,
     "emitDeclarationOnly": false,
     "sourceMap": true,

--- a/packages/column-live-view-engine/vite.config.ts
+++ b/packages/column-live-view-engine/vite.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
     },
   },
   pack: {
-    dts: {
-      tsgo: true,
-    },
-    exports: true,
+    entry: "src/index.ts",
+    dts: true,
+    fixedExtension: false,
+    exports: false,
   },
   lint: {
     options: {

--- a/packages/column-live-view-engine/vite.config.ts
+++ b/packages/column-live-view-engine/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite-plus";
+import { libraryPack } from "../../vite.pack";
 
 export default defineConfig({
   test: {
@@ -12,12 +13,7 @@ export default defineConfig({
       },
     },
   },
-  pack: {
-    entry: "src/index.ts",
-    dts: true,
-    fixedExtension: false,
-    exports: false,
-  },
+  pack: libraryPack("src/index.ts"),
   lint: {
     options: {
       typeAware: true,

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "vp pack",
     "test": "vp test run --coverage && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,6 +14,22 @@
     "./runtime": {
       "types": "./dist/runtime.d.ts",
       "import": "./dist/runtime.js"
+    },
+    "./query": {
+      "types": "./dist/topic-contract.d.ts",
+      "import": "./dist/topic-contract.js"
+    },
+    "./health": {
+      "types": "./dist/health-contract.d.ts",
+      "import": "./dist/health-contract.js"
+    },
+    "./live-protocol": {
+      "types": "./dist/live-protocol.d.ts",
+      "import": "./dist/live-protocol.js"
+    },
+    "./kafka": {
+      "types": "./dist/kafka-contract.d.ts",
+      "import": "./dist/kafka-contract.js"
     }
   },
   "scripts": {

--- a/packages/config/src/health-contract.ts
+++ b/packages/config/src/health-contract.ts
@@ -1,0 +1,84 @@
+export type RuntimeStatus = "ready" | "degraded" | "starting" | "stopping";
+export type TopicHealthStatus = "ready" | "degraded" | "starting";
+export type KafkaRegionStatus = "connected" | "disconnected" | "degraded" | "starting";
+export type KafkaTopicStatus = "ready" | "degraded" | "starting" | "stalled";
+
+export type TopicRuntimeHealth = {
+  readonly status: TopicHealthStatus;
+  readonly rowCount: number;
+  readonly liveRowCount: number;
+  readonly deletedRowCount: number;
+  readonly version: number;
+  readonly lastMutationAt: number | null;
+  readonly mutationsPerSecond: number;
+  readonly rowsPerSecond: number;
+  readonly pendingMutationBatches: number;
+  readonly activeViews: number;
+  readonly activeSubscriptions: number;
+  readonly queuedEvents: number;
+  readonly maxQueueDepth: number;
+  readonly memoryBytes: number;
+  readonly tombstoneCount: number;
+  readonly compactionPending: boolean;
+};
+
+export type KafkaRegionHealth = {
+  readonly status: KafkaRegionStatus;
+  readonly brokers: string;
+  readonly lastConnectedAt: number | null;
+  readonly lastError: string | null;
+};
+
+export type KafkaTopicRegionHealth = {
+  readonly connected: boolean;
+  readonly assignedPartitions: number;
+  readonly messagesPerSecond: number;
+  readonly bytesPerSecond: number;
+  readonly decodedMessagesPerSecond: number;
+  readonly decodeFailuresPerSecond: number;
+  readonly lastMessageAt: number | null;
+  readonly lastCommitAt: number | null;
+  readonly consumerLagMessages: number | null;
+  readonly consumerLagMs: number | null;
+  readonly lagSampledAt: number | null;
+  readonly highWatermarkOffset: string | null;
+  readonly committedOffset: string | null;
+  readonly lastError: string | null;
+};
+
+export type KafkaTopicHealth = {
+  readonly status: KafkaTopicStatus;
+  readonly sourceTopic: string;
+  readonly viewServerTopic: string;
+  readonly regions: Record<string, KafkaTopicRegionHealth>;
+};
+
+export type TransportHealth = {
+  readonly activeClients: number;
+  readonly activeStreams: number;
+  readonly activeSubscriptions: number;
+  readonly messagesPerSecond: number;
+  readonly bytesPerSecond: number;
+  readonly queuedMessages: number;
+  readonly queuedBytes: number;
+  readonly droppedClients: number;
+  readonly backpressureEvents: number;
+  readonly reconnects: number;
+  readonly lastError: string | null;
+};
+
+export type ViewServerHealth<Topics extends object = Record<string, object>> = {
+  readonly status: RuntimeStatus;
+  readonly version: number;
+  readonly uptimeMs: number;
+  readonly engine: {
+    readonly topics: {
+      readonly [Topic in Extract<keyof Topics, string>]: TopicRuntimeHealth;
+    };
+  };
+  readonly kafka?: {
+    readonly regions: Record<string, KafkaRegionHealth>;
+    readonly topics: Record<string, KafkaTopicHealth>;
+  };
+  readonly transport: TransportHealth;
+};

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -23,8 +23,8 @@ import {
   type ViewServerInMemoryRuntime,
   type ViewServerRuntimeError,
   type ViewServerTransportError,
-} from "./index.ts";
-import { runtimeConfig, runtimeEnvironmentConfig } from "./runtime.ts";
+} from "./index";
+import { runtimeConfig, runtimeEnvironmentConfig } from "./runtime";
 
 const Order = Schema.Struct({
   id: Schema.String,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,764 +1,95 @@
-import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
-import type { Clock, Config, Effect, Schema } from "effect";
-import type * as BigDecimal from "effect/BigDecimal";
-
-export type TopicName = string;
-export type SortDirection = "asc" | "desc";
-export type AggregateKind = "count" | "countDistinct" | "sum" | "min" | "max" | "avg";
-export type RuntimeStatus = "ready" | "degraded" | "starting" | "stopping";
-export type TopicHealthStatus = "ready" | "degraded" | "starting";
-export type KafkaRegionStatus = "connected" | "disconnected" | "degraded" | "starting";
-export type KafkaTopicStatus = "ready" | "degraded" | "starting" | "stalled";
-
-export type SchemaType<S> = Schema.Schema.Type<S>;
-export type RowSchema = Schema.Schema<object>;
-export type RowFromSchema<S extends RowSchema> = SchemaType<S>;
-
-export type StringFieldKey<Row> = Extract<
-  {
-    readonly [Key in keyof Row]-?: Row[Key] extends string ? Key : never;
-  }[keyof Row],
-  string
->;
-
-export type NumericFieldKey<Row> = Extract<
-  {
-    readonly [Key in keyof Row]-?: Row[Key] extends number | bigint | BigDecimal.BigDecimal
-      ? Key
-      : never;
-  }[keyof Row],
-  string
->;
-
-export type FieldKey<Row> = Extract<keyof Row, string>;
-
-export type TopicDefinition<S extends RowSchema, Key extends string> = {
-  readonly schema: S;
-  readonly key: Key;
-};
-
-export type TopicDefinitions = Record<string, TopicDefinition<RowSchema, string>>;
-
-export type TopicSchema<Topics, Topic extends keyof Topics> = Topics[Topic] extends {
-  readonly schema: infer S extends RowSchema;
-}
-  ? S
-  : never;
-
-export type TopicRow<Topics, Topic extends keyof Topics> = RowFromSchema<
-  TopicSchema<Topics, Topic>
->;
-
-export type EqualityFilter<Value> =
-  | Value
-  | {
-      readonly eq?: Value;
-      readonly neq?: Value;
-      readonly in?: ReadonlyArray<Value>;
-    };
-
-export type RangeFilter<Value> =
-  | Value
-  | {
-      readonly eq?: Value;
-      readonly neq?: Value;
-      readonly in?: ReadonlyArray<Value>;
-      readonly gt?: Value;
-      readonly gte?: Value;
-      readonly lt?: Value;
-      readonly lte?: Value;
-    };
-
-export type StringFilter<Value extends string> =
-  | Value
-  | {
-      readonly eq?: Value;
-      readonly neq?: Value;
-      readonly in?: ReadonlyArray<Value>;
-      readonly startsWith?: string;
-    };
-
-export type FieldFilter<Value> = Value extends string
-  ? StringFilter<Value>
-  : Value extends number | bigint | BigDecimal.BigDecimal
-    ? RangeFilter<Value>
-    : EqualityFilter<Value>;
-
-export type Where<Row> = {
-  readonly [Field in FieldKey<Row>]?: FieldFilter<Row[Field]>;
-};
-
-export type OrderBy<Row> = {
-  readonly field: FieldKey<Row>;
-  readonly direction: SortDirection;
-};
-
-export type RawQuery<Row> = {
-  readonly where?: Where<Row>;
-  readonly orderBy?: ReadonlyArray<OrderBy<Row>>;
-  readonly offset?: number;
-  readonly limit?: number;
-  readonly fields?: ReadonlyArray<FieldKey<Row>>;
-};
-
-export type CountAggregate<Alias extends string = string> = {
-  readonly type: "count";
-  readonly as: Alias;
-};
-
-export type CountDistinctAggregate<Row, Alias extends string = string> = {
-  readonly type: "countDistinct";
-  readonly field: FieldKey<Row>;
-  readonly as: Alias;
-};
-
-export type SumAggregate<Row, Alias extends string = string> = {
-  readonly type: "sum";
-  readonly field: NumericFieldKey<Row>;
-  readonly as: Alias;
-};
-
-export type AverageAggregate<Row, Alias extends string = string> = {
-  readonly type: "avg";
-  readonly field: NumericFieldKey<Row>;
-  readonly as: Alias;
-};
-
-export type ComparableAggregate<Row, Alias extends string = string> = {
-  readonly type: "min" | "max";
-  readonly field: FieldKey<Row>;
-  readonly as: Alias;
-};
-
-export type Aggregate<Row, Alias extends string = string> =
-  | CountAggregate<Alias>
-  | CountDistinctAggregate<Row, Alias>
-  | SumAggregate<Row, Alias>
-  | AverageAggregate<Row, Alias>
-  | ComparableAggregate<Row, Alias>;
-
-export type GroupedQuery<Row> = {
-  readonly groupBy: ReadonlyArray<FieldKey<Row>>;
-  readonly aggregates: ReadonlyArray<Aggregate<Row>>;
-  readonly where?: Where<Row>;
-  readonly offset?: number;
-  readonly limit?: number;
-};
-
-export type LiveQuery<Row> = RawQuery<Row> | GroupedQuery<Row>;
-
-type PickRawFields<Row, Query> = Query extends { readonly fields: ReadonlyArray<infer Field> }
-  ? Pick<Row, Extract<Field, keyof Row>>
-  : Row;
-
-type AggregateResultValue<Row, Agg> = Agg extends { readonly type: "count" | "countDistinct" }
-  ? bigint
-  : Agg extends { readonly type: "sum"; readonly field: infer Field }
-    ? Field extends keyof Row
-      ? Row[Field] extends bigint
-        ? bigint
-        : BigDecimal.BigDecimal
-      : never
-    : Agg extends { readonly type: "avg" }
-      ? BigDecimal.BigDecimal
-      : Agg extends { readonly type: "min" | "max"; readonly field: infer Field }
-        ? Field extends keyof Row
-          ? Row[Field]
-          : never
-        : never;
-
-type AggregateResultObject<Row, Agg> = Agg extends { readonly as: infer Alias extends string }
-  ? {
-      readonly [Key in Alias]: AggregateResultValue<Row, Agg>;
-    }
-  : object;
-
-type UnionToIntersection<Union> = (Union extends unknown ? (value: Union) => void : never) extends (
-  value: infer Intersection,
-) => void
-  ? Intersection
-  : never;
-
-type Simplify<T> = { readonly [Key in keyof T]: T[Key] };
-
-type GroupedResult<Row, Query> = Query extends {
-  readonly groupBy: ReadonlyArray<infer GroupField>;
-  readonly aggregates: ReadonlyArray<infer Agg>;
-}
-  ? Simplify<
-      Pick<Row, Extract<GroupField, keyof Row>> &
-        UnionToIntersection<AggregateResultObject<Row, Agg>>
-    >
-  : never;
-
-export type LiveQueryRow<Row, Query> =
-  Query extends GroupedQuery<Row> ? GroupedResult<Row, Query> : PickRawFields<Row, Query>;
-
-export type LiveQueryResult<Row> = {
-  readonly rows: ReadonlyArray<Row>;
-  readonly totalRows?: number;
-  readonly version: number;
-};
-
-type RejectBroadAggregateAliases<Query> = Query extends {
-  readonly aggregates: ReadonlyArray<infer Agg>;
-}
-  ? Agg extends { readonly as: infer Alias extends string }
-    ? string extends Alias
-      ? { readonly aggregates: never }
-      : unknown
-    : unknown
-  : unknown;
-
-type AggregateAliases<Query> = Query extends {
-  readonly aggregates: ReadonlyArray<infer Agg>;
-}
-  ? Agg extends { readonly as: infer Alias extends string }
-    ? Alias
-    : never
-  : never;
-
-type GroupedFields<Query> = Query extends {
-  readonly groupBy: ReadonlyArray<infer Field>;
-}
-  ? Extract<Field, string>
-  : never;
-
-type RejectAggregateAliasCollisions<Query> =
-  Extract<AggregateAliases<Query>, GroupedFields<Query>> extends never
-    ? unknown
-    : { readonly aggregates: never };
-
-type ValidateLiveQuery<Query> = RejectBroadAggregateAliases<Query> &
-  RejectAggregateAliasCollisions<Query>;
-
-export type UseLiveQuery<Topics extends object> = <
-  Topic extends Extract<keyof Topics, string>,
-  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
->(
-  topic: Topic,
-  query: Query & ValidateLiveQuery<Query>,
-) => LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;
-
-export type ViewServerProviderOptions = {
-  readonly url: string;
-};
-
-export type ViewServerBackpressureError = {
-  readonly _tag: "ViewServerBackpressureError";
-  readonly code: "BackpressureExceeded";
-  readonly message: string;
-  readonly topic?: string;
-  readonly queryId?: string;
-  readonly queuedEvents?: number;
-  readonly maxQueueDepth?: number;
-};
-
-export type ViewServerRuntimeError =
-  | ViewServerBackpressureError
-  | {
-      readonly _tag: "ViewServerRuntimeError";
-      readonly code:
-        | "InvalidTopic"
-        | "InvalidRow"
-        | "SnapshotStale"
-        | "RuntimeUnavailable"
-        | "RuntimeResetFailed";
-      readonly message: string;
-      readonly topic?: string;
-    };
-
-export type ViewServerTransportError =
-  | ViewServerBackpressureError
-  | {
-      readonly _tag: "ViewServerTransportError";
-      readonly code: "TransportError" | "SubscriptionClosed";
-      readonly message: string;
-      readonly topic?: string;
-      readonly queryId?: string;
-    };
-
-export type ViewServerInMemoryRuntime<Topics extends object> = {
-  readonly publish: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    row: TopicRow<Topics, Topic>,
-  ) => Effect.Effect<void, ViewServerRuntimeError>;
-  readonly publishMany: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    rows: ReadonlyArray<TopicRow<Topics, Topic>>,
-  ) => Effect.Effect<void, ViewServerRuntimeError>;
-  readonly patch: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    key: string,
-    patch: Partial<TopicRow<Topics, Topic>>,
-  ) => Effect.Effect<void, ViewServerRuntimeError>;
-  readonly delete: <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    key: string,
-  ) => Effect.Effect<void, ViewServerRuntimeError>;
-  readonly snapshot: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends LiveQuery<TopicRow<Topics, Topic>>,
-  >(
-    topic: Topic,
-    query: Query & ValidateLiveQuery<Query>,
-  ) => Effect.Effect<
-    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ViewServerRuntimeError
-  >;
-  readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
-  readonly reset: () => Effect.Effect<void, ViewServerRuntimeError>;
-};
-
-export type ViewServerInMemoryProviderOptions<Topics extends object> = {
-  readonly seed?: {
-    readonly [Topic in keyof Topics]?: ReadonlyArray<TopicRow<Topics, Topic>>;
-  };
-  readonly runtime?: ViewServerInMemoryRuntime<Topics>;
-  readonly onRuntime?: (runtime: ViewServerInMemoryRuntime<Topics>) => void;
-  readonly clock?: Clock.Clock;
-};
-
-export type ReactHookContracts<Topics extends object> = {
-  readonly useLiveQuery: UseLiveQuery<Topics>;
-  readonly useViewServerHealth: () => ViewServerHealth<Topics>;
-  readonly useViewServerTestRuntime: () => ViewServerInMemoryRuntime<Topics>;
-};
-
-export type RuntimeValue<A> = A | Config.Config<A>;
-export type RuntimeRegions = Record<string, RuntimeValue<string>>;
-export type NonEmptyReadonlyArray<A> = readonly [A, ...ReadonlyArray<A>];
-
-type RejectExtraKeys<Candidate, Shape> = {
-  readonly [Key in Exclude<keyof Candidate, keyof Shape>]: never;
-};
-
-type ExactObject<Candidate, Shape> = Candidate & RejectExtraKeys<Candidate, Shape>;
-
-type ExactMappingReturn<Input, Row, Mapping extends (input: Input) => Row> = Mapping &
-  ((input: Input) => ExactObject<ReturnType<Mapping>, Row>);
-
-const ProtoCodecTypeId = Symbol("@view-server/config/ProtoCodec");
-
-export type ProtoCodec<T> = {
-  readonly [ProtoCodecTypeId]: ReadonlyArray<T>;
-};
-
-export const defineProto = <T>(): ProtoCodec<T> => ({
-  [ProtoCodecTypeId]: [],
-});
-
-export type ProtobufEsGeneratedMessageDescriptor<T extends object> = {
-  readonly typeName: string;
-  readonly fields?: unknown;
-  readonly field?: Record<string, unknown>;
-  readonly _viewServerProtoType: (value: T) => T;
-};
-
-export type ProtoType<Proto> =
-  Proto extends ProtoCodec<infer T>
-    ? T
-    : Proto extends DescMessage
-      ? MessageShape<Proto>
-      : Proto extends ProtobufEsGeneratedMessageDescriptor<infer T>
-        ? T
-        : never;
-
-type SupportedProto<Proto> = [ProtoType<Proto>] extends [never] ? never : Proto;
-
-export type KafkaMessageMetadata<Region extends string = string> = {
-  readonly sourceTopic: string;
-  readonly sourceRegion: Region;
-  readonly partition: number;
-  readonly offset: string;
-  readonly timestamp: number | null;
-  readonly headers: Readonly<
-    Record<string, string | Uint8Array | ReadonlyArray<string | Uint8Array>>
-  >;
-};
-
-export type KafkaMappingInput<
-  Topics extends object,
-  ViewTopic extends Extract<keyof Topics, string>,
-  Region extends string,
-  ProtoValue,
-  ProtoKey,
-> = {
-  readonly key: [ProtoKey] extends [undefined] ? string : ProtoType<ProtoKey>;
-  readonly value: ProtoType<ProtoValue>;
-  readonly region: Region;
-  readonly schema: TopicSchema<Topics, ViewTopic>;
-  readonly metadata: KafkaMessageMetadata<Region>;
-};
-
-type KafkaTopicWithoutProtoKey<
-  Topics extends object,
-  Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
-  ProtoValue,
-  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-  Mapping extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-  ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-  ) => TopicRow<Topics, ViewTopic>,
-> = {
-  readonly regions: TopicRegions;
-  readonly protoValue: SupportedProto<ProtoValue>;
-  readonly viewServerTopic: ViewTopic;
-  readonly mapping: ExactMappingReturn<
-    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-    TopicRow<Topics, ViewTopic>,
-    Mapping
-  >;
-};
-
-type KafkaTopicWithProtoKey<
-  Topics extends object,
-  Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
-  ProtoValue,
-  ProtoKey,
-  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-  Mapping extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-  ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-  ) => TopicRow<Topics, ViewTopic>,
-> = {
-  readonly regions: TopicRegions;
-  readonly protoValue: SupportedProto<ProtoValue>;
-  readonly protoKey: SupportedProto<ProtoKey>;
-  readonly viewServerTopic: ViewTopic;
-  readonly mapping: ExactMappingReturn<
-    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-    TopicRow<Topics, ViewTopic>,
-    Mapping
-  >;
-};
-
-export type KafkaTopicDefinition<
-  Topics extends object,
-  Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
-  ProtoValue = unknown,
-  ProtoKey = unknown,
-  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
-    NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-  MappingWithoutProtoKey extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-  ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-  ) => TopicRow<Topics, ViewTopic>,
-  MappingWithProtoKey extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-  ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-  ) => TopicRow<Topics, ViewTopic>,
-> =
-  | KafkaTopicWithoutProtoKey<
-      Topics,
-      Regions,
-      ViewTopic,
-      ProtoValue,
-      TopicRegions,
-      MappingWithoutProtoKey
-    >
-  | KafkaTopicWithProtoKey<
-      Topics,
-      Regions,
-      ViewTopic,
-      ProtoValue,
-      ProtoKey,
-      TopicRegions,
-      MappingWithProtoKey
-    >;
-
-type ValidateKafkaTopic<
-  Topics extends object,
-  Regions extends RuntimeRegions,
-  Candidate,
-> = Candidate extends {
-  readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
-    Extract<keyof Regions, string>
-  >;
-  readonly protoValue: infer ProtoValue;
-  readonly protoKey: infer ProtoKey;
-  readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
-  readonly mapping: infer Mapping;
-}
-  ? Mapping extends (
-      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-    ) => TopicRow<Topics, ViewTopic>
-    ? KafkaTopicWithProtoKey<
-        Topics,
-        Regions,
-        ViewTopic,
-        ProtoValue,
-        ProtoKey,
-        TopicRegions,
-        Mapping
-      >
-    : never
-  : Candidate extends {
-        readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
-          Extract<keyof Regions, string>
-        >;
-        readonly protoValue: infer ProtoValue;
-        readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
-        readonly mapping: infer Mapping;
-      }
-    ? Mapping extends (
-        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-      ) => TopicRow<Topics, ViewTopic>
-      ? KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>
-      : never
-    : never;
-
-type ValidateKafkaTopics<
-  Topics extends object,
-  Regions extends RuntimeRegions,
-  KafkaTopics extends Record<string, object>,
-> = {
-  readonly [SourceTopic in keyof KafkaTopics]: ValidateKafkaTopic<
-    Topics,
-    Regions,
-    KafkaTopics[SourceTopic]
-  >;
-};
-
-export type RuntimeOptions<
-  Topics extends object,
-  Regions extends RuntimeRegions,
-  KafkaTopics extends Record<string, object>,
-> = {
-  readonly websocketPort: RuntimeValue<number>;
-  readonly tcpPublishPort: RuntimeValue<number>;
-  readonly kafka: {
-    readonly regions: Regions;
-    readonly topics: ValidateKafkaTopics<Topics, Regions, KafkaTopics>;
-  };
-};
-
-export type RuntimeOptionsCandidate = {
-  readonly websocketPort: RuntimeValue<number>;
-  readonly tcpPublishPort: RuntimeValue<number>;
-  readonly kafka: {
-    readonly regions: RuntimeRegions;
-    readonly topics: Record<string, object>;
-  };
-};
-
-export type ValidateRuntimeOptions<
-  Topics extends object,
-  Options,
-> = Options extends RuntimeOptionsCandidate
-  ? RuntimeOptions<Topics, Options["kafka"]["regions"], Options["kafka"]["topics"]>
-  : never;
-
-export type RuntimeOptionsDefinition<Topics extends object, Options> = ValidateRuntimeOptions<
-  Topics,
-  Options
->;
-
-type RejectExtraRuntimeKafkaKeys<Options, Shape> = Options extends {
-  readonly kafka: infer CandidateKafka;
-}
-  ? Shape extends {
-      readonly kafka: infer RuntimeKafka;
-    }
-    ? {
-        readonly kafka: CandidateKafka & RejectExtraKeys<CandidateKafka, RuntimeKafka>;
-      }
-    : unknown
-  : unknown;
-
-type ExactRuntimeOptions<Topics extends object, Options> = Options &
-  ValidateRuntimeOptions<Topics, Options> &
-  RejectExtraKeys<Options, ValidateRuntimeOptions<Topics, Options>> &
-  RejectExtraRuntimeKafkaKeys<Options, ValidateRuntimeOptions<Topics, Options>>;
-
-export type RuntimeEnvironmentConfig = {
-  readonly websocketPort: Config.Config<number>;
-  readonly tcpPublishPort: Config.Config<number>;
-};
-
-export type TopicRuntimeHealth = {
-  readonly status: TopicHealthStatus;
-  readonly rowCount: number;
-  readonly liveRowCount: number;
-  readonly deletedRowCount: number;
-  readonly version: number;
-  readonly lastMutationAt: number | null;
-  readonly mutationsPerSecond: number;
-  readonly rowsPerSecond: number;
-  readonly pendingMutationBatches: number;
-  readonly activeViews: number;
-  readonly activeSubscriptions: number;
-  readonly queuedEvents: number;
-  readonly maxQueueDepth: number;
-  readonly memoryBytes: number;
-  readonly tombstoneCount: number;
-  readonly compactionPending: boolean;
-};
-
-export type KafkaRegionHealth = {
-  readonly status: KafkaRegionStatus;
-  readonly brokers: string;
-  readonly lastConnectedAt: number | null;
-  readonly lastError: string | null;
-};
-
-export type KafkaTopicRegionHealth = {
-  readonly connected: boolean;
-  readonly assignedPartitions: number;
-  readonly messagesPerSecond: number;
-  readonly bytesPerSecond: number;
-  readonly decodedMessagesPerSecond: number;
-  readonly decodeFailuresPerSecond: number;
-  readonly lastMessageAt: number | null;
-  readonly lastCommitAt: number | null;
-  readonly consumerLagMessages: number | null;
-  readonly consumerLagMs: number | null;
-  readonly lagSampledAt: number | null;
-  readonly highWatermarkOffset: string | null;
-  readonly committedOffset: string | null;
-  readonly lastError: string | null;
-};
-
-export type KafkaTopicHealth = {
-  readonly status: KafkaTopicStatus;
-  readonly sourceTopic: string;
-  readonly viewServerTopic: string;
-  readonly regions: Record<string, KafkaTopicRegionHealth>;
-};
-
-export type TransportHealth = {
-  readonly activeClients: number;
-  readonly activeStreams: number;
-  readonly activeSubscriptions: number;
-  readonly messagesPerSecond: number;
-  readonly bytesPerSecond: number;
-  readonly queuedMessages: number;
-  readonly queuedBytes: number;
-  readonly droppedClients: number;
-  readonly backpressureEvents: number;
-  readonly reconnects: number;
-  readonly lastError: string | null;
-};
-
-export type ViewServerHealth<Topics extends object = Record<string, object>> = {
-  readonly status: RuntimeStatus;
-  readonly version: number;
-  readonly uptimeMs: number;
-  readonly engine: {
-    readonly topics: {
-      readonly [Topic in Extract<keyof Topics, string>]: TopicRuntimeHealth;
-    };
-  };
-  readonly kafka?: {
-    readonly regions: Record<string, KafkaRegionHealth>;
-    readonly topics: Record<string, KafkaTopicHealth>;
-  };
-  readonly transport: TransportHealth;
-};
-
-export type SnapshotEvent<Row> = {
-  readonly type: "snapshot";
-  readonly topic: string;
-  readonly queryId: string;
-  readonly version: number;
-  readonly keys: ReadonlyArray<string>;
-  readonly rows: ReadonlyArray<Row>;
-  readonly totalRows?: number;
-};
-
-export type DeltaOperation<Row> =
-  | {
-      readonly type: "insert";
-      readonly key: string;
-      readonly row: Row;
-      readonly index: number;
-    }
-  | {
-      readonly type: "update";
-      readonly key: string;
-      readonly row: Row;
-      readonly index: number;
-    }
-  | {
-      readonly type: "move";
-      readonly key: string;
-      readonly fromIndex: number;
-      readonly toIndex: number;
-    }
-  | {
-      readonly type: "remove";
-      readonly key: string;
-    };
-
-export type DeltaEvent<Row> = {
-  readonly type: "delta";
-  readonly topic: string;
-  readonly queryId: string;
-  readonly fromVersion: number;
-  readonly toVersion: number;
-  readonly operations: ReadonlyArray<DeltaOperation<Row>>;
-  readonly totalRows?: number;
-};
-
-export type StatusEventCode =
-  | "Ready"
-  | "SnapshotStale"
-  | "SubscriptionClosed"
-  | "TransportError"
-  | "BackpressureExceeded";
-
-export type StatusEvent =
-  | {
-      readonly type: "status";
-      readonly topic: string;
-      readonly queryId: string;
-      readonly status: "ready";
-      readonly code: "Ready";
-      readonly message?: string;
-    }
-  | {
-      readonly type: "status";
-      readonly topic: string;
-      readonly queryId: string;
-      readonly status: "stale";
-      readonly code: "SnapshotStale" | "BackpressureExceeded";
-      readonly message?: string;
-    }
-  | {
-      readonly type: "status";
-      readonly topic: string;
-      readonly queryId: string;
-      readonly status: "closed";
-      readonly code: "SubscriptionClosed" | "BackpressureExceeded";
-      readonly message?: string;
-    }
-  | {
-      readonly type: "status";
-      readonly topic: string;
-      readonly queryId: string;
-      readonly status: "error";
-      readonly code: "TransportError" | "BackpressureExceeded";
-      readonly message?: string;
-    };
-
-export type LiveSubscription<Row> = {
-  readonly events: AsyncIterable<SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent>;
-  readonly close: () => Effect.Effect<void, ViewServerTransportError>;
-};
-
-export type LiveTransportAdapter = {
-  readonly subscribe: <Row>(
-    topic: string,
-    query: LiveQuery<Row>,
-  ) => Effect.Effect<LiveSubscription<Row>, ViewServerTransportError>;
-};
+import {
+  defineKafkaTopic,
+  type ExactRuntimeOptions,
+  type KafkaTopicHelper,
+  type RuntimeOptionsCandidate,
+  type RuntimeOptionsDefinition,
+} from "./kafka-contract";
+import type { RowFromSchema, RowSchema, StringFieldKey, TopicDefinition } from "./topic-contract";
+
+export type {
+  Aggregate,
+  AggregateKind,
+  AverageAggregate,
+  ComparableAggregate,
+  CountAggregate,
+  CountDistinctAggregate,
+  EqualityFilter,
+  FieldFilter,
+  FieldKey,
+  GroupedQuery,
+  LiveQuery,
+  LiveQueryResult,
+  LiveQueryRow,
+  NumericFieldKey,
+  OrderBy,
+  RangeFilter,
+  RawQuery,
+  RowFromSchema,
+  RowSchema,
+  SchemaType,
+  SortDirection,
+  StringFieldKey,
+  StringFilter,
+  SumAggregate,
+  TopicDefinition,
+  TopicDefinitions,
+  TopicName,
+  TopicRow,
+  TopicSchema,
+  UseLiveQuery,
+  ValidateLiveQuery,
+  Where,
+} from "./topic-contract";
+export type {
+  KafkaRegionHealth,
+  KafkaRegionStatus,
+  KafkaTopicHealth,
+  KafkaTopicRegionHealth,
+  KafkaTopicStatus,
+  RuntimeStatus,
+  TopicHealthStatus,
+  TopicRuntimeHealth,
+  TransportHealth,
+  ViewServerHealth,
+} from "./health-contract";
+export type {
+  ReactHookContracts,
+  ViewServerBackpressureError,
+  ViewServerInMemoryProviderOptions,
+  ViewServerInMemoryRuntime,
+  ViewServerProviderOptions,
+  RuntimeEnvironmentConfig,
+  ViewServerRuntimeError,
+  ViewServerTransportError,
+} from "./runtime-contract";
+export type {
+  DeltaEvent,
+  DeltaOperation,
+  LiveSubscription,
+  LiveTransportAdapter,
+  SnapshotEvent,
+  StatusEvent,
+  StatusEventCode,
+} from "./live-protocol";
+export { defineKafkaTopic, defineProto } from "./kafka-contract";
+export type {
+  ExactRuntimeOptions,
+  KafkaMappingInput,
+  KafkaMessageMetadata,
+  KafkaTopicDefinition,
+  KafkaTopicHelper,
+  NonEmptyReadonlyArray,
+  ProtoCodec,
+  ProtoType,
+  ProtobufEsGeneratedMessageDescriptor,
+  RuntimeOptions,
+  RuntimeOptionsCandidate,
+  RuntimeOptionsDefinition,
+  RuntimeRegions,
+  RuntimeValue,
+  ValidateRuntimeOptions,
+} from "./kafka-contract";
 
 export type ViewServerConfig<Topics extends object> = {
   readonly topics: Topics;
@@ -779,107 +110,6 @@ type ValidateTopicDefinitions<Topics extends object> = {
 
 export type DefineViewServerConfigInput<Topics extends object> = {
   readonly topics: Topics & ValidateTopicDefinitions<Topics>;
-};
-
-export type KafkaTopicHelper<Topics extends object> = <const Regions extends RuntimeRegions>() => {
-  <
-    const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-    ProtoValue,
-    ProtoKey,
-    const ViewTopic extends Extract<keyof Topics, string>,
-    Mapping extends (
-      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-    ) => TopicRow<Topics, ViewTopic>,
-  >(
-    topic: KafkaTopicWithProtoKey<
-      Topics,
-      Regions,
-      ViewTopic,
-      ProtoValue,
-      ProtoKey,
-      TopicRegions,
-      Mapping
-    >,
-  ): KafkaTopicWithProtoKey<
-    Topics,
-    Regions,
-    ViewTopic,
-    ProtoValue,
-    ProtoKey,
-    TopicRegions,
-    Mapping
-  >;
-  <
-    const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-    ProtoValue,
-    const ViewTopic extends Extract<keyof Topics, string>,
-    Mapping extends (
-      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-    ) => TopicRow<Topics, ViewTopic>,
-  >(
-    topic: KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>,
-  ): KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>;
-};
-
-export const defineKafkaTopic = <Topics extends object>(): KafkaTopicHelper<Topics> => {
-  function forRegions<const Regions extends RuntimeRegions>() {
-    function topicHelper<
-      const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-      ProtoValue,
-      ProtoKey,
-      const ViewTopic extends Extract<keyof Topics, string>,
-      Mapping extends (
-        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-      ) => TopicRow<Topics, ViewTopic>,
-    >(
-      topic: KafkaTopicWithProtoKey<
-        Topics,
-        Regions,
-        ViewTopic,
-        ProtoValue,
-        ProtoKey,
-        TopicRegions,
-        Mapping
-      >,
-    ): KafkaTopicWithProtoKey<
-      Topics,
-      Regions,
-      ViewTopic,
-      ProtoValue,
-      ProtoKey,
-      TopicRegions,
-      Mapping
-    >;
-    function topicHelper<
-      const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-      ProtoValue,
-      const ViewTopic extends Extract<keyof Topics, string>,
-      Mapping extends (
-        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-      ) => TopicRow<Topics, ViewTopic>,
-    >(
-      topic: KafkaTopicWithoutProtoKey<
-        Topics,
-        Regions,
-        ViewTopic,
-        ProtoValue,
-        TopicRegions,
-        Mapping
-      >,
-    ): KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>;
-    function topicHelper<
-      const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-      ProtoValue,
-      ProtoKey,
-      const ViewTopic extends Extract<keyof Topics, string>,
-    >(topic: KafkaTopicDefinition<Topics, Regions, ViewTopic, ProtoValue, ProtoKey, TopicRegions>) {
-      return topic;
-    }
-
-    return topicHelper;
-  }
-
-  return forRegions;
 };
 
 export const defineViewServerConfig = <

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -1,0 +1,357 @@
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import type { Config } from "effect";
+import type { TopicRow, TopicSchema } from "./topic-contract";
+
+export type RuntimeValue<A> = A | Config.Config<A>;
+export type RuntimeRegions = Record<string, RuntimeValue<string>>;
+export type NonEmptyReadonlyArray<A> = readonly [A, ...ReadonlyArray<A>];
+
+type RejectExtraKeys<Candidate, Shape> = {
+  readonly [Key in Exclude<keyof Candidate, keyof Shape>]: never;
+};
+
+type ExactObject<Candidate, Shape> = Candidate & RejectExtraKeys<Candidate, Shape>;
+
+type ExactMappingReturn<Input, Row, Mapping extends (input: Input) => Row> = Mapping &
+  ((input: Input) => ExactObject<ReturnType<Mapping>, Row>);
+
+const ProtoCodecTypeId = Symbol("@view-server/config/ProtoCodec");
+
+export type ProtoCodec<T> = {
+  readonly [ProtoCodecTypeId]: ReadonlyArray<T>;
+};
+
+export const defineProto = <T>(): ProtoCodec<T> => ({
+  [ProtoCodecTypeId]: [],
+});
+
+export type ProtobufEsGeneratedMessageDescriptor<T extends object> = {
+  readonly typeName: string;
+  readonly fields?: unknown;
+  readonly field?: Record<string, unknown>;
+  readonly _viewServerProtoType: (value: T) => T;
+};
+
+export type ProtoType<Proto> =
+  Proto extends ProtoCodec<infer T>
+    ? T
+    : Proto extends DescMessage
+      ? MessageShape<Proto>
+      : Proto extends ProtobufEsGeneratedMessageDescriptor<infer T>
+        ? T
+        : never;
+
+type SupportedProto<Proto> = [ProtoType<Proto>] extends [never] ? never : Proto;
+
+export type KafkaMessageMetadata<Region extends string = string> = {
+  readonly sourceTopic: string;
+  readonly sourceRegion: Region;
+  readonly partition: number;
+  readonly offset: string;
+  readonly timestamp: number | null;
+  readonly headers: Readonly<
+    Record<string, string | Uint8Array | ReadonlyArray<string | Uint8Array>>
+  >;
+};
+
+export type KafkaMappingInput<
+  Topics extends object,
+  ViewTopic extends Extract<keyof Topics, string>,
+  Region extends string,
+  ProtoValue,
+  ProtoKey,
+> = {
+  readonly key: [ProtoKey] extends [undefined] ? string : ProtoType<ProtoKey>;
+  readonly value: ProtoType<ProtoValue>;
+  readonly region: Region;
+  readonly schema: TopicSchema<Topics, ViewTopic>;
+  readonly metadata: KafkaMessageMetadata<Region>;
+};
+
+type KafkaTopicWithoutProtoKey<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  ViewTopic extends Extract<keyof Topics, string>,
+  ProtoValue,
+  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+  Mapping extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+  ) => TopicRow<Topics, ViewTopic>,
+> = {
+  readonly regions: TopicRegions;
+  readonly protoValue: SupportedProto<ProtoValue>;
+  readonly viewServerTopic: ViewTopic;
+  readonly mapping: ExactMappingReturn<
+    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+    TopicRow<Topics, ViewTopic>,
+    Mapping
+  >;
+};
+
+type KafkaTopicWithProtoKey<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  ViewTopic extends Extract<keyof Topics, string>,
+  ProtoValue,
+  ProtoKey,
+  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+  Mapping extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+  ) => TopicRow<Topics, ViewTopic>,
+> = {
+  readonly regions: TopicRegions;
+  readonly protoValue: SupportedProto<ProtoValue>;
+  readonly protoKey: SupportedProto<ProtoKey>;
+  readonly viewServerTopic: ViewTopic;
+  readonly mapping: ExactMappingReturn<
+    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    TopicRow<Topics, ViewTopic>,
+    Mapping
+  >;
+};
+
+export type KafkaTopicDefinition<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  ViewTopic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
+  ProtoValue = unknown,
+  ProtoKey = unknown,
+  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
+    NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+  MappingWithoutProtoKey extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+  ) => TopicRow<Topics, ViewTopic>,
+  MappingWithProtoKey extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+  ) => TopicRow<Topics, ViewTopic>,
+> =
+  | KafkaTopicWithoutProtoKey<
+      Topics,
+      Regions,
+      ViewTopic,
+      ProtoValue,
+      TopicRegions,
+      MappingWithoutProtoKey
+    >
+  | KafkaTopicWithProtoKey<
+      Topics,
+      Regions,
+      ViewTopic,
+      ProtoValue,
+      ProtoKey,
+      TopicRegions,
+      MappingWithProtoKey
+    >;
+
+type ValidateKafkaTopic<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  Candidate,
+> = Candidate extends {
+  readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
+    Extract<keyof Regions, string>
+  >;
+  readonly protoValue: infer ProtoValue;
+  readonly protoKey: infer ProtoKey;
+  readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
+  readonly mapping: infer Mapping;
+}
+  ? Mapping extends (
+      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    ) => TopicRow<Topics, ViewTopic>
+    ? KafkaTopicWithProtoKey<
+        Topics,
+        Regions,
+        ViewTopic,
+        ProtoValue,
+        ProtoKey,
+        TopicRegions,
+        Mapping
+      >
+    : never
+  : Candidate extends {
+        readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
+          Extract<keyof Regions, string>
+        >;
+        readonly protoValue: infer ProtoValue;
+        readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
+        readonly mapping: infer Mapping;
+      }
+    ? Mapping extends (
+        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+      ) => TopicRow<Topics, ViewTopic>
+      ? KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>
+      : never
+    : never;
+
+type ValidateKafkaTopics<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  KafkaTopics extends Record<string, object>,
+> = {
+  readonly [SourceTopic in keyof KafkaTopics]: ValidateKafkaTopic<
+    Topics,
+    Regions,
+    KafkaTopics[SourceTopic]
+  >;
+};
+
+export type RuntimeOptions<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  KafkaTopics extends Record<string, object>,
+> = {
+  readonly websocketPort: RuntimeValue<number>;
+  readonly tcpPublishPort: RuntimeValue<number>;
+  readonly kafka: {
+    readonly regions: Regions;
+    readonly topics: ValidateKafkaTopics<Topics, Regions, KafkaTopics>;
+  };
+};
+
+export type RuntimeOptionsCandidate = {
+  readonly websocketPort: RuntimeValue<number>;
+  readonly tcpPublishPort: RuntimeValue<number>;
+  readonly kafka: {
+    readonly regions: RuntimeRegions;
+    readonly topics: Record<string, object>;
+  };
+};
+
+export type ValidateRuntimeOptions<
+  Topics extends object,
+  Options,
+> = Options extends RuntimeOptionsCandidate
+  ? RuntimeOptions<Topics, Options["kafka"]["regions"], Options["kafka"]["topics"]>
+  : never;
+
+export type RuntimeOptionsDefinition<Topics extends object, Options> = ValidateRuntimeOptions<
+  Topics,
+  Options
+>;
+
+type RejectExtraRuntimeKafkaKeys<Options, Shape> = Options extends {
+  readonly kafka: infer CandidateKafka;
+}
+  ? Shape extends {
+      readonly kafka: infer RuntimeKafka;
+    }
+    ? {
+        readonly kafka: CandidateKafka & RejectExtraKeys<CandidateKafka, RuntimeKafka>;
+      }
+    : unknown
+  : unknown;
+
+export type ExactRuntimeOptions<Topics extends object, Options> = Options &
+  ValidateRuntimeOptions<Topics, Options> &
+  RejectExtraKeys<Options, ValidateRuntimeOptions<Topics, Options>> &
+  RejectExtraRuntimeKafkaKeys<Options, ValidateRuntimeOptions<Topics, Options>>;
+
+export type KafkaTopicHelper<Topics extends object> = <const Regions extends RuntimeRegions>() => {
+  <
+    const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+    ProtoValue,
+    ProtoKey,
+    const ViewTopic extends Extract<keyof Topics, string>,
+    Mapping extends (
+      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    ) => TopicRow<Topics, ViewTopic>,
+  >(
+    topic: KafkaTopicWithProtoKey<
+      Topics,
+      Regions,
+      ViewTopic,
+      ProtoValue,
+      ProtoKey,
+      TopicRegions,
+      Mapping
+    >,
+  ): KafkaTopicWithProtoKey<
+    Topics,
+    Regions,
+    ViewTopic,
+    ProtoValue,
+    ProtoKey,
+    TopicRegions,
+    Mapping
+  >;
+  <
+    const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+    ProtoValue,
+    const ViewTopic extends Extract<keyof Topics, string>,
+    Mapping extends (
+      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+    ) => TopicRow<Topics, ViewTopic>,
+  >(
+    topic: KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>,
+  ): KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>;
+};
+
+export const defineKafkaTopic = <Topics extends object>(): KafkaTopicHelper<Topics> => {
+  function forRegions<const Regions extends RuntimeRegions>() {
+    function topicHelper<
+      const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+      ProtoValue,
+      ProtoKey,
+      const ViewTopic extends Extract<keyof Topics, string>,
+      Mapping extends (
+        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+      ) => TopicRow<Topics, ViewTopic>,
+    >(
+      topic: KafkaTopicWithProtoKey<
+        Topics,
+        Regions,
+        ViewTopic,
+        ProtoValue,
+        ProtoKey,
+        TopicRegions,
+        Mapping
+      >,
+    ): KafkaTopicWithProtoKey<
+      Topics,
+      Regions,
+      ViewTopic,
+      ProtoValue,
+      ProtoKey,
+      TopicRegions,
+      Mapping
+    >;
+    function topicHelper<
+      const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+      ProtoValue,
+      const ViewTopic extends Extract<keyof Topics, string>,
+      Mapping extends (
+        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+      ) => TopicRow<Topics, ViewTopic>,
+    >(
+      topic: KafkaTopicWithoutProtoKey<
+        Topics,
+        Regions,
+        ViewTopic,
+        ProtoValue,
+        TopicRegions,
+        Mapping
+      >,
+    ): KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>;
+    function topicHelper<
+      const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+      ProtoValue,
+      ProtoKey,
+      const ViewTopic extends Extract<keyof Topics, string>,
+    >(topic: KafkaTopicDefinition<Topics, Regions, ViewTopic, ProtoValue, ProtoKey, TopicRegions>) {
+      return topic;
+    }
+
+    return topicHelper;
+  }
+
+  return forRegions;
+};

--- a/packages/config/src/live-protocol.ts
+++ b/packages/config/src/live-protocol.ts
@@ -1,0 +1,100 @@
+import type { Effect } from "effect";
+import type { ViewServerTransportError } from "./runtime-contract";
+import type { LiveQuery } from "./topic-contract";
+
+export type SnapshotEvent<Row> = {
+  readonly type: "snapshot";
+  readonly topic: string;
+  readonly queryId: string;
+  readonly version: number;
+  readonly keys: ReadonlyArray<string>;
+  readonly rows: ReadonlyArray<Row>;
+  readonly totalRows?: number;
+};
+
+export type DeltaOperation<Row> =
+  | {
+      readonly type: "insert";
+      readonly key: string;
+      readonly row: Row;
+      readonly index: number;
+    }
+  | {
+      readonly type: "update";
+      readonly key: string;
+      readonly row: Row;
+      readonly index: number;
+    }
+  | {
+      readonly type: "move";
+      readonly key: string;
+      readonly fromIndex: number;
+      readonly toIndex: number;
+    }
+  | {
+      readonly type: "remove";
+      readonly key: string;
+    };
+
+export type DeltaEvent<Row> = {
+  readonly type: "delta";
+  readonly topic: string;
+  readonly queryId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly operations: ReadonlyArray<DeltaOperation<Row>>;
+  readonly totalRows?: number;
+};
+
+export type StatusEventCode =
+  | "Ready"
+  | "SnapshotStale"
+  | "SubscriptionClosed"
+  | "TransportError"
+  | "BackpressureExceeded";
+
+export type StatusEvent =
+  | {
+      readonly type: "status";
+      readonly topic: string;
+      readonly queryId: string;
+      readonly status: "ready";
+      readonly code: "Ready";
+      readonly message?: string;
+    }
+  | {
+      readonly type: "status";
+      readonly topic: string;
+      readonly queryId: string;
+      readonly status: "stale";
+      readonly code: "SnapshotStale" | "BackpressureExceeded";
+      readonly message?: string;
+    }
+  | {
+      readonly type: "status";
+      readonly topic: string;
+      readonly queryId: string;
+      readonly status: "closed";
+      readonly code: "SubscriptionClosed" | "BackpressureExceeded";
+      readonly message?: string;
+    }
+  | {
+      readonly type: "status";
+      readonly topic: string;
+      readonly queryId: string;
+      readonly status: "error";
+      readonly code: "TransportError" | "BackpressureExceeded";
+      readonly message?: string;
+    };
+
+export type LiveSubscription<Row> = {
+  readonly events: AsyncIterable<SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent>;
+  readonly close: () => Effect.Effect<void, ViewServerTransportError>;
+};
+
+export type LiveTransportAdapter = {
+  readonly subscribe: <Row>(
+    topic: string,
+    query: LiveQuery<Row>,
+  ) => Effect.Effect<LiveSubscription<Row>, ViewServerTransportError>;
+};

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -1,0 +1,100 @@
+import type { Clock, Config, Effect } from "effect";
+import type { ViewServerHealth } from "./health-contract";
+import type {
+  LiveQuery,
+  LiveQueryResult,
+  LiveQueryRow,
+  TopicRow,
+  UseLiveQuery,
+  ValidateLiveQuery,
+} from "./topic-contract";
+
+export type ViewServerProviderOptions = {
+  readonly url: string;
+};
+
+export type ViewServerBackpressureError = {
+  readonly _tag: "ViewServerBackpressureError";
+  readonly code: "BackpressureExceeded";
+  readonly message: string;
+  readonly topic?: string;
+  readonly queryId?: string;
+  readonly queuedEvents?: number;
+  readonly maxQueueDepth?: number;
+};
+
+export type ViewServerRuntimeError =
+  | ViewServerBackpressureError
+  | {
+      readonly _tag: "ViewServerRuntimeError";
+      readonly code:
+        | "InvalidTopic"
+        | "InvalidRow"
+        | "SnapshotStale"
+        | "RuntimeUnavailable"
+        | "RuntimeResetFailed";
+      readonly message: string;
+      readonly topic?: string;
+    };
+
+export type ViewServerTransportError =
+  | ViewServerBackpressureError
+  | {
+      readonly _tag: "ViewServerTransportError";
+      readonly code: "TransportError" | "SubscriptionClosed";
+      readonly message: string;
+      readonly topic?: string;
+      readonly queryId?: string;
+    };
+
+export type ViewServerInMemoryRuntime<Topics extends object> = {
+  readonly publish: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    row: TopicRow<Topics, Topic>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly publishMany: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    rows: ReadonlyArray<TopicRow<Topics, Topic>>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly patch: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    key: string,
+    patch: Partial<TopicRow<Topics, Topic>>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly delete: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    key: string,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly snapshot: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends LiveQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query & ValidateLiveQuery<Query>,
+  ) => Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRuntimeError
+  >;
+  readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
+  readonly reset: () => Effect.Effect<void, ViewServerRuntimeError>;
+};
+
+export type ViewServerInMemoryProviderOptions<Topics extends object> = {
+  readonly seed?: {
+    readonly [Topic in keyof Topics]?: ReadonlyArray<TopicRow<Topics, Topic>>;
+  };
+  readonly runtime?: ViewServerInMemoryRuntime<Topics>;
+  readonly onRuntime?: (runtime: ViewServerInMemoryRuntime<Topics>) => void;
+  readonly clock?: Clock.Clock;
+};
+
+export type ReactHookContracts<Topics extends object> = {
+  readonly useLiveQuery: UseLiveQuery<Topics>;
+  readonly useViewServerHealth: () => ViewServerHealth<Topics>;
+  readonly useViewServerTestRuntime: () => ViewServerInMemoryRuntime<Topics>;
+};
+
+export type RuntimeEnvironmentConfig = {
+  readonly websocketPort: Config.Config<number>;
+  readonly tcpPublishPort: Config.Config<number>;
+};

--- a/packages/config/src/runtime.ts
+++ b/packages/config/src/runtime.ts
@@ -1,5 +1,5 @@
 import { Config } from "effect";
-import type { RuntimeEnvironmentConfig } from "./index.ts";
+import type { RuntimeEnvironmentConfig } from "./index";
 
 export const runtimeEnvironmentConfig: RuntimeEnvironmentConfig = {
   websocketPort: Config.number("VIEW_SERVER_WEBSOCKET_PORT"),

--- a/packages/config/src/runtime.ts
+++ b/packages/config/src/runtime.ts
@@ -1,5 +1,5 @@
 import { Config } from "effect";
-import type { RuntimeEnvironmentConfig } from "./index.js";
+import type { RuntimeEnvironmentConfig } from "./index.ts";
 
 export const runtimeEnvironmentConfig: RuntimeEnvironmentConfig = {
   websocketPort: Config.number("VIEW_SERVER_WEBSOCKET_PORT"),

--- a/packages/config/src/runtime.ts
+++ b/packages/config/src/runtime.ts
@@ -1,6 +1,8 @@
 import { Config } from "effect";
 import type { RuntimeEnvironmentConfig } from "./index";
 
+export type { RuntimeEnvironmentConfig } from "./index";
+
 export const runtimeEnvironmentConfig: RuntimeEnvironmentConfig = {
   websocketPort: Config.number("VIEW_SERVER_WEBSOCKET_PORT"),
   tcpPublishPort: Config.number("VIEW_SERVER_TCP_PUBLISH_PORT"),

--- a/packages/config/src/topic-contract.ts
+++ b/packages/config/src/topic-contract.ts
@@ -1,0 +1,236 @@
+import type { Schema } from "effect";
+import type * as BigDecimal from "effect/BigDecimal";
+
+export type TopicName = string;
+export type SortDirection = "asc" | "desc";
+export type AggregateKind = "count" | "countDistinct" | "sum" | "min" | "max" | "avg";
+
+export type SchemaType<S> = Schema.Schema.Type<S>;
+export type RowSchema = Schema.Schema<object>;
+export type RowFromSchema<S extends RowSchema> = SchemaType<S>;
+
+export type StringFieldKey<Row> = Extract<
+  {
+    readonly [Key in keyof Row]-?: Row[Key] extends string ? Key : never;
+  }[keyof Row],
+  string
+>;
+
+export type NumericFieldKey<Row> = Extract<
+  {
+    readonly [Key in keyof Row]-?: Row[Key] extends number | bigint | BigDecimal.BigDecimal
+      ? Key
+      : never;
+  }[keyof Row],
+  string
+>;
+
+export type FieldKey<Row> = Extract<keyof Row, string>;
+
+export type TopicDefinition<S extends RowSchema, Key extends string> = {
+  readonly schema: S;
+  readonly key: Key;
+};
+
+export type TopicDefinitions = Record<string, TopicDefinition<RowSchema, string>>;
+
+export type TopicSchema<Topics, Topic extends keyof Topics> = Topics[Topic] extends {
+  readonly schema: infer S extends RowSchema;
+}
+  ? S
+  : never;
+
+export type TopicRow<Topics, Topic extends keyof Topics> = RowFromSchema<
+  TopicSchema<Topics, Topic>
+>;
+
+export type EqualityFilter<Value> =
+  | Value
+  | {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+    };
+
+export type RangeFilter<Value> =
+  | Value
+  | {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+      readonly gt?: Value;
+      readonly gte?: Value;
+      readonly lt?: Value;
+      readonly lte?: Value;
+    };
+
+export type StringFilter<Value extends string> =
+  | Value
+  | {
+      readonly eq?: Value;
+      readonly neq?: Value;
+      readonly in?: ReadonlyArray<Value>;
+      readonly startsWith?: string;
+    };
+
+export type FieldFilter<Value> = Value extends string
+  ? StringFilter<Value>
+  : Value extends number | bigint | BigDecimal.BigDecimal
+    ? RangeFilter<Value>
+    : EqualityFilter<Value>;
+
+export type Where<Row> = {
+  readonly [Field in FieldKey<Row>]?: FieldFilter<Row[Field]>;
+};
+
+export type OrderBy<Row> = {
+  readonly field: FieldKey<Row>;
+  readonly direction: SortDirection;
+};
+
+export type RawQuery<Row> = {
+  readonly where?: Where<Row>;
+  readonly orderBy?: ReadonlyArray<OrderBy<Row>>;
+  readonly offset?: number;
+  readonly limit?: number;
+  readonly fields?: ReadonlyArray<FieldKey<Row>>;
+};
+
+export type CountAggregate<Alias extends string = string> = {
+  readonly type: "count";
+  readonly as: Alias;
+};
+
+export type CountDistinctAggregate<Row, Alias extends string = string> = {
+  readonly type: "countDistinct";
+  readonly field: FieldKey<Row>;
+  readonly as: Alias;
+};
+
+export type SumAggregate<Row, Alias extends string = string> = {
+  readonly type: "sum";
+  readonly field: NumericFieldKey<Row>;
+  readonly as: Alias;
+};
+
+export type AverageAggregate<Row, Alias extends string = string> = {
+  readonly type: "avg";
+  readonly field: NumericFieldKey<Row>;
+  readonly as: Alias;
+};
+
+export type ComparableAggregate<Row, Alias extends string = string> = {
+  readonly type: "min" | "max";
+  readonly field: FieldKey<Row>;
+  readonly as: Alias;
+};
+
+export type Aggregate<Row, Alias extends string = string> =
+  | CountAggregate<Alias>
+  | CountDistinctAggregate<Row, Alias>
+  | SumAggregate<Row, Alias>
+  | AverageAggregate<Row, Alias>
+  | ComparableAggregate<Row, Alias>;
+
+export type GroupedQuery<Row> = {
+  readonly groupBy: ReadonlyArray<FieldKey<Row>>;
+  readonly aggregates: ReadonlyArray<Aggregate<Row>>;
+  readonly where?: Where<Row>;
+  readonly offset?: number;
+  readonly limit?: number;
+};
+
+export type LiveQuery<Row> = RawQuery<Row> | GroupedQuery<Row>;
+
+type PickRawFields<Row, Query> = Query extends { readonly fields: ReadonlyArray<infer Field> }
+  ? Pick<Row, Extract<Field, keyof Row>>
+  : Row;
+
+type AggregateResultValue<Row, Agg> = Agg extends { readonly type: "count" | "countDistinct" }
+  ? bigint
+  : Agg extends { readonly type: "sum"; readonly field: infer Field }
+    ? Field extends keyof Row
+      ? Row[Field] extends bigint
+        ? bigint
+        : BigDecimal.BigDecimal
+      : never
+    : Agg extends { readonly type: "avg" }
+      ? BigDecimal.BigDecimal
+      : Agg extends { readonly type: "min" | "max"; readonly field: infer Field }
+        ? Field extends keyof Row
+          ? Row[Field]
+          : never
+        : never;
+
+type AggregateResultObject<Row, Agg> = Agg extends { readonly as: infer Alias extends string }
+  ? {
+      readonly [Key in Alias]: AggregateResultValue<Row, Agg>;
+    }
+  : object;
+
+type UnionToIntersection<Union> = (Union extends unknown ? (value: Union) => void : never) extends (
+  value: infer Intersection,
+) => void
+  ? Intersection
+  : never;
+
+type Simplify<T> = { readonly [Key in keyof T]: T[Key] };
+
+type GroupedResult<Row, Query> = Query extends {
+  readonly groupBy: ReadonlyArray<infer GroupField>;
+  readonly aggregates: ReadonlyArray<infer Agg>;
+}
+  ? Simplify<
+      Pick<Row, Extract<GroupField, keyof Row>> &
+        UnionToIntersection<AggregateResultObject<Row, Agg>>
+    >
+  : never;
+
+export type LiveQueryRow<Row, Query> =
+  Query extends GroupedQuery<Row> ? GroupedResult<Row, Query> : PickRawFields<Row, Query>;
+
+export type LiveQueryResult<Row> = {
+  readonly rows: ReadonlyArray<Row>;
+  readonly totalRows?: number;
+  readonly version: number;
+};
+
+type RejectBroadAggregateAliases<Query> = Query extends {
+  readonly aggregates: ReadonlyArray<infer Agg>;
+}
+  ? Agg extends { readonly as: infer Alias extends string }
+    ? string extends Alias
+      ? { readonly aggregates: never }
+      : unknown
+    : unknown
+  : unknown;
+
+type AggregateAliases<Query> = Query extends {
+  readonly aggregates: ReadonlyArray<infer Agg>;
+}
+  ? Agg extends { readonly as: infer Alias extends string }
+    ? Alias
+    : never
+  : never;
+
+type GroupedFields<Query> = Query extends {
+  readonly groupBy: ReadonlyArray<infer Field>;
+}
+  ? Extract<Field, string>
+  : never;
+
+type RejectAggregateAliasCollisions<Query> =
+  Extract<AggregateAliases<Query>, GroupedFields<Query>> extends never
+    ? unknown
+    : { readonly aggregates: never };
+
+export type ValidateLiveQuery<Query> = RejectBroadAggregateAliases<Query> &
+  RejectAggregateAliasCollisions<Query>;
+
+export type UseLiveQuery<Topics extends object> = <
+  Topic extends Extract<keyof Topics, string>,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
+>(
+  topic: Topic,
+  query: Query & ValidateLiveQuery<Query>,
+) => LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;

--- a/packages/config/tsconfig.build.json
+++ b/packages/config/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "noEmit": false,
     "emitDeclarationOnly": false,
     "sourceMap": true,

--- a/packages/config/tsconfig.build.json
+++ b/packages/config/tsconfig.build.json
@@ -1,8 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
-    "rewriteRelativeImportExtensions": true,
     "noEmit": false,
     "emitDeclarationOnly": false,
     "sourceMap": true,

--- a/packages/config/vite.config.ts
+++ b/packages/config/vite.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
     },
   },
   pack: {
-    dts: {
-      tsgo: true,
-    },
-    exports: true,
+    entry: ["src/index.ts", "src/runtime.ts"],
+    dts: true,
+    fixedExtension: false,
+    exports: false,
   },
   lint: {
     options: {

--- a/packages/config/vite.config.ts
+++ b/packages/config/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite-plus";
+import { libraryPack } from "../../vite.pack";
 
 export default defineConfig({
   test: {
@@ -12,12 +13,14 @@ export default defineConfig({
       },
     },
   },
-  pack: {
-    entry: ["src/index.ts", "src/runtime.ts"],
-    dts: true,
-    fixedExtension: false,
-    exports: false,
-  },
+  pack: libraryPack([
+    "src/index.ts",
+    "src/runtime.ts",
+    "src/topic-contract.ts",
+    "src/health-contract.ts",
+    "src/live-protocol.ts",
+    "src/kafka-contract.ts",
+  ]),
   lint: {
     options: {
       typeAware: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
       '@effect/language-service':
         specifier: 'catalog:'
         version: 0.86.2
+      '@view-server/column-live-view-engine':
+        specifier: workspace:*
+        version: link:packages/column-live-view-engine
+      '@view-server/config':
+        specifier: workspace:*
+        version: link:packages/config
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -1,0 +1,61 @@
+import type { ColumnLiveViewEngine } from "@view-server/column-live-view-engine";
+import * as enginePackage from "@view-server/column-live-view-engine";
+import type { ViewServerHealth } from "@view-server/config/health";
+import type { KafkaMappingInput } from "@view-server/config/kafka";
+import type { LiveSubscription } from "@view-server/config/live-protocol";
+import type { RawQuery } from "@view-server/config/query";
+import type { RuntimeEnvironmentConfig } from "@view-server/config/runtime";
+import * as configPackage from "@view-server/config";
+import * as healthPackage from "@view-server/config/health";
+import * as kafkaPackage from "@view-server/config/kafka";
+import * as liveProtocolPackage from "@view-server/config/live-protocol";
+import * as queryPackage from "@view-server/config/query";
+import * as runtimePackage from "@view-server/config/runtime";
+
+const requireExport = (moduleName: string, moduleValue: object, exportName: string) => {
+  if (!(exportName in moduleValue)) {
+    throw new Error(`${moduleName} is missing export ${exportName}`);
+  }
+};
+
+const requireModule = (moduleName: string, moduleValue: unknown) => {
+  if (typeof moduleValue !== "object" || moduleValue === null) {
+    throw new Error(`${moduleName} did not resolve to an ES module namespace object`);
+  }
+};
+
+requireExport("@view-server/config", configPackage, "defineViewServerConfig");
+requireExport("@view-server/config", configPackage, "defineProto");
+requireExport("@view-server/config", configPackage, "defineKafkaTopic");
+requireModule("@view-server/config/query", queryPackage);
+requireModule("@view-server/config/health", healthPackage);
+requireModule("@view-server/config/live-protocol", liveProtocolPackage);
+requireExport("@view-server/config/kafka", kafkaPackage, "defineProto");
+requireExport("@view-server/config/kafka", kafkaPackage, "defineKafkaTopic");
+requireExport("@view-server/config/runtime", runtimePackage, "runtimeConfig");
+requireExport("@view-server/config/runtime", runtimePackage, "runtimeEnvironmentConfig");
+requireExport("@view-server/column-live-view-engine", enginePackage, "createColumnLiveViewEngine");
+requireExport("@view-server/column-live-view-engine", enginePackage, "InvalidTopicError");
+
+const _engineType: ColumnLiveViewEngine<Record<string, never>> | undefined = undefined;
+const _runtimeConfigType: RuntimeEnvironmentConfig | undefined = undefined;
+const _queryType: RawQuery<{ readonly id: string }> | undefined = undefined;
+const _healthType: ViewServerHealth<{ readonly orders: { readonly id: string } }> | undefined =
+  undefined;
+const _subscriptionType: LiveSubscription<{ readonly id: string }> | undefined = undefined;
+const _mappingInputType:
+  | KafkaMappingInput<
+      { readonly orders: { readonly schema: never } },
+      "orders",
+      "usa",
+      never,
+      undefined
+    >
+  | undefined = undefined;
+
+void _engineType;
+void _runtimeConfigType;
+void _queryType;
+void _healthType;
+void _subscriptionType;
+void _mappingInputType;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "noEmit": true,
     "module": "preserve",
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "plugins": [
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,10 @@ export default defineConfig({
     "*": "vp check --fix",
   },
   fmt: {
-    ignorePatterns: [".repos/**"],
+    ignorePatterns: [".repos/**", "scripts/**"],
   },
   lint: {
-    ignorePatterns: [".repos/**"],
+    ignorePatterns: [".repos/**", "scripts/**"],
     options: { typeAware: true, typeCheck: true },
   },
   run: {

--- a/vite.pack.ts
+++ b/vite.pack.ts
@@ -1,0 +1,8 @@
+type LibraryPackEntry = string | Array<string>;
+
+export const libraryPack = (entry: LibraryPackEntry) => ({
+  entry,
+  dts: true,
+  fixedExtension: false,
+  exports: false,
+});


### PR DESCRIPTION
## Summary
- extract public column live view engine contract types into engine-contract.ts
- extract engine error classes and the engine error union into engine-errors.ts
- keep index.ts as the public barrel plus in-memory runtime implementation
- add public root-export instanceof checks for moved error classes

## Validation
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error
- vp run --filter @view-server/column-live-view-engine test
- pnpm run ready
- policy scan: no as any/as unknown/as never, direct vitest imports, console.*, node assert/test, or Date usage in engine/config

## Review
- runtime reviewer found no blockers; root re-exports preserve class identity and public API compatibility
- Effect/testing reviewer found no blockers; type-only contract coverage handling is acceptable and exact type tests still run through ./index.ts
- architecture reviewer found no blockers; engine-contract.ts is a deep public Interface module and engine-errors.ts enables future runtime reuse
- final validation green with package threshold at 100% and 53 engine tests passing