### PR TITLE
Deepen TopicStore transaction module

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -26,11 +26,11 @@ import {
   activeStoreRawQueryExecutionCount,
   releaseMaterializedQueryExecution,
 } from "./active-query";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
 import {
-  acquireLiveSubscriptionHandoff,
+  acquireSubscriptionHandoff,
   closeInterruptedAcquiredSubscription,
-  type LiveTopicSubscriber,
-} from "./live-subscription";
+} from "./subscription-handoff";
 import {
   prepareRawQuery,
   rawQueryCompilerMetadata,
@@ -39,8 +39,11 @@ import {
 import { evaluateCompiledGroupedQuery, prepareGroupedQuery } from "./grouped-query-compiler";
 import { cloneRecord, cloneRow, fieldValue, rowsEqual } from "./row-values";
 import {
+  acquireTopicStoreSubscription,
+  closeBackpressuredTopicStoreSubscription,
   closeTopicStoreSubscriptions,
   collectTopicStoreHealth,
+  publishTopicStoreRow,
   registerTopicStoreSubscription,
   resetTopicStore,
   TopicStore,
@@ -156,6 +159,21 @@ const position = (
 
 const makeEngine = (): Effect.Effect<Engine> =>
   createColumnLiveViewEngine({ topics: viewServer.topics });
+
+const registerTestTopicStoreSubscriber = (
+  store: TopicStore,
+  subscriber: LiveTopicSubscriber,
+): Effect.Effect<void> =>
+  acquireTopicStoreSubscription(store, (permit, markAcquired) =>
+    Effect.gen(function* () {
+      const subscription = {
+        close: () => Effect.void,
+      };
+      yield* registerTopicStoreSubscription(permit, subscriber);
+      yield* markAcquired(subscription);
+      return subscription;
+    }),
+  ).pipe(Effect.asVoid);
 
 const instrument = (
   id: string,
@@ -1966,7 +1984,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       };
 
       const handoffFiber = yield* Effect.forkChild(
-        acquireLiveSubscriptionHandoff(
+        acquireSubscriptionHandoff(
           (markAcquired) =>
             Effect.gen(function* () {
               yield* markAcquired(subscription);
@@ -2000,7 +2018,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       };
 
       const handoffFiber = yield* Effect.forkChild(
-        acquireLiveSubscriptionHandoff((markAcquired) =>
+        acquireSubscriptionHandoff((markAcquired) =>
           Effect.uninterruptible(
             Effect.gen(function* () {
               yield* markAcquired(subscription);
@@ -2015,6 +2033,98 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       yield* Deferred.await(acquired);
       yield* Fiber.interrupt(handoffFiber);
       expect(closeCount).toBe(1);
+    }),
+  );
+
+  it.effect("closes acquired subscriptions when topic-store acquisition is interrupted", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      const acquired = yield* Deferred.make<void>();
+      let closeCount = 0;
+      const subscription = {
+        events: Stream.empty,
+        close: () =>
+          Effect.sync(() => {
+            closeCount += 1;
+          }),
+      };
+
+      const handoffFiber = yield* Effect.forkChild(
+        acquireTopicStoreSubscription(store, (_permit, markAcquired) =>
+          Effect.uninterruptible(
+            Effect.gen(function* () {
+              yield* markAcquired(subscription);
+              yield* Deferred.succeed(acquired, undefined);
+              yield* Effect.sleep("10 millis");
+              return subscription;
+            }),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(acquired);
+      yield* Fiber.interrupt(handoffFiber);
+      expect(closeCount).toBe(1);
+    }),
+  );
+
+  it.effect("records backpressure close only once for already closed subscribers", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      let finalizeCount = 0;
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-backpressure-idempotent",
+        notify: () => Effect.void,
+        queuedEvents: Effect.succeed(0),
+        end: Effect.void,
+        closeWithStatus: () => Effect.void,
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+      const finalize = Effect.sync(() => {
+        finalizeCount += 1;
+      });
+
+      yield* registerTestTopicStoreSubscriber(store, subscriber);
+      yield* closeBackpressuredTopicStoreSubscription(store, subscriber, finalize);
+      yield* closeBackpressuredTopicStoreSubscription(store, subscriber, finalize);
+
+      const health = yield* collectTopicStoreHealth(store, false);
+      expect(finalizeCount).toBe(1);
+      expect(subscriber.backpressureEvents).toBe(1);
+      expect(health.activeSubscriptions).toBe(0);
+      expect(health.backpressureEvents).toBe(1);
+    }),
+  );
+
+  it.effect("does not notify subscribers that were closed after mutation capture", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      let notifyCount = 0;
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-closed-before-notify",
+        notify: () =>
+          Effect.sync(() => {
+            notifyCount += 1;
+          }),
+        queuedEvents: Effect.succeed(0),
+        end: Effect.void,
+        closeWithStatus: () => Effect.void,
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+
+      yield* registerTestTopicStoreSubscriber(store, subscriber);
+      subscriber.closed = true;
+      yield* publishTopicStoreRow(store, order("1", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      expect(notifyCount).toBe(0);
     }),
   );
 
@@ -2042,7 +2152,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         backpressureEvents: 0,
         closed: false,
       };
-      yield* registerTopicStoreSubscription(store, subscriber);
+      yield* registerTestTopicStoreSubscriber(store, subscriber);
       expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
 
       const closeFiber = yield* Effect.forkChild(closeTopicStoreSubscriptions(store));
@@ -2079,7 +2189,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         backpressureEvents: 0,
         closed: false,
       };
-      yield* registerTopicStoreSubscription(store, subscriber);
+      yield* registerTestTopicStoreSubscriber(store, subscriber);
       expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
 
       const resetFiber = yield* Effect.forkChild(resetTopicStore(store));

--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -25,10 +25,11 @@ import {
   InvalidTopicError,
   type ColumnLiveViewEngineError,
 } from "./engine-errors";
-import { acquireLiveSubscriptionHandoff, type LiveSubscription } from "./live-subscription";
+import type { LiveSubscription } from "./live-subscription";
 import { collectColumnLiveViewEngineHealth } from "./engine-health";
 import { snapshotExecutableQuery, subscribeExecutableQuery } from "./query-execution";
 import {
+  acquireTopicStoreSubscription,
   closeTopicStoreSubscriptions,
   deleteTopicStoreRow,
   patchTopicStoreRow,
@@ -36,7 +37,6 @@ import {
   publishTopicStoreRows,
   resetTopicStore,
   TopicStore,
-  withTopicStoreMutation,
 } from "./topic-store";
 
 export { InvalidQueryError } from "./raw-query-compiler";
@@ -242,29 +242,25 @@ class InMemoryColumnLiveViewEngine<
       function* (this: InMemoryColumnLiveViewEngine<Topics>) {
         yield* this.ensureOpen();
         const store = yield* this.getStore(topic);
-        const acquireSubscription = (
-          markAcquired: (subscription: LiveSubscription<ResultRow>) => Effect.Effect<void>,
-        ) =>
-          withTopicStoreMutation(
-            store,
+        const subscription = yield* acquireTopicStoreSubscription(
+          store,
+          (
+            permit,
+            markAcquired: (subscription: LiveSubscription<ResultRow>) => Effect.Effect<void>,
+          ): Effect.Effect<LiveSubscription<ResultRow>, ColumnLiveViewEngineError> =>
             Effect.gen({ self: this }, function* () {
               yield* this.ensureOpen();
               const queryId = `query-${this.nextQueryId}`;
               this.nextQueryId += 1;
-              const acquiredSubscription = yield* subscribeExecutableQuery<ResultRow>(
-                topic,
-                store,
-                query,
-                {
-                  queryId,
-                  queueCapacity: this.subscriptionQueueCapacity,
-                },
-              );
+              const acquiredSubscription = yield* subscribeExecutableQuery<ResultRow>(query, {
+                permit,
+                queryId,
+                queueCapacity: this.subscriptionQueueCapacity,
+              });
               yield* markAcquired(acquiredSubscription);
               return acquiredSubscription;
             }),
-          );
-        const subscription = yield* acquireLiveSubscriptionHandoff(acquireSubscription);
+        );
 
         return {
           events: subscription.events,

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -1,14 +1,14 @@
 import type { DeltaEvent, SnapshotEvent, StatusEvent } from "@view-server/config";
-import { Cause, Effect, Exit, Option, Queue, Stream } from "effect";
+import { Cause, Effect, Option, Queue, Stream } from "effect";
 import type { LiveQueryExecution } from "./active-query";
-import type { TopicStore } from "./topic-store";
+import type { TopicStore, TopicStoreSubscriptionPermit } from "./topic-store";
 import {
+  closeBackpressuredTopicStoreSubscription,
+  closeTopicStoreSubscription,
   registerTopicStoreSubscription,
-  reportTopicStoreSubscriptionBackpressure,
   trackTopicStoreSubscriptionQueueDepth,
-  unregisterTopicStoreSubscription,
-  withTopicStoreMutation,
 } from "./topic-store";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
 
 type RowObject = object;
 
@@ -17,23 +17,11 @@ type LiveSubscriptionEvent<Row extends RowObject> =
   | DeltaEvent<Row>
   | StatusEvent;
 
-export type LiveTopicSubscriber = {
-  readonly topic: string;
-  readonly queryId: string;
-  readonly notify: (store: TopicStore) => Effect.Effect<void>;
-  readonly queuedEvents: Effect.Effect<number>;
-  readonly end: Effect.Effect<void>;
-  readonly closeWithStatus: (event: StatusEvent) => Effect.Effect<void>;
-  maxQueueDepth: number;
-  backpressureEvents: number;
-  closed: boolean;
-};
-
 type MakeLiveSubscriptionOptions<ResultRow extends RowObject> = {
-  readonly store: TopicStore;
   readonly queryId: string;
   readonly queueCapacity: number;
   readonly execution: LiveQueryExecution<ResultRow>;
+  readonly permit: TopicStoreSubscriptionPermit;
   readonly release: Effect.Effect<void>;
 };
 
@@ -41,47 +29,6 @@ export type LiveSubscription<ResultRow extends RowObject> = {
   readonly events: Stream.Stream<LiveSubscriptionEvent<ResultRow>>;
   readonly close: () => Effect.Effect<void, never>;
 };
-
-type ClosableSubscription = {
-  readonly close: () => Effect.Effect<void, never>;
-};
-
-type LiveSubscriptionHandoffOptions = {
-  readonly beforeReturn?: Effect.Effect<void>;
-};
-
-type MarkAcquiredSubscription<ResultRow extends RowObject> = (
-  subscription: LiveSubscription<ResultRow>,
-) => Effect.Effect<void>;
-
-export const closeInterruptedAcquiredSubscription = Effect.fn(
-  "ColumnLiveViewEngine.liveSubscription.closeInterruptedAcquired",
-)(function* (exit: Exit.Exit<unknown, unknown>, subscription: ClosableSubscription | undefined) {
-  if (!Exit.hasInterrupts(exit) || subscription === undefined) {
-    return;
-  }
-  yield* subscription.close();
-});
-
-export const acquireLiveSubscriptionHandoff = Effect.fn(
-  "ColumnLiveViewEngine.liveSubscription.acquireHandoff",
-)(function* <ResultRow extends RowObject, Error, Requirements>(
-  acquire: (
-    markAcquired: MarkAcquiredSubscription<ResultRow>,
-  ) => Effect.Effect<LiveSubscription<ResultRow>, Error, Requirements>,
-  options: LiveSubscriptionHandoffOptions = {},
-) {
-  let acquiredSubscription: ClosableSubscription | undefined;
-  const markAcquired: MarkAcquiredSubscription<ResultRow> = (subscription) =>
-    Effect.sync(() => {
-      acquiredSubscription = subscription;
-    });
-
-  return yield* acquire(markAcquired).pipe(
-    Effect.tap(() => options.beforeReturn ?? Effect.void),
-    Effect.onExit((exit) => closeInterruptedAcquiredSubscription(exit, acquiredSubscription)),
-  );
-});
 
 const backpressureStatusEvent = (
   store: { readonly topic: string },
@@ -105,10 +52,7 @@ const closeForBackpressure = Effect.fn(
 ) {
   yield* Effect.uninterruptible(
     Effect.gen(function* () {
-      subscriber.closed = true;
-      yield* reportTopicStoreSubscriptionBackpressure(store, subscriber);
-      yield* unregisterTopicStoreSubscription(store, subscriber);
-      yield* release;
+      yield* closeBackpressuredTopicStoreSubscription(store, subscriber, release);
       yield* Queue.takeAll(queue).pipe(Effect.ignore);
       yield* Queue.offer(queue, backpressureStatusEvent(store, subscriber)).pipe(Effect.ignore);
       yield* Queue.end(queue);
@@ -118,8 +62,9 @@ const closeForBackpressure = Effect.fn(
 
 export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.make")(
   function* <ResultRow extends RowObject>(options: MakeLiveSubscriptionOptions<ResultRow>) {
-    const { execution, queryId, queueCapacity, store } = options;
+    const { execution, permit, queryId, queueCapacity } = options;
     const { release } = options;
+    const { store } = permit;
     const queue = yield* Queue.dropping<LiveSubscriptionEvent<ResultRow>, Cause.Done>(
       queueCapacity,
     );
@@ -163,20 +108,17 @@ export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscrip
       closed: false,
     };
 
-    yield* registerTopicStoreSubscription(store, subscriber);
+    yield* registerTopicStoreSubscription(permit, subscriber);
     yield* Queue.offer(queue, execution.initial(queryId));
     yield* trackTopicStoreSubscriptionQueueDepth(store, subscriber, yield* Queue.size(queue));
 
     const close = Effect.fn("ColumnLiveViewEngine.liveSubscription.close")(function* () {
-      yield* withTopicStoreMutation(
+      yield* closeTopicStoreSubscription(
         store,
+        subscriber,
         Effect.gen(function* () {
-          if (!subscriber.closed) {
-            subscriber.closed = true;
-            yield* unregisterTopicStoreSubscription(store, subscriber);
-            yield* releaseExecution;
-            yield* subscriber.end;
-          }
+          yield* releaseExecution;
+          yield* subscriber.end;
         }),
       );
     });

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -17,7 +17,12 @@ import {
   type CompiledRawQuery,
 } from "./raw-query-compiler";
 import { liveQueryResult, type QueryEvaluation } from "./query-result";
-import { topicStoreRawQueryMetadata, topicStoreReadModel, type TopicStore } from "./topic-store";
+import {
+  topicStoreRawQueryMetadata,
+  topicStoreReadModel,
+  type TopicStore,
+  type TopicStoreSubscriptionPermit,
+} from "./topic-store";
 
 type RowObject = object;
 
@@ -79,20 +84,21 @@ export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExec
 
 export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.subscribe")(
   function* <ResultRow extends RowObject>(
-    topic: string,
-    store: TopicStore,
     query: unknown,
     input: {
+      readonly permit: TopicStoreSubscriptionPermit;
       readonly queryId: string;
       readonly queueCapacity: number;
     },
   ) {
+    const { store } = input.permit;
+    const { topic } = store;
     const executable = yield* prepareExecutableQuery<ResultRow>(topic, store, query);
     const storeReadModel = topicStoreReadModel(store);
     if (executable.kind === "raw") {
       const execution = yield* acquireRawQueryExecution(storeReadModel, executable.compiled);
       return yield* makeLiveSubscription({
-        store,
+        permit: input.permit,
         queryId: input.queryId,
         execution,
         queueCapacity: input.queueCapacity,
@@ -106,7 +112,7 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
       () => evaluateCompiledGroupedQuery(storeReadModel, executable.compiled),
     );
     return yield* makeLiveSubscription({
-      store,
+      permit: input.permit,
       queryId: input.queryId,
       execution,
       queueCapacity: input.queueCapacity,

--- a/packages/column-live-view-engine/src/subscription-handoff.ts
+++ b/packages/column-live-view-engine/src/subscription-handoff.ts
@@ -1,0 +1,50 @@
+import { Effect, Exit } from "effect";
+
+type ClosableSubscription = {
+  readonly close: () => Effect.Effect<void, never>;
+};
+
+export type MarkAcquiredSubscription<Subscription extends ClosableSubscription> = (
+  subscription: Subscription,
+) => Effect.Effect<void>;
+
+export type SubscriptionHandoffAcquire<
+  Subscription extends ClosableSubscription,
+  Error,
+  Requirements,
+> = (
+  markAcquired: MarkAcquiredSubscription<Subscription>,
+) => Effect.Effect<Subscription, Error, Requirements>;
+
+export type SubscriptionHandoffOptions = {
+  readonly beforeReturn?: Effect.Effect<void>;
+};
+
+export const closeInterruptedAcquiredSubscription = Effect.fn(
+  "ColumnLiveViewEngine.subscriptionHandoff.closeInterruptedAcquired",
+)(function* (exit: Exit.Exit<unknown, unknown>, subscription: ClosableSubscription | undefined) {
+  if (!Exit.hasInterrupts(exit) || subscription === undefined) {
+    return;
+  }
+  yield* subscription.close();
+});
+
+export function acquireSubscriptionHandoff<
+  Subscription extends ClosableSubscription,
+  Error,
+  Requirements,
+>(
+  acquire: SubscriptionHandoffAcquire<Subscription, Error, Requirements>,
+  options: SubscriptionHandoffOptions = {},
+): Effect.Effect<Subscription, Error, Requirements> {
+  let acquiredSubscription: ClosableSubscription | undefined;
+  const markAcquired: MarkAcquiredSubscription<Subscription> = (subscription) =>
+    Effect.sync(() => {
+      acquiredSubscription = subscription;
+    });
+
+  return acquire(markAcquired).pipe(
+    Effect.tap(() => options.beforeReturn ?? Effect.void),
+    Effect.onExit((exit) => closeInterruptedAcquiredSubscription(exit, acquiredSubscription)),
+  );
+}

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -8,11 +8,22 @@ import {
 import { createTopicHealthLedger } from "./topic-health-ledger";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
-import type { LiveTopicSubscriber } from "./live-subscription";
+import {
+  acquireSubscriptionHandoff,
+  type MarkAcquiredSubscription,
+  type SubscriptionHandoffOptions,
+} from "./subscription-handoff";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
 
 type RowObject = object;
 
 type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
+const topicStoreSubscriptionPermitBrand: unique symbol = Symbol("TopicStoreSubscriptionPermit");
+
+export type TopicStoreSubscriptionPermit = {
+  readonly [topicStoreSubscriptionPermitBrand]: true;
+  readonly store: TopicStore;
+};
 
 export type TopicStoreHealthView = {
   readonly topic: string;
@@ -39,6 +50,7 @@ type TopicStoreState = {
   readonly rows: Map<string, object>;
   readonly subscribers: Set<LiveTopicSubscriber>;
   readonly mutationSemaphore: Semaphore.Semaphore;
+  readonly notificationSemaphore: Semaphore.Semaphore;
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
   readonly schema: Schema.Decoder<object>;
@@ -66,6 +78,7 @@ export class TopicStore {
       rows,
       subscribers,
       mutationSemaphore: Semaphore.makeUnsafe(1),
+      notificationSemaphore: Semaphore.makeUnsafe(1),
       rawQueryMetadata: rawQueryCompilerMetadata(schema),
       healthLedger: createTopicHealthLedger(),
       schema,
@@ -98,7 +111,7 @@ export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerM
 export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
   topicStoreState(store).readModel;
 
-export const withTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore.transaction")(
+const withTopicStoreTransaction = Effect.fn("ColumnLiveViewEngine.topicStore.transaction")(
   function* <Success, Error, Requirements>(
     store: TopicStore,
     effect: Effect.Effect<Success, Error, Requirements>,
@@ -108,6 +121,45 @@ export const withTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore
     );
   },
 );
+
+const withTopicStoreNotification = Effect.fn("ColumnLiveViewEngine.topicStore.notification")(
+  function* <Success, Error, Requirements>(
+    store: TopicStore,
+    effect: Effect.Effect<Success, Error, Requirements>,
+  ) {
+    return yield* topicStoreState(store).notificationSemaphore.withPermits(1)(
+      Effect.uninterruptible(effect),
+    );
+  },
+);
+
+export function acquireTopicStoreSubscription<
+  Subscription extends { readonly close: () => Effect.Effect<void, never> },
+  Error,
+  Requirements,
+>(
+  store: TopicStore,
+  acquire: (
+    permit: TopicStoreSubscriptionPermit,
+    markAcquired: MarkAcquiredSubscription<Subscription>,
+  ) => Effect.Effect<Subscription, Error, Requirements>,
+  options: SubscriptionHandoffOptions = {},
+): Effect.Effect<Subscription, Error, Requirements> {
+  return acquireSubscriptionHandoff(
+    (markAcquired: (subscription: Subscription) => Effect.Effect<void>) =>
+      withTopicStoreTransaction(
+        store,
+        acquire(
+          {
+            [topicStoreSubscriptionPermitBrand]: true,
+            store,
+          },
+          markAcquired,
+        ),
+      ),
+    options,
+  );
+}
 
 const resetStatusEvent = (store: TopicStore, subscriber: LiveTopicSubscriber): StatusEvent => ({
   type: "status",
@@ -140,15 +192,22 @@ const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.n
   store: TopicStore,
   subscribers: ReadonlyArray<LiveTopicSubscriber>,
 ) {
-  for (const subscriber of subscribers) {
-    yield* subscriber.notify(store);
-  }
+  yield* withTopicStoreNotification(
+    store,
+    Effect.gen(function* () {
+      for (const subscriber of subscribers) {
+        if (!subscriber.closed) {
+          yield* subscriber.notify(store);
+        }
+      }
+    }),
+  );
 });
 
 const commitTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore.commitMutation")(
   function* (store: TopicStore, mutate: (state: TopicStoreState) => number) {
     const occurredAt = yield* Clock.currentTimeMillis;
-    const subscribers = yield* Effect.sync(() => {
+    return yield* Effect.sync(() => {
       const state = topicStoreState(store);
       const rowsChanged = mutate(state);
       const subscribersToNotify = commitTopicStoreState(state);
@@ -160,9 +219,23 @@ const commitTopicStoreMutation = Effect.fn("ColumnLiveViewEngine.topicStore.comm
       });
       return subscribersToNotify;
     });
-    yield* notifyTopicStoreSubscribers(store, subscribers);
   },
 );
+
+const commitAndNotifyTopicStoreMutation = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.commitAndNotifyMutation",
+)(function* (store: TopicStore, mutate: (state: TopicStoreState) => number) {
+  yield* withTopicStoreMutationBatch(
+    store,
+    Effect.gen(function* () {
+      const subscribers = yield* withTopicStoreTransaction(
+        store,
+        commitTopicStoreMutation(store, mutate),
+      );
+      yield* notifyTopicStoreSubscribers(store, subscribers);
+    }),
+  );
+});
 
 const withTopicStoreMutationBatch = Effect.fn("ColumnLiveViewEngine.topicStore.mutationBatch")(
   function* <Success, Error, Requirements>(
@@ -223,15 +296,15 @@ export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStor
 
 export const registerTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.add",
-)((store: TopicStore, subscriber: LiveTopicSubscriber) =>
+)((permit: TopicStoreSubscriptionPermit, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
-    const state = topicStoreState(store);
+    const state = topicStoreState(permit.store);
     state.healthLedger.openSubscription(subscriber);
     state.subscribers.add(subscriber);
   }),
 );
 
-export const unregisterTopicStoreSubscription = Effect.fn(
+const unregisterTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.remove",
 )((store: TopicStore, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
@@ -250,7 +323,7 @@ export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
   }),
 );
 
-export const reportTopicStoreSubscriptionBackpressure = Effect.fn(
+const reportTopicStoreSubscriptionBackpressure = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.backpressure",
 )((store: TopicStore, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
@@ -259,53 +332,95 @@ export const reportTopicStoreSubscriptionBackpressure = Effect.fn(
   }),
 );
 
+export const closeTopicStoreSubscription = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.close",
+)(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
+  yield* withTopicStoreNotification(
+    store,
+    withTopicStoreTransaction(
+      store,
+      Effect.gen(function* () {
+        if (subscriber.closed) {
+          return;
+        }
+        subscriber.closed = true;
+        yield* unregisterTopicStoreSubscription(store, subscriber);
+        yield* finalize;
+      }),
+    ),
+  );
+});
+
+export const closeBackpressuredTopicStoreSubscription = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.closeBackpressured",
+)(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
+  yield* withTopicStoreTransaction(
+    store,
+    Effect.gen(function* () {
+      if (subscriber.closed) {
+        return;
+      }
+      subscriber.closed = true;
+      yield* reportTopicStoreSubscriptionBackpressure(store, subscriber);
+      yield* unregisterTopicStoreSubscription(store, subscriber);
+      yield* finalize;
+    }),
+  );
+});
+
 export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* (
   store: TopicStore,
 ) {
-  yield* withTopicStoreMutation(
+  yield* withTopicStoreNotification(
     store,
-    Effect.gen(function* () {
-      const subscribers = yield* Effect.sync(() => {
-        const state = topicStoreState(store);
-        state.rows.clear();
-        state.version = 0;
-        const closingSubscribers = [...state.subscribers];
-        for (const subscriber of closingSubscribers) {
-          subscriber.closed = true;
+    withTopicStoreTransaction(
+      store,
+      Effect.gen(function* () {
+        const subscribers = yield* Effect.sync(() => {
+          const state = topicStoreState(store);
+          state.rows.clear();
+          state.version = 0;
+          const closingSubscribers = [...state.subscribers];
+          for (const subscriber of closingSubscribers) {
+            subscriber.closed = true;
+          }
+          state.subscribers.clear();
+          state.healthLedger.reset();
+          return closingSubscribers;
+        });
+        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
+        for (const subscriber of subscribers) {
+          yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
         }
-        state.subscribers.clear();
-        state.healthLedger.reset();
-        return closingSubscribers;
-      });
-      yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
-      for (const subscriber of subscribers) {
-        yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
-      }
-    }),
+      }),
+    ),
   );
 });
 
 export const closeTopicStoreSubscriptions = Effect.fn(
   "ColumnLiveViewEngine.topicStore.closeSubscriptions",
 )(function* (store: TopicStore) {
-  yield* withTopicStoreMutation(
+  yield* withTopicStoreNotification(
     store,
-    Effect.gen(function* () {
-      const subscribers = yield* Effect.sync(() => {
-        const state = topicStoreState(store);
-        const closingSubscribers = [...state.subscribers];
-        for (const subscriber of closingSubscribers) {
-          subscriber.closed = true;
-          state.healthLedger.closeSubscription(subscriber);
+    withTopicStoreTransaction(
+      store,
+      Effect.gen(function* () {
+        const subscribers = yield* Effect.sync(() => {
+          const state = topicStoreState(store);
+          const closingSubscribers = [...state.subscribers];
+          for (const subscriber of closingSubscribers) {
+            subscriber.closed = true;
+            state.healthLedger.closeSubscription(subscriber);
+          }
+          state.subscribers.clear();
+          return closingSubscribers;
+        });
+        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
+        for (const subscriber of subscribers) {
+          yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
         }
-        state.subscribers.clear();
-        return closingSubscribers;
-      });
-      yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
-      for (const subscriber of subscribers) {
-        yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
-      }
-    }),
+      }),
+    ),
   );
 });
 
@@ -359,16 +474,10 @@ export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.p
 >(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
   const decoded = yield* decodeRow(store, row, invalidRow);
   const key = yield* rowKey(store, decoded, invalidRow);
-  yield* withTopicStoreMutationBatch(
-    store,
-    withTopicStoreMutation(
-      store,
-      commitTopicStoreMutation(store, (state) => {
-        state.rows.set(key, decoded);
-        return 1;
-      }),
-    ),
-  );
+  yield* commitAndNotifyTopicStoreMutation(store, (state) => {
+    state.rows.set(key, decoded);
+    return 1;
+  });
 });
 
 export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.publishMany")(
@@ -384,18 +493,12 @@ export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.
         return { key, row };
       }),
     );
-    yield* withTopicStoreMutationBatch(
-      store,
-      withTopicStoreMutation(
-        store,
-        commitTopicStoreMutation(store, (state) => {
-          for (const { key, row } of keyedRows) {
-            state.rows.set(key, row);
-          }
-          return keyedRows.length;
-        }),
-      ),
-    );
+    yield* commitAndNotifyTopicStoreMutation(store, (state) => {
+      for (const { key, row } of keyedRows) {
+        state.rows.set(key, row);
+      }
+      return keyedRows.length;
+    });
   },
 );
 
@@ -405,26 +508,31 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
 >(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
   yield* withTopicStoreMutationBatch(
     store,
-    withTopicStoreMutation(
-      store,
-      Effect.gen(function* () {
-        const state = topicStoreState(store);
-        yield* validatePatchKeys(store, patch, invalidRow);
-        const current = state.rows.get(key);
-        if (current === undefined) {
-          return yield* Effect.fail(invalidRow(store.topic, `Cannot patch missing key: ${key}`));
-        }
-        const decoded = yield* decodeRow(store, { ...current, ...patch }, invalidRow);
-        const decodedKey = yield* rowKey(store, decoded, invalidRow);
-        if (decodedKey !== key) {
-          return yield* Effect.fail(invalidRow(store.topic, "Patch must not change the row key."));
-        }
-        yield* commitTopicStoreMutation(store, (currentState) => {
-          currentState.rows.set(key, decoded);
-          return 1;
-        });
-      }),
-    ),
+    Effect.gen(function* () {
+      const subscribers = yield* withTopicStoreTransaction(
+        store,
+        Effect.gen(function* () {
+          const state = topicStoreState(store);
+          yield* validatePatchKeys(store, patch, invalidRow);
+          const current = state.rows.get(key);
+          if (current === undefined) {
+            return yield* Effect.fail(invalidRow(store.topic, `Cannot patch missing key: ${key}`));
+          }
+          const decoded = yield* decodeRow(store, { ...current, ...patch }, invalidRow);
+          const decodedKey = yield* rowKey(store, decoded, invalidRow);
+          if (decodedKey !== key) {
+            return yield* Effect.fail(
+              invalidRow(store.topic, "Patch must not change the row key."),
+            );
+          }
+          return yield* commitTopicStoreMutation(store, (currentState) => {
+            currentState.rows.set(key, decoded);
+            return 1;
+          });
+        }),
+      );
+      yield* notifyTopicStoreSubscribers(store, subscribers);
+    }),
   );
 });
 
@@ -432,13 +540,7 @@ export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.de
   store: TopicStore,
   key: string,
 ) {
-  yield* withTopicStoreMutationBatch(
-    store,
-    withTopicStoreMutation(
-      store,
-      commitTopicStoreMutation(store, (state) => {
-        return state.rows.delete(key) ? 1 : 0;
-      }),
-    ),
-  );
+  yield* commitAndNotifyTopicStoreMutation(store, (state) => {
+    return state.rows.delete(key) ? 1 : 0;
+  });
 });

--- a/packages/column-live-view-engine/src/topic-subscriber.ts
+++ b/packages/column-live-view-engine/src/topic-subscriber.ts
@@ -1,0 +1,15 @@
+import type { StatusEvent } from "@view-server/config";
+import type { Effect } from "effect";
+import type { TopicStore } from "./topic-store";
+
+export type LiveTopicSubscriber = {
+  readonly topic: string;
+  readonly queryId: string;
+  readonly notify: (store: TopicStore) => Effect.Effect<void>;
+  readonly queuedEvents: Effect.Effect<number>;
+  readonly end: Effect.Effect<void>;
+  readonly closeWithStatus: (event: StatusEvent) => Effect.Effect<void>;
+  maxQueueDepth: number;
+  backpressureEvents: number;
+  closed: boolean;
+};


### PR DESCRIPTION
## What changed

- Move live subscription handoff and subscriber contracts into focused internal modules.
- Make TopicStore own subscription acquisition through an internal permit seam.
- Add TopicStore mutation + notification serialization so backpressure can close without nested transaction deadlocks.
- Derive subscription query execution store/topic from the TopicStore permit instead of split parameters.
- Add lifecycle regressions for interrupted acquisition, idempotent backpressure close, stale closed-subscriber notification skipping, and interrupted close/reset cleanup.

## Validation

- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Review

- 3 local reviewer agents: final pass reported no findings.
