### PR TITLE
Deepen topic store transaction module

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -7,7 +7,12 @@ import {
   releaseRawQueryExecution,
 } from "./active-query";
 import { prepareRawQuery } from "./raw-query-compiler";
-import { publishTopicStoreRow, TopicStore } from "./topic-store";
+import {
+  publishTopicStoreRow,
+  TopicStore,
+  topicStoreRawQueryMetadata,
+  topicStoreReadModel,
+} from "./topic-store";
 
 const invalidRow = (_topic: string, message: string): Error => new Error(message);
 
@@ -46,7 +51,7 @@ describe("column-live-view-engine active query execution", () => {
         invalidRow,
       );
 
-      const compiled = yield* prepareRawQuery("scores", store.rawQueryMetadata, {
+      const compiled = yield* prepareRawQuery("scores", topicStoreRawQueryMetadata(store), {
         select: ["id", "score", "count", "value"],
         where: {
           status: "open",
@@ -59,9 +64,9 @@ describe("column-live-view-engine active query execution", () => {
         ],
       });
 
-      const firstExecution = yield* acquireRawQueryExecution(store, compiled);
-      const secondExecution = yield* acquireRawQueryExecution(store, compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(1);
+      const firstExecution = yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+      const secondExecution = yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
 
       const firstCursor = firstExecution.createCursor();
       const secondCursor = secondExecution.createCursor();
@@ -94,20 +99,26 @@ describe("column-live-view-engine active query execution", () => {
       expect(afterPublishFirst._tag).toBe("Some");
       expect(afterPublishSecond._tag).toBe("Some");
 
-      yield* releaseRawQueryExecution(store, compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(1);
-      const afterRefcountDecrement = yield* acquireRawQueryExecution(store, compiled);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      const afterRefcountDecrement = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        compiled,
+      );
       expect(afterRefcountDecrement.initial("query-c").totalRows).toBe(2);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
 
-      yield* releaseRawQueryExecution(store, compiled);
-      yield* releaseRawQueryExecution(store, compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(0);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
 
-      const afterRefcountExhausted = yield* acquireRawQueryExecution(store, compiled);
+      const afterRefcountExhausted = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        compiled,
+      );
       expect(afterRefcountExhausted.initial("query-d").totalRows).toBe(2);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(1);
-      yield* releaseRawQueryExecution(store, compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
     }),
   );
 
@@ -126,34 +137,45 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
       yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
 
-      const idOnly = yield* prepareRawQuery("projection-sharing", store.rawQueryMetadata, {
-        select: ["id"],
-        where: {
-          status: "open",
+      const idOnly = yield* prepareRawQuery(
+        "projection-sharing",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
         },
-        orderBy: [{ field: "score", direction: "desc" }],
-      });
-      const idAndScore = yield* prepareRawQuery("projection-sharing", store.rawQueryMetadata, {
-        select: ["id", "score"],
-        where: {
-          status: "open",
+      );
+      const idAndScore = yield* prepareRawQuery(
+        "projection-sharing",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
         },
-        orderBy: [{ field: "score", direction: "desc" }],
-      });
+      );
 
-      const idOnlyExecution = yield* acquireRawQueryExecution(store, idOnly);
-      const idAndScoreExecution = yield* acquireRawQueryExecution(store, idAndScore);
+      const idOnlyExecution = yield* acquireRawQueryExecution(topicStoreReadModel(store), idOnly);
+      const idAndScoreExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        idAndScore,
+      );
 
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
       expect(idOnlyExecution.initial("ids").rows).toStrictEqual([{ id: "b" }, { id: "a" }]);
       expect(idAndScoreExecution.initial("scores").rows).toStrictEqual([
         { id: "b", score: 2 },
         { id: "a", score: 1 },
       ]);
 
-      yield* releaseRawQueryExecution(store, idOnly);
-      yield* releaseRawQueryExecution(store, idAndScore);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(0);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), idOnly);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), idAndScore);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
     }),
   );
 
@@ -165,14 +187,14 @@ describe("column-live-view-engine active query execution", () => {
         "id",
         () => {},
       );
-      const compiled = yield* prepareRawQuery("numbers", store.rawQueryMetadata, {
+      const compiled = yield* prepareRawQuery("numbers", topicStoreRawQueryMetadata(store), {
         select: ["id"],
         where: {
           score: 1,
         },
       });
 
-      yield* releaseRawQueryExecution(store, compiled);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
     }),
   );
 
@@ -205,65 +227,115 @@ describe("column-live-view-engine active query execution", () => {
         invalidRow,
       );
 
-      const infFilter = yield* prepareRawQuery("numbers", numericStore.rawQueryMetadata, {
-        select: ["id", "score"],
-        where: {
-          score: Number.POSITIVE_INFINITY,
+      const infFilter = yield* prepareRawQuery(
+        "numbers",
+        topicStoreRawQueryMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: Number.POSITIVE_INFINITY,
+          },
         },
-      });
-      const nanFilter = yield* prepareRawQuery("numbers", numericStore.rawQueryMetadata, {
-        select: ["id", "score"],
-        where: {
-          score: Number.NaN,
+      );
+      const nanFilter = yield* prepareRawQuery(
+        "numbers",
+        topicStoreRawQueryMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: Number.NaN,
+          },
         },
-      });
-      const zeroFilter = yield* prepareRawQuery("numbers", numericStore.rawQueryMetadata, {
-        select: ["id", "score"],
-        where: {
-          score: 10,
+      );
+      const zeroFilter = yield* prepareRawQuery(
+        "numbers",
+        topicStoreRawQueryMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: 10,
+          },
         },
-      });
-      const positiveZeroFilter = yield* prepareRawQuery("numbers", numericStore.rawQueryMetadata, {
-        select: ["id", "score"],
-        where: {
-          score: 0,
+      );
+      const positiveZeroFilter = yield* prepareRawQuery(
+        "numbers",
+        topicStoreRawQueryMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: 0,
+          },
         },
-      });
-      const negativeZeroFilter = yield* prepareRawQuery("numbers", numericStore.rawQueryMetadata, {
-        select: ["id", "score"],
-        where: {
-          score: -0,
+      );
+      const negativeZeroFilter = yield* prepareRawQuery(
+        "numbers",
+        topicStoreRawQueryMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: -0,
+          },
         },
-      });
-      const offsetFilter = yield* prepareRawQuery("numbers", numericStore.rawQueryMetadata, {
-        select: ["id", "score"],
-        offset: 1,
-      });
-      const bigIntFilter = yield* prepareRawQuery("bigints", bigintStore.rawQueryMetadata, {
-        select: ["id", "amount"],
-        where: {
-          amount: 3n,
+      );
+      const offsetFilter = yield* prepareRawQuery(
+        "numbers",
+        topicStoreRawQueryMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          offset: 1,
         },
-      });
-      const decimalFilter = yield* prepareRawQuery("decimals", decimalStore.rawQueryMetadata, {
-        select: ["id", "price"],
-        where: {
-          price: fromStringUnsafe("1.23"),
+      );
+      const bigIntFilter = yield* prepareRawQuery(
+        "bigints",
+        topicStoreRawQueryMetadata(bigintStore),
+        {
+          select: ["id", "amount"],
+          where: {
+            amount: 3n,
+          },
         },
-      });
+      );
+      const decimalFilter = yield* prepareRawQuery(
+        "decimals",
+        topicStoreRawQueryMetadata(decimalStore),
+        {
+          select: ["id", "price"],
+          where: {
+            price: fromStringUnsafe("1.23"),
+          },
+        },
+      );
 
