### PR TITLE
Fix late PR 21 query validation comments

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -2415,6 +2415,21 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         message: "Raw query where field price does not support startsWith.",
       });
 
+      const arrayStartsWithQuery: object = {
+        select: ["id"],
+        where: {
+          tags: { startsWith: "equity" },
+        },
+      };
+      const arrayStartsWith = yield* Effect.flip(
+        // @ts-expect-error runtime query validation rejects unsupported array startsWith operators.
+        engine.snapshot("instruments", arrayStartsWithQuery),
+      );
+      expect(arrayStartsWith).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: "Raw query where field tags does not support startsWith.",
+      });
+
       const invalidNeqQuery: object = {
         select: ["id"],
         where: {

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -41,6 +41,7 @@ export type RawQueryCompilerMetadata = {
   readonly fieldNames: ReadonlySet<string>;
   readonly fieldMetadata: ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>>;
   readonly structuredFieldNames: ReadonlySet<string>;
+  readonly structuredObjectFieldNames: ReadonlySet<string>;
   readonly stringFieldNames: ReadonlySet<string>;
   readonly numericFieldNames: ReadonlySet<string>;
   readonly bigintFieldNames: ReadonlySet<string>;
@@ -213,12 +214,27 @@ const schemaStructuredFieldNames = (schema: Schema.Decoder<object>): ReadonlySet
   return fields;
 };
 
+const schemaStructuredObjectFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isStructuredObject) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
 export const rawQueryCompilerMetadata = (
   schema: Schema.Decoder<object>,
 ): RawQueryCompilerMetadata => ({
   fieldNames: schemaFieldNames(schema),
   fieldMetadata: schemaFieldMetadata(schema),
   structuredFieldNames: schemaStructuredFieldNames(schema),
+  structuredObjectFieldNames: schemaStructuredObjectFieldNames(schema),
   stringFieldNames: schemaStringFieldNames(schema),
   numericFieldNames: schemaNumericFieldNames(schema),
   bigintFieldNames: schemaBigintFieldNames(schema),
@@ -420,11 +436,11 @@ const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.validate")
     if (!isPlainRecord(filter) || isBigDecimal(filter)) {
       continue;
     }
-    if (metadata.structuredFieldNames.has(field)) {
-      continue;
-    }
     const keys = Object.keys(filter);
     const operatorKeyCount = keys.filter((key) => filterOperatorKeys.has(key)).length;
+    if (metadata.structuredObjectFieldNames.has(field)) {
+      continue;
+    }
     if (operatorKeyCount > 0 && operatorKeyCount !== keys.length) {
       return yield* InvalidQueryError.make({
         topic,
@@ -448,7 +464,7 @@ const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.validate")
         });
       }
     }
-    if (operatorKeyCount === 0 && !metadata.structuredFieldNames.has(field)) {
+    if (operatorKeyCount === 0) {
       return yield* InvalidQueryError.make({
         topic,
         message: `Raw query where field ${field} contains unsupported filter operator.`,

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -198,6 +198,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigDecimal",
     });
     expect(viewServerSchemaFieldMetadata(Schema.BigInt)).toStrictEqual({
@@ -205,6 +206,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: true,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigint",
     });
     expect(viewServerSchemaFieldMetadata(Schema.BigDecimal)).toStrictEqual({
@@ -212,6 +214,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigDecimal",
     });
     expect(
@@ -221,6 +224,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigint",
     });
     expect(
@@ -230,6 +234,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigDecimal",
     });
     expect(viewServerSchemaFieldMetadata(Schema.Literal(1))).toStrictEqual({
@@ -237,6 +242,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigDecimal",
     });
     expect(viewServerSchemaFieldMetadata(Schema.Literals([1, 2]))).toStrictEqual({
@@ -244,6 +250,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigDecimal",
     });
     expect(viewServerSchemaFieldMetadata(Schema.Literal(1n))).toStrictEqual({
@@ -251,6 +258,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
       sumResultKind: "bigint",
     });
     expect(
@@ -260,6 +268,7 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(
       viewServerSchemaFieldMetadata(Schema.Union([Schema.BigInt, Schema.Undefined])),
@@ -268,48 +277,56 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata(Schema.Undefined)).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata(Schema.Union([Schema.Undefined]))).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata(Schema.Union([]))).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata(undefined)).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata("not-a-schema")).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata({ ast: "not-an-effect-ast" })).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(viewServerSchemaFieldMetadata(Schema.Literals(["open", "closed"]))).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: true,
       isStructured: false,
+      isStructuredObject: false,
     });
     expect(
       viewServerSchemaFieldMetadata(
@@ -323,12 +340,21 @@ describe("defineViewServerConfig", () => {
       isPureBigInt: false,
       isString: false,
       isStructured: true,
+      isStructuredObject: true,
     });
     expect(viewServerSchemaFieldMetadata(Schema.Struct({ id: Schema.String }))).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
       isString: false,
       isStructured: true,
+      isStructuredObject: true,
+    });
+    expect(viewServerSchemaFieldMetadata(Schema.Array(Schema.String))).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: true,
+      isStructuredObject: false,
     });
   });
 
