### PR TITLE
Add production runtime package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,28 @@
 
 ## Remote React provider
 
-Server code exposes a runtime through Effect RPC WebSocket:
+Server code starts a runtime through Effect RPC WebSocket and same-server
+`GET /health`:
 
 ```ts
-import { createInMemoryViewServer } from "@view-server/in-memory";
-import { createViewServerWebSocketServer } from "@view-server/server";
+import { createViewServerRuntime } from "@view-server/runtime";
 import { Effect } from "effect";
 import { viewServer } from "./view-server-config";
 
-const runtime = createInMemoryViewServer(viewServer);
-
-const server = await Effect.runPromise(
-  createViewServerWebSocketServer(viewServer, {
-    liveClient: runtime.liveClient,
-    runtime: runtime.client,
+const runtime = await Effect.runPromise(
+  createViewServerRuntime(viewServer, {
+    host: "127.0.0.1",
+    websocketPort: 8080,
   }),
 );
 
-console.log(server.url);
+console.log(runtime.url);
+console.log(runtime.healthUrl);
 ```
+
+`runtime.healthUrl` serves the cached runtime health snapshot for deployment
+readiness checks. Internal `bigint` health fields, such as Kafka lag, are encoded
+as decimal strings in the JSON response.
 
 Browser React code keeps using the normal provider and hooks:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check:effect": "effect-language-service diagnostics --project packages/config/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/client/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/in-memory/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/server/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/react/tsconfig.json --format text --strict",
+    "check:effect": "effect-language-service diagnostics --project packages/config/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/client/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/in-memory/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/server/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/react/tsconfig.json --format text --strict",
     "check:package-exports": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/check-package-exports.ts && node --experimental-strip-types scripts/check-package-exports.ts",
     "ready": "vp run -r build && pnpm run check:package-exports && vp check && pnpm run check:effect && vp run -r test",
     "prepare": "vp config && effect-language-service patch"
@@ -17,6 +17,7 @@
     "@view-server/in-memory": "workspace:*",
     "@view-server/protocol": "workspace:*",
     "@view-server/react": "workspace:*",
+    "@view-server/runtime": "workspace:*",
     "@view-server/server": "workspace:*",
     "typescript": "catalog:",
     "vite-plus": "catalog:"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@view-server/runtime",