-      const infExecution = yield* acquireRawQueryExecution(numericStore, infFilter);
-      const nanExecution = yield* acquireRawQueryExecution(numericStore, nanFilter);
-      const zeroExecution = yield* acquireRawQueryExecution(numericStore, zeroFilter);
-      yield* acquireRawQueryExecution(numericStore, positiveZeroFilter);
-      yield* acquireRawQueryExecution(numericStore, negativeZeroFilter);
-      const offsetExecution = yield* acquireRawQueryExecution(numericStore, offsetFilter);
-      const bigintExecution = yield* acquireRawQueryExecution(bigintStore, bigIntFilter);
-      const decimalExecution = yield* acquireRawQueryExecution(decimalStore, decimalFilter);
+      const infExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(numericStore),
+        infFilter,
+      );
+      const nanExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(numericStore),
+        nanFilter,
+      );
+      const zeroExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(numericStore),
+        zeroFilter,
+      );
+      yield* acquireRawQueryExecution(topicStoreReadModel(numericStore), positiveZeroFilter);
+      yield* acquireRawQueryExecution(topicStoreReadModel(numericStore), negativeZeroFilter);
+      const offsetExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(numericStore),
+        offsetFilter,
+      );
+      const bigintExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(bigintStore),
+        bigIntFilter,
+      );
+      const decimalExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(decimalStore),
+        decimalFilter,
+      );
 
-      expect(yield* activeStoreRawQueryExecutionCount(numericStore)).toBe(6);
-      expect(yield* activeStoreRawQueryExecutionCount(bigintStore)).toBe(1);
-      expect(yield* activeStoreRawQueryExecutionCount(decimalStore)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(numericStore))).toBe(6);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(bigintStore))).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(decimalStore))).toBe(1);
 
       const infCursor = infExecution.createCursor();
       const nanCursor = nanExecution.createCursor();
@@ -286,14 +358,14 @@ describe("column-live-view-engine active query execution", () => {
       expect((yield* bigintExecution.next("q", bigintCursor))._tag).toBe("None");
       expect((yield* decimalExecution.next("q", decimalCursor))._tag).toBe("None");
 
-      yield* releaseRawQueryExecution(numericStore, infFilter);
-      yield* releaseRawQueryExecution(numericStore, nanFilter);
-      yield* releaseRawQueryExecution(numericStore, zeroFilter);
-      yield* releaseRawQueryExecution(numericStore, positiveZeroFilter);
-      yield* releaseRawQueryExecution(numericStore, negativeZeroFilter);
-      yield* releaseRawQueryExecution(numericStore, offsetFilter);
-      yield* releaseRawQueryExecution(bigintStore, bigIntFilter);
-      yield* releaseRawQueryExecution(decimalStore, decimalFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), infFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), nanFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), zeroFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), positiveZeroFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), negativeZeroFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), offsetFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(bigintStore), bigIntFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(decimalStore), decimalFilter);
     }),
   );
 
@@ -327,44 +399,71 @@ describe("column-live-view-engine active query execution", () => {
         invalidRow,
       );
 
-      const undefinedFilter = yield* prepareRawQuery("events", eventStore.rawQueryMetadata, {
-        select: ["id", "label"],
-        where: {
-          label: undefined,
+      const undefinedFilter = yield* prepareRawQuery(
+        "events",
+        topicStoreRawQueryMetadata(eventStore),
+        {
+          select: ["id", "label"],
+          where: {
+            label: undefined,
+          },
         },
-      });
-      const nullFilter = yield* prepareRawQuery("events", eventStore.rawQueryMetadata, {
+      );
+      const nullFilter = yield* prepareRawQuery("events", topicStoreRawQueryMetadata(eventStore), {
         select: ["id", "label"],
         where: {
           label: null,
         },
       });
-      const arrayFilter = yield* prepareRawQuery("events", eventStore.rawQueryMetadata, {
+      const arrayFilter = yield* prepareRawQuery("events", topicStoreRawQueryMetadata(eventStore), {
         select: ["id", "tags"],
         where: {
           tags: ["open", "closed"],
         },
       });
-      const objectFilter = yield* prepareRawQuery("events", eventStore.rawQueryMetadata, {
-        select: ["id", "metadata"],
-        where: {
-          metadata: { kind: "test", scope: "global" },
+      const objectFilter = yield* prepareRawQuery(
+        "events",
+        topicStoreRawQueryMetadata(eventStore),
+        {
+          select: ["id", "metadata"],
+          where: {
+            metadata: { kind: "test", scope: "global" },
+          },
         },
-      });
-      const booleanFilter = yield* prepareRawQuery("events", eventStore.rawQueryMetadata, {
-        select: ["id", "active"],
-        where: {
-          active: true,
+      );
+      const booleanFilter = yield* prepareRawQuery(
+        "events",
+        topicStoreRawQueryMetadata(eventStore),
+        {
+          select: ["id", "active"],
+          where: {
+            active: true,
+          },
         },
-      });
+      );
 
-      const undefinedExecution = yield* acquireRawQueryExecution(eventStore, undefinedFilter);
-      const nullExecution = yield* acquireRawQueryExecution(eventStore, nullFilter);
-      const arrayExecution = yield* acquireRawQueryExecution(eventStore, arrayFilter);
-      const objectExecution = yield* acquireRawQueryExecution(eventStore, objectFilter);
-      const booleanExecution = yield* acquireRawQueryExecution(eventStore, booleanFilter);
+      const undefinedExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(eventStore),
+        undefinedFilter,
+      );
+      const nullExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(eventStore),
+        nullFilter,
+      );
+      const arrayExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(eventStore),
+        arrayFilter,
+      );
+      const objectExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(eventStore),
+        objectFilter,
+      );
+      const booleanExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(eventStore),
+        booleanFilter,
+      );
 
-      expect(yield* activeStoreRawQueryExecutionCount(eventStore)).toBe(5);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(eventStore))).toBe(5);
 
       expect(undefinedExecution.initial("query").totalRows).toBe(0);
       expect(nullExecution.initial("query").totalRows).toBe(0);
@@ -384,11 +483,11 @@ describe("column-live-view-engine active query execution", () => {
       expect((yield* objectExecution.next("query", objectCursor))._tag).toBe("None");
       expect((yield* booleanExecution.next("query", booleanCursor))._tag).toBe("None");
 
-      yield* releaseRawQueryExecution(eventStore, undefinedFilter);
-      yield* releaseRawQueryExecution(eventStore, nullFilter);
-      yield* releaseRawQueryExecution(eventStore, arrayFilter);
-      yield* releaseRawQueryExecution(eventStore, objectFilter);
-      yield* releaseRawQueryExecution(eventStore, booleanFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), undefinedFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), nullFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), arrayFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), objectFilter);
+      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), booleanFilter);
     }),
   );
 
@@ -405,22 +504,26 @@ describe("column-live-view-engine active query execution", () => {
         "id",
         () => {},
       );
-      const splitFieldsQuery = yield* prepareRawQuery("delimiter-fields", store.rawQueryMetadata, {
-        select: ["id"],
-        orderBy: [
-          {
-            field: "a",
-            direction: "asc",
-          },
-          {
-            field: "b",
-            direction: "desc",
-          },
-        ],
-      });
+      const splitFieldsQuery = yield* prepareRawQuery(
+        "delimiter-fields",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          orderBy: [
+            {
+              field: "a",
+              direction: "asc",
+            },
+            {
+              field: "b",
+              direction: "desc",
+            },
+          ],
+        },
+      );
       const delimiterFieldQuery = yield* prepareRawQuery(
         "delimiter-fields",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id"],
           orderBy: [
@@ -432,13 +535,13 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      yield* acquireRawQueryExecution(store, splitFieldsQuery);
-      yield* acquireRawQueryExecution(store, delimiterFieldQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), splitFieldsQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), delimiterFieldQuery);
 
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(2);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(2);
 
