### PR TITLE
Move raw window scan into storage

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -7,14 +7,15 @@ import {
 } from "./raw-query-compiler";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
-import type { TopicRowEntry, TopicRowScan } from "./row-scan";
+import type { TopicRawWindowScan, TopicRawWindowScanResult, TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 
-export type ActiveQueryStoreState = TopicRowScan<object> & {
-  readonly identity: object;
-  readonly topic: string;
-};
+export type ActiveQueryStoreState = TopicRowScan<object> &
+  TopicRawWindowScan<object> & {
+    readonly identity: object;
+    readonly topic: string;
+  };
 
 export type LiveQueryExecutionCursor<ResultRow extends RowObject> = {
   evaluation: QueryEvaluation<ResultRow>;
@@ -51,10 +52,7 @@ type MaterializedQueryExecutionSlot = {
   refs: number;
 };
 
-type ActiveQueryBaseEvaluation<Row extends RowObject> = {
-  readonly keys: ReadonlyArray<string>;
-  readonly window: ReadonlyArray<TopicRowEntry<Row>>;
-  readonly totalRows: number;
+type ActiveQueryBaseEvaluation<Row extends RowObject> = TopicRawWindowScanResult<Row> & {
   readonly version: number;
 };
 
@@ -118,28 +116,19 @@ const getActiveQueryEntry = <ResultRow extends RowObject>(
 };
 
 const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: TopicRowScan<Row>,
+  store: TopicRawWindowScan<Row> & { readonly version: () => number },
   compiled: CompiledRawQuery<Row, ResultRow>,
 ): ActiveQueryBaseEvaluation<Row> => {
-  const storeVersion = store.version();
-  const filtered: Array<TopicRowEntry<Row>> = [];
-  store.scanRows((key, row) => {
-    if (compiled.predicate.matches(row)) {
-      filtered.push({ key, row });
-    }
+  const version = store.version();
+  const window = store.scanRawWindow({
+    matches: compiled.predicate.matches,
+    compare: compiled.ordering.compare,
+    offset: compiled.window.offset,
+    limit: compiled.window.limit,
   });
-  const ordered = filtered.toSorted(compiled.ordering.compare);
-  const offset = compiled.window.offset;
-  const window = ordered.slice(
-    offset,
-    compiled.window.limit === undefined ? undefined : offset + compiled.window.limit,
-  );
-
   return {
-    keys: window.map((entry) => entry.key),
-    window,
-    totalRows: filtered.length,
-    version: storeVersion,
+    ...window,
+    version,
   };
 };
 
@@ -162,7 +151,7 @@ const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObjec
 };
 
 export const evaluateRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: TopicRowScan<Row>,
+  store: TopicRawWindowScan<Row> & { readonly version: () => number },
   compiled: CompiledRawQuery<Row, ResultRow>,
 ): QueryEvaluation<ResultRow> =>
   projectBaseEvaluation(compiled, evaluateBaseQuery(store, compiled));

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -1,6 +1,11 @@
 import { Effect, Schema } from "effect";
 import type { ActiveQueryStoreState } from "./active-query";
-import type { TopicRowVisitor } from "./row-scan";
+import type {
+  TopicRawWindowScanPlan,
+  TopicRawWindowScanResult,
+  TopicRowEntry,
+  TopicRowVisitor,
+} from "./row-scan";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
 
@@ -30,6 +35,7 @@ export class ColumnarTopicStore {
       identity: this,
       topic,
       scanRows: (visitor) => this.scanRows(visitor),
+      scanRawWindow: (plan) => this.scanRawWindow(plan),
       version: () => this.versionValue,
     };
   }
@@ -70,6 +76,25 @@ export class ColumnarTopicStore {
     for (const [key, row] of this.rows) {
       visitor(key, row);
     }
+  }
+
+  scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
+    const filtered: Array<TopicRowEntry<object>> = [];
+    for (const [key, row] of this.rows) {
+      if (plan.matches(row)) {
+        filtered.push({ key, row });
+      }
+    }
+    const ordered = filtered.toSorted(plan.compare);
+    const window = ordered.slice(
+      plan.offset,
+      plan.limit === undefined ? undefined : plan.offset + plan.limit,
+    );
+    return {
+      keys: window.map((entry) => entry.key),
+      window,
+      totalRows: filtered.length,
+    };
   }
 
   prepareRow = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.prepare")(function* <

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -981,10 +981,18 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       );
       const evaluation = evaluateRawQuery(
         {
-          scanRows: (visitor) => {
-            for (const { key, row } of rows) {
-              visitor(key, row);
-            }
+          scanRawWindow: (plan) => {
+            const filtered = rows.filter((entry) => plan.matches(entry.row));
+            const ordered = filtered.toSorted(plan.compare);
+            const window = ordered.slice(
+              plan.offset,
+              plan.limit === undefined ? undefined : plan.offset + plan.limit,
+            );
+            return {
+              keys: window.map((entry) => entry.key),
+              window,
+              totalRows: filtered.length,
+            };
           },
           version: () => 7,
         },

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -7,7 +7,24 @@ export type TopicRowEntry<Row extends RowObject> = {
 
 export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => void;
 
+export type TopicRawWindowScanPlan<Row extends RowObject> = {
+  readonly matches: (row: Row) => boolean;
+  readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
+  readonly offset: number;
+  readonly limit: number | undefined;
+};
+
+export type TopicRawWindowScanResult<Row extends RowObject> = {
+  readonly keys: ReadonlyArray<string>;
+  readonly window: ReadonlyArray<TopicRowEntry<Row>>;
+  readonly totalRows: number;
+};
+
 export type TopicRowScan<Row extends RowObject> = {
   readonly scanRows: (visitor: TopicRowVisitor<Row>) => void;
   readonly version: () => number;
+};
+
+export type TopicRawWindowScan<Row extends RowObject> = {
+  readonly scanRawWindow: (plan: TopicRawWindowScanPlan<Row>) => TopicRawWindowScanResult<Row>;
 };


### PR DESCRIPTION
## Summary
- Add separate TopicRawWindowScan Interface for raw window materialization.
- Keep TopicRowScan narrow for grouped callers.
- Move raw filter/order/window materialization into ColumnarTopicStore scanRawWindow.
- Keep Active Query responsible for projection, snapshots, deltas, and version attachment.

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Review
- First review round found Interface Locality and version-source issues.
- Fixed by splitting TopicRowScan and TopicRawWindowScan, and by using store.version as the only raw evaluation version source.
- Second review round: 3 local review agents reported no findings.