### PR TITLE
Introduce topic row scan interface

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -5,13 +5,13 @@ import {
   type CompiledRawQuery,
   type RuntimeRawQuery,
 } from "./raw-query-compiler";
-import type { RawQueryRowStore } from "./raw-query-compiler";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
+import type { TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 
-export type ActiveQueryStoreState = RawQueryRowStore<object> & {
+export type ActiveQueryStoreState = TopicRowScan<object> & {
   readonly identity: object;
   readonly topic: string;
 };
@@ -121,11 +121,13 @@ const evaluateBaseQuery = (
   store: ActiveQueryStoreState,
   compiled: CompiledRawQuery<object, object>,
 ): ActiveQueryBaseEvaluation => {
-  const storeRows = store.rows();
   const storeVersion = store.version();
-  const filtered = Array.from(storeRows, ([key, row]) => ({ key, row })).filter((entry) =>
-    compiled.matches(entry.row),
-  );
+  const filtered: Array<StoredRowOf<object>> = [];
+  store.scanRows((key, row) => {
+    if (compiled.matches(row)) {
+      filtered.push({ key, row });
+    }
+  });
   const ordered = filtered.toSorted(compiled.compare);
   const offset = compiled.offset;
   const window = ordered.slice(

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from "effect";
 import type { ActiveQueryStoreState } from "./active-query";
+import type { TopicRowVisitor } from "./row-scan";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
 
@@ -28,7 +29,7 @@ export class ColumnarTopicStore {
     this.readModel = {
       identity: this,
       topic,
-      rows: () => this.rows,
+      scanRows: (visitor) => this.scanRows(visitor),
       version: () => this.versionValue,
     };
   }
@@ -63,6 +64,12 @@ export class ColumnarTopicStore {
 
   delete(key: string): number {
     return this.rows.delete(key) ? 1 : 0;
+  }
+
+  scanRows(visitor: TopicRowVisitor<object>): void {
+    for (const [key, row] of this.rows) {
+      visitor(key, row);
+    }
   }
 
   prepareRow = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.prepare")(function* <

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -12,13 +12,10 @@ import {
   type RawQueryCompilerMetadata,
   prepareRawQuery,
 } from "./raw-query-compiler";
-import {
-  compareQueryValue,
-  stableQueryValueString,
-  type RawQueryRowStore,
-} from "./raw-query-compiler";
+import { compareQueryValue, stableQueryValueString } from "./raw-query-compiler";
 import { cloneUnknown, fieldValue, isPlainRecord } from "./row-values";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
+import type { TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 
@@ -59,7 +56,7 @@ export type CompiledGroupedQuery<Row extends RowObject, ResultRow extends RowObj
   readonly query: RuntimeGroupedQuery;
   readonly cacheKey: string;
   readonly matches: (row: Row) => boolean;
-  readonly evaluate: (store: RawQueryRowStore<Row>) => QueryEvaluation<ResultRow>;
+  readonly evaluate: (store: TopicRowScan<Row>) => QueryEvaluation<ResultRow>;
 };
 
 type AggregateState =
@@ -591,14 +588,14 @@ export const prepareGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.
 );
 
 const evaluateGroupedRows = <Row extends RowObject>(
-  store: RawQueryRowStore<Row>,
+  store: TopicRowScan<Row>,
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
 ): QueryEvaluation<RowObject> => {
   const groups = new Map<string, GroupState>();
-  for (const row of store.rows().values()) {
+  store.scanRows((_key, row) => {
     if (!matches(row)) {
-      continue;
+      return;
     }
     const key = groupKey(query.groupBy, row);
     let group = groups.get(key);
@@ -609,7 +606,7 @@ const evaluateGroupedRows = <Row extends RowObject>(
     for (const [alias, aggregate] of Object.entries(query.aggregates)) {
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
-  }
+  });
   const ordered = Array.from(groups.values(), finalizeGroup).toSorted((left, right) =>
     compareGroupedRows(left, right, query.orderBy ?? []),
   );
@@ -628,6 +625,6 @@ const evaluateGroupedRows = <Row extends RowObject>(
 };
 
 export const evaluateCompiledGroupedQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: RawQueryRowStore<Row>,
+  store: TopicRowScan<Row>,
   compiled: CompiledGroupedQuery<Row, ResultRow>,
 ): QueryEvaluation<ResultRow> => compiled.evaluate(store);

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -32,6 +32,7 @@ import {
   closeInterruptedAcquiredSubscription,
 } from "./subscription-handoff";
 import {
+  evaluateCompiledRawQuery,
   prepareRawQuery,
   rawQueryCompilerMetadata,
   stableQueryValueString,
@@ -937,7 +938,11 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       );
       const evaluation = evaluateCompiledGroupedQuery(
         {
-          rows: () => rows,
+          scanRows: (visitor) => {
+            for (const [key, row] of rows) {
+              visitor(key, row);
+            }
+          },
           version: () => 1,
         },
         compiled,
@@ -948,6 +953,57 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           totalQuantity: "3",
         },
       ]);
+    }),
+  );
+
+  it.effect("evaluates raw queries through the storage scan interface", () =>
+    Effect.gen(function* () {
+      const rows = [
+        { key: "closed", row: order("closed", "closed", 1, 1) },
+        { key: "open-high", row: order("open-high", "open", 20, 3) },
+        { key: "open-low", row: order("open-low", "open", 10, 2) },
+      ];
+      const compiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id", "price"],
+          where: {
+            status: "open",
+          },
+          orderBy: [
+            {
+              field: "price",
+              direction: "desc",
+            },
+          ],
+        },
+      );
+      const evaluation = evaluateCompiledRawQuery(
+        {
+          scanRows: (visitor) => {
+            for (const { key, row } of rows) {
+              visitor(key, row);
+            }
+          },
+          version: () => 7,
+        },
+        compiled,
+      );
+
+      expect(evaluation.keys).toStrictEqual(["open-high", "open-low"]);
+      expect(evaluation.rows).toStrictEqual([
+        {
+          id: "open-high",
+          price: 20,
+        },
+        {
+          id: "open-low",
+          price: 10,
+        },
+      ]);
+      expect(evaluation.totalRows).toBe(2);
+      expect(evaluation.version).toBe(7);
     }),
   );
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -10,6 +10,7 @@ import {
   valuesEqual,
 } from "./row-values";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
+import type { TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");
@@ -56,11 +57,6 @@ export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject>
   readonly project: (row: Row) => ResultRow;
   readonly offset: number;
   readonly limit: number | undefined;
-};
-
-export type RawQueryRowStore<Row extends RowObject> = {
-  readonly rows: () => ReadonlyMap<string, Row>;
-  readonly version: () => number;
 };
 
 type FilterObject = {
@@ -865,12 +861,15 @@ export const prepareRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.prepare"
 });
 
 export const evaluateCompiledRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: RawQueryRowStore<Row>,
+  store: TopicRowScan<Row>,
   compiled: CompiledRawQuery<Row, ResultRow>,
 ): QueryEvaluation<ResultRow> => {
-  const filtered = Array.from(store.rows(), ([key, row]) => ({ key, row })).filter((entry) =>
-    compiled.matches(entry.row),
-  );
+  const filtered: Array<StoredRowOf<Row>> = [];
+  store.scanRows((key, row) => {
+    if (compiled.matches(row)) {
+      filtered.push({ key, row });
+    }
+  });
   const ordered = filtered.toSorted(compiled.compare);
   const offset = compiled.offset;
   const windowed = ordered.slice(

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -1,0 +1,8 @@
+type RowObject = object;
+
+export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => void;
+
+export type TopicRowScan<Row extends RowObject> = {
+  readonly scanRows: (visitor: TopicRowVisitor<Row>) => void;
+  readonly version: () => number;
+};


### PR DESCRIPTION
## Summary
- add a storage-owned TopicRowScan visitor interface for engine row reads
- remove Active Query/raw/grouped query dependence on rows(): ReadonlyMap
- update ColumnarTopicStore to expose scanRows and add raw scan-only coverage

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Review
- 3-agent review cycle completed
- initial P2 on eager ReadonlyArray scan was fixed with visitor-style scanRows
- second review pass had no code findings
