### PR TITLE
Deepen topic health ledger

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -2182,11 +2182,14 @@ describe("ColumnLiveViewEngine validation and health", () => {
       yield* engine.publishMany("orders", [order("1", "open", 10, 1), order("2", "closed", 20, 2)]);
       yield* engine.patch("orders", "1", { price: 30 });
       yield* engine.delete("orders", "2");
+      yield* engine.delete("orders", "missing");
 
       const mutated = yield* engine.health();
-      expect(mutated.version).toBe(3);
+      expect(mutated.version).toBe(4);
       expect(mutated.topics["orders"].rowCount).toBe(1);
-      expect(mutated.topics["orders"].version).toBe(3);
+      expect(mutated.topics["orders"].version).toBe(4);
+      expect(mutated.topics["orders"].lastMutationAt).not.toBeNull();
+      expect(mutated.topics["orders"].pendingMutationBatches).toBe(0);
 
       yield* engine.reset();
 

--- a/packages/column-live-view-engine/src/topic-health-ledger.test.ts
+++ b/packages/column-live-view-engine/src/topic-health-ledger.test.ts
@@ -8,63 +8,231 @@ describe("column-live-view-engine topic health ledger", () => {
     const opened = { id: "opened" };
     const unknown = { id: "unknown" };
 
-    expect(ledger.snapshot().activeSubscriptions).toBe(0);
+    expect(ledger.snapshot(0).activeSubscriptions).toBe(0);
 
     ledger.openSubscription(opened);
     ledger.openSubscription(opened);
-    expect(ledger.snapshot()).toStrictEqual({
+    expect(ledger.snapshot(0)).toStrictEqual({
       activeSubscriptions: 1,
       queuedEvents: 0,
       maxQueueDepth: 0,
       backpressureEvents: 0,
+      rowCount: 0,
+      version: 0,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
     });
 
     ledger.updateQueueDepth(unknown, 3);
-    expect(ledger.snapshot().queuedEvents).toBe(0);
+    expect(ledger.snapshot(0).queuedEvents).toBe(0);
 
     ledger.markBackpressure(unknown);
-    expect(ledger.snapshot().backpressureEvents).toBe(0);
+    expect(ledger.snapshot(0).backpressureEvents).toBe(0);
 
     ledger.updateQueueDepth(opened, 2);
     ledger.markBackpressure(opened);
 
-    expect(ledger.snapshot()).toStrictEqual({
+    expect(ledger.snapshot(0)).toStrictEqual({
       activeSubscriptions: 1,
       queuedEvents: 2,
       maxQueueDepth: 2,
       backpressureEvents: 1,
+      rowCount: 0,
+      version: 0,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
     });
 
     ledger.updateQueueDepth(opened, 5);
-    expect(ledger.snapshot()).toStrictEqual({
+    expect(ledger.snapshot(0)).toStrictEqual({
       activeSubscriptions: 1,
       queuedEvents: 5,
       maxQueueDepth: 5,
       backpressureEvents: 1,
+      rowCount: 0,
+      version: 0,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
     });
 
     ledger.closeSubscription(opened);
-    expect(ledger.snapshot()).toStrictEqual({
+    expect(ledger.snapshot(0)).toStrictEqual({
       activeSubscriptions: 0,
       queuedEvents: 0,
       maxQueueDepth: 5,
       backpressureEvents: 1,
+      rowCount: 0,
+      version: 0,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
     });
 
     ledger.closeSubscription(opened);
-    expect(ledger.snapshot()).toStrictEqual({
+    expect(ledger.snapshot(0)).toStrictEqual({
       activeSubscriptions: 0,
       queuedEvents: 0,
       maxQueueDepth: 5,
       backpressureEvents: 1,
+      rowCount: 0,
+      version: 0,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
     });
 
     ledger.reset();
-    expect(ledger.snapshot()).toStrictEqual({
+    expect(ledger.snapshot(0)).toStrictEqual({
       activeSubscriptions: 0,
       queuedEvents: 0,
       maxQueueDepth: 0,
       backpressureEvents: 0,
+      rowCount: 0,
+      version: 0,
+      lastMutationAt: null,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
+    });
+  });
+
+  it("tracks mutation rates and pending batches", () => {
+    const ledger = createTopicHealthLedger();
+
+    ledger.beginMutationBatch();
+    ledger.beginMutationBatch();
+    expect(ledger.snapshot(1_000).pendingMutationBatches).toBe(2);
+
+    ledger.recordMutation({
+      version: 1,
+      rowCount: 2,
+      rowsChanged: 2,
+      occurredAt: 1_000,
+    });
+    ledger.recordMutation({
+      version: 2,
+      rowCount: 3,
+      rowsChanged: 1,
+      occurredAt: 1_500,
+    });
+    ledger.recordMutation({
+      version: 3,
+      rowCount: 4,
+      rowsChanged: 4,
+      occurredAt: 1_500,
+    });
+    ledger.endMutationBatch();
+
+    expect(ledger.snapshot(1_500)).toStrictEqual({
+      activeSubscriptions: 0,
+      queuedEvents: 0,
+      maxQueueDepth: 0,
+      backpressureEvents: 0,
+      rowCount: 4,
+      version: 3,
+      lastMutationAt: 1_500,
+      mutationsPerSecond: 3,
+      rowsPerSecond: 7,
+      pendingMutationBatches: 1,
+    });
+
+    expect(ledger.snapshot(2_501)).toStrictEqual({
+      activeSubscriptions: 0,
+      queuedEvents: 0,
+      maxQueueDepth: 0,
+      backpressureEvents: 0,
+      rowCount: 4,
+      version: 3,
+      lastMutationAt: 1_500,
+      mutationsPerSecond: 0,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 1,
+    });
+
+    ledger.recordMutation({
+      version: 4,
+      rowCount: 1,
+      rowsChanged: -10,
+      occurredAt: 2_501,
+    });
+    ledger.endMutationBatch();
+    ledger.endMutationBatch();
+
+    expect(ledger.snapshot(2_501)).toStrictEqual({
+      activeSubscriptions: 0,
+      queuedEvents: 0,
+      maxQueueDepth: 0,
+      backpressureEvents: 0,
+      rowCount: 1,
+      version: 4,
+      lastMutationAt: 2_501,
+      mutationsPerSecond: 1,
+      rowsPerSecond: 0,
+      pendingMutationBatches: 0,
+    });
+  });
+
+  it("bounds sparse mutation rate buckets without health reads", () => {
+    const ledger = createTopicHealthLedger();
+
+    for (let mutationIndex = 0; mutationIndex < 1_200; mutationIndex += 1) {
+      ledger.recordMutation({
+        version: mutationIndex + 1,
+        rowCount: mutationIndex + 1,
+        rowsChanged: 1,
+        occurredAt: mutationIndex * 2,
+      });
+    }
+
+    expect(ledger.snapshot(2_398)).toStrictEqual({
+      activeSubscriptions: 0,
+      queuedEvents: 0,
+      maxQueueDepth: 0,
+      backpressureEvents: 0,
+      rowCount: 1_200,
+      version: 1_200,
+      lastMutationAt: 2_398,
+      mutationsPerSecond: 501,
+      rowsPerSecond: 501,
+      pendingMutationBatches: 0,
+    });
+  });
+
+  it("ignores future buckets when the clock moves backward", () => {
+    const ledger = createTopicHealthLedger();
+
+    ledger.recordMutation({
+      version: 1,
+      rowCount: 1,
+      rowsChanged: 1,
+      occurredAt: 5_000,
+    });
+    ledger.recordMutation({
+      version: 2,
+      rowCount: 2,
+      rowsChanged: 1,
+      occurredAt: 4_000,
+    });
+
+    expect(ledger.snapshot(4_000)).toStrictEqual({
+      activeSubscriptions: 0,
+      queuedEvents: 0,
+      maxQueueDepth: 0,
+      backpressureEvents: 0,
+      rowCount: 2,
+      version: 2,
+      lastMutationAt: 4_000,
+      mutationsPerSecond: 1,
+      rowsPerSecond: 1,
+      pendingMutationBatches: 0,
     });
   });
 });

--- a/packages/column-live-view-engine/src/topic-health-ledger.ts
+++ b/packages/column-live-view-engine/src/topic-health-ledger.ts
@@ -9,26 +9,93 @@ type TopicHealthTotals = {
   queuedEvents: number;
   maxQueueDepth: number;
   backpressureEvents: number;
+  rowCount: number;
+  version: number;
+  lastMutationAt: number | null;
+  mutationsPerSecond: number;
+  rowsPerSecond: number;
+  pendingMutationBatches: number;
 };
 
 type TopicHealthLedger = {
+  readonly beginMutationBatch: () => void;
+  readonly endMutationBatch: () => void;
+  readonly recordMutation: (input: {
+    readonly version: number;
+    readonly rowCount: number;
+    readonly rowsChanged: number;
+    readonly occurredAt: number;
+  }) => void;
   readonly openSubscription: (subscription: object) => void;
   readonly closeSubscription: (subscription: object) => void;
   readonly updateQueueDepth: (subscription: object, queueDepth: number) => void;
   readonly markBackpressure: (subscription: object) => void;
   readonly reset: () => void;
-  readonly snapshot: () => TopicHealthTotals;
+  readonly snapshot: (now: number) => TopicHealthTotals;
 };
+
+type MutationRateBucket = {
+  occurredAt: number;
+  mutations: number;
+  rowsChanged: number;
+};
+
+const mutationRateWindowMillis = 1_000;
+const maxMutationRateBuckets = mutationRateWindowMillis + 1;
 
 export const createTopicHealthLedger = (): TopicHealthLedger => {
   const subscriptions = new Map<object, TopicHealthSubscription>();
+  const mutationRateBuckets = Array.from(
+    { length: maxMutationRateBuckets },
+    (): MutationRateBucket | undefined => undefined,
+  );
   let activeSubscriptions = 0;
   let queuedEvents = 0;
   let maxQueueDepth = 0;
   let backpressureEvents = 0;
+  let rowCount = 0;
+  let version = 0;
+  let lastMutationAt: number | null = null;
+  let pendingMutationBatches = 0;
 
   const ensureSubscription = (subscription: object): TopicHealthSubscription | undefined =>
     subscriptions.get(subscription);
+
+  const mutationRateBucketIndex = (occurredAt: number): number => {
+    return Math.abs(occurredAt % maxMutationRateBuckets);
+  };
+
+  const beginMutationBatch = (): void => {
+    pendingMutationBatches += 1;
+  };
+
+  const endMutationBatch = (): void => {
+    pendingMutationBatches = Math.max(0, pendingMutationBatches - 1);
+  };
+
+  const recordMutation = (input: {
+    readonly version: number;
+    readonly rowCount: number;
+    readonly rowsChanged: number;
+    readonly occurredAt: number;
+  }): void => {
+    const occurredAt = Math.trunc(input.occurredAt);
+    rowCount = input.rowCount;
+    version = input.version;
+    lastMutationAt = occurredAt;
+    const bucketIndex = mutationRateBucketIndex(occurredAt);
+    const existingBucket = mutationRateBuckets[bucketIndex];
+    if (existingBucket !== undefined && existingBucket.occurredAt === occurredAt) {
+      existingBucket.mutations += 1;
+      existingBucket.rowsChanged += Math.max(0, input.rowsChanged);
+      return;
+    }
+    mutationRateBuckets[bucketIndex] = {
+      occurredAt,
+      mutations: 1,
+      rowsChanged: Math.max(0, input.rowsChanged),
+    };
+  };
 
   const openSubscription = (subscription: object): void => {
     subscriptions.set(subscription, {
@@ -75,20 +142,51 @@ export const createTopicHealthLedger = (): TopicHealthLedger => {
 
   const reset = (): void => {
     subscriptions.clear();
+    mutationRateBuckets.fill(undefined);
     activeSubscriptions = 0;
     queuedEvents = 0;
     maxQueueDepth = 0;
     backpressureEvents = 0;
+    rowCount = 0;
+    version = 0;
+    lastMutationAt = null;
+    pendingMutationBatches = 0;
   };
 
-  const snapshot = (): TopicHealthTotals => ({
-    activeSubscriptions,
-    queuedEvents: Math.max(0, queuedEvents),
-    maxQueueDepth,
-    backpressureEvents,
-  });
+  const snapshot = (now: number): TopicHealthTotals => {
+    const occurredBefore = Math.trunc(now) - mutationRateWindowMillis;
+    const occurredAfter = Math.trunc(now);
+    let mutationsPerSecond = 0;
+    let rowsPerSecond = 0;
+    for (const mutationRateBucket of mutationRateBuckets) {
+      if (
+        mutationRateBucket === undefined ||
+        mutationRateBucket.occurredAt < occurredBefore ||
+        mutationRateBucket.occurredAt > occurredAfter
+      ) {
+        continue;
+      }
+      mutationsPerSecond += mutationRateBucket.mutations;
+      rowsPerSecond += mutationRateBucket.rowsChanged;
+    }
+    return {
+      activeSubscriptions,
+      queuedEvents: Math.max(0, queuedEvents),
+      maxQueueDepth,
+      backpressureEvents,
+      rowCount,
+      version,
+      lastMutationAt,
+      mutationsPerSecond,
+      rowsPerSecond,
+      pendingMutationBatches,
+    };
+  };
 
   return {
+    beginMutationBatch,
+    endMutationBatch,
+    recordMutation,
     openSubscription: (subscription: object): void => {
       if (subscriptions.has(subscription)) {
         return;

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema, Semaphore } from "effect";
+import { Clock, Effect, Schema, Semaphore } from "effect";
 import type { StatusEvent, TopicRuntimeHealth } from "@view-server/config";
 import {
   activeStoreRawQueryExecutionCount,
@@ -146,20 +146,47 @@ const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.n
 });
 
 const commitTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore.commitMutation")(
-  function* (store: TopicStore, mutate: (state: TopicStoreState) => void) {
+  function* (store: TopicStore, mutate: (state: TopicStoreState) => number) {
+    const occurredAt = yield* Clock.currentTimeMillis;
     const subscribers = yield* Effect.sync(() => {
       const state = topicStoreState(store);
-      mutate(state);
-      return commitTopicStoreState(state);
+      const rowsChanged = mutate(state);
+      const subscribersToNotify = commitTopicStoreState(state);
+      state.healthLedger.recordMutation({
+        version: state.version,
+        rowCount: state.rows.size,
+        rowsChanged,
+        occurredAt,
+      });
+      return subscribersToNotify;
     });
     yield* notifyTopicStoreSubscribers(store, subscribers);
+  },
+);
+
+const withTopicStoreMutationBatch = Effect.fn("ColumnLiveViewEngine.topicStore.mutationBatch")(
+  function* <Success, Error, Requirements>(
+    store: TopicStore,
+    effect: Effect.Effect<Success, Error, Requirements>,
+  ) {
+    const ledger = topicStoreState(store).healthLedger;
+    return yield* Effect.acquireUseRelease(
+      Effect.sync(() => {
+        ledger.beginMutationBatch();
+      }),
+      () => effect,
+      () =>
+        Effect.sync(() => {
+          ledger.endMutationBatch();
+        }),
+    );
   },
 );
 
 export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
   function* (store: TopicStore, closed: boolean) {
     const state = topicStoreState(store);
-    const totals = state.healthLedger.snapshot();
+    const totals = state.healthLedger.snapshot(yield* Clock.currentTimeMillis);
     let queuedEvents = 0;
 
     for (const subscriber of state.subscribers) {
@@ -169,20 +196,19 @@ export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStor
 
     const activeSubscriptions = state.subscribers.size;
     const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
-    const rowCount = state.rows.size;
     const status: TopicRuntimeHealth["status"] = closed ? "degraded" : "ready";
 
     return {
       topic: store.topic,
       status,
-      rowCount,
-      liveRowCount: rowCount,
+      rowCount: totals.rowCount,
+      liveRowCount: totals.rowCount,
       deletedRowCount: 0,
-      version: state.version,
-      lastMutationAt: null,
-      mutationsPerSecond: 0,
-      rowsPerSecond: 0,
-      pendingMutationBatches: 0,
+      version: totals.version,
+      lastMutationAt: totals.lastMutationAt,
+      mutationsPerSecond: totals.mutationsPerSecond,
+      rowsPerSecond: totals.rowsPerSecond,
+      pendingMutationBatches: totals.pendingMutationBatches,
       activeViews,
       activeSubscriptions,
       queuedEvents,
@@ -333,11 +359,15 @@ export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.p
 >(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
   const decoded = yield* decodeRow(store, row, invalidRow);
   const key = yield* rowKey(store, decoded, invalidRow);
-  yield* withTopicStoreMutation(
+  yield* withTopicStoreMutationBatch(
     store,
-    commitTopicStoreMutation(store, (state) => {
-      state.rows.set(key, decoded);
-    }),
+    withTopicStoreMutation(
+      store,
+      commitTopicStoreMutation(store, (state) => {
+        state.rows.set(key, decoded);
+        return 1;
+      }),
+    ),
   );
 });
 
@@ -354,13 +384,17 @@ export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.
         return { key, row };
       }),
     );
-    yield* withTopicStoreMutation(
+    yield* withTopicStoreMutationBatch(
       store,
-      commitTopicStoreMutation(store, (state) => {
-        for (const { key, row } of keyedRows) {
-          state.rows.set(key, row);
-        }
-      }),
+      withTopicStoreMutation(
+        store,
+        commitTopicStoreMutation(store, (state) => {
+          for (const { key, row } of keyedRows) {
+            state.rows.set(key, row);
+          }
+          return keyedRows.length;
+        }),
+      ),
     );
   },
 );
@@ -369,24 +403,28 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
   Patch extends Partial<RowObject>,
   Error,
 >(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
-  yield* withTopicStoreMutation(
+  yield* withTopicStoreMutationBatch(
     store,
-    Effect.gen(function* () {
-      const state = topicStoreState(store);
-      yield* validatePatchKeys(store, patch, invalidRow);
-      const current = state.rows.get(key);
-      if (current === undefined) {
-        return yield* Effect.fail(invalidRow(store.topic, `Cannot patch missing key: ${key}`));
-      }
-      const decoded = yield* decodeRow(store, { ...current, ...patch }, invalidRow);
-      const decodedKey = yield* rowKey(store, decoded, invalidRow);
-      if (decodedKey !== key) {
-        return yield* Effect.fail(invalidRow(store.topic, "Patch must not change the row key."));
-      }
-      yield* commitTopicStoreMutation(store, (currentState) => {
-        currentState.rows.set(key, decoded);
-      });
-    }),
+    withTopicStoreMutation(
+      store,
+      Effect.gen(function* () {
+        const state = topicStoreState(store);
+        yield* validatePatchKeys(store, patch, invalidRow);
+        const current = state.rows.get(key);
+        if (current === undefined) {
+          return yield* Effect.fail(invalidRow(store.topic, `Cannot patch missing key: ${key}`));
+        }
+        const decoded = yield* decodeRow(store, { ...current, ...patch }, invalidRow);
+        const decodedKey = yield* rowKey(store, decoded, invalidRow);
+        if (decodedKey !== key) {
+          return yield* Effect.fail(invalidRow(store.topic, "Patch must not change the row key."));
+        }
+        yield* commitTopicStoreMutation(store, (currentState) => {
+          currentState.rows.set(key, decoded);
+          return 1;
+        });
+      }),
+    ),
   );
 });
 
@@ -394,10 +432,13 @@ export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.de
   store: TopicStore,
   key: string,
 ) {
-  yield* withTopicStoreMutation(
+  yield* withTopicStoreMutationBatch(
     store,
-    commitTopicStoreMutation(store, (state) => {
-      state.rows.delete(key);
-    }),
+    withTopicStoreMutation(
+      store,
+      commitTopicStoreMutation(store, (state) => {
+        return state.rows.delete(key) ? 1 : 0;
+      }),
+    ),
   );
 });


### PR DESCRIPTION
## Summary
- move row/version/lastMutationAt/rate/pending mutation state into the topic health ledger
- record cheap mutation batch counters through the topic-store mutation seam
- use a fixed-size millisecond ring buffer for mutation/row per-second rates so health rate tracking remains bounded even without health reads
- add focused ledger and engine health coverage for pending batches, sparse mutations, clock rollback, missing deletes, and reset behavior

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- pnpm run ready
- forbidden-pattern scan clean for casts, direct vitest imports, Testing Library, assert, toEqual, act/flushSync, test ids, Date usage, Effect.succeed return workaround, and coverage ignores

## Review loop
- 3 local review agents initially found the unbounded sparse rate-bucket issue
- fixed with a fixed-size ring buffer and added regression coverage
- 3 local review agents re-reviewed the updated diff and reported clean