-      yield* releaseRawQueryExecution(store, splitFieldsQuery);
-      yield* releaseRawQueryExecution(store, delimiterFieldQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), splitFieldsQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), delimiterFieldQuery);
     }),
   );
 
@@ -460,22 +563,22 @@ describe("column-live-view-engine active query execution", () => {
       queryPayload["value"] = 1n;
       queryPayload["label"] = "special";
 
-      const compiled = yield* prepareRawQuery("special", store.rawQueryMetadata, {
+      const compiled = yield* prepareRawQuery("special", topicStoreRawQueryMetadata(store), {
         select: ["id", "payload"],
         where: {
           payload: queryPayload,
         },
       });
 
-      const execution = yield* acquireRawQueryExecution(store, compiled);
+      const execution = yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
       const cursor = execution.createCursor();
 
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
       expect(execution.initial("query").rows).toStrictEqual([]);
       expect((yield* execution.next("query", cursor))._tag).toBe("None");
 
-      yield* releaseRawQueryExecution(store, compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(0);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
     }),
   );
 
@@ -503,7 +606,7 @@ describe("column-live-view-engine active query execution", () => {
 
       const firstFunctionQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -513,7 +616,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const matchingFirstFunctionQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -523,7 +626,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const secondFunctionQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -533,7 +636,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const anonymousFunctionQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -543,7 +646,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const firstSymbolQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -553,7 +656,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const secondSymbolQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -563,7 +666,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const firstMapQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -573,7 +676,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const secondMapQuery = yield* prepareRawQuery(
         "special-non-serializable",
-        store.rawQueryMetadata,
+        topicStoreRawQueryMetadata(store),
         {
           select: ["id", "marker"],
           where: {
@@ -582,29 +685,32 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const firstFunctionExecution = yield* acquireRawQueryExecution(store, firstFunctionQuery);
-      yield* acquireRawQueryExecution(store, matchingFirstFunctionQuery);
-      yield* acquireRawQueryExecution(store, secondFunctionQuery);
-      yield* acquireRawQueryExecution(store, anonymousFunctionQuery);
-      yield* acquireRawQueryExecution(store, firstSymbolQuery);
-      yield* acquireRawQueryExecution(store, secondSymbolQuery);
-      yield* acquireRawQueryExecution(store, firstMapQuery);
-      yield* acquireRawQueryExecution(store, secondMapQuery);
+      const firstFunctionExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        firstFunctionQuery,
+      );
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), matchingFirstFunctionQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), secondFunctionQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), anonymousFunctionQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), firstSymbolQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), secondSymbolQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), firstMapQuery);
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), secondMapQuery);
 
       const cursor = firstFunctionExecution.createCursor();
 
-      expect(yield* activeStoreRawQueryExecutionCount(store)).toBe(7);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(7);
       expect(firstFunctionExecution.initial("query").totalRows).toBe(0);
       expect((yield* firstFunctionExecution.next("query", cursor))._tag).toBe("None");
 
-      yield* releaseRawQueryExecution(store, firstFunctionQuery);
-      yield* releaseRawQueryExecution(store, matchingFirstFunctionQuery);
-      yield* releaseRawQueryExecution(store, secondFunctionQuery);
-      yield* releaseRawQueryExecution(store, anonymousFunctionQuery);
-      yield* releaseRawQueryExecution(store, firstSymbolQuery);
-      yield* releaseRawQueryExecution(store, secondSymbolQuery);
-      yield* releaseRawQueryExecution(store, firstMapQuery);
-      yield* releaseRawQueryExecution(store, secondMapQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstFunctionQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), matchingFirstFunctionQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondFunctionQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), anonymousFunctionQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstSymbolQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondSymbolQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstMapQuery);
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondMapQuery);
     }),
   );
 });

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -2,15 +2,15 @@ import { Effect, Option } from "effect";
 import { isBigDecimal } from "effect/BigDecimal";
 import type { DeltaEvent, SnapshotEvent } from "@view-server/config";
 import { type CompiledRawQuery, type RuntimeRawQuery } from "./raw-query-compiler";
+import type { RawQueryRowStore } from "./raw-query-compiler";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
 import { isPlainRecord } from "./row-values";
 
 type RowObject = object;
 