@@ -1648,6 +1674,19 @@ const assertCompileTimeContracts = () => {
     // @ts-expect-error optional filters reject present undefined values.
     useLiveQuery("positions", optionalBigintUndefinedFilterQuery);
 
+    const optionalBigintUnionFilterQuery = (optionalQuantity: bigint | undefined) =>
+      ({
+        select: ["id"],
+        where: {
+          optionalQuantity,
+        },
+      }) satisfies {
+        readonly select: readonly ["id"];
+        readonly where: { readonly optionalQuantity: bigint | undefined };
+      };
+    // @ts-expect-error optional filters reject unions that can contain undefined.
+    useLiveQuery("positions", optionalBigintUnionFilterQuery(1n));
+
     const optionalBigintUndefinedEqualityFilterQuery = {
       select: ["id"],
       where: {
@@ -1659,6 +1698,19 @@ const assertCompileTimeContracts = () => {
     };
     // @ts-expect-error optional equality filters reject present undefined values.
     useLiveQuery("positions", optionalBigintUndefinedEqualityFilterQuery);
+
+    const optionalBigintUnionEqualityFilterQuery = (eq: bigint | undefined) =>
+      ({
+        select: ["id"],
+        where: {
+          optionalQuantity: { eq },
+        },
+      }) satisfies {
+        readonly select: readonly ["id"];
+        readonly where: { readonly optionalQuantity: { readonly eq: bigint | undefined } };
+      };
+    // @ts-expect-error optional equality filters reject unions that can contain undefined.
+    useLiveQuery("positions", optionalBigintUnionEqualityFilterQuery(1n));
 
     const optionalBigintRangeFilterQuery = {
       select: ["id"],

--- a/packages/config/src/query-filter.ts
+++ b/packages/config/src/query-filter.ts
@@ -76,10 +76,11 @@ type ExactOperatorFilter<Value, Filter> = Filter extends object
     : Filter & RejectExtraKeys<Filter, ExactFieldFilterShape<Value>>
   : unknown;
 
-type ExactFilter<Value, Filter> =
-  Filter extends DefinedFilterValue<Value>
+type ExactFilter<Value, Filter> = undefined extends Filter
+  ? never
+  : [Filter] extends [DefinedFilterValue<Value>]
     ? unknown
-    : Filter extends FieldFilter<Value>
+    : [Filter] extends [FieldFilter<Value>]
       ? ExactOperatorFilter<Value, Filter>
       : never;
 

--- a/packages/config/src/schema-field-metadata.ts
+++ b/packages/config/src/schema-field-metadata.ts
@@ -5,6 +5,7 @@ export type ViewServerSchemaFieldMetadata = {
   readonly isPureBigInt: boolean;
   readonly isString: boolean;
   readonly isStructured: boolean;
+  readonly isStructuredObject: boolean;
   readonly sumResultKind?: "bigint" | "bigDecimal";
 };
 
@@ -70,6 +71,13 @@ const isStructuredAst = (ast: SchemaAST.AST): boolean => {
   return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isStructuredAst);
 };
 
+const isStructuredObjectAst = (ast: SchemaAST.AST): boolean => {
+  if (SchemaAST.isObjects(ast) || SchemaAST.isObjectKeyword(ast)) {
+    return true;
+  }
+  return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isStructuredObjectAst);
+};
+
 export const viewServerSchemaFieldMetadata = (schema: unknown): ViewServerSchemaFieldMetadata => {
   const ast = schemaAst(schema);
   if (ast === undefined) {
@@ -78,6 +86,7 @@ export const viewServerSchemaFieldMetadata = (schema: unknown): ViewServerSchema
       isPureBigInt: false,
       isString: false,
       isStructured: false,
+      isStructuredObject: false,
     };
   }
   const numericKind = numericKindAst(ast);
@@ -88,6 +97,7 @@ export const viewServerSchemaFieldMetadata = (schema: unknown): ViewServerSchema
     isPureBigInt,
     isString: isStringAst(ast),
     isStructured: isStructuredAst(ast),
+    isStructuredObject: isStructuredObjectAst(ast),
     ...(isNumeric ? { sumResultKind: numericKind } : {}),
   };
 };


### PR DESCRIPTION
Fixes the late Codex comments from #21.\n\nChanges:\n- Reject optional filter expressions typed as unions containing undefined.\n- Preserve direct object equality for object-shaped structured fields while continuing to reject unsupported operator filters on array fields.\n- Add regressions for union-undefined optional filters and array startsWith runtime validation.\n\nValidation:\n- pnpm --filter @view-server/config run test\n- pnpm --filter @view-server/column-live-view-engine run test\n- vp check --fix\n- pnpm run check:effect\n- pnpm run check:package-exports\n- vp run -r build\n- pnpm run ready\n- forbidden-pattern scan clean