### PR TITLE
Expose declarative raw scan metadata

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -121,6 +121,8 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
 ): ActiveQueryBaseEvaluation<Row> => {
   const version = store.version();
   const window = store.scanRawWindow({
+    where: compiled.query.where,
+    orderBy: compiled.query.orderBy ?? [],
     matches: compiled.predicate.matches,
     compare: compiled.ordering.compare,
     offset: compiled.window.offset,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -982,6 +982,15 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       const evaluation = evaluateRawQuery(
         {
           scanRawWindow: (plan) => {
+            expect(plan.where).toStrictEqual({
+              status: "open",
+            });
+            expect(plan.orderBy).toStrictEqual([
+              {
+                field: "price",
+                direction: "desc",
+              },
+            ]);
             const filtered = rows.filter((entry) => plan.matches(entry.row));
             const ordered = filtered.toSorted(plan.compare);
             const window = ordered.slice(

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -7,7 +7,14 @@ export type TopicRowEntry<Row extends RowObject> = {
 
 export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => void;
 
+export type TopicRawOrderByPlan = {
+  readonly field: string;
+  readonly direction: "asc" | "desc";
+};
+
 export type TopicRawWindowScanPlan<Row extends RowObject> = {
+  readonly where: Readonly<Record<string, unknown>> | undefined;
+  readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
   readonly matches: (row: Row) => boolean;
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
   readonly offset: number;


### PR DESCRIPTION
## Summary
- Add declarative where and orderBy metadata to TopicRawWindowScanPlan.
- Pass decoded raw query metadata from Active Query into storage scan plans.
- Add an interface-focused test proving scanRawWindow receives the expected metadata.

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Review
- First local review round found a semantic test gap.
- Added metadata assertions in the fake raw scan test.
- Second local review round: 3 review agents reported no findings.