+  "version": "0.0.0",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "vp run -t @view-server/in-memory#build && vp run -t @view-server/server#build && vp pack",
+    "test": "vp run -t @view-server/in-memory#build && vp run -t @view-server/server#build && vp test run --coverage --typecheck"
+  },
+  "dependencies": {
+    "@view-server/client": "workspace:*",
+    "@view-server/config": "workspace:*",
+    "@view-server/in-memory": "workspace:*",
+    "@view-server/server": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "@types/node": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
+    "@vitest/runner": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -1,0 +1,100 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import { defineViewServerConfig, type ViewServerRuntimeError } from "@view-server/config";
+import type { Effect } from "effect";
+import { Schema } from "effect";
+import {
+  makeViewServerRuntime,
+  type ViewServerRuntime,
+  type ViewServerRuntimeOptions,
+} from "./index";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+const runtimeEffect = makeViewServerRuntime(viewServer);
+declare const runtime: Effect.Success<typeof runtimeEffect>;
+
+describe("runtime type contracts", () => {
+  it("preserves configured topic types through runtime clients", () => {
+    expectTypeOf(runtime.url).toEqualTypeOf<ViewServerRuntime<typeof viewServer.topics>["url"]>();
+    expectTypeOf(runtime.healthUrl).toEqualTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>["healthUrl"]
+    >();
+    expectTypeOf(runtime.health).toEqualTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>["health"]
+    >();
+    expectTypeOf(runtime.close).toEqualTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>["close"]
+    >();
+
+    const publish = runtime.client.publish("orders", {
+      id: "order-1",
+      price: 10,
+    });
+    expectTypeOf<Parameters<typeof runtime.client.publish>>().toEqualTypeOf<
+      Parameters<ViewServerRuntime<typeof viewServer.topics>["client"]["publish"]>
+    >();
+    const subscribe = runtime.liveClient.subscribe("orders", {
+      select: ["id", "price"],
+    });
+
+    expectTypeOf<Effect.Error<typeof publish>>().toEqualTypeOf<ViewServerRuntimeError>();
+    expectTypeOf(subscribe).not.toBeAny();
+
+    const invalidPublish = runtime.client.publish("orders", {
+      id: "order-1",
+      price: 10,
+      // @ts-expect-error runtime mutation client rejects fields outside the topic row.
+      prcie: 10,
+    });
+
+    const invalidSubscribe = runtime.liveClient.subscribe("orders", {
+      select: [
+        // @ts-expect-error runtime live client rejects fields outside the topic row.
+        "prcie",
+      ],
+    });
+    const invalidTopicPublish = runtime.client.publish(
+      // @ts-expect-error runtime mutation client rejects unknown topics.
+      "missing",
+      {
+        id: "order-1",
+        price: 10,
+      },
+    );
+    const invalidSnapshot = runtime.client.snapshot("orders", {
+      select: ["id"],
+      where: {
+        // @ts-expect-error runtime query client rejects unknown filter fields.
+        prcie: { gte: 10 },
+      },
+    });
+    const invalidOptions = makeViewServerRuntime(viewServer, {
+      // @ts-expect-error runtime options reject string ports.
+      websocketPort: "8080",
+    });
+    const invalidPathOptions = makeViewServerRuntime(viewServer, {
+      // @ts-expect-error runtime paths must be absolute HTTP paths.
+      rpcPath: "runtime-rpc",
+    });
+    expectTypeOf(invalidPublish).not.toBeAny();
+    expectTypeOf(invalidSubscribe).not.toBeAny();
+    expectTypeOf(invalidTopicPublish).not.toBeAny();
+    expectTypeOf(invalidSnapshot).not.toBeAny();
+    expectTypeOf(invalidOptions).not.toBeAny();
+    expectTypeOf(invalidPathOptions).not.toBeAny();
+    expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("port");
+    expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("path");
+  });
+});

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "@effect/vitest";
+import { makeViewServerClient } from "@view-server/client/remote";
+import { defineViewServerConfig } from "@view-server/config";
+import { makeInMemoryViewServer } from "@view-server/in-memory";
+import { Effect, Exit, Fiber, Schema, Stream } from "effect";
+import type { ViewServerRuntimeDependencies } from "./internal";
+import { makeViewServerRuntimeWithDependencies } from "./internal";
+import { makeViewServerRuntime } from "./index";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+});
+
+const HealthJson = Schema.Struct({
+  status: Schema.Literal("ready"),
+  engine: Schema.Struct({
+    topics: Schema.Struct({
+      orders: Schema.Struct({
+        rowCount: Schema.Number,
+      }),
+    }),
+  }),
+});
+
+class RuntimeHealthJsonParseError extends Schema.TaggedErrorClass<RuntimeHealthJsonParseError>()(
+  "RuntimeHealthJsonParseError",
+  {
+    cause: Schema.Unknown,
+  },
+) {}
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+type OrderRow = typeof Order.Type;
+
+const order = (id: string, price: number): OrderRow => ({
+  id,
+  price,
+});
+
+const fetchHealth = Effect.fn("ViewServerRuntime.test.health.fetch")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(text),
+    catch: (cause) => new RuntimeHealthJsonParseError({ cause }),
+  });
+  const health = yield* Schema.decodeUnknownEffect(HealthJson)(value);
+  return { response, health };
+});
+
+describe("@view-server/runtime", () => {
+  it.live("starts a websocket runtime with health endpoint and in-memory mutation client", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        rpcPath: "/runtime-rpc",
+        healthPath: "/runtime-health",
+      });
+      const remoteClient = yield* makeViewServerClient(viewServer, { url: runtime.url });
+      const subscription = yield* remoteClient.subscribe("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* Effect.sleep("10 millis");
+
+      yield* runtime.client.publish("orders", order("a", 10));
+
+      const events = yield* Fiber.join(eventsFiber);
+      expect(runtime.url.endsWith("/runtime-rpc")).toBe(true);
+      expect(runtime.healthUrl.endsWith("/runtime-health")).toBe(true);
+      expect(events[0]).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-0",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
+      });
+      expect(events[1]).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [{ type: "insert", key: "a", row: { id: "a", price: 10 }, index: 0 }],
+        totalRows: 1,
+      });
+
+      const health = yield* fetchHealth(runtime.healthUrl);
+      expect(health.response.status).toBe(200);
+      expect(health.health.engine.topics.orders.rowCount).toBe(1);
+
+      yield* subscription.close();
+      yield* remoteClient.close;
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("supports default paths and queue capacity options", () =>
+    Effect.gen(function* () {
+      const defaultRuntime = yield* makeViewServerRuntime(viewServer);
+      expect(defaultRuntime.url.endsWith("/rpc")).toBe(true);
+      expect(defaultRuntime.healthUrl.endsWith("/health")).toBe(true);
+      yield* defaultRuntime.close;
+
+      const configuredRuntime = yield* makeViewServerRuntime(viewServer, {
+        websocketPort: 0,
+        subscriptionQueueCapacity: 1,
+      });
+      expect(configuredRuntime.url.endsWith("/rpc")).toBe(true);
+      expect(configuredRuntime.healthUrl.endsWith("/health")).toBe(true);
+      yield* configuredRuntime.close;
+    }),
+  );
+
+  it.live(
+    "releases the in-memory runtime when server startup fails before returning a runtime",
+    () =>
+      Effect.gen(function* () {
+        let closed = false;
+        const dependencies: ViewServerRuntimeDependencies<typeof viewServer.topics> = {
+          makeInMemory: (config, options) =>
+            makeInMemoryViewServer(config, options).pipe(
+              Effect.map((inMemory) => ({
+                ...inMemory,
+                close: inMemory.close.pipe(
+                  Effect.ensuring(
+                    Effect.sync(() => {
+                      closed = true;
+                    }),
+                  ),
+                ),
+              })),
+            ),
+          makeServer: () => Effect.die(new Error("server startup failed")),
+        };
+
+        const startupExit = yield* Effect.exit(
+          makeViewServerRuntimeWithDependencies(dependencies, viewServer),
+        );
+
+        expect(Exit.isFailure(startupExit)).toBe(true);
+        expect(closed).toBe(true);
+      }),
+  );
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,0 +1,30 @@
+import type { ViewServerConfig } from "@view-server/config";
+import { Effect } from "effect";
+import type { HttpServerError } from "effect/unstable/http";
+import {
+  makeDefaultRuntimeDependencies,
+  makeViewServerRuntimeWithDependencies,
+  type ViewServerRuntime,
+  type ViewServerRuntimeOptions,
+  type ViewServerRuntimeTopicDefinitions,
+} from "./internal";
+
+export type { ViewServerRuntime, ViewServerRuntimeOptions };
+
+export const makeViewServerRuntime: <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  options?: ViewServerRuntimeOptions,
+) => Effect.Effect<ViewServerRuntime<Topics>, HttpServerError.ServeError> = Effect.fn(
+  "ViewServerRuntime.make",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  options: ViewServerRuntimeOptions = {},
+) {
+  return yield* makeViewServerRuntimeWithDependencies(
+    makeDefaultRuntimeDependencies<Topics>(),
+    config,
+    options,
+  );
+});
+
+export const createViewServerRuntime = makeViewServerRuntime;

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -1,0 +1,113 @@
+import type { ViewServerLiveClient } from "@view-server/client";
+import type {
+  RowSchema,
+  TopicDefinitions,
+  ViewServerConfig,
+  ViewServerHealth,
+  ViewServerRuntimeClient,
+  ViewServerRuntimeError,
+} from "@view-server/config";
+import {
+  makeInMemoryViewServer,
+  type ViewServerInMemoryInstance,
+  type ViewServerInMemoryOptions,
+} from "@view-server/in-memory";
+import {
+  makeViewServerWebSocketServer,
+  type ViewServerWebSocketServer,
+  type ViewServerWebSocketServerInput,
+  type ViewServerWebSocketServerOptions,
+} from "@view-server/server";
+import { Effect, Exit, type Schema } from "effect";
+import type { HttpServerError } from "effect/unstable/http";
+
+export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
+  Record<
+    string,
+    {
+      readonly schema: RowSchema & Schema.Decoder<object>;
+      readonly key: string;
+    }
+  >;
+
+type RuntimeHttpPath = `/${string}` | "*";
+
+export type ViewServerRuntimeOptions = {
+  readonly host?: string;
+  readonly websocketPort?: number;
+  readonly rpcPath?: RuntimeHttpPath;
+  readonly healthPath?: RuntimeHttpPath;
+  readonly subscriptionQueueCapacity?: number;
+};
+
+export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly url: string;
+  readonly healthUrl: string;
+  readonly client: ViewServerRuntimeClient<Topics>;
+  readonly liveClient: ViewServerLiveClient<Topics>;
+  readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
+  readonly close: Effect.Effect<void>;
+};
+
+export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly makeInMemory: (
+    config: ViewServerConfig<Topics>,
+    options: ViewServerInMemoryOptions,
+  ) => Effect.Effect<ViewServerInMemoryInstance<Topics>>;
+  readonly makeServer: (
+    config: ViewServerConfig<Topics>,
+    input: ViewServerWebSocketServerInput<Topics>,
+    options: ViewServerWebSocketServerOptions,
+  ) => Effect.Effect<ViewServerWebSocketServer, HttpServerError.ServeError>;
+};
+
+export const makeDefaultRuntimeDependencies = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(): ViewServerRuntimeDependencies<Topics> => ({
+  makeInMemory: makeInMemoryViewServer,
+  makeServer: makeViewServerWebSocketServer,
+});
+
+export const makeViewServerRuntimeWithDependencies: <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  dependencies: ViewServerRuntimeDependencies<Topics>,
+  config: ViewServerConfig<Topics>,
+  options?: ViewServerRuntimeOptions,
+) => Effect.Effect<ViewServerRuntime<Topics>, HttpServerError.ServeError> = Effect.fn(
+  "ViewServerRuntime.makeWithDependencies",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  dependencies: ViewServerRuntimeDependencies<Topics>,
+  config: ViewServerConfig<Topics>,
+  options: ViewServerRuntimeOptions = {},
+) {
+  const inMemoryOptions =
+    options.subscriptionQueueCapacity === undefined
+      ? {}
+      : { subscriptionQueueCapacity: options.subscriptionQueueCapacity };
+  const serverOptions = {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.websocketPort === undefined ? {} : { port: options.websocketPort }),
+    ...(options.rpcPath === undefined ? {} : { path: options.rpcPath }),
+    ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
+  };
+  const inMemory = yield* dependencies.makeInMemory(config, inMemoryOptions);
+  const server = yield* dependencies
+    .makeServer(
+      config,
+      {
+        liveClient: inMemory.liveClient,
+        runtime: inMemory.client,
+      },
+      serverOptions,
+    )
+    .pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? inMemory.close : Effect.void)));
+  return {
+    url: server.url,
+    healthUrl: server.healthUrl,
+    client: inMemory.client,
+    liveClient: inMemory.liveClient,
+    health: inMemory.client.health,
+    close: server.close.pipe(Effect.ensuring(inMemory.close)),
+  };
+});

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.test-d.ts"]
+}

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vite-plus";
+import { libraryPack } from "../../vite.pack";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    typecheck: {
+      enabled: true,
+      checker: "tsc",
+      include: ["src/**/*.test-d.ts"],
+      tsconfig: "./tsconfig.json",
+    },
+    coverage: {
+      provider: "istanbul",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.test-d.ts"],
+      reporter: ["text"],
+      thresholds: {
+        "100": true,
+      },
+    },
+  },
+  pack: libraryPack("src/index.ts"),
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+  fmt: {},
+});

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,8 +1,12 @@
 import { NodeSocket } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import type { ViewServerLiveEvent } from "@view-server/client";