-type ActiveQueryStoreState = {
-  readonly rows: ReadonlyMap<string, object>;
-  readonly version: number;
+export type ActiveQueryStoreState = RawQueryRowStore<object> & {
+  readonly identity: object;
   readonly topic: string;
 };
 
@@ -49,7 +49,7 @@ type ActiveQueryBaseEvaluation = {
   readonly version: number;
 };
 
-type QueryExecutionCache = WeakMap<ActiveQueryStoreState, Map<string, RawQueryExecutionSlot>>;
+type QueryExecutionCache = WeakMap<object, Map<string, RawQueryExecutionSlot>>;
 
 const activeQueryExecutionCache: QueryExecutionCache = new WeakMap();
 
@@ -173,12 +173,12 @@ const queryCacheKey = (query: RuntimeRawQuery): string => {
 };
 
 const getActiveQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryExecutionSlot> => {
-  const existing = activeQueryExecutionCache.get(store);
+  const existing = activeQueryExecutionCache.get(store.identity);
   if (existing !== undefined) {
     return existing;
   }
   const created = new Map<string, RawQueryExecutionSlot>();
-  activeQueryExecutionCache.set(store, created);
+  activeQueryExecutionCache.set(store.identity, created);
   return created;
 };
 
@@ -198,7 +198,9 @@ const evaluateBaseQuery = (
   store: ActiveQueryStoreState,
   compiled: CompiledRawQuery<object, object>,
 ): ActiveQueryBaseEvaluation => {
-  const filtered = Array.from(store.rows, ([key, row]) => ({ key, row })).filter((entry) =>
+  const storeRows = store.rows();
+  const storeVersion = store.version();
+  const filtered = Array.from(storeRows, ([key, row]) => ({ key, row })).filter((entry) =>
     compiled.matches(entry.row),
   );
   const ordered = filtered.toSorted(compiled.compare);
@@ -212,7 +214,7 @@ const evaluateBaseQuery = (
     keys: window.map((entry) => entry.key),
     window,
     totalRows: filtered.length,
-    version: store.version,
+    version: storeVersion,
   };
 };
 
@@ -265,14 +267,15 @@ export const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery
     Effect.sync(() => {
       let snapshot = {
         evaluation: evaluateBaseQuery(store, canonicalCompiled),
-        version: store.version,
+        version: store.version(),
       };
 
       const latest = () => {
-        if (snapshot.version !== store.version) {
+        const storeVersion = store.version();
+        if (snapshot.version !== storeVersion) {
           snapshot = {
             evaluation: evaluateBaseQuery(store, canonicalCompiled),
-            version: store.version,
+            version: storeVersion,
           };
         }
         return snapshot.evaluation;
@@ -324,7 +327,7 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
       }
       map.delete(key);
       if (map.size === 0) {
-        activeQueryExecutionCache.delete(store);
+        activeQueryExecutionCache.delete(store.identity);
       }
       return undefined;
     }),
@@ -334,12 +337,12 @@ export const clearStoreRawQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.clearStore",
 )((store: ActiveQueryStoreState) =>
   Effect.sync(() => {
-    activeQueryExecutionCache.delete(store);
+    activeQueryExecutionCache.delete(store.identity);
   }),
 );
 
 export const activeStoreRawQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.countStore",
 )((store: ActiveQueryStoreState) =>
-  Effect.sync(() => activeQueryExecutionCache.get(store)?.size ?? 0),
+  Effect.sync(() => activeQueryExecutionCache.get(store.identity)?.size ?? 0),
 );

--- a/packages/column-live-view-engine/src/engine-health.ts
+++ b/packages/column-live-view-engine/src/engine-health.ts
@@ -56,22 +56,22 @@ export const collectColumnLiveViewEngineHealth = Effect.fn("ColumnLiveViewEngine
       backpressureEvents += topicBackpressureEvents;
       topics[topic] = {
         status: topicHealth.status,
-        rowCount: store.rows.size,
-        liveRowCount: store.rows.size,
-        deletedRowCount: 0,
+        rowCount: topicHealth.rowCount,
+        liveRowCount: topicHealth.liveRowCount,
+        deletedRowCount: topicHealth.deletedRowCount,
         version: topicHealth.version,
-        lastMutationAt: null,
-        mutationsPerSecond: 0,
-        rowsPerSecond: 0,
-        pendingMutationBatches: 0,
+        lastMutationAt: topicHealth.lastMutationAt,
+        mutationsPerSecond: topicHealth.mutationsPerSecond,
+        rowsPerSecond: topicHealth.rowsPerSecond,
+        pendingMutationBatches: topicHealth.pendingMutationBatches,
         activeViews: topicHealth.activeViews,
         activeSubscriptions: topicHealth.activeSubscriptions,
         queuedEvents: topicQueuedEvents,
         maxQueueDepth: topicMaxQueueDepth,
         backpressureEvents: topicBackpressureEvents,
-        memoryBytes: 0,
-        tombstoneCount: 0,
-        compactionPending: false,
+        memoryBytes: topicHealth.memoryBytes,
+        tombstoneCount: topicHealth.tombstoneCount,
+        compactionPending: topicHealth.compactionPending,
       };
     }
 

--- a/packages/column-live-view-engine/src/index.test-d.ts
+++ b/packages/column-live-view-engine/src/index.test-d.ts
@@ -19,6 +19,7 @@ import type {
   ColumnLiveViewTopicHealth,
   EngineClosedError,
 } from "./index";
+import type { TopicStore } from "./topic-store";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -388,5 +389,12 @@ describe("ColumnLiveViewEngine type contract", () => {
     void _groupedSubscription;
     void _groupedVariableSnapshot;
     void _groupedVariableSubscription;
+  });
+
+  it("keeps TopicStore nominal inside engine internals", () => {
+    const fakeTopicStore = { topic: "orders" };
+    // @ts-expect-error TopicStore cannot be structurally faked with only the public topic field.
+    const topicStore: TopicStore = fakeTopicStore;
+    expectTypeOf(topicStore).toEqualTypeOf<TopicStore>();
   });
 });

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -6,7 +6,7 @@ import {
   type SnapshotEvent,
   type StatusEvent,
 } from "@view-server/config";
-import { Cause, Effect, Schema, Scope, Stream } from "effect";
+import { Cause, Deferred, Effect, Exit, Fiber, Schema, Scope, Stream } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
 import {
   createColumnLiveViewEngine,
@@ -19,7 +19,23 @@ import {
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
 } from "./index";
+import { acquireRawQueryExecution, activeStoreRawQueryExecutionCount } from "./active-query";
+import {
+  acquireLiveSubscriptionHandoff,
+  closeInterruptedAcquiredSubscription,
+  type LiveTopicSubscriber,
+} from "./live-subscription";
+import { prepareRawQuery } from "./raw-query-compiler";
 import { cloneRecord, cloneRow, fieldValue, rowsEqual } from "./row-values";
+import {
+  closeTopicStoreSubscriptions,
+  collectTopicStoreHealth,
+  registerTopicStoreSubscription,
+  resetTopicStore,
+  TopicStore,
+  topicStoreRawQueryMetadata,
+  topicStoreReadModel,
+} from "./topic-store";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -964,6 +980,54 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       yield* firstSubscription.close();
       yield* secondSubscription.close();
+
+      const closed = yield* engine.health();
+      expect(closed.topics["orders"].activeViews).toBe(0);
+    }),
+  );
+
+  it.effect("keeps shared active-query projections separate across deltas", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("a", "open", 10, 1), order("b", "open", 20, 2)]);
+
+      const baseQuery = {
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+      } satisfies Omit<RawQuery<OrderRow>, "select">;
+      const idSubscription = yield* engine.subscribe("orders", {
+        ...baseQuery,
+        select: ["id"],
+      });
+      const priceSubscription = yield* engine.subscribe("orders", {
+        ...baseQuery,
+        select: ["id", "price"],
+      });
+      const takeId = yield* makeEventReader(idSubscription);
+      const takePrice = yield* makeEventReader(priceSubscription);
+      let idState = stateFromSnapshot(firstEvent(yield* takeId(1)));
+      let priceState = stateFromSnapshot(firstEvent(yield* takePrice(1)));
+
+      const shared = yield* engine.health();
+      expect(shared.topics["orders"].activeViews).toBe(1);
+
+      yield* engine.patch("orders", "a", { price: 30 });
+      idState = expectDeltaConverges(idState, firstEvent(yield* takeId(1)), [
+        { id: "b" },
+        { id: "a" },
+      ]);
+      priceState = expectDeltaConverges(priceState, firstEvent(yield* takePrice(1)), [
+        { id: "b", price: 20 },
+        { id: "a", price: 30 },
+      ]);
+
+      yield* idSubscription.close();
+      yield* priceSubscription.close();
+
+      const closed = yield* engine.health();
+      expect(closed.topics["orders"].activeViews).toBe(0);
     }),
   );
 
@@ -1066,6 +1130,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       const closed = yield* engine.health();
       expect(closed.topics["orders"].activeSubscriptions).toBe(0);
+      expect(closed.topics["orders"].activeViews).toBe(0);
       expect(closed.activeSubscriptions).toBe(0);
     }),
   );
@@ -1112,6 +1177,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       const health = yield* engine.health();
       expect(health.topics["orders"].activeSubscriptions).toBe(0);
+      expect(health.topics["orders"].activeViews).toBe(0);
       expect(health.activeSubscriptions).toBe(0);
     }),
   );
@@ -1139,6 +1205,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       const health = yield* engine.health();
       expect(health.topics["orders"].activeSubscriptions).toBe(0);
+      expect(health.topics["orders"].activeViews).toBe(0);
       expect(health.activeSubscriptions).toBe(0);
     }),
   );
@@ -1158,7 +1225,169 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       const health = yield* engine.health();
       expect(health.status).toBe("stopping");
       expect(health.topics["orders"].activeSubscriptions).toBe(0);
