### PR TITLE
Add typed raw scan plans

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -122,7 +122,8 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   const version = store.version();
   const window = store.scanRawWindow({
     where: compiled.query.where,
-    orderBy: compiled.query.orderBy ?? [],
+    predicate: compiled.predicate.plan,
+    orderBy: compiled.ordering.plan,
     matches: compiled.predicate.matches,
     compare: compiled.ordering.compare,
     offset: compiled.window.offset,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -985,6 +985,16 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.where).toStrictEqual({
               status: "open",
             });
+            expect(plan.predicate).toStrictEqual({
+              filters: [
+                {
+                  field: "status",
+                  operator: "eq",
+                  value: "open",
+                },
+              ],
+              callbackRequired: false,
+            });
             expect(plan.orderBy).toStrictEqual([
               {
                 field: "price",
@@ -1021,6 +1031,554 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       ]);
       expect(evaluation.totalRows).toBe(2);
       expect(evaluation.version).toBe(7);
+    }),
+  );
+
+  it.effect("passes typed scalar predicate plans to the storage scan interface", () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id"],
+          where: {
+            status: {
+              neq: "cancelled",
+              in: ["open", "closed"],
+            },
+            price: {
+              neq: 50,
+              gt: 1,
+              gte: 2,
+              lt: 100,
+              lte: 99,
+            },
+            customerId: {
+              startsWith: "customer-",
+            },
+            region: "emea",
+          },
+          orderBy: [
+            {
+              field: "region",
+              direction: "asc",
+            },
+            {
+              field: "price",
+              direction: "desc",
+            },
+          ],
+        },
+      );
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [
+                {
+                  field: "status",
+                  operator: "neq",
+                  value: "cancelled",
+                },
+                {
+                  field: "status",
+                  operator: "in",
+                  values: ["open", "closed"],
+                },
+                {
+                  field: "price",
+                  operator: "neq",
+                  value: 50,
+                },
+                {
+                  field: "price",
+                  operator: "gt",
+                  value: 1,
+                },
+                {
+                  field: "price",
+                  operator: "gte",
+                  value: 2,
+                },
+                {
+                  field: "price",
+                  operator: "lt",
+                  value: 100,
+                },
+                {
+                  field: "price",
+                  operator: "lte",
+                  value: 99,
+                },
+                {
+                  field: "customerId",
+                  operator: "startsWith",
+                  value: "customer-",
+                },
+                {
+                  field: "region",
+                  operator: "eq",
+                  value: "emea",
+                },
+              ],
+              callbackRequired: false,
+            });
+            expect(plan.orderBy).toStrictEqual([
+              {
+                field: "region",
+                direction: "asc",
+              },
+              {
+                field: "price",
+                direction: "desc",
+              },
+            ]);
+            expect(plan.matches(order("open-low", "open", 10, 2))).toBe(true);
+            expect(plan.matches(order("cancelled", "cancelled", 10, 2))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 11,
+        },
+        compiled,
+      );
+
+      expect(evaluation.keys).toStrictEqual([]);
+      expect(evaluation.rows).toStrictEqual([]);
+      expect(evaluation.totalRows).toBe(0);
+      expect(evaluation.version).toBe(11);
+    }),
+  );
+
+  it.effect("passes typed bigint and bigdecimal range plans to the storage scan interface", () =>
+    Effect.gen(function* () {
+      const excludedPrice = fromStringUnsafe("0");
+      const maxPrice = fromStringUnsafe("100");
+      const compiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id"],
+          where: {
+            quantity: {
+              gte: 10n,
+            },
+            price: {
+              neq: excludedPrice,
+              lt: maxPrice,
+            },
+          },
+        },
+      );
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [
+                {
+                  field: "quantity",
+                  operator: "gte",
+                  value: 10n,
+                },
+                {
+                  field: "price",
+                  operator: "neq",
+                  value: excludedPrice,
+                },
+                {
+                  field: "price",
+                  operator: "lt",
+                  value: maxPrice,
+                },
+              ],
+              callbackRequired: false,
+            });
+            expect(plan.matches(position("aapl", "AAPL", 20n, "10"))).toBe(true);
+            expect(plan.matches(position("goog", "GOOG", 1n, "10"))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 12,
+        },
+        compiled,
+      );
+
+      expect(evaluation.keys).toStrictEqual([]);
+      expect(evaluation.rows).toStrictEqual([]);
+      expect(evaluation.totalRows).toBe(0);
+      expect(evaluation.version).toBe(12);
+    }),
+  );
+
+  it.effect("passes typed numeric literal range plans to the storage scan interface", () =>
+    Effect.gen(function* () {
+      const LiteralMetrics = Schema.Struct({
+        id: Schema.String,
+        score: Schema.Literal(1),
+        bucket: Schema.Literal(1n),
+      });
+      const compiled = yield* prepareRawQuery<object, object>(
+        "literalMetrics",
+        rawQueryCompilerMetadata(LiteralMetrics),
+        {
+          select: ["id"],
+          where: {
+            score: {
+              gte: 1,
+            },
+            bucket: {
+              lte: 1n,
+            },
+          },
+        },
+      );
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [
+                {
+                  field: "score",
+                  operator: "gte",
+                  value: 1,
+                },
+                {
+                  field: "bucket",
+                  operator: "lte",
+                  value: 1n,
+                },
+              ],
+              callbackRequired: false,
+            });
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 18,
+        },
+        compiled,
+      );
+
+      expect(evaluation.keys).toStrictEqual([]);
+      expect(evaluation.rows).toStrictEqual([]);
+      expect(evaluation.totalRows).toBe(0);
+      expect(evaluation.version).toBe(18);
+    }),
+  );
+
+  it.effect("keeps malformed scalar operators callback-only in the storage scan plan", () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id"],
+          where: {
+            status: {
+              eq: undefined,
+              in: [undefined],
+            },
+            price: {
+              gt: undefined,
+              gte: "9",
+              lt: Number.NaN,
+              lte: fromStringUnsafe("50"),
+            },
+            customerId: {
+              startsWith: 1,
+            },
+            note: undefined,
+          },
+        },
+      );
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches(order("open", "open", 10, 1))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 14,
+        },
+        compiled,
+      );
+
+      expect(evaluation.keys).toStrictEqual([]);
+      expect(evaluation.rows).toStrictEqual([]);
+      expect(evaluation.totalRows).toBe(0);
+      expect(evaluation.version).toBe(14);
+
+      const structuredScalarCompiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id"],
+          where: {
+            status: ["open"],
+            customerId: {
+              eq: ["customer-open"],
+            },
+            region: {
+              in: [["emea"]],
+            },
+            price: Number.NaN,
+          },
+        },
+      );
+      const structuredScalarEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches(order("open", "open", 10, 1))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 17,
+        },
+        structuredScalarCompiled,
+      );
+
+      expect(structuredScalarEvaluation.keys).toStrictEqual([]);
+      expect(structuredScalarEvaluation.rows).toStrictEqual([]);
+      expect(structuredScalarEvaluation.totalRows).toBe(0);
+      expect(structuredScalarEvaluation.version).toBe(17);
+
+      const bigintCompiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id"],
+          where: {
+            quantity: {
+              neq: 1,
+            },
+          },
+        },
+      );
+      const bigintEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches(position("bad", "BAD", 10n, "10"))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 15,
+        },
+        bigintCompiled,
+      );
+
+      expect(bigintEvaluation.keys).toStrictEqual([]);
+      expect(bigintEvaluation.rows).toStrictEqual([]);
+      expect(bigintEvaluation.totalRows).toBe(0);
+      expect(bigintEvaluation.version).toBe(15);
+
+      const bigDecimalCompiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id"],
+          where: {
+            price: {
+              lt: 100,
+            },
+          },
+        },
+      );
+      const bigDecimalEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches(position("bad-price", "BAD", 10n, "10"))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 16,
+        },
+        bigDecimalCompiled,
+      );
+
+      expect(bigDecimalEvaluation.keys).toStrictEqual([]);
+      expect(bigDecimalEvaluation.rows).toStrictEqual([]);
+      expect(bigDecimalEvaluation.totalRows).toBe(0);
+      expect(bigDecimalEvaluation.version).toBe(16);
+
+      const booleanCompiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id"],
+          where: {
+            active: {
+              neq: true,
+            },
+          },
+        },
+      );
+      const booleanEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches(position("active", "ACT", 10n, "10", true))).toBe(false);
+            expect(plan.matches(position("inactive", "INA", 10n, "10", false))).toBe(true);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 19,
+        },
+        booleanCompiled,
+      );
+
+      expect(booleanEvaluation.keys).toStrictEqual([]);
+      expect(booleanEvaluation.rows).toStrictEqual([]);
+      expect(booleanEvaluation.totalRows).toBe(0);
+      expect(booleanEvaluation.version).toBe(19);
+
+      const MixedNumeric = Schema.Struct({
+        id: Schema.String,
+        amount: Schema.Union([Schema.Number, Schema.BigInt, Schema.BigDecimal]),
+      });
+      const mixedNumericCompiled = yield* prepareRawQuery<object, object>(
+        "mixedNumeric",
+        rawQueryCompilerMetadata(MixedNumeric),
+        {
+          select: ["id"],
+          where: {
+            amount: {
+              gt: 1,
+            },
+          },
+        },
+      );
+      const mixedNumericEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches({ id: "number", amount: 2 })).toBe(true);
+            expect(plan.matches({ id: "bigint", amount: 2n })).toBe(false);
+            expect(plan.matches({ id: "decimal", amount: fromStringUnsafe("2") })).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 20,
+        },
+        mixedNumericCompiled,
+      );
+
+      expect(mixedNumericEvaluation.keys).toStrictEqual([]);
+      expect(mixedNumericEvaluation.rows).toStrictEqual([]);
+      expect(mixedNumericEvaluation.totalRows).toBe(0);
+      expect(mixedNumericEvaluation.version).toBe(20);
+    }),
+  );
+
+  it.effect("keeps structured object predicates callback-only in the storage scan plan", () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery<object, object>(
+        "instruments",
+        rawQueryCompilerMetadata(Instrument),
+        {
+          select: ["id"],
+          where: {
+            operatorLike: {
+              eq: "xnys",
+            },
+            operatorRangeLike: {
+              gte: 2,
+            },
+            tags: ["equity"],
+          },
+        },
+      );
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.where).toStrictEqual({
+              operatorLike: {
+                eq: "xnys",
+              },
+              operatorRangeLike: {
+                gte: 2,
+              },
+              tags: ["equity"],
+            });
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+            });
+            expect(plan.matches(instrument("1", "xnys", 1, ["equity"]))).toBe(false);
+            expect(plan.matches(instrument("2", "xlon", 2, ["equity"]))).toBe(false);
+            const directMatch = instrument("3", "xnys", 2, ["equity"]);
+            expect(plan.matches(directMatch)).toBe(true);
+            return {
+              keys: ["3"],
+              window: [
+                {
+                  key: "3",
+                  row: directMatch,
+                },
+              ],
+              totalRows: 1,
+            };
+          },
+          version: () => 13,
+        },
+        compiled,
+      );
+
+      expect(evaluation.keys).toStrictEqual(["3"]);
+      expect(evaluation.rows).toStrictEqual([
+        {
+          id: "3",
+        },
+      ]);
+      expect(evaluation.totalRows).toBe(1);
+      expect(evaluation.version).toBe(13);
     }),
   );
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -1,5 +1,5 @@
 import { viewServerSchemaFieldMetadata, type FieldKey, type OrderBy } from "@view-server/config";