+import type { ViewServerLiveClient, ViewServerLiveEvent } from "@view-server/client";
 import { makeViewServerClient } from "@view-server/client/remote";
-import { defineViewServerConfig, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
+import {
+  defineViewServerConfig,
+  VIEW_SERVER_HEALTH_TOPIC,
+  type ViewServerHealth,
+} from "@view-server/config";
 import { createInMemoryViewServer } from "@view-server/in-memory";
 import { ViewServerRpcErrorSchema, ViewServerRpcs } from "@view-server/protocol";
 import {
@@ -16,6 +20,7 @@ import {
   Stream,
 } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
+import * as AtomRef from "effect/unstable/reactivity/AtomRef";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import { makeViewServerWebSocketServer } from "./index";
@@ -34,6 +39,39 @@ const Quote = Schema.Struct({
   id: Schema.String,
   price: Schema.BigDecimal,
 });
+
+const HealthJson = Schema.Struct({
+  status: Schema.String,
+  engine: Schema.Struct({
+    topics: Schema.Struct({
+      orders: Schema.Struct({
+        rowCount: Schema.Number,
+      }),
+    }),
+  }),
+});
+
+const HealthKafkaJson = Schema.Struct({
+  status: Schema.String,
+  kafka: Schema.Struct({
+    topics: Schema.Struct({
+      source_orders: Schema.Struct({
+        regions: Schema.Struct({
+          usa: Schema.Struct({
+            consumerLagMessages: Schema.String,
+          }),
+        }),
+      }),
+    }),
+  }),
+});
+
+class ServerTestJsonParseError extends Schema.TaggedErrorClass<ServerTestJsonParseError>()(
+  "ServerTestJsonParseError",
+  {
+    cause: Schema.Unknown,
+  },
+) {}
 
 const BadJsonField = Schema.String.pipe(
   Schema.encodeTo(Schema.Any, {
@@ -109,6 +147,16 @@ const makeRawRpcClient = Effect.fn("ViewServerServer.test.rawRpcClient.make")(fu
     close: runtime.disposeEffect,
     rpc: Context.get(context, RawViewServerRpcClient),
   };
+});
+
+const fetchJson = Effect.fn("ViewServerServer.test.fetchJson")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(text),
+    catch: (cause) => new ServerTestJsonParseError({ cause }),
+  });
+  return { response, value };
 });
 
 describe("@view-server/server", () => {
@@ -190,6 +238,101 @@ describe("@view-server/server", () => {
       expect(afterClose.engine.topics.orders.activeSubscriptions).toBe(0);
 
       yield* client.close;
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("serves GET /health beside the websocket RPC endpoint", () =>
+    Effect.gen(function* () {
+      const inMemory = createInMemoryViewServer(viewServer);
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: inMemory.client,
+      });
+
+      yield* inMemory.client.publish("orders", order("a", 10));
+
+      const readyHealth = yield* fetchJson(server.healthUrl);
+      const readyBody = yield* Schema.decodeUnknownEffect(HealthJson)(readyHealth.value);
+      expect(readyHealth.response.status).toBe(200);
+      expect(readyBody.status).toBe("ready");
+      expect(readyBody.engine.topics.orders.rowCount).toBe(1);
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("serves cached health snapshots without rebuilding runtime health", () =>
+    Effect.gen(function* () {
+      const inMemory = createInMemoryViewServer(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const degradedHealth: ViewServerHealth<typeof viewServer.topics> = {
+        ...baseHealth,
+        status: "degraded",
+        kafka: {
+          regions: {},
+          topics: {
+            source_orders: {
+              status: "ready",
+              sourceTopic: "source_orders",
+              viewServerTopic: "orders",
+              regions: {
+                usa: {
+                  connected: true,
+                  assignedPartitions: 1,
+                  messagesPerSecond: 0,
+                  bytesPerSecond: 0,
+                  decodedMessagesPerSecond: 0,
+                  decodeFailuresPerSecond: 0,
+                  lastMessageAt: null,
+                  lastCommitAt: null,
+                  consumerLagMessages: 42n,
+                  consumerLagMs: null,
+                  lagSampledAt: null,
+                  highWatermarkOffset: null,
+                  committedOffset: null,
+                  lastError: null,
+                },
+              },
+            },
+          },
+        },
+      };
+      const cachedHealth = AtomRef.make<ViewServerHealth<typeof viewServer.topics>>(degradedHealth);
+      const liveClient: ViewServerLiveClient<typeof viewServer.topics> = {
+        ...inMemory.liveClient,
+        health: cachedHealth,
+      };
+      let runtimeHealthCalls = 0;
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient,
+        runtime: {
+          health: () =>
+            Effect.sync(() => {
+              runtimeHealthCalls += 1;
+              return baseHealth;
+            }),
+        },
+      });
+
+      const firstHealth = yield* fetchJson(server.healthUrl);
+      const firstBody = yield* Schema.decodeUnknownEffect(HealthKafkaJson)(firstHealth.value);
+      expect(firstHealth.response.status).toBe(503);
+      expect(firstBody.status).toBe("degraded");
+      expect(firstBody.kafka.topics.source_orders.regions.usa.consumerLagMessages).toBe("42");
+      expect(runtimeHealthCalls).toBe(0);
+
+      yield* Effect.sync(() => {
+        cachedHealth.set(baseHealth);
+      });
+      const secondHealth = yield* fetchJson(server.healthUrl);
+      const secondBody = yield* Schema.decodeUnknownEffect(HealthJson)(secondHealth.value);
+      expect(secondHealth.response.status).toBe(200);
+      expect(secondBody.status).toBe("ready");
+      expect(runtimeHealthCalls).toBe(0);
+
       yield* server.close;
       yield* inMemory.close;
     }),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,7 @@ import { NodeHttpServer } from "@effect/platform-node";
 import type {
   TopicDefinitions,
   ViewServerConfig,
+  ViewServerHealth,
   ViewServerRuntimeClient,
 } from "@view-server/config";
 import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
@@ -16,7 +17,7 @@ import {
   viewServerEncodeLiveEvent,
 } from "@view-server/protocol";
 import { Context, Effect, Layer, ManagedRuntime, Stream } from "effect";
-import { HttpRouter, HttpServer, HttpServerError } from "effect/unstable/http";
+import { HttpRouter, HttpServer, HttpServerError, HttpServerResponse } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 import * as Http from "node:http";
 
@@ -34,12 +35,39 @@ export type ViewServerWebSocketServerOptions = {
   readonly host?: string;
   readonly port?: number;
   readonly path?: HttpRouter.PathInput;
+  readonly healthPath?: HttpRouter.PathInput;
 };
 
 export type ViewServerWebSocketServer = {
   readonly url: string;
+  readonly healthUrl: string;
   readonly close: Effect.Effect<void>;
 };
+
+export type Jsonify<T> = T extends bigint
+  ? string
+  : T extends string | number | boolean | null
+    ? T
+    : T extends ReadonlyArray<infer Item>
+      ? ReadonlyArray<Jsonify<Item>>
+      : T extends object
+        ? { readonly [Key in keyof T]: Jsonify<T[Key]> }
+        : never;
+
+export type ViewServerHealthHttpJson<Topics extends TopicDefinitions = TopicDefinitions> = Jsonify<
+  ViewServerHealth<Topics>
+>;
+
+const jsonStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, nextValue: unknown) =>
+    typeof nextValue === "bigint" ? nextValue.toString() : nextValue,
+  );
+
+const jsonResponse = (status: number, value: unknown): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.text(jsonStringify(value), {
+    status,
+    contentType: "application/json",
+  });
 
 const makeHandlers = <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
@@ -80,6 +108,18 @@ const makeHandlers = <const Topics extends TopicDefinitions>(
       ),
   });
 
+const makeHealthRoute = <const Topics extends TopicDefinitions>(
+  input: ViewServerWebSocketServerInput<Topics>,
+  path: HttpRouter.PathInput,
+) =>
+  HttpRouter.add(
+    "GET",
+    path,
+    Effect.sync(() => input.liveClient.health.value).pipe(
+      Effect.map((health) => jsonResponse(health.status === "ready" ? 200 : 503, health)),
+    ),
+  );
+
 export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
   input: ViewServerWebSocketServerInput<Topics>,
@@ -92,15 +132,18 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   options: ViewServerWebSocketServerOptions = {},
 ) {
   const path = options.path ?? "/rpc";
+  const healthPath = options.healthPath ?? "/health";
   const protocol = RpcServer.layerProtocolWebsocket({ path }).pipe(Layer.provide(HttpRouter.layer));
   const handlers = ViewServerRpcs.toLayer(makeHandlers(config, input));
+  const healthRoute = makeHealthRoute(input, healthPath);
+  const httpApp = Layer.merge(protocol, healthRoute);
   const rpcLayer = RpcServer.layer(ViewServerRpcs, {
     disableFatalDefects: true,
   }).pipe(
     Layer.provide(handlers),
     Layer.provideMerge(protocol),
     Layer.provide(
-      HttpRouter.serve(protocol, {
+      HttpRouter.serve(httpApp, {
         disableListenLog: true,
         disableLogger: true,
       }),
@@ -120,8 +163,10 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   const serverUrl = httpUrl.startsWith("http://0.0.0.0:")
     ? `ws://127.0.0.1:${httpUrl.slice("http://0.0.0.0:".length)}`
     : httpUrl.replace("http://", "ws://");
+  const publicHttpUrl = serverUrl.replace("ws://", "http://");
   return {
     url: `${serverUrl}${path}`,
+    healthUrl: `${publicHttpUrl}${healthPath}`,
     close: managedRuntime.disposeEffect,
   };
 });

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1014,9 +1014,12 @@ Recommended packages:
 ```txt
 packages/config
 packages/column-live-view-engine
+packages/client
+packages/protocol
+packages/in-memory
+packages/server
 packages/runtime
 packages/react
-packages/testing
 apps/examples
 ```
 
@@ -1024,9 +1027,12 @@ Responsibilities:
 
 - `packages/config`: `defineViewServerConfig`, query DSL types, schema/topic typing, shared public types.
 - `packages/column-live-view-engine`: in-memory columnar store, snapshot, subscribe, deltas, grouped aggregates, health core.
-- `packages/runtime`: server runtime, Effect RPC/WebSocket adapter, HTTP `/health`, `/metrics`, TCP publish, Kafka ingest, graceful shutdown.
-- `packages/react`: `ViewServerProvider`, `createInMemoryViewServer`, `ViewServerInMemoryProvider`, `useLiveQuery`, `useViewServerHealth`.
-- `packages/testing`: test helpers only, no production-only shortcuts.
+- `packages/client`: transport-neutral live client contracts, query state, and remote client entrypoints.
+- `packages/protocol`: Effect RPC WebSocket wire schema and encode/decode boundary.
+- `packages/in-memory`: in-process runtime client backed by the engine.
+- `packages/server`: Effect RPC WebSocket server and same-server HTTP health endpoint.
+- `packages/runtime`: production composition of in-memory runtime, server, health URL, lifecycle, and future Kafka/TCP/gRPC ingestion adapters.
+- `packages/react`: production React provider/hooks plus a separate testing entrypoint for the in-memory provider.
 - `apps/examples`: minimal real app proving browser usage and runtime URL injection.
 
 All packages must have explicit public exports. Do not leak internals accidentally.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,15 +40,15 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     vite-plus:
-      specifier: latest
-      version: 0.1.22
+      specifier: 0.1.23
+      version: 0.1.23
     vitest-browser-react:
       specifier: 2.2.0
       version: 2.2.0
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.23
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.23
 
 importers:
 
@@ -75,6 +75,9 @@ importers:
       '@view-server/react':
         specifier: workspace:*
         version: link:packages/react
+      '@view-server/runtime':
+        specifier: workspace:*
+        version: link:packages/runtime
       '@view-server/server':
         specifier: workspace:*
         version: link:packages/server
@@ -83,7 +86,7 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
 
   packages/client:
     dependencies:
@@ -105,10 +108,10 @@ importers:
         version: 4.0.0-beta.70(effect@4.0.0-beta.70)(ioredis@5.10.1)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -116,8 +119,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/column-live-view-engine:
     dependencies:
@@ -130,10 +133,10 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -141,8 +144,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/config:
     dependencies:
@@ -155,10 +158,10 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -166,8 +169,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/in-memory:
     dependencies:
@@ -186,10 +189,10 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -197,8 +200,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/protocol:
     dependencies:
@@ -211,10 +214,10 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -222,8 +225,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/react:
     dependencies:
@@ -245,7 +248,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@types/react':
         specifier: 19.2.15
         version: 19.2.15
@@ -260,10 +263,10 @@ importers:
         version: link:../server
       '@vitest/browser':
         specifier: 4.1.6
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -280,11 +283,48 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
       vitest-browser-react:
         specifier: 'catalog:'
-        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(@voidzero-dev/vite-plus-test@0.1.22)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(@voidzero-dev/vite-plus-test@0.1.23)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+
+  packages/runtime:
+    dependencies:
+      '@view-server/client':
+        specifier: workspace:*
+        version: link:../client
+      '@view-server/config':
+        specifier: workspace:*
+        version: link:../config
+      '@view-server/in-memory':
+        specifier: workspace:*
+        version: link:../in-memory
+      '@view-server/server':
+        specifier: workspace:*
+        version: link:../server
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.70
+    devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
+      '@vitest/runner':
+        specifier: 'catalog:'
+        version: 4.1.6
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/server:
     dependencies:
@@ -306,7 +346,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)
+        version: 4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -315,7 +355,7 @@ importers:
         version: link:../in-memory
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
-        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+        version: 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.6
@@ -323,8 +363,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
 packages:
 
@@ -504,286 +544,286 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/runtime@0.129.0':
-    resolution: {integrity: sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ==}
+  '@oxc-project/runtime@0.133.0':
+    resolution: {integrity: sha512-PkvjA1Lq5++V5S1E6Patr92ZVcieE6EalDr1VJTqv4BnjZdOUC4W3p8k1wMXSd5/2aFP4b/A6N5sg2Bkzcr9vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@oxc-project/types@0.129.0':
-    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.48.0':
-    resolution: {integrity: sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.52.0':
+    resolution: {integrity: sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.48.0':
-    resolution: {integrity: sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==}
+  '@oxfmt/binding-android-arm64@0.52.0':
+    resolution: {integrity: sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.48.0':
-    resolution: {integrity: sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==}
+  '@oxfmt/binding-darwin-arm64@0.52.0':
+    resolution: {integrity: sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.48.0':
-    resolution: {integrity: sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==}
+  '@oxfmt/binding-darwin-x64@0.52.0':
+    resolution: {integrity: sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.48.0':
-    resolution: {integrity: sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==}
+  '@oxfmt/binding-freebsd-x64@0.52.0':
+    resolution: {integrity: sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
-    resolution: {integrity: sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
+    resolution: {integrity: sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
-    resolution: {integrity: sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
+    resolution: {integrity: sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
-    resolution: {integrity: sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
+    resolution: {integrity: sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.48.0':
-    resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
+  '@oxfmt/binding-linux-arm64-musl@0.52.0':
+    resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
-    resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
+    resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
-    resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
+    resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
-    resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
+  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
+    resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
-    resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
+  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
+    resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.48.0':
-    resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
+  '@oxfmt/binding-linux-x64-gnu@0.52.0':
+    resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.48.0':
-    resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
+  '@oxfmt/binding-linux-x64-musl@0.52.0':
+    resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.48.0':
-    resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
+  '@oxfmt/binding-openharmony-arm64@0.52.0':
+    resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
-    resolution: {integrity: sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==}
+  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
+    resolution: {integrity: sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
-    resolution: {integrity: sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==}
+  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
+    resolution: {integrity: sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.48.0':
-    resolution: {integrity: sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.52.0':
+    resolution: {integrity: sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.22.1':
-    resolution: {integrity: sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==}
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.22.1':
-    resolution: {integrity: sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==}
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.22.1':
-    resolution: {integrity: sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==}
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.22.1':
-    resolution: {integrity: sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==}
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.22.1':
-    resolution: {integrity: sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==}
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.22.1':
-    resolution: {integrity: sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==}
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.63.0':
-    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
+  '@oxlint/binding-android-arm-eabi@1.67.0':
+    resolution: {integrity: sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.63.0':
-    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
+  '@oxlint/binding-android-arm64@1.67.0':
+    resolution: {integrity: sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.63.0':
-    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
+  '@oxlint/binding-darwin-arm64@1.67.0':
+    resolution: {integrity: sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.63.0':
-    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
+  '@oxlint/binding-darwin-x64@1.67.0':
+    resolution: {integrity: sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.63.0':
-    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
+  '@oxlint/binding-freebsd-x64@1.67.0':
+    resolution: {integrity: sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
-    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
+    resolution: {integrity: sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
-    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
+  '@oxlint/binding-linux-arm-musleabihf@1.67.0':
+    resolution: {integrity: sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.63.0':
-    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
+  '@oxlint/binding-linux-arm64-gnu@1.67.0':
+    resolution: {integrity: sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.63.0':
-    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
+  '@oxlint/binding-linux-arm64-musl@1.67.0':
+    resolution: {integrity: sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
-    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
+  '@oxlint/binding-linux-ppc64-gnu@1.67.0':
+    resolution: {integrity: sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
-    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
+  '@oxlint/binding-linux-riscv64-gnu@1.67.0':
+    resolution: {integrity: sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.63.0':
-    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
+  '@oxlint/binding-linux-riscv64-musl@1.67.0':
+    resolution: {integrity: sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.63.0':
-    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
+  '@oxlint/binding-linux-s390x-gnu@1.67.0':
+    resolution: {integrity: sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.63.0':
-    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
+  '@oxlint/binding-linux-x64-gnu@1.67.0':
+    resolution: {integrity: sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.63.0':
-    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
+  '@oxlint/binding-linux-x64-musl@1.67.0':
+    resolution: {integrity: sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.63.0':
-    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
+  '@oxlint/binding-openharmony-arm64@1.67.0':
+    resolution: {integrity: sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.63.0':
-    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
+  '@oxlint/binding-win32-arm64-msvc@1.67.0':
+    resolution: {integrity: sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.63.0':
-    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
+  '@oxlint/binding-win32-ia32-msvc@1.67.0':
+    resolution: {integrity: sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.63.0':
-    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
+  '@oxlint/binding-win32-x64-msvc@1.67.0':
+    resolution: {integrity: sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -955,8 +995,8 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
-  '@voidzero-dev/vite-plus-core@0.1.22':
-    resolution: {integrity: sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg==}
+  '@voidzero-dev/vite-plus-core@0.1.23':
+    resolution: {integrity: sha512-Twi+95cq1pObzkNR4u6lP7z4gPhtS0/vxeBAdbTvAeA12qlyyFED7mQZnAgaVIN3k1C1ve0997F3/ncUBAwQ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
@@ -1018,56 +1058,56 @@ packages:
       yaml:
         optional: true
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.22':
-    resolution: {integrity: sha512-+6sRVGCAQSpO96WC0EZtSLJ01VzNiZL/eQUQ8NLVl1oH+0+KgHF2UXyqUXGCGf/JCu34egEwBEjDU3WUwN2mxg==}
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.23':
+    resolution: {integrity: sha512-5tRAYzVHE6X+QK7MVE2URyubL5d9+wbXhepImVEwkdOhGThxsTiCchxzJrjeqVSFf0GT8eFC3URBuKTzWBD9NA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.22':
-    resolution: {integrity: sha512-rqsCW/Brt2froW7VhLE+gVHKtGniyLdHlfcmTLfuM5vnd5skdQlymibRw/lviJU+mSl0x8pGcXZbvA4TLHbCoA==}
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.23':
+    resolution: {integrity: sha512-05qpV7lqe9iiyCIWKhdlwEiMG4NYPt/9FZa+fBvXo0YOV4JTC1yTUMWr1X4edzYJg7Y1Jdx06u3Tu2AJvGKwSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.22':
-    resolution: {integrity: sha512-OL/WT6pvJpFS1L+hWe8g2LCEHCJfEBSgxV0vbSoQDdfTuilUJaVK8rljVWgtIVjUQSjIx8jKfPsl/I8iEBh0GQ==}
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.23':
+    resolution: {integrity: sha512-qb5gUpBJovwfkDjHZKHy8LTh+69kQIKlIXVYLe8wVAw6+cEI4WNWPf6YHJdnPIKtOYsGNZ5vllFHbtT3i6uOfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.22':
-    resolution: {integrity: sha512-SdZLL2aXm9XlbNfygsIifxhTjnRa2gI5oXNCh9QmLmXN36yhXt816I5Tl5IQ5DJwxhnG1+5Uqp2D6tHaT5g6nQ==}
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.23':
+    resolution: {integrity: sha512-mvB3XYltfUn55WdgRYZHDY+bgeOwrwsMhdftXDC8T7tIUglIxcuo3+xMOZOrbFFjJXNPelUjvU1R9ItAR8rY1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.22':
-    resolution: {integrity: sha512-Qn6WPTn61A47ZBCPm+v8kCrMgXlI5p10pllKYkce2PFeCotN6v1bqu2GBZIkLVSi534ywGqdkiG1kaesM9e1vw==}
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.23':
+    resolution: {integrity: sha512-Hf7phM8L2wUdLloQHbylRzmJEv9PIUCC5Yvdo1UycWyiEl99CUgAlrSmZyfkKxPh+MSFaa+xNwfXdf9zwXM8mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.22':
-    resolution: {integrity: sha512-DsVE09IgvYBR2PY2Bohd08tScYDa8K8KJkIGc8Y6uRXR14NEldoufmWJdCmEsGLA8puRv5HV3ZheWFFjmw5Liw==}
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.23':
+    resolution: {integrity: sha512-YJ+OT7tddkUshfojk1jIyJcQHA3h5cMKSpCVVJcJwTCZNb9z9zRcjZCxGbwwTOqrV4PzP8TVy50aEEl0jP1lTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@voidzero-dev/vite-plus-test@0.1.22':
-    resolution: {integrity: sha512-6VKDNXH+ygDyTXpBYn+g+2a9j3zuAZRlP2ZSx0RcjPMdGUMpX6Mox4CmdK8SkZUvi+f6a1siX50ZnCOcQoTgmQ==}
+  '@voidzero-dev/vite-plus-test@0.1.23':
+    resolution: {integrity: sha512-50NmnIMHsES5f+4iScEwqAR6LlsE1oP7n1HBxaYVX839tjMWCYHRUiBlBZFU+OoWwuFNq0I1ap0j0vamvJsYGg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1089,14 +1129,14 @@ packages:
       jsdom:
         optional: true
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.22':
-    resolution: {integrity: sha512-/1JDhTu7SAIjpqJVAN3D3zmN/O8cCRwdn63Qs0ep5GzNYh3+TtVyw3xdUY7YHeyuSypgKlqnr6IPeMlNijOG/Q==}
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.23':
+    resolution: {integrity: sha512-/y2Yz5/kbDv4VlgGHiCXNTZ2ZeIPjSo5iogytb3kX2skxaQi7JqAwxjYjfjSD6q6e6lFIyxNEX81BSbcbIFVXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.22':
-    resolution: {integrity: sha512-GITqtIWeTaWZ7mo1799sIB6XhhSAL1TmuJvrtBz8e3SAUpjDsIYACDYumUDhowPdIHRO3rasyJg9jJZA82BjKQ==}
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.23':
+    resolution: {integrity: sha512-YoHCatW5TBhQvIJU0ewA4TVGvznTfhLgjqHY8Pn3HVFNWhNO9DCOsP4ihpvKzYFS7F9dx0xmmAYXOH/suArDFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1365,23 +1405,34 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  oxfmt@0.48.0:
-    resolution: {integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==}
+  oxfmt@0.52.0:
+    resolution: {integrity: sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
 
-  oxlint-tsgolint@0.22.1:
-    resolution: {integrity: sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==}
+  oxlint-tsgolint@0.23.0:
+    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
 
-  oxlint@1.63.0:
-    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
+  oxlint@1.67.0:
+    resolution: {integrity: sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
+        optional: true
+      vite-plus:
         optional: true
 
   pathe@2.0.3:
@@ -1523,8 +1574,8 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
-  vite-plus@0.1.22:
-    resolution: {integrity: sha512-fCCmEKjI+Hv74PdL/MKcrBkdYPHFNcqD5568KxwN0sa4SGxtcbs55i/577LxKs0w5zIjuLRZZ0zQPu9MO+9itg==}
+  vite-plus@0.1.23:
+    resolution: {integrity: sha512-4VCb0L6uaN3dTvBD6u4Wk0MqhXIKvi2InyCRw+RkOQ0NEt7bgcF4xD9aJRakH0r0EW9MQKLUGjIUH25dtGjncA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1744,10 +1795,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.22)(effect@4.0.0-beta.70)':
+  '@effect/vitest@4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)':
     dependencies:
       effect: 4.0.0-beta.70
-      vitest: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1813,142 +1864,142 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@oxc-project/runtime@0.129.0': {}
-
-  '@oxc-project/types@0.129.0': {}
+  '@oxc-project/runtime@0.133.0': {}
 
   '@oxc-project/types@0.132.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.48.0':
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.52.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.48.0':
+  '@oxfmt/binding-android-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.48.0':
+  '@oxfmt/binding-darwin-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.48.0':
+  '@oxfmt/binding-darwin-x64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.48.0':
+  '@oxfmt/binding-freebsd-x64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.48.0':
+  '@oxfmt/binding-linux-arm64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.48.0':
+  '@oxfmt/binding-linux-x64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.48.0':
+  '@oxfmt/binding-linux-x64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.48.0':
+  '@oxfmt/binding-openharmony-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.48.0':
+  '@oxfmt/binding-win32-x64-msvc@0.52.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.22.1':
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.22.1':
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.22.1':
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.22.1':
+  '@oxlint-tsgolint/linux-x64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.22.1':
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.22.1':
+  '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.63.0':
+  '@oxlint/binding-android-arm-eabi@1.67.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.63.0':
+  '@oxlint/binding-android-arm64@1.67.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.63.0':
+  '@oxlint/binding-darwin-arm64@1.67.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.63.0':
+  '@oxlint/binding-darwin-x64@1.67.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.63.0':
+  '@oxlint/binding-freebsd-x64@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+  '@oxlint/binding-linux-arm64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.63.0':
+  '@oxlint/binding-linux-arm64-musl@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+  '@oxlint/binding-linux-riscv64-musl@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+  '@oxlint/binding-linux-s390x-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.63.0':
+  '@oxlint/binding-linux-x64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.63.0':
+  '@oxlint/binding-linux-x64-musl@1.67.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.63.0':
+  '@oxlint/binding-openharmony-arm64@1.67.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+  '@oxlint/binding-win32-arm64-msvc@1.67.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+  '@oxlint/binding-win32-ia32-msvc@1.67.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.63.0':
+  '@oxlint/binding-win32-x64-msvc@1.67.0':
     optional: true
 
   '@oxlint/plugins@1.61.0': {}
@@ -2038,7 +2089,7 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
 
-  '@vitest/browser@4.1.6(@voidzero-dev/vite-plus-test@0.1.22)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))':
+  '@vitest/browser@4.1.6(@voidzero-dev/vite-plus-test@0.1.23)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.6(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))
@@ -2047,7 +2098,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -2055,7 +2106,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.22)':
+  '@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.6
@@ -2067,7 +2118,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
     transitivePeerDependencies:
       - supports-color
 
@@ -2096,10 +2147,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-core@0.1.23(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
-      '@oxc-project/runtime': 0.129.0
-      '@oxc-project/types': 0.129.0
+      '@oxc-project/runtime': 0.133.0
+      '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
       postcss: 8.5.15
     optionalDependencies:
@@ -2108,29 +2159,29 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.9.0
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.22':
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.22':
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.22':
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.22':
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.22':
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.22':
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.22(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.2.0
@@ -2144,7 +2195,7 @@ snapshots:
       ws: 8.20.1
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/coverage-istanbul': 4.1.6(@voidzero-dev/vite-plus-test@0.1.22)
+      '@vitest/coverage-istanbul': 4.1.6(@voidzero-dev/vite-plus-test@0.1.23)
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -2167,10 +2218,10 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.22':
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.22':
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.23':
     optional: true
 
   assertion-error@2.0.1: {}
@@ -2389,61 +2440,63 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oxfmt@0.48.0:
+  oxfmt@0.52.0(vite-plus@0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.48.0
-      '@oxfmt/binding-android-arm64': 0.48.0
-      '@oxfmt/binding-darwin-arm64': 0.48.0
-      '@oxfmt/binding-darwin-x64': 0.48.0
-      '@oxfmt/binding-freebsd-x64': 0.48.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.48.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.48.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.48.0
-      '@oxfmt/binding-linux-arm64-musl': 0.48.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.48.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.48.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.48.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.48.0
-      '@oxfmt/binding-linux-x64-gnu': 0.48.0
-      '@oxfmt/binding-linux-x64-musl': 0.48.0
-      '@oxfmt/binding-openharmony-arm64': 0.48.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.48.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.48.0
-      '@oxfmt/binding-win32-x64-msvc': 0.48.0
+      '@oxfmt/binding-android-arm-eabi': 0.52.0
+      '@oxfmt/binding-android-arm64': 0.52.0
+      '@oxfmt/binding-darwin-arm64': 0.52.0
+      '@oxfmt/binding-darwin-x64': 0.52.0
+      '@oxfmt/binding-freebsd-x64': 0.52.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
+      '@oxfmt/binding-linux-arm64-musl': 0.52.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-musl': 0.52.0
+      '@oxfmt/binding-openharmony-arm64': 0.52.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
+      '@oxfmt/binding-win32-x64-msvc': 0.52.0
+      vite-plus: 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint-tsgolint@0.22.1:
+  oxlint-tsgolint@0.23.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.22.1
-      '@oxlint-tsgolint/darwin-x64': 0.22.1
-      '@oxlint-tsgolint/linux-arm64': 0.22.1
-      '@oxlint-tsgolint/linux-x64': 0.22.1
-      '@oxlint-tsgolint/win32-arm64': 0.22.1
-      '@oxlint-tsgolint/win32-x64': 0.22.1
+      '@oxlint-tsgolint/darwin-arm64': 0.23.0
+      '@oxlint-tsgolint/darwin-x64': 0.23.0
+      '@oxlint-tsgolint/linux-arm64': 0.23.0
+      '@oxlint-tsgolint/linux-x64': 0.23.0
+      '@oxlint-tsgolint/win32-arm64': 0.23.0
+      '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.63.0(oxlint-tsgolint@0.22.1):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.63.0
-      '@oxlint/binding-android-arm64': 1.63.0
-      '@oxlint/binding-darwin-arm64': 1.63.0
-      '@oxlint/binding-darwin-x64': 1.63.0
-      '@oxlint/binding-freebsd-x64': 1.63.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
-      '@oxlint/binding-linux-arm64-gnu': 1.63.0
-      '@oxlint/binding-linux-arm64-musl': 1.63.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
-      '@oxlint/binding-linux-riscv64-musl': 1.63.0
-      '@oxlint/binding-linux-s390x-gnu': 1.63.0
-      '@oxlint/binding-linux-x64-gnu': 1.63.0
-      '@oxlint/binding-linux-x64-musl': 1.63.0
-      '@oxlint/binding-openharmony-arm64': 1.63.0
-      '@oxlint/binding-win32-arm64-msvc': 1.63.0
-      '@oxlint/binding-win32-ia32-msvc': 1.63.0
-      '@oxlint/binding-win32-x64-msvc': 1.63.0
-      oxlint-tsgolint: 0.22.1
+      '@oxlint/binding-android-arm-eabi': 1.67.0
+      '@oxlint/binding-android-arm64': 1.67.0
+      '@oxlint/binding-darwin-arm64': 1.67.0
+      '@oxlint/binding-darwin-x64': 1.67.0
+      '@oxlint/binding-freebsd-x64': 1.67.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
+      '@oxlint/binding-linux-arm64-gnu': 1.67.0
+      '@oxlint/binding-linux-arm64-musl': 1.67.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-musl': 1.67.0
+      '@oxlint/binding-linux-s390x-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-musl': 1.67.0
+      '@oxlint/binding-openharmony-arm64': 1.67.0
+      '@oxlint/binding-win32-arm64-msvc': 1.67.0
+      '@oxlint/binding-win32-ia32-msvc': 1.67.0
+      '@oxlint/binding-win32-x64-msvc': 1.67.0
+      oxlint-tsgolint: 0.23.0
+      vite-plus: 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
 
   pathe@2.0.3: {}
 
@@ -2563,24 +2616,24 @@ snapshots:
 
   uuid@14.0.0: {}
 
-  vite-plus@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0):
+  vite-plus@0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
-      '@oxc-project/types': 0.129.0
+      '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.22(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
-      oxfmt: 0.48.0
-      oxlint: 1.63.0(oxlint-tsgolint@0.22.1)
-      oxlint-tsgolint: 0.22.1
+      '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
+      oxfmt: 0.52.0(vite-plus@0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint-tsgolint: 0.23.0
     optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.22
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.22
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.22
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.22
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.22
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.22
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.22
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.22
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.23
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.23
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.23
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.23
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.23
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.23
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.23
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.23
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@edge-runtime/vm'
@@ -2603,6 +2656,7 @@ snapshots:
       - sass-embedded
       - stylus
       - sugarss
+      - svelte
       - terser
       - tsx
       - typescript
@@ -2624,11 +2678,11 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(@voidzero-dev/vite-plus-test@0.1.22)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(@voidzero-dev/vite-plus-test@0.1.23)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      vitest: '@voidzero-dev/vite-plus-test@0.1.22(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,9 +18,9 @@ catalog:
   "@vitest/runner": 4.1.6
   effect: 4.0.0-beta.70
   typescript: 6.0.3
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.23
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.23
+  vite-plus: 0.1.23
   "@effect/atom-react": 4.0.0-beta.70
   scheduler: 0.27.0
   vitest-browser-react: 2.2.0

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -14,8 +14,10 @@ import * as protocolPackage from "@view-server/protocol";
 import type { ViewServerWireEvent } from "@view-server/protocol";
 import { createViewServerReact } from "@view-server/react";
 import { createInMemoryViewServerReact } from "@view-server/react/testing";
+import { createViewServerRuntime } from "@view-server/runtime";
+import type { ViewServerRuntime } from "@view-server/runtime";
 import { createViewServerWebSocketServer } from "@view-server/server";
-import type { ViewServerWebSocketServer } from "@view-server/server";
+import type { ViewServerHealthHttpJson, ViewServerWebSocketServer } from "@view-server/server";
 import * as configPackage from "@view-server/config";
 import * as healthPackage from "@view-server/config/health";
 import * as kafkaPackage from "@view-server/config/kafka";
@@ -24,6 +26,7 @@ import * as queryPackage from "@view-server/config/query";
 import * as runtimePackage from "@view-server/config/runtime";
 import * as reactPackage from "@view-server/react";
 import * as reactTestingPackage from "@view-server/react/testing";
+import * as runtimeRootPackage from "@view-server/runtime";
 import * as serverPackage from "@view-server/server";
 
 const requireExport = (moduleName: string, moduleValue: object, exportName: string) => {
@@ -73,6 +76,8 @@ rejectExport("@view-server/in-memory", inMemoryPackage, "makeHealthRefreshSchedu
 requireExport("@view-server/react", reactPackage, "createViewServerReact");
 rejectExport("@view-server/react", reactPackage, "createInMemoryViewServerReact");
 requireExport("@view-server/react/testing", reactTestingPackage, "createInMemoryViewServerReact");
+requireExport("@view-server/runtime", runtimeRootPackage, "makeViewServerRuntime");
+requireExport("@view-server/runtime", runtimeRootPackage, "createViewServerRuntime");
 requireExport("@view-server/server", serverPackage, "makeViewServerWebSocketServer");
 requireExport("@view-server/server", serverPackage, "createViewServerWebSocketServer");
 
@@ -84,6 +89,8 @@ const _healthType: ViewServerHealth<{ readonly orders: { readonly id: string } }
   undefined;
 const _subscriptionType: LiveSubscription<{ readonly id: string }> | undefined = undefined;
 const _serverType: ViewServerWebSocketServer | undefined = undefined;
+const _runtimeType: ViewServerRuntime<never> | undefined = undefined;
+const _healthHttpJsonType: ViewServerHealthHttpJson | undefined = undefined;
 const _wireEventType: ViewServerWireEvent | undefined = undefined;
 const _mappingInputType:
   | KafkaMappingInput<
@@ -102,9 +109,12 @@ void _queryType;
 void _healthType;
 void _subscriptionType;
 void _serverType;
+void _runtimeType;
+void _healthHttpJsonType;
 void _wireEventType;
 void _mappingInputType;
 void createInMemoryViewServer;
 void createViewServerReact;
 void createInMemoryViewServerReact;
+void createViewServerRuntime;
 void createViewServerWebSocketServer;


### PR DESCRIPTION
## Summary
- add @view-server/runtime as the production composition package for in-memory engine + Effect RPC WebSocket server
- add cached HTTP /health support beside the WebSocket RPC endpoint, including BigInt JSON encoding for health fields
- add runtime/server tests, package export checks, docs, and pin Vite+ tooling to 0.1.23 so the lockfile does not drift on latest

## Validation
- pnpm run ready
- pnpm --filter @view-server/runtime run build
- pnpm --filter @view-server/runtime run test
- policy scan: no forbidden casts/assert/toEqual/coverage-ignore/Testing Library/direct vitest imports
- 3 review agents: clean