### PR TITLE
Fix PR 20 query validation regressions

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -79,6 +79,9 @@ const Instrument = Schema.Struct({
   operatorLike: Schema.Struct({
     eq: Schema.String,
   }),
+  operatorRangeLike: Schema.Struct({
+    gte: Schema.Number,
+  }),
   tags: Schema.Array(Schema.String),
 });
 
@@ -113,10 +116,11 @@ const orderSelect: readonly ["id", "customerId", "status", "price", "region", "u
   "region",
   "updatedAt",
 ];
-const instrumentSelect: readonly ["id", "metadata", "operatorLike", "tags"] = [
+const instrumentSelect: readonly ["id", "metadata", "operatorLike", "operatorRangeLike", "tags"] = [
   "id",
   "metadata",
   "operatorLike",
+  "operatorRangeLike",
   "tags",
 ];
 
@@ -169,6 +173,9 @@ const instrument = (
   },
   operatorLike: {
     eq: venue,
+  },
+  operatorRangeLike: {
+    gte: tier,
   },
   tags: [...tags],
 });
@@ -508,6 +515,16 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       });
       expect(rowIds(operatorLikeDirectObjectQuery.rows)).toStrictEqual(["1"]);
 
+      const operatorRangeLikeDirectObjectQuery = yield* engine.snapshot("instruments", {
+        select: ["id"],
+        where: {
+          operatorRangeLike: {
+            gte: 2,
+          },
+        },
+      });
+      expect(rowIds(operatorRangeLikeDirectObjectQuery.rows)).toStrictEqual(["2"]);
+
       const operatorLikeWrappedObjectQuery = yield* engine.snapshot("instruments", {
         select: ["id"],
         where: {
@@ -633,12 +650,16 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         operatorLike: {
           eq: "xlon",
         },
+        operatorRangeLike: {
+          gte: 2,
+        },
         tags: ["equity", "uk"],
       };
       yield* engine.patch("instruments", "1", patch);
 
       patch.metadata.risk.tier = 777;
       patch.operatorLike.eq = "mutated-after-patch";
+      patch.operatorRangeLike.gte = 777;
       patch.tags.push("mutated-after-patch");
 
       const afterPatchMutation = yield* engine.snapshot("instruments", {
@@ -964,6 +985,51 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           group: "z",
           totalAmount: "3",
           averageAmount: "1.5",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("keeps non-plain object grouped keys distinct by stable value", () =>
+    Effect.gen(function* () {
+      const Payload = Schema.Struct({
+        id: Schema.String,
+        payload: Schema.ObjectKeyword,
+      });
+      const payloadViewServer = defineViewServerConfig({
+        topics: {
+          payloads: {
+            schema: Payload,
+            key: "id",
+          },
+        },
+      });
+      const payloadEngine = yield* createColumnLiveViewEngine({
+        topics: payloadViewServer.topics,
+      });
+      yield* payloadEngine.publishMany("payloads", [
+        { id: "map-a-1", payload: new Map([["venue", "xnys"]]) },
+        { id: "map-b", payload: new Map([["venue", "xlon"]]) },
+        { id: "map-a-2", payload: new Map([["venue", "xnys"]]) },
+      ]);
+
+      const snapshot = yield* payloadEngine.snapshot("payloads", {
+        groupBy: ["payload"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+      });
+
+      expect(snapshot.totalRows).toBe(2);
+      expect(snapshot.rows).toStrictEqual([
+        {
+          payload: new Map([["venue", "xnys"]]),
+          rowCount: 2n,
+        },
+        {
+          payload: new Map([["venue", "xlon"]]),
+          rowCount: 1n,
         },
       ]);
     }),
@@ -2757,15 +2823,79 @@ describe("ColumnLiveViewEngine validation and health", () => {
       "unsupported",
       "function:anonymousFilter",
     ]);
-    expect(JSON.parse(stableQueryValueString(new Map()))).toStrictEqual([
+    expect(JSON.parse(stableQueryValueString(new Map()))).toStrictEqual(["map", []]);
+    expect(
+      JSON.parse(
+        stableQueryValueString(
+          new Map<unknown, unknown>([
+            [{ id: "same" }, "b"],
+            [{ id: "same" }, "a"],
+          ]),
+        ),
+      ),
+    ).toStrictEqual([
+      "map",
+      [
+        [
+          ["object", [["id", ["string", "same"]]]],
+          ["string", "a"],
+        ],
+        [
+          ["object", [["id", ["string", "same"]]]],
+          ["string", "b"],
+        ],
+      ],
+    ]);
+    expect(
+      JSON.parse(
+        stableQueryValueString(
+          new Map<unknown, unknown>([
+            [{ id: "b" }, "same"],
+            [{ id: "a" }, "same"],
+          ]),
+        ),
+      ),
+    ).toStrictEqual([
+      "map",
+      [
+        [
+          ["object", [["id", ["string", "a"]]]],
+          ["string", "same"],
+        ],
+        [
+          ["object", [["id", ["string", "b"]]]],
+          ["string", "same"],
+        ],
+      ],
+    ]);
+    expect(JSON.parse(stableQueryValueString(new Set(["b", "a"])))).toStrictEqual([
+      "set",
+      [
+        ["string", "a"],
+        ["string", "b"],
+      ],
+    ]);
+    class CustomQueryValue {}
+    expect(JSON.parse(stableQueryValueString(new CustomQueryValue()))).toStrictEqual([
       "nonPlainObject",
-      "[object Map]",
+      "[object Object]",
     ]);
     expect(JSON.parse(stableQueryValueString(undefined))).toStrictEqual(["undefined"]);
 
     const cyclicArray: Array<unknown> = [];
     cyclicArray.push(cyclicArray);
     expect(JSON.parse(stableQueryValueString(cyclicArray))).toStrictEqual(["array", [["cycle"]]]);
+
+    const cyclicMap = new Map<unknown, unknown>();
+    cyclicMap.set("self", cyclicMap);
+    expect(JSON.parse(stableQueryValueString(cyclicMap))).toStrictEqual([
+      "map",
+      [[["string", "self"], ["cycle"]]],
+    ]);
+
+    const cyclicSet = new Set<unknown>();
+    cyclicSet.add(cyclicSet);
+    expect(JSON.parse(stableQueryValueString(cyclicSet))).toStrictEqual(["set", [["cycle"]]]);
 
     type CyclicObject = {
       self?: CyclicObject;

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -420,6 +420,9 @@ const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.validate")
     if (!isPlainRecord(filter) || isBigDecimal(filter)) {
       continue;
     }
+    if (metadata.structuredFieldNames.has(field)) {
+      continue;
+    }
     const keys = Object.keys(filter);
     const operatorKeyCount = keys.filter((key) => filterOperatorKeys.has(key)).length;
     if (operatorKeyCount > 0 && operatorKeyCount !== keys.length) {
@@ -467,8 +470,19 @@ type StableQueryValueToken =
   | readonly ["unsupported", string]
   | readonly ["cycle"]
   | readonly ["array", ReadonlyArray<StableQueryValueToken>]
+  | readonly ["map", ReadonlyArray<readonly [StableQueryValueToken, StableQueryValueToken]>]
   | readonly ["object", ReadonlyArray<StableQueryObjectEntry>]
+  | readonly ["set", ReadonlyArray<StableQueryValueToken>]
   | readonly ["nonPlainObject", string];
+
+const compareStableQueryValueToken = (
+  left: StableQueryValueToken,
+  right: StableQueryValueToken,
+): number => {
+  const leftString = JSON.stringify(left);
+  const rightString = JSON.stringify(right);
+  return Number(leftString > rightString) - Number(leftString < rightString);
+};
 
 const stableQueryValueToken = (value: unknown, active: WeakSet<object>): StableQueryValueToken => {
   if (isBigDecimal(value)) {
@@ -497,6 +511,33 @@ const stableQueryValueToken = (value: unknown, active: WeakSet<object>): StableQ
     ];
     active.delete(value);
     return token;
+  }
+  if (value instanceof Map) {
+    if (active.has(value)) {
+      return ["cycle"];
+    }
+    active.add(value);
+    const entries = Array.from(
+      value.entries(),
+      ([key, entryValue]) =>
+        [stableQueryValueToken(key, active), stableQueryValueToken(entryValue, active)] as const,
+    ).toSorted((left, right) => {
+      const keyComparison = compareStableQueryValueToken(left[0], right[0]);
+      return keyComparison === 0 ? compareStableQueryValueToken(left[1], right[1]) : keyComparison;
+    });
+    active.delete(value);
+    return ["map", entries];
+  }
+  if (value instanceof Set) {
+    if (active.has(value)) {
+      return ["cycle"];
+    }
+    active.add(value);
+    const values = Array.from(value.values(), (entry) =>
+      stableQueryValueToken(entry, active),
+    ).toSorted(compareStableQueryValueToken);
+    active.delete(value);
+    return ["set", values];
   }
   if (isPlainRecord(value)) {
     if (active.has(value)) {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1636,6 +1636,30 @@ const assertCompileTimeContracts = () => {
       ReadonlyArray<{ readonly id: string }>
     >();
 
+    const optionalBigintUndefinedFilterQuery = {
+      select: ["id"],
+      where: {
+        optionalQuantity: undefined,
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly optionalQuantity: undefined };
+    };
+    // @ts-expect-error optional filters reject present undefined values.
+    useLiveQuery("positions", optionalBigintUndefinedFilterQuery);
+
+    const optionalBigintUndefinedEqualityFilterQuery = {
+      select: ["id"],
+      where: {
+        optionalQuantity: { eq: undefined },
+      },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly optionalQuantity: { readonly eq: undefined } };
+    };
+    // @ts-expect-error optional equality filters reject present undefined values.
+    useLiveQuery("positions", optionalBigintUndefinedEqualityFilterQuery);
+
     const optionalBigintRangeFilterQuery = {
       select: ["id"],
       where: {

--- a/packages/config/src/query-filter.ts
+++ b/packages/config/src/query-filter.ts
@@ -76,11 +76,12 @@ type ExactOperatorFilter<Value, Filter> = Filter extends object
     : Filter & RejectExtraKeys<Filter, ExactFieldFilterShape<Value>>
   : unknown;
 
-type ExactFilter<Value, Filter> = Filter extends Value
-  ? unknown
-  : Filter extends FieldFilter<Value>
-    ? ExactOperatorFilter<Value, Filter>
-    : never;
+type ExactFilter<Value, Filter> =
+  Filter extends DefinedFilterValue<Value>
+    ? unknown
+    : Filter extends FieldFilter<Value>
+      ? ExactOperatorFilter<Value, Filter>
+      : never;
 
 export type ExactWhere<Row, Query> = Query extends {
   readonly where: infer QueryWhere;


### PR DESCRIPTION
Fixes the Codex review comments left after PR #20 was merged.\n\nChanges:\n- Reject present undefined filters on optional fields at the exact-query type boundary.\n- Preserve structured equality filters whose object shape looks like scalar operators.\n- Encode Map/Set values into stable query/group keys so grouped object-valued keys do not collapse by object tag.\n\nValidation:\n- pnpm run ready\n- Forbidden-pattern scan clean