### PR TITLE
Move live client contract out of protocol

### DIFF
--- a/packages/client/src/live-client.ts
+++ b/packages/client/src/live-client.ts
@@ -1,5 +1,37 @@
-export type {
-  ViewServerLiveClient,
-  ViewServerLiveEvent,
-  ViewServerLiveSubscription,
-} from "@view-server/protocol";
+import type {
+  DeltaEvent,
+  ExactRawQuery,
+  LiveQueryRow,
+  SnapshotEvent,
+  StatusEvent,
+  TopicDefinitions,
+  TopicRow,
+  ValidateLiveQuery,
+  ViewServerHealth,
+  ViewServerRuntimeError,
+  ViewServerTransportError,
+} from "@view-server/config";
+import type { Effect, Stream } from "effect";
+import type * as AtomRef from "effect/unstable/reactivity/AtomRef";
+
+export type ViewServerLiveEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
+
+export type ViewServerLiveSubscription<Row> = {
+  readonly events: Stream.Stream<ViewServerLiveEvent<Row>>;
+  readonly close: () => Effect.Effect<void, ViewServerTransportError>;
+};
+
+export type ViewServerLiveClient<Topics extends TopicDefinitions> = {
+  readonly subscribe: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends { readonly select: ReadonlyArray<unknown> },
+  >(
+    topic: Topic,
+    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
+  ) => Effect.Effect<
+    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
+  readonly health: AtomRef.ReadonlyRef<ViewServerHealth<Topics>>;
+  readonly close: Effect.Effect<void>;
+};

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -15,9 +15,6 @@ import {
   viewServerDecodeHealth,
   viewServerDecodeLiveEvent,
   viewServerEncodeRawQuery,
-  type ViewServerLiveClient,
-  type ViewServerLiveEvent,
-  type ViewServerLiveSubscription,
   type ViewServerRpcError,
   type ViewServerWireHealth,
   type ViewServerWireRawQuery,
@@ -27,6 +24,11 @@ import type * as Duration from "effect/Duration";
 import * as AtomRef from "effect/unstable/reactivity/AtomRef";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
+import type {
+  ViewServerLiveClient,
+  ViewServerLiveEvent,
+  ViewServerLiveSubscription,
+} from "./live-client";
 
 export type ViewServerRemoteClientError = ViewServerRuntimeError | ViewServerTransportError;
 

--- a/packages/protocol/src/index.test-d.ts
+++ b/packages/protocol/src/index.test-d.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import type * as Protocol from "./index";
+
+describe("@view-server/protocol type contract", () => {
+  it("does not export transport-neutral live client contracts", () => {
+    expectTypeOf<keyof typeof Protocol>().not.toEqualTypeOf<
+      "ViewServerLiveClient" | "ViewServerLiveEvent" | "ViewServerLiveSubscription"
+    >();
+
+    // @ts-expect-error live client contracts belong to @view-server/client.
+    expectTypeOf<Protocol.ViewServerLiveClient<never>>().toBeNever();
+    // @ts-expect-error live event contracts belong to @view-server/client.
+    expectTypeOf<Protocol.ViewServerLiveEvent<never>>().toBeNever();
+    // @ts-expect-error live subscription contracts belong to @view-server/client.
+    expectTypeOf<Protocol.ViewServerLiveSubscription<never>>().toBeNever();
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2,7 +2,6 @@ import type {
   DeltaEvent,
   ExactRawQuery,
   FieldKey,
-  LiveQueryRow,
   OrderBy,
   RowSchema,
   SnapshotEvent,
@@ -11,38 +10,16 @@ import type {
   TopicRow,
   TopicRuntimeHealth,
   TransportHealth,
-  ValidateLiveQuery,
   ViewServerBackpressureError,
   ViewServerHealth,
   ViewServerRuntimeError,
   ViewServerTransportError,
   Where,
 } from "@view-server/config";
-import { Effect, Schema, type Stream } from "effect";
-import type * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import { Effect, Schema } from "effect";
 import { Rpc, RpcGroup } from "effect/unstable/rpc";
 
-export type ViewServerLiveEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
-
-export type ViewServerLiveSubscription<Row> = {
-  readonly events: Stream.Stream<ViewServerLiveEvent<Row>>;
-  readonly close: () => Effect.Effect<void, ViewServerTransportError>;
-};
-
-export type ViewServerLiveClient<Topics extends TopicDefinitions> = {
-  readonly subscribe: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(
-    topic: Topic,
-    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
-  ) => Effect.Effect<
-    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ViewServerRuntimeError | ViewServerTransportError
-  >;
-  readonly health: AtomRef.ReadonlyRef<ViewServerHealth<Topics>>;
-  readonly close: Effect.Effect<void>;
-};
+type ViewServerProtocolEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
 
 const StringOrNull = Schema.NullOr(Schema.String);
 const NumberOrNull = Schema.NullOr(Schema.Number);
@@ -791,7 +768,7 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
   config: { readonly topics: Topics },
   expectedTopic: Extract<keyof Topics, string>,
   selectedFields: ReadonlySet<string>,
-  event: ViewServerLiveEvent<object>,
+  event: ViewServerProtocolEvent<object>,
 ) {
   if (event.topic !== expectedTopic) {
     return yield* Effect.fail(
@@ -836,11 +813,11 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
 });
 
 function typedLiveEvent<Row>(
-  event: ViewServerLiveEvent<Record<string, unknown>>,
-): ViewServerLiveEvent<Row>;
+  event: ViewServerProtocolEvent<Record<string, unknown>>,
+): ViewServerProtocolEvent<Row>;
 function typedLiveEvent(
-  event: ViewServerLiveEvent<Record<string, unknown>>,
-): ViewServerLiveEvent<Record<string, unknown>> {
+  event: ViewServerProtocolEvent<Record<string, unknown>>,
+): ViewServerProtocolEvent<Record<string, unknown>> {
   return event;
 }
 
@@ -875,7 +852,7 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
     });
   }
   type DecodedDeltaOperation = Extract<
-    ViewServerLiveEvent<Record<string, unknown>>,
+    ViewServerProtocolEvent<Record<string, unknown>>,
     { readonly type: "delta" }
   >["operations"][number];
   const operations: Array<DecodedDeltaOperation> = [];

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",
+    "@view-server/client": "workspace:*",
     "@view-server/config": "workspace:*",
     "@view-server/protocol": "workspace:*",
     "effect": "catalog:"
@@ -25,7 +26,6 @@
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
-    "@view-server/client": "workspace:*",
     "@view-server/in-memory": "workspace:*",
     "@vitest/coverage-istanbul": "catalog:",
     "@vitest/runner": "catalog:",

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,13 +1,10 @@
 import { NodeSocket } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
+import type { ViewServerLiveEvent } from "@view-server/client";
 import { makeViewServerClient } from "@view-server/client/remote";
 import { defineViewServerConfig } from "@view-server/config";
 import { createInMemoryViewServer } from "@view-server/in-memory";
-import {
-  ViewServerRpcErrorSchema,
-  ViewServerRpcs,
-  type ViewServerLiveEvent,
-} from "@view-server/protocol";
+import { ViewServerRpcErrorSchema, ViewServerRpcs } from "@view-server/protocol";
 import {
   Context,
   Effect,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,12 +4,12 @@ import type {
   ViewServerConfig,
   ViewServerRuntimeClient,
 } from "@view-server/config";
+import type { ViewServerLiveClient } from "@view-server/client";
 import {
   ViewServerRpcs,
   viewServerDecodeRawQuery,
   viewServerDecodeTopic,
   viewServerEncodeLiveEvent,
-  type ViewServerLiveClient,
 } from "@view-server/protocol";
 import { Context, Effect, Layer, ManagedRuntime, Stream } from "effect";
 import { HttpRouter, HttpServer, HttpServerError } from "effect/unstable/http";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.70(effect@4.0.0-beta.70)(ioredis@5.10.1)
+      '@view-server/client':
+        specifier: workspace:*
+        version: link:../client
       '@view-server/config':
         specifier: workspace:*
         version: link:../config
@@ -307,9 +310,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
-      '@view-server/client':
-        specifier: workspace:*
-        version: link:../client
       '@view-server/in-memory':
         specifier: workspace:*
         version: link:../in-memory


### PR DESCRIPTION
## Summary
- move transport-neutral live client/event/subscription contracts from @view-server/protocol to @view-server/client
- keep @view-server/protocol focused on wire schemas, RPC group, and encode/decode helpers
- make @view-server/server depend on the client contract seam explicitly
- add protocol type coverage proving live client contracts are not exported from protocol

## Reviews
- 3 review agents found no blockers
- addressed reviewer suggestion for removed protocol type export coverage

## Validation
- pnpm run ready
- strict Effect LSP: 0 errors, 0 warnings, 0 messages
- forbidden-pattern scan clean