### PR TITLE
Make React provider own remote client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - Use `toStrictEqual`, not `toEqual`, for structural equality. Exact shape matters for public contracts and wire/runtime events.
 - Use the Vitest skill before changing type tests, browser tests, coverage, or Vite/Vite+ config.
 - Tests should be dumb and explicit. Avoid branching assertions such as `if (_tag === ...) { expect(...) }`.
+- Do not use `try` / `catch` / `finally` in tests. Keep tests linear; put explicit cleanup at the end or use fixtures/helpers.
 - Prefer e2e-style tests for the column live view engine: publish rows, subscribe, assert snapshot, publish/patch/delete, assert deltas and convergence.
 - Do not add narrow implementation unit tests that would block future SIMD/Rust/native rewrites unless the behavior is a stable public contract.
 - Type tests must cover both good and bad examples, including `@ts-expect-error` negative cases.
@@ -141,6 +142,7 @@ These issues block merge until fixed or explicitly accepted by the user:
 - Browser tests import directly from `vitest`, Testing Library, or use `act`, `flushSync`, `getByTestId`, or `data-testid`.
 - Tests use `assert.*` instead of `expect` / `expectTypeOf`.
 - Tests use `toEqual` instead of `toStrictEqual`.
+- Tests use `try`, `catch`, or `finally` blocks instead of linear assertions and explicit cleanup.
 - Tests use substring assertions where stale/extra rows could still pass.
 - Implementation or tests add coverage ignore comments such as `c8 ignore`, `v8 ignore`, or `istanbul ignore`.
 - Implementation adds casts, especially broad casts (`as any`, `as unknown`, `as never`), or hides type erasure behind casts.

