### PR TITLE
Split compiled raw query parts

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -124,15 +124,15 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   const storeVersion = store.version();
   const filtered: Array<TopicRowEntry<Row>> = [];
   store.scanRows((key, row) => {
-    if (compiled.matches(row)) {
+    if (compiled.predicate.matches(row)) {
       filtered.push({ key, row });
     }
   });
-  const ordered = filtered.toSorted(compiled.compare);
-  const offset = compiled.offset;
+  const ordered = filtered.toSorted(compiled.ordering.compare);
+  const offset = compiled.window.offset;
   const window = ordered.slice(
     offset,
-    compiled.limit === undefined ? undefined : offset + compiled.limit,
+    compiled.window.limit === undefined ? undefined : offset + compiled.window.limit,
   );
 
   return {
@@ -149,7 +149,7 @@ const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObjec
 ): QueryEvaluation<ResultRow> => {
   const window = evaluation.window.map((entry) => ({
     key: entry.key,
-    row: compiled.project(entry.row),
+    row: compiled.projection.project(entry.row),
   }));
 
   return {

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -577,7 +577,7 @@ export const prepareGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.
       select: decoded.groupBy,
       ...(decoded.where === undefined ? {} : { where: decoded.where }),
     });
-    const matches = rawFilter.matches;
+    const { matches } = rawFilter.predicate;
     return {
       query: decoded,
       cacheKey: groupedCacheKey(decoded),

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -51,9 +51,25 @@ export type RawQueryCompilerMetadata = {
 export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject> = {
   readonly [compiledRawQueryBrand]: true;
   readonly query: RuntimeRawQuery;
+  readonly predicate: CompiledRawPredicate<Row>;
+  readonly ordering: CompiledRawOrdering<Row>;
+  readonly projection: CompiledRawProjection<Row, ResultRow>;
+  readonly window: CompiledRawWindow;
+};
+
+export type CompiledRawPredicate<Row extends RowObject> = {
   readonly matches: (row: Row) => boolean;
+};
+
+export type CompiledRawOrdering<Row extends RowObject> = {
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
+};
+
+export type CompiledRawProjection<Row extends RowObject, ResultRow extends RowObject> = {
   readonly project: (row: Row) => ResultRow;
+};
+
+export type CompiledRawWindow = {
   readonly offset: number;
   readonly limit: number | undefined;
 };
@@ -773,19 +789,23 @@ const matchesFilter = (value: unknown, filter: unknown): boolean => {
 
 const compileMatches = <Row extends RowObject>(
   where: RuntimeRawQuery["where"],
-): ((row: Row) => boolean) => {
+): CompiledRawPredicate<Row> => {
   if (where === undefined) {
-    return () => true;
+    return {
+      matches: () => true,
+    };
   }
 
   const filters = Object.entries(where);
-  return (row) => {
-    for (const [field, filter] of filters) {
-      if (!matchesFilter(fieldValue(row, field), filter)) {
-        return false;
+  return {
+    matches: (row) => {
+      for (const [field, filter] of filters) {
+        if (!matchesFilter(fieldValue(row, field), filter)) {
+          return false;
+        }
       }
-    }
-    return true;
+      return true;
+    },
   };
 };
 
@@ -830,23 +850,47 @@ function projectCompiledRow(
 
 const compileProjection = <Row extends RowObject, ResultRow extends RowObject>(
   select: ReadonlyArray<string>,
-): ((row: Row) => ResultRow) => {
+): CompiledRawProjection<Row, ResultRow> => {
   const selectedFields = [...select];
-  return (row) => projectCompiledRow(row, selectedFields);
+  return {
+    project: (row) => projectCompiledRow(row, selectedFields),
+  };
+};
+
+const compileOrdering = <Row extends RowObject>(
+  orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
+): CompiledRawOrdering<Row> => ({
+  compare: (left, right) => compareRows(left, right, orderBy),
+});
+
+const compileWindow = (query: RuntimeRawQuery): CompiledRawWindow => ({
+  offset: query.offset ?? 0,
+  limit: query.limit,
+});
+
+const compileRawQueryParts = <Row extends RowObject, ResultRow extends RowObject>(
+  query: RuntimeRawQuery,
+): Pick<CompiledRawQuery<Row, ResultRow>, "predicate" | "ordering" | "projection" | "window"> => {
+  const orderBy = query.orderBy ?? [];
+  return {
+    predicate: compileMatches(query.where),
+    ordering: compileOrdering(orderBy),
+    projection: compileProjection(query.select),
+    window: compileWindow(query),
+  };
 };
 
 const compileRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
   query: RuntimeRawQuery,
 ): CompiledRawQuery<Row, ResultRow> => {
-  const orderBy = query.orderBy ?? [];
+  const parts = compileRawQueryParts<Row, ResultRow>(query);
   return {
     [compiledRawQueryBrand]: true,
     query,
-    matches: compileMatches(query.where),
-    compare: (left, right) => compareRows(left, right, orderBy),
-    project: compileProjection(query.select),
-    offset: query.offset ?? 0,
-    limit: query.limit,
+    predicate: parts.predicate,
+    ordering: parts.ordering,
+    projection: parts.projection,
+    window: parts.window,
   };
 };
 


### PR DESCRIPTION
## Summary
- Split CompiledRawQuery into explicit predicate, ordering, projection, and window parts.
- Update Active Query to evaluate through those parts.
- Keep grouped query filtering reusing the raw predicate part.

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Review
- 3 local review agents reported no findings.
- Existing raw/grouped/live E2E coverage was considered sufficient because behavior is unchanged.