### PR TITLE
Decouple raw compiler row entries

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -6,8 +6,8 @@ import {
   type RuntimeRawQuery,
 } from "./raw-query-compiler";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
-import type { QueryEvaluation, StoredRowOf } from "./query-result";
-import type { TopicRowScan } from "./row-scan";
+import type { QueryEvaluation } from "./query-result";
+import type { TopicRowEntry, TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 
@@ -53,7 +53,7 @@ type MaterializedQueryExecutionSlot = {
 
 type ActiveQueryBaseEvaluation<Row extends RowObject> = {
   readonly keys: ReadonlyArray<string>;
-  readonly window: ReadonlyArray<StoredRowOf<Row>>;
+  readonly window: ReadonlyArray<TopicRowEntry<Row>>;
   readonly totalRows: number;
   readonly version: number;
 };
@@ -122,7 +122,7 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   compiled: CompiledRawQuery<Row, ResultRow>,
 ): ActiveQueryBaseEvaluation<Row> => {
   const storeVersion = store.version();
-  const filtered: Array<StoredRowOf<Row>> = [];
+  const filtered: Array<TopicRowEntry<Row>> = [];
   store.scanRows((key, row) => {
     if (compiled.matches(row)) {
       filtered.push({ key, row });

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -9,7 +9,7 @@ import {
   isRecord,
   valuesEqual,
 } from "./row-values";
-import type { StoredRowOf } from "./query-result";
+import type { TopicRowEntry } from "./row-scan";
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");
@@ -52,7 +52,7 @@ export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject>
   readonly [compiledRawQueryBrand]: true;
   readonly query: RuntimeRawQuery;
   readonly matches: (row: Row) => boolean;
-  readonly compare: (left: StoredRowOf<Row>, right: StoredRowOf<Row>) => number;
+  readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
   readonly project: (row: Row) => ResultRow;
   readonly offset: number;
   readonly limit: number | undefined;
@@ -790,8 +790,8 @@ const compileMatches = <Row extends RowObject>(
 };
 
 const compareRows = <Row extends RowObject>(
-  left: StoredRowOf<Row>,
-  right: StoredRowOf<Row>,
+  left: TopicRowEntry<Row>,
+  right: TopicRowEntry<Row>,
   orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
 ): number => {
   for (const order of orderBy) {

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -1,5 +1,10 @@
 type RowObject = object;
 
+export type TopicRowEntry<Row extends RowObject> = {
+  readonly key: string;
+  readonly row: Row;
+};
+
 export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => void;
 
 export type TopicRowScan<Row extends RowObject> = {


### PR DESCRIPTION
## Summary
- Add storage-facing TopicRowEntry to the row scan interface.
- Make raw query compilation depend on storage row entries instead of query-result StoredRowOf.
- Keep Active Query as the bridge from scanned storage rows into query evaluation output.

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run ready

## Review
- 3 local review agents reported no findings.