### PR TITLE
Deepen query execution with grouped active queries

### DIFF
--- a/packages/client/src/index.test-d.ts
+++ b/packages/client/src/index.test-d.ts
@@ -45,17 +45,13 @@ describe("client type contracts", () => {
 
   it("rejects nullish selected fields", () => {
     const undefinedSelectedField = client.subscribe("orders", {
-      select: [
-        // @ts-expect-error selected fields must be topic field names, not undefined.
-        undefined,
-      ],
+      // @ts-expect-error selected fields must be topic field names, not undefined.
+      select: [undefined],
     });
 
     const nullSelectedField = client.subscribe("orders", {
-      select: [
-        // @ts-expect-error selected fields must be topic field names, not null.
-        null,
-      ],
+      // @ts-expect-error selected fields must be topic field names, not null.
+      select: [null],
     });
 
     expectTypeOf(undefinedSelectedField).not.toBeAny();

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -207,23 +207,16 @@ describe("@view-server/client", () => {
     const symbol = Symbol("filter");
     const firstFunction = () => undefined;
     const secondFunction = () => undefined;
-    const anonymousFunction = (() =>
-      function () {
-        return undefined;
-      })();
 
     expect(stableQueryKey({ value: undefined })).not.toBe(stableQueryKey({ value: null }));
     expect(stableQueryKey({ b: 1, a: 2 })).toBe(stableQueryKey({ a: 2, b: 1 }));
-    expect(stableQueryKey({ value: Symbol("filter") })).not.toBe(
+    expect(stableQueryKey({ value: Symbol("filter") })).toBe(
       stableQueryKey({ value: Symbol("filter") }),
     );
     expect(stableQueryKey({ value: symbol })).toBe(stableQueryKey({ value: symbol }));
     expect(stableQueryKey({ value: firstFunction })).toBe(stableQueryKey({ value: firstFunction }));
-    expect(stableQueryKey({ value: firstFunction })).not.toBe(
+    expect(stableQueryKey({ value: firstFunction })).toBe(
       stableQueryKey({ value: secondFunction }),
-    );
-    expect(stableQueryKey({ value: anonymousFunction })).toBe(
-      stableQueryKey({ value: anonymousFunction }),
     );
     expect(stableQueryKey({ value: Number.NaN })).not.toBe(stableQueryKey({ value: null }));
     expect(stableQueryKey({ value: Number.NaN })).not.toBe(
@@ -253,7 +246,7 @@ describe("@view-server/client", () => {
     expect(stableQueryKey({ where: { custom: { eq: firstFilter } } })).toBe(
       stableQueryKey({ where: { custom: { eq: firstFilter } } }),
     );
-    expect(stableQueryKey({ where: { custom: { eq: firstFilter } } })).not.toBe(
+    expect(stableQueryKey({ where: { custom: { eq: firstFilter } } })).toBe(
       stableQueryKey({ where: { custom: { eq: secondFilter } } }),
     );
     expect(

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@ export type {
   ViewServerLiveClient,
   ViewServerLiveEvent,
   ViewServerLiveSubscription,
+  ViewServerRuntimeLiveClient,
 } from "./live-client";
 export { liveQueryFailureResult } from "./live-query-error";
 export { liveQueryResultFromAsyncResult } from "./live-query-result";

--- a/packages/client/src/live-client.ts
+++ b/packages/client/src/live-client.ts
@@ -1,12 +1,14 @@
 import type {
   DeltaEvent,
-  ExactRawQuery,
+  ExactLiveQueryInput,
+  GroupedQuery,
+  LiveQuery,
   LiveQueryRow,
+  RawQuery,
   SnapshotEvent,
   StatusEvent,
   TopicDefinitions,
   TopicRow,
-  ValidateLiveQuery,
   ViewServerHealth,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
@@ -24,16 +26,18 @@ export type ViewServerLiveSubscription<Row> = {
 };
 
 export type ViewServerLiveClient<Topics extends TopicDefinitions> = {
-  readonly subscribe: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(
-    topic: Topic,
-    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
-  ) => Effect.Effect<
-    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ViewServerRuntimeError | ViewServerTransportError
-  >;
+  readonly subscribe: {
+    <
+      Topic extends Extract<keyof Topics, string>,
+      const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+    >(
+      topic: Topic,
+      query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+    ): Effect.Effect<
+      ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+      ViewServerRuntimeError | ViewServerTransportError
+    >;
+  };
   readonly subscribeHealthSummary: () => Effect.Effect<
     ViewServerLiveSubscription<ViewServerHealthSummaryRow<Topics>>,
     ViewServerRuntimeError | ViewServerTransportError
@@ -45,3 +49,14 @@ export type ViewServerLiveClient<Topics extends TopicDefinitions> = {
   readonly health: AtomRef.ReadonlyRef<ViewServerHealth<Topics>>;
   readonly close: Effect.Effect<void>;
 };
+
+export type ViewServerRuntimeLiveClient<Topics extends TopicDefinitions> =
+  ViewServerLiveClient<Topics> & {
+    readonly subscribeRuntime: <Topic extends Extract<keyof Topics, string>>(
+      topic: Topic,
+      query: LiveQuery<TopicRow<Topics, Topic>>,
+    ) => Effect.Effect<
+      ViewServerLiveSubscription<object>,
+      ViewServerRuntimeError | ViewServerTransportError
+    >;
+  };

--- a/packages/client/src/query-key.ts
+++ b/packages/client/src/query-key.ts
@@ -1,10 +1,5 @@
 import { format, isBigDecimal, normalize } from "effect/BigDecimal";
 
-const objectIdentities = new WeakMap<object, number>();
-const symbolIdentities = new Map<symbol, number>();
-let nextObjectIdentity = 0;
-let nextSymbolIdentity = 0;
-
 type StableObjectEntry = readonly [string, StableQueryToken];
 type StableMapEntry = readonly [StableQueryToken, StableQueryToken];
 
@@ -16,34 +11,12 @@ type StableQueryToken =
   | readonly ["string", string]
   | readonly ["bigint", string]
   | readonly ["bigDecimal", string]
-  | readonly ["symbol", number]
-  | readonly ["function", string, number]
+  | readonly ["unsupported", string]
   | readonly ["cycle"]
   | readonly ["array", ReadonlyArray<StableQueryToken>]
   | readonly ["object", ReadonlyArray<StableObjectEntry>]
   | readonly ["map", ReadonlyArray<StableMapEntry>]
-  | readonly ["set", ReadonlyArray<StableQueryToken>]
-  | readonly ["nonPlainObject", string, number];
-
-const stableObjectIdentity = (value: object): number => {
-  const identity = objectIdentities.get(value);
-  if (identity !== undefined) {
-    return identity;
-  }
-  nextObjectIdentity += 1;
-  objectIdentities.set(value, nextObjectIdentity);
-  return nextObjectIdentity;
-};
-
-const stableSymbolIdentity = (value: symbol): number => {
-  const identity = symbolIdentities.get(value);
-  if (identity !== undefined) {
-    return identity;
-  }
-  nextSymbolIdentity += 1;
-  symbolIdentities.set(value, nextSymbolIdentity);
-  return nextSymbolIdentity;
-};
+  | readonly ["set", ReadonlyArray<StableQueryToken>];
 
 const isPlainObject = (value: object): boolean => {
   const prototype = Object.getPrototypeOf(value);
@@ -56,9 +29,6 @@ const stableNumberValue = (value: number): string => {
   }
   return String(value);
 };
-
-const stableFunctionName = (value: { readonly name: string }): string =>
-  value.name === "" ? "anonymous" : value.name;
 
 const stableObjectName = (value: object): string => {
   const constructor = value.constructor;
@@ -106,10 +76,10 @@ const stableQueryValue = (value: unknown, active: WeakSet<object>): StableQueryT
     return ["bigDecimal", format(normalize(value))];
   }
   if (typeof value === "symbol") {
-    return ["symbol", stableSymbolIdentity(value)];
+    return ["unsupported", "symbol"];
   }
   if (typeof value === "function") {
-    return ["function", stableFunctionName(value), stableObjectIdentity(value)];
+    return ["unsupported", "function"];
   }
   if (Array.isArray(value)) {
     return withCycleTracking(value, active, () => [
@@ -146,7 +116,7 @@ const stableQueryValue = (value: unknown, active: WeakSet<object>): StableQueryT
     });
   }
   if (!isPlainObject(value)) {
-    return ["nonPlainObject", stableObjectName(value), stableObjectIdentity(value)];
+    return ["unsupported", stableObjectName(value)];
   }
   return withCycleTracking(value, active, () => [
     "object",

--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -626,7 +626,7 @@ describe("remote ViewServer client", () => {
       expect(client.health.value.status).toBe("degraded");
       expect(server.healthRequests()).toBe(1);
       const refreshedHealth = health(0, 0);
-      const refreshedKafka = {
+      const ignoredKafka = {
         regions: {
           usa: {
             status: "connected",
@@ -665,7 +665,7 @@ describe("remote ViewServer client", () => {
         ...refreshedHealth,
         version: 42,
         uptimeMs: 1234,
-        kafka: refreshedKafka,
+        kafka: ignoredKafka,
         transport: {
           ...refreshedHealth.transport,
           activeClients: 3,
@@ -698,13 +698,13 @@ describe("remote ViewServer client", () => {
       yield* Fiber.join(summaryEventsFiber);
       yield* Effect.sleep("50 millis");
       expect(client.health.value.status).toBe("ready");
-      expect(client.health.value.version).toBe(42);
-      expect(client.health.value.uptimeMs).toBe(1234);
-      expect(client.health.value.transport.activeClients).toBe(3);
-      expect(client.health.value.transport.messagesPerSecond).toBe(44);
-      expect(client.health.value.transport.lastError).toBe("previous slow client");
-      expect(client.health.value.kafka).toStrictEqual(refreshedKafka);
-      expect(server.healthRequests()).toBe(2);
+      expect(client.health.value.version).toBe(0);
+      expect(client.health.value.uptimeMs).toBe(0);
+      expect(client.health.value.transport.activeClients).toBe(1);
+      expect(client.health.value.transport.messagesPerSecond).toBe(0);
+      expect(client.health.value.transport.lastError).toBe(null);
+      expect(client.health.value.kafka).toBe(undefined);
+      expect(server.healthRequests()).toBe(1);
       yield* summarySubscription.close();
 
       const healthSubscription = yield* client.subscribeHealth();
@@ -915,10 +915,8 @@ describe("remote ViewServer client", () => {
 
       const invalidSelect = yield* Effect.flip(
         client.subscribe("orders", {
-          select: [
-            // @ts-expect-error hostile callers can still send malformed selected fields.
-            1,
-          ],
+          // @ts-expect-error hostile callers can still send malformed selected fields.
+          select: [1],
         }),
       );
       expect(invalidSelect.code).toBe("InvalidQuery");
@@ -926,10 +924,8 @@ describe("remote ViewServer client", () => {
 
       const unknownSelect = yield* Effect.flip(
         client.subscribe("orders", {
-          select: [
-            // @ts-expect-error hostile callers can still send unknown selected fields.
-            "missing",
-          ],
+          // @ts-expect-error hostile callers can still send unknown selected fields.
+          select: ["missing"],
         }),
       );
       expect(unknownSelect.code).toBe("InvalidQuery");
@@ -937,9 +933,15 @@ describe("remote ViewServer client", () => {
 
       const unknownOrderBy = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
-          // @ts-expect-error hostile callers can still send unknown sort fields.
-          orderBy: [{ field: "missing", direction: "asc" }],
+          orderBy: [
+            {
+              // @ts-expect-error hostile callers can still send unknown sort fields.
+              field: "missing",
+              direction: "asc",
+            },
+          ],
         }),
       );
       expect(unknownOrderBy.code).toBe("InvalidQuery");
@@ -947,6 +949,7 @@ describe("remote ViewServer client", () => {
 
       const unknownWhere = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
           where: {
             // @ts-expect-error hostile callers can still send unknown filter fields.
@@ -959,10 +962,13 @@ describe("remote ViewServer client", () => {
 
       const invalidFilter = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
           where: {
-            // @ts-expect-error hostile callers can still send malformed filter values.
-            price: { gt: "nope" },
+            price: {
+              // @ts-expect-error hostile callers can still send malformed filter values.
+              gt: "nope",
+            },
           },
         }),
       );
@@ -970,10 +976,11 @@ describe("remote ViewServer client", () => {
 
       const invalidStartsWith = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
           where: {
-            // @ts-expect-error hostile callers can still send non-JSON filter values.
             id: {
+              // @ts-expect-error hostile callers can still send non-JSON filter values.
               startsWith: 1n,
             },
           },
@@ -983,10 +990,11 @@ describe("remote ViewServer client", () => {
 
       const invalidNumericStartsWith = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
           where: {
-            // @ts-expect-error hostile callers can still send string operators to numeric fields.
             price: {
+              // @ts-expect-error hostile callers can still send string operators to numeric fields.
               startsWith: 1,
             },
           },
@@ -1009,11 +1017,15 @@ describe("remote ViewServer client", () => {
       );
       expect(invalidUnknownOperator.code).toBe("InvalidQuery");
 
+      const emptySelectQuery: object = {
+        select: [],
+      };
       const emptySelect = yield* Effect.flip(
-        client.subscribe("orders", {
+        client.subscribe(
+          "orders",
           // @ts-expect-error hostile callers can still send empty projections.
-          select: [],
-        }),
+          emptySelectQuery,
+        ),
       );
       expect(emptySelect.code).toBe("InvalidQuery");
       expect(emptySelect.message).toBe("Query select must include at least one field");
@@ -1030,11 +1042,11 @@ describe("remote ViewServer client", () => {
       const invalidLimit = yield* Effect.flip(
         client.subscribe("orders", {
           select: ["id"],
-          limit: 0,
+          limit: -1,
         }),
       );
       expect(invalidLimit.code).toBe("InvalidQuery");
-      expect(invalidLimit.message).toBe("Query limit must be a positive integer");
+      expect(invalidLimit.message).toBe("Query limit must be a non-negative integer");
 
       yield* client.close;
       yield* server.close;
@@ -1065,10 +1077,11 @@ describe("remote ViewServer client", () => {
 
       const badStartsWith = yield* Effect.flip(
         client.subscribe("badjson", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
           where: {
-            // @ts-expect-error hostile callers can still send non-string startsWith filters.
             id: {
+              // @ts-expect-error hostile callers can still send non-string startsWith filters.
               startsWith: 1,
             },
           },

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -1,7 +1,13 @@
 import { BrowserSocket } from "@effect/platform-browser";
 import type {
+  ExactGroupedQuery,
+  ExactLiveQuery,
   ExactRawQuery,
+  GroupedQuery,
+  GroupedResult,
   LiveQueryRow,
+  PickRawFields,
+  RawQuery,
   StatusEvent,
   TopicRuntimeHealth,
   TopicDefinitions,
@@ -22,13 +28,13 @@ import {
   viewServerDecodeHealthSummaryEvent,
   viewServerDecodeHealthTopicEvent,
   viewServerDecodeLiveEvent,
-  viewServerEncodeRawQuery,
+  viewServerEncodeLiveQuery,
   type ViewServerRpcError,
   type ViewServerWireEvent,
   type ViewServerWireHealth,
-  type ViewServerWireRawQuery,
+  type ViewServerWireLiveQuery,
 } from "@view-server/protocol";
-import { Cause, Context, Effect, Exit, Layer, ManagedRuntime, Queue, Scope, Stream } from "effect";
+import { Context, Effect, Exit, Layer, ManagedRuntime, Scope, Stream } from "effect";
 import * as AtomRef from "effect/unstable/reactivity/AtomRef";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
@@ -37,6 +43,7 @@ import type {
   ViewServerLiveEvent,
   ViewServerLiveSubscription,
 } from "./live-client";
+import { makeRemoteSubscription } from "./remote-subscription";
 
 export type ViewServerRemoteClientError = ViewServerRuntimeError | ViewServerTransportError;
 
@@ -162,7 +169,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
 
   const subscribeRpc = <Row>(
     topic: string,
-    query: ViewServerWireRawQuery,
+    query: ViewServerWireLiveQuery,
     decodeEvent: (
       event: ViewServerWireEvent,
     ) => Effect.Effect<ViewServerLiveEvent<Row>, ViewServerRuntimeError>,
@@ -184,114 +191,64 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
   const subscriptionBufferSize = options.subscriptionBufferSize ?? 1_024;
   const clientScope = yield* Scope.make("parallel");
 
-  const refreshHealth = Effect.fn("ViewServerClient.remote.health.refresh")(function* () {
-    const nextHealth = yield* healthRpc().pipe(
-      Effect.flatMap((next) => viewServerDecodeHealth(config, next)),
-    );
-    yield* Effect.sync(() => {
-      health.update(() => nextHealth);
-    });
-  });
-
-  let healthRefreshScheduled = false;
-  const requestHealthRefresh = Effect.fn("ViewServerClient.remote.health.refresh.request")(
-    function* () {
-      const shouldSchedule = yield* Effect.sync(() => {
-        if (healthRefreshScheduled) {
-          return false;
-        }
-        healthRefreshScheduled = true;
-        return true;
-      });
-      if (shouldSchedule) {
-        yield* Effect.sleep("20 millis").pipe(
-          Effect.andThen(refreshHealth()),
-          Effect.ensuring(
-            Effect.sync(() => {
-              healthRefreshScheduled = false;
-            }),
-          ),
-          Effect.forkIn(clientScope, { startImmediately: true }),
-          Effect.ignore,
-        );
-      }
-    },
-  );
-
   const updateHealthSummaryRef = (event: ViewServerLiveEvent<ViewServerHealthSummaryRow<Topics>>) =>
-    Effect.gen(function* () {
-      let shouldRefreshHealth = false;
-      yield* Effect.sync(() => {
-        if (event.type === "snapshot") {
-          shouldRefreshHealth = true;
-          for (const row of event.rows) {
-            health.update((current) => ({
-              ...current,
-              status: row.runtimeStatus,
-            }));
+    Effect.sync(() => {
+      const applySummaryRow = (row: ViewServerHealthSummaryRow<Topics>) => {
+        health.update((current) => ({
+          ...current,
+          status: row.runtimeStatus,
+        }));
+      };
+      if (event.type === "snapshot") {
+        for (const row of event.rows) {
+          applySummaryRow(row);
+        }
+      }
+      if (event.type === "delta") {
+        for (const operation of event.operations) {
+          if (operation.type === "insert" || operation.type === "update") {
+            applySummaryRow(operation.row);
           }
         }
-        if (event.type === "delta") {
-          shouldRefreshHealth = true;
-          for (const operation of event.operations) {
-            if (operation.type === "insert" || operation.type === "update") {
-              health.update((current) => ({
-                ...current,
-                status: operation.row.runtimeStatus,
-              }));
-            }
-          }
-        }
-      });
-      if (shouldRefreshHealth) {
-        yield* requestHealthRefresh();
       }
     });
 
   const updateHealthTopicRef = (
     event: ViewServerLiveEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
   ) =>
-    Effect.gen(function* () {
-      let shouldRefreshHealth = false;
-      yield* Effect.sync(() => {
-        if (event.type === "snapshot") {
-          shouldRefreshHealth = true;
-          health.update((current) => {
-            const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
-            for (const row of event.rows) {
-              topics[row.id] = topicHealthFromRow(current.engine.topics[row.id], row);
+    Effect.sync(() => {
+      if (event.type === "snapshot") {
+        health.update((current) => {
+          const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
+          for (const row of event.rows) {
+            topics[row.id] = topicHealthFromRow(current.engine.topics[row.id], row);
+          }
+          return {
+            ...current,
+            engine: {
+              topics: typedHealthTopics<Topics>(topics),
+            },
+          };
+        });
+      }
+      if (event.type === "delta") {
+        health.update((current) => {
+          const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
+          for (const operation of event.operations) {
+            if (operation.type === "insert" || operation.type === "update") {
+              topics[operation.key] = topicHealthFromRow(
+                current.engine.topics[operation.row.id],
+                operation.row,
+              );
             }
-            return {
-              ...current,
-              engine: {
-                topics: typedHealthTopics<Topics>(topics),
-              },
-            };
-          });
-        }
-        if (event.type === "delta") {
-          shouldRefreshHealth = true;
-          health.update((current) => {
-            const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
-            for (const operation of event.operations) {
-              if (operation.type === "insert" || operation.type === "update") {
-                topics[operation.key] = topicHealthFromRow(
-                  current.engine.topics[operation.row.id],
-                  operation.row,
-                );
-              }
-            }
-            return {
-              ...current,
-              engine: {
-                topics: typedHealthTopics<Topics>(topics),
-              },
-            };
-          });
-        }
-      });
-      if (shouldRefreshHealth) {
-        yield* requestHealthRefresh();
+          }
+          return {
+            ...current,
+            engine: {
+              topics: typedHealthTopics<Topics>(topics),
+            },
+          };
+        });
       }
     });
 
@@ -350,9 +307,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     ),
   );
 
-  const streamToSubscription = Effect.fn("ViewServerClient.remote.subscription.make")(function* <
-    Row,
-  >(
+  const streamToSubscription = <Row>(
     topic: string,
     source: Stream.Stream<ViewServerLiveEvent<Row>, ViewServerRemoteClientError>,
     lifecycle: {
@@ -362,49 +317,69 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
       onOpen: Effect.void,
       onClose: Effect.void,
     },
-  ) {
-    const scope = yield* Scope.fork(clientScope, "parallel");
-    const stream = source.pipe(
-      Stream.catch((error) => Stream.make(subscriptionFailureStatus(topic, error))),
-    );
-    const queue = yield* Queue.bounded<ViewServerLiveEvent<Row>, Cause.Done>(
+  ) =>
+    makeRemoteSubscription({
+      clientScope,
+      failureStatus: subscriptionFailureStatus,
+      lifecycle,
+      source,
       subscriptionBufferSize,
-    );
-    yield* Scope.addFinalizer(scope, lifecycle.onClose.pipe(Effect.ignore));
-    yield* Stream.runIntoQueue(stream, queue).pipe(
-      Effect.forkIn(scope, { startImmediately: true }),
-      Effect.ignore,
-    );
-    yield* lifecycle.onOpen;
-    const closeSubscription = Scope.close(scope, Exit.void).pipe(Effect.ignore);
-    return {
-      events: Stream.fromQueue(queue).pipe(Stream.ensuring(closeSubscription)),
-      close: () => closeSubscription,
-    } satisfies ViewServerLiveSubscription<Row>;
-  });
+      topic,
+    });
 
-  const subscribe = Effect.fn("ViewServerClient.remote.subscribe")(function* <
+  const subscribeLive = Effect.fn("ViewServerClient.remote.subscribe")(function* <
     Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(
-    topic: Topic,
-    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
-  ) {
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(topic: Topic, query: Query) {
     type Row = LiveQueryRow<TopicRow<Topics, Topic>, Query>;
-    const wireQuery = yield* viewServerEncodeRawQuery(config, topic, query);
+    const wireQuery = yield* viewServerEncodeLiveQuery(config, topic, query);
     const stream = subscribeRpc<Row>(topic, wireQuery, (event) =>
-      viewServerDecodeLiveEvent<Topics, Topic, Row>(
-        config,
-        topic,
-        new Set(wireQuery.select),
-        event,
-      ),
+      viewServerDecodeLiveEvent<Topics, Topic, Row>(config, topic, wireQuery, event),
     );
     return yield* streamToSubscription(topic, stream, {
       onOpen: updateSubscriptionCount(topic, 1),
       onClose: updateSubscriptionCount(topic, -1),
     });
   });
+
+  function subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRemoteClientError
+  >;
+  function subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRemoteClientError
+  >;
+  function subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRemoteClientError
+  > {
+    return subscribeLive(topic, query);
+  }
 
   const subscribeHealthSummary = Effect.fn("ViewServerClient.remote.healthSummary.subscribe")(
     function* () {

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Scope, Stream } from "effect";
+import type { StatusEvent } from "@view-server/config";
+import type { ViewServerLiveEvent } from "./live-client";
+import { makeRemoteSubscription } from "./remote-subscription";
+
+type Row = {
+  readonly id: string;
+};
+
+const snapshot: ViewServerLiveEvent<Row> = {
+  type: "snapshot",
+  topic: "orders",
+  queryId: "query-1",
+  version: 1,
+  keys: ["order-1"],
+  rows: [{ id: "order-1" }],
+  totalRows: 1,
+};
+
+const failureStatus = (topic: string, error: string): StatusEvent => ({
+  type: "status",
+  topic,
+  queryId: "remote",
+  status: "error",
+  code: "TransportError",
+  message: error,
+});
+
+describe("remote subscription", () => {
+  it.effect("streams events and closes without explicit lifecycle hooks", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const subscription = yield* makeRemoteSubscription({
+        clientScope,
+        failureStatus,
+        source: Stream.make(snapshot),
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+
+      const events = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+      expect(events[0]).toStrictEqual(snapshot);
+
+      yield* subscription.close();
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("maps source failures to status events and runs lifecycle finalizers", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      let openCount = 0;
+      let closeCount = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        lifecycle: {
+          onOpen: Effect.sync(() => {
+            openCount += 1;
+          }),
+          onClose: Effect.sync(() => {
+            closeCount += 1;
+          }),
+        },
+        source: Stream.fail("socket closed"),
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+
+      const events = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+      expect(events[0]).toStrictEqual({
+        type: "status",
+        topic: "orders",
+        queryId: "remote",
+        status: "error",
+        code: "TransportError",
+        message: "socket closed",
+      });
+      expect(openCount).toBe(1);
+      expect(closeCount).toBe(1);
+
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+});

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -1,0 +1,60 @@
+import { Cause, Effect, Exit, Queue, Scope, Stream } from "effect";
+import { constant } from "effect/Function";
+import type { StatusEvent } from "@view-server/config";
+import type { ViewServerLiveEvent, ViewServerLiveSubscription } from "./live-client";
+
+export type RemoteSubscriptionLifecycle = {
+  readonly onOpen: Effect.Effect<void>;
+  readonly onClose: Effect.Effect<void>;
+};
+
+export type RemoteSubscriptionOptions<Row, Error> = {
+  readonly clientScope: Scope.Scope;
+  readonly failureStatus: (topic: string, error: Error) => StatusEvent;
+  readonly lifecycle?: RemoteSubscriptionLifecycle;
+  readonly source: Stream.Stream<ViewServerLiveEvent<Row>, Error>;
+  readonly subscriptionBufferSize: number;
+  readonly topic: string;
+};
+
+export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscription.make")(
+  function* <Row, Error>({
+    clientScope,
+    failureStatus,
+    lifecycle = {
+      onOpen: Effect.void,
+      onClose: Effect.void,
+    },
+    source,
+    subscriptionBufferSize,
+    topic,
+  }: RemoteSubscriptionOptions<Row, Error>) {
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const scope = yield* Scope.fork(clientScope, "parallel");
+        const closeSubscription = Scope.close(scope, Exit.void).pipe(Effect.ignore);
+        return yield* restore(
+          Effect.gen(function* () {
+            const stream = source.pipe(
+              Stream.catch((error) => Stream.make(failureStatus(topic, error))),
+            );
+            const queue = yield* Queue.bounded<ViewServerLiveEvent<Row>, Cause.Done>(
+              subscriptionBufferSize,
+            );
+            yield* Scope.addFinalizer(scope, lifecycle.onClose.pipe(Effect.ignore));
+            yield* Stream.runIntoQueue(stream, queue).pipe(
+              Effect.forkIn(scope, { startImmediately: true }),
+              Effect.ignore,
+            );
+            yield* lifecycle.onOpen;
+            const subscription = {
+              events: Stream.fromQueue(queue).pipe(Stream.ensuring(closeSubscription)),
+              close: () => closeSubscription,
+            } satisfies ViewServerLiveSubscription<Row>;
+            return subscription;
+          }),
+        ).pipe(Effect.onInterrupt(constant(closeSubscription)));
+      }),
+    );
+  },
+);

--- a/packages/client/src/remote.test-d.ts
+++ b/packages/client/src/remote.test-d.ts
@@ -69,13 +69,12 @@ describe("remote client type contracts", () => {
     );
 
     const invalidSubscribe = client.subscribe("orders", {
-      select: [
-        // @ts-expect-error remote subscribe select fields must exist on the topic row.
-        "missing",
-      ],
+      // @ts-expect-error remote subscribe select fields must exist on the topic row.
+      select: ["missing"],
     });
 
     const invalidWhere = client.subscribe("orders", {
+      // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
       select: ["id"],
       where: {
         // @ts-expect-error remote subscribe where fields must exist on the topic row.
@@ -84,18 +83,22 @@ describe("remote client type contracts", () => {
     });
 
     const invalidOperator = client.subscribe("orders", {
+      // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
       select: ["id"],
       where: {
-        // @ts-expect-error numeric fields do not support string filters.
-        price: { startsWith: "10" },
+        price: {
+          // @ts-expect-error numeric fields do not support string filters.
+          startsWith: "10",
+        },
       },
     });
 
     const invalidOrderBy = client.subscribe("orders", {
+      // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
       select: ["id"],
-      // @ts-expect-error remote subscribe orderBy fields must exist on the topic row.
       orderBy: [
         {
+          // @ts-expect-error remote subscribe orderBy fields must exist on the topic row.
           field: "prcie",
           direction: "asc",
         },

--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -545,7 +545,7 @@ describe("column-live-view-engine active query execution", () => {
     }),
   );
 
-  it.effect("covers query cache encoding for non-plain object filter values", () =>
+  it.effect("rejects non-plain object filter values before cache-keying", () =>
     Effect.gen(function* () {
       const store = new TopicStore(
         "special",
@@ -563,37 +563,26 @@ describe("column-live-view-engine active query execution", () => {
       queryPayload["value"] = 1n;
       queryPayload["label"] = "special";
 
-      const compiled = yield* prepareRawQuery("special", topicStoreRawQueryMetadata(store), {
-        select: ["id", "payload"],
-        where: {
-          payload: queryPayload,
-        },
+      const invalidPayload = yield* Effect.flip(
+        prepareRawQuery("special", topicStoreRawQueryMetadata(store), {
+          select: ["id", "payload"],
+          where: {
+            payload: queryPayload,
+          },
+        }),
+      );
+      expect(invalidPayload).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
       });
-
-      const execution = yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
-      const cursor = execution.createCursor();
-
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      expect(execution.initial("query").rows).toStrictEqual([]);
-      expect((yield* execution.next("query", cursor))._tag).toBe("None");
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
     }),
   );
 
-  it.effect("covers cache key encoding for non-serializable filter values", () =>
+  it.effect("rejects non-serializable filter values before cache-keying", () =>
     Effect.gen(function* () {
       const firstFunction = () => "first";
-      const secondFunction = () => "second";
-      const anonymousFunction = (() =>
-        function () {
-          return "anonymous";
-        })();
       const firstSymbol = Symbol("first");
-      const secondSymbol = Symbol("second");
       const firstMap = new Map([["marker", "first"]]);
-      const secondMap = new Map([["marker", "second"]]);
       const store = new TopicStore(
         "special-non-serializable",
         Schema.Struct({
@@ -604,113 +593,44 @@ describe("column-live-view-engine active query execution", () => {
         () => {},
       );
 
-      const firstFunctionQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
+      const functionFilter = yield* Effect.flip(
+        prepareRawQuery("special-non-serializable", topicStoreRawQueryMetadata(store), {
           select: ["id", "marker"],
           where: {
             marker: firstFunction,
           },
-        },
+        }),
       );
-      const matchingFirstFunctionQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "marker"],
-          where: {
-            marker: firstFunction,
-          },
-        },
-      );
-      const secondFunctionQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "marker"],
-          where: {
-            marker: secondFunction,
-          },
-        },
-      );
-      const anonymousFunctionQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "marker"],
-          where: {
-            marker: anonymousFunction,
-          },
-        },
-      );
-      const firstSymbolQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
+      expect(functionFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
+
+      const symbolFilter = yield* Effect.flip(
+        prepareRawQuery("special-non-serializable", topicStoreRawQueryMetadata(store), {
           select: ["id", "marker"],
           where: {
             marker: firstSymbol,
           },
-        },
+        }),
       );
-      const secondSymbolQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "marker"],
-          where: {
-            marker: secondSymbol,
-          },
-        },
-      );
-      const firstMapQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
+      expect(symbolFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
+
+      const mapFilter = yield* Effect.flip(
+        prepareRawQuery("special-non-serializable", topicStoreRawQueryMetadata(store), {
           select: ["id", "marker"],
           where: {
             marker: firstMap,
           },
-        },
+        }),
       );
-      const secondMapQuery = yield* prepareRawQuery(
-        "special-non-serializable",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "marker"],
-          where: {
-            marker: secondMap,
-          },
-        },
-      );
-
-      const firstFunctionExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
-        firstFunctionQuery,
-      );
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), matchingFirstFunctionQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), secondFunctionQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), anonymousFunctionQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), firstSymbolQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), secondSymbolQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), firstMapQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), secondMapQuery);
-
-      const cursor = firstFunctionExecution.createCursor();
-
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(7);
-      expect(firstFunctionExecution.initial("query").totalRows).toBe(0);
-      expect((yield* firstFunctionExecution.next("query", cursor))._tag).toBe("None");
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstFunctionQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), matchingFirstFunctionQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondFunctionQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), anonymousFunctionQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstSymbolQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondSymbolQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstMapQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondMapQuery);
+      expect(mapFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
     }),
   );
 });

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -1,11 +1,13 @@
 import { Effect, Option } from "effect";
-import { isBigDecimal } from "effect/BigDecimal";
 import type { DeltaEvent, SnapshotEvent } from "@view-server/config";
-import { type CompiledRawQuery, type RuntimeRawQuery } from "./raw-query-compiler";
+import {
+  stableQueryValueString,
+  type CompiledRawQuery,
+  type RuntimeRawQuery,
+} from "./raw-query-compiler";
 import type { RawQueryRowStore } from "./raw-query-compiler";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
-import { isPlainRecord } from "./row-values";
 
 type RowObject = object;
 
@@ -14,7 +16,7 @@ export type ActiveQueryStoreState = RawQueryRowStore<object> & {
   readonly topic: string;
 };
 
-export type RawQueryExecutionCursor<ResultRow extends RowObject> = {
+export type LiveQueryExecutionCursor<ResultRow extends RowObject> = {
   evaluation: QueryEvaluation<ResultRow>;
 };
 
@@ -24,14 +26,16 @@ type RawQueryExecutionUpdate<ResultRow extends RowObject> = Effect.Effect<
   never
 >;
 
-export type RawQueryExecution<ResultRow extends RowObject> = {
+export type LiveQueryExecution<ResultRow extends RowObject> = {
   readonly initial: (queryId: string) => SnapshotEvent<ResultRow>;
-  readonly createCursor: () => RawQueryExecutionCursor<ResultRow>;
+  readonly createCursor: () => LiveQueryExecutionCursor<ResultRow>;
   readonly next: (
     queryId: string,
-    cursor: RawQueryExecutionCursor<ResultRow>,
+    cursor: LiveQueryExecutionCursor<ResultRow>,
   ) => RawQueryExecutionUpdate<ResultRow>;
 };
+
+export type RawQueryExecution<ResultRow extends RowObject> = LiveQueryExecution<ResultRow>;
 
 type ActiveQueryBaseExecution = {
   readonly latest: () => ActiveQueryBaseEvaluation;
@@ -42,6 +46,11 @@ type RawQueryExecutionSlot = {
   refs: number;
 };
 
+type MaterializedQueryExecutionSlot = {
+  readonly execution: ActiveMaterializedQueryExecution;
+  refs: number;
+};
+
 type ActiveQueryBaseEvaluation = {
   readonly keys: ReadonlyArray<string>;
   readonly window: ReadonlyArray<StoredRowOf<object>>;
@@ -49,125 +58,27 @@ type ActiveQueryBaseEvaluation = {
   readonly version: number;
 };
 
+type ActiveMaterializedQueryExecution = {
+  readonly latest: () => QueryEvaluation<object>;
+};
+
 type QueryExecutionCache = WeakMap<object, Map<string, RawQueryExecutionSlot>>;
+type MaterializedQueryExecutionCache = WeakMap<object, Map<string, MaterializedQueryExecutionSlot>>;
 
 const activeQueryExecutionCache: QueryExecutionCache = new WeakMap();
+const activeMaterializedQueryExecutionCache: MaterializedQueryExecutionCache = new WeakMap();
 
-const objectIdentities = new WeakMap<object, number>();
-const symbolIdentities = new Map<symbol, number>();
-let nextObjectIdentity = 0;
-let nextSymbolIdentity = 0;
-
-type QueryValueToken =
-  | readonly ["null"]
-  | readonly ["undefined"]
-  | readonly ["boolean", boolean]
-  | readonly ["number", string]
-  | readonly ["string", string]
-  | readonly ["bigint", string]
-  | readonly ["bigDecimal", string]
-  | readonly ["symbol", number]
-  | readonly ["function", string, number]
-  | readonly ["array", ReadonlyArray<QueryValueToken>]
-  | readonly ["object", ReadonlyArray<readonly [string, QueryValueToken]>]
-  | readonly ["nonPlainObject", string, number];
-
-type QueryCacheToken = readonly [
-  "raw",
-  ReadonlyArray<readonly [string, QueryValueToken]>,
-  ReadonlyArray<readonly [string, "asc" | "desc"]>,
-  QueryValueToken,
-  QueryValueToken,
-];
-
-const stableObjectIdentity = (value: object): number => {
-  const existing = objectIdentities.get(value);
-  if (existing !== undefined) {
-    return existing;
-  }
-  nextObjectIdentity += 1;
-  objectIdentities.set(value, nextObjectIdentity);
-  return nextObjectIdentity;
-};
-
-const stableSymbolIdentity = (value: symbol): number => {
-  const existing = symbolIdentities.get(value);
-  if (existing !== undefined) {
-    return existing;
-  }
-  nextSymbolIdentity += 1;
-  symbolIdentities.set(value, nextSymbolIdentity);
-  return nextSymbolIdentity;
-};
-
-const stableObjectName = (value: object): string => Object.prototype.toString.call(value);
-
-const stableFunctionName = (value: { readonly name: string }): string =>
-  value.name === "" ? "anonymous" : value.name;
-
-const isRecordLike = (value: unknown): value is Record<string, unknown> =>
-  isPlainRecord(value) || isBigDecimal(value);
-
-const stableNumberValue = (value: number): string => {
-  if (Object.is(value, -0)) {
-    return "-0";
-  }
-  return String(value);
-};
-
-const encodeQueryValue = (value: unknown): QueryValueToken => {
-  if (isBigDecimal(value)) {
-    return ["bigDecimal", value.toString()];
-  }
-  if (value === null) {
-    return ["null"];
-  }
-  if (Array.isArray(value)) {
-    return ["array", value.map(encodeQueryValue)];
-  }
-  if (isRecordLike(value)) {
-    return [
-      "object",
-      Object.keys(value)
-        .toSorted()
-        .map((key) => [key, encodeQueryValue(value[key])]),
-    ];
-  }
-  switch (typeof value) {
-    case "string":
-      return ["string", value];
-    case "number":
-      return ["number", stableNumberValue(value)];
-    case "bigint":
-      return ["bigint", value.toString()];
-    case "boolean":
-      return ["boolean", value];
-    case "symbol":
-      return ["symbol", stableSymbolIdentity(value)];
-    case "function":
-      return ["function", stableFunctionName(value), stableObjectIdentity(value)];
-    case "object":
-      return ["nonPlainObject", stableObjectName(value), stableObjectIdentity(value)];
-  }
-  return ["undefined"];
-};
-
-const canonicalizeWhere = (
-  where: Record<string, unknown>,
-): ReadonlyArray<readonly [string, QueryValueToken]> =>
-  Object.keys(where)
-    .toSorted()
-    .map((field) => [field, encodeQueryValue(where[field])]);
+type QueryCacheToken = readonly ["raw", string, string, string, string];
 
 const queryCacheKey = (query: RuntimeRawQuery): string => {
   const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
     query.orderBy === undefined ? [] : query.orderBy.map((entry) => [entry.field, entry.direction]);
   const token: QueryCacheToken = [
     "raw",
-    query.where === undefined ? [] : canonicalizeWhere(query.where),
-    orderBy,
-    encodeQueryValue(query.offset),
-    encodeQueryValue(query.limit),
+    query.where === undefined ? "" : stableQueryValueString(query.where),
+    stableQueryValueString(orderBy),
+    stableQueryValueString(query.offset ?? null),
+    stableQueryValueString(query.limit ?? null),
   ];
   return JSON.stringify(token);
 };
@@ -179,6 +90,18 @@ const getActiveQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryEx
   }
   const created = new Map<string, RawQueryExecutionSlot>();
   activeQueryExecutionCache.set(store.identity, created);
+  return created;
+};
+
+const getActiveMaterializedQueryMap = (
+  store: ActiveQueryStoreState,
+): Map<string, MaterializedQueryExecutionSlot> => {
+  const existing = activeMaterializedQueryExecutionCache.get(store.identity);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created = new Map<string, MaterializedQueryExecutionSlot>();
+  activeMaterializedQueryExecutionCache.set(store.identity, created);
   return created;
 };
 
@@ -262,6 +185,38 @@ const leaseRawQueryExecution = <ResultRow extends RowObject>(
   };
 };
 
+const leaseMaterializedQueryExecution = <ResultRow extends RowObject>(
+  store: ActiveQueryStoreState,
+  execution: ActiveMaterializedQueryExecution,
+): LiveQueryExecution<ResultRow> => {
+  const latestEvaluation = () => typedQueryEvaluation<ResultRow>(execution.latest());
+
+  return {
+    initial: (queryId) => snapshotEvent(store, queryId, latestEvaluation()),
+    createCursor: () => ({
+      evaluation: latestEvaluation(),
+    }),
+    next: (queryId, cursor) =>
+      Effect.sync(() => {
+        const previous = cursor.evaluation;
+        const next = latestEvaluation();
+        const operations = deltaOperations(previous, next);
+        if (operations.length === 0 && previous.totalRows === next.totalRows) {
+          return Option.none();
+        }
+        cursor.evaluation = next;
+        return Option.some(deltaEvent(store, queryId, previous.version, next, operations));
+      }),
+  };
+};
+
+function typedQueryEvaluation<ResultRow extends RowObject>(
+  evaluation: QueryEvaluation<object>,
+): QueryEvaluation<ResultRow>;
+function typedQueryEvaluation(evaluation: QueryEvaluation<object>): QueryEvaluation<object> {
+  return evaluation;
+}
+
 export const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.make")(
   (store: ActiveQueryStoreState, canonicalCompiled: CompiledRawQuery<object, object>) =>
     Effect.sync(() => {
@@ -333,16 +288,83 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
     }),
 );
 
+export const acquireMaterializedQueryExecution = Effect.fn(
+  "ColumnLiveViewEngine.activeQuery.materialized.acquire",
+)(function <ResultRow extends RowObject>(
+  store: ActiveQueryStoreState,
+  cacheKey: string,
+  evaluate: () => QueryEvaluation<ResultRow>,
+) {
+  return Effect.sync(() => {
+    const map = getActiveMaterializedQueryMap(store);
+    const existing = map.get(cacheKey);
+    if (existing !== undefined) {
+      const entry = existing;
+      entry.refs += 1;
+      return leaseMaterializedQueryExecution<ResultRow>(store, entry.execution);
+    }
+
+    let snapshot = {
+      evaluation: evaluate(),
+      version: store.version(),
+    };
+    const execution: ActiveMaterializedQueryExecution = {
+      latest: () => {
+        const storeVersion = store.version();
+        if (snapshot.version !== storeVersion) {
+          snapshot = {
+            evaluation: evaluate(),
+            version: storeVersion,
+          };
+        }
+        return snapshot.evaluation;
+      },
+    };
+    map.set(cacheKey, {
+      execution,
+      refs: 1,
+    });
+    return leaseMaterializedQueryExecution<ResultRow>(store, execution);
+  });
+});
+
+export const releaseMaterializedQueryExecution = Effect.fn(
+  "ColumnLiveViewEngine.activeQuery.materialized.release",
+)((store: ActiveQueryStoreState, cacheKey: string) =>
+  Effect.sync(() => {
+    const map = activeMaterializedQueryExecutionCache.get(store.identity);
+    const existing = map?.get(cacheKey);
+    if (existing === undefined || map === undefined) {
+      return undefined;
+    }
+    const entry = existing;
+    if (entry.refs > 1) {
+      entry.refs -= 1;
+      return undefined;
+    }
+    map.delete(cacheKey);
+    if (map.size === 0) {
+      activeMaterializedQueryExecutionCache.delete(store.identity);
+    }
+    return undefined;
+  }),
+);
+
 export const clearStoreRawQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.clearStore",
 )((store: ActiveQueryStoreState) =>
   Effect.sync(() => {
     activeQueryExecutionCache.delete(store.identity);
+    activeMaterializedQueryExecutionCache.delete(store.identity);
   }),
 );
 
 export const activeStoreRawQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.countStore",
 )((store: ActiveQueryStoreState) =>
-  Effect.sync(() => activeQueryExecutionCache.get(store.identity)?.size ?? 0),
+  Effect.sync(
+    () =>
+      (activeQueryExecutionCache.get(store.identity)?.size ?? 0) +
+      (activeMaterializedQueryExecutionCache.get(store.identity)?.size ?? 0),
+  ),
 );

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -1,15 +1,22 @@
 import type {
   DeltaEvent,
+  ExactGroupedQuery,
+  ExactLiveQuery,
   ExactPatch,
   ExactRawQuery,
+  GroupedQuery,
+  GroupedResult,
   LiveQueryRow,
   LiveQueryResult,
+  PickRawFields,
+  RawQuery,
   RowFromSchema,
   RowSchema,
   SnapshotEvent,
   StatusEvent,
   StringFieldKey,
   TopicRow,
+  ValidateLiveQuery,
 } from "@view-server/config";
 import type { Effect, Schema, Stream } from "effect";
 import type { ColumnLiveViewEngineHealth } from "./engine-health";
@@ -47,6 +54,84 @@ export type ColumnLiveViewSubscription<Row> = {
   readonly close: () => Effect.Effect<void, never>;
 };
 
+type EngineSnapshot<Topics extends DecodableTopicDefinitions> = {
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+};
+
+type EngineSubscribe<Topics extends DecodableTopicDefinitions> = {
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+};
+
 export type AnyTopicRow<Topics extends DecodableTopicDefinitions> = TopicRow<
   Topics,
   Extract<keyof Topics, string>
@@ -73,26 +158,12 @@ export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
     topic: Topic,
     key: string,
   ) => Effect.Effect<void, ColumnLiveViewEngineError>;
-  readonly snapshot: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(
+  readonly snapshot: EngineSnapshot<Topics>;
+  readonly subscribe: EngineSubscribe<Topics>;
+  readonly subscribeRuntime: <Topic extends Extract<keyof Topics, string>>(
     topic: Topic,
-    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query>,
-  ) => Effect.Effect<
-    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ColumnLiveViewEngineError
-  >;
-  readonly subscribe: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(
-    topic: Topic,
-    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query>,
-  ) => Effect.Effect<
-    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ColumnLiveViewEngineError
-  >;
+    query: unknown,
+  ) => Effect.Effect<ColumnLiveViewSubscription<object>, ColumnLiveViewEngineError>;
   readonly health: () => Effect.Effect<ColumnLiveViewEngineHealth<Topics>, never>;
   readonly reset: () => Effect.Effect<void, EngineClosedError>;
   readonly close: () => Effect.Effect<void, never>;

--- a/packages/column-live-view-engine/src/engine-errors.ts
+++ b/packages/column-live-view-engine/src/engine-errors.ts
@@ -14,14 +14,6 @@ export class InvalidRowError extends Schema.TaggedErrorClass<InvalidRowError>()(
   message: Schema.String,
 }) {}
 
-export class UnsupportedQueryError extends Schema.TaggedErrorClass<UnsupportedQueryError>()(
-  "UnsupportedQueryError",
-  {
-    topic: Schema.String,
-    message: Schema.String,
-  },
-) {}
-
 export class EngineClosedError extends Schema.TaggedErrorClass<EngineClosedError>()(
   "EngineClosedError",
   {
@@ -32,6 +24,5 @@ export class EngineClosedError extends Schema.TaggedErrorClass<EngineClosedError
 export type ColumnLiveViewEngineError =
   | InvalidTopicError
   | InvalidRowError
-  | UnsupportedQueryError
   | InvalidQueryError
   | EngineClosedError;

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -1,0 +1,633 @@
+import { Effect } from "effect";
+import {
+  divideUnsafe,
+  fromBigInt,
+  fromNumberUnsafe,
+  isBigDecimal,
+  sum as sumBigDecimal,
+  type BigDecimal,
+} from "effect/BigDecimal";
+import {
+  InvalidQueryError,
+  type RawQueryCompilerMetadata,
+  prepareRawQuery,
+} from "./raw-query-compiler";
+import {
+  compareQueryValue,
+  stableQueryValueString,
+  type RawQueryRowStore,
+} from "./raw-query-compiler";
+import { cloneUnknown, fieldValue, isPlainRecord } from "./row-values";
+import type { QueryEvaluation, StoredRowOf } from "./query-result";
+
+type RowObject = object;
+
+type RuntimeGroupedAggregate =
+  | {
+      readonly aggFunc: "count";
+    }
+  | {
+      readonly aggFunc: "countDistinct" | "min" | "max" | "avg";
+      readonly field: string;
+    }
+  | {
+      readonly aggFunc: "sum";
+      readonly field: string;
+      readonly resultKind: "bigint" | "bigDecimal";
+    };
+
+type RuntimeGroupedOrderBy =
+  | {
+      readonly field: string;
+      readonly direction: "asc" | "desc";
+    }
+  | {
+      readonly aggregate: string;
+      readonly direction: "asc" | "desc";
+    };
+
+export type RuntimeGroupedQuery = {
+  readonly groupBy: ReadonlyArray<string>;
+  readonly aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>;
+  readonly where?: Record<string, unknown>;
+  readonly orderBy?: ReadonlyArray<RuntimeGroupedOrderBy>;
+  readonly offset?: number;
+  readonly limit?: number;
+};
+
+export type CompiledGroupedQuery<Row extends RowObject, ResultRow extends RowObject> = {
+  readonly query: RuntimeGroupedQuery;
+  readonly cacheKey: string;
+  readonly matches: (row: Row) => boolean;
+  readonly evaluate: (store: RawQueryRowStore<Row>) => QueryEvaluation<ResultRow>;
+};
+
+type AggregateState =
+  | {
+      readonly aggFunc: "count";
+      count: bigint;
+    }
+  | {
+      readonly aggFunc: "countDistinct";
+      readonly values: Set<string>;
+      count: bigint;
+    }
+  | {
+      readonly aggFunc: "sum";
+      readonly resultKind: "bigint";
+      bigintTotal: bigint;
+    }
+  | {
+      readonly aggFunc: "sum";
+      readonly resultKind: "bigDecimal";
+      decimalTotal: BigDecimal;
+    }
+  | {
+      readonly aggFunc: "avg";
+      count: bigint;
+      total: BigDecimal;
+    }
+  | {
+      readonly aggFunc: "min" | "max";
+      value: unknown;
+      hasValue: boolean;
+    };
+
+type GroupState = {
+  readonly key: string;
+  readonly row: Record<string, unknown>;
+  readonly aggregates: Record<string, AggregateState>;
+};
+
+const groupedQueryKeys = new Set([
+  "groupBy",
+  "aggregates",
+  "select",
+  "where",
+  "orderBy",
+  "offset",
+  "limit",
+]);
+const dangerousRecordKeys = new Set(["__proto__", "prototype", "constructor"]);
+const isDenseArray = (value: ReadonlyArray<unknown>): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    if (!(index in value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const isValidWindowNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+const bigintToDecimal = (value: bigint): BigDecimal => fromBigInt(value);
+
+const numberToDecimal = (value: number): BigDecimal => fromNumberUnsafe(value);
+
+const runtimeValueToDecimal = (value: unknown): BigDecimal | undefined => {
+  if (isBigDecimal(value)) {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return bigintToDecimal(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return numberToDecimal(value);
+  }
+  return undefined;
+};
+
+const emptyAggregateState = (aggregate: RuntimeGroupedAggregate): AggregateState => {
+  if (aggregate.aggFunc === "count") {
+    return {
+      aggFunc: "count",
+      count: 0n,
+    };
+  }
+  if (aggregate.aggFunc === "countDistinct") {
+    return {
+      aggFunc: "countDistinct",
+      values: new Set<string>(),
+      count: 0n,
+    };
+  }
+  if (aggregate.aggFunc === "sum") {
+    return aggregate.resultKind === "bigint"
+      ? {
+          aggFunc: "sum",
+          resultKind: "bigint",
+          bigintTotal: 0n,
+        }
+      : {
+          aggFunc: "sum",
+          resultKind: "bigDecimal",
+          decimalTotal: fromBigInt(0n),
+        };
+  }
+  if (aggregate.aggFunc === "avg") {
+    return {
+      aggFunc: "avg",
+      count: 0n,
+      total: fromBigInt(0n),
+    };
+  }
+  return {
+    aggFunc: aggregate.aggFunc,
+    value: undefined,
+    hasValue: false,
+  };
+};
+
+const aggregateFieldValue = (row: RowObject, aggregate: RuntimeGroupedAggregate): unknown =>
+  "field" in aggregate ? fieldValue(row, aggregate.field) : undefined;
+
+const updateAggregateState = (
+  state: AggregateState,
+  aggregate: RuntimeGroupedAggregate,
+  row: RowObject,
+): void => {
+  const value = aggregateFieldValue(row, aggregate);
+  if (state.aggFunc === "count") {
+    state.count += 1n;
+    return;
+  }
+  if (state.aggFunc === "countDistinct") {
+    const sizeBefore = state.values.size;
+    state.values.add(stableQueryValueString(value));
+    if (state.values.size !== sizeBefore) {
+      state.count += 1n;
+    }
+    return;
+  }
+  if (state.aggFunc === "sum") {
+    if (state.resultKind === "bigint") {
+      if (typeof value === "bigint") {
+        state.bigintTotal += value;
+      }
+      return;
+    }
+    const decimal = runtimeValueToDecimal(value);
+    if (decimal !== undefined) {
+      state.decimalTotal = sumBigDecimal(state.decimalTotal, decimal);
+    }
+    return;
+  }
+  if (state.aggFunc === "avg") {
+    const decimal = runtimeValueToDecimal(value);
+    if (decimal !== undefined) {
+      state.count += 1n;
+      state.total = sumBigDecimal(state.total, decimal);
+    }
+    return;
+  }
+  if (!state.hasValue) {
+    state.value = cloneUnknown(value);
+    state.hasValue = true;
+    return;
+  }
+  const comparison = compareQueryValue(value, state.value);
+  if (comparison === undefined || comparison === 0) {
+    return;
+  }
+  if ((state.aggFunc === "min" && comparison < 0) || (state.aggFunc === "max" && comparison > 0)) {
+    state.value = cloneUnknown(value);
+  }
+};
+
+const aggregateStateValue = (state: AggregateState): unknown => {
+  if (state.aggFunc === "count") {
+    return state.count;
+  }
+  if (state.aggFunc === "countDistinct") {
+    return state.count;
+  }
+  if (state.aggFunc === "sum") {
+    return state.resultKind === "bigint" ? state.bigintTotal : state.decimalTotal;
+  }
+  if (state.aggFunc === "avg") {
+    return state.count === 0n ? fromBigInt(0n) : divideUnsafe(state.total, fromBigInt(state.count));
+  }
+  return cloneUnknown(state.value);
+};
+
+const groupKey = (groupBy: ReadonlyArray<string>, row: RowObject): string =>
+  stableQueryValueString(groupBy.map((field) => [field, fieldValue(row, field)]));
+
+const newGroupState = (
+  key: string,
+  groupBy: ReadonlyArray<string>,
+  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+  row: RowObject,
+): GroupState => {
+  const resultRow: Record<string, unknown> = {};
+  for (const field of groupBy) {
+    resultRow[field] = cloneUnknown(fieldValue(row, field));
+  }
+  const aggregateStates: Record<string, AggregateState> = {};
+  for (const [alias, aggregate] of Object.entries(aggregates)) {
+    aggregateStates[alias] = emptyAggregateState(aggregate);
+  }
+  return {
+    key,
+    row: resultRow,
+    aggregates: aggregateStates,
+  };
+};
+
+const finalizeGroup = (group: GroupState): StoredRowOf<RowObject> => {
+  const row: Record<string, unknown> = { ...group.row };
+  for (const [alias, state] of Object.entries(group.aggregates)) {
+    row[alias] = aggregateStateValue(state);
+  }
+  return {
+    key: group.key,
+    row,
+  };
+};
+
+const compareGroupedRows = (
+  left: StoredRowOf<RowObject>,
+  right: StoredRowOf<RowObject>,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): number => {
+  for (const order of orderBy) {
+    const field = "field" in order ? order.field : order.aggregate;
+    const comparison = compareQueryValue(fieldValue(left.row, field), fieldValue(right.row, field));
+    if (comparison !== undefined && comparison !== 0) {
+      return order.direction === "asc" ? comparison : -comparison;
+    }
+  }
+  return Number(left.key > right.key) - Number(left.key < right.key);
+};
+
+const decodeGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.decode")((
+  topic: string,
+  metadata: RawQueryCompilerMetadata,
+  query: unknown,
+): Effect.Effect<RuntimeGroupedQuery, InvalidQueryError> => {
+  if (!isPlainRecord(query)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query must be a plain object.",
+    });
+  }
+  for (const key of Object.keys(query)) {
+    if (!groupedQueryKeys.has(key)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query contains unsupported key: ${key}.`,
+      });
+    }
+  }
+  if (Object.hasOwn(query, "select")) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query must not include select.",
+    });
+  }
+
+  const groupBy = query["groupBy"];
+  if (!Array.isArray(groupBy) || groupBy.length === 0 || !isDenseArray(groupBy)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query groupBy must be a non-empty array of strings.",
+    });
+  }
+  const decodedGroupBy: Array<string> = [];
+  for (const field of groupBy) {
+    if (typeof field !== "string") {
+      return InvalidQueryError.make({
+        topic,
+        message: "Grouped query groupBy must be a non-empty array of strings.",
+      });
+    }
+    if (!metadata.fieldNames.has(field)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query groupBy contains unknown field: ${field}.`,
+      });
+    }
+    decodedGroupBy.push(field);
+  }
+
+  const aggregates = query["aggregates"];
+  if (!isPlainRecord(aggregates) || Object.keys(aggregates).length === 0) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query aggregates must be a non-empty plain object.",
+    });
+  }
+  const aggregateAliases = new Set(Object.keys(aggregates));
+  for (const field of decodedGroupBy) {
+    if (aggregateAliases.has(field)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate alias collides with groupBy field: ${field}.`,
+      });
+    }
+  }
+  const decodedAggregates: Record<string, RuntimeGroupedAggregate> = {};
+  for (const [alias, aggregate] of Object.entries(aggregates)) {
+    if (dangerousRecordKeys.has(alias)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate alias is not allowed: ${alias}.`,
+      });
+    }
+    if (!isPlainRecord(aggregate)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate ${alias} must be a plain object.`,
+      });
+    }
+    const aggregateKeys = Object.keys(aggregate);
+    const aggFunc = aggregate["aggFunc"];
+    if (
+      aggFunc !== "count" &&
+      aggFunc !== "countDistinct" &&
+      aggFunc !== "sum" &&
+      aggFunc !== "min" &&
+      aggFunc !== "max" &&
+      aggFunc !== "avg"
+    ) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate ${alias} has an unsupported aggFunc.`,
+      });
+    }
+    if (aggFunc === "count") {
+      if (aggregateKeys.some((key) => key !== "aggFunc")) {
+        return InvalidQueryError.make({
+          topic,
+          message: `Grouped query count aggregate ${alias} must not include a field.`,
+        });
+      }
+      decodedAggregates[alias] = { aggFunc };
+      continue;
+    }
+    for (const key of aggregateKeys) {
+      if (key !== "aggFunc" && key !== "field") {
+        return InvalidQueryError.make({
+          topic,
+          message: `Grouped query aggregate ${alias} contains unsupported key: ${key}.`,
+        });
+      }
+    }
+    const field = aggregate["field"];
+    if (typeof field !== "string") {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate ${alias} field must be a string.`,
+      });
+    }
+    if (!metadata.fieldNames.has(field)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate ${alias} contains unknown field: ${field}.`,
+      });
+    }
+    if ((aggFunc === "sum" || aggFunc === "avg") && !metadata.numericFieldNames.has(field)) {
+      return InvalidQueryError.make({
+        topic,
+        message: `Grouped query aggregate ${alias} must reference a numeric field.`,
+      });
+    }
+    if (aggFunc === "sum") {
+      const resultKind = metadata.fieldMetadata.get(field)?.sumResultKind;
+      if (resultKind === undefined) {
+        return InvalidQueryError.make({
+          topic,
+          message: `Grouped query aggregate ${alias} must reference a numeric field.`,
+        });
+      }
+      decodedAggregates[alias] = {
+        aggFunc,
+        field,
+        resultKind,
+      };
+    } else {
+      decodedAggregates[alias] = {
+        aggFunc,
+        field,
+      };
+    }
+  }
+
+  const where = query["where"];
+  if (where !== undefined && !isPlainRecord(where)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query where must be a plain object.",
+    });
+  }
+
+  const orderBy = query["orderBy"];
+  if (orderBy !== undefined && !Array.isArray(orderBy)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query orderBy must be an array.",
+    });
+  }
+  const decodedOrderBy: Array<RuntimeGroupedOrderBy> = [];
+  if (Array.isArray(orderBy)) {
+    for (const entry of orderBy) {
+      if (!isPlainRecord(entry)) {
+        return InvalidQueryError.make({
+          topic,
+          message: "Grouped query orderBy entries must be plain objects.",
+        });
+      }
+      for (const key of Object.keys(entry)) {
+        if (key !== "field" && key !== "aggregate" && key !== "direction") {
+          return InvalidQueryError.make({
+            topic,
+            message: `Grouped query orderBy contains unsupported key: ${key}.`,
+          });
+        }
+      }
+      const direction = entry["direction"];
+      if (direction !== "asc" && direction !== "desc") {
+        return InvalidQueryError.make({
+          topic,
+          message: "Grouped query orderBy direction must be asc or desc.",
+        });
+      }
+      const hasField = Object.hasOwn(entry, "field");
+      const hasAggregate = Object.hasOwn(entry, "aggregate");
+      if (hasField === hasAggregate) {
+        return InvalidQueryError.make({
+          topic,
+          message: "Grouped query orderBy entries must choose field or aggregate.",
+        });
+      }
+      if (hasField) {
+        const field = entry["field"];
+        if (typeof field !== "string" || !decodedGroupBy.includes(field)) {
+          return InvalidQueryError.make({
+            topic,
+            message: "Grouped query orderBy field must be present in groupBy.",
+          });
+        }
+        decodedOrderBy.push({ field, direction });
+      } else {
+        const aggregate = entry["aggregate"];
+        if (typeof aggregate !== "string" || !aggregateAliases.has(aggregate)) {
+          return InvalidQueryError.make({
+            topic,
+            message: "Grouped query orderBy aggregate must reference an aggregate alias.",
+          });
+        }
+        decodedOrderBy.push({ aggregate, direction });
+      }
+    }
+  }
+
+  const offset = query["offset"];
+  if (offset !== undefined && !isValidWindowNumber(offset)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query offset must be a non-negative safe integer.",
+    });
+  }
+
+  const limit = query["limit"];
+  if (limit !== undefined && !isValidWindowNumber(limit)) {
+    return InvalidQueryError.make({
+      topic,
+      message: "Grouped query limit must be a non-negative safe integer.",
+    });
+  }
+
+  return Effect.succeed({
+    groupBy: decodedGroupBy,
+    aggregates: decodedAggregates,
+    ...(where === undefined ? {} : { where }),
+    ...(decodedOrderBy.length === 0 ? {} : { orderBy: decodedOrderBy }),
+    ...(offset === undefined ? {} : { offset }),
+    ...(limit === undefined ? {} : { limit }),
+  });
+});
+
+const groupedCacheKey = (query: RuntimeGroupedQuery): string =>
+  stableQueryValueString([
+    "grouped",
+    query.groupBy,
+    Object.entries(query.aggregates).toSorted(
+      ([left], [right]) => Number(left > right) - Number(left < right),
+    ),
+    query.where === undefined ? [] : stableQueryValueString(query.where),
+    query.orderBy ?? [],
+    query.offset ?? null,
+    query.limit ?? null,
+  ]);
+
+function typedEvaluation<ResultRow extends RowObject>(
+  evaluation: QueryEvaluation<RowObject>,
+): QueryEvaluation<ResultRow>;
+function typedEvaluation(evaluation: QueryEvaluation<RowObject>): QueryEvaluation<RowObject> {
+  return evaluation;
+}
+
+export const prepareGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.prepare")(
+  function* <Row extends RowObject, ResultRow extends RowObject>(
+    topic: string,
+    metadata: RawQueryCompilerMetadata,
+    query: unknown,
+  ) {
+    const decoded = yield* decodeGroupedQuery(topic, metadata, query);
+    const rawFilter = yield* prepareRawQuery<Row, RowObject>(topic, metadata, {
+      select: decoded.groupBy,
+      ...(decoded.where === undefined ? {} : { where: decoded.where }),
+    });
+    const matches = rawFilter.matches;
+    return {
+      query: decoded,
+      cacheKey: groupedCacheKey(decoded),
+      matches,
+      evaluate: (store) => typedEvaluation<ResultRow>(evaluateGroupedRows(store, decoded, matches)),
+    } satisfies CompiledGroupedQuery<Row, ResultRow>;
+  },
+);
+
+const evaluateGroupedRows = <Row extends RowObject>(
+  store: RawQueryRowStore<Row>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+): QueryEvaluation<RowObject> => {
+  const groups = new Map<string, GroupState>();
+  for (const row of store.rows().values()) {
+    if (!matches(row)) {
+      continue;
+    }
+    const key = groupKey(query.groupBy, row);
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = newGroupState(key, query.groupBy, query.aggregates, row);
+      groups.set(key, group);
+    }
+    for (const [alias, aggregate] of Object.entries(query.aggregates)) {
+      updateAggregateState(group.aggregates[alias]!, aggregate, row);
+    }
+  }
+  const ordered = Array.from(groups.values(), finalizeGroup).toSorted((left, right) =>
+    compareGroupedRows(left, right, query.orderBy ?? []),
+  );
+  const offset = query.offset ?? 0;
+  const window = ordered.slice(
+    offset,
+    query.limit === undefined ? undefined : offset + query.limit,
+  );
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: window.map((entry) => entry.key),
+    window,
+    totalRows: ordered.length,
+    version: store.version(),
+  };
+};
+
+export const evaluateCompiledGroupedQuery = <Row extends RowObject, ResultRow extends RowObject>(
+  store: RawQueryRowStore<Row>,
+  compiled: CompiledGroupedQuery<Row, ResultRow>,
+): QueryEvaluation<ResultRow> => compiled.evaluate(store);

--- a/packages/column-live-view-engine/src/index.test-d.ts
+++ b/packages/column-live-view-engine/src/index.test-d.ts
@@ -2,12 +2,13 @@ import { describe, expectTypeOf, it } from "@effect/vitest";
 import {
   defineViewServerConfig,
   type DeltaEvent,
-  type LiveQuery,
+  type ExactGroupedQuery,
   type LiveQueryResult,
   type RawQuery,
   type SnapshotEvent,
 } from "@view-server/config";
 import type { Effect, Stream } from "effect";
+import type { BigDecimal } from "effect/BigDecimal";
 import { Schema } from "effect";
 import type {
   ColumnLiveViewEngine,
@@ -170,31 +171,32 @@ describe("ColumnLiveViewEngine type contract", () => {
   });
 
   it("rejects invalid raw query select and topics", () => {
-    const _invalidSelectedField = engine.snapshot("orders", {
-      // @ts-expect-error invalid selected field is rejected.
-      select: ["missing"],
-    });
-    const _invalidSubscribeSelectedField = engine.subscribe("orders", {
-      // @ts-expect-error invalid selected field is rejected for subscriptions.
-      select: ["missing"],
-    });
+    // @ts-expect-error invalid selected field is rejected.
+    const _invalidSelectedField = engine.snapshot("orders", { select: ["missing"] });
+    // @ts-expect-error invalid selected field is rejected for subscriptions.
+    const _invalidSubscribeSelectedField = engine.subscribe("orders", { select: ["missing"] });
 
-    const _invalidWhereField = engine.snapshot("orders", {
+    const invalidWhereFieldQuery = {
       select: ["id"],
-      // @ts-expect-error invalid where field is rejected.
-      where: { missing: "value" },
-    });
+      where: {
+        missing: "value",
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly missing: "value" };
+    };
+    // @ts-expect-error invalid where field is rejected.
+    const _invalidWhereField = engine.snapshot("orders", invalidWhereFieldQuery);
 
-    const _invalidOrderField = engine.snapshot("orders", {
+    const invalidOrderFieldQuery = {
       select: ["id"],
-      // @ts-expect-error invalid order field is rejected.
-      orderBy: [
-        {
-          field: "missing",
-          direction: "asc",
-        },
-      ],
-    });
+      orderBy: [{ field: "missing", direction: "asc" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [{ readonly field: "missing"; readonly direction: "asc" }];
+    };
+    // @ts-expect-error invalid order field is rejected.
+    const _invalidOrderField = engine.snapshot("orders", invalidOrderFieldQuery);
 
     // @ts-expect-error invalid topic is rejected.
     const _invalidTopic = engine.snapshot("missing", { select: ["id"] });
@@ -361,34 +363,67 @@ describe("ColumnLiveViewEngine type contract", () => {
     void _invalidKeyConfig;
   });
 
-  it("rejects grouped queries in the raw-only engine slice", () => {
-    const _groupedSnapshot = engine.snapshot("orders", {
-      // @ts-expect-error grouped queries are not part of this raw-only slice.
+  it("types grouped aggregate snapshots and subscriptions", () => {
+    const groupedSnapshot = engine.snapshot("orders", {
       groupBy: ["status"],
-      // @ts-expect-error grouped queries are not part of this raw-only slice.
-      aggregates: { count: { aggFunc: "count" } },
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+        totalPrice: { aggFunc: "sum", field: "price" },
+        averagePrice: { aggFunc: "avg", field: "price" },
+        distinctCustomers: { aggFunc: "countDistinct", field: "customerId" },
+        minRegion: { aggFunc: "min", field: "region" },
+      },
+      orderBy: [{ aggregate: "rowCount", direction: "desc" }],
     });
+    expectTypeOf<EffectSuccess<typeof groupedSnapshot>>().toEqualTypeOf<
+      LiveQueryResult<{
+        readonly status: "open" | "closed" | "cancelled";
+        readonly rowCount: bigint;
+        readonly totalPrice: BigDecimal;
+        readonly averagePrice: BigDecimal;
+        readonly distinctCustomers: bigint;
+        readonly minRegion: string;
+      }>
+    >();
 
-    const _groupedSubscription = engine.subscribe("orders", {
-      // @ts-expect-error grouped subscriptions are not part of this raw-only slice.
+    const groupedSubscription = engine.subscribe("orders", {
       groupBy: ["status"],
-      // @ts-expect-error grouped subscriptions are not part of this raw-only slice.
-      aggregates: { count: { aggFunc: "count" } },
+      aggregates: { rowCount: { aggFunc: "count" } },
     });
+    expectTypeOf<EffectSuccess<typeof groupedSubscription>>().toEqualTypeOf<
+      ColumnLiveViewSubscription<{
+        readonly status: "open" | "closed" | "cancelled";
+        readonly rowCount: bigint;
+      }>
+    >();
 
-    const groupedVariable: LiveQuery<OrderRow> = {
+    const invalidGroupedOrderByAggregateQuery = {
       groupBy: ["status"],
-      aggregates: { count: { aggFunc: "count" } },
+      aggregates: { rowCount: { aggFunc: "count" } },
+      orderBy: [{ aggregate: "missing", direction: "desc" }],
+    } satisfies {
+      readonly groupBy: readonly ["status"];
+      readonly aggregates: { readonly rowCount: { readonly aggFunc: "count" } };
+      readonly orderBy: readonly [{ readonly aggregate: "missing"; readonly direction: "desc" }];
     };
-    // @ts-expect-error widened grouped query variables are rejected.
-    const _groupedVariableSnapshot = engine.snapshot("orders", groupedVariable);
-    // @ts-expect-error widened grouped subscription variables are rejected.
-    const _groupedVariableSubscription = engine.subscribe("orders", groupedVariable);
+    // @ts-expect-error grouped orderBy aggregate must reference an aggregate alias.
+    const _invalidGroupedOrderByAggregate: ExactGroupedQuery<
+      typeof Order.Type,
+      typeof invalidGroupedOrderByAggregateQuery
+    > = invalidGroupedOrderByAggregateQuery;
 
-    void _groupedSnapshot;
-    void _groupedSubscription;
-    void _groupedVariableSnapshot;
-    void _groupedVariableSubscription;
+    const invalidGroupedFieldQuery = {
+      groupBy: ["missing"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+    } satisfies {
+      readonly groupBy: readonly ["missing"];
+      readonly aggregates: { readonly rowCount: { readonly aggFunc: "count" } };
+    };
+    // @ts-expect-error groupBy fields must exist on the topic row.
+    const _invalidGroupedField: ExactGroupedQuery<
+      typeof Order.Type,
+      typeof invalidGroupedFieldQuery
+    > = invalidGroupedFieldQuery;
   });
 
   it("keeps TopicStore nominal inside engine internals", () => {

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -2300,7 +2300,10 @@ describe("ColumnLiveViewEngine subscriptions", () => {
           if (getterReads === 1) {
             return { eq: "open" };
           }
-          throw new Error("clone failed");
+          throw {
+            _tag: "HostileGetterFailure",
+            message: "clone failed",
+          };
         },
       });
       const throwingWhereQuery: object = {

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -2,30 +2,41 @@ import { describe, expect, it } from "@effect/vitest";
 import {
   defineViewServerConfig,
   type DeltaEvent,
+  type GroupedQuery,
   type RawQuery,
   type SnapshotEvent,
   type StatusEvent,
 } from "@view-server/config";
-import { Cause, Deferred, Effect, Exit, Fiber, Schema, Scope, Stream } from "effect";
-import { fromStringUnsafe } from "effect/BigDecimal";
+import { Cause, Deferred, Effect, Exit, Fiber, Option, Schema, Scope, Stream } from "effect";
+import { format as formatBigDecimal, fromStringUnsafe, isBigDecimal } from "effect/BigDecimal";
 import {
   createColumnLiveViewEngine,
   EngineClosedError,
+  InvalidQueryError,
   InvalidRowError,
   InvalidTopicError,
-  UnsupportedQueryError,
   type ColumnLiveViewEngine,
   type ColumnLiveViewEngineConfig,
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
 } from "./index";
-import { acquireRawQueryExecution, activeStoreRawQueryExecutionCount } from "./active-query";
+import {
+  acquireMaterializedQueryExecution,
+  acquireRawQueryExecution,
+  activeStoreRawQueryExecutionCount,
+  releaseMaterializedQueryExecution,
+} from "./active-query";
 import {
   acquireLiveSubscriptionHandoff,
   closeInterruptedAcquiredSubscription,
   type LiveTopicSubscriber,
 } from "./live-subscription";
-import { prepareRawQuery } from "./raw-query-compiler";
+import {
+  prepareRawQuery,
+  rawQueryCompilerMetadata,
+  stableQueryValueString,
+} from "./raw-query-compiler";
+import { evaluateCompiledGroupedQuery, prepareGroupedQuery } from "./grouped-query-compiler";
 import { cloneRecord, cloneRow, fieldValue, rowsEqual } from "./row-values";
 import {
   closeTopicStoreSubscriptions,
@@ -91,6 +102,7 @@ const viewServer = defineViewServerConfig({
 type Topics = typeof viewServer.topics;
 type Engine = ColumnLiveViewEngine<Topics>;
 type OrderRow = typeof Order.Type;
+type PositionRow = typeof Position.Type;
 type InstrumentRow = typeof Instrument.Type;
 
 const orderSelect: readonly ["id", "customerId", "status", "price", "region", "updatedAt"] = [
@@ -121,6 +133,21 @@ const order = (
   price,
   region,
   updatedAt,
+});
+
+const position = (
+  id: string,
+  symbol: string,
+  quantity: bigint,
+  price: string,
+  active = true,
+): PositionRow => ({
+  id,
+  accountId: `account-${id}`,
+  symbol,
+  active,
+  quantity,
+  price: fromStringUnsafe(price),
 });
 
 const makeEngine = (): Effect.Effect<Engine> =>
@@ -157,6 +184,34 @@ const rowField = (row: object, field: string): unknown => {
 
 const rowIds = (rows: ReadonlyArray<object>): ReadonlyArray<unknown> =>
   rows.map((row) => rowField(row, "id"));
+
+const normalizeDecimalFields = <Row extends object>(
+  rows: ReadonlyArray<Row>,
+): ReadonlyArray<Record<string, unknown>> =>
+  rows.map((row) =>
+    Object.fromEntries(
+      Object.entries(row).map(([key, value]) => [
+        key,
+        isBigDecimal(value) ? formatBigDecimal(value) : value,
+      ]),
+    ),
+  );
+
+const normalizeDecimalAndBigIntFields = <Row extends object>(
+  rows: ReadonlyArray<Row>,
+): ReadonlyArray<Record<string, unknown>> =>
+  rows.map((row) =>
+    Object.fromEntries(
+      Object.entries(row).map(([key, value]) => [
+        key,
+        isBigDecimal(value)
+          ? formatBigDecimal(value)
+          : typeof value === "bigint"
+            ? value.toString()
+            : value,
+      ]),
+    ),
+  );
 
 const takeEvents = <Row>(
   subscription: ColumnLiveViewSubscription<Row>,
@@ -503,13 +558,14 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       });
       expect(rowIds(objectInQuery.rows)).toStrictEqual(["2"]);
 
-      const invalidObjectInQuery = yield* engine.snapshot("instruments", {
+      const invalidObjectRuntimeQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error runtime validation handles hostile untyped structured filters.
           operatorLike: { in: [undefined] },
         },
-      });
+      };
+      // @ts-expect-error runtime validation handles hostile untyped structured filters.
+      const invalidObjectInQuery = yield* engine.snapshot("instruments", invalidObjectRuntimeQuery);
       expect(rowIds(invalidObjectInQuery.rows)).toStrictEqual([]);
 
       const fullSnapshot = yield* engine.snapshot("instruments", {
@@ -589,6 +645,586 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         select: instrumentSelect,
       });
       expect(afterPatchMutation.rows).toStrictEqual([instrument("1", "xlon", 2, ["equity", "uk"])]);
+    }),
+  );
+
+  it.effect("evaluates grouped snapshots with aggregate ordering and windows", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("1", "open", 10, 1, "emea"),
+        order("2", "open", 20, 2, "amer"),
+        order("3", "closed", 5, 3, "emea"),
+        order("4", "closed", 20, 4, "amer"),
+        order("5", "cancelled", 0, 5, "emea"),
+      ]);
+
+      const snapshot = yield* engine.snapshot("orders", {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          distinctRegions: { aggFunc: "countDistinct", field: "region" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+          averagePrice: { aggFunc: "avg", field: "price" },
+          minUpdatedAt: { aggFunc: "min", field: "updatedAt" },
+          maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
+        },
+        orderBy: [
+          { aggregate: "totalPrice", direction: "desc" },
+          { field: "status", direction: "asc" },
+        ],
+        offset: 0,
+        limit: 2,
+      });
+
+      expect(snapshot.totalRows).toBe(3);
+      expect(normalizeDecimalFields(snapshot.rows)).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 2n,
+          distinctRegions: 2n,
+          totalPrice: "30",
+          averagePrice: "15",
+          minUpdatedAt: 1,
+          maxUpdatedAt: 2,
+        },
+        {
+          status: "closed",
+          rowCount: 2n,
+          distinctRegions: 2n,
+          totalPrice: "25",
+          averagePrice: "12.5",
+          minUpdatedAt: 3,
+          maxUpdatedAt: 4,
+        },
+      ]);
+
+      const filteredSnapshot = yield* engine.snapshot("orders", {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: "emea",
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      });
+      expect(filteredSnapshot.totalRows).toBe(3);
+      expect(filteredSnapshot.rows).toStrictEqual([
+        { status: "cancelled", rowCount: 1n },
+        { status: "closed", rowCount: 1n },
+        { status: "open", rowCount: 1n },
+      ]);
+
+      const noExplicitOrderSnapshot = yield* engine.snapshot("orders", {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      });
+      expect(noExplicitOrderSnapshot.rows).toStrictEqual([
+        { status: "cancelled", rowCount: 1n },
+        { status: "closed", rowCount: 2n },
+        { status: "open", rowCount: 2n },
+      ]);
+
+      const delimiterEngine = yield* makeEngine();
+      yield* delimiterEngine.publishMany("orders", [
+        {
+          ...order("1", "open", 10, 1, 'region:string:"emea|x'),
+          customerId: 'customer|region:string:"emea',
+        },
+        {
+          ...order("2", "open", 20, 2, "x"),
+          customerId: 'customer|region:string:"emea',
+        },
+      ]);
+      const delimiterSnapshot = yield* delimiterEngine.snapshot("orders", {
+        groupBy: ["customerId", "region"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        orderBy: [
+          { field: "customerId", direction: "asc" },
+          { field: "region", direction: "asc" },
+        ],
+      });
+      expect(delimiterSnapshot.totalRows).toBe(2);
+      expect(delimiterSnapshot.rows).toStrictEqual([
+        {
+          customerId: 'customer|region:string:"emea',
+          region: 'region:string:"emea|x',
+          rowCount: 1n,
+        },
+        {
+          customerId: 'customer|region:string:"emea',
+          region: "x",
+          rowCount: 1n,
+        },
+      ]);
+
+      yield* engine.patch("orders", "1", { note: "same" });
+      yield* engine.patch("orders", "2", { note: "same" });
+      const equalMinMaxSnapshot = yield* engine.snapshot("orders", {
+        groupBy: ["status"],
+        aggregates: {
+          minNote: { aggFunc: "min", field: "note" },
+          maxNote: { aggFunc: "max", field: "note" },
+        },
+        where: {
+          status: "open",
+        },
+      });
+      expect(equalMinMaxSnapshot.rows).toStrictEqual([
+        { status: "open", minNote: "same", maxNote: "same" },
+      ]);
+
+      const emptyNumericQuery: object = {
+        groupBy: ["status"],
+        aggregates: {
+          noteTotal: { aggFunc: "sum", field: "note" },
+          averageNote: { aggFunc: "avg", field: "note" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      };
+      const nonNumericAggregateError = yield* Effect.flip(
+        engine.snapshot(
+          "orders",
+          // @ts-expect-error hostile runtime callers can still aggregate non-numeric fields.
+          emptyNumericQuery,
+        ),
+      );
+      expect(nonNumericAggregateError).toBeInstanceOf(InvalidQueryError);
+      expect(nonNumericAggregateError.message).toBe(
+        "Grouped query aggregate noteTotal must reference a numeric field.",
+      );
+    }),
+  );
+
+  it.effect("normalizes BigDecimal values for grouped keys and distinct aggregates", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("positions", [
+        position("1", "AAPL", 10n, "1.50"),
+        position("2", "AAPL", 20n, "1.5"),
+      ]);
+
+      const groupedByPrice = yield* engine.snapshot("positions", {
+        groupBy: ["price"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      });
+      expect(normalizeDecimalFields(groupedByPrice.rows)).toStrictEqual([
+        {
+          price: "1.5",
+          rowCount: 2n,
+        },
+      ]);
+
+      const distinctPrice = yield* engine.snapshot("positions", {
+        groupBy: ["symbol"],
+        aggregates: {
+          distinctPrice: { aggFunc: "countDistinct", field: "price" },
+        },
+      });
+      expect(distinctPrice.rows).toStrictEqual([
+        {
+          symbol: "AAPL",
+          distinctPrice: 1n,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("evaluates grouped bigint aggregate states", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("positions", [
+        position("1", "AAPL", 10n, "1.00"),
+        position("2", "AAPL", 20n, "2.00"),
+        position("3", "MSFT", 5n, "3.00"),
+      ]);
+
+      const bigintSnapshot = yield* engine.snapshot("positions", {
+        groupBy: ["symbol"],
+        aggregates: {
+          totalQuantity: { aggFunc: "sum", field: "quantity" },
+          averageQuantity: { aggFunc: "avg", field: "quantity" },
+          minQuantity: { aggFunc: "min", field: "quantity" },
+          maxQuantity: { aggFunc: "max", field: "quantity" },
+        },
+        orderBy: [{ aggregate: "totalQuantity", direction: "desc" }],
+      });
+      expect(normalizeDecimalAndBigIntFields(bigintSnapshot.rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          totalQuantity: "30",
+          averageQuantity: "15",
+          minQuantity: "10",
+          maxQuantity: "20",
+        },
+        {
+          symbol: "MSFT",
+          totalQuantity: "5",
+          averageQuantity: "5",
+          minQuantity: "5",
+          maxQuantity: "5",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("ignores malformed runtime values for bigint grouped sums", () =>
+    Effect.gen(function* () {
+      const PositionForCompiler = Schema.Struct({
+        id: Schema.String,
+        symbol: Schema.String,
+        quantity: Schema.BigInt,
+      });
+      const rows = new Map<string, object>([
+        ["bad", { id: "bad", symbol: "AAPL", quantity: "not-a-bigint" }],
+        ["good", { id: "good", symbol: "AAPL", quantity: 3n }],
+      ]);
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(PositionForCompiler),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            totalQuantity: { aggFunc: "sum", field: "quantity" },
+          },
+        },
+      );
+      const evaluation = evaluateCompiledGroupedQuery(
+        {
+          rows: () => rows,
+          version: () => 1,
+        },
+        compiled,
+      );
+      expect(normalizeDecimalAndBigIntFields(evaluation.rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          totalQuantity: "3",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("evaluates grouped mixed numeric aggregate states", () =>
+    Effect.gen(function* () {
+      const Mixed = Schema.Struct({
+        id: Schema.String,
+        group: Schema.String,
+        amount: Schema.Union([Schema.Number, Schema.BigInt, Schema.BigDecimal]),
+        optionalQuantity: Schema.Union([Schema.BigInt, Schema.Undefined]),
+      });
+      const mixedViewServer = defineViewServerConfig({
+        topics: {
+          mixed: {
+            schema: Mixed,
+            key: "id",
+          },
+        },
+      });
+      const mixedEngine = yield* createColumnLiveViewEngine({
+        topics: mixedViewServer.topics,
+      });
+      yield* mixedEngine.publishMany("mixed", [
+        { id: "1", group: "x", amount: 1n, optionalQuantity: 5n },
+        { id: "2", group: "x", amount: 2, optionalQuantity: undefined },
+        { id: "3", group: "x", amount: fromStringUnsafe("3.5"), optionalQuantity: 7n },
+        { id: "4", group: "x", amount: Number.NaN, optionalQuantity: undefined },
+        { id: "5", group: "y", amount: Number.NaN, optionalQuantity: undefined },
+        { id: "6", group: "z", amount: 1n, optionalQuantity: 1n },
+        { id: "7", group: "z", amount: 2n, optionalQuantity: 2n },
+      ]);
+      const mixedQuery = {
+        groupBy: ["group"],
+        aggregates: {
+          totalAmount: { aggFunc: "sum", field: "amount" },
+          averageAmount: { aggFunc: "avg", field: "amount" },
+        },
+      } satisfies GroupedQuery<typeof Mixed.Type>;
+      const mixedSnapshot = yield* mixedEngine.snapshot("mixed", mixedQuery);
+      expect(normalizeDecimalAndBigIntFields(mixedSnapshot.rows)).toStrictEqual([
+        {
+          group: "x",
+          totalAmount: "6.5",
+          averageAmount:
+            "2.166666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666667e+0",
+        },
+        {
+          group: "y",
+          totalAmount: "0",
+          averageAmount: "0",
+        },
+        {
+          group: "z",
+          totalAmount: "3",
+          averageAmount: "1.5",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("shares materialized grouped subscriptions and emits grouped deltas", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [order("1", "open", 10, 1), order("2", "closed", 5, 2)]);
+      const query = {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+      } satisfies {
+        readonly groupBy: readonly ["status"];
+        readonly aggregates: {
+          readonly rowCount: { readonly aggFunc: "count" };
+          readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+        };
+        readonly orderBy: readonly [{ readonly aggregate: "rowCount"; readonly direction: "desc" }];
+      };
+
+      const first = yield* engine.subscribe("orders", query);
+      const second = yield* engine.subscribe("orders", query);
+      const readFirst = yield* makeEventReader(first);
+      const readSecond = yield* makeEventReader(second);
+      const firstSnapshot = firstEvent(yield* readFirst(1));
+      const secondSnapshot = firstEvent(yield* readSecond(1));
+      expectSnapshotEvent(firstSnapshot);
+      expectSnapshotEvent(secondSnapshot);
+      expect(normalizeDecimalFields(firstSnapshot.rows)).toStrictEqual([
+        { status: "closed", rowCount: 1n, totalPrice: "5" },
+        { status: "open", rowCount: 1n, totalPrice: "10" },
+      ]);
+
+      let health = yield* engine.health();
+      expect(health.topics.orders.activeViews).toBe(1);
+      expect(health.topics.orders.activeSubscriptions).toBe(2);
+
+      yield* engine.publish("orders", order("3", "open", 7, 3));
+      const firstDelta = firstEvent(yield* readFirst(1));
+      const secondDelta = firstEvent(yield* readSecond(1));
+      expectDeltaEvent(firstDelta);
+      expectDeltaEvent(secondDelta);
+      expect(firstDelta.totalRows).toBe(2);
+      expect(secondDelta.totalRows).toBe(2);
+
+      yield* first.close();
+      health = yield* engine.health();
+      expect(health.topics.orders.activeViews).toBe(1);
+      expect(health.topics.orders.activeSubscriptions).toBe(1);
+
+      yield* second.close();
+      health = yield* engine.health();
+      expect(health.topics.orders.activeViews).toBe(0);
+      expect(health.topics.orders.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("rejects malformed grouped queries through the typed error channel", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const sparseGroupBy = Array<string>();
+      sparseGroupBy[1] = "status";
+      const nonPlainGroupedQuery: object = Object.assign(new Map(), {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+      });
+      const invalidCases: ReadonlyArray<{
+        readonly query: unknown;
+        readonly message: string;
+      }> = [
+        { query: null, message: "plain object" },
+        { query: nonPlainGroupedQuery, message: "plain object" },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            typo: true,
+          },
+          message: "unsupported key: typo",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            select: ["id"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+          },
+          message: "must not include select",
+        },
+        {
+          query: { groupBy: [], aggregates: { rowCount: { aggFunc: "count" } } },
+          message: "groupBy",
+        },
+        {
+          query: { groupBy: sparseGroupBy, aggregates: { rowCount: { aggFunc: "count" } } },
+          message: "groupBy",
+        },
+        {
+          query: { groupBy: [1], aggregates: { rowCount: { aggFunc: "count" } } },
+          message: "groupBy",
+        },
+        {
+          query: { groupBy: ["missing"], aggregates: { rowCount: { aggFunc: "count" } } },
+          message: "unknown field: missing",
+        },
+        { query: { groupBy: ["status"], aggregates: [] }, message: "aggregates" },
+        {
+          query: { groupBy: ["status"], aggregates: { status: { aggFunc: "count" } } },
+          message: "collides",
+        },
+        {
+          query: { groupBy: ["status"], aggregates: { constructor: { aggFunc: "count" } } },
+          message: "aggregate alias is not allowed",
+        },
+        {
+          query: { groupBy: ["status"], aggregates: { rowCount: "count" } },
+          message: "plain object",
+        },
+        {
+          query: { groupBy: ["status"], aggregates: { rowCount: { aggFunc: "median" } } },
+          message: "unsupported aggFunc",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count", field: "price" } },
+          },
+          message: "must not include a field",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { total: { aggFunc: "sum", field: "price", typo: true } },
+          },
+          message: "unsupported key: typo",
+        },
+        {
+          query: { groupBy: ["status"], aggregates: { total: { aggFunc: "sum" } } },
+          message: "field must be a string",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { total: { aggFunc: "sum", field: "missing" } },
+          },
+          message: "unknown field: missing",
+        },
+        {
+          query: { groupBy: ["status"], aggregates: { rowCount: { aggFunc: "count" } }, where: [] },
+          message: "where",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: "bad",
+          },
+          message: "orderBy",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: ["bad"],
+          },
+          message: "plain objects",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ field: "status", direction: "asc", typo: true }],
+          },
+          message: "unsupported key: typo",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ field: "status", direction: "sideways" }],
+          },
+          message: "direction",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ direction: "asc" }],
+          },
+          message: "choose field or aggregate",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ field: "status", aggregate: "rowCount", direction: "asc" }],
+          },
+          message: "choose field or aggregate",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ field: "price", direction: "asc" }],
+          },
+          message: "field must be present in groupBy",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ aggregate: "missing", direction: "asc" }],
+          },
+          message: "aggregate must reference an aggregate alias",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            offset: -1,
+          },
+          message: "offset",
+        },
+        {
+          query: {
+            groupBy: ["status"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            limit: "1",
+          },
+          message: "limit",
+        },
+      ];
+
+      for (const invalidCase of invalidCases) {
+        const error = yield* Effect.flip(
+          // @ts-expect-error hostile untyped runtime grouped query is still handled by runtime guards.
+          engine.snapshot("orders", invalidCase.query),
+        );
+        expect(error._tag).toBe("InvalidQueryError");
+        expect(error.message).toContain(invalidCase.message);
+      }
+
+      const orderMetadata = rawQueryCompilerMetadata(Order);
+      const inconsistentMetadata = {
+        ...orderMetadata,
+        fieldMetadata: new Map(),
+      };
+      const missingSumResultKind = yield* Effect.flip(
+        prepareGroupedQuery<typeof Order.Type, object>("orders", inconsistentMetadata, {
+          groupBy: ["status"],
+          aggregates: { totalPrice: { aggFunc: "sum", field: "price" } },
+        }),
+      );
+      expect(missingSumResultKind).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("must reference a numeric field"),
+      });
     }),
   );
 
@@ -1391,6 +2027,42 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("materialized active queries ignore unchanged evaluations and unknown releases", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      const readModel = topicStoreReadModel(store);
+      let evaluationCount = 0;
+      const evaluate = () => {
+        evaluationCount += 1;
+        return {
+          rows: [],
+          keys: [],
+          window: [],
+          totalRows: 0,
+          version: readModel.version(),
+        };
+      };
+
+      const execution = yield* acquireMaterializedQueryExecution(
+        readModel,
+        "empty-materialized",
+        evaluate,
+      );
+      const cursor = execution.createCursor();
+      const unchanged = yield* execution.next("query-unchanged", cursor);
+
+      expect(Option.isNone(unchanged)).toBe(true);
+      expect(evaluationCount).toBe(1);
+      yield* acquireMaterializedQueryExecution(readModel, "second-materialized", evaluate);
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(2);
+      yield* releaseMaterializedQueryExecution(readModel, "empty-materialized");
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
+      yield* releaseMaterializedQueryExecution(readModel, "missing-materialized");
+      yield* releaseMaterializedQueryExecution(readModel, "second-materialized");
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
+    }),
+  );
+
   it.effect("does not emit deltas for invisible updates or no-op visible patches", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();
@@ -1486,13 +2158,14 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       const engine = yield* makeEngine();
       yield* engine.publish("orders", order("1", "open", 10, 1));
 
-      const invalidGt = yield* engine.snapshot("orders", {
+      const invalidGtQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
           price: { gt: "9" },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const invalidGt = yield* engine.snapshot("orders", invalidGtQuery);
       expect(invalidGt.rows).toStrictEqual([]);
 
       const invalidGtNaN = yield* engine.snapshot("orders", {
@@ -1505,62 +2178,182 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(invalidGtNaN.rows).toStrictEqual([]);
 
-      const invalidGte = yield* engine.snapshot("orders", {
+      const invalidGteQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
           price: { gte: "9" },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const invalidGte = yield* engine.snapshot("orders", invalidGteQuery);
       expect(invalidGte.rows).toStrictEqual([]);
 
-      const invalidLt = yield* engine.snapshot("orders", {
+      const invalidLtQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
           price: { lt: "11" },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const invalidLt = yield* engine.snapshot("orders", invalidLtQuery);
       expect(invalidLt.rows).toStrictEqual([]);
 
-      const invalidLte = yield* engine.snapshot("orders", {
+      const invalidLteQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
           price: { lte: "11" },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const invalidLte = yield* engine.snapshot("orders", invalidLteQuery);
       expect(invalidLte.rows).toStrictEqual([]);
 
-      const invalidIn = yield* engine.snapshot("orders", {
+      const invalidInQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not throw or broaden results.
           status: {
             in: 1,
           },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not throw or broaden results.
+      const invalidIn = yield* engine.snapshot("orders", invalidInQuery);
       expect(invalidIn.rows).toStrictEqual([]);
 
-      const invalidStartsWith = yield* engine.snapshot("orders", {
+      const cyclicFilter: Array<unknown> = [];
+      cyclicFilter.push(cyclicFilter);
+      const cyclicQueryValue: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not throw or broaden results.
+          status: cyclicFilter,
+        },
+      };
+      const cyclicQueryValueError = yield* Effect.flip(
+        // @ts-expect-error hostile runtime query cycles must be rejected at the boundary.
+        engine.snapshot("orders", cyclicQueryValue),
+      );
+      expect(cyclicQueryValueError).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: "Raw query where field status contains unsupported query value.",
+      });
+
+      type CyclicRecord = {
+        self?: CyclicRecord;
+      };
+      const cyclicRecord: CyclicRecord = {};
+      cyclicRecord.self = cyclicRecord;
+      const cyclicRecordQueryValue: object = {
+        select: ["id"],
+        where: {
+          status: cyclicRecord,
+        },
+      };
+      const cyclicRecordQueryValueError = yield* Effect.flip(
+        // @ts-expect-error hostile runtime query object cycles must be rejected at the boundary.
+        engine.snapshot("orders", cyclicRecordQueryValue),
+      );
+      expect(cyclicRecordQueryValueError).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: "Raw query where field status contains unsupported query value.",
+      });
+
+      const invalidStartsWithQuery: object = {
+        select: ["id"],
+        where: {
           customerId: {
             startsWith: Symbol("customer"),
           },
         },
+      };
+      const invalidStartsWith = yield* Effect.flip(
+        // @ts-expect-error malformed runtime queries must not throw or broaden results.
+        engine.snapshot("orders", invalidStartsWithQuery),
+      );
+      expect(invalidStartsWith).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
       });
-      expect(invalidStartsWith.rows).toStrictEqual([]);
 
-      const invalidNeq = yield* engine.snapshot("orders", {
+      const invalidFunctionFilterQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
-          price: { neq: "10" },
+          customerId: {
+            eq: () => "customer",
+          },
+        },
+      };
+      const invalidFunctionFilter = yield* Effect.flip(
+        // @ts-expect-error malformed runtime queries must not throw or broaden results.
+        engine.snapshot("orders", invalidFunctionFilterQuery),
+      );
+      expect(invalidFunctionFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
+
+      let getterReads = 0;
+      const throwingWhere = {};
+      Object.defineProperty(throwingWhere, "status", {
+        enumerable: true,
+        get() {
+          getterReads += 1;
+          if (getterReads === 1) {
+            return { eq: "open" };
+          }
+          throw new Error("clone failed");
         },
       });
+      const throwingWhereQuery: object = {
+        select: ["id"],
+        where: throwingWhere,
+      };
+      const throwingWhereResult = yield* Effect.flip(
+        // @ts-expect-error hostile runtime query getters must be rejected at the boundary.
+        engine.snapshot("orders", throwingWhereQuery),
+      );
+      expect(throwingWhereResult).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("where could not be cloned"),
+      });
+
+      const stringRangeQuery: object = {
+        select: ["id"],
+        where: {
+          status: { gte: "open" },
+        },
+      };
+      const stringRange = yield* Effect.flip(
+        // @ts-expect-error runtime query validation rejects unsupported string range operators.
+        engine.snapshot("orders", stringRangeQuery),
+      );
+      expect(stringRange).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: "Raw query where field status does not support range operators.",
+      });
+
+      const numericStartsWithQuery: object = {
+        select: ["id"],
+        where: {
+          price: { startsWith: "1" },
+        },
+      };
+      const numericStartsWith = yield* Effect.flip(
+        // @ts-expect-error runtime query validation rejects unsupported numeric startsWith operators.
+        engine.snapshot("orders", numericStartsWithQuery),
+      );
+      expect(numericStartsWith).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: "Raw query where field price does not support startsWith.",
+      });
+
+      const invalidNeqQuery: object = {
+        select: ["id"],
+        where: {
+          price: { neq: "10" },
+        },
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const invalidNeq = yield* engine.snapshot("orders", invalidNeqQuery);
       expect(invalidNeq.rows).toStrictEqual([]);
 
       const invalidNeqNaN = yield* engine.snapshot("orders", {
@@ -1573,15 +2366,16 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(invalidNeqNaN.rows).toStrictEqual([]);
 
-      const undefinedEquals = yield* engine.snapshot("orders", {
+      const undefinedEqualsQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
           status: {
             eq: undefined,
           },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const undefinedEquals = yield* engine.snapshot("orders", undefinedEqualsQuery);
       expect(undefinedEquals.rows).toStrictEqual([]);
 
       const undefinedDirectRuntimeQuery: object = {
@@ -1592,13 +2386,14 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       const undefinedDirectFilter = yield* engine.snapshot("orders", undefinedDirectRuntimeQuery);
       expect(undefinedDirectFilter.rows).toStrictEqual([]);
 
-      const undefinedInFilter = yield* engine.snapshot("orders", {
+      const undefinedInFilterQuery: object = {
         select: ["id"],
         where: {
-          // @ts-expect-error malformed runtime queries must not broaden results.
           status: { in: [undefined] },
         },
-      });
+      };
+      // @ts-expect-error malformed runtime queries must not broaden results.
+      const undefinedInFilter = yield* engine.snapshot("orders", undefinedInFilterQuery);
       expect(undefinedInFilter.rows).toStrictEqual([]);
 
       const sparseValues = Array<string>();
@@ -1609,9 +2404,14 @@ describe("ColumnLiveViewEngine subscriptions", () => {
           status: { in: sparseValues },
         },
       };
-      // @ts-expect-error hostile untyped runtime query is still handled by runtime guards.
-      const sparseInFilter = yield* engine.snapshot("orders", sparseRuntimeQuery);
-      expect(sparseInFilter.rows).toStrictEqual([]);
+      const sparseInFilter = yield* Effect.flip(
+        // @ts-expect-error hostile untyped runtime query is still handled by runtime guards.
+        engine.snapshot("orders", sparseRuntimeQuery),
+      );
+      expect(sparseInFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
 
       const emptyFilter = yield* Effect.flip(
         engine.snapshot("orders", {
@@ -1626,30 +2426,32 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         message: expect.stringContaining("unsupported filter operator"),
       });
 
-      const unknownOperator = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          where: {
-            // @ts-expect-error malformed runtime queries must not broaden results.
-            status: {
-              equals: "open",
-            },
+      const unknownOperatorQuery: object = {
+        select: ["id"],
+        where: {
+          status: {
+            equals: "open",
           },
-        }),
+        },
+      };
+      const unknownOperator = yield* Effect.flip(
+        // @ts-expect-error malformed runtime queries must not broaden results.
+        engine.snapshot("orders", unknownOperatorQuery),
       );
       expect(unknownOperator).toMatchObject({
         _tag: "InvalidQueryError",
         message: expect.stringContaining("unsupported filter operator"),
       });
 
+      const typoFieldEmptyFilterQuery: object = {
+        select: ["id"],
+        where: {
+          statuz: {},
+        },
+      };
       const typoFieldEmptyFilter = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          where: {
-            // @ts-expect-error malformed runtime query select must be rejected.
-            statuz: {},
-          },
-        }),
+        // @ts-expect-error malformed runtime query where field must be rejected.
+        engine.snapshot("orders", typoFieldEmptyFilterQuery),
       );
       expect(typoFieldEmptyFilter).toMatchObject({
         _tag: "InvalidQueryError",
@@ -1928,6 +2730,58 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 });
 
 describe("ColumnLiveViewEngine validation and health", () => {
+  it("encodes primitive and unsupported query values deterministically", () => {
+    function namedFilter() {
+      return "ignored";
+    }
+    const anonymousFilter = () => "ignored";
+
+    expect(JSON.parse(stableQueryValueString(null))).toStrictEqual(["null"]);
+    expect(JSON.parse(stableQueryValueString(1n))).toStrictEqual(["bigint", "1"]);
+    expect(JSON.parse(stableQueryValueString("x"))).toStrictEqual(["string", "x"]);
+    expect(JSON.parse(stableQueryValueString(-0))).toStrictEqual(["number", "-0"]);
+    expect(JSON.parse(stableQueryValueString(false))).toStrictEqual(["boolean", false]);
+    expect(JSON.parse(stableQueryValueString(Symbol("filter")))).toStrictEqual([
+      "unsupported",
+      "symbol:filter",
+    ]);
+    expect(JSON.parse(stableQueryValueString(Symbol()))).toStrictEqual(["unsupported", "symbol:"]);
+    expect(JSON.parse(stableQueryValueString(namedFilter))).toStrictEqual([
+      "unsupported",
+      "function:namedFilter",
+    ]);
+    expect(JSON.parse(stableQueryValueString(anonymousFilter))).toStrictEqual([
+      "unsupported",
+      "function:anonymousFilter",
+    ]);
+    expect(JSON.parse(stableQueryValueString(new Map()))).toStrictEqual([
+      "nonPlainObject",
+      "[object Map]",
+    ]);
+    expect(JSON.parse(stableQueryValueString(undefined))).toStrictEqual(["undefined"]);
+
+    const cyclicArray: Array<unknown> = [];
+    cyclicArray.push(cyclicArray);
+    expect(JSON.parse(stableQueryValueString(cyclicArray))).toStrictEqual(["array", [["cycle"]]]);
+
+    type CyclicObject = {
+      self?: CyclicObject;
+    };
+    const cyclicObject: CyclicObject = {};
+    cyclicObject.self = cyclicObject;
+    expect(JSON.parse(stableQueryValueString(cyclicObject))).toStrictEqual([
+      "object",
+      [["self", ["cycle"]]],
+    ]);
+  });
+
+  it("uses injective stable keys for structured query values", () => {
+    const left = { a: "b", c: "d" };
+    const right = { 'a:string:"b",c': "d" };
+
+    expect(stableQueryValueString(left)).not.toBe(stableQueryValueString(right));
+  });
+
   it("treats rows with different selected column counts as different", () => {
     expect(rowsEqual({ id: "1" }, { id: "1", note: "new" })).toBe(false);
   });
@@ -2114,6 +2968,36 @@ describe("ColumnLiveViewEngine validation and health", () => {
         rows: [],
         totalRows: 0,
       });
+
+      const metadata = rawQueryCompilerMetadata({
+        // @ts-expect-error hostile schema metadata can contain malformed field entries.
+        fields: {
+          id: "not-a-schema",
+          price: Schema.Number,
+        },
+      });
+      expect(metadata.fieldNames.has("id")).toBe(true);
+      expect(metadata.numericFieldNames.has("id")).toBe(false);
+      expect(metadata.numericFieldNames.has("price")).toBe(true);
+
+      const invalidNumericAggregateQuery: object = {
+        groupBy: ["label"],
+        aggregates: {
+          totalId: { aggFunc: "sum", field: "id" },
+        },
+      };
+      const invalidNumericAggregate = yield* Effect.flip(
+        engine.snapshot(
+          "loose",
+          // @ts-expect-error malformed schema metadata makes the query shape untyped.
+          invalidNumericAggregateQuery,
+        ),
+      );
+      expect(invalidNumericAggregate).toMatchObject({
+        _tag: "InvalidQueryError",
+        topic: "loose",
+        message: "Grouped query aggregate totalId must reference a numeric field.",
+      });
     }),
   );
 
@@ -2258,11 +3142,22 @@ describe("ColumnLiveViewEngine validation and health", () => {
     }),
   );
 
-  it.effect("keeps a runtime guard for untyped grouped aggregate query callers", () =>
+  it.effect("subscribes through the runtime-validated entrypoint", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      const subscription = yield* engine.subscribeRuntime("orders", { select: ["id"] });
+      yield* subscription.close();
+
+      const health = yield* engine.health();
+      expect(health.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("keeps runtime guards for untyped grouped aggregate query callers", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();
       const groupedRuntimeQuery: object = {
-        groupBy: ["status"],
+        groupBy: ["missing"],
         aggregates: { count: { aggFunc: "count" } },
       };
 
@@ -2272,16 +3167,16 @@ describe("ColumnLiveViewEngine validation and health", () => {
       );
 
       expect(error).toMatchObject({
-        _tag: "UnsupportedQueryError",
-        message: expect.stringContaining("Grouped aggregate queries are not implemented"),
+        _tag: "InvalidQueryError",
+        topic: "orders",
       });
-      expect(error).toBeInstanceOf(UnsupportedQueryError);
+      expect(error.message).toContain("unknown field: missing");
 
       const subscribeError = yield* Effect.flip(
         // @ts-expect-error hostile untyped runtime query is still handled by runtime guards.
         engine.subscribe("orders", groupedRuntimeQuery),
       );
-      expect(subscribeError._tag).toBe("UnsupportedQueryError");
+      expect(subscribeError._tag).toBe("InvalidQueryError");
     }),
   );
 
@@ -2317,12 +3212,13 @@ describe("ColumnLiveViewEngine validation and health", () => {
       const engine = yield* makeEngine();
       yield* engine.publish("orders", order("1", "open", 10, 1));
 
+      const invalidWhereQuery: object = {
+        select: ["id"],
+        where: "bad",
+      };
       const invalidWhere = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          // @ts-expect-error malformed runtime query where must be rejected.
-          where: "bad",
-        }),
+        // @ts-expect-error malformed runtime query where must be rejected.
+        engine.snapshot("orders", invalidWhereQuery),
       );
       expect(invalidWhere).toMatchObject({
         _tag: "InvalidQueryError",
@@ -2330,12 +3226,13 @@ describe("ColumnLiveViewEngine validation and health", () => {
         message: expect.stringContaining("where"),
       });
 
+      const invalidWhereArrayQuery: object = {
+        select: ["id"],
+        where: [],
+      };
       const invalidWhereArray = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          // @ts-expect-error malformed runtime query where array must be rejected.
-          where: [],
-        }),
+        // @ts-expect-error malformed runtime query where array must be rejected.
+        engine.snapshot("orders", invalidWhereArrayQuery),
       );
       expect(invalidWhereArray._tag).toBe("InvalidQueryError");
 
@@ -2380,11 +3277,13 @@ describe("ColumnLiveViewEngine validation and health", () => {
         message: expect.stringContaining("unsupported key: whre"),
       });
 
+      const invalidOrderByQuery: object = {
+        select: ["id"],
+        orderBy: "bad",
+      };
       const invalidOrderBy = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          orderBy: "bad",
-        }),
+        // @ts-expect-error malformed runtime query orderBy must be rejected.
+        engine.snapshot("orders", invalidOrderByQuery),
       );
       expect(invalidOrderBy._tag).toBe("InvalidQueryError");
 
@@ -2396,11 +3295,15 @@ describe("ColumnLiveViewEngine validation and health", () => {
       );
       expect(invalidFields._tag).toBe("InvalidQueryError");
 
+      const invalidFieldEntryQuery: object = {
+        select: [1],
+      };
       const invalidFieldEntry = yield* Effect.flip(
-        engine.snapshot("orders", {
+        engine.snapshot(
+          "orders",
           // @ts-expect-error malformed runtime query field entries must be rejected.
-          select: [1],
-        }),
+          invalidFieldEntryQuery,
+        ),
       );
       expect(invalidFieldEntry._tag).toBe("InvalidQueryError");
 
@@ -2413,11 +3316,13 @@ describe("ColumnLiveViewEngine validation and health", () => {
       );
       expect(invalidEmptySelect._tag).toBe("InvalidQueryError");
 
+      const invalidOffsetQuery: object = {
+        select: ["id"],
+        offset: "0",
+      };
       const invalidOffset = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          offset: "0",
-        }),
+        // @ts-expect-error malformed runtime query offset must be rejected.
+        engine.snapshot("orders", invalidOffsetQuery),
       );
       expect(invalidOffset).toMatchObject({
         _tag: "InvalidQueryError",
@@ -2457,11 +3362,13 @@ describe("ColumnLiveViewEngine validation and health", () => {
         message: expect.stringContaining("offset"),
       });
 
+      const invalidLimitQuery: object = {
+        select: ["id"],
+        limit: "1",
+      };
       const invalidLimit = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          limit: "1",
-        }),
+        // @ts-expect-error malformed runtime query limit must be rejected.
+        engine.snapshot("orders", invalidLimitQuery),
       );
       expect(invalidLimit).toMatchObject({
         _tag: "InvalidQueryError",
@@ -2479,12 +3386,13 @@ describe("ColumnLiveViewEngine validation and health", () => {
         message: expect.stringContaining("limit"),
       });
 
+      const invalidOrderByEntryQuery: object = {
+        select: ["id"],
+        orderBy: ["bad"],
+      };
       const invalidOrderByEntry = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          // @ts-expect-error malformed runtime query orderBy entry must be rejected.
-          orderBy: ["bad"],
-        }),
+        // @ts-expect-error malformed runtime query orderBy entry must be rejected.
+        engine.snapshot("orders", invalidOrderByEntryQuery),
       );
       expect(invalidOrderByEntry._tag).toBe("InvalidQueryError");
 
@@ -2507,69 +3415,77 @@ describe("ColumnLiveViewEngine validation and health", () => {
         message: expect.stringContaining("unsupported key: typo"),
       });
 
+      const invalidOrderByFieldQuery: object = {
+        select: ["id"],
+        orderBy: [
+          {
+            direction: "asc",
+          },
+        ],
+      };
       const invalidOrderByField = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          // @ts-expect-error malformed runtime query orderBy field must be rejected.
-          orderBy: [
-            {
-              direction: "asc",
-            },
-          ],
-        }),
+        // @ts-expect-error malformed runtime query orderBy field must be rejected.
+        engine.snapshot("orders", invalidOrderByFieldQuery),
       );
       expect(invalidOrderByField._tag).toBe("InvalidQueryError");
 
+      const unknownOrderByFieldQuery: object = {
+        select: ["id"],
+        orderBy: [
+          {
+            field: "prcie",
+            direction: "asc",
+          },
+        ],
+      };
       const unknownOrderByField = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          // @ts-expect-error runtime query unknown orderBy fields must be rejected.
-          orderBy: [
-            {
-              field: "prcie",
-              direction: "asc",
-            },
-          ],
-        }),
+        // @ts-expect-error runtime query unknown orderBy fields must be rejected.
+        engine.snapshot("orders", unknownOrderByFieldQuery),
       );
       expect(unknownOrderByField).toMatchObject({
         _tag: "InvalidQueryError",
         message: expect.stringContaining("orderBy"),
       });
 
+      const unknownProjectionFieldQuery: object = {
+        select: ["prcie"],
+      };
       const unknownProjectionField = yield* Effect.flip(
-        engine.snapshot("orders", {
+        engine.snapshot(
+          "orders",
           // @ts-expect-error runtime query unknown projected fields must be rejected.
-          select: ["prcie"],
-        }),
+          unknownProjectionFieldQuery,
+        ),
       );
       expect(unknownProjectionField).toMatchObject({
         _tag: "InvalidQueryError",
         message: expect.stringContaining("select"),
       });
 
+      const unknownWhereFieldQuery: object = {
+        select: ["id"],
+        where: {
+          prcie: 10,
+        },
+      };
       const unknownWhereField = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          where: {
-            // @ts-expect-error runtime query unknown where fields must be rejected.
-            prcie: 10,
-          },
-        }),
+        // @ts-expect-error runtime query unknown where fields must be rejected.
+        engine.snapshot("orders", unknownWhereFieldQuery),
       );
       expect(unknownWhereField).toMatchObject({
         _tag: "InvalidQueryError",
         message: expect.stringContaining("where"),
       });
 
+      const unknownFilterOperatorQuery: object = {
+        select: ["id"],
+        where: {
+          status: { equals: "open" },
+        },
+      };
       const unknownFilterOperator = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          where: {
-            // @ts-expect-error runtime query unknown filter operators must be rejected.
-            status: { equals: "open" },
-          },
-        }),
+        // @ts-expect-error runtime query unknown filter operators must be rejected.
+        engine.snapshot("orders", unknownFilterOperatorQuery),
       );
       expect(unknownFilterOperator).toMatchObject({
         _tag: "InvalidQueryError",
@@ -2590,17 +3506,18 @@ describe("ColumnLiveViewEngine validation and health", () => {
         message: expect.stringContaining("unsupported filter operator"),
       });
 
+      const invalidOrderByDirectionQuery: object = {
+        select: ["id"],
+        orderBy: [
+          {
+            field: "price",
+            direction: "sideways",
+          },
+        ],
+      };
       const invalidOrderByDirection = yield* Effect.flip(
-        engine.snapshot("orders", {
-          select: ["id"],
-          // @ts-expect-error malformed runtime query orderBy direction must be rejected.
-          orderBy: [
-            {
-              field: "price",
-              direction: "sideways",
-            },
-          ],
-        }),
+        // @ts-expect-error malformed runtime query orderBy direction must be rejected.
+        engine.snapshot("orders", invalidOrderByDirectionQuery),
       );
       expect(invalidOrderByDirection._tag).toBe("InvalidQueryError");
     }),

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -1,11 +1,30 @@
-import type { ExactPatch, ExactRawQuery, LiveQueryRow, TopicRow } from "@view-server/config";
+import type {
+  ExactGroupedQuery,
+  ExactLiveQuery,
+  ExactPatch,
+  ExactRawQuery,
+  GroupedQuery,
+  GroupedResult,
+  LiveQueryRow,
+  LiveQueryResult,
+  PickRawFields,
+  RawQuery,
+  TopicRow,
+  ValidateLiveQuery,
+} from "@view-server/config";
 import { Effect } from "effect";
 import type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