-import { Effect, Schema } from "effect";
+import { Effect, Schema, SchemaAST } from "effect";
 import { format as formatBigDecimal, isBigDecimal, normalize, Order } from "effect/BigDecimal";
 import {
   cloneRecord,
@@ -9,7 +9,7 @@ import {
   isRecord,
   valuesEqual,
 } from "./row-values";
-import type { TopicRowEntry } from "./row-scan";
+import type { TopicRawOrderByPlan, TopicRawPredicatePlan, TopicRowEntry } from "./row-scan";
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");
@@ -45,7 +45,7 @@ export type RawQueryCompilerMetadata = {
   readonly stringFieldNames: ReadonlySet<string>;
   readonly numericFieldNames: ReadonlySet<string>;
   readonly bigintFieldNames: ReadonlySet<string>;
-  readonly bigDecimalFieldNames: ReadonlySet<string>;
+  readonly rangeValueKinds: ReadonlyMap<string, ReadonlySet<RangeValueKind>>;
 };
 
 export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject> = {
@@ -58,10 +58,12 @@ export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject>
 };
 
 export type CompiledRawPredicate<Row extends RowObject> = {
+  readonly plan: TopicRawPredicatePlan;
   readonly matches: (row: Row) => boolean;
 };
 
 export type CompiledRawOrdering<Row extends RowObject> = {
+  readonly plan: ReadonlyArray<TopicRawOrderByPlan>;
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
 };
 
@@ -84,6 +86,8 @@ type FilterObject = {
   readonly lte?: unknown;
   readonly startsWith?: string;
 };
+
+type RangeValueKind = "number" | "bigint" | "bigDecimal";
 
 const rawQueryKeys = new Set(["where", "orderBy", "offset", "limit", "select"]);
 const filterOperatorKeys = new Set(["eq", "neq", "in", "gt", "gte", "lt", "lte", "startsWith"]);
@@ -137,6 +141,50 @@ const isQueryValueSafe = (value: unknown, active: WeakSet<object> = new WeakSet(
 const isSchemaWithFields = (schema: Schema.Decoder<object>): schema is SchemaWithFields =>
   "fields" in schema && isRecord(schema.fields);
 
+const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
+  if (!isRecord(schema)) {
+    return undefined;
+  }
+  const ast = schema["ast"];
+  return SchemaAST.isAST(ast) ? ast : undefined;
+};
+
+const isBigDecimalAst = (ast: SchemaAST.AST): boolean =>
+  SchemaAST.isDeclaration(ast) &&
+  isRecord(ast.annotations?.["typeConstructor"]) &&
+  ast.annotations["typeConstructor"]["_tag"] === "effect/BigDecimal";
+
+const rangeValueKindsAst = (ast: SchemaAST.AST): ReadonlySet<RangeValueKind> => {
+  if (SchemaAST.isNumber(ast)) {
+    return new Set(["number"]);
+  }
+  if (SchemaAST.isBigInt(ast)) {
+    return new Set(["bigint"]);
+  }
+  if (isBigDecimalAst(ast)) {
+    return new Set(["bigDecimal"]);
+  }
+  if (SchemaAST.isLiteral(ast)) {
+    if (typeof ast.literal === "number") {
+      return new Set(["number"]);
+    }
+    if (typeof ast.literal === "bigint") {
+      return new Set(["bigint"]);
+    }
+    return new Set();
+  }
+  if (!SchemaAST.isUnion(ast) || ast.types.length === 0) {
+    return new Set();
+  }
+  const kinds = new Set<RangeValueKind>();
+  for (const member of ast.types) {
+    for (const kind of rangeValueKindsAst(member)) {
+      kinds.add(kind);
+    }
+  }
+  return kinds;
+};
+
 const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
   isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
 
@@ -183,15 +231,22 @@ const schemaBigintFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<str
   return fields;
 };
 
-const schemaBigDecimalFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+const schemaRangeValueKinds = (
+  schema: Schema.Decoder<object>,
+): ReadonlyMap<string, ReadonlySet<RangeValueKind>> => {
   if (!isSchemaWithFields(schema)) {
-    return new Set();
+    return new Map();
   }
 
-  const fields = new Set<string>();
+  const fields = new Map<string, ReadonlySet<RangeValueKind>>();
   for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    if (viewServerSchemaFieldMetadata(fieldSchema).sumResultKind === "bigDecimal") {
-      fields.add(field);
+    const ast = schemaAst(fieldSchema);
+    if (ast === undefined) {
+      continue;
+    }
+    const kinds = rangeValueKindsAst(ast);
+    if (kinds.size > 0) {
+      fields.set(field, kinds);
     }
   }
   return fields;
@@ -249,7 +304,7 @@ export const rawQueryCompilerMetadata = (
   stringFieldNames: schemaStringFieldNames(schema),
   numericFieldNames: schemaNumericFieldNames(schema),
   bigintFieldNames: schemaBigintFieldNames(schema),
-  bigDecimalFieldNames: schemaBigDecimalFieldNames(schema),
+  rangeValueKinds: schemaRangeValueKinds(schema),
 });
 
 const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")((
@@ -787,17 +842,232 @@ const matchesFilter = (value: unknown, filter: unknown): boolean => {
   return true;
 };
 
-const compileMatches = <Row extends RowObject>(
+const rangeValueKind = (value: unknown): RangeValueKind | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return "number";
+  }
+  if (typeof value === "bigint") {
+    return "bigint";
+  }
+  if (isBigDecimal(value)) {
+    return "bigDecimal";
+  }
+  return undefined;
+};
+
+const isScalarPlanValue = (value: unknown): boolean =>
+  value === null ||
+  typeof value === "string" ||
+  typeof value === "boolean" ||
+  typeof value === "bigint" ||
+  isBigDecimal(value) ||
+  (typeof value === "number" && Number.isFinite(value));
+
+const isRangePlanValue = (
+  field: string,
+  value: unknown,
+  metadata: RawQueryCompilerMetadata,
+): boolean => {
+  const kind = rangeValueKind(value);
+  const fieldKinds = metadata.rangeValueKinds.get(field);
+  return kind !== undefined && fieldKinds?.size === 1 && fieldKinds.has(kind);
+};
+
+const isEqualityPlanValue = (value: unknown): boolean => isScalarPlanValue(value);
+
+const isNotEqualPlanValue = (
+  field: string,
+  value: unknown,
+  metadata: RawQueryCompilerMetadata,
+): boolean => {
+  if (!isEqualityPlanValue(value)) {
+    return false;
+  }
+  if (metadata.numericFieldNames.has(field)) {
+    return isRangePlanValue(field, value, metadata);
+  }
+  if (metadata.stringFieldNames.has(field)) {
+    return typeof value === "string";
+  }
+  return false;
+};
+
+const isInPlanValues = (value: unknown): value is ReadonlyArray<unknown> =>
+  Array.isArray(value) &&
+  isDenseArray(value) &&
+  value.every((candidate) => isEqualityPlanValue(candidate));
+
+type PredicateFieldPlan = {
+  readonly filters: TopicRawPredicatePlan["filters"];
+  readonly callbackRequired: boolean;
+};
+
+const predicateFilterPlans = (
+  field: string,
+  filter: unknown,
+  metadata: RawQueryCompilerMetadata,
+): PredicateFieldPlan => {
+  if (metadata.structuredFieldNames.has(field) || filter === undefined) {
+    return {
+      filters: [],
+      callbackRequired: true,
+    };
+  }
+  if (!isPlainRecord(filter) || isBigDecimal(filter)) {
+    if (!isScalarPlanValue(filter)) {
+      return {
+        filters: [],
+        callbackRequired: true,
+      };
+    }
+    return {
+      filters: [
+        {
+          field,
+          operator: "eq",
+          value: filter,
+        },
+      ],
+      callbackRequired: false,
+    };
+  }
+
+  const operatorKeys = Object.keys(filter).filter((key) => filterOperatorKeys.has(key));
+  let callbackRequired = operatorKeys.length === 0;
+  const plans: Array<TopicRawPredicatePlan["filters"][number]> = [];
+  if ("eq" in filter) {
+    if (isEqualityPlanValue(filter["eq"])) {
+      plans.push({
+        field,
+        operator: "eq",
+        value: filter["eq"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("neq" in filter) {
+    if (isNotEqualPlanValue(field, filter["neq"], metadata)) {
+      plans.push({
+        field,
+        operator: "neq",
+        value: filter["neq"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("in" in filter) {
+    if (isInPlanValues(filter["in"])) {
+      plans.push({
+        field,
+        operator: "in",
+        values: [...filter["in"]],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("gt" in filter) {
+    if (isRangePlanValue(field, filter["gt"], metadata)) {
+      plans.push({
+        field,
+        operator: "gt",
+        value: filter["gt"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("gte" in filter) {
+    if (isRangePlanValue(field, filter["gte"], metadata)) {
+      plans.push({
+        field,
+        operator: "gte",
+        value: filter["gte"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("lt" in filter) {
+    if (isRangePlanValue(field, filter["lt"], metadata)) {
+      plans.push({
+        field,
+        operator: "lt",
+        value: filter["lt"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("lte" in filter) {
+    if (isRangePlanValue(field, filter["lte"], metadata)) {
+      plans.push({
+        field,
+        operator: "lte",
+        value: filter["lte"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("startsWith" in filter) {
+    if (typeof filter["startsWith"] === "string") {
+      plans.push({
+        field,
+        operator: "startsWith",
+        value: filter["startsWith"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  return {
+    filters: plans,
+    callbackRequired,
+  };
+};
+
+const compilePredicatePlan = (
+  metadata: RawQueryCompilerMetadata,
   where: RuntimeRawQuery["where"],
-): CompiledRawPredicate<Row> => {
+): TopicRawPredicatePlan => {
   if (where === undefined) {
     return {
+      filters: [],
+      callbackRequired: false,
+    };
+  }
+
+  const filters: Array<TopicRawPredicatePlan["filters"][number]> = [];
+  let callbackRequired = false;
+  for (const [field, filter] of Object.entries(where)) {
+    const fieldPlan = predicateFilterPlans(field, filter, metadata);
+    filters.push(...fieldPlan.filters);
+    callbackRequired ||= fieldPlan.callbackRequired;
+  }
+  return {
+    filters,
+    callbackRequired,
+  };
+};
+
+const compileMatches = <Row extends RowObject>(
+  metadata: RawQueryCompilerMetadata,
+  where: RuntimeRawQuery["where"],
+): CompiledRawPredicate<Row> => {
+  const plan = compilePredicatePlan(metadata, where);
+  if (where === undefined) {
+    return {
+      plan,
       matches: () => true,
     };
   }
 
   const filters = Object.entries(where);
   return {
+    plan,
     matches: (row) => {
       for (const [field, filter] of filters) {
         if (!matchesFilter(fieldValue(row, field), filter)) {
@@ -860,6 +1130,7 @@ const compileProjection = <Row extends RowObject, ResultRow extends RowObject>(
 const compileOrdering = <Row extends RowObject>(
   orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
 ): CompiledRawOrdering<Row> => ({
+  plan: [...orderBy],
   compare: (left, right) => compareRows(left, right, orderBy),
 });
 
@@ -869,11 +1140,12 @@ const compileWindow = (query: RuntimeRawQuery): CompiledRawWindow => ({
 });
 
 const compileRawQueryParts = <Row extends RowObject, ResultRow extends RowObject>(
+  metadata: RawQueryCompilerMetadata,
   query: RuntimeRawQuery,
 ): Pick<CompiledRawQuery<Row, ResultRow>, "predicate" | "ordering" | "projection" | "window"> => {
   const orderBy = query.orderBy ?? [];
   return {
-    predicate: compileMatches(query.where),
+    predicate: compileMatches(metadata, query.where),
     ordering: compileOrdering(orderBy),
     projection: compileProjection(query.select),
     window: compileWindow(query),
@@ -881,9 +1153,10 @@ const compileRawQueryParts = <Row extends RowObject, ResultRow extends RowObject
 };
 
 const compileRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
+  metadata: RawQueryCompilerMetadata,
   query: RuntimeRawQuery,
 ): CompiledRawQuery<Row, ResultRow> => {
-  const parts = compileRawQueryParts<Row, ResultRow>(query);
+  const parts = compileRawQueryParts<Row, ResultRow>(metadata, query);
   return {
     [compiledRawQueryBrand]: true,
     query,
@@ -900,5 +1173,5 @@ export const prepareRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.prepare"
 >(topic: string, metadata: RawQueryCompilerMetadata, query: unknown) {
   const decoded = yield* decodeRawQuery(topic, metadata, query);
   yield* validateRuntimeQuery(topic, metadata, decoded);
-  return compileRawQuery<Row, ResultRow>(decoded);
+  return compileRawQuery<Row, ResultRow>(metadata, decoded);
 });

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -12,8 +12,35 @@ export type TopicRawOrderByPlan = {
   readonly direction: "asc" | "desc";
 };
 
+export type TopicRawPredicateFilterPlan =
+  | {
+      readonly field: string;
+      readonly operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "startsWith";
+      readonly value: unknown;
+    }
+  | {
+      readonly field: string;
+      readonly operator: "in";
+      readonly values: ReadonlyArray<unknown>;
+    };
+
+export type TopicRawPredicatePlan = {
+  /**
+   * Safe scalar hints that storage can use to narrow a raw scan.
+   * `matches` remains the correctness guard unless an adapter implements a
+   * proven equivalent for every emitted hint.
+   */
+  readonly filters: ReadonlyArray<TopicRawPredicateFilterPlan>;
+  /**
+   * True when the compiler intentionally omitted part of the predicate from
+   * `filters`, for example structured fields or malformed runtime filters.
+   */
+  readonly callbackRequired: boolean;
+};
+
 export type TopicRawWindowScanPlan<Row extends RowObject> = {
   readonly where: Readonly<Record<string, unknown>> | undefined;
+  readonly predicate: TopicRawPredicatePlan;
   readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
   readonly matches: (row: Row) => boolean;
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;


### PR DESCRIPTION
Adds typed raw scan metadata for the column live view engine.

Summary:
- Adds TopicRawPredicatePlan with scalar pushdown hints and callbackRequired.
- Passes compiled predicate and order metadata into TopicRawWindowScanPlan.
- Keeps matches and compare as correctness guards for current storage.
- Uses exact SchemaAST range value kinds so number, bigint, BigDecimal, and mixed numeric fields are conservative.
- Treats structured fields, malformed runtime filters, mixed numeric fields, and unsupported neq values as callback-only.

Validation:
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready
- 3-agent review loop clean