### PR TITLE
Restrict runtime connection paths

### DIFF
--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -88,12 +88,27 @@ describe("runtime type contracts", () => {
       // @ts-expect-error runtime paths must be absolute HTTP paths.
       rpcPath: "runtime-rpc",
     });
+    const invalidHealthPathOptions = makeViewServerRuntime(viewServer, {
+      // @ts-expect-error runtime health paths must be absolute HTTP paths.
+      healthPath: "runtime-health",
+    });
+    const invalidWildcardRpcPathOptions = makeViewServerRuntime(viewServer, {
+      // @ts-expect-error runtime RPC path must be a concrete slash-prefixed client URL path.
+      rpcPath: "*",
+    });
+    const invalidWildcardHealthPathOptions = makeViewServerRuntime(viewServer, {
+      // @ts-expect-error runtime health path must be a concrete slash-prefixed client URL path.
+      healthPath: "*",
+    });
     expectTypeOf(invalidPublish).not.toBeAny();
     expectTypeOf(invalidSubscribe).not.toBeAny();
     expectTypeOf(invalidTopicPublish).not.toBeAny();
     expectTypeOf(invalidSnapshot).not.toBeAny();
     expectTypeOf(invalidOptions).not.toBeAny();
     expectTypeOf(invalidPathOptions).not.toBeAny();
+    expectTypeOf(invalidHealthPathOptions).not.toBeAny();
+    expectTypeOf(invalidWildcardRpcPathOptions).not.toBeAny();
+    expectTypeOf(invalidWildcardHealthPathOptions).not.toBeAny();
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("port");
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("path");
   });

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -30,7 +30,7 @@ export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
     }
   >;
 
-type RuntimeHttpPath = `/${string}` | "*";
+type RuntimeHttpPath = `/${string}`;
 
 export type ViewServerRuntimeOptions = {
   readonly host?: string;

--- a/packages/server/src/index.test-d.ts
+++ b/packages/server/src/index.test-d.ts
@@ -1,0 +1,41 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import type { ViewServerWebSocketServerOptions } from "./index";
+
+describe("server type contracts", () => {
+  it("only accepts concrete slash-prefixed connection paths", () => {
+    const options = {
+      path: "/rpc",
+      healthPath: "/health",
+    } satisfies ViewServerWebSocketServerOptions;
+    const prefixedOptions = {
+      path: "/view-server/rpc",
+      healthPath: "/view-server/health",
+    } satisfies ViewServerWebSocketServerOptions;
+
+    const invalidWildcardRpcPath: ViewServerWebSocketServerOptions = {
+      // @ts-expect-error WebSocket RPC path must produce a concrete client URL.
+      path: "*",
+    };
+    const invalidWildcardHealthPath: ViewServerWebSocketServerOptions = {
+      // @ts-expect-error health path must produce a concrete fetch URL.
+      healthPath: "*",
+    };
+    const invalidBareRpcPath: ViewServerWebSocketServerOptions = {
+      // @ts-expect-error WebSocket RPC path must be slash-prefixed.
+      path: "rpc",
+    };
+    const invalidBareHealthPath: ViewServerWebSocketServerOptions = {
+      // @ts-expect-error health path must be slash-prefixed.
+      healthPath: "health",
+    };
+
+    expectTypeOf(options.path).toEqualTypeOf<"/rpc">();
+    expectTypeOf(options.healthPath).toEqualTypeOf<"/health">();
+    expectTypeOf(prefixedOptions.path).toEqualTypeOf<"/view-server/rpc">();
+    expectTypeOf(prefixedOptions.healthPath).toEqualTypeOf<"/view-server/health">();
+    expectTypeOf(invalidWildcardRpcPath).not.toBeAny();
+    expectTypeOf(invalidWildcardHealthPath).not.toBeAny();
+    expectTypeOf(invalidBareRpcPath).not.toBeAny();
+    expectTypeOf(invalidBareHealthPath).not.toBeAny();
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -34,8 +34,8 @@ export type ViewServerWebSocketServerInput<Topics extends TopicDefinitions> = {
 export type ViewServerWebSocketServerOptions = {
   readonly host?: string;
   readonly port?: number;
-  readonly path?: HttpRouter.PathInput;
-  readonly healthPath?: HttpRouter.PathInput;
+  readonly path?: `/${string}`;
+  readonly healthPath?: `/${string}`;
 };
 
 export type ViewServerWebSocketServer = {
@@ -110,7 +110,7 @@ const makeHandlers = <const Topics extends TopicDefinitions>(
 
 const makeHealthRoute = <const Topics extends TopicDefinitions>(
   input: ViewServerWebSocketServerInput<Topics>,
-  path: HttpRouter.PathInput,
+  path: `/${string}`,
 ) =>
   HttpRouter.add(
     "GET",


### PR DESCRIPTION
## Summary
- Reject wildcard runtime/server connection paths at the type boundary
- Keep slash-prefixed custom mount paths for reverse proxy deployments
- Add runtime and server type tests for valid defaults, prefixed paths, wildcard rejection, and bare-path rejection

## Validation
- pnpm run ready
- pnpm --filter @view-server/server run test
- pnpm --filter @view-server/runtime run test
- vp check --fix packages/server/src/index.test-d.ts packages/server/src/index.ts packages/runtime/src/internal.ts packages/runtime/src/index.test-d.ts
- forbidden-pattern scan clean for packages/scripts