+  ColumnLiveViewSubscription,
   DecodableTopicDefinitions,
 } from "./engine-contract";
-import { EngineClosedError, InvalidRowError, InvalidTopicError } from "./engine-errors";
+import {
+  EngineClosedError,
+  InvalidRowError,
+  InvalidTopicError,
+  type ColumnLiveViewEngineError,
+} from "./engine-errors";
 import { acquireLiveSubscriptionHandoff, type LiveSubscription } from "./live-subscription";
 import { collectColumnLiveViewEngineHealth } from "./engine-health";
 import { snapshotExecutableQuery, subscribeExecutableQuery } from "./query-execution";
@@ -21,12 +40,7 @@ import {
 } from "./topic-store";
 
 export { InvalidQueryError } from "./raw-query-compiler";
-export {
-  EngineClosedError,
-  InvalidRowError,
-  InvalidTopicError,
-  UnsupportedQueryError,
-} from "./engine-errors";
+export { EngineClosedError, InvalidRowError, InvalidTopicError } from "./engine-errors";
 export type { ColumnLiveViewEngineError } from "./engine-errors";
 export type {
   ColumnLiveViewEngine,
@@ -149,57 +163,169 @@ class InMemoryColumnLiveViewEngine<
     yield* deleteTopicStoreRow(store, key);
   });
 