--- a/README.md
+++ b/README.md
@@ -25,19 +25,14 @@ console.log(server.url);
 Browser React code keeps using the normal provider and hooks:
 
 ```tsx
-import { createViewServerClient } from "@view-server/client/remote";
 import { createViewServerReact } from "@view-server/react";
-import { Effect } from "effect";
 import { viewServer } from "./view-server-config";
 
 const react = createViewServerReact(viewServer);
-const client = await Effect.runPromise(
-  createViewServerClient(viewServer, { url: "ws://127.0.0.1:3000/rpc" }),
-);
 
 export function App() {
   return (
-    <react.ViewServerProvider client={client}>
+    <react.ViewServerProvider url={window.__APP_CONFIG__.VIEW_SERVER_URL}>
       <Orders />
     </react.ViewServerProvider>
   );

--- a/packages/react/src/index.test-d.ts
+++ b/packages/react/src/index.test-d.ts
@@ -14,6 +14,7 @@ import type { Effect } from "effect";
 import { Schema } from "effect";
 import type { ReactNode } from "react";
 import { createViewServerReact } from "./index";
+import { ViewServerReactClientProvider } from "./internal";
 import { createInMemoryViewServerReact, type ViewServerInMemoryOptions } from "./testing";
 
 const Order = Schema.Struct({
@@ -36,6 +37,7 @@ const viewServer = defineViewServerConfig({
 
 const react = createViewServerReact(viewServer);
 const { ViewServerProvider, useLiveQuery, useViewServerHealth } = react;
+const ViewServerClientProvider = react[ViewServerReactClientProvider];
 
 const createInMemoryViewServer = (options?: ViewServerInMemoryOptions) =>
   createInMemoryViewServerReact(react, options);
@@ -188,7 +190,8 @@ describe("React type contracts", () => {
 
   it("keeps health and in-memory client keyed by configured topics", () => {
     const health = useViewServerHealth();
-    const provider = ViewServerProvider({ client: liveClient, children: null });
+    const provider = ViewServerProvider({ url: "ws://127.0.0.1:8080/rpc", children: null });
+    const clientProvider = ViewServerClientProvider({ client: liveClient, children: null });
     const inMemoryViewServer = createInMemoryViewServer({ subscriptionQueueCapacity: 1 });
     type Client = typeof inMemoryViewServer.client;
     const publish = inMemoryViewServer.client.publish("orders", {
@@ -202,6 +205,7 @@ describe("React type contracts", () => {
 
     expectTypeOf(health.engine.topics.orders.rowCount).toEqualTypeOf<number>();
     expectTypeOf(provider).toEqualTypeOf<ReactNode>();
+    expectTypeOf(clientProvider).toEqualTypeOf<ReactNode>();
     expectTypeOf<Parameters<Client["publish"]>>().toEqualTypeOf<
       [topic: "orders", row: typeof Order.Type]
     >();
@@ -249,7 +253,7 @@ describe("React type contracts", () => {
       select: ["id", "price"],
     });
     const provider = consumerReact.ViewServerProvider({
-      client: liveClient,
+      url: "ws://127.0.0.1:8080/rpc",
       children: null,
     });
 
@@ -260,6 +264,12 @@ describe("React type contracts", () => {
       }>
     >();
     expectTypeOf(provider).toEqualTypeOf<ReactNode>();
+
+    void consumerReact.ViewServerProvider({
+      // @ts-expect-error public production provider accepts a URL, not a caller-owned client.
+      client: liveClient,
+      children: null,
+    });
 
     consumerReact.useLiveQuery("orders", {
       // @ts-expect-error consumer package imports still reject unknown selected fields.

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -2,10 +2,11 @@ import { describe, expect, inject, it, vi } from "@effect/vitest";
 import { makeViewServerClient } from "@view-server/client/remote";
 import { defineViewServerConfig } from "@view-server/config";
 import { createInMemoryViewServer as createCoreInMemoryViewServer } from "@view-server/in-memory";
-import { Effect, Schema } from "effect";
+import { Duration, Effect, Schema } from "effect";
 import { Component, type ReactNode } from "react";
 import { render } from "vitest-browser-react";
 import { createViewServerReact } from "./index";
+import { ViewServerReactClientProvider } from "./internal";
 import { createInMemoryViewServerReact, type ViewServerInMemoryOptions } from "./testing";
 
 declare module "vitest" {
@@ -46,6 +47,7 @@ const viewServer = defineViewServerConfig({
 
 const react = createViewServerReact(viewServer);
 const { useLiveQuery, useViewServerHealth } = react;
+const ViewServerClientProvider = react[ViewServerReactClientProvider];
 
 const createInMemoryViewServer = (options?: ViewServerInMemoryOptions) =>
   createInMemoryViewServerReact(react, options);
@@ -105,9 +107,9 @@ describe("createViewServerReact", () => {
     }
 
     const view = await render(
-      <react.ViewServerProvider client={inMemory.liveClient}>
+      <ViewServerClientProvider client={inMemory.liveClient}>
         <OrdersView />
-      </react.ViewServerProvider>,
+      </ViewServerClientProvider>,
     );
     await Effect.runPromise(inMemory.client.publish("orders", order("a", 10)));
     await expect.element(view.getByText("orders: a", { exact: true })).toBeVisible();
@@ -136,21 +138,18 @@ describe("createViewServerReact", () => {
       return <output role="status">{health.status}</output>;
     }
 
-    try {
-      const missingProvider = await render(
-        <ProviderErrorBoundary>
-          <HealthView />
-        </ProviderErrorBoundary>,
-      );
-      await expect
-        .element(
-          missingProvider.getByText("ViewServerProvider is missing a client.", { exact: true }),
-        )
-        .toBeVisible();
-      await missingProvider.unmount();
-    } finally {
-      consoleError.mockRestore();
-    }
+    const missingProvider = await render(
+      <ProviderErrorBoundary>
+        <HealthView />
+      </ProviderErrorBoundary>,
+    );
+    await expect
+      .element(
+        missingProvider.getByText("ViewServerProvider is missing a client.", { exact: true }),
+      )
+      .toBeVisible();
+    await missingProvider.unmount();
+    consoleError.mockRestore();
   });
 
   it("switches hook clients when the generic provider client prop changes", async () => {
@@ -171,17 +170,17 @@ describe("createViewServerReact", () => {
     }
 
     const view = await render(
-      <react.ViewServerProvider client={first.liveClient}>
+      <ViewServerClientProvider client={first.liveClient}>
         <OrdersView />
-      </react.ViewServerProvider>,
+      </ViewServerClientProvider>,
     );
     await Effect.runPromise(first.client.publish("orders", order("first", 10)));
     await expect.element(view.getByText("orders: first", { exact: true })).toBeVisible();
 
     await view.rerender(
-      <react.ViewServerProvider client={second.liveClient}>
+      <ViewServerClientProvider client={second.liveClient}>
         <OrdersView />
-      </react.ViewServerProvider>,
+      </ViewServerClientProvider>,
     );
     await Effect.runPromise(second.client.publish("orders", order("second", 20)));
     await expect.element(view.getByText("orders: second", { exact: true })).toBeVisible();
@@ -340,12 +339,9 @@ describe("createViewServerReact", () => {
       .toBeVisible();
     await localView.unmount();
 
-    const remote = await Effect.runPromise(
-      makeViewServerClient(viewServer, { url: inject("viewServerRemoteUrl") }),
-    );
     const remoteId = `remote-${crypto.randomUUID()}`;
     const remoteView = await render(
-      <react.ViewServerProvider client={remote}>
+      <react.ViewServerProvider url={inject("viewServerRemoteUrl")}>
         <OrdersView id={remoteId} />
         <HealthView label={`remote health ${remoteId}`} />
       </react.ViewServerProvider>,
@@ -357,11 +353,132 @@ describe("createViewServerReact", () => {
       .element(remoteView.getByText(`remote health ${remoteId}: ready`, { exact: true }))
       .toBeVisible();
 
-    await expect.poll(() => remote.health.value.engine.topics.orders.activeSubscriptions).toBe(1);
+    const remoteProbe = await Effect.runPromise(
+      makeViewServerClient(viewServer, {
+        healthPollInterval: "10 millis",
+        url: inject("viewServerRemoteUrl"),
+      }),
+    );
+    await expect
+      .poll(() => remoteProbe.health.value.engine.topics.orders.activeSubscriptions)
+      .toBe(1);
 
     await remoteView.unmount();
-    await expect.poll(() => remote.health.value.engine.topics.orders.activeSubscriptions).toBe(0);
-    await Effect.runPromise(remote.close);
+
+    await expect
+      .poll(() => remoteProbe.health.value.engine.topics.orders.activeSubscriptions)
+      .toBe(0);
+    await Effect.runPromise(remoteProbe.close);
+  });
+
+  it("owns remote client creation from provider URL and options", async () => {
+    function HealthView(props: { readonly label: string }) {
+      const health = useViewServerHealth();
+      return (
+        <output aria-label={props.label} role="status">
+          {props.label}: {health.status}
+        </output>
+      );
+    }
+
+    const disabledPollingView = await render(
+      <react.ViewServerProvider
+        healthPollInterval={false}
+        subscriptionBufferSize={8}
+        url={inject("viewServerRemoteUrl")}
+      >
+        <HealthView label="disabled polling health" />
+      </react.ViewServerProvider>,
+    );
+    await expect
+      .element(disabledPollingView.getByText("disabled polling health: ready", { exact: true }))
+      .toBeVisible();
+    await disabledPollingView.unmount();
+
+    const stringPollingView = await render(
+      <react.ViewServerProvider healthPollInterval="1 second" url={inject("viewServerRemoteUrl")}>
+        <HealthView label="string polling health" />
+      </react.ViewServerProvider>,
+    );
+    await expect
+      .element(stringPollingView.getByText("string polling health: ready", { exact: true }))
+      .toBeVisible();
+    await stringPollingView.unmount();
+
+    const durationPollingView = await render(
+      <react.ViewServerProvider
+        healthPollInterval={Duration.millis(1_000)}
+        url={inject("viewServerRemoteUrl")}
+      >
+        <HealthView label="duration polling health" />
+      </react.ViewServerProvider>,
+    );
+    await expect
+      .element(durationPollingView.getByText("duration polling health: ready", { exact: true }))
+      .toBeVisible();
+    await durationPollingView.unmount();
+
+    const bigintPollingView = await render(
+      <react.ViewServerProvider
+        healthPollInterval={1_000_000_000n}
+        url={inject("viewServerRemoteUrl")}
+      >
+        <HealthView label="bigint polling health" />
+      </react.ViewServerProvider>,
+    );
+    await expect
+      .element(bigintPollingView.getByText("bigint polling health: ready", { exact: true }))
+      .toBeVisible();
+    await bigintPollingView.unmount();
+  });
+
+  it("recreates remote provider clients when URL options change", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    function HealthView() {
+      const health = useViewServerHealth();
+      return <output role="status">{health.status}</output>;
+    }
+
+    const provider = await render(
+      <ProviderErrorBoundary>
+        <react.ViewServerProvider healthPollInterval={false} url={inject("viewServerRemoteUrl")}>
+          <HealthView />
+        </react.ViewServerProvider>
+      </ProviderErrorBoundary>,
+    );
+    await expect.element(provider.getByText("ready", { exact: true })).toBeVisible();
+
+    await provider.rerender(
+      <ProviderErrorBoundary>
+        <react.ViewServerProvider healthPollInterval={false} url="ws://127.0.0.1:1/rpc">
+          <HealthView />
+        </react.ViewServerProvider>
+      </ProviderErrorBoundary>,
+    );
+    await expect.element(provider.getByRole("alert")).toBeVisible();
+    await provider.unmount();
+    consoleError.mockRestore();
+  });
+
+  it("surfaces remote provider connection failures through error boundaries", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    function HealthView() {
+      const health = useViewServerHealth();
+      return <output role="status">{health.status}</output>;
+    }
+
+    const failedProvider = await render(
+      <ProviderErrorBoundary>
+        <react.ViewServerProvider url="ws://127.0.0.1:1/rpc">
+          <HealthView />
+        </react.ViewServerProvider>
+      </ProviderErrorBoundary>,
+    );
+    await expect.element(failedProvider.getByRole("alert")).toBeVisible();
+    await failedProvider.unmount();
+    consoleError.mockRestore();
   });
 
   it("closes live subscriptions when browser components unmount", async () => {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -6,6 +6,7 @@ import {
   stableQueryKey,
   type ViewServerLiveClient,
 } from "@view-server/client";
+import { makeViewServerClient, type ViewServerClientOptions } from "@view-server/client/remote";
 import type {
   ExactRawQuery,
   LiveQueryResult,
@@ -16,20 +17,28 @@ import type {
   ViewServerConfig,
   ViewServerHealth,
 } from "@view-server/config";
-import { Effect, Stream } from "effect";
+import { Duration, Effect, Stream } from "effect";
 import * as Atom from "effect/unstable/reactivity/Atom";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { createContext, useContext, useMemo, type ReactNode } from "react";
-import { ViewServerReactConfig } from "./internal";
+import { ViewServerReactClientProvider, ViewServerReactConfig } from "./internal";
 
 export type ViewServerReactBindings<Topics extends TopicDefinitions> = {
   readonly [ViewServerReactConfig]: ViewServerConfig<Topics>;
+  readonly [ViewServerReactClientProvider]: (
+    props: ViewServerClientProviderProps<Topics>,
+  ) => ReactNode;
   readonly useLiveQuery: UseLiveQueryHook<Topics>;
   readonly useViewServerHealth: () => ViewServerHealth<Topics>;
-  readonly ViewServerProvider: (props: ViewServerProviderProps<Topics>) => ReactNode;
+  readonly ViewServerProvider: (props: ViewServerProviderProps) => ReactNode;
 };
 
-export type ViewServerProviderProps<Topics extends TopicDefinitions> = {
+type ViewServerClientProviderProps<Topics extends TopicDefinitions> = {
   readonly client: ViewServerLiveClient<Topics>;
+  readonly children?: ReactNode;
+};
+
+export type ViewServerProviderProps = ViewServerClientOptions & {
   readonly children?: ReactNode;
 };
 
@@ -50,6 +59,18 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
 ): ViewServerReactBindings<Topics> => {
   const ClientContext = createContext<ViewServerLiveClient<Topics> | null>(null);
+  const RemoteClientAtom = AtomReact.make((options: ViewServerClientOptions) =>
+    Atom.make((get) =>
+      Effect.gen(function* () {
+        const services = yield* Effect.context();
+        const client = yield* makeViewServerClient(config, options);
+        get.addFinalizer(() => {
+          Effect.runForkWith(services)(client.close);
+        });
+        return client;
+      }),
+    ),
+  );
 
   const useClient = (): ViewServerLiveClient<Topics> => {
     const client = useContext(ClientContext);
@@ -59,10 +80,57 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
     return client;
   };
 
-  function ViewServerProvider(props: ViewServerProviderProps<Topics>): ReactNode {
+  function ViewServerClientProvider(props: ViewServerClientProviderProps<Topics>): ReactNode {
     return (
       <AtomReact.RegistryProvider>
         <ClientContext.Provider value={props.client}>{props.children}</ClientContext.Provider>
+      </AtomReact.RegistryProvider>
+    );
+  }
+
+  function RemoteClientBoundary(props: { readonly children?: ReactNode }): ReactNode {
+    const result = AtomReact.useAtomValue(RemoteClientAtom.use());
+    if (AsyncResult.isSuccess(result)) {
+      return <ClientContext.Provider value={result.value}>{props.children}</ClientContext.Provider>;
+    }
+    if (AsyncResult.isFailure(result)) {
+      throw new Error(String(result.cause));
+    }
+    return null;
+  }
+
+  const providerKeyFromHealthPollInterval = (
+    interval: ViewServerProviderProps["healthPollInterval"],
+  ): string => {
+    if (interval === undefined) {
+      return "default";
+    }
+    if (interval === false) {
+      return "false";
+    }
+    return Duration.fromInputUnsafe(interval).toString();
+  };
+
+  function ViewServerProvider(props: ViewServerProviderProps): ReactNode {
+    const options = {
+      url: props.url,
+      ...(props.subscriptionBufferSize === undefined
+        ? {}
+        : { subscriptionBufferSize: props.subscriptionBufferSize }),
+      ...(props.healthPollInterval === undefined
+        ? {}
+        : { healthPollInterval: props.healthPollInterval }),
+    } satisfies ViewServerClientOptions;
+    const providerKey = [
+      props.url,
+      String(props.subscriptionBufferSize ?? ""),
+      providerKeyFromHealthPollInterval(props.healthPollInterval),
+    ].join(":");
+    return (
+      <AtomReact.RegistryProvider>
+        <RemoteClientAtom.Provider key={providerKey} value={options}>
+          <RemoteClientBoundary>{props.children}</RemoteClientBoundary>
+        </RemoteClientAtom.Provider>
       </AtomReact.RegistryProvider>
     );
   }
@@ -99,6 +167,7 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
 
   return {
     [ViewServerReactConfig]: config,
+    [ViewServerReactClientProvider]: ViewServerClientProvider,
     useLiveQuery,
     useViewServerHealth,
     ViewServerProvider,

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,1 +1,4 @@
 export const ViewServerReactConfig: unique symbol = Symbol("ViewServerReact.config");
+export const ViewServerReactClientProvider: unique symbol = Symbol(
+  "ViewServerReact.clientProvider",
+);

--- a/packages/react/src/testing.tsx
+++ b/packages/react/src/testing.tsx
@@ -9,7 +9,7 @@ import { Effect } from "effect";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import type { ReactNode } from "react";
 import type { ViewServerReactBindings } from "./index";
-import { ViewServerReactConfig } from "./internal";
+import { ViewServerReactClientProvider, ViewServerReactConfig } from "./internal";
 
 export type { ViewServerInMemoryOptions } from "@view-server/in-memory";
 
@@ -36,7 +36,7 @@ export const createInMemoryViewServerReact = <const Topics extends DecodableTopi
   react: ViewServerReactBindings<Topics>,
   options: ViewServerInMemoryOptions = {},
 ): ViewServerInMemoryReactInstance<Topics> => {
-  const { ViewServerProvider } = react;
+  const ViewServerClientProvider = react[ViewServerReactClientProvider];
   const inMemory = createInMemoryViewServer(react[ViewServerReactConfig], options);
 
   function InMemoryLifetimeMount(): null {
@@ -47,10 +47,10 @@ export const createInMemoryViewServerReact = <const Topics extends DecodableTopi
   function ViewServerInMemoryProvider(props: ViewServerInMemoryProviderProps): ReactNode {
     return (
       <InMemoryLifetimeAtom.Provider value={inMemory.close}>
-        <ViewServerProvider client={inMemory.liveClient}>
+        <ViewServerClientProvider client={inMemory.liveClient}>
           <InMemoryLifetimeMount />
           {props.children}
-        </ViewServerProvider>
+        </ViewServerClientProvider>
       </InMemoryLifetimeAtom.Provider>
     );
   }


### PR DESCRIPTION
## Summary
- Make the public React ViewServerProvider accept a remote URL/options instead of a caller-owned client
- Keep the client-backed provider as an internal symbol seam for testing/in-memory helpers
- Add remote provider lifecycle coverage, URL rerender coverage, bigint Duration.Input coverage, and no try/catch/finally test guidance

## Validation
- pnpm run ready
- pnpm --filter @view-server/react run test
- pnpm exec effect-language-service diagnostics --project packages/react/tsconfig.json --format text --strict
- vp check --fix
- forbidden pattern scans for React/provider changes

## Review
- 3 subagent review pass: no blockers after fixes