+      expect(health.topics["orders"].activeViews).toBe(0);
       expect(health.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("only closes acquired subscriptions for interrupted exits", () =>
+    Effect.gen(function* () {
+      let closeCount = 0;
+      const subscription = {
+        events: Stream.empty,
+        close: () =>
+          Effect.sync(() => {
+            closeCount += 1;
+          }),
+      };
+
+      yield* closeInterruptedAcquiredSubscription(Exit.succeed(undefined), subscription);
+      yield* closeInterruptedAcquiredSubscription(Exit.interrupt(1), undefined);
+      expect(closeCount).toBe(0);
+
+      yield* closeInterruptedAcquiredSubscription(Exit.interrupt(1), subscription);
+      expect(closeCount).toBe(1);
+    }),
+  );
+
+  it.effect("closes acquired subscriptions when handoff is interrupted", () =>
+    Effect.gen(function* () {
+      const acquired = yield* Deferred.make<void>();
+      const keepHandoffOpen = yield* Deferred.make<void>();
+      let closeCount = 0;
+      const subscription = {
+        events: Stream.empty,
+        close: () =>
+          Effect.sync(() => {
+            closeCount += 1;
+          }),
+      };
+
+      const handoffFiber = yield* Effect.forkChild(
+        acquireLiveSubscriptionHandoff(
+          (markAcquired) =>
+            Effect.gen(function* () {
+              yield* markAcquired(subscription);
+              return subscription;
+            }),
+          {
+            beforeReturn: Effect.gen(function* () {
+              yield* Deferred.succeed(acquired, undefined);
+              yield* Deferred.await(keepHandoffOpen);
+            }),
+          },
+        ),
+      );
+
+      yield* Deferred.await(acquired);
+      yield* Fiber.interrupt(handoffFiber);
+      expect(closeCount).toBe(1);
+    }),
+  );
+
+  it.effect("closes acquired subscriptions when acquisition exits interrupted", () =>
+    Effect.gen(function* () {
+      const acquired = yield* Deferred.make<void>();
+      let closeCount = 0;
+      const subscription = {
+        events: Stream.empty,
+        close: () =>
+          Effect.sync(() => {
+            closeCount += 1;
+          }),
+      };
+
+      const handoffFiber = yield* Effect.forkChild(
+        acquireLiveSubscriptionHandoff((markAcquired) =>
+          Effect.uninterruptible(
+            Effect.gen(function* () {
+              yield* markAcquired(subscription);
+              yield* Deferred.succeed(acquired, undefined);
+              yield* Effect.sleep("10 millis");
+              return subscription;
+            }),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(acquired);
+      yield* Fiber.interrupt(handoffFiber);
+      expect(closeCount).toBe(1);
+    }),
+  );
+
+  it.effect("interrupted topic-store close still releases subscribers and active queries", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      const compiled = yield* prepareRawQuery("orders", topicStoreRawQueryMetadata(store), {
+        select: ["id"],
+      });
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+
+      const closeStarted = yield* Deferred.make<void>();
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-close",
+        notify: () => Effect.void,
+        queuedEvents: Effect.succeed(0),
+        end: Effect.void,
+        closeWithStatus: () =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(closeStarted, undefined);
+            yield* Effect.sleep("10 millis");
+          }),
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+      yield* registerTopicStoreSubscription(store, subscriber);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+
+      const closeFiber = yield* Effect.forkChild(closeTopicStoreSubscriptions(store));
+      yield* Deferred.await(closeStarted);
+      yield* Fiber.interrupt(closeFiber);
+
+      const health = yield* collectTopicStoreHealth(store, false);
+      expect(health.activeSubscriptions).toBe(0);
+      expect(health.activeViews).toBe(0);
+    }),
+  );
+
+  it.effect("interrupted topic-store reset still releases subscribers and active queries", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      const compiled = yield* prepareRawQuery("orders", topicStoreRawQueryMetadata(store), {
+        select: ["id"],
+      });
+      yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+
+      const closeStarted = yield* Deferred.make<void>();
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-reset",
+        notify: () => Effect.void,
+        queuedEvents: Effect.succeed(0),
+        end: Effect.void,
+        closeWithStatus: () =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(closeStarted, undefined);
+            yield* Effect.sleep("10 millis");
+          }),
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+      yield* registerTopicStoreSubscription(store, subscriber);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+
+      const resetFiber = yield* Effect.forkChild(resetTopicStore(store));
+      yield* Deferred.await(closeStarted);
+      yield* Fiber.interrupt(resetFiber);
+
+      const health = yield* collectTopicStoreHealth(store, false);
+      expect(health.activeSubscriptions).toBe(0);
+      expect(health.activeViews).toBe(0);
+      expect(health.version).toBe(0);
     }),
   );
 
@@ -1628,6 +1857,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(health.activeSubscriptions).toBe(0);
       expect(health.backpressureEvents).toBe(1);
       expect(health.topics["orders"].activeSubscriptions).toBe(0);
+      expect(health.topics["orders"].activeViews).toBe(0);
       expect(health.topics["orders"].backpressureEvents).toBe(1);
       expect(health.topics["orders"].maxQueueDepth).toBe(1);
 
@@ -1680,6 +1910,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       const health = yield* engine.health();
       expect(health.version).toBe(0);
       expect(health.activeSubscriptions).toBe(0);
+      expect(health.topics["orders"].activeViews).toBe(0);
     }),
   );
 

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -6,6 +6,7 @@ import type {
   DecodableTopicDefinitions,
 } from "./engine-contract";
 import { EngineClosedError, InvalidRowError, InvalidTopicError } from "./engine-errors";
+import { acquireLiveSubscriptionHandoff, type LiveSubscription } from "./live-subscription";
 import { collectColumnLiveViewEngineHealth } from "./engine-health";
 import { snapshotExecutableQuery, subscribeExecutableQuery } from "./query-execution";
 import {
@@ -16,6 +17,7 @@ import {
   publishTopicStoreRows,
   resetTopicStore,
   TopicStore,
+  withTopicStoreMutation,
 } from "./topic-store";
 
 export { InvalidQueryError } from "./raw-query-compiler";
@@ -168,16 +170,30 @@ class InMemoryColumnLiveViewEngine<
   >(this: InMemoryColumnLiveViewEngine<Topics>, topic: Topic, query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query>) {
     yield* this.ensureOpen();
     const store = yield* this.getStore(topic);
-    const subscription = yield* store.mutationSemaphore.withPermits(1)(
-      Effect.gen({ self: this }, function* () {
-        yield* this.ensureOpen();
-        const queryId = `query-${this.nextQueryId}`;
-        this.nextQueryId += 1;
-        return yield* subscribeExecutableQuery<
-          LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>
-        >(topic, store, query, { queryId, queueCapacity: this.subscriptionQueueCapacity });
-      }),
-    );
+    type ResultRow = LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>;
+    const acquireSubscription = (
+      markAcquired: (subscription: LiveSubscription<ResultRow>) => Effect.Effect<void>,
+    ) =>
+      withTopicStoreMutation(
+        store,
+        Effect.gen({ self: this }, function* () {
+          yield* this.ensureOpen();
+          const queryId = `query-${this.nextQueryId}`;
+          this.nextQueryId += 1;
+          const acquiredSubscription = yield* subscribeExecutableQuery<ResultRow>(
+            topic,
+            store,
+            query,
+            {
+              queryId,
+              queueCapacity: this.subscriptionQueueCapacity,
+            },
+          );
+          yield* markAcquired(acquiredSubscription);
+          return acquiredSubscription;
+        }),
+      );
+    const subscription = yield* acquireLiveSubscriptionHandoff(acquireSubscription);
 
     return {
       events: subscription.events,
@@ -198,22 +214,28 @@ class InMemoryColumnLiveViewEngine<
     { self: this },
     function* (this: InMemoryColumnLiveViewEngine<Topics>) {
       yield* this.ensureOpen();
-      for (const store of this.stores.values()) {
-        yield* resetTopicStore(store);
-      }
-      this.engineVersion = 0;
+      yield* Effect.uninterruptible(
+        Effect.gen({ self: this }, function* () {
+          for (const store of this.stores.values()) {
+            yield* resetTopicStore(store);
+          }
+          this.engineVersion = 0;
+        }),
+      );
     },
   );
 
   readonly close: ColumnLiveViewEngine<Topics>["close"] = Effect.fn("ColumnLiveViewEngine.close")(
     { self: this },
     function* (this: InMemoryColumnLiveViewEngine<Topics>) {
-      if (!this.closed) {
-        this.closed = true;
-        for (const store of this.stores.values()) {
-          yield* closeTopicStoreSubscriptions(store);
-        }
-      }
+      yield* Effect.uninterruptible(
+        Effect.gen({ self: this }, function* () {
+          this.closed = true;
+          for (const store of this.stores.values()) {
+            yield* closeTopicStoreSubscriptions(store);
+          }
+        }),
+      );
     },
   );
 }

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -1,5 +1,5 @@
 import type { DeltaEvent, SnapshotEvent, StatusEvent } from "@view-server/config";
-import { Cause, Effect, Option, Queue, Stream } from "effect";
+import { Cause, Effect, Exit, Option, Queue, Stream } from "effect";
 import type { RawQueryExecution } from "./active-query";
 import type { TopicStore } from "./topic-store";
 import {
@@ -7,6 +7,7 @@ import {
   reportTopicStoreSubscriptionBackpressure,
   trackTopicStoreSubscriptionQueueDepth,
   unregisterTopicStoreSubscription,
+  withTopicStoreMutation,
 } from "./topic-store";
 
 type RowObject = object;
@@ -41,6 +42,47 @@ export type LiveSubscription<ResultRow extends RowObject> = {
   readonly close: () => Effect.Effect<void, never>;
 };
 
+type ClosableSubscription = {
+  readonly close: () => Effect.Effect<void, never>;
+};
+
+type LiveSubscriptionHandoffOptions = {
+  readonly beforeReturn?: Effect.Effect<void>;
+};
+
+type MarkAcquiredSubscription<ResultRow extends RowObject> = (
+  subscription: LiveSubscription<ResultRow>,
+) => Effect.Effect<void>;
+
+export const closeInterruptedAcquiredSubscription = Effect.fn(
+  "ColumnLiveViewEngine.liveSubscription.closeInterruptedAcquired",
+)(function* (exit: Exit.Exit<unknown, unknown>, subscription: ClosableSubscription | undefined) {
+  if (!Exit.hasInterrupts(exit) || subscription === undefined) {
+    return;
+  }
+  yield* subscription.close();
+});
+
+export const acquireLiveSubscriptionHandoff = Effect.fn(
+  "ColumnLiveViewEngine.liveSubscription.acquireHandoff",
+)(function* <ResultRow extends RowObject, Error, Requirements>(
+  acquire: (
+    markAcquired: MarkAcquiredSubscription<ResultRow>,
+  ) => Effect.Effect<LiveSubscription<ResultRow>, Error, Requirements>,
+  options: LiveSubscriptionHandoffOptions = {},
+) {
+  let acquiredSubscription: ClosableSubscription | undefined;
+  const markAcquired: MarkAcquiredSubscription<ResultRow> = (subscription) =>
+    Effect.sync(() => {
+      acquiredSubscription = subscription;
+    });
+
+  return yield* acquire(markAcquired).pipe(
+    Effect.tap(() => options.beforeReturn ?? Effect.void),
+    Effect.onExit((exit) => closeInterruptedAcquiredSubscription(exit, acquiredSubscription)),
+  );
+});
+
 const backpressureStatusEvent = (
   store: { readonly topic: string },
   subscriber: { readonly queryId: string },
@@ -61,13 +103,17 @@ const closeForBackpressure = Effect.fn(
   queue: Queue.Queue<LiveSubscriptionEvent<ResultRow>, Cause.Done>,
   release: Effect.Effect<void>,
 ) {
-  subscriber.closed = true;
-  yield* reportTopicStoreSubscriptionBackpressure(store, subscriber);
-  yield* unregisterTopicStoreSubscription(store, subscriber);
-  yield* release;
-  yield* Queue.takeAll(queue).pipe(Effect.ignore);
-  yield* Queue.offer(queue, backpressureStatusEvent(store, subscriber)).pipe(Effect.ignore);
-  yield* Queue.end(queue);
+  yield* Effect.uninterruptible(
+    Effect.gen(function* () {
+      subscriber.closed = true;
+      yield* reportTopicStoreSubscriptionBackpressure(store, subscriber);
+      yield* unregisterTopicStoreSubscription(store, subscriber);
+      yield* release;
+      yield* Queue.takeAll(queue).pipe(Effect.ignore);
+      yield* Queue.offer(queue, backpressureStatusEvent(store, subscriber)).pipe(Effect.ignore);
+      yield* Queue.end(queue);
+    }),
+  );
 });
 
 export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.make")(
@@ -122,7 +168,8 @@ export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscrip
     yield* trackTopicStoreSubscriptionQueueDepth(store, subscriber, yield* Queue.size(queue));
 
     const close = Effect.fn("ColumnLiveViewEngine.liveSubscription.close")(function* () {
-      yield* store.mutationSemaphore.withPermits(1)(
+      yield* withTopicStoreMutation(
+        store,
         Effect.gen(function* () {
           if (!subscriber.closed) {
             subscriber.closed = true;

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -8,7 +8,7 @@ import {
   type CompiledRawQuery,
 } from "./raw-query-compiler";
 import { liveQueryResult, type QueryEvaluation } from "./query-result";
-import type { TopicStore } from "./topic-store";
+import { topicStoreRawQueryMetadata, topicStoreReadModel, type TopicStore } from "./topic-store";
 
 type RowObject = object;
 
@@ -36,7 +36,7 @@ export const prepareExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecu
     }
     const compiled = yield* prepareRawQuery<object, ResultRow>(
       topic,
-      store.rawQueryMetadata,
+      topicStoreRawQueryMetadata(store),
       query,
     );
     return {
@@ -50,13 +50,7 @@ export const evaluateExecutableQuery = <ResultRow extends RowObject>(
   store: TopicStore,
   executable: ExecutableQuery<ResultRow>,
 ): QueryEvaluation<ResultRow> =>
-  evaluateCompiledRawQuery(
-    {
-      rows: store.rows,
-      version: store.version,
-    },
-    executable.compiled,
-  );
+  evaluateCompiledRawQuery(topicStoreReadModel(store), executable.compiled);
 
 export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.snapshot")(
   function* <ResultRow extends RowObject>(topic: string, store: TopicStore, query: unknown) {
@@ -76,13 +70,14 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
     },
   ) {
     const executable = yield* prepareExecutableQuery<ResultRow>(topic, store, query);
-    const execution = yield* acquireRawQueryExecution(store, executable.compiled);
+    const storeReadModel = topicStoreReadModel(store);
+    const execution = yield* acquireRawQueryExecution(storeReadModel, executable.compiled);
     return yield* makeLiveSubscription({
       store,
       queryId: input.queryId,
       execution,
       queueCapacity: input.queueCapacity,
-      release: releaseRawQueryExecution(store, executable.compiled),
+      release: releaseRawQueryExecution(storeReadModel, executable.compiled),
     });
   },
 );

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -53,8 +53,8 @@ export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject>
 };
 
 export type RawQueryRowStore<Row extends RowObject> = {
-  readonly rows: ReadonlyMap<string, Row>;
-  readonly version: number;
+  readonly rows: () => ReadonlyMap<string, Row>;
+  readonly version: () => number;
 };
 
 type FilterObject = {
@@ -629,7 +629,7 @@ export const evaluateCompiledRawQuery = <Row extends RowObject, ResultRow extend
   store: RawQueryRowStore<Row>,
   compiled: CompiledRawQuery<Row, ResultRow>,
 ): QueryEvaluation<ResultRow> => {
-  const filtered = Array.from(store.rows, ([key, row]) => ({ key, row })).filter((entry) =>
+  const filtered = Array.from(store.rows(), ([key, row]) => ({ key, row })).filter((entry) =>
     compiled.matches(entry.row),
   );
   const ordered = filtered.toSorted(compiled.compare);
@@ -648,6 +648,6 @@ export const evaluateCompiledRawQuery = <Row extends RowObject, ResultRow extend
     keys: window.map((entry) => entry.key),
     window,
     totalRows: filtered.length,
-    version: store.version,
+    version: store.version(),
   };
 };

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,6 +1,10 @@
 import { Effect, Schema, Semaphore } from "effect";
 import type { StatusEvent, TopicRuntimeHealth } from "@view-server/config";
-import { activeStoreRawQueryExecutionCount, clearStoreRawQueryExecutions } from "./active-query";
+import {
+  activeStoreRawQueryExecutionCount,
+  clearStoreRawQueryExecutions,
+  type ActiveQueryStoreState,
+} from "./active-query";
 import { createTopicHealthLedger } from "./topic-health-ledger";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
@@ -31,23 +35,79 @@ export type TopicStoreHealthView = {
   readonly compactionPending: boolean;
 };
 
-export class TopicStore {
-  readonly rows = new Map<string, object>();
-  readonly subscribers = new Set<LiveTopicSubscriber>();
-  readonly mutationSemaphore = Semaphore.makeUnsafe(1);
+type TopicStoreState = {
+  readonly rows: Map<string, object>;
+  readonly subscribers: Set<LiveTopicSubscriber>;
+  readonly mutationSemaphore: Semaphore.Semaphore;
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
-  readonly healthLedger = createTopicHealthLedger();
-  version = 0;
+  readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
+  readonly schema: Schema.Decoder<object>;
+  readonly keyField: string;
+  readonly onCommit: () => void;
+  readonly readModel: ActiveQueryStoreState;
+  version: number;
+};
+
+const topicStoreStates = new WeakMap<TopicStore, TopicStoreState>();
+
+export class TopicStore {
+  declare private readonly topicStoreBrand: void;
 
   constructor(
     readonly topic: string,
-    readonly schema: Schema.Decoder<object>,
-    readonly keyField: string,
-    readonly onCommit: () => void,
+    schema: Schema.Decoder<object>,
+    keyField: string,
+    onCommit: () => void,
   ) {
-    this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
+    const rows = new Map<string, object>();
+    const subscribers = new Set<LiveTopicSubscriber>();
+    let version = 0;
+    const state: TopicStoreState = {
+      rows,
+      subscribers,
+      mutationSemaphore: Semaphore.makeUnsafe(1),
+      rawQueryMetadata: rawQueryCompilerMetadata(schema),
+      healthLedger: createTopicHealthLedger(),
+      schema,
+      keyField,
+      onCommit,
+      readModel: {
+        identity: this,
+        topic,
+        rows: () => rows,
+        version: () => version,
+      },
+      get version() {
+        return version;
+      },
+      set version(nextVersion: number) {
+        version = nextVersion;
+      },
+    };
+    topicStoreStates.set(this, state);
   }
 }
+
+const topicStoreState = (store: TopicStore): TopicStoreState => {
+  return topicStoreStates.get(store)!;
+};
+
+export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerMetadata =>
+  topicStoreState(store).rawQueryMetadata;
+
+export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
+  topicStoreState(store).readModel;
+
+export const withTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore.transaction")(
+  function* <Success, Error, Requirements>(
+    store: TopicStore,
+    effect: Effect.Effect<Success, Error, Requirements>,
+  ) {
+    return yield* topicStoreState(store).mutationSemaphore.withPermits(1)(
+      Effect.uninterruptible(effect),
+    );
+  },
+);
 
 const resetStatusEvent = (store: TopicStore, subscriber: LiveTopicSubscriber): StatusEvent => ({
   type: "status",
@@ -70,29 +130,46 @@ const engineClosedStatusEvent = (
   message: "Subscription closed because the engine closed.",
 });
 
-const commitTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.commit")(function* (
+const commitTopicStoreState = (state: TopicStoreState): ReadonlyArray<LiveTopicSubscriber> => {
+  state.version += 1;
+  state.onCommit();
+  return [...state.subscribers];
+};
+
+const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.notify")(function* (
   store: TopicStore,
+  subscribers: ReadonlyArray<LiveTopicSubscriber>,
 ) {
-  store.version += 1;
-  store.onCommit();
-  for (const subscriber of store.subscribers) {
+  for (const subscriber of subscribers) {
     yield* subscriber.notify(store);
   }
 });
 
+const commitTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore.commitMutation")(
+  function* (store: TopicStore, mutate: (state: TopicStoreState) => void) {
+    const subscribers = yield* Effect.sync(() => {
+      const state = topicStoreState(store);
+      mutate(state);
+      return commitTopicStoreState(state);
+    });
+    yield* notifyTopicStoreSubscribers(store, subscribers);
+  },
+);
+
 export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
   function* (store: TopicStore, closed: boolean) {
-    const totals = store.healthLedger.snapshot();
+    const state = topicStoreState(store);
+    const totals = state.healthLedger.snapshot();
     let queuedEvents = 0;
 
-    for (const subscriber of store.subscribers) {
+    for (const subscriber of state.subscribers) {
       const currentQueuedEvents = yield* subscriber.queuedEvents;
       queuedEvents += currentQueuedEvents;
     }
 
-    const activeSubscriptions = store.subscribers.size;
-    const activeViews = yield* activeStoreRawQueryExecutionCount(store);
-    const rowCount = store.rows.size;
+    const activeSubscriptions = state.subscribers.size;
+    const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
+    const rowCount = state.rows.size;
     const status: TopicRuntimeHealth["status"] = closed ? "degraded" : "ready";
 
     return {
@@ -101,7 +178,7 @@ export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStor
       rowCount,
       liveRowCount: rowCount,
       deletedRowCount: 0,
-      version: store.version,
+      version: state.version,
       lastMutationAt: null,
       mutationsPerSecond: 0,
       rowsPerSecond: 0,
@@ -122,8 +199,9 @@ export const registerTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.add",
 )((store: TopicStore, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
-    store.healthLedger.openSubscription(subscriber);
-    store.subscribers.add(subscriber);
+    const state = topicStoreState(store);
+    state.healthLedger.openSubscription(subscriber);
+    state.subscribers.add(subscriber);
   }),
 );
 
@@ -131,8 +209,9 @@ export const unregisterTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.remove",
 )((store: TopicStore, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
-    store.healthLedger.closeSubscription(subscriber);
-    store.subscribers.delete(subscriber);
+    const state = topicStoreState(store);
+    state.healthLedger.closeSubscription(subscriber);
+    state.subscribers.delete(subscriber);
   }),
 );
 
@@ -140,7 +219,7 @@ export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.queueDepth",
 )((store: TopicStore, subscriber: LiveTopicSubscriber, queueDepth: number) =>
   Effect.sync(() => {
-    store.healthLedger.updateQueueDepth(subscriber, queueDepth);
+    topicStoreState(store).healthLedger.updateQueueDepth(subscriber, queueDepth);
     subscriber.maxQueueDepth = Math.max(subscriber.maxQueueDepth, queueDepth);
   }),
 );
@@ -149,7 +228,7 @@ export const reportTopicStoreSubscriptionBackpressure = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.backpressure",
 )((store: TopicStore, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
-    store.healthLedger.markBackpressure(subscriber);
+    topicStoreState(store).healthLedger.markBackpressure(subscriber);
     subscriber.backpressureEvents += 1;
   }),
 );
@@ -157,17 +236,25 @@ export const reportTopicStoreSubscriptionBackpressure = Effect.fn(
 export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* (
   store: TopicStore,
 ) {
-  yield* store.mutationSemaphore.withPermits(1)(
+  yield* withTopicStoreMutation(
+    store,
     Effect.gen(function* () {
-      store.rows.clear();
-      store.version = 0;
-      for (const subscriber of store.subscribers) {
-        subscriber.closed = true;
+      const subscribers = yield* Effect.sync(() => {
+        const state = topicStoreState(store);
+        state.rows.clear();
+        state.version = 0;
+        const closingSubscribers = [...state.subscribers];
+        for (const subscriber of closingSubscribers) {
+          subscriber.closed = true;
+        }
+        state.subscribers.clear();
+        state.healthLedger.reset();
+        return closingSubscribers;
+      });
+      yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
+      for (const subscriber of subscribers) {
         yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
       }
-      store.subscribers.clear();
-      store.healthLedger.reset();
-      yield* clearStoreRawQueryExecutions(store);
     }),
   );
 });
@@ -175,15 +262,23 @@ export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset"
 export const closeTopicStoreSubscriptions = Effect.fn(
   "ColumnLiveViewEngine.topicStore.closeSubscriptions",
 )(function* (store: TopicStore) {
-  yield* store.mutationSemaphore.withPermits(1)(
+  yield* withTopicStoreMutation(
+    store,
     Effect.gen(function* () {
-      for (const subscriber of store.subscribers) {
-        subscriber.closed = true;
+      const subscribers = yield* Effect.sync(() => {
+        const state = topicStoreState(store);
+        const closingSubscribers = [...state.subscribers];
+        for (const subscriber of closingSubscribers) {
+          subscriber.closed = true;
+          state.healthLedger.closeSubscription(subscriber);
+        }
+        state.subscribers.clear();
+        return closingSubscribers;
+      });
+      yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
+      for (const subscriber of subscribers) {
         yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
-        store.healthLedger.closeSubscription(subscriber);
       }
-      store.subscribers.clear();
-      yield* clearStoreRawQueryExecutions(store);
     }),
   );
 });
@@ -195,7 +290,7 @@ const decodeRow = Effect.fn("ColumnLiveViewEngine.topicStore.decodeRow")(functio
 ) {
   return yield* Effect.try({
     try: () => {
-      const decoded = Schema.decodeUnknownSync(store.schema)(row);
+      const decoded = Schema.decodeUnknownSync(topicStoreState(store).schema)(row);
       return cloneRow(decoded);
     },
     catch: (cause) => invalidRow(store.topic, String(cause)),
@@ -206,10 +301,11 @@ const rowKey = Effect.fn("ColumnLiveViewEngine.topicStore.rowKey")(function* <
   Error,
   Row extends RowObject,
 >(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
-  const key = fieldValue(row, store.keyField);
+  const keyField = topicStoreState(store).keyField;
+  const key = fieldValue(row, keyField);
   if (typeof key !== "string") {
     return yield* Effect.fail(
-      invalidRow(store.topic, `Key field ${store.keyField} must decode to a string.`),
+      invalidRow(store.topic, `Key field ${keyField} must decode to a string.`),
     );
   }
   return key;
@@ -220,8 +316,9 @@ const validatePatchKeys = Effect.fn("ColumnLiveViewEngine.topicStore.patchKeys.v
     if (!isPlainRecord(patch)) {
       return yield* Effect.fail(invalidRow(store.topic, "Patch must be a plain object."));
     }
+    const metadata = topicStoreRawQueryMetadata(store);
     for (const key of Reflect.ownKeys(patch)) {
-      if (typeof key !== "string" || !store.rawQueryMetadata.fieldNames.has(key)) {
+      if (typeof key !== "string" || !metadata.fieldNames.has(key)) {
         return yield* Effect.fail(
           invalidRow(store.topic, `Patch contains unknown field: ${String(key)}.`),
         );
@@ -236,10 +333,10 @@ export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.p
 >(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
   const decoded = yield* decodeRow(store, row, invalidRow);
   const key = yield* rowKey(store, decoded, invalidRow);
-  yield* store.mutationSemaphore.withPermits(1)(
-    Effect.gen(function* () {
-      store.rows.set(key, decoded);
-      yield* commitTopicStore(store);
+  yield* withTopicStoreMutation(
+    store,
+    commitTopicStoreMutation(store, (state) => {
+      state.rows.set(key, decoded);
     }),
   );
 });
@@ -257,12 +354,12 @@ export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.
         return { key, row };
       }),
     );
-    yield* store.mutationSemaphore.withPermits(1)(
-      Effect.gen(function* () {
+    yield* withTopicStoreMutation(
+      store,
+      commitTopicStoreMutation(store, (state) => {
         for (const { key, row } of keyedRows) {
-          store.rows.set(key, row);
+          state.rows.set(key, row);
         }
-        yield* commitTopicStore(store);
       }),
     );
   },
@@ -272,10 +369,12 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
   Patch extends Partial<RowObject>,
   Error,
 >(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
-  yield* store.mutationSemaphore.withPermits(1)(
+  yield* withTopicStoreMutation(
+    store,
     Effect.gen(function* () {
+      const state = topicStoreState(store);
       yield* validatePatchKeys(store, patch, invalidRow);
-      const current = store.rows.get(key);
+      const current = state.rows.get(key);
       if (current === undefined) {
         return yield* Effect.fail(invalidRow(store.topic, `Cannot patch missing key: ${key}`));
       }
@@ -284,8 +383,9 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
       if (decodedKey !== key) {
         return yield* Effect.fail(invalidRow(store.topic, "Patch must not change the row key."));
       }
-      store.rows.set(key, decoded);
-      yield* commitTopicStore(store);
+      yield* commitTopicStoreMutation(store, (currentState) => {
+        currentState.rows.set(key, decoded);
+      });
     }),
   );
 });
@@ -294,10 +394,10 @@ export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.de
   store: TopicStore,
   key: string,
 ) {
-  yield* store.mutationSemaphore.withPermits(1)(
-    Effect.gen(function* () {
-      store.rows.delete(key);
-      yield* commitTopicStore(store);
+  yield* withTopicStoreMutation(
+    store,
+    commitTopicStoreMutation(store, (state) => {
+      state.rows.delete(key);
     }),
   );
 });


### PR DESCRIPTION
## Summary
- hide TopicStore mutable internals behind a transaction module seam
- route active-query read metadata through intentional store accessors
- make subscription acquisition handoff interrupt-safe and add cleanup regressions

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- pnpm run ready

## Review
- 3 local review agents passed after the subscribe acquisition race fix