-  readonly snapshot: ColumnLiveViewEngine<Topics>["snapshot"] = Effect.fn(
-    "ColumnLiveViewEngine.snapshot",
-  )({ self: this }, function* <
+  private readonly snapshotQuery = <
     Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(this: InMemoryColumnLiveViewEngine<Topics>, topic: Topic, query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query>) {
-    yield* this.ensureOpen();
-    const store = yield* this.getStore(topic);
-    return yield* snapshotExecutableQuery<
-      LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>
-    >(topic, store, query);
-  });
+    ResultRow extends object,
+  >(
+    topic: Topic,
+    query: unknown,
+  ) =>
+    Effect.fn("ColumnLiveViewEngine.snapshot")(
+      { self: this },
+      function* (this: InMemoryColumnLiveViewEngine<Topics>) {
+        yield* this.ensureOpen();
+        const store = yield* this.getStore(topic);
+        return yield* snapshotExecutableQuery<ResultRow>(topic, store, query);
+      },
+    )();
 
-  readonly subscribe: ColumnLiveViewEngine<Topics>["subscribe"] = Effect.fn(
-    "ColumnLiveViewEngine.subscribe",
-  )({ self: this }, function* <
+  snapshot<
     Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(this: InMemoryColumnLiveViewEngine<Topics>, topic: Topic, query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query>) {
-    yield* this.ensureOpen();
-    const store = yield* this.getStore(topic);
-    type ResultRow = LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>;
-    const acquireSubscription = (
-      markAcquired: (subscription: LiveSubscription<ResultRow>) => Effect.Effect<void>,
-    ) =>
-      withTopicStoreMutation(
-        store,
-        Effect.gen({ self: this }, function* () {
-          yield* this.ensureOpen();
-          const queryId = `query-${this.nextQueryId}`;
-          this.nextQueryId += 1;
-          const acquiredSubscription = yield* subscribeExecutableQuery<ResultRow>(
-            topic,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  snapshot<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  snapshot<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  snapshot<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  > {
+    return this.snapshotQuery(topic, query);
+  }
+
+  private readonly subscribeQuery = <
+    Topic extends Extract<keyof Topics, string>,
+    ResultRow extends object,
+  >(
+    topic: Topic,
+    query: unknown,
+  ) =>
+    Effect.fn("ColumnLiveViewEngine.subscribe")(
+      { self: this },
+      function* (this: InMemoryColumnLiveViewEngine<Topics>) {
+        yield* this.ensureOpen();
+        const store = yield* this.getStore(topic);
+        const acquireSubscription = (
+          markAcquired: (subscription: LiveSubscription<ResultRow>) => Effect.Effect<void>,
+        ) =>
+          withTopicStoreMutation(
             store,
-            query,
-            {
-              queryId,
-              queueCapacity: this.subscriptionQueueCapacity,
-            },
+            Effect.gen({ self: this }, function* () {
+              yield* this.ensureOpen();
+              const queryId = `query-${this.nextQueryId}`;
+              this.nextQueryId += 1;
+              const acquiredSubscription = yield* subscribeExecutableQuery<ResultRow>(
+                topic,
+                store,
+                query,
+                {
+                  queryId,
+                  queueCapacity: this.subscriptionQueueCapacity,
+                },
+              );
+              yield* markAcquired(acquiredSubscription);
+              return acquiredSubscription;
+            }),
           );
-          yield* markAcquired(acquiredSubscription);
-          return acquiredSubscription;
-        }),
-      );
-    const subscription = yield* acquireLiveSubscriptionHandoff(acquireSubscription);
+        const subscription = yield* acquireLiveSubscriptionHandoff(acquireSubscription);
 
-    return {
-      events: subscription.events,
-      close: subscription.close,
-    };
-  });
+        return {
+          events: subscription.events,
+          close: subscription.close,
+        };
+      },
+    )();
+
+  subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  subscribe<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  > {
+    return this.subscribeQuery(topic, query);
+  }
+
+  readonly subscribeRuntime: ColumnLiveViewEngine<Topics>["subscribeRuntime"] = (topic, query) =>
+    this.subscribeQuery(topic, query);
 
   readonly health: ColumnLiveViewEngine<Topics>["health"] = Effect.fn(
     "ColumnLiveViewEngine.health",

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -1,6 +1,6 @@
 import type { DeltaEvent, SnapshotEvent, StatusEvent } from "@view-server/config";
 import { Cause, Effect, Exit, Option, Queue, Stream } from "effect";
-import type { RawQueryExecution } from "./active-query";
+import type { LiveQueryExecution } from "./active-query";
 import type { TopicStore } from "./topic-store";
 import {
   registerTopicStoreSubscription,
@@ -33,7 +33,7 @@ type MakeLiveSubscriptionOptions<ResultRow extends RowObject> = {
   readonly store: TopicStore;
   readonly queryId: string;
   readonly queueCapacity: number;
-  readonly execution: RawQueryExecution<ResultRow>;
+  readonly execution: LiveQueryExecution<ResultRow>;
   readonly release: Effect.Effect<void>;
 };
 

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -1,7 +1,16 @@
 import { Effect } from "effect";
-import { UnsupportedQueryError } from "./engine-errors";
 import { makeLiveSubscription } from "./live-subscription";
-import { acquireRawQueryExecution, releaseRawQueryExecution } from "./active-query";
+import {
+  acquireMaterializedQueryExecution,
+  acquireRawQueryExecution,
+  releaseMaterializedQueryExecution,
+  releaseRawQueryExecution,
+} from "./active-query";
+import {
+  evaluateCompiledGroupedQuery,
+  prepareGroupedQuery,
+  type CompiledGroupedQuery,
+} from "./grouped-query-compiler";
 import {
   evaluateCompiledRawQuery,
   prepareRawQuery,
@@ -12,10 +21,15 @@ import { topicStoreRawQueryMetadata, topicStoreReadModel, type TopicStore } from
 
 type RowObject = object;
 
-export type ExecutableQuery<ResultRow extends RowObject> = {
-  readonly kind: "raw";
-  readonly compiled: CompiledRawQuery<object, ResultRow>;
-};
+export type ExecutableQuery<ResultRow extends RowObject> =
+  | {
+      readonly kind: "raw";
+      readonly compiled: CompiledRawQuery<object, ResultRow>;
+    }
+  | {
+      readonly kind: "grouped";
+      readonly compiled: CompiledGroupedQuery<object, ResultRow>;
+    };
 
 export const isGroupedQuery = (query: unknown): boolean =>
   typeof query === "object" &&
@@ -23,16 +37,18 @@ export const isGroupedQuery = (query: unknown): boolean =>
   !Array.isArray(query) &&
   ("groupBy" in query || "aggregates" in query);
 
-const unsupportedGroupedQuery = (topic: string) =>
-  new UnsupportedQueryError({
-    topic,
-    message: "Grouped aggregate queries are not implemented in this slice.",
-  });
-
 export const prepareExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.prepare")(
   function* <ResultRow extends RowObject>(topic: string, store: TopicStore, query: unknown) {
     if (isGroupedQuery(query)) {
-      return yield* unsupportedGroupedQuery(topic);
+      const compiled = yield* prepareGroupedQuery<object, ResultRow>(
+        topic,
+        topicStoreRawQueryMetadata(store),
+        query,
+      );
+      return {
+        kind: "grouped",
+        compiled,
+      } satisfies ExecutableQuery<ResultRow>;
     }
     const compiled = yield* prepareRawQuery<object, ResultRow>(
       topic,
@@ -50,7 +66,9 @@ export const evaluateExecutableQuery = <ResultRow extends RowObject>(
   store: TopicStore,
   executable: ExecutableQuery<ResultRow>,
 ): QueryEvaluation<ResultRow> =>
-  evaluateCompiledRawQuery(topicStoreReadModel(store), executable.compiled);
+  executable.kind === "raw"
+    ? evaluateCompiledRawQuery(topicStoreReadModel(store), executable.compiled)
+    : evaluateCompiledGroupedQuery(topicStoreReadModel(store), executable.compiled);
 
 export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.snapshot")(
   function* <ResultRow extends RowObject>(topic: string, store: TopicStore, query: unknown) {
@@ -71,13 +89,28 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
   ) {
     const executable = yield* prepareExecutableQuery<ResultRow>(topic, store, query);
     const storeReadModel = topicStoreReadModel(store);
-    const execution = yield* acquireRawQueryExecution(storeReadModel, executable.compiled);
+    if (executable.kind === "raw") {
+      const execution = yield* acquireRawQueryExecution(storeReadModel, executable.compiled);
+      return yield* makeLiveSubscription({
+        store,
+        queryId: input.queryId,
+        execution,
+        queueCapacity: input.queueCapacity,
+        release: releaseRawQueryExecution(storeReadModel, executable.compiled),
+      });
+    }
+
+    const execution = yield* acquireMaterializedQueryExecution(
+      storeReadModel,
+      executable.compiled.cacheKey,
+      () => evaluateCompiledGroupedQuery(storeReadModel, executable.compiled),
+    );
     return yield* makeLiveSubscription({
       store,
       queryId: input.queryId,
       execution,
       queueCapacity: input.queueCapacity,
-      release: releaseRawQueryExecution(storeReadModel, executable.compiled),
+      release: releaseMaterializedQueryExecution(storeReadModel, executable.compiled.cacheKey),
     });
   },
 );

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -1,6 +1,6 @@
-import type { FieldKey, OrderBy } from "@view-server/config";
-import { Effect, Schema, SchemaAST } from "effect";
-import { isBigDecimal, Order } from "effect/BigDecimal";
+import { viewServerSchemaFieldMetadata, type FieldKey, type OrderBy } from "@view-server/config";
+import { Effect, Schema } from "effect";
+import { format as formatBigDecimal, isBigDecimal, normalize, Order } from "effect/BigDecimal";
 import {
   cloneRecord,
   cloneUnknown,
@@ -39,7 +39,12 @@ type SchemaWithFields = Schema.Decoder<object> & {
 
 export type RawQueryCompilerMetadata = {
   readonly fieldNames: ReadonlySet<string>;
+  readonly fieldMetadata: ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>>;
   readonly structuredFieldNames: ReadonlySet<string>;
+  readonly stringFieldNames: ReadonlySet<string>;
+  readonly numericFieldNames: ReadonlySet<string>;
+  readonly bigintFieldNames: ReadonlySet<string>;
+  readonly bigDecimalFieldNames: ReadonlySet<string>;
 };
 
 export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject> = {
@@ -70,6 +75,7 @@ type FilterObject = {
 
 const rawQueryKeys = new Set(["where", "orderBy", "offset", "limit", "select"]);
 const filterOperatorKeys = new Set(["eq", "neq", "in", "gt", "gte", "lt", "lte", "startsWith"]);
+const rangeFilterOperatorKeys = new Set(["gt", "gte", "lt", "lte"]);
 
 const isDenseArray = (value: ReadonlyArray<unknown>): boolean => {
   for (let index = 0; index < value.length; index += 1) {
@@ -83,18 +89,114 @@ const isDenseArray = (value: ReadonlyArray<unknown>): boolean => {
 const isValidWindowNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 
+const isQueryValueSafe = (value: unknown, active: WeakSet<object> = new WeakSet()): boolean => {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    typeof value === "boolean" ||
+    isBigDecimal(value)
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    if (active.has(value)) {
+      return false;
+    }
+    active.add(value);
+    const safe = isDenseArray(value) && value.every((entry) => isQueryValueSafe(entry, active));
+    active.delete(value);
+    return safe;
+  }
+  if (isPlainRecord(value)) {
+    if (active.has(value)) {
+      return false;
+    }
+    active.add(value);
+    const safe = Object.values(value).every((entry) => isQueryValueSafe(entry, active));
+    active.delete(value);
+    return safe;
+  }
+  return false;
+};
+
 const isSchemaWithFields = (schema: Schema.Decoder<object>): schema is SchemaWithFields =>
   "fields" in schema && isRecord(schema.fields);
 
 const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
   isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
 
-const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
-  if (!isRecord(schema)) {
-    return undefined;
+const schemaFieldMetadata = (
+  schema: Schema.Decoder<object>,
+): ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Map();
   }
-  const ast = schema["ast"];
-  return SchemaAST.isAST(ast) ? ast : undefined;
+
+  const fields = new Map<string, ReturnType<typeof viewServerSchemaFieldMetadata>>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    fields.set(field, viewServerSchemaFieldMetadata(fieldSchema));
+  }
+  return fields;
+};
+
+const schemaNumericFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (!viewServerSchemaFieldMetadata(fieldSchema).isNumeric) {
+      continue;
+    }
+    fields.add(field);
+  }
+  return fields;
+};
+
+const schemaBigintFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isPureBigInt) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+const schemaBigDecimalFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).sumResultKind === "bigDecimal") {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+const schemaStringFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isString) {
+      fields.add(field);
+    }
+  }
+  return fields;
 };
 
 const schemaStructuredFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
@@ -104,11 +206,7 @@ const schemaStructuredFieldNames = (schema: Schema.Decoder<object>): ReadonlySet
 
   const fields = new Set<string>();
   for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    const ast = schemaAst(fieldSchema);
-    if (
-      ast !== undefined &&
-      (SchemaAST.isObjects(ast) || SchemaAST.isArrays(ast) || SchemaAST.isObjectKeyword(ast))
-    ) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isStructured) {
       fields.add(field);
     }
   }
@@ -119,7 +217,12 @@ export const rawQueryCompilerMetadata = (
   schema: Schema.Decoder<object>,
 ): RawQueryCompilerMetadata => ({
   fieldNames: schemaFieldNames(schema),
+  fieldMetadata: schemaFieldMetadata(schema),
   structuredFieldNames: schemaStructuredFieldNames(schema),
+  stringFieldNames: schemaStringFieldNames(schema),
+  numericFieldNames: schemaNumericFieldNames(schema),
+  bigintFieldNames: schemaBigintFieldNames(schema),
+  bigDecimalFieldNames: schemaBigDecimalFieldNames(schema),
 });
 
 const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")((
@@ -161,6 +264,12 @@ const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")((
         return InvalidQueryError.make({
           topic,
           message: `Raw query where contains unknown field: ${field}.`,
+        });
+      }
+      if (!isQueryValueSafe(where[field])) {
+        return InvalidQueryError.make({
+          topic,
+          message: `Raw query where field ${field} contains unsupported query value.`,
         });
       }
     }
@@ -319,6 +428,23 @@ const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.validate")
         message: `Raw query where field ${field} contains unsupported filter operator.`,
       });
     }
+    if (operatorKeyCount > 0) {
+      if (keys.includes("startsWith") && !metadata.stringFieldNames.has(field)) {
+        return yield* InvalidQueryError.make({
+          topic,
+          message: `Raw query where field ${field} does not support startsWith.`,
+        });
+      }
+      if (
+        keys.some((key) => rangeFilterOperatorKeys.has(key)) &&
+        !metadata.numericFieldNames.has(field)
+      ) {
+        return yield* InvalidQueryError.make({
+          topic,
+          message: `Raw query where field ${field} does not support range operators.`,
+        });
+      }
+    }
     if (operatorKeyCount === 0 && !metadata.structuredFieldNames.has(field)) {
       return yield* InvalidQueryError.make({
         topic,
@@ -328,22 +454,78 @@ const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.validate")
   }
 });
 
-const stableValueString = (value: unknown): string => {
+type StableQueryObjectEntry = readonly [string, StableQueryValueToken];
+
+type StableQueryValueToken =
+  | readonly ["null"]
+  | readonly ["undefined"]
+  | readonly ["boolean", boolean]
+  | readonly ["number", string]
+  | readonly ["string", string]
+  | readonly ["bigint", string]
+  | readonly ["bigDecimal", string]
+  | readonly ["unsupported", string]
+  | readonly ["cycle"]
+  | readonly ["array", ReadonlyArray<StableQueryValueToken>]
+  | readonly ["object", ReadonlyArray<StableQueryObjectEntry>]
+  | readonly ["nonPlainObject", string];
+
+const stableQueryValueToken = (value: unknown, active: WeakSet<object>): StableQueryValueToken => {
+  if (isBigDecimal(value)) {
+    return ["bigDecimal", formatBigDecimal(normalize(value))];
+  }
+  if (value === null) {
+    return ["null"];
+  }
+  if (typeof value === "bigint") {
+    return ["bigint", value.toString()];
+  }
+  if (typeof value === "symbol") {
+    return ["unsupported", `symbol:${value.description ?? ""}`];
+  }
+  if (typeof value === "function") {
+    return ["unsupported", `function:${value.name}`];
+  }
   if (Array.isArray(value)) {
-    return `[${value.map(stableValueString).join(",")}]`;
+    if (active.has(value)) {
+      return ["cycle"];
+    }
+    active.add(value);
+    const token: StableQueryValueToken = [
+      "array",
+      value.map((entry) => stableQueryValueToken(entry, active)),
+    ];
+    active.delete(value);
+    return token;
   }
   if (isPlainRecord(value)) {
-    return `{${Object.keys(value)
+    if (active.has(value)) {
+      return ["cycle"];
+    }
+    active.add(value);
+    const entries: Array<StableQueryObjectEntry> = Object.keys(value)
       .toSorted()
-      .map((key) => `${key}:${stableValueString(value[key])}`)
-      .join(",")}}`;
+      .map((key) => [key, stableQueryValueToken(value[key], active)]);
+    active.delete(value);
+    return ["object", entries];
   }
-  return `${typeof value}:${
-    JSON.stringify(value, (_key, entry: unknown) =>
-      typeof entry === "bigint" ? entry.toString() : entry,
-    ) ?? ""
-  }`;
+  if (typeof value === "object" && value !== null) {
+    return ["nonPlainObject", Object.prototype.toString.call(value)];
+  }
+  if (typeof value === "number") {
+    return ["number", Object.is(value, -0) ? "-0" : String(value)];
+  }
+  if (typeof value === "string") {
+    return ["string", value];
+  }
+  if (typeof value === "boolean") {
+    return ["boolean", value];
+  }
+  return ["undefined"];
 };
+
+export const stableQueryValueString = (value: unknown): string =>
+  JSON.stringify(stableQueryValueToken(value, new WeakSet()));
 
 const valueRank = (value: unknown): number => {
   if (value == null) {
@@ -384,12 +566,12 @@ const compareFilterValue = (left: unknown, right: unknown): number | undefined =
 };
 
 const compareByStableString = (left: unknown, right: unknown): number => {
-  const leftString = stableValueString(left);
-  const rightString = stableValueString(right);
+  const leftString = stableQueryValueString(left);
+  const rightString = stableQueryValueString(right);
   return Number(leftString > rightString) - Number(leftString < rightString);
 };
 
-const compareValue = (left: unknown, right: unknown): number | undefined => {
+export const compareQueryValue = (left: unknown, right: unknown): number | undefined => {
   const leftRank = valueRank(left);
   const rightRank = valueRank(right);
   if (leftRank !== rightRank) {
@@ -561,7 +743,7 @@ const compareRows = <Row extends RowObject>(
   orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
 ): number => {
   for (const order of orderBy) {
-    const comparison = compareValue(
+    const comparison = compareQueryValue(
       fieldValue(left.row, order.field),
       fieldValue(right.row, order.field),
     );

--- a/packages/config/src/grouped-query-contract.ts
+++ b/packages/config/src/grouped-query-contract.ts
@@ -1,8 +1,12 @@
 import type {
-  Aggregate,
   AggregateAliasesFromAggregates,
   AggregateResultValue,
   Aggregates,
+  AverageAggregate,
+  ComparableAggregate,
+  CountAggregate,
+  CountDistinctAggregate,
+  SumAggregate,
 } from "./query-aggregate";
 import type { FieldKey, Simplify } from "./query-core";
 import type { RejectExtraKeys } from "./query-exact";
@@ -23,8 +27,26 @@ type NonEmptyFieldTuple<Row, Tuple> = Tuple extends readonly [unknown, ...Array<
   ? { readonly [Index in keyof Tuple]: Tuple[Index] & FieldKey<Row> }
   : never;
 
+type ExactAggregate<Row, Candidate> = Candidate extends {
+  readonly aggFunc: "count";
+}
+  ? Candidate & CountAggregate & RejectExtraKeys<Candidate, CountAggregate>
+  : Candidate extends { readonly aggFunc: "countDistinct" }
+    ? Candidate &
+        CountDistinctAggregate<Row> &
+        RejectExtraKeys<Candidate, CountDistinctAggregate<Row>>
+    : Candidate extends { readonly aggFunc: "sum" }
+      ? Candidate & SumAggregate<Row> & RejectExtraKeys<Candidate, SumAggregate<Row>>
+      : Candidate extends { readonly aggFunc: "avg" }
+        ? Candidate & AverageAggregate<Row> & RejectExtraKeys<Candidate, AverageAggregate<Row>>
+        : Candidate extends { readonly aggFunc: "min" | "max" }
+          ? Candidate &
+              ComparableAggregate<Row> &
+              RejectExtraKeys<Candidate, ComparableAggregate<Row>>
+          : never;
+
 type ExactAggregates<Row, Candidate> = {
-  readonly [Alias in keyof Candidate]: Candidate[Alias] & Aggregate<Row>;
+  readonly [Alias in keyof Candidate]: ExactAggregate<Row, Candidate[Alias]>;
 };
 
 type GroupedOrderByField<Row, GroupBy> = Extract<

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -10,6 +10,7 @@ import {
   VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
   VIEW_SERVER_HEALTH_TOPIC,
   viewServerReservedTopicNames,
+  viewServerSchemaFieldMetadata,
   viewServerTopicNameIsReserved,
   viewServerHealthSummaryFromHealth,
   viewServerHealthSummaryRowFromHealth,
@@ -19,6 +20,7 @@ import {
   type KafkaTopicDefinition,
   type ExactGroupedQuery,
   type ExactRawQuery,
+  type GroupedQuery,
   type LiveQueryResult,
   type LiveQueryRow,
   type LiveSubscription,
@@ -65,8 +67,10 @@ const Position = Schema.Struct({
   symbol: Schema.String,
   active: Schema.Boolean,
   quantity: Schema.BigInt,
+  optionalQuantity: Schema.Union([Schema.BigInt, Schema.Undefined]),
   price: Schema.BigDecimal,
   notional: Schema.Number,
+  optionalNotional: Schema.Union([Schema.Number, Schema.Undefined]),
 });
 
 declare const decimal: (value: string) => BigDecimal.BigDecimal;
@@ -160,13 +164,23 @@ const runtimeTopicHealth = (
 });
 
 type LiveQueryCall<Topics extends object> = {
-  <Topic extends Extract<keyof Topics, string>, const Query extends object>(
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
     topic: Topic,
-    query: ExactGroupedQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
   ): LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;
-  <Topic extends Extract<keyof Topics, string>, const Query extends object>(
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
     topic: Topic,
-    query: ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
   ): LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;
 };
 
@@ -178,6 +192,146 @@ const kafkaRegions = {
 const kafkaTopic = viewServer.kafkaTopic<typeof kafkaRegions>();
 
 describe("defineViewServerConfig", () => {
+  it("derives schema field metadata for query validation", () => {
+    expect(viewServerSchemaFieldMetadata(Schema.Number)).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigDecimal",
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.BigInt)).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: true,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigint",
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.BigDecimal)).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigDecimal",
+    });
+    expect(
+      viewServerSchemaFieldMetadata(Schema.Union([Schema.BigInt, Schema.BigInt])),
+    ).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigint",
+    });
+    expect(
+      viewServerSchemaFieldMetadata(Schema.Union([Schema.BigInt, Schema.Number])),
+    ).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigDecimal",
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Literal(1))).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigDecimal",
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Literals([1, 2]))).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigDecimal",
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Literal(1n))).toStrictEqual({
+      isNumeric: true,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+      sumResultKind: "bigint",
+    });
+    expect(
+      viewServerSchemaFieldMetadata(Schema.Union([Schema.Number, Schema.Undefined])),
+    ).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(
+      viewServerSchemaFieldMetadata(Schema.Union([Schema.BigInt, Schema.Undefined])),
+    ).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Undefined)).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Union([Schema.Undefined]))).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Union([]))).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata(undefined)).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata("not-a-schema")).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata({ ast: "not-an-effect-ast" })).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Literals(["open", "closed"]))).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: true,
+      isStructured: false,
+    });
+    expect(
+      viewServerSchemaFieldMetadata(
+        Schema.Union([
+          Schema.Struct({ id: Schema.String }),
+          Schema.Struct({ id: Schema.String, name: Schema.String }),
+        ]),
+      ),
+    ).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: true,
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Struct({ id: Schema.String }))).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: true,
+    });
+  });
+
   it("defines topics and pure runtime option contracts without starting a runtime", () => {
     const runtimeOptions = viewServer.defineRuntimeOptions({
       websocketPort: runtimeEnvironmentConfig.websocketPort,
@@ -692,6 +846,40 @@ describe("public type surface", () => {
         readonly maxQuantity: bigint;
       }>();
 
+      const optionalNumericSumQuery = {
+        groupBy: ["accountId"],
+        aggregates: {
+          totalOptionalQuantity: { aggFunc: "sum", field: "optionalQuantity" },
+        },
+      } satisfies {
+        readonly groupBy: readonly ["accountId"];
+        readonly aggregates: {
+          readonly totalOptionalQuantity: {
+            readonly aggFunc: "sum";
+            readonly field: "optionalQuantity";
+          };
+        };
+      };
+      // @ts-expect-error optional numeric fields cannot be summed without an explicit non-null mapping.
+      useLiveQuery("positions", optionalNumericSumQuery);
+
+      const optionalNumberSumQuery = {
+        groupBy: ["accountId"],
+        aggregates: {
+          totalOptionalNotional: { aggFunc: "sum", field: "optionalNotional" },
+        },
+      } satisfies {
+        readonly groupBy: readonly ["accountId"];
+        readonly aggregates: {
+          readonly totalOptionalNotional: {
+            readonly aggFunc: "sum";
+            readonly field: "optionalNotional";
+          };
+        };
+      };
+      // @ts-expect-error optional numeric fields cannot be summed without an explicit non-null mapping.
+      useLiveQuery("positions", optionalNumberSumQuery);
+
       const dynamicAggregateAlias: string = "dynamicTotal";
       const dynamicAggregateQuery = {
         groupBy: ["status"],
@@ -1010,6 +1198,7 @@ const assertCompileTimeContracts = () => {
     );
 
     const invalidSnapshotFilter = runtime.snapshot("orders", {
+      // @ts-expect-error invalid query collapse keeps selected fields from being accepted
       select: ["id"],
       where: {
         // @ts-expect-error snapshot filters must use values from the selected topic row
@@ -1311,29 +1500,41 @@ const assertCompileTimeContracts = () => {
       where: { status: "open" },
     });
 
-    useLiveQuery("orders", {
+    const unknownWhereFieldQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error raw queries reject fields not present on the selected topic
         missing: "open",
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly missing: "open" };
+    };
+    // @ts-expect-error raw queries reject fields not present on the selected topic.
+    useLiveQuery("orders", unknownWhereFieldQuery);
 
-    useLiveQuery("orders", {
+    const wrongFilterValueQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error filter values must match the selected field type
         price: "not-a-number",
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly price: "not-a-number" };
+    };
+    // @ts-expect-error filter values must match the selected field type.
+    useLiveQuery("orders", wrongFilterValueQuery);
 
-    useLiveQuery("orders", {
+    const stringRangeFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error string filters do not accept range operators
         status: { gte: "open" },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly status: { readonly gte: "open" } };
+    };
+    // @ts-expect-error string filters do not accept range operators.
+    useLiveQuery("orders", stringRangeFilterQuery);
 
     const invalidStatusInFilter = {
       select: ["id"],
@@ -1352,86 +1553,166 @@ const assertCompileTimeContracts = () => {
     const _invalidStatusInFilter: RawQuery<typeof Order.Type> &
       ExactRawQuery<typeof Order.Type, typeof invalidStatusInFilter> = invalidStatusInFilter;
 
-    useLiveQuery("orders", {
+    const numericStartsWithFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error number filters do not accept string-only operators
         price: { startsWith: "1" },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly price: { readonly startsWith: "1" } };
+    };
+    // @ts-expect-error number filters do not accept string-only operators.
+    useLiveQuery("orders", numericStartsWithFilterQuery);
 
-    useLiveQuery("positions", {
+    const booleanRangeFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error boolean filters do not accept range operators
         active: { gte: true },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly active: { readonly gte: true } };
+    };
+    // @ts-expect-error boolean filters do not accept range operators.
+    useLiveQuery("positions", booleanRangeFilterQuery);
 
-    useLiveQuery("positions", {
+    const booleanStartsWithFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error boolean filters do not accept string-only operators
         active: { startsWith: "t" },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly active: { readonly startsWith: "t" } };
+    };
+    // @ts-expect-error boolean filters do not accept string-only operators.
+    useLiveQuery("positions", booleanStartsWithFilterQuery);
 
-    useLiveQuery("positions", {
+    const bigDecimalStringFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error BigDecimal filters require BigDecimal values, not strings
         price: { gte: "10.00" },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly price: { readonly gte: "10.00" } };
+    };
+    // @ts-expect-error BigDecimal filters require BigDecimal values, not strings.
+    useLiveQuery("positions", bigDecimalStringFilterQuery);
 
-    useLiveQuery("positions", {
+    const bigDecimalStartsWithFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error BigDecimal filters do not accept string-only operators
         price: { startsWith: "10" },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly price: { readonly startsWith: "10" } };
+    };
+    // @ts-expect-error BigDecimal filters do not accept string-only operators.
+    useLiveQuery("positions", bigDecimalStartsWithFilterQuery);
 
-    useLiveQuery("positions", {
+    const bigintNumberFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error bigint filters require bigint values, not numbers
         quantity: { gte: 1 },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly quantity: { readonly gte: 1 } };
+    };
+    // @ts-expect-error bigint filters require bigint values, not numbers.
+    useLiveQuery("positions", bigintNumberFilterQuery);
 
-    useLiveQuery("orders", {
+    const optionalNumericEqualityRows = useLiveQuery("positions", {
       select: ["id"],
-      // @ts-expect-error orderBy fields are constrained to the selected topic row
-      orderBy: [
-        {
-          field: "missing",
-          direction: "asc",
-        },
-      ],
-    });
+      where: {
+        optionalQuantity: { eq: 1n },
+        optionalNotional: 100,
+      },
+    }).rows;
+    expectTypeOf(optionalNumericEqualityRows).toEqualTypeOf<
+      ReadonlyArray<{ readonly id: string }>
+    >();
 
-    useLiveQuery("orders", {
+    const optionalBigintRangeFilterQuery = {
       select: ["id"],
-      // @ts-expect-error sort direction is constrained to asc or desc
-      orderBy: [
-        {
-          field: "price",
-          direction: "ascending",
-        },
-      ],
-    });
+      where: {
+        optionalQuantity: { gte: 1n },
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly optionalQuantity: { readonly gte: 1n } };
+    };
+    // @ts-expect-error optional numeric fields only support equality filters.
+    useLiveQuery("positions", optionalBigintRangeFilterQuery);
 
-    useLiveQuery("orders", {
+    const optionalBigintEqualityWithRangeFilterQuery = {
       select: ["id"],
-      // @ts-expect-error raw orderBy cannot reference aggregate aliases.
-      orderBy: [
-        {
-          aggregate: "totalPrice",
-          direction: "desc",
-        },
-      ],
-    });
+      where: {
+        optionalQuantity: { eq: 1n, gte: 1n },
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly optionalQuantity: { readonly eq: 1n; readonly gte: 1n } };
+    };
+    // @ts-expect-error optional numeric exact filters reject range operators even when equality is present.
+    useLiveQuery("positions", optionalBigintEqualityWithRangeFilterQuery);
+
+    const optionalNumberRangeFilterQuery = {
+      select: ["id"],
+      where: {
+        optionalNotional: { lte: 100 },
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly optionalNotional: { readonly lte: 100 } };
+    };
+    // @ts-expect-error optional numeric fields only support equality filters.
+    useLiveQuery("positions", optionalNumberRangeFilterQuery);
+
+    const optionalNumberEqualityWithRangeFilterQuery = {
+      select: ["id"],
+      where: {
+        optionalNotional: { eq: 100, lte: 100 },
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly optionalNotional: { readonly eq: 100; readonly lte: 100 } };
+    };
+    // @ts-expect-error optional numeric exact filters reject range operators even when equality is present.
+    useLiveQuery("positions", optionalNumberEqualityWithRangeFilterQuery);
+
+    const unknownOrderByFieldQuery = {
+      select: ["id"],
+      orderBy: [{ field: "missing", direction: "asc" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [{ readonly field: "missing"; readonly direction: "asc" }];
+    };
+    // @ts-expect-error orderBy fields are constrained to the selected topic row.
+    useLiveQuery("orders", unknownOrderByFieldQuery);
+
+    const invalidOrderByDirectionQuery = {
+      select: ["id"],
+      orderBy: [{ field: "price", direction: "ascending" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [{ readonly field: "price"; readonly direction: "ascending" }];
+    };
+    // @ts-expect-error sort direction is constrained to asc or desc.
+    useLiveQuery("orders", invalidOrderByDirectionQuery);
+
+    const rawAggregateOrderByQuery = {
+      select: ["id"],
+      orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [{ readonly aggregate: "totalPrice"; readonly direction: "desc" }];
+    };
+    // @ts-expect-error raw orderBy cannot reference aggregate aliases.
+    useLiveQuery("orders", rawAggregateOrderByQuery);
 
     const invalidSelectedFields = {
       select: ["id", "missing"],
@@ -1490,6 +1771,38 @@ const assertCompileTimeContracts = () => {
       typeof invalidAggregateAliasCollision
     > &
       ValidateLiveQuery<typeof invalidAggregateAliasCollision> = invalidAggregateAliasCollision;
+
+    const invalidEmptyAggregates = {
+      groupBy: ["status"],
+      aggregates: {},
+    } satisfies {
+      readonly groupBy: readonly ["status"];
+      readonly aggregates: {};
+    };
+    // @ts-expect-error grouped queries require at least one aggregate alias.
+    const _invalidEmptyAggregates: ExactGroupedQuery<
+      typeof Order.Type,
+      typeof invalidEmptyAggregates
+    > &
+      ValidateLiveQuery<typeof invalidEmptyAggregates> = invalidEmptyAggregates;
+
+    const invalidDangerousAggregateAlias = {
+      groupBy: ["status"],
+      aggregates: { constructor: { aggFunc: "count" } },
+    } satisfies {
+      readonly groupBy: readonly ["status"];
+      readonly aggregates: {
+        readonly constructor: {
+          readonly aggFunc: "count";
+        };
+      };
+    };
+    // @ts-expect-error grouped aggregate aliases must not use dangerous object keys.
+    const _invalidDangerousAggregateAlias: ExactGroupedQuery<
+      typeof Order.Type,
+      typeof invalidDangerousAggregateAlias
+    > &
+      ValidateLiveQuery<typeof invalidDangerousAggregateAlias> = invalidDangerousAggregateAlias;
 
     const invalidGroupedOrderByRawField = {
       groupBy: ["status"],
@@ -1636,17 +1949,21 @@ const assertCompileTimeContracts = () => {
       typeof invalidGroupedOrderByBothFieldAndAggregate
     > = invalidGroupedOrderByBothFieldAndAggregate;
 
-    useLiveQuery("orders", {
+    const rawOrderByFieldAndAggregateQuery = {
       select: ["id"],
-      // @ts-expect-error raw orderBy entries cannot also include aggregate.
-      orderBy: [
+      orderBy: [{ field: "price", aggregate: "totalPrice", direction: "desc" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [
         {
-          field: "price",
-          aggregate: "totalPrice",
-          direction: "desc",
+          readonly field: "price";
+          readonly aggregate: "totalPrice";
+          readonly direction: "desc";
         },
-      ],
-    });
+      ];
+    };
+    // @ts-expect-error raw orderBy entries cannot also include aggregate.
+    useLiveQuery("orders", rawOrderByFieldAndAggregateQuery);
 
     const invalidOrderSumField = {
       groupBy: ["status"],
@@ -1665,6 +1982,47 @@ const assertCompileTimeContracts = () => {
     // @ts-expect-error sum and avg aggregate fields must be numeric
     const _invalidOrderSumField: ExactGroupedQuery<typeof Order.Type, typeof invalidOrderSumField> =
       invalidOrderSumField;
+
+    const invalidAggregateExtraKey = {
+      groupBy: ["status"],
+      aggregates: {
+        totalPrice: { aggFunc: "sum", field: "price", typo: true },
+      },
+    } satisfies {
+      readonly groupBy: readonly ["status"];
+      readonly aggregates: {
+        readonly totalPrice: {
+          readonly aggFunc: "sum";
+          readonly field: "price";
+          readonly typo: true;
+        };
+      };
+    };
+    // @ts-expect-error aggregate definitions reject extra keys through variables.
+    const _invalidAggregateExtraKey: ExactGroupedQuery<
+      typeof Order.Type,
+      typeof invalidAggregateExtraKey
+    > = invalidAggregateExtraKey;
+
+    const invalidCountAggregateField = {
+      groupBy: ["status"],
+      aggregates: {
+        rowCount: { aggFunc: "count", field: "price" },
+      },
+    } satisfies {
+      readonly groupBy: readonly ["status"];
+      readonly aggregates: {
+        readonly rowCount: {
+          readonly aggFunc: "count";
+          readonly field: "price";
+        };
+      };
+    };
+    // @ts-expect-error count aggregate definitions must not include a field.
+    const _invalidCountAggregateField: ExactGroupedQuery<
+      typeof Order.Type,
+      typeof invalidCountAggregateField
+    > = invalidCountAggregateField;
 
     const invalidPositionSumField = {
       groupBy: ["accountId"],
@@ -1873,5 +2231,24 @@ describe("reserved system topic validation", () => {
         },
       }),
     ).toThrow("View Server topic name is reserved for system health streams");
+  });
+
+  it("rejects reserved row field names at runtime", () => {
+    const reservedFieldName = "__proto__";
+    const BadRow = Schema.Struct({
+      id: Schema.String,
+      [reservedFieldName]: Schema.String,
+    });
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          badRows: {
+            schema: BadRow,
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("uses a reserved row field name: __proto__");
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -19,18 +19,22 @@ export type {
   CountDistinctAggregate,
   EqualityFilter,
   ExactGroupedQuery,
+  ExactLiveQuery,
+  ExactLiveQueryInput,
   ExactPatch,
   ExactRawQuery,
   FieldFilter,
   FieldKey,
   GroupedOrderBy,
   GroupedQuery,
+  GroupedResult,
   LiveQuery,
   LiveQueryResult,
   LiveQueryRow,
   NumericFieldKey,
   OrderBy,
   OrderByField,
+  PickRawFields,
   RangeFilter,
   RawQuery,
   RowFromSchema,
@@ -84,6 +88,10 @@ export type {
   ViewServerRuntimeError,
   ViewServerTransportError,
 } from "./runtime-contract";
+export {
+  viewServerSchemaFieldMetadata,
+  type ViewServerSchemaFieldMetadata,
+} from "./schema-field-metadata";
 export type {
   DeltaEvent,
   DeltaOperation,
@@ -149,6 +157,12 @@ export const defineViewServerConfig = <
   for (const topic of Object.keys(input.topics)) {
     if (viewServerTopicNameIsReserved(topic)) {
       throw new Error(`View Server topic name is reserved for system health streams: ${topic}`);
+    }
+    const schema = input.topics[topic]!.schema;
+    for (const field of Object.keys(schema.fields)) {
+      if (field === "__proto__" || field === "prototype" || field === "constructor") {
+        throw new Error(`View Server topic ${topic} uses a reserved row field name: ${field}`);
+      }
     }
   }
   return {

--- a/packages/config/src/query-aggregate.ts
+++ b/packages/config/src/query-aggregate.ts
@@ -38,15 +38,15 @@ export type Aggregates<Row> = Readonly<Record<string, Aggregate<Row>>>;
 
 export type AggregateAliasesFromAggregates<Aggregates> = Extract<keyof Aggregates, string>;
 
+type SumResultValue<Value> = [Value] extends [bigint] ? bigint : BigDecimal.BigDecimal;
+
 export type AggregateResultValue<Row, Agg> = Agg extends {
   readonly aggFunc: "count" | "countDistinct";
 }
   ? bigint
   : Agg extends { readonly aggFunc: "sum"; readonly field: infer Field }
     ? Field extends keyof Row
-      ? Row[Field] extends bigint
-        ? bigint
-        : BigDecimal.BigDecimal
+      ? SumResultValue<Row[Field]>
       : never
     : Agg extends { readonly aggFunc: "avg" }
       ? BigDecimal.BigDecimal

--- a/packages/config/src/query-core.ts
+++ b/packages/config/src/query-core.ts
@@ -19,11 +19,18 @@ export type StringFieldKey<Row> = Extract<
   string
 >;
 
+type NumericValue = number | bigint | BigDecimal.BigDecimal;
+type IsNumericFieldValue<Value> = [Value] extends [never]
+  ? false
+  : undefined extends Value
+    ? false
+    : [Value] extends [NumericValue]
+      ? true
+      : false;
+
 export type NumericFieldKey<Row> = Extract<
   {
-    readonly [Key in keyof Row]-?: Row[Key] extends number | bigint | BigDecimal.BigDecimal
-      ? Key
-      : never;
+    readonly [Key in keyof Row]-?: IsNumericFieldValue<Row[Key]> extends true ? Key : never;
   }[keyof Row],
   string
 >;

--- a/packages/config/src/query-filter.ts
+++ b/packages/config/src/query-filter.ts
@@ -31,11 +31,15 @@ export type StringFilter<Value extends string> =
       readonly startsWith?: string;
     };
 
-export type FieldFilter<Value> = Value extends string
-  ? StringFilter<Value>
-  : Value extends number | bigint | BigDecimal.BigDecimal
-    ? RangeFilter<Value>
-    : EqualityFilter<Value>;
+type DefinedFilterValue<Value> = Exclude<Value, undefined>;
+
+export type FieldFilter<Value> = undefined extends Value
+  ? EqualityFilter<DefinedFilterValue<Value>>
+  : Value extends string
+    ? StringFilter<Value>
+    : Value extends number | bigint | BigDecimal.BigDecimal
+      ? RangeFilter<Value>
+      : EqualityFilter<Value>;
 
 export type Where<Row> = {
   readonly [Field in FieldKey<Row>]?: FieldFilter<Row[Field]>;
@@ -58,10 +62,18 @@ type FieldFilterShape<Value> = Value extends string
       readonly lte?: Value;
     };
 
+type ExactFieldFilterShape<Value> = undefined extends Value
+  ? {
+      readonly eq?: DefinedFilterValue<Value>;
+      readonly neq?: DefinedFilterValue<Value>;
+      readonly in?: ReadonlyArray<DefinedFilterValue<Value>>;
+    }
+  : FieldFilterShape<Value>;
+
 type ExactOperatorFilter<Value, Filter> = Filter extends object
   ? Filter extends ReadonlyArray<unknown>
     ? unknown
-    : Filter & RejectExtraKeys<Filter, FieldFilterShape<Value>>
+    : Filter & RejectExtraKeys<Filter, ExactFieldFilterShape<Value>>
   : unknown;
 
 type ExactFilter<Value, Filter> = Filter extends Value

--- a/packages/config/src/query-result-contract.ts
+++ b/packages/config/src/query-result-contract.ts
@@ -1,10 +1,17 @@
-import type { GroupedQuery, GroupedResult } from "./grouped-query-contract";
-import type { PickRawFields, RawQuery } from "./raw-query-contract";
+import type { ExactGroupedQuery, GroupedQuery, GroupedResult } from "./grouped-query-contract";
+import type { ExactRawQuery, PickRawFields, RawQuery } from "./raw-query-contract";
 
 export type LiveQuery<Row> = RawQuery<Row> | GroupedQuery<Row>;
 
-export type LiveQueryRow<Row, Query> =
-  Query extends GroupedQuery<Row> ? GroupedResult<Row, Query> : PickRawFields<Row, Query>;
+export type ExactLiveQuery<Row, Query> = Query extends {
+  readonly groupBy: ReadonlyArray<unknown>;
+}
+  ? ExactGroupedQuery<Row, Query>
+  : ExactRawQuery<Row, Query>;
+
+export type LiveQueryRow<Row, Query> = Query extends { readonly groupBy: ReadonlyArray<unknown> }
+  ? GroupedResult<Row, Query>
+  : PickRawFields<Row, Query>;
 
 export type LiveQueryResult<Row> = {
   readonly rows: ReadonlyArray<Row>;
@@ -52,5 +59,26 @@ type RejectBroadAggregateAliases<Query> = Query extends {
     : unknown
   : unknown;
 
+type RejectEmptyAggregates<Query> = Query extends {
+  readonly aggregates: infer Aggs;
+}
+  ? keyof Aggs extends never
+    ? { readonly aggregates: never }
+    : unknown
+  : unknown;
+
+type DangerousAggregateAlias = "__proto__" | "prototype" | "constructor";
+
+type RejectDangerousAggregateAliases<Query> =
+  Extract<AggregateAliases<Query>, DangerousAggregateAlias> extends never
+    ? unknown
+    : { readonly aggregates: never };
+
 export type ValidateLiveQuery<Query> = RejectAggregateAliasCollisions<Query> &
-  RejectBroadAggregateAliases<Query>;
+  RejectBroadAggregateAliases<Query> &
+  RejectEmptyAggregates<Query> &
+  RejectDangerousAggregateAliases<Query>;
+
+export type ExactLiveQueryInput<Row, Query> = Query &
+  ExactLiveQuery<Row, Query> &
+  ValidateLiveQuery<Query>;

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -1,12 +1,13 @@
 import type { Config, Effect } from "effect";
 import type { ViewServerHealth } from "./health-contract";
 import type {
+  ExactLiveQueryInput,
   ExactPatch,
-  ExactRawQuery,
-  LiveQueryResult,
+  GroupedQuery,
   LiveQueryRow,
+  LiveQueryResult,
+  RawQuery,
   TopicRow,
-  ValidateLiveQuery,
 } from "./topic-contract";
 
 export type ViewServerBackpressureError = {
@@ -45,6 +46,17 @@ export type ViewServerTransportError =
       readonly queryId?: string;
     };
 
+type RuntimeSnapshot<Topics extends object> = <
+  Topic extends Extract<keyof Topics, string>,
+  const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+>(
+  topic: Topic,
+  query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+) => Effect.Effect<
+  LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+  ViewServerRuntimeError
+>;
+
 export type ViewServerRuntimeClient<Topics extends object> = {
   readonly publish: <Topic extends Extract<keyof Topics, string>>(
     topic: Topic,
@@ -66,16 +78,7 @@ export type ViewServerRuntimeClient<Topics extends object> = {
     topic: Topic,
     key: string,
   ) => Effect.Effect<void, ViewServerRuntimeError>;
-  readonly snapshot: <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends { readonly select: ReadonlyArray<unknown> },
-  >(
-    topic: Topic,
-    query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
-  ) => Effect.Effect<
-    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ViewServerRuntimeError
-  >;
+  readonly snapshot: RuntimeSnapshot<Topics>;
   readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
   readonly reset: () => Effect.Effect<void, ViewServerRuntimeError>;
 };

--- a/packages/config/src/schema-field-metadata.ts
+++ b/packages/config/src/schema-field-metadata.ts
@@ -1,0 +1,93 @@
+import { SchemaAST } from "effect";
+
+export type ViewServerSchemaFieldMetadata = {
+  readonly isNumeric: boolean;
+  readonly isPureBigInt: boolean;
+  readonly isString: boolean;
+  readonly isStructured: boolean;
+  readonly sumResultKind?: "bigint" | "bigDecimal";
+};
+
+type NumericKind = "none" | "bigint" | "bigDecimal";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
+  if (!isRecord(schema)) {
+    return undefined;
+  }
+  const ast = schema["ast"];
+  return SchemaAST.isAST(ast) ? ast : undefined;
+};
+
+const isBigDecimalAst = (ast: SchemaAST.AST): boolean =>
+  SchemaAST.isDeclaration(ast) &&
+  isRecord(ast.annotations?.["typeConstructor"]) &&
+  ast.annotations["typeConstructor"]["_tag"] === "effect/BigDecimal";
+
+const isStringLiteralAst = (ast: SchemaAST.AST): boolean =>
+  SchemaAST.isLiteral(ast) && typeof ast.literal === "string";
+
+const numericKindAst = (ast: SchemaAST.AST): NumericKind => {
+  if (SchemaAST.isBigInt(ast)) {
+    return "bigint";
+  }
+  if (SchemaAST.isLiteral(ast) && typeof ast.literal === "bigint") {
+    return "bigint";
+  }
+  if (SchemaAST.isNumber(ast) || isBigDecimalAst(ast)) {
+    return "bigDecimal";
+  }
+  if (SchemaAST.isLiteral(ast) && typeof ast.literal === "number") {
+    return "bigDecimal";
+  }
+  if (!SchemaAST.isUnion(ast) || ast.types.length === 0) {
+    return "none";
+  }
+  let sawBigDecimal = false;
+  for (const member of ast.types) {
+    const kind = numericKindAst(member);
+    if (kind === "none") {
+      return "none";
+    }
+    sawBigDecimal ||= kind === "bigDecimal";
+  }
+  return sawBigDecimal ? "bigDecimal" : "bigint";
+};
+
+const isStringAst = (ast: SchemaAST.AST): boolean => {
+  if (SchemaAST.isString(ast) || isStringLiteralAst(ast)) {
+    return true;
+  }
+  return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isStringAst);
+};
+
+const isStructuredAst = (ast: SchemaAST.AST): boolean => {
+  if (SchemaAST.isObjects(ast) || SchemaAST.isArrays(ast) || SchemaAST.isObjectKeyword(ast)) {
+    return true;
+  }
+  return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isStructuredAst);
+};
+
+export const viewServerSchemaFieldMetadata = (schema: unknown): ViewServerSchemaFieldMetadata => {
+  const ast = schemaAst(schema);
+  if (ast === undefined) {
+    return {
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: false,
+    };
+  }
+  const numericKind = numericKindAst(ast);
+  const isNumeric = numericKind !== "none";
+  const isPureBigInt = SchemaAST.isBigInt(ast);
+  return {
+    isNumeric,
+    isPureBigInt,
+    isString: isStringAst(ast),
+    isStructured: isStructuredAst(ast),
+    ...(isNumeric ? { sumResultKind: numericKind } : {}),
+  };
+};

--- a/packages/config/src/topic-contract.ts
+++ b/packages/config/src/topic-contract.ts
@@ -46,6 +46,8 @@ export type { ExactPatch, ExactRawQuery, PickRawFields, RawQuery } from "./raw-q
 export type { ExactGroupedQuery, GroupedQuery, GroupedResult } from "./grouped-query-contract";
 export type {
   LiveQuery,
+  ExactLiveQuery,
+  ExactLiveQueryInput,
   LiveQueryResult,
   LiveQueryRow,
   ValidateLiveQuery,

--- a/packages/in-memory/src/index.test.ts
+++ b/packages/in-memory/src/index.test.ts
@@ -142,6 +142,33 @@ describe("@view-server/in-memory", () => {
     }),
   );
 
+  it.effect("subscribes through the runtime live-client entrypoint", () =>
+    Effect.gen(function* () {
+      const inMemory = yield* makeInMemoryViewServer(viewServer, {});
+      yield* inMemory.client.publish("orders", order("a", 10));
+
+      const subscription = yield* inMemory.liveClient.subscribeRuntime("orders", {
+        select: ["id", "price"],
+      });
+      const events = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+
+      expect(events[0]).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-0",
+        version: 1,
+        keys: ["a"],
+        rows: [{ id: "a", price: 10 }],
+        totalRows: 1,
+      });
+
+      yield* subscription.close();
+      const health = yield* inMemory.client.health();
+      expect(health.engine.topics.orders.activeSubscriptions).toBe(0);
+      yield* inMemory.close;
+    }),
+  );
+
   it.effect("refreshes health after close", () =>
     Effect.gen(function* () {
       const inMemory = yield* makeInMemoryViewServer(viewServer, {});
@@ -316,14 +343,10 @@ describe("@view-server/in-memory", () => {
           updatedAt: 20,
         }),
       );
-      const unsupportedQuery = yield* Effect.flip(
-        inMemory.client.snapshot("orders", {
-          // @ts-expect-error grouped queries are rejected by the raw in-memory runtime slice.
-          groupBy: ["status"],
-          // @ts-expect-error grouped queries are rejected by the raw in-memory runtime slice.
-          aggregates: { count: { aggFunc: "count" } },
-        }),
-      );
+      const groupedQuery = yield* inMemory.client.snapshot("orders", {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+      });
       const invalidQuery = yield* Effect.flip(
         inMemory.client.snapshot("orders", {
           // @ts-expect-error hostile runtime callers can still send unknown projected fields.
@@ -338,7 +361,7 @@ describe("@view-server/in-memory", () => {
 
       expect(invalidTopic.code).toBe("InvalidTopic");
       expect(invalidRow.code).toBe("InvalidRow");
-      expect(unsupportedQuery.code).toBe("UnsupportedQuery");
+      expect(groupedQuery.rows).toStrictEqual([{ status: "open", rowCount: 1n }]);
       expect(invalidQuery.code).toBe("InvalidQuery");
       expect(runtimeUnavailable.code).toBe("RuntimeUnavailable");
     }),

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -3,19 +3,29 @@ import {
   InvalidQueryError,
   InvalidRowError,
   InvalidTopicError,
-  UnsupportedQueryError,
   type ColumnLiveViewEngine,
   type ColumnLiveViewEngineError,
   type DecodableTopicDefinitions,
 } from "@view-server/column-live-view-engine";
-import type { ViewServerLiveClient, ViewServerLiveEvent } from "@view-server/client";
 import type {
+  ViewServerLiveEvent,
+  ViewServerLiveSubscription,
+  ViewServerRuntimeLiveClient,
+} from "@view-server/client";
+import type {
+  ExactLiveQueryInput,
+  GroupedQuery,
+  LiveQueryRow,
+  LiveQueryResult,
+  RawQuery,
+  TopicRow,
   ViewServerConfig,
   ViewServerHealth,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
   ViewServerInMemoryRuntime,
   ViewServerRuntimeError,
+  ViewServerTransportError,
 } from "@view-server/config";
 import {
   VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
@@ -31,7 +41,7 @@ export type { DecodableTopicDefinitions } from "@view-server/column-live-view-en
 
 export type ViewServerInMemoryInstance<Topics extends DecodableTopicDefinitions> = {
   readonly client: ViewServerInMemoryRuntime<Topics>;
-  readonly liveClient: ViewServerLiveClient<Topics>;
+  readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
   readonly close: Effect.Effect<void>;
 };
 
@@ -64,14 +74,6 @@ const engineErrorToRuntimeError = (error: ColumnLiveViewEngineError): ViewServer
       topic: error.topic,
     };
   }
-  if (error instanceof UnsupportedQueryError) {
-    return {
-      _tag: "ViewServerRuntimeError",
-      code: "UnsupportedQuery",
-      message: error.message,
-      topic: error.topic,
-    };
-  }
   return {
     _tag: "ViewServerRuntimeError",
     code: "RuntimeUnavailable",
@@ -86,6 +88,16 @@ const makeRuntime = Effect.fn("ViewServerInMemory.runtime.make")(<
   health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
 ): Effect.Effect<ViewServerInMemoryRuntime<Topics>> => {
   const requestHealthRefresh = makeHealthRefreshScheduler(refreshHealth(engine, health));
+  const snapshot = <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+  ): Effect.Effect<
+    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRuntimeError
+  > => engine.snapshot<Topic, Query>(topic, query).pipe(Effect.mapError(engineErrorToRuntimeError));
   return Effect.succeed<ViewServerInMemoryRuntime<Topics>>({
     publish: (topic, row) =>
       engine.publish(topic, row).pipe(
@@ -107,8 +119,7 @@ const makeRuntime = Effect.fn("ViewServerInMemory.runtime.make")(<
         Effect.tap(() => requestHealthRefresh),
         Effect.mapError(engineErrorToRuntimeError),
       ),
-    snapshot: (topic, query) =>
-      engine.snapshot(topic, query).pipe(Effect.mapError(engineErrorToRuntimeError)),
+    snapshot,
     health: () => readHealth(engine, health).pipe(Effect.mapError(engineErrorToRuntimeError)),
     reset: () =>
       engine.reset().pipe(
@@ -122,8 +133,53 @@ const makeLiveClient = Effect.fn("ViewServerInMemory.liveClient.make")(
   <const Topics extends DecodableTopicDefinitions>(
     engine: ColumnLiveViewEngine<Topics>,
     health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
-  ): Effect.Effect<ViewServerLiveClient<Topics>> =>
-    Effect.sync<ViewServerLiveClient<Topics>>(() => {
+  ): Effect.Effect<ViewServerRuntimeLiveClient<Topics>> =>
+    Effect.sync<ViewServerRuntimeLiveClient<Topics>>(() => {
+      function subscribe<
+        Topic extends Extract<keyof Topics, string>,
+        const Query extends
+          | RawQuery<TopicRow<Topics, Topic>>
+          | GroupedQuery<TopicRow<Topics, Topic>>,
+      >(
+        topic: Topic,
+        query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+      ): Effect.Effect<
+        ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+        ViewServerRuntimeError | ViewServerTransportError
+      >;
+      function subscribe<
+        Topic extends Extract<keyof Topics, string>,
+        const Query extends
+          | RawQuery<TopicRow<Topics, Topic>>
+          | GroupedQuery<TopicRow<Topics, Topic>>,
+      >(
+        topic: Topic,
+        query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+      ): Effect.Effect<
+        ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+        ViewServerRuntimeError | ViewServerTransportError
+      > {
+        return engine.subscribe<Topic, Query>(topic, query).pipe(
+          Effect.map((subscription) => ({
+            events: subscription.events,
+            close: () => subscription.close().pipe(Effect.andThen(refreshHealth(engine, health))),
+          })),
+          Effect.tap(() => refreshHealth(engine, health)),
+          Effect.mapError(engineErrorToRuntimeError),
+        );
+      }
+      const subscribeRuntime: ViewServerRuntimeLiveClient<Topics>["subscribeRuntime"] = (
+        topic,
+        query,
+      ) =>
+        engine.subscribeRuntime(topic, query).pipe(
+          Effect.map((subscription) => ({
+            events: subscription.events,
+            close: () => subscription.close().pipe(Effect.andThen(refreshHealth(engine, health))),
+          })),
+          Effect.tap(() => refreshHealth(engine, health)),
+          Effect.mapError(engineErrorToRuntimeError),
+        );
       const activeHealthSubscriptions = new Set<{ close: Effect.Effect<void> }>();
       const closeActiveHealthSubscriptions = Effect.suspend(() =>
         Effect.forEach(
@@ -204,15 +260,8 @@ const makeLiveClient = Effect.fn("ViewServerInMemory.liveClient.make")(
         };
       });
       return {
-        subscribe: (topic, query) =>
-          engine.subscribe(topic, query).pipe(
-            Effect.map((subscription) => ({
-              events: subscription.events,
-              close: () => subscription.close().pipe(Effect.andThen(refreshHealth(engine, health))),
-            })),
-            Effect.tap(() => refreshHealth(engine, health)),
-            Effect.mapError(engineErrorToRuntimeError),
-          ),
+        subscribe,
+        subscribeRuntime,
         subscribeHealthSummary: () =>
           makeHealthSubscription<ViewServerHealthSummaryRow<Topics>>(
             VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
@@ -233,27 +282,33 @@ const makeLiveClient = Effect.fn("ViewServerInMemory.liveClient.make")(
     }),
 );
 
-export const makeInMemoryViewServer = Effect.fn("ViewServerInMemory.make")(function* <
-  const Topics extends DecodableTopicDefinitions,
->(config: ViewServerConfig<Topics>, input: ViewServerInMemoryOptions) {
-  const engineConfig =
-    input.subscriptionQueueCapacity === undefined
-      ? { topics: config.topics }
-      : {
-          topics: config.topics,
-          subscriptionQueueCapacity: input.subscriptionQueueCapacity,
-        };
-  const engine = yield* createColumnLiveViewEngine<Topics>(engineConfig);
-  const engineHealth = yield* engine.health();
-  const health = AtomRef.make(healthFromEngine(engineHealth));
-  const client = yield* makeRuntime(engine, health);
-  const liveClient = yield* makeLiveClient(engine, health);
-  return {
-    client,
-    liveClient,
-    close: liveClient.close,
-  };
-});
+export const makeInMemoryViewServer: <const Topics extends DecodableTopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  input: ViewServerInMemoryOptions,
+) => Effect.Effect<ViewServerInMemoryInstance<Topics>> = Effect.fn("ViewServerInMemory.make")(
+  function* <const Topics extends DecodableTopicDefinitions>(
+    config: ViewServerConfig<Topics>,
+    input: ViewServerInMemoryOptions,
+  ) {
+    const engineConfig =
+      input.subscriptionQueueCapacity === undefined
+        ? { topics: config.topics }
+        : {
+            topics: config.topics,
+            subscriptionQueueCapacity: input.subscriptionQueueCapacity,
+          };
+    const engine = yield* createColumnLiveViewEngine<Topics>(engineConfig);
+    const engineHealth = yield* engine.health();
+    const health = AtomRef.make(healthFromEngine(engineHealth));
+    const client = yield* makeRuntime(engine, health);
+    const liveClient = yield* makeLiveClient(engine, health);
+    return {
+      client,
+      liveClient,
+      close: liveClient.close,
+    };
+  },
+);
 
 export const createInMemoryViewServer = <const Topics extends DecodableTopicDefinitions>(
   config: ViewServerConfig<Topics>,

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   type ViewServerHealthTopicRow,
 } from "@view-server/config";
 import { Effect, Schema } from "effect";
+import * as BigDecimal from "effect/BigDecimal";
 import {
   ViewServerBackpressureErrorSchema,
   ViewServerHealthSchema,
@@ -16,18 +17,23 @@ import {
   ViewServerSubscribePayloadSchema,
   ViewServerTransportErrorSchema,
   ViewServerWireEventSchema,
+  ViewServerWireGroupedQuerySchema,
   ViewServerWireRawQuerySchema,
   ViewServerWireRowSchema,
+  viewServerDecodeGroupedQuery,
   viewServerDecodeHealth,
   viewServerDecodeHealthQuery,
   viewServerDecodeHealthSummaryEvent,
   viewServerDecodeHealthTopicEvent,
   viewServerDecodeLiveEvent,
+  viewServerDecodeLiveQuery,
   viewServerDecodeRawQuery,
   viewServerDecodeTopic,
+  viewServerEncodeGroupedQuery,
   viewServerEncodeHealthSummaryEvent,
   viewServerEncodeHealthTopicEvent,
   viewServerEncodeLiveEvent,
+  viewServerEncodeLiveQuery,
   viewServerEncodeRawQuery,
 } from "./index";
 import { SchemaGetter } from "effect";
@@ -35,6 +41,15 @@ import { SchemaGetter } from "effect";
 const Order = Schema.Struct({
   id: Schema.String,
   price: Schema.Number,
+  quantity: Schema.BigInt,
+  decimalPrice: Schema.BigDecimal,
+  optionalPrice: Schema.Union([Schema.Number, Schema.Undefined]),
+  optionalQuantity: Schema.Union([Schema.BigInt, Schema.Undefined]),
+  unset: Schema.Undefined,
+  metadata: Schema.Struct({
+    _viewServerScalar: Schema.String,
+    value: Schema.String,
+  }),
 });
 
 const BadJsonField = Schema.String.pipe(
@@ -60,6 +75,9 @@ const viewServer = defineViewServerConfig({
     },
   },
 });
+
+const formatDecodedDecimal = (value: unknown): string =>
+  BigDecimal.isBigDecimal(value) ? BigDecimal.format(value) : String(value);
 
 const topicHealth = {
   status: "ready",
@@ -133,6 +151,33 @@ describe("@view-server/protocol", () => {
           quantity: { gte: "10" },
         },
         orderBy: [{ field: "quantity", direction: "asc" }],
+        offset: 0,
+        limit: 10,
+      });
+
+      const groupedQuery = yield* Schema.decodeUnknownEffect(ViewServerWireGroupedQuerySchema)({
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        where: {
+          price: { gte: 10 },
+        },
+        orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+        offset: 0,
+        limit: 10,
+      });
+      expect(groupedQuery).toStrictEqual({
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        where: {
+          price: { gte: 10 },
+        },
+        orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
         offset: 0,
         limit: 10,
       });
@@ -422,7 +467,8 @@ describe("@view-server/protocol", () => {
         where: { price: 10 },
       });
 
-      const statusEvent = yield* viewServerEncodeLiveEvent(viewServer, "orders", new Set(["id"]), {
+      const idQuery = { select: ["id"] };
+      const statusEvent = yield* viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
         type: "status",
         topic: "orders",
         queryId: "query-0",
@@ -437,7 +483,7 @@ describe("@view-server/protocol", () => {
         code: "Ready",
       });
 
-      const snapshot = yield* viewServerEncodeLiveEvent(viewServer, "orders", new Set(["id"]), {
+      const snapshot = yield* viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
         type: "snapshot",
         topic: "orders",
         queryId: "query-0",
@@ -456,7 +502,7 @@ describe("@view-server/protocol", () => {
         totalRows: 1,
       });
 
-      const delta = yield* viewServerEncodeLiveEvent(viewServer, "orders", new Set(["id"]), {
+      const delta = yield* viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
         type: "delta",
         topic: "orders",
         queryId: "query-0",
@@ -476,25 +522,495 @@ describe("@view-server/protocol", () => {
         typeof viewServer.topics,
         "orders",
         typeof Order.Type
-      >(viewServer, "orders", new Set(["id"]), statusEvent);
+      >(viewServer, "orders", idQuery, statusEvent);
       expect(decodedStatus).toStrictEqual(statusEvent);
 
       const decodedSnapshot = yield* viewServerDecodeLiveEvent<
         typeof viewServer.topics,
         "orders",
         Pick<typeof Order.Type, "id">
-      >(viewServer, "orders", new Set(["id"]), snapshot);
+      >(viewServer, "orders", idQuery, snapshot);
       expect(decodedSnapshot).toStrictEqual(snapshot);
 
       const decodedDelta = yield* viewServerDecodeLiveEvent<
         typeof viewServer.topics,
         "orders",
         Pick<typeof Order.Type, "id">
-      >(viewServer, "orders", new Set(["id"]), delta);
+      >(viewServer, "orders", idQuery, delta);
       expect(decodedDelta).toStrictEqual(delta);
 
       const decodedHealth = yield* viewServerDecodeHealth(viewServer, wireHealth);
       expect(decodedHealth.status).toBe("ready");
+    }),
+  );
+
+  it.effect("encodes and decodes grouped query and grouped live event operations", () =>
+    Effect.gen(function* () {
+      const groupedQuery = {
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+          averagePrice: { aggFunc: "avg", field: "price" },
+          minPrice: { aggFunc: "min", field: "price" },
+          maxPrice: { aggFunc: "max", field: "price" },
+          distinctPrice: { aggFunc: "countDistinct", field: "price" },
+        },
+        where: {
+          id: { startsWith: "a" },
+          price: { in: [10, 11], gte: 10 },
+        },
+        orderBy: [
+          { field: "id", direction: "asc" },
+          { aggregate: "totalPrice", direction: "desc" },
+        ],
+        offset: 0,
+        limit: 10,
+      };
+
+      const encodedGrouped = yield* viewServerEncodeGroupedQuery(
+        viewServer,
+        "orders",
+        groupedQuery,
+      );
+      expect(encodedGrouped).toStrictEqual(groupedQuery);
+
+      const minimalGroupedQuery = {
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      };
+      const encodedMinimalGrouped = yield* viewServerEncodeGroupedQuery(
+        viewServer,
+        "orders",
+        minimalGroupedQuery,
+      );
+      expect(encodedMinimalGrouped).toStrictEqual(minimalGroupedQuery);
+
+      const encodedDecimalGrouped = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+        groupBy: ["id"],
+        aggregates: {
+          totalDecimalPrice: { aggFunc: "sum", field: "decimalPrice" },
+        },
+      });
+      expect(encodedDecimalGrouped).toStrictEqual({
+        groupBy: ["id"],
+        aggregates: {
+          totalDecimalPrice: { aggFunc: "sum", field: "decimalPrice" },
+        },
+      });
+
+      const optionalGroupedQuery = {
+        groupBy: ["id"],
+        aggregates: {
+          totalOptionalPrice: { aggFunc: "sum", field: "optionalPrice" },
+          totalOptionalQuantity: { aggFunc: "sum", field: "optionalQuantity" },
+        },
+      };
+      const optionalGroupedEncodeError = yield* Effect.flip(
+        viewServerEncodeGroupedQuery(viewServer, "orders", optionalGroupedQuery),
+      );
+      expect(optionalGroupedEncodeError.code).toBe("InvalidQuery");
+      expect(optionalGroupedEncodeError.message).toBe(
+        "Grouped aggregate totalOptionalPrice must reference a numeric field",
+      );
+      const optionalGroupedDecodeError = yield* Effect.flip(
+        viewServerDecodeGroupedQuery(viewServer, "orders", optionalGroupedQuery),
+      );
+      expect(optionalGroupedDecodeError.code).toBe("InvalidQuery");
+      expect(optionalGroupedDecodeError.message).toBe(
+        "Grouped aggregate totalOptionalPrice must reference a numeric field",
+      );
+
+      const optionalBigIntGroupedQuery = {
+        groupBy: ["id"],
+        aggregates: {
+          totalOptionalQuantity: { aggFunc: "sum", field: "optionalQuantity" },
+        },
+      };
+      const optionalBigIntGroupedError = yield* Effect.flip(
+        viewServerEncodeGroupedQuery(viewServer, "orders", optionalBigIntGroupedQuery),
+      );
+      expect(optionalBigIntGroupedError.code).toBe("InvalidQuery");
+      expect(optionalBigIntGroupedError.message).toBe(
+        "Grouped aggregate totalOptionalQuantity must reference a numeric field",
+      );
+
+      const decodedGrouped = yield* viewServerDecodeGroupedQuery(
+        viewServer,
+        "orders",
+        encodedGrouped,
+      );
+      expect(decodedGrouped).toStrictEqual(groupedQuery);
+
+      const decodedMinimalGrouped = yield* viewServerDecodeGroupedQuery(
+        viewServer,
+        "orders",
+        encodedMinimalGrouped,
+      );
+      expect(decodedMinimalGrouped).toStrictEqual(minimalGroupedQuery);
+
+      const decodedOptionalBigIntGroupedError = yield* Effect.flip(
+        viewServerDecodeGroupedQuery(viewServer, "orders", optionalBigIntGroupedQuery),
+      );
+      expect(decodedOptionalBigIntGroupedError.code).toBe("InvalidQuery");
+      expect(decodedOptionalBigIntGroupedError.message).toBe(
+        "Grouped aggregate totalOptionalQuantity must reference a numeric field",
+      );
+
+      const encodedLiveGrouped = yield* viewServerEncodeLiveQuery(
+        viewServer,
+        "orders",
+        groupedQuery,
+      );
+      expect(encodedLiveGrouped).toStrictEqual(groupedQuery);
+
+      const encodedLiveRaw = yield* viewServerEncodeLiveQuery(viewServer, "orders", {
+        select: ["id"],
+      });
+      expect(encodedLiveRaw).toStrictEqual({ select: ["id"] });
+
+      const decodedLiveGrouped = yield* viewServerDecodeLiveQuery(
+        viewServer,
+        "orders",
+        encodedLiveGrouped,
+      );
+      expect(decodedLiveGrouped).toStrictEqual(groupedQuery);
+
+      const decodedLiveRaw = yield* viewServerDecodeLiveQuery(viewServer, "orders", encodedLiveRaw);
+      expect(decodedLiveRaw).toStrictEqual({ select: ["id"] });
+
+      const invalidOptionalLiveQuery = yield* Effect.flip(
+        viewServerEncodeLiveQuery(viewServer, "orders", optionalGroupedQuery),
+      );
+      expect(invalidOptionalLiveQuery.code).toBe("InvalidQuery");
+
+      const groupedRow = {
+        id: "a",
+        rowCount: 2n,
+        totalPrice: BigDecimal.fromStringUnsafe("21"),
+        averagePrice: BigDecimal.fromStringUnsafe("10.5"),
+        minPrice: 10,
+        maxPrice: 11,
+        distinctPrice: 2n,
+      };
+
+      const groupedSnapshot = yield* viewServerEncodeLiveEvent(
+        viewServer,
+        "orders",
+        encodedGrouped,
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [groupedRow],
+          totalRows: 1,
+        },
+      );
+      expect(groupedSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-0",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            id: "a",
+            rowCount: { _viewServerAggregate: "bigint", value: "2" },
+            totalPrice: { _viewServerAggregate: "bigdecimal", value: "21" },
+            averagePrice: { _viewServerAggregate: "bigdecimal", value: "10.5" },
+            minPrice: { _viewServerAggregate: "json", value: 10 },
+            maxPrice: { _viewServerAggregate: "json", value: 11 },
+            distinctPrice: { _viewServerAggregate: "bigint", value: "2" },
+          },
+        ],
+        totalRows: 1,
+      });
+
+      const decodedGroupedSnapshot = yield* viewServerDecodeLiveEvent<
+        typeof viewServer.topics,
+        "orders",
+        typeof groupedRow
+      >(viewServer, "orders", encodedGrouped, groupedSnapshot);
+      const decodedGroupedSnapshotRows =
+        decodedGroupedSnapshot.type === "snapshot"
+          ? decodedGroupedSnapshot.rows.map((row) => ({
+              ...row,
+              totalPrice: formatDecodedDecimal(row.totalPrice),
+              averagePrice: formatDecodedDecimal(row.averagePrice),
+            }))
+          : [];
+      expect({
+        ...decodedGroupedSnapshot,
+        rows: decodedGroupedSnapshotRows,
+      }).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-0",
+        version: 1,
+        keys: ["a"],
+        rows: [{ ...groupedRow, totalPrice: "21", averagePrice: "10.5" }],
+        totalRows: 1,
+      });
+
+      const invalidMinSnapshot = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", encodedGrouped, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-undefined",
+          version: 1,
+          keys: ["a"],
+          rows: [{ ...groupedRow, minPrice: undefined }],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidMinSnapshot.message).toMatch(/Invalid field minPrice/);
+
+      const optionalMinQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+        groupBy: ["id"],
+        aggregates: {
+          minUnset: { aggFunc: "min", field: "unset" },
+        },
+      });
+      const optionalMinSnapshot = yield* viewServerEncodeLiveEvent(
+        viewServer,
+        "orders",
+        optionalMinQuery,
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-unset-min",
+          version: 1,
+          keys: ["a"],
+          rows: [{ id: "a", minUnset: undefined }],
+          totalRows: 1,
+        },
+      );
+      expect(optionalMinSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-unset-min",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            id: "a",
+            minUnset: { _viewServerAggregate: "json", value: null },
+          },
+        ],
+        totalRows: 1,
+      });
+      const decodedOptionalMinSnapshot = yield* viewServerDecodeLiveEvent<
+        typeof viewServer.topics,
+        "orders",
+        { readonly id: string; readonly minUnset: undefined }
+      >(viewServer, "orders", optionalMinQuery, optionalMinSnapshot);
+      expect(decodedOptionalMinSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-unset-min",
+        version: 1,
+        keys: ["a"],
+        rows: [{ id: "a", minUnset: undefined }],
+        totalRows: 1,
+      });
+
+      const objectAggregateQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+        groupBy: ["id"],
+        aggregates: {
+          firstMetadata: { aggFunc: "min", field: "metadata" },
+        },
+      });
+      const objectAggregateSnapshot = yield* viewServerEncodeLiveEvent(
+        viewServer,
+        "orders",
+        objectAggregateQuery,
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-object",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              firstMetadata: {
+                _viewServerScalar: "bigint",
+                value: "not-protocol",
+              },
+            },
+          ],
+          totalRows: 1,
+        },
+      );
+      expect(objectAggregateSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-object",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            id: "a",
+            firstMetadata: {
+              _viewServerAggregate: "json",
+              value: {
+                _viewServerScalar: "bigint",
+                value: "not-protocol",
+              },
+            },
+          },
+        ],
+        totalRows: 1,
+      });
+      const decodedObjectAggregateSnapshot = yield* viewServerDecodeLiveEvent<
+        typeof viewServer.topics,
+        "orders",
+        {
+          readonly id: string;
+          readonly firstMetadata: { readonly _viewServerScalar: string; readonly value: string };
+        }
+      >(viewServer, "orders", objectAggregateQuery, objectAggregateSnapshot);
+      expect(decodedObjectAggregateSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-object",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            id: "a",
+            firstMetadata: {
+              _viewServerScalar: "bigint",
+              value: "not-protocol",
+            },
+          },
+        ],
+        totalRows: 1,
+      });
+
+      const bigIntSumQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+        groupBy: ["id"],
+        aggregates: {
+          totalQuantity: { aggFunc: "sum", field: "quantity" },
+        },
+      });
+      const bigIntSumSnapshot = yield* viewServerEncodeLiveEvent(
+        viewServer,
+        "orders",
+        bigIntSumQuery,
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-bigint-sum",
+          version: 1,
+          keys: ["a"],
+          rows: [{ id: "a", totalQuantity: 3n }],
+          totalRows: 1,
+        },
+      );
+      expect(bigIntSumSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-bigint-sum",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            id: "a",
+            totalQuantity: { _viewServerAggregate: "bigint", value: "3" },
+          },
+        ],
+        totalRows: 1,
+      });
+      const decodedBigIntSumSnapshot = yield* viewServerDecodeLiveEvent<
+        typeof viewServer.topics,
+        "orders",
+        {
+          readonly id: string;
+          readonly totalQuantity: bigint;
+        }
+      >(viewServer, "orders", bigIntSumQuery, bigIntSumSnapshot);
+      expect(decodedBigIntSumSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-bigint-sum",
+        version: 1,
+        keys: ["a"],
+        rows: [{ id: "a", totalQuantity: 3n }],
+        totalRows: 1,
+      });
+
+      const groupedDelta = yield* viewServerEncodeLiveEvent(viewServer, "orders", encodedGrouped, {
+        type: "delta",
+        topic: "orders",
+        queryId: "grouped-0",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          { type: "insert", key: "a", row: groupedRow, index: 0 },
+          {
+            type: "update",
+            key: "b",
+            row: { ...groupedRow, id: "b", rowCount: 3n },
+            index: 1,
+          },
+          { type: "move", key: "a", fromIndex: 1, toIndex: 0 },
+          { type: "remove", key: "c" },
+        ],
+        totalRows: 2,
+      });
+
+      const decodedGroupedDelta = yield* viewServerDecodeLiveEvent<
+        typeof viewServer.topics,
+        "orders",
+        typeof groupedRow
+      >(viewServer, "orders", encodedGrouped, groupedDelta);
+      const decodedGroupedDeltaOperations =
+        decodedGroupedDelta.type === "delta"
+          ? decodedGroupedDelta.operations.map((operation) =>
+              operation.type === "insert" || operation.type === "update"
+                ? {
+                    ...operation,
+                    row: {
+                      ...operation.row,
+                      totalPrice: formatDecodedDecimal(operation.row.totalPrice),
+                      averagePrice: formatDecodedDecimal(operation.row.averagePrice),
+                    },
+                  }
+                : operation,
+            )
+          : [];
+      expect({
+        ...decodedGroupedDelta,
+        operations: decodedGroupedDeltaOperations,
+      }).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "grouped-0",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          {
+            type: "insert",
+            key: "a",
+            row: { ...groupedRow, totalPrice: "21", averagePrice: "10.5" },
+            index: 0,
+          },
+          {
+            type: "update",
+            key: "b",
+            row: { ...groupedRow, id: "b", rowCount: 3n, totalPrice: "21", averagePrice: "10.5" },
+            index: 1,
+          },
+          { type: "move", key: "a", fromIndex: 1, toIndex: 0 },
+          { type: "remove", key: "c" },
+        ],
+        totalRows: 2,
+      });
     }),
   );
 
@@ -795,7 +1311,15 @@ describe("@view-server/protocol", () => {
       const queryCases = [
         [{ select: [] }, "Query select must include at least one field"],
         [{ select: ["id"], offset: -1 }, "Query offset must be a non-negative integer"],
-        [{ select: ["id"], limit: 0 }, "Query limit must be a positive integer"],
+        [
+          { select: ["id"], offset: Number.MAX_SAFE_INTEGER + 1 },
+          "Query offset must be a non-negative integer",
+        ],
+        [{ select: ["id"], limit: -1 }, "Query limit must be a non-negative integer"],
+        [
+          { select: ["id"], limit: Number.MAX_SAFE_INTEGER + 1 },
+          "Query limit must be a non-negative integer",
+        ],
         [{ select: ["missing"] }, "Query references an unknown field for topic: orders"],
         [
           { select: ["id"], where: { missing: "x" } },
@@ -829,6 +1353,182 @@ describe("@view-server/protocol", () => {
         viewServerDecodeRawQuery(viewServer, "orders", { select: ["id"], whre: {} }),
       );
       expect(decodeExtraKey.code).toBe("InvalidQuery");
+
+      const malformedGroupedEncode = yield* Effect.flip(
+        viewServerEncodeGroupedQuery(viewServer, "orders", {
+          groupBy: ["id"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          typo: true,
+        }),
+      );
+      expect(malformedGroupedEncode.code).toBe("InvalidQuery");
+
+      const malformedGroupedDecode = yield* Effect.flip(
+        viewServerDecodeGroupedQuery(viewServer, "orders", {
+          groupBy: ["id"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          typo: true,
+        }),
+      );
+      expect(malformedGroupedDecode.code).toBe("InvalidQuery");
+
+      const groupedQueryCases = [
+        [
+          { groupBy: [], aggregates: { rowCount: { aggFunc: "count" } } },
+          "Grouped query groupBy must include at least one field",
+        ],
+        [
+          { groupBy: ["id"], aggregates: {} },
+          "Grouped query aggregates must include at least one aggregate",
+        ],
+        [
+          { groupBy: ["missing"], aggregates: { rowCount: { aggFunc: "count" } } },
+          "Query references an unknown field for topic: orders",
+        ],
+        [
+          { groupBy: ["id"], aggregates: { id: { aggFunc: "count" } } },
+          "Aggregate alias collides with groupBy field: id",
+        ],
+        [
+          { groupBy: ["id"], aggregates: { constructor: { aggFunc: "count" } } },
+          "Grouped aggregate alias is not allowed: constructor",
+        ],
+        [
+          { groupBy: ["id"], aggregates: { total: { aggFunc: "sum", field: "missing" } } },
+          "Query references an unknown field for topic: orders",
+        ],
+        [
+          { groupBy: ["id"], aggregates: { total: { aggFunc: "sum", field: "id" } } },
+          "Grouped aggregate total must reference a numeric field",
+        ],
+        [
+          {
+            groupBy: ["id"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            where: { missing: "x" },
+          },
+          "Query references an unknown field for topic: orders",
+        ],
+        [
+          {
+            groupBy: ["id"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ field: "price", direction: "asc" }],
+          },
+          "Grouped orderBy field is not in groupBy: price",
+        ],
+        [
+          {
+            groupBy: ["id"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            orderBy: [{ aggregate: "missing", direction: "asc" }],
+          },
+          "Grouped orderBy aggregate is not defined: missing",
+        ],
+        [
+          { groupBy: ["id"], aggregates: { rowCount: { aggFunc: "count" } }, offset: -1 },
+          "Query offset must be a non-negative integer",
+        ],
+        [
+          {
+            groupBy: ["id"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            offset: Number.MAX_SAFE_INTEGER + 1,
+          },
+          "Query offset must be a non-negative integer",
+        ],
+        [
+          { groupBy: ["id"], aggregates: { rowCount: { aggFunc: "count" } }, limit: -1 },
+          "Query limit must be a non-negative integer",
+        ],
+        [
+          {
+            groupBy: ["id"],
+            aggregates: { rowCount: { aggFunc: "count" } },
+            limit: Number.MAX_SAFE_INTEGER + 1,
+          },
+          "Query limit must be a non-negative integer",
+        ],
+      ] as const;
+      for (const [query, message] of groupedQueryCases) {
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeGroupedQuery(viewServer, "orders", query),
+        );
+        expect(encodeError.code).toBe("InvalidQuery");
+        expect(encodeError.message).toBe(message);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeGroupedQuery(viewServer, "orders", query),
+        );
+        expect(decodeError.code).toBe("InvalidQuery");
+        expect(decodeError.message).toBe(message);
+      }
+
+      const malformedSchemaConfig = {
+        topics: {
+          broken: {
+            schema: {
+              fields: {
+                id: { ast: "not-a-schema-ast" },
+              },
+            },
+            key: "id",
+          },
+        },
+      };
+      const malformedSchemaNumericField = yield* Effect.flip(
+        // @ts-expect-error hostile config can have malformed field schemas.
+        viewServerEncodeGroupedQuery(malformedSchemaConfig, "broken", {
+          groupBy: ["id"],
+          aggregates: { total: { aggFunc: "sum", field: "id" } },
+        }),
+      );
+      expect(malformedSchemaNumericField.message).toBe(
+        "Grouped aggregate total must reference a numeric field",
+      );
+
+      const malformedPrimitiveSchemaConfig = {
+        topics: {
+          broken: {
+            schema: {
+              fields: {
+                id: "not-a-schema",
+              },
+            },
+            key: "id",
+          },
+        },
+      };
+      const primitiveSchemaNumericField = yield* Effect.flip(
+        // @ts-expect-error hostile config can have primitive field schemas.
+        viewServerEncodeGroupedQuery(malformedPrimitiveSchemaConfig, "broken", {
+          groupBy: ["id"],
+          aggregates: { total: { aggFunc: "sum", field: "id" } },
+        }),
+      );
+      expect(primitiveSchemaNumericField.message).toBe(
+        "Grouped aggregate total must reference a numeric field",
+      );
+
+      const invalidGroupedEncodeTopic = yield* Effect.flip(
+        // @ts-expect-error hostile callers can still encode unknown topics.
+        viewServerEncodeGroupedQuery(viewServer, "missing", {
+          groupBy: ["id"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+        }),
+      );
+      expect(invalidGroupedEncodeTopic.code).toBe("InvalidTopic");
+
+      const liveGroupedDecodeError = yield* Effect.flip(
+        viewServerDecodeLiveQuery(viewServer, "orders", {
+          groupBy: ["id"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          orderBy: [{ aggregate: "missing", direction: "asc" }],
+        }),
+      );
+      expect(liveGroupedDecodeError.message).toBe(
+        "Grouped orderBy aggregate is not defined: missing",
+      );
 
       const invalidFilter = yield* Effect.flip(
         viewServerEncodeRawQuery(viewServer, "orders", {
@@ -870,6 +1570,48 @@ describe("@view-server/protocol", () => {
       );
       expect(invalidDecodedStringStartsWith.message).toMatch(/Invalid filter for id/);
 
+      const structuredEncodeStartsWith = yield* Effect.flip(
+        viewServerEncodeRawQuery(viewServer, "orders", {
+          select: ["id"],
+          where: {
+            metadata: {
+              startsWith: {
+                _viewServerScalar: "kind",
+                value: "x",
+              },
+            },
+          },
+        }),
+      );
+      expect(structuredEncodeStartsWith.message).toBe(
+        "Filter metadata does not support startsWith",
+      );
+
+      const structuredDecodeStartsWith = yield* Effect.flip(
+        viewServerDecodeRawQuery(viewServer, "orders", {
+          select: ["id"],
+          where: {
+            metadata: {
+              startsWith: {
+                _viewServerScalar: "kind",
+                value: "x",
+              },
+            },
+          },
+        }),
+      );
+      expect(structuredDecodeStartsWith.message).toBe(
+        "Filter metadata does not support startsWith",
+      );
+
+      const invalidRangeOperator = yield* Effect.flip(
+        viewServerEncodeRawQuery(viewServer, "orders", {
+          select: ["id"],
+          where: { id: { gt: "a" } },
+        }),
+      );
+      expect(invalidRangeOperator.message).toBe("Filter id does not support range operators");
+
       const nonJsonFilter = yield* Effect.flip(
         viewServerEncodeRawQuery(viewServer, "badjson", {
           select: ["id"],
@@ -894,8 +1636,10 @@ describe("@view-server/protocol", () => {
       );
       expect(badDecodedField.code).toBe("InvalidQuery");
 
+      const idQuery = { select: ["id"] };
+      const priceQuery = { select: ["price"] };
       const wrongEncodeTopic = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "orders", new Set(["id"]), {
+        viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
           type: "status",
           topic: "badjson",
           queryId: "query-0",
@@ -909,7 +1653,7 @@ describe("@view-server/protocol", () => {
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
           viewServer,
           "orders",
-          new Set(["id"]),
+          idQuery,
           {
             type: "status",
             topic: "badjson",
@@ -922,7 +1666,7 @@ describe("@view-server/protocol", () => {
       expect(wrongDecodeTopic.code).toBe("InvalidRow");
 
       const missingField = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "orders", new Set(["id"]), {
+        viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
           type: "snapshot",
           topic: "orders",
           queryId: "query-0",
@@ -935,7 +1679,7 @@ describe("@view-server/protocol", () => {
       expect(missingField.message).toBe("Missing row field for topic orders: id");
 
       const extraEncodeField = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "orders", new Set(["id"]), {
+        viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
           type: "snapshot",
           topic: "orders",
           queryId: "query-0",
@@ -948,7 +1692,7 @@ describe("@view-server/protocol", () => {
       expect(extraEncodeField.message).toBe("Unexpected row field for topic orders: price");
 
       const invalidEncodeFieldType = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "orders", new Set(["price"]), {
+        viewServerEncodeLiveEvent(viewServer, "orders", priceQuery, {
           type: "snapshot",
           topic: "orders",
           queryId: "query-0",
@@ -964,7 +1708,7 @@ describe("@view-server/protocol", () => {
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
           viewServer,
           "orders",
-          new Set(["id"]),
+          idQuery,
           {
             type: "snapshot",
             topic: "orders",
@@ -982,7 +1726,7 @@ describe("@view-server/protocol", () => {
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
           viewServer,
           "orders",
-          new Set(["price"]),
+          priceQuery,
           {
             type: "snapshot",
             topic: "orders",
@@ -1000,7 +1744,7 @@ describe("@view-server/protocol", () => {
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
           viewServer,
           "orders",
-          new Set(["price"]),
+          priceQuery,
           {
             type: "snapshot",
             topic: "orders",
@@ -1015,7 +1759,7 @@ describe("@view-server/protocol", () => {
       expect(invalidFieldType.code).toBe("InvalidRow");
 
       const nonJsonRow = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "badjson", new Set(["id"]), {
+        viewServerEncodeLiveEvent(viewServer, "badjson", idQuery, {
           type: "snapshot",
           topic: "badjson",
           queryId: "query-0",
@@ -1026,6 +1770,547 @@ describe("@view-server/protocol", () => {
         }),
       );
       expect(nonJsonRow.message).toMatch(/Field id is not JSON-safe/);
+
+      const groupedQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          averagePrice: { aggFunc: "avg", field: "price" },
+        },
+      });
+
+      const missingGroupedField = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [{ rowCount: 1n, averagePrice: BigDecimal.fromStringUnsafe("1.5") }],
+          totalRows: 1,
+        }),
+      );
+      expect(missingGroupedField.message).toBe("Missing grouped row field for topic orders: id");
+
+      const missingGroupedAggregate = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [{ id: "a", averagePrice: BigDecimal.fromStringUnsafe("1.5") }],
+          totalRows: 1,
+        }),
+      );
+      expect(missingGroupedAggregate.message).toBe(
+        "Missing grouped aggregate for topic orders: rowCount",
+      );
+
+      const missingGroupedAggregateDefinition = yield* Effect.flip(
+        viewServerEncodeLiveEvent(
+          viewServer,
+          "orders",
+          {
+            groupBy: ["id"],
+            aggregates: {
+              // @ts-expect-error hostile query payload can omit an aggregate definition value.
+              missing: undefined,
+            },
+          },
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [{ id: "a", missing: 1n }],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(missingGroupedAggregateDefinition.message).toBe(
+        "Missing grouped aggregate definition for topic orders: missing",
+      );
+
+      const unexpectedGroupedField = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: 1n,
+              averagePrice: BigDecimal.fromStringUnsafe("1.5"),
+              extra: true,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(unexpectedGroupedField.message).toBe(
+        "Unexpected grouped row field for topic orders: extra",
+      );
+
+      const nonJsonGroupedAggregate = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: Symbol("bad"),
+              averagePrice: BigDecimal.fromStringUnsafe("1.5"),
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(nonJsonGroupedAggregate.message).toBe("Aggregate rowCount must be a bigint.");
+
+      const invalidBigDecimalGroupedAggregate = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: 1n,
+              averagePrice: 1,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidBigDecimalGroupedAggregate.message).toBe(
+        "Aggregate averagePrice must be a BigDecimal.",
+      );
+
+      const invalidGroupedField = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: 10,
+                rowCount: { _viewServerAggregate: "bigint", value: "1" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(invalidGroupedField.message).toMatch(/Invalid field id/);
+
+      const missingDecodedGroupedField = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                rowCount: { _viewServerAggregate: "bigint", value: "1" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(missingDecodedGroupedField.message).toBe(
+        "Missing grouped row field for topic orders: id",
+      );
+
+      const missingDecodedGroupedAggregate = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(missingDecodedGroupedAggregate.message).toBe(
+        "Missing grouped aggregate for topic orders: rowCount",
+      );
+
+      const missingDecodedGroupedAggregateDefinition = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          {
+            groupBy: ["id"],
+            aggregates: {
+              // @ts-expect-error hostile query payload can omit an aggregate definition value.
+              missing: undefined,
+            },
+          },
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                missing: { _viewServerAggregate: "bigint", value: "1" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(missingDecodedGroupedAggregateDefinition.message).toBe(
+        "Missing grouped aggregate definition for topic orders: missing",
+      );
+
+      const unexpectedDecodedGroupedField = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "bigint", value: "1" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+                extra: true,
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(unexpectedDecodedGroupedField.message).toBe(
+        "Unexpected grouped row field for topic orders: extra",
+      );
+
+      const nonJsonDecodedGroupedAggregate = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "nope", value: "bad" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(nonJsonDecodedGroupedAggregate.message).toBe(
+        "Aggregate rowCount must be a View Server aggregate envelope.",
+      );
+
+      const invalidGroupedBigInt = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "bigint", value: "not-a-bigint" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(invalidGroupedBigInt.message).toBe("Aggregate rowCount must be a bigint envelope.");
+
+      const invalidGroupedBigDecimal = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "bigint", value: "1" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "nope" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(invalidGroupedBigDecimal.message).toMatch(/Invalid aggregate averagePrice/);
+
+      const wrongGroupedBigDecimalEnvelope = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "bigint", value: "1" },
+                averagePrice: { _viewServerAggregate: "bigint", value: "1" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(wrongGroupedBigDecimalEnvelope.message).toBe(
+        "Aggregate averagePrice must be a BigDecimal envelope.",
+      );
+
+      const groupedMinQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+        groupBy: ["id"],
+        aggregates: {
+          minPrice: { aggFunc: "min", field: "price" },
+        },
+      });
+      const wrongJsonEnvelope = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedMinQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-min",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                minPrice: { _viewServerAggregate: "bigint", value: "1" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(wrongJsonEnvelope.message).toBe(
+        "Aggregate minPrice must be a JSON aggregate envelope.",
+      );
+
+      const invalidJsonAggregateValue = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedMinQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-min",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                minPrice: { _viewServerAggregate: "json", value: "not-a-number" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(invalidJsonAggregateValue.message).toMatch(/Invalid field minPrice/);
+
+      const missingAggregateSourceField = yield* Effect.flip(
+        viewServerEncodeLiveEvent(
+          viewServer,
+          "orders",
+          {
+            groupBy: ["id"],
+            aggregates: {
+              badPrice: { aggFunc: "min", field: "missing" },
+            },
+          },
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-missing-field",
+            version: 1,
+            keys: ["a"],
+            rows: [{ id: "a", badPrice: 1 }],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(missingAggregateSourceField.message).toBe(
+        "Aggregate references unknown field for topic orders: missing",
+      );
+
+      const malformedEventSchemaConfig = {
+        topics: {
+          broken: {
+            schema: {
+              fields: {
+                group: Schema.String,
+                value: "not-a-schema",
+              },
+            },
+            key: "group",
+          },
+        },
+      };
+      const malformedEventSchemaSnapshot = yield* viewServerEncodeLiveEvent(
+        // @ts-expect-error hostile config can have malformed aggregate field schemas.
+        malformedEventSchemaConfig,
+        "broken",
+        {
+          groupBy: ["group"],
+          aggregates: {
+            totalValue: { aggFunc: "sum", field: "value" },
+          },
+        },
+        {
+          type: "snapshot",
+          topic: "broken",
+          queryId: "grouped-malformed-schema",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              group: "a",
+              totalValue: BigDecimal.fromStringUnsafe("1"),
+            },
+          ],
+          totalRows: 1,
+        },
+      );
+      expect(malformedEventSchemaSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "broken",
+        queryId: "grouped-malformed-schema",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            group: "a",
+            totalValue: { _viewServerAggregate: "bigdecimal", value: "1" },
+          },
+        ],
+        totalRows: 1,
+      });
+
+      const malformedEventAstSchemaConfig = {
+        topics: {
+          broken: {
+            schema: {
+              fields: {
+                group: Schema.String,
+                value: { ast: "not-a-schema-ast" },
+              },
+            },
+            key: "group",
+          },
+        },
+      };
+      const malformedEventAstSchemaSnapshot = yield* viewServerEncodeLiveEvent(
+        // @ts-expect-error hostile config can have malformed aggregate field schema ASTs.
+        malformedEventAstSchemaConfig,
+        "broken",
+        {
+          groupBy: ["group"],
+          aggregates: {
+            totalValue: { aggFunc: "sum", field: "value" },
+          },
+        },
+        {
+          type: "snapshot",
+          topic: "broken",
+          queryId: "grouped-malformed-schema-ast",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              group: "a",
+              totalValue: BigDecimal.fromStringUnsafe("1"),
+            },
+          ],
+          totalRows: 1,
+        },
+      );
+      expect(malformedEventAstSchemaSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "broken",
+        queryId: "grouped-malformed-schema-ast",
+        version: 1,
+        keys: ["a"],
+        rows: [
+          {
+            group: "a",
+            totalValue: { _viewServerAggregate: "bigdecimal", value: "1" },
+          },
+        ],
+        totalRows: 1,
+      });
 
       const missingHealthTopic = yield* Effect.flip(
         viewServerDecodeHealth(viewServer, {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,13 +10,22 @@ export type { ViewServerRpcError } from "./protocol-rpc";
 
 export {
   ViewServerSubscribePayloadSchema,
+  ViewServerWireGroupedQuerySchema,
+  type ViewServerWireGroupedQuery,
+  type ViewServerWireLiveQuery,
   ViewServerWireRawQuerySchema,
   type ViewServerWireRawQuery,
   viewServerDecodeHealthQuery,
   viewServerDecodeTopic,
+  viewServerEncodeLiveQuery,
   viewServerEncodeRawQuery,
+  viewServerEncodeGroupedQuery,
+  viewServerDecodeLiveQuery,
   viewServerDecodeRawQuery,
+  viewServerDecodeGroupedQuery,
+  type ViewServerValidatedLiveQuery,
   type ViewServerValidatedRawQuery,
+  type ViewServerValidatedGroupedQuery,
 } from "./protocol-query-codec";
 
 export {

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -5,9 +5,31 @@ import type {
   TopicDefinitions,
   ViewServerRuntimeError,
 } from "@view-server/config";
+import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
+import * as BigDecimal from "effect/BigDecimal";
 
 export type ViewServerProtocolEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
+
+type ViewServerEventRawQuery = {
+  readonly select: ReadonlyArray<string>;
+};
+
+type ViewServerEventGroupedAggregate =
+  | {
+      readonly aggFunc: "count";
+    }
+  | {
+      readonly aggFunc: "countDistinct" | "sum" | "avg" | "min" | "max";
+      readonly field: string;
+    };
+
+type ViewServerEventGroupedQuery = {
+  readonly groupBy: ReadonlyArray<string>;
+  readonly aggregates: Readonly<Record<string, ViewServerEventGroupedAggregate>>;
+};
+
+type ViewServerEventQuery = ViewServerEventRawQuery | ViewServerEventGroupedQuery;
 
 export const ViewServerWireRowSchema: Schema.Codec<Schema.JsonObject> = Schema.Record(
   Schema.String,
@@ -119,6 +141,63 @@ const invalidRow = (topic: string, message: string): ViewServerRuntimeError => (
   topic,
 });
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isBigIntFieldSchema = (schema: Schema.Codec<unknown>): boolean =>
+  viewServerSchemaFieldMetadata(schema).sumResultKind === "bigint";
+
+const isGroupedQuery = (query: ViewServerEventQuery): query is ViewServerEventGroupedQuery =>
+  "groupBy" in query;
+
+const bigintPattern = /^-?\d+$/;
+
+type AggregateEnvelope =
+  | {
+      readonly _viewServerAggregate: "bigint";
+      readonly value: string;
+    }
+  | {
+      readonly _viewServerAggregate: "bigdecimal";
+      readonly value: string;
+    }
+  | {
+      readonly _viewServerAggregate: "json";
+      readonly value: Schema.Json;
+    };
+
+const isAggregateEnvelope = (value: unknown): value is AggregateEnvelope =>
+  isRecord(value) &&
+  (value["_viewServerAggregate"] === "bigint" ||
+    value["_viewServerAggregate"] === "bigdecimal" ||
+    value["_viewServerAggregate"] === "json");
+
+const encodeJsonAggregateEnvelope = (value: Schema.Json): AggregateEnvelope => ({
+  _viewServerAggregate: "json",
+  value,
+});
+
+const encodeBigIntAggregateEnvelope = (value: bigint): AggregateEnvelope => ({
+  _viewServerAggregate: "bigint",
+  value: value.toString(),
+});
+
+const encodeBigDecimalAggregateEnvelope = (value: BigDecimal.BigDecimal): AggregateEnvelope => ({
+  _viewServerAggregate: "bigdecimal",
+  value: BigDecimal.format(value),
+});
+
+const decodeAggregateEnvelope = Effect.fn("ViewServerProtocol.row.aggregate.envelope.decode")(
+  function* (topic: string, field: string, value: unknown) {
+    if (!isAggregateEnvelope(value)) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Aggregate ${field} must be a View Server aggregate envelope.`),
+      );
+    }
+    return value;
+  },
+);
+
 const encodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.encode")(function* (
   topic: string,
   field: string,
@@ -195,6 +274,232 @@ const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.decode")(fu
   return output;
 });
 
+const encodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.encode")(
+  function* (topic: string, field: string, value: unknown) {
+    if (typeof value !== "bigint") {
+      return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint.`));
+    }
+    return encodeBigIntAggregateEnvelope(value);
+  },
+);
+
+const decodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.decode")(
+  function* (topic: string, field: string, value: unknown) {
+    const envelope = yield* decodeAggregateEnvelope(topic, field, value);
+    if (envelope._viewServerAggregate !== "bigint" || !bigintPattern.test(envelope.value)) {
+      return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint envelope.`));
+    }
+    return BigInt(envelope.value);
+  },
+);
+
+const encodeBigDecimalAggregateValue = Effect.fn(
+  "ViewServerProtocol.row.aggregate.bigDecimal.encode",
+)(function* (topic: string, field: string, value: unknown) {
+  if (!BigDecimal.isBigDecimal(value)) {
+    return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a BigDecimal.`));
+  }
+  return encodeBigDecimalAggregateEnvelope(value);
+});
+
+const decodeBigDecimalAggregateValue = Effect.fn(
+  "ViewServerProtocol.row.aggregate.bigDecimal.decode",
+)(function* (topic: string, field: string, value: unknown) {
+  const envelope = yield* decodeAggregateEnvelope(topic, field, value);
+  if (envelope._viewServerAggregate !== "bigdecimal") {
+    return yield* Effect.fail(
+      invalidRow(topic, `Aggregate ${field} must be a BigDecimal envelope.`),
+    );
+  }
+  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(Schema.BigDecimal))(
+    envelope.value,
+  ).pipe(
+    Effect.mapError((error) => invalidRow(topic, `Invalid aggregate ${field}: ${error.message}`)),
+  );
+});
+
+const encodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.encode")(
+  function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
+    const encoded = yield* encodeEventJsonFieldValue(topic, field, schema, value);
+    return encodeJsonAggregateEnvelope(encoded);
+  },
+);
+
+const decodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.decode")(
+  function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
+    const envelope = yield* decodeAggregateEnvelope(topic, field, value);
+    if (envelope._viewServerAggregate !== "json") {
+      return yield* Effect.fail(
+        invalidRow(topic, `Aggregate ${field} must be a JSON aggregate envelope.`),
+      );
+    }
+    return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(envelope.value).pipe(
+      Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
+    );
+  },
+);
+
+const aggregateFieldSchema = Effect.fn("ViewServerProtocol.row.aggregate.fieldSchema")(function* <
+  const Topics extends TopicDefinitions,
+>(config: { readonly topics: Topics }, topic: Extract<keyof Topics, string>, field: string) {
+  const fieldSchema = config.topics[topic]!.schema.fields[field];
+  if (fieldSchema === undefined) {
+    return yield* Effect.fail(
+      invalidRow(topic, `Aggregate references unknown field for topic ${topic}: ${field}`),
+    );
+  }
+  return fieldSchema;
+});
+
+const encodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.encode")(function* <
+  const Topics extends TopicDefinitions,
+>(
+  config: { readonly topics: Topics },
+  topic: Extract<keyof Topics, string>,
+  field: string,
+  aggregate: ViewServerEventGroupedAggregate,
+  value: unknown,
+) {
+  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
+    return yield* encodeBigIntAggregateValue(topic, field, value);
+  }
+  const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
+  if (aggregate.aggFunc === "avg") {
+    return yield* encodeBigDecimalAggregateValue(topic, field, value);
+  }
+  if (aggregate.aggFunc === "sum") {
+    if (isBigIntFieldSchema(fieldSchema)) {
+      return yield* encodeBigIntAggregateValue(topic, field, value);
+    }
+    return yield* encodeBigDecimalAggregateValue(topic, field, value);
+  }
+  return yield* encodeJsonAggregateValue(topic, field, fieldSchema, value);
+});
+
+const decodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.decode")(function* <
+  const Topics extends TopicDefinitions,
+>(
+  config: { readonly topics: Topics },
+  topic: Extract<keyof Topics, string>,
+  field: string,
+  aggregate: ViewServerEventGroupedAggregate,
+  value: unknown,
+) {
+  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
+    return yield* decodeBigIntAggregateValue(topic, field, value);
+  }
+  const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
+  if (aggregate.aggFunc === "avg") {
+    return yield* decodeBigDecimalAggregateValue(topic, field, value);
+  }
+  if (aggregate.aggFunc === "sum") {
+    if (isBigIntFieldSchema(fieldSchema)) {
+      return yield* decodeBigIntAggregateValue(topic, field, value);
+    }
+    return yield* decodeBigDecimalAggregateValue(topic, field, value);
+  }
+  return yield* decodeJsonAggregateValue(topic, field, fieldSchema, value);
+});
+
+const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode")(function* <
+  const Topics extends TopicDefinitions,
+>(
+  config: { readonly topics: Topics },
+  topic: Extract<keyof Topics, string>,
+  query: ViewServerEventGroupedQuery,
+  row: object,
+) {
+  const topicSchema = config.topics[topic]!.schema;
+  const groupFields = new Set<string>(query.groupBy);
+  const aggregateAliases = new Set<string>(Object.keys(query.aggregates));
+  const output: Record<string, Schema.Json> = {};
+  for (const field of groupFields) {
+    if (!Object.hasOwn(row, field)) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
+      );
+    }
+  }
+  for (const alias of aggregateAliases) {
+    if (!Object.hasOwn(row, alias)) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
+      );
+    }
+  }
+  for (const [field, value] of Object.entries(row)) {
+    if (groupFields.has(field)) {
+      const fieldSchema = topicSchema.fields[field]!;
+      output[field] = yield* encodeEventJsonFieldValue(topic, field, fieldSchema, value);
+    } else if (aggregateAliases.has(field)) {
+      const aggregate = query.aggregates[field];
+      if (aggregate === undefined) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
+        );
+      }
+      output[field] = yield* encodeAggregateValue(config, topic, field, aggregate, value);
+    } else {
+      return yield* Effect.fail(
+        invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
+      );
+    }
+  }
+  return output;
+});
+
+const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode")(function* <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  query: ViewServerEventGroupedQuery,
+  row: ViewServerWireRow,
+) {
+  const topicSchema = config.topics[topic]!.schema;
+  const groupFields = new Set<string>(query.groupBy);
+  const aggregateAliases = new Set<string>(Object.keys(query.aggregates));
+  const output: Record<string, unknown> = {};
+  for (const field of groupFields) {
+    if (!Object.hasOwn(row, field)) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
+      );
+    }
+  }
+  for (const alias of aggregateAliases) {
+    if (!Object.hasOwn(row, alias)) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
+      );
+    }
+  }
+  for (const [field, value] of Object.entries(row)) {
+    if (groupFields.has(field)) {
+      const fieldSchema = topicSchema.fields[field]!;
+      output[field] = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(fieldSchema))(
+        value,
+      ).pipe(
+        Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
+      );
+    } else if (aggregateAliases.has(field)) {
+      const aggregate = query.aggregates[field];
+      if (aggregate === undefined) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
+        );
+      }
+      output[field] = yield* decodeAggregateValue(config, topic, field, aggregate, value);
+    } else {
+      return yield* Effect.fail(
+        invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
+      );
+    }
+  }
+  return output;
+});
+
 const encodeStatusEvent = (event: StatusEvent): ViewServerWireEvent => event;
 
 export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.encode")(function* <
@@ -202,7 +507,7 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
 >(
   config: { readonly topics: Topics },
   expectedTopic: Extract<keyof Topics, string>,
-  selectedFields: ReadonlySet<string>,
+  query: ViewServerEventQuery,
   event: ViewServerProtocolEvent<object>,
 ) {
   if (event.topic !== expectedTopic) {
@@ -217,9 +522,12 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
     return encodeStatusEvent(event);
   }
   if (event.type === "snapshot") {
-    const rows = yield* Effect.forEach(event.rows, (row) =>
-      encodeProjectedRow(config, expectedTopic, selectedFields, row),
-    );
+    const rows = yield* Effect.forEach(event.rows, (row) => {
+      if (isGroupedQuery(query)) {
+        return encodeGroupedRow(config, expectedTopic, query, row);
+      }
+      return encodeProjectedRow(config, expectedTopic, new Set<string>(query.select), row);
+    });
     return {
       ...event,
       rows,
@@ -232,7 +540,9 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
   const operations: Array<WireDeltaOperation> = [];
   for (const operation of event.operations) {
     if (operation.type === "insert" || operation.type === "update") {
-      const row = yield* encodeProjectedRow(config, expectedTopic, selectedFields, operation.row);
+      const row = yield* isGroupedQuery(query)
+        ? encodeGroupedRow(config, expectedTopic, query, operation.row)
+        : encodeProjectedRow(config, expectedTopic, new Set<string>(query.select), operation.row);
       operations.push({
         ...operation,
         row,
@@ -263,7 +573,7 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
 >(
   config: { readonly topics: Topics },
   expectedTopic: Topic,
-  selectedFields: ReadonlySet<string>,
+  query: ViewServerEventQuery,
   event: ViewServerWireEvent,
 ) {
   if (event.topic !== expectedTopic) {
@@ -278,9 +588,12 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
     return typedLiveEvent<Row>(event);
   }
   if (event.type === "snapshot") {
-    const rows = yield* Effect.forEach(event.rows, (row) =>
-      decodeProjectedRow(config, expectedTopic, selectedFields, row),
-    );
+    const rows = yield* Effect.forEach(event.rows, (row) => {
+      if (isGroupedQuery(query)) {
+        return decodeGroupedRow(config, expectedTopic, query, row);
+      }
+      return decodeProjectedRow(config, expectedTopic, new Set<string>(query.select), row);
+    });
     return typedLiveEvent<Row>({
       ...event,
       rows,
@@ -293,7 +606,9 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
   const operations: Array<DecodedDeltaOperation> = [];
   for (const operation of event.operations) {
     if (operation.type === "insert" || operation.type === "update") {
-      const row = yield* decodeProjectedRow(config, expectedTopic, selectedFields, operation.row);
+      const row = yield* isGroupedQuery(query)
+        ? decodeGroupedRow(config, expectedTopic, query, operation.row)
+        : decodeProjectedRow(config, expectedTopic, new Set<string>(query.select), operation.row);
       operations.push({
         ...operation,
         row,

--- a/packages/protocol/src/protocol-query-codec.ts
+++ b/packages/protocol/src/protocol-query-codec.ts
@@ -1,6 +1,7 @@
 import type {
-  ExactRawQuery,
+  Aggregates,
   FieldKey,
+  GroupedOrderBy,
   OrderBy,
   RowSchema,
   TopicDefinitions,
@@ -8,6 +9,7 @@ import type {
   ViewServerRuntimeError,
   Where,
 } from "@view-server/config";
+import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
 
 type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
@@ -28,6 +30,41 @@ export const ViewServerWireRawQuerySchema = Schema.Struct({
 });
 
 export type ViewServerWireRawQuery = typeof ViewServerWireRawQuerySchema.Type;
+
+const ViewServerWireAggregateSchema = Schema.Union([
+  Schema.Struct({
+    aggFunc: Schema.Literal("count"),
+  }),
+  Schema.Struct({
+    aggFunc: Schema.Literals(["countDistinct", "sum", "avg", "min", "max"]),
+    field: Schema.String,
+  }),
+]);
+
+export const ViewServerWireGroupedQuerySchema = Schema.Struct({
+  groupBy: Schema.Array(Schema.String),
+  aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
+  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Json)),
+  orderBy: Schema.optionalKey(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          field: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+        Schema.Struct({
+          aggregate: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+      ]),
+    ),
+  ),
+  offset: Schema.optionalKey(Schema.Number),
+  limit: Schema.optionalKey(Schema.Number),
+});
+
+export type ViewServerWireGroupedQuery = typeof ViewServerWireGroupedQuerySchema.Type;
+export type ViewServerWireLiveQuery = ViewServerWireRawQuery | ViewServerWireGroupedQuery;
 
 export const ViewServerSubscribePayloadSchema = Schema.Struct({
   topic: Schema.String,
@@ -56,6 +93,30 @@ const LooseWireRawQuerySchema = Schema.Struct({
 
 type LooseWireRawQuery = typeof LooseWireRawQuerySchema.Type;
 
+const LooseWireGroupedQuerySchema = Schema.Struct({
+  groupBy: Schema.Array(Schema.String),
+  aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
+  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
+  orderBy: Schema.optionalKey(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          field: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+        Schema.Struct({
+          aggregate: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+      ]),
+    ),
+  ),
+  offset: Schema.optionalKey(Schema.Number),
+  limit: Schema.optionalKey(Schema.Number),
+});
+
+type LooseWireGroupedQuery = typeof LooseWireGroupedQuerySchema.Type;
+
 type TrustedRawQuery<Row> = {
   readonly select: ReadonlyArray<FieldKey<Row>>;
   readonly where?: Where<Row>;
@@ -64,10 +125,26 @@ type TrustedRawQuery<Row> = {
   readonly limit?: number;
 };
 
-export type ViewServerValidatedRawQuery<Row> = TrustedRawQuery<Row> &
-  ExactRawQuery<Row, TrustedRawQuery<Row>>;
+export type ViewServerValidatedRawQuery<Row> = TrustedRawQuery<Row>;
+
+type TrustedGroupedQuery<Row> = {
+  readonly groupBy: readonly [FieldKey<Row>, ...Array<FieldKey<Row>>];
+  readonly aggregates: Aggregates<Row>;
+  readonly where?: Where<Row>;
+  readonly orderBy?: ReadonlyArray<GroupedOrderBy<Row>>;
+  readonly offset?: number;
+  readonly limit?: number;
+};
+
+export type ViewServerValidatedGroupedQuery<Row> = TrustedGroupedQuery<Row>;
+
+export type ViewServerValidatedLiveQuery<Row> =
+  | ViewServerValidatedRawQuery<Row>
+  | ViewServerValidatedGroupedQuery<Row>;
 
 const filterOperatorKeys = new Set(["eq", "neq", "in", "gt", "gte", "lt", "lte", "startsWith"]);
+const rangeFilterOperatorKeys = new Set(["gt", "gte", "lt", "lte"]);
+const dangerousRecordKeys = new Set(["__proto__", "prototype", "constructor"]);
 
 const strictParseOptions = {
   onExcessProperty: "error",
@@ -76,10 +153,17 @@ const strictParseOptions = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isNumericFieldSchema = (schema: JsonFieldSchema | undefined): boolean => {
+  return schema !== undefined && viewServerSchemaFieldMetadata(schema).isNumeric;
+};
+
 const isFilterObject = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) &&
   Object.keys(value).length > 0 &&
   Object.keys(value).every((key) => filterOperatorKeys.has(key));
+
+const isGroupedQueryInput = (query: unknown): query is { readonly groupBy: unknown } =>
+  isRecord(query) && Object.hasOwn(query, "groupBy");
 
 const invalidTopic = (topic: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",
@@ -129,6 +213,19 @@ const isRawQueryForTopic = (schema: RowSchema, query: LooseWireRawQuery): boolea
   }
   return true;
 };
+
+const validateWindow = Effect.fn("ViewServerProtocol.query.window.validate")(function* (
+  topic: string,
+  offset: number | undefined,
+  limit: number | undefined,
+) {
+  if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 0)) {
+    return yield* Effect.fail(invalidQuery(topic, "Query offset must be a non-negative integer"));
+  }
+  if (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 0)) {
+    return yield* Effect.fail(invalidQuery(topic, "Query limit must be a non-negative integer"));
+  }
+});
 
 export const viewServerDecodeTopic = Effect.fn("ViewServerProtocol.topic.decode")(function* <
   const Topics extends TopicDefinitions,
@@ -221,12 +318,36 @@ const decodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.deco
   return decoded;
 });
 
+const validateOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.validate")(
+  function* (
+    topic: string,
+    field: string,
+    schema: JsonFieldSchema,
+    value: Record<string, unknown>,
+  ) {
+    const metadata = viewServerSchemaFieldMetadata(schema);
+    if (metadata.isStructured) {
+      return;
+    }
+    const keys = Object.keys(value);
+    if (keys.includes("startsWith") && !metadata.isString) {
+      return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
+    }
+    if (keys.some((key) => rangeFilterOperatorKeys.has(key)) && !metadata.isNumeric) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Filter ${field} does not support range operators`),
+      );
+    }
+  },
+);
+
 const encodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.encode")(function* (
   topic: string,
   field: string,
   schema: JsonFieldSchema,
   value: Record<string, unknown>,
 ) {
+  yield* validateOperatorFilterValue(topic, field, schema, value);
   const output: Record<string, Schema.Json> = {};
   for (const [operator, operatorValue] of Object.entries(value)) {
     if (operator === "in" && Array.isArray(operatorValue)) {
@@ -248,6 +369,7 @@ const decodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.
   schema: JsonFieldSchema,
   value: Record<string, unknown>,
 ) {
+  yield* validateOperatorFilterValue(topic, field, schema, value);
   const output: Record<string, unknown> = {};
   for (const [operator, operatorValue] of Object.entries(value)) {
     if (operator === "in" && Array.isArray(operatorValue)) {
@@ -351,12 +473,7 @@ export const viewServerEncodeRawQuery = Effect.fn("ViewServerProtocol.query.enco
   if (decoded.select.length === 0) {
     return yield* Effect.fail(invalidQuery(topic, "Query select must include at least one field"));
   }
-  if (decoded.offset !== undefined && (!Number.isInteger(decoded.offset) || decoded.offset < 0)) {
-    return yield* Effect.fail(invalidQuery(topic, "Query offset must be a non-negative integer"));
-  }
-  if (decoded.limit !== undefined && (!Number.isInteger(decoded.limit) || decoded.limit <= 0)) {
-    return yield* Effect.fail(invalidQuery(topic, "Query limit must be a positive integer"));
-  }
+  yield* validateWindow(topic, decoded.offset, decoded.limit);
   for (const field of decoded.select) {
     if (getFieldSchema(config, topic, field) === undefined) {
       return yield* Effect.fail(
@@ -384,40 +501,214 @@ export const viewServerEncodeRawQuery = Effect.fn("ViewServerProtocol.query.enco
   return wireQuery;
 });
 
-function validatedRawQuery<Row>(query: LooseWireRawQuery): ViewServerValidatedRawQuery<Row>;
-function validatedRawQuery(query: LooseWireRawQuery): LooseWireRawQuery {
-  return query;
-}
+const validateGroupedQuery = Effect.fn("ViewServerProtocol.groupedQuery.validate")(function* (
+  topic: string,
+  schema: RowSchema,
+  decoded: LooseWireGroupedQuery,
+) {
+  if (decoded.groupBy.length === 0) {
+    return yield* Effect.fail(
+      invalidQuery(topic, "Grouped query groupBy must include at least one field"),
+    );
+  }
+  const aggregateAliases = Object.keys(decoded.aggregates);
+  if (aggregateAliases.length === 0) {
+    return yield* Effect.fail(
+      invalidQuery(topic, "Grouped query aggregates must include at least one aggregate"),
+    );
+  }
+  for (const groupField of decoded.groupBy) {
+    if (schema.fields[groupField] === undefined) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
+      );
+    }
+  }
+  for (const [alias, aggregate] of Object.entries(decoded.aggregates)) {
+    if (dangerousRecordKeys.has(alias)) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Grouped aggregate alias is not allowed: ${alias}`),
+      );
+    }
+    if (decoded.groupBy.includes(alias)) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Aggregate alias collides with groupBy field: ${alias}`),
+      );
+    }
+    if (aggregate.aggFunc !== "count" && schema.fields[aggregate.field] === undefined) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
+      );
+    }
+    if (
+      (aggregate.aggFunc === "sum" || aggregate.aggFunc === "avg") &&
+      !isNumericFieldSchema(schema.fields[aggregate.field])
+    ) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Grouped aggregate ${alias} must reference a numeric field`),
+      );
+    }
+  }
+  if (decoded.where !== undefined && !hasOnlyKnownFields(schema, Object.keys(decoded.where))) {
+    return yield* Effect.fail(
+      invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
+    );
+  }
+  if (decoded.orderBy !== undefined) {
+    for (const entry of decoded.orderBy) {
+      if ("field" in entry && !decoded.groupBy.includes(entry.field)) {
+        return yield* Effect.fail(
+          invalidQuery(topic, `Grouped orderBy field is not in groupBy: ${entry.field}`),
+        );
+      }
+      if ("aggregate" in entry && !Object.hasOwn(decoded.aggregates, entry.aggregate)) {
+        return yield* Effect.fail(
+          invalidQuery(topic, `Grouped orderBy aggregate is not defined: ${entry.aggregate}`),
+        );
+      }
+    }
+  }
+  yield* validateWindow(topic, decoded.offset, decoded.limit);
+});
 
-export const viewServerDecodeRawQuery = Effect.fn("ViewServerProtocol.query.decode")(function* <
-  const Topics extends TopicDefinitions,
-  Topic extends Extract<keyof Topics, string>,
->(config: { readonly topics: Topics }, topic: Topic, query: unknown) {
-  const decoded = yield* Schema.decodeUnknownEffect(LooseWireRawQuerySchema)(
-    query,
-    strictParseOptions,
-  ).pipe(Effect.mapError((error) => invalidQuery(topic, error.message)));
-  if (decoded.select.length === 0) {
-    return yield* Effect.fail(invalidQuery(topic, "Query select must include at least one field"));
-  }
-  if (decoded.offset !== undefined && (!Number.isInteger(decoded.offset) || decoded.offset < 0)) {
-    return yield* Effect.fail(invalidQuery(topic, "Query offset must be a non-negative integer"));
-  }
-  if (decoded.limit !== undefined && (!Number.isInteger(decoded.limit) || decoded.limit <= 0)) {
-    return yield* Effect.fail(invalidQuery(topic, "Query limit must be a positive integer"));
-  }
-  const topicSchema = config.topics[topic]!.schema;
-  if (isRawQueryForTopic(topicSchema, decoded)) {
-    const where = yield* decodeWhere(topic, topicSchema, decoded.where);
-    return validatedRawQuery<TopicRow<Topics, Topic>>({
-      select: decoded.select,
+export const viewServerEncodeGroupedQuery = Effect.fn("ViewServerProtocol.groupedQuery.encode")(
+  function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
+    config: { readonly topics: Topics },
+    topic: Topic,
+    query: unknown,
+  ) {
+    if (!hasTopic(config, topic)) {
+      return yield* Effect.fail(invalidTopic(topic));
+    }
+    const decoded = yield* Schema.decodeUnknownEffect(LooseWireGroupedQuerySchema)(
+      query,
+      strictParseOptions,
+    ).pipe(Effect.mapError((error) => invalidQuery(topic, error.message)));
+    const topicSchema = config.topics[topic]!.schema;
+    yield* validateGroupedQuery(topic, topicSchema, decoded);
+    const where = yield* encodeWhere(config, topic, decoded.where);
+    const wireQuery: ViewServerWireGroupedQuery = {
+      groupBy: decoded.groupBy,
+      aggregates: decoded.aggregates,
       ...(where === undefined ? {} : { where }),
       ...(decoded.orderBy === undefined ? {} : { orderBy: decoded.orderBy }),
       ...(decoded.offset === undefined ? {} : { offset: decoded.offset }),
       ...(decoded.limit === undefined ? {} : { limit: decoded.limit }),
-    });
-  }
-  return yield* Effect.fail(
-    invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
-  );
+    };
+    return wireQuery;
+  },
+);
+
+export const viewServerEncodeLiveQuery = Effect.fn("ViewServerProtocol.liveQuery.encode")(
+  function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
+    config: { readonly topics: Topics },
+    topic: Topic,
+    query: unknown,
+  ) {
+    if (isGroupedQueryInput(query)) {
+      return yield* viewServerEncodeGroupedQuery(config, topic, query);
+    }
+    return yield* viewServerEncodeRawQuery(config, topic, query);
+  },
+);
+
+function validatedRawQuery<Row>(query: LooseWireRawQuery): ViewServerValidatedRawQuery<Row>;
+function validatedRawQuery(query: LooseWireRawQuery) {
+  return query;
+}
+
+export const viewServerDecodeRawQuery: <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  query: unknown,
+) => Effect.Effect<ViewServerValidatedRawQuery<TopicRow<Topics, Topic>>, ViewServerRuntimeError> =
+  Effect.fn("ViewServerProtocol.query.decode")(function* <
+    const Topics extends TopicDefinitions,
+    Topic extends Extract<keyof Topics, string>,
+  >(config: { readonly topics: Topics }, topic: Topic, query: unknown) {
+    const decodedTopic = yield* viewServerDecodeTopic(config, topic);
+    const decoded = yield* Schema.decodeUnknownEffect(LooseWireRawQuerySchema)(
+      query,
+      strictParseOptions,
+    ).pipe(Effect.mapError((error) => invalidQuery(topic, error.message)));
+    if (decoded.select.length === 0) {
+      return yield* Effect.fail(
+        invalidQuery(topic, "Query select must include at least one field"),
+      );
+    }
+    yield* validateWindow(topic, decoded.offset, decoded.limit);
+    const topicSchema = config.topics[decodedTopic]!.schema;
+    if (isRawQueryForTopic(topicSchema, decoded)) {
+      const where = yield* decodeWhere(topic, topicSchema, decoded.where);
+      return validatedRawQuery<TopicRow<Topics, Topic>>({
+        select: decoded.select,
+        ...(where === undefined ? {} : { where }),
+        ...(decoded.orderBy === undefined ? {} : { orderBy: decoded.orderBy }),
+        ...(decoded.offset === undefined ? {} : { offset: decoded.offset }),
+        ...(decoded.limit === undefined ? {} : { limit: decoded.limit }),
+      });
+    }
+    return yield* Effect.fail(
+      invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
+    );
+  });
+
+function validatedGroupedQuery<Row>(
+  query: LooseWireGroupedQuery,
+): ViewServerValidatedGroupedQuery<Row>;
+function validatedGroupedQuery(query: LooseWireGroupedQuery) {
+  return query;
+}
+
+export const viewServerDecodeGroupedQuery: <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  query: unknown,
+) => Effect.Effect<
+  ViewServerValidatedGroupedQuery<TopicRow<Topics, Topic>>,
+  ViewServerRuntimeError
+> = Effect.fn("ViewServerProtocol.groupedQuery.decode")(function* <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(config: { readonly topics: Topics }, topic: Topic, query: unknown) {
+  const decodedTopic = yield* viewServerDecodeTopic(config, topic);
+  const decoded = yield* Schema.decodeUnknownEffect(LooseWireGroupedQuerySchema)(
+    query,
+    strictParseOptions,
+  ).pipe(Effect.mapError((error) => invalidQuery(topic, error.message)));
+  const topicSchema = config.topics[decodedTopic]!.schema;
+  yield* validateGroupedQuery(topic, topicSchema, decoded);
+  const where = yield* decodeWhere(topic, topicSchema, decoded.where);
+  return validatedGroupedQuery<TopicRow<Topics, Topic>>({
+    groupBy: decoded.groupBy,
+    aggregates: decoded.aggregates,
+    ...(where === undefined ? {} : { where }),
+    ...(decoded.orderBy === undefined ? {} : { orderBy: decoded.orderBy }),
+    ...(decoded.offset === undefined ? {} : { offset: decoded.offset }),
+    ...(decoded.limit === undefined ? {} : { limit: decoded.limit }),
+  });
 });
+
+export const viewServerDecodeLiveQuery: <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  query: unknown,
+) => Effect.Effect<ViewServerValidatedLiveQuery<TopicRow<Topics, Topic>>, ViewServerRuntimeError> =
+  Effect.fn("ViewServerProtocol.liveQuery.decode")(function* <
+    const Topics extends TopicDefinitions,
+    Topic extends Extract<keyof Topics, string>,
+  >(config: { readonly topics: Topics }, topic: Topic, query: unknown) {
+    if (isGroupedQueryInput(query)) {
+      return yield* viewServerDecodeGroupedQuery(config, topic, query);
+    }
+    return yield* viewServerDecodeRawQuery(config, topic, query);
+  });

--- a/packages/react/src/index.test-d.ts
+++ b/packages/react/src/index.test-d.ts
@@ -12,6 +12,7 @@ import {
 } from "@view-server/react/testing";
 import type { Effect } from "effect";
 import { Schema } from "effect";
+import type * as BigDecimal from "effect/BigDecimal";
 import type { ReactNode } from "react";
 import { createViewServerReact } from "./index";
 import { ViewServerReactClientProvider } from "./internal";
@@ -105,55 +106,77 @@ describe("React type contracts", () => {
   });
 
   it("rejects invalid raw query select", () => {
-    useLiveQuery("orders", {
-      // @ts-expect-error raw queries must explicitly select columns.
+    const missingSelectQuery = {
       where: {
         status: "open",
       },
-    });
+    };
+    // @ts-expect-error raw queries must explicitly select columns.
+    useLiveQuery("orders", missingSelectQuery);
 
-    useLiveQuery("orders", {
-      // @ts-expect-error raw queries must select at least one column.
+    const emptySelectQuery = {
       select: [],
-    });
+    };
+    // @ts-expect-error raw queries must select at least one column.
+    useLiveQuery("orders", emptySelectQuery);
 
-    useLiveQuery("orders", {
+    const unknownWhereFieldQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error unknown where fields are rejected.
         prcie: 10,
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: {
+        readonly prcie: 10;
+      };
+    };
+    // @ts-expect-error unknown where fields are rejected.
+    useLiveQuery("orders", unknownWhereFieldQuery);
 
-    useLiveQuery("orders", {
+    const unknownOrderByFieldQuery = {
       select: ["id"],
-      // @ts-expect-error unknown orderBy fields are rejected.
       orderBy: [
         {
           field: "prcie",
           direction: "asc",
         },
       ],
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [
+        {
+          readonly field: "prcie";
+          readonly direction: "asc";
+        },
+      ];
+    };
+    // @ts-expect-error unknown orderBy fields are rejected.
+    useLiveQuery("orders", unknownOrderByFieldQuery);
 
-    useLiveQuery("orders", {
-      // @ts-expect-error unknown projected fields are rejected.
+    const unknownProjectedFieldQuery = {
       select: ["id", "prcie"],
-    });
+    } satisfies {
+      readonly select: readonly ["id", "prcie"];
+    };
+    // @ts-expect-error unknown projected fields are rejected.
+    useLiveQuery("orders", unknownProjectedFieldQuery);
 
-    useLiveQuery("orders", {
-      select: [
-        // @ts-expect-error selected fields must be topic field names, not undefined.
-        undefined,
-      ],
-    });
+    const undefinedSelectedFieldQuery = {
+      select: [undefined],
+    } satisfies {
+      readonly select: readonly [undefined];
+    };
+    // @ts-expect-error selected fields must be topic field names, not undefined.
+    useLiveQuery("orders", undefinedSelectedFieldQuery);
 
-    useLiveQuery("orders", {
-      select: [
-        // @ts-expect-error selected fields must be topic field names, not null.
-        null,
-      ],
-    });
+    const nullSelectedFieldQuery = {
+      select: [null],
+    } satisfies {
+      readonly select: readonly [null];
+    };
+    // @ts-expect-error selected fields must be topic field names, not null.
+    useLiveQuery("orders", nullSelectedFieldQuery);
 
     const dynamicSingleTupleSelectedFieldsQuery = {
       select: [dynamicSingleField],
@@ -167,25 +190,41 @@ describe("React type contracts", () => {
   });
 
   it("rejects invalid raw query operators", () => {
-    useLiveQuery("orders", {
+    const stringRangeFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error string fields do not support range filters.
         status: {
           gte: "open",
         },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: {
+        readonly status: {
+          readonly gte: "open";
+        };
+      };
+    };
+    // @ts-expect-error string fields do not support range filters.
+    useLiveQuery("orders", stringRangeFilterQuery);
 
-    useLiveQuery("orders", {
+    const numericStringFilterQuery = {
       select: ["id"],
       where: {
-        // @ts-expect-error numeric fields do not support string filters.
         price: {
           startsWith: "10",
         },
       },
-    });
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: {
+        readonly price: {
+          readonly startsWith: "10";
+        };
+      };
+    };
+    // @ts-expect-error numeric fields do not support string filters.
+    useLiveQuery("orders", numericStringFilterQuery);
   });
 
   it("keeps health and in-memory client keyed by configured topics", () => {
@@ -231,16 +270,30 @@ describe("React type contracts", () => {
     createInMemoryViewServerReact(viewServer);
   });
 
-  it("rejects grouped queries for the in-memory runtime slice", () => {
+  it("preserves grouped query result types for React and in-memory clients", () => {
     const { client } = createInMemoryViewServer();
-    const groupedQuery = {
+    const groupedRows = useLiveQuery("orders", {
       groupBy: ["status"],
-      aggregates: { count: { aggFunc: "count" } },
-    };
-
-    const invalidGroupedSnapshot =
-      // @ts-expect-error grouped queries are not part of the raw in-memory runtime slice yet.
-      client.snapshot("orders", groupedQuery);
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+        totalPrice: { aggFunc: "sum", field: "price" },
+      },
+      orderBy: [
+        { field: "status", direction: "asc" },
+        { aggregate: "totalPrice", direction: "desc" },
+      ],
+    });
+    const groupedSnapshot = client.snapshot("orders", {
+      groupBy: ["status"],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+        totalPrice: { aggFunc: "sum", field: "price" },
+      },
+      orderBy: [
+        { field: "status", direction: "asc" },
+        { aggregate: "totalPrice", direction: "desc" },
+      ],
+    });
 
     const invalidPatch = client.patch("orders", "order-1", {
       price: 10,
@@ -248,8 +301,35 @@ describe("React type contracts", () => {
       prcie: 10,
     });
 
-    expectTypeOf(invalidGroupedSnapshot).not.toBeAny();
+    expectTypeOf(groupedRows).toEqualTypeOf<
+      LiveQueryResult<{
+        readonly status: "open" | "closed" | "cancelled";
+        readonly rowCount: bigint;
+        readonly totalPrice: BigDecimal.BigDecimal;
+      }>
+    >();
+    expectTypeOf<Effect.Success<typeof groupedSnapshot>>().toEqualTypeOf<
+      LiveQueryResult<{
+        readonly status: "open" | "closed" | "cancelled";
+        readonly rowCount: bigint;
+        readonly totalPrice: BigDecimal.BigDecimal;
+      }>
+    >();
     expectTypeOf(invalidPatch).not.toBeAny();
+
+    useLiveQuery("orders", {
+      groupBy: ["status"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+      // @ts-expect-error grouped orderBy field must be present in groupBy.
+      orderBy: [{ field: "price", direction: "asc" }],
+    });
+
+    useLiveQuery("orders", {
+      groupBy: ["status"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+      // @ts-expect-error grouped orderBy aggregate must reference an aggregate alias.
+      orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+    });
   });
 
   it("preserves consumer types through @view-server/react package imports", () => {
@@ -282,17 +362,13 @@ describe("React type contracts", () => {
     });
 
     consumerReact.useLiveQuery("orders", {
-      select: [
-        // @ts-expect-error consumer package imports still reject undefined selected fields.
-        undefined,
-      ],
+      // @ts-expect-error consumer package imports still reject undefined selected fields.
+      select: [undefined],
     });
 
     consumerReact.useLiveQuery("orders", {
-      select: [
-        // @ts-expect-error consumer package imports still reject null selected fields.
-        null,
-      ],
+      // @ts-expect-error consumer package imports still reject null selected fields.
+      select: [null],
     });
   });
 

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -993,14 +993,10 @@ describe("createViewServerReact", () => {
       ),
     );
     const groupedSnapshot = await Effect.runPromise(
-      Effect.flip(
-        client.snapshot("orders", {
-          // @ts-expect-error grouped queries are rejected by the raw in-memory runtime slice.
-          groupBy: ["status"],
-          // @ts-expect-error grouped queries are rejected by the raw in-memory runtime slice.
-          aggregates: { count: { aggFunc: "count" } },
-        }),
-      ),
+      client.snapshot("orders", {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+      }),
     );
     const invalidQuery = await Effect.runPromise(
       Effect.flip(
@@ -1013,7 +1009,7 @@ describe("createViewServerReact", () => {
 
     expect(invalidTopic.code).toBe("InvalidTopic");
     expect(invalidRow.code).toBe("InvalidRow");
-    expect(groupedSnapshot.code).toBe("UnsupportedQuery");
+    expect(groupedSnapshot.rows).toStrictEqual([{ status: "open", rowCount: 1n }]);
     expect(invalidQuery.code).toBe("InvalidQuery");
     await view.unmount();
   });

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -9,9 +9,15 @@ import {
 } from "@view-server/client";
 import { makeViewServerClient, type ViewServerClientOptions } from "@view-server/client/remote";
 import type {
+  ExactGroupedQuery,
+  ExactLiveQuery,
   ExactRawQuery,
+  GroupedQuery,
+  GroupedResult,
   LiveQueryResult,
   LiveQueryRow,
+  PickRawFields,
+  RawQuery,
   TopicDefinitions,
   TopicRow,
   ValidateLiveQuery,
@@ -48,18 +54,26 @@ export type ViewServerProviderProps = ViewServerClientOptions & {
   readonly children?: ReactNode;
 };
 
-export type UseLiveQueryHook<Topics extends TopicDefinitions> = <
-  Topic extends Extract<keyof Topics, string>,
-  const Query extends { readonly select: ReadonlyArray<unknown> },
->(
-  topic: Topic,
-  query: Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>,
-) => LiveQueryResult<
-  LiveQueryRow<
-    TopicRow<Topics, Topic>,
-    Query & ExactRawQuery<TopicRow<Topics, Topic>, Query> & ValidateLiveQuery<Query>
-  >
->;
+export type UseLiveQueryHook<Topics extends TopicDefinitions> = {
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): LiveQueryResult<PickRawFields<TopicRow<Topics, Topic>, Query>>;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): LiveQueryResult<GroupedResult<TopicRow<Topics, Topic>, Query>>;
+};
 
 export const createViewServerReact = <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
@@ -147,14 +161,40 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
     return liveQueryResultFromAsyncResult<Row>(result);
   };
 
-  const useLiveQuery: UseLiveQueryHook<Topics> = (topic, query) => {
+  function useLiveQuery<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): LiveQueryResult<PickRawFields<TopicRow<Topics, Topic>, Query>>;
+  function useLiveQuery<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): LiveQueryResult<GroupedResult<TopicRow<Topics, Topic>, Query>>;
+  function useLiveQuery<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+  ): LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>> {
     const client = useClient();
-    type Row = LiveQueryRow<TopicRow<Topics, typeof topic>, typeof query>;
+    type Row = LiveQueryRow<TopicRow<Topics, Topic>, Query>;
     const queryKey = stableQueryKey(query);
     return useSubscription<Row>(`${client.health.key}:query:${topic}:${queryKey}`, () =>
-      client.subscribe(topic, query),
+      client.subscribe<Topic, Query>(topic, query),
     );
-  };
+  }
 
   const connectionStatusFromLiveQueryStatus = (
     status: LiveQueryResult<unknown>["status"],

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -3,6 +3,9 @@ import { playwright } from "vitest/browser/providers/playwright";
 import { libraryPack } from "../../vite.pack";
 
 export default defineConfig({
+  optimizeDeps: {
+    include: ["effect/Function"],
+  },
   test: {
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     globalSetup: ["./test/remote-global-setup.ts"],

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -60,10 +60,8 @@ describe("runtime type contracts", () => {
     });
 
     const invalidSubscribe = runtime.liveClient.subscribe("orders", {
-      select: [
-        // @ts-expect-error runtime live client rejects fields outside the topic row.
-        "prcie",
-      ],
+      // @ts-expect-error runtime live client rejects fields outside the topic row.
+      select: ["prcie"],
     });
     const invalidTopicPublish = runtime.client.publish(
       // @ts-expect-error runtime mutation client rejects unknown topics.
@@ -74,6 +72,7 @@ describe("runtime type contracts", () => {
       },
     );
     const invalidSnapshot = runtime.client.snapshot("orders", {
+      // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
       select: ["id"],
       where: {
         // @ts-expect-error runtime query client rejects unknown filter fields.

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,11 +1,12 @@
 import { NodeSocket } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import type { ViewServerLiveClient, ViewServerLiveEvent } from "@view-server/client";
+import type { ViewServerLiveEvent, ViewServerRuntimeLiveClient } from "@view-server/client";
 import { makeViewServerClient } from "@view-server/client/remote";
 import {
   defineViewServerConfig,
   VIEW_SERVER_HEALTH_TOPIC,
   type ViewServerHealth,
+  type ViewServerRuntimeError,
 } from "@view-server/config";
 import { createInMemoryViewServer } from "@view-server/in-memory";
 import { ViewServerRpcErrorSchema, ViewServerRpcs } from "@view-server/protocol";
@@ -46,21 +47,6 @@ const HealthJson = Schema.Struct({
     topics: Schema.Struct({
       orders: Schema.Struct({
         rowCount: Schema.Number,
-      }),
-    }),
-  }),
-});
-
-const HealthKafkaJson = Schema.Struct({
-  status: Schema.String,
-  kafka: Schema.Struct({
-    topics: Schema.Struct({
-      source_orders: Schema.Struct({
-        regions: Schema.Struct({
-          usa: Schema.Struct({
-            consumerLagMessages: Schema.String,
-          }),
-        }),
       }),
     }),
   }),
@@ -137,7 +123,9 @@ class RawViewServerRpcClient extends Context.Service<
 const makeRawRpcClient = Effect.fn("ViewServerServer.test.rawRpcClient.make")(function* (
   url: string,
 ) {
-  const layer = Layer.effect(RawViewServerRpcClient)(RpcClient.make(ViewServerRpcs)).pipe(
+  const layer: Layer.Layer<RawViewServerRpcClient, never, never> = Layer.effect(
+    RawViewServerRpcClient,
+  )(RpcClient.make(ViewServerRpcs)).pipe(
     Layer.provide(RpcClient.layerProtocolSocket()),
     Layer.provide([NodeSocket.layerWebSocket(url), RpcSerialization.layerNdjson]),
   );
@@ -264,7 +252,98 @@ describe("@view-server/server", () => {
     }),
   );
 
-  it.live("serves cached health snapshots without rebuilding runtime health", () =>
+  it.live("returns 500 when runtime health fails", () =>
+    Effect.gen(function* () {
+      const inMemory = createInMemoryViewServer(viewServer);
+      const healthError: ViewServerRuntimeError = {
+        _tag: "ViewServerRuntimeError",
+        code: "RuntimeUnavailable",
+        message: "health unavailable",
+      };
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: {
+          health: () => Effect.fail(healthError),
+        },
+      });
+
+      const health = yield* fetchJson(server.healthUrl);
+
+      expect(health.response.status).toBe(500);
+      expect(health.value).toStrictEqual(healthError);
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("returns 503 for degraded health and serializes bigint fields", () =>
+    Effect.gen(function* () {
+      const inMemory = createInMemoryViewServer(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const degradedHealth: ViewServerHealth<typeof viewServer.topics> = {
+        ...baseHealth,
+        status: "degraded",
+        kafka: {
+          regions: {},
+          topics: {
+            source_orders: {
+              status: "degraded",
+              sourceTopic: "source_orders",
+              viewServerTopic: "orders",
+              regions: {
+                usa: {
+                  connected: true,
+                  assignedPartitions: 1,
+                  messagesPerSecond: 0,
+                  bytesPerSecond: 0,
+                  decodedMessagesPerSecond: 0,
+                  decodeFailuresPerSecond: 0,
+                  lastMessageAt: null,
+                  lastCommitAt: null,
+                  consumerLagMessages: 42n,
+                  consumerLagMs: null,
+                  lagSampledAt: null,
+                  highWatermarkOffset: null,
+                  committedOffset: null,
+                  lastError: null,
+                },
+              },
+            },
+          },
+        },
+      };
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: {
+          health: () => Effect.succeed(degradedHealth),
+        },
+      });
+
+      const health = yield* fetchJson(server.healthUrl);
+
+      expect(health.response.status).toBe(503);
+      expect(health.value).toMatchObject({
+        status: "degraded",
+        kafka: {
+          topics: {
+            source_orders: {
+              regions: {
+                usa: {
+                  consumerLagMessages: "42",
+                },
+              },
+            },
+          },
+        },
+      });
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("serves fresh runtime health for Kubernetes readiness", () =>
     Effect.gen(function* () {
       const inMemory = createInMemoryViewServer(viewServer);
       const baseHealth = yield* inMemory.client.health();
@@ -301,7 +380,7 @@ describe("@view-server/server", () => {
         },
       };
       const cachedHealth = AtomRef.make<ViewServerHealth<typeof viewServer.topics>>(degradedHealth);
-      const liveClient: ViewServerLiveClient<typeof viewServer.topics> = {
+      const liveClient: ViewServerRuntimeLiveClient<typeof viewServer.topics> = {
         ...inMemory.liveClient,
         health: cachedHealth,
       };
@@ -318,11 +397,10 @@ describe("@view-server/server", () => {
       });
 
       const firstHealth = yield* fetchJson(server.healthUrl);
-      const firstBody = yield* Schema.decodeUnknownEffect(HealthKafkaJson)(firstHealth.value);
-      expect(firstHealth.response.status).toBe(503);
-      expect(firstBody.status).toBe("degraded");
-      expect(firstBody.kafka.topics.source_orders.regions.usa.consumerLagMessages).toBe("42");
-      expect(runtimeHealthCalls).toBe(0);
+      const firstBody = yield* Schema.decodeUnknownEffect(HealthJson)(firstHealth.value);
+      expect(firstHealth.response.status).toBe(200);
+      expect(firstBody.status).toBe("ready");
+      expect(runtimeHealthCalls).toBe(1);
 
       yield* Effect.sync(() => {
         cachedHealth.set(baseHealth);
@@ -331,7 +409,7 @@ describe("@view-server/server", () => {
       const secondBody = yield* Schema.decodeUnknownEffect(HealthJson)(secondHealth.value);
       expect(secondHealth.response.status).toBe(200);
       expect(secondBody.status).toBe("ready");
-      expect(runtimeHealthCalls).toBe(0);
+      expect(runtimeHealthCalls).toBe(2);
 
       yield* server.close;
       yield* inMemory.close;
@@ -415,11 +493,11 @@ describe("@view-server/server", () => {
       const invalidLimit = yield* Effect.flip(
         raw.rpc["ViewServer.Subscribe"]({
           topic: "orders",
-          query: { select: ["id"], limit: 0 },
+          query: { select: ["id"], limit: -1 },
         }).pipe(Stream.runDrain),
       ).pipe(Effect.flatMap(Schema.decodeUnknownEffect(ViewServerRpcErrorSchema)));
       expect(invalidLimit.code).toBe("InvalidQuery");
-      expect(invalidLimit.message).toBe("Query limit must be a positive integer");
+      expect(invalidLimit.message).toBe("Query limit must be a non-negative integer");
 
       const extraTopLevelQueryKey = yield* Effect.flip(
         raw.rpc["ViewServer.Subscribe"]({
@@ -527,14 +605,13 @@ describe("@view-server/server", () => {
         function* (event: ViewServerLiveEvent<object>) {
           const liveClient = {
             ...inMemory.liveClient,
-            subscribe: () =>
+            subscribeRuntime: () =>
               Effect.succeed({
                 events: Stream.make(event),
                 close: () => Effect.void,
               }),
           };
           const server = yield* makeViewServerWebSocketServer(viewServer, {
-            // @ts-expect-error this fake client intentionally violates the row type contract.
             liveClient,
             runtime: inMemory.client,
           });
@@ -624,14 +701,13 @@ describe("@view-server/server", () => {
       };
       const liveClient = {
         ...inMemory.liveClient,
-        subscribe: () =>
+        subscribeRuntime: () =>
           Effect.succeed({
             events: Stream.make(event),
             close: () => Effect.void,
           }),
       };
       const server = yield* makeViewServerWebSocketServer(edgeViewServer, {
-        // @ts-expect-error this fake client intentionally emits a row with a non-json encoding.
         liveClient,
         runtime: inMemory.client,
       });
@@ -923,10 +999,8 @@ describe("@view-server/server", () => {
 
       const invalidQuery = yield* Effect.flip(
         client.subscribe("orders", {
-          select: [
-            // @ts-expect-error hostile callers can still send malformed queries over the wire.
-            1,
-          ],
+          // @ts-expect-error hostile callers can still send malformed queries over the wire.
+          select: [1],
         }),
       );
       expect(invalidQuery.code).toBe("InvalidQuery");
@@ -934,10 +1008,8 @@ describe("@view-server/server", () => {
 
       const unknownSelect = yield* Effect.flip(
         client.subscribe("orders", {
-          select: [
-            // @ts-expect-error hostile callers can still send unknown projected fields.
-            "missing",
-          ],
+          // @ts-expect-error hostile callers can still send unknown projected fields.
+          select: ["missing"],
         }),
       );
       expect(unknownSelect.code).toBe("InvalidQuery");
@@ -945,6 +1017,7 @@ describe("@view-server/server", () => {
 
       const unknownWhere = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
           where: {
             // @ts-expect-error hostile callers can still send unknown filter fields.
@@ -957,10 +1030,11 @@ describe("@view-server/server", () => {
 
       const unknownOrderBy = yield* Effect.flip(
         client.subscribe("orders", {
+          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
           select: ["id"],
-          // @ts-expect-error hostile callers can still send unknown sort fields.
           orderBy: [
             {
+              // @ts-expect-error hostile callers can still send unknown sort fields.
               field: "missing",
               direction: "asc",
             },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,11 +6,11 @@ import type {
   ViewServerRuntimeClient,
 } from "@view-server/config";
 import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
-import type { ViewServerLiveClient } from "@view-server/client";
+import type { ViewServerRuntimeLiveClient } from "@view-server/client";
 import {
   ViewServerRpcs,
   viewServerDecodeHealthQuery,
-  viewServerDecodeRawQuery,
+  viewServerDecodeLiveQuery,
   viewServerDecodeTopic,
   viewServerEncodeHealthSummaryEvent,
   viewServerEncodeHealthTopicEvent,
@@ -27,7 +27,7 @@ type ViewServerServerRuntime<Topics extends TopicDefinitions> = Pick<
 >;
 
 export type ViewServerWebSocketServerInput<Topics extends TopicDefinitions> = {
-  readonly liveClient: ViewServerLiveClient<Topics>;
+  readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
   readonly runtime: ViewServerServerRuntime<Topics>;
 };
 
@@ -72,8 +72,8 @@ const jsonResponse = (status: number, value: unknown): HttpServerResponse.HttpSe
 const makeHandlers = <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
   input: ViewServerWebSocketServerInput<Topics>,
-) =>
-  ViewServerRpcs.of({
+) => {
+  return ViewServerRpcs.of({
     "ViewServer.Health": () => input.runtime.health(),
     "ViewServer.Subscribe": (payload) =>
       Stream.unwrap(
@@ -95,18 +95,20 @@ const makeHandlers = <const Topics extends TopicDefinitions>(
             );
           }
           const topic = yield* viewServerDecodeTopic(config, payload.topic);
-          const query = yield* viewServerDecodeRawQuery(config, topic, payload.query);
-          const subscription = yield* input.liveClient.subscribe(topic, query);
-          const selectedFields = new Set<string>(query.select);
+          const query = yield* viewServerDecodeLiveQuery<Topics, typeof topic>(
+            config,
+            topic,
+            payload.query,
+          );
+          const subscription = yield* input.liveClient.subscribeRuntime(topic, query);
           return subscription.events.pipe(
-            Stream.mapEffect((event) =>
-              viewServerEncodeLiveEvent(config, topic, selectedFields, event),
-            ),
+            Stream.mapEffect((event) => viewServerEncodeLiveEvent(config, topic, query, event)),
             Stream.ensuring(subscription.close().pipe(Effect.ignore)),
           );
         }),
       ),
   });
+};
 
 const makeHealthRoute = <const Topics extends TopicDefinitions>(
   input: ViewServerWebSocketServerInput<Topics>,
@@ -115,8 +117,11 @@ const makeHealthRoute = <const Topics extends TopicDefinitions>(
   HttpRouter.add(
     "GET",
     path,
-    Effect.sync(() => input.liveClient.health.value).pipe(
-      Effect.map((health) => jsonResponse(health.status === "ready" ? 200 : 503, health)),
+    input.runtime.health().pipe(
+      Effect.match({
+        onFailure: (error) => jsonResponse(500, error),
+        onSuccess: (health) => jsonResponse(health.status === "ready" ? 200 : 503, health),
+      }),
     ),
   );
 


### PR DESCRIPTION
## Summary
- Add grouped query compilation/evaluation, grouped protocol encoding/decoding, and grouped live query typing across config, engine, protocol, client, React, server, and runtime surfaces.
- Deepen active query execution so raw projections can share base evaluation and grouped queries share materialized execution by cache key.
- Add remote subscription lifecycle helper to centralize stream finalization and pushed health stream behavior without unary health refreshes on every update.

## Validation
- vp check
- pnpm run check:effect
- pnpm run check:package-exports
- vp run -r build
- Sequential package tests passed: config, protocol, column-live-view-engine, client, in-memory, server, runtime, react
- React package browser tests passed with Chromium, Firefox, WebKit and 100% coverage
- Forbidden-pattern scans clean for Testing Library, act, flushSync, getByTestId/data-testid, toEqual, coverage ignores, unsafe casts, removed runtime validated symbols, and console usage

## Review
- Two existing review agents found no blockers, only known residual risks: grouped full recompute, raw offset/limit cache split, provider initial failure UX.
- Replacement read-only Codex CLI review also found no blocking findings, including untracked new files before commit.

## Known Follow-ups
- Grouped active queries still full-recompute per store version in this slice.
- Raw active query cache still includes offset/limit, so cross-window sharing is not yet the full physical-plan split.