### PR TITLE
Move raw query evaluation into Active Query

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -38,7 +38,7 @@ export type LiveQueryExecution<ResultRow extends RowObject> = {
 export type RawQueryExecution<ResultRow extends RowObject> = LiveQueryExecution<ResultRow>;
 
 type ActiveQueryBaseExecution = {
-  readonly latest: () => ActiveQueryBaseEvaluation;
+  readonly latest: () => ActiveQueryBaseEvaluation<object>;
 };
 
 type RawQueryExecutionSlot = {
@@ -51,9 +51,9 @@ type MaterializedQueryExecutionSlot = {
   refs: number;
 };
 
-type ActiveQueryBaseEvaluation = {
+type ActiveQueryBaseEvaluation<Row extends RowObject> = {
   readonly keys: ReadonlyArray<string>;
-  readonly window: ReadonlyArray<StoredRowOf<object>>;
+  readonly window: ReadonlyArray<StoredRowOf<Row>>;
   readonly totalRows: number;
   readonly version: number;
 };
@@ -117,12 +117,12 @@ const getActiveQueryEntry = <ResultRow extends RowObject>(
   return { map, key };
 };
 
-const evaluateBaseQuery = (
-  store: ActiveQueryStoreState,
-  compiled: CompiledRawQuery<object, object>,
-): ActiveQueryBaseEvaluation => {
+const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRowScan<Row>,
+  compiled: CompiledRawQuery<Row, ResultRow>,
+): ActiveQueryBaseEvaluation<Row> => {
   const storeVersion = store.version();
-  const filtered: Array<StoredRowOf<object>> = [];
+  const filtered: Array<StoredRowOf<Row>> = [];
   store.scanRows((key, row) => {
     if (compiled.matches(row)) {
       filtered.push({ key, row });
@@ -143,9 +143,9 @@ const evaluateBaseQuery = (
   };
 };
 
-const projectBaseEvaluation = <ResultRow extends RowObject>(
-  compiled: CompiledRawQuery<object, ResultRow>,
-  evaluation: ActiveQueryBaseEvaluation,
+const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  evaluation: ActiveQueryBaseEvaluation<Row>,
 ): QueryEvaluation<ResultRow> => {
   const window = evaluation.window.map((entry) => ({
     key: entry.key,
@@ -160,6 +160,12 @@ const projectBaseEvaluation = <ResultRow extends RowObject>(
     version: evaluation.version,
   };
 };
+
+export const evaluateRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRowScan<Row>,
+  compiled: CompiledRawQuery<Row, ResultRow>,
+): QueryEvaluation<ResultRow> =>
+  projectBaseEvaluation(compiled, evaluateBaseQuery(store, compiled));
 
 const leaseRawQueryExecution = <ResultRow extends RowObject>(
   store: ActiveQueryStoreState,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -24,6 +24,7 @@ import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
   activeStoreRawQueryExecutionCount,
+  evaluateRawQuery,
   releaseMaterializedQueryExecution,
 } from "./active-query";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
@@ -32,7 +33,6 @@ import {
   closeInterruptedAcquiredSubscription,
 } from "./subscription-handoff";
 import {
-  evaluateCompiledRawQuery,
   prepareRawQuery,
   rawQueryCompilerMetadata,
   stableQueryValueString,
@@ -979,7 +979,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           ],
         },
       );
-      const evaluation = evaluateCompiledRawQuery(
+      const evaluation = evaluateRawQuery(
         {
           scanRows: (visitor) => {
             for (const { key, row } of rows) {

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -3,6 +3,7 @@ import { makeLiveSubscription } from "./live-subscription";
 import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
+  evaluateRawQuery,
   releaseMaterializedQueryExecution,
   releaseRawQueryExecution,
 } from "./active-query";
@@ -11,11 +12,7 @@ import {
   prepareGroupedQuery,
   type CompiledGroupedQuery,
 } from "./grouped-query-compiler";
-import {
-  evaluateCompiledRawQuery,
-  prepareRawQuery,
-  type CompiledRawQuery,
-} from "./raw-query-compiler";
+import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
 import { liveQueryResult, type QueryEvaluation } from "./query-result";
 import {
   topicStoreRawQueryMetadata,
@@ -72,7 +69,7 @@ export const evaluateExecutableQuery = <ResultRow extends RowObject>(
   executable: ExecutableQuery<ResultRow>,
 ): QueryEvaluation<ResultRow> =>
   executable.kind === "raw"
-    ? evaluateCompiledRawQuery(topicStoreReadModel(store), executable.compiled)
+    ? evaluateRawQuery(topicStoreReadModel(store), executable.compiled)
     : evaluateCompiledGroupedQuery(topicStoreReadModel(store), executable.compiled);
 
 export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.snapshot")(

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -9,8 +9,7 @@ import {
   isRecord,
   valuesEqual,
 } from "./row-values";
-import type { QueryEvaluation, StoredRowOf } from "./query-result";
-import type { TopicRowScan } from "./row-scan";
+import type { StoredRowOf } from "./query-result";
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");
@@ -859,33 +858,3 @@ export const prepareRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.prepare"
   yield* validateRuntimeQuery(topic, metadata, decoded);
   return compileRawQuery<Row, ResultRow>(decoded);
 });
-
-export const evaluateCompiledRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: TopicRowScan<Row>,
-  compiled: CompiledRawQuery<Row, ResultRow>,
-): QueryEvaluation<ResultRow> => {
-  const filtered: Array<StoredRowOf<Row>> = [];
-  store.scanRows((key, row) => {
-    if (compiled.matches(row)) {
-      filtered.push({ key, row });
-    }
-  });
-  const ordered = filtered.toSorted(compiled.compare);
-  const offset = compiled.offset;
-  const windowed = ordered.slice(
-    offset,
-    compiled.limit === undefined ? undefined : offset + compiled.limit,
-  );
-  const window = windowed.map((entry) => ({
-    key: entry.key,
-    row: compiled.project(entry.row),
-  }));
-
-  return {
-    rows: window.map((entry) => entry.row),
-    keys: window.map((entry) => entry.key),
-    window,
-    totalRows: filtered.length,
-    version: store.version(),
-  };
-};


### PR DESCRIPTION
## Summary
- move raw query evaluation out of raw-query-compiler into active-query
- make evaluateRawQuery generic over TopicRowScan<Row> and CompiledRawQuery<Row, ResultRow>
- route raw snapshots through the same Active Query evaluation/projection path as raw live subscriptions

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run ready

## Review
- 3-agent review cycle completed
- one reviewer finding on widened ActiveQueryStoreState interface was fixed
- second review pass had no findings
