### PR TITLE
Add dense columnar topic store slots

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -1,17 +1,19 @@
 import { Effect, Schema } from "effect";
 import type { ActiveQueryStoreState } from "./active-query";
 import type {
+  TopicRawPredicateFilterPlan,
   TopicRawWindowScanPlan,
   TopicRawWindowScanResult,
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
-import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
+import { cloneRow, fieldValue, isPlainRecord, valuesEqual } from "./row-values";
 
 type RowObject = object;
 
 type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
+type ColumnValues = Array<unknown>;
 
 export type PreparedTopicRow = {
   readonly key: string;
@@ -22,7 +24,9 @@ export class ColumnarTopicStore {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly readModel: ActiveQueryStoreState;
 
-  private readonly rows = new Map<string, object>();
+  private readonly slots: Array<TopicRowEntry<object>> = [];
+  private readonly keyToSlot = new Map<string, number>();
+  private readonly columns = new Map<string, ColumnValues>();
   private versionValue = 0;
 
   constructor(
@@ -31,6 +35,9 @@ export class ColumnarTopicStore {
     private readonly keyField: string,
   ) {
     this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
+    for (const field of this.rawQueryMetadata.fieldNames) {
+      this.columns.set(field, []);
+    }
     this.readModel = {
       identity: this,
       topic,
@@ -41,7 +48,7 @@ export class ColumnarTopicStore {
   }
 
   get rowCount(): number {
-    return this.rows.size;
+    return this.slots.length;
   }
 
   get version(): number {
@@ -54,12 +61,24 @@ export class ColumnarTopicStore {
   }
 
   clear(): void {
-    this.rows.clear();
+    this.slots.length = 0;
+    this.keyToSlot.clear();
+    for (const column of this.columns.values()) {
+      column.length = 0;
+    }
     this.versionValue = 0;
   }
 
   setPrepared(prepared: PreparedTopicRow): void {
-    this.rows.set(prepared.key, prepared.row);
+    const existingSlot = this.keyToSlot.get(prepared.key);
+    if (existingSlot !== undefined) {
+      this.writeSlot(existingSlot, prepared);
+      return;
+    }
+
+    const slot = this.slots.length;
+    this.keyToSlot.set(prepared.key, slot);
+    this.writeSlot(slot, prepared);
   }
 
   setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
@@ -69,20 +88,41 @@ export class ColumnarTopicStore {
   }
 
   delete(key: string): number {
-    return this.rows.delete(key) ? 1 : 0;
+    const slot = this.keyToSlot.get(key);
+    if (slot === undefined) {
+      return 0;
+    }
+
+    const lastSlot = this.slots.length - 1;
+    const lastEntry = this.slots[lastSlot]!;
+    this.keyToSlot.delete(key);
+    if (slot !== lastSlot) {
+      this.slots[slot] = lastEntry;
+      this.keyToSlot.set(lastEntry.key, slot);
+      for (const column of this.columns.values()) {
+        column[slot] = column[lastSlot];
+      }
+    }
+    this.slots.pop();
+    for (const column of this.columns.values()) {
+      column.pop();
+    }
+    return 1;
   }
 
   scanRows(visitor: TopicRowVisitor<object>): void {
-    for (const [key, row] of this.rows) {
-      visitor(key, row);
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      const entry = this.slots[slot]!;
+      visitor(entry.key, entry.row);
     }
   }
 
   scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
     const filtered: Array<TopicRowEntry<object>> = [];
-    for (const [key, row] of this.rows) {
-      if (plan.matches(row)) {
-        filtered.push({ key, row });
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      const entry = this.slots[slot]!;
+      if (this.slotMayMatchFilters(slot, plan.predicate.filters) && plan.matches(entry.row)) {
+        filtered.push(entry);
       }
     }
     const ordered = filtered.toSorted(plan.compare);
@@ -126,7 +166,7 @@ export class ColumnarTopicStore {
     invalidRow: InvalidRowErrorFactory<Error>,
   ) {
     yield* this.validatePatchKeys(patch, invalidRow);
-    const current = this.rows.get(key);
+    const current = this.rowForKey(key);
     if (current === undefined) {
       return yield* Effect.fail(invalidRow(this.topic, `Cannot patch missing key: ${key}`));
     }
@@ -185,4 +225,89 @@ export class ColumnarTopicStore {
       }
     }
   });
+
+  private writeSlot(slot: number, prepared: PreparedTopicRow): void {
+    this.slots[slot] = {
+      key: prepared.key,
+      row: prepared.row,
+    };
+    for (const [field, column] of this.columns) {
+      column[slot] = fieldValue(prepared.row, field);
+    }
+  }
+
+  private rowForKey(key: string): object | undefined {
+    const slot = this.keyToSlot.get(key);
+    if (slot === undefined) {
+      return undefined;
+    }
+    return this.slots[slot]!.row;
+  }
+
+  private slotMayMatchFilters(
+    slot: number,
+    filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+  ): boolean {
+    for (const filter of filters) {
+      if (!this.slotMayMatchFilter(slot, filter)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private slotMayMatchFilter(slot: number, filter: TopicRawPredicateFilterPlan): boolean {
+    const column = this.columns.get(filter.field);
+    if (column === undefined) {
+      return true;
+    }
+    const value = column[slot];
+
+    if (filter.operator === "eq") {
+      return valuesEqual(value, filter.value);
+    }
+    if (filter.operator === "neq") {
+      return !valuesEqual(value, filter.value);
+    }
+    if (filter.operator === "in") {
+      return filter.values.some((candidate) => valuesEqual(value, candidate));
+    }
+    if (filter.operator === "startsWith") {
+      if (typeof filter.value !== "string") {
+        return true;
+      }
+      return typeof value === "string" && value.startsWith(filter.value);
+    }
+
+    const comparison = compareRangeColumnValue(value, filter.value);
+    if (comparison === undefined) {
+      return true;
+    }
+    if (filter.operator === "gt") {
+      return comparison > 0;
+    }
+    if (filter.operator === "gte") {
+      return comparison >= 0;
+    }
+    if (filter.operator === "lt") {
+      return comparison < 0;
+    }
+    return comparison <= 0;
+  }
 }
+
+const compareRangeColumnValue = (left: unknown, right: unknown): number | undefined => {
+  if (typeof left === "number" && typeof right === "number") {
+    if (!Number.isFinite(left) || !Number.isFinite(right)) {
+      return undefined;
+    }
+    return left - right;
+  }
+  if (typeof left === "bigint" && typeof right === "bigint") {
+    if (left === right) {
+      return 0;
+    }
+    return left < right ? -1 : 1;
+  }
+  return undefined;
+};

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -44,6 +44,7 @@ import {
   closeBackpressuredTopicStoreSubscription,
   closeTopicStoreSubscriptions,
   collectTopicStoreHealth,
+  deleteTopicStoreRow,
   publishTopicStoreRow,
   registerTopicStoreSubscription,
   resetTopicStore,
@@ -2202,6 +2203,152 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expect(rowIds(notOpen.rows)).toStrictEqual(["4"]);
     }),
   );
+
+  it.effect("keeps column slot values in sync across replace, delete, reuse, and patch", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("1", "closed", 10, 1),
+        order("2", "open", 20, 2),
+        order("3", "open", 30, 3),
+      ]);
+
+      yield* engine.publish("orders", order("1", "open", 40, 4));
+
+      const afterReplace = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+          price: { gt: 35 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+      });
+      expect(afterReplace.rows).toStrictEqual([{ id: "1", price: 40 }]);
+      expect(afterReplace.totalRows).toBe(1);
+
+      yield* engine.delete("orders", "1");
+
+      const afterDelete = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+          price: { gt: 35 },
+        },
+      });
+      expect(afterDelete.rows).toStrictEqual([]);
+      expect(afterDelete.totalRows).toBe(0);
+
+      const movedRowAfterDelete = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+          price: { lt: 35 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+      });
+      expect(movedRowAfterDelete.rows).toStrictEqual([
+        { id: "3", price: 30 },
+        { id: "2", price: 20 },
+      ]);
+      expect(movedRowAfterDelete.totalRows).toBe(2);
+
+      yield* engine.publish("orders", order("4", "open", 50, 5));
+
+      const afterSlotReuse = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+          price: { gt: 35 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+      });
+      expect(afterSlotReuse.rows).toStrictEqual([{ id: "4", price: 50 }]);
+      expect(afterSlotReuse.totalRows).toBe(1);
+
+      yield* engine.patch("orders", "4", { status: "closed", price: 5 });
+
+      const afterPatchOut = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+          price: { gt: 35 },
+        },
+      });
+      expect(afterPatchOut.rows).toStrictEqual([]);
+      expect(afterPatchOut.totalRows).toBe(0);
+
+      yield* engine.patch("orders", "4", { status: "open", price: 45 });
+
+      const afterPatchIn = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+          price: { gt: 35 },
+        },
+      });
+      expect(afterPatchIn.rows).toStrictEqual([{ id: "4", price: 45 }]);
+      expect(afterPatchIn.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("uses bigint column range narrowing for less-than filters", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("positions", [
+        position("1", "AAPL", 5n, "10"),
+        position("2", "MSFT", 15n, "20"),
+      ]);
+
+      const snapshot = yield* engine.snapshot("positions", {
+        select: ["id"],
+        where: {
+          quantity: { lt: 10n },
+        },
+      });
+
+      expect(snapshot.rows).toStrictEqual([{ id: "1" }]);
+      expect(snapshot.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("preserves compiled predicate miss behavior for custom storage scanners", () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery("orders", rawQueryCompilerMetadata(Order), {
+        select: ["id"],
+        where: {
+          status: { eq: "open" },
+          customerId: { startsWith: "customer-" },
+        },
+      });
+      const rows = [
+        order("1", "closed", 10, 1),
+        { ...order("2", "open", 20, 2), customerId: "account-2" },
+      ];
+
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            const window = rows
+              .filter((row) => plan.matches(row))
+              .map((row) => ({
+                key: row.id,
+                row,
+              }));
+            return {
+              keys: window.map((entry) => entry.key),
+              window,
+              totalRows: window.length,
+            };
+          },
+          version: () => 1,
+        },
+        compiled,
+      );
+
+      expect(evaluation.rows).toStrictEqual([]);
+      expect(evaluation.totalRows).toBe(0);
+    }),
+  );
 });
 
 describe("ColumnLiveViewEngine subscriptions", () => {
@@ -2699,6 +2846,47 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("honors explicit topic-store subscription handoff options", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      let beforeReturnCount = 0;
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-explicit-handoff-options",
+        notify: () => Effect.void,
+        queuedEvents: Effect.succeed(0),
+        end: Effect.void,
+        closeWithStatus: () => Effect.void,
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+
+      yield* acquireTopicStoreSubscription(
+        store,
+        (permit, markAcquired) =>
+          Effect.gen(function* () {
+            const subscription = {
+              close: () => Effect.void,
+            };
+            yield* registerTopicStoreSubscription(permit, subscriber);
+            yield* markAcquired(subscription);
+            return subscription;
+          }),
+        {
+          beforeReturn: Effect.sync(() => {
+            beforeReturnCount += 1;
+          }),
+        },
+      );
+
+      const health = yield* collectTopicStoreHealth(store, false);
+      expect(beforeReturnCount).toBe(1);
+      expect(health.activeSubscriptions).toBe(1);
+      yield* closeTopicStoreSubscriptions(store);
+    }),
+  );
+
   it.effect("records backpressure close only once for already closed subscribers", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});
@@ -2727,6 +2915,164 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(subscriber.backpressureEvents).toBe(1);
       expect(health.activeSubscriptions).toBe(0);
       expect(health.backpressureEvents).toBe(1);
+    }),
+  );
+
+  it.effect("collects topic-store throughput and drains subscribers on normal close", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      let closeStatusCount = 0;
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-normal-close",
+        notify: () => Effect.void,
+        queuedEvents: Effect.succeed(2),
+        end: Effect.void,
+        closeWithStatus: () =>
+          Effect.sync(() => {
+            closeStatusCount += 1;
+          }),
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+
+      yield* registerTestTopicStoreSubscriber(store, subscriber);
+      yield* publishTopicStoreRow(store, order("1", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const readyHealth = yield* collectTopicStoreHealth(store, false);
+      expect(readyHealth.status).toBe("ready");
+      expect(readyHealth.rowCount).toBe(1);
+      expect(readyHealth.mutationsPerSecond).toBeGreaterThanOrEqual(0);
+      expect(readyHealth.rowsPerSecond).toBeGreaterThanOrEqual(0);
+      expect(readyHealth.activeSubscriptions).toBe(1);
+      expect(readyHealth.queuedEvents).toBe(2);
+
+      yield* closeTopicStoreSubscriptions(store);
+
+      const closedHealth = yield* collectTopicStoreHealth(store, true);
+      expect(closeStatusCount).toBe(1);
+      expect(closedHealth.status).toBe("degraded");
+      expect(closedHealth.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("drains subscribers and storage on normal topic-store reset", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      let resetStatusCount = 0;
+      const subscriber: LiveTopicSubscriber = {
+        topic: "orders",
+        queryId: "query-normal-reset",
+        notify: () => Effect.void,
+        queuedEvents: Effect.succeed(0),
+        end: Effect.void,
+        closeWithStatus: () =>
+          Effect.sync(() => {
+            resetStatusCount += 1;
+          }),
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        closed: false,
+      };
+
+      yield* registerTestTopicStoreSubscriber(store, subscriber);
+      yield* publishTopicStoreRow(store, order("1", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      yield* resetTopicStore(store);
+
+      const health = yield* collectTopicStoreHealth(store, false);
+      expect(resetStatusCount).toBe(1);
+      expect(health.status).toBe("ready");
+      expect(health.rowCount).toBe(0);
+      expect(health.activeSubscriptions).toBe(0);
+      expect(health.version).toBe(0);
+    }),
+  );
+
+  it.effect("keeps deleted slots out of scans and handles hostile plans conservatively", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(store, order("1", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("2", "open", 20, 2), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("3", "open", 30, 3), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* deleteTopicStoreRow(store, "1");
+
+      const readModel = topicStoreReadModel(store);
+      const scannedKeys: Array<string> = [];
+      readModel.scanRows((key) => {
+        scannedKeys.push(key);
+      });
+      expect(scannedKeys.toSorted()).toStrictEqual(["2", "3"]);
+
+      const compareByKey = (left: { readonly key: string }, right: { readonly key: string }) =>
+        left.key.localeCompare(right.key);
+      const matchesOnlySecondRow = (row: object) => fieldValue(row, "id") === "2";
+      const missingColumn = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "missing", operator: "eq", value: "anything" }],
+          callbackRequired: true,
+        },
+        orderBy: [],
+        matches: matchesOnlySecondRow,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(missingColumn.keys).toStrictEqual(["2"]);
+
+      const invalidStartsWithPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "customerId", operator: "startsWith", value: 1 }],
+          callbackRequired: true,
+        },
+        orderBy: [],
+        matches: matchesOnlySecondRow,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(invalidStartsWithPlan.keys).toStrictEqual(["2"]);
+
+      const invalidRangePlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: "10" }],
+          callbackRequired: true,
+        },
+        orderBy: [],
+        matches: matchesOnlySecondRow,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(invalidRangePlan.keys).toStrictEqual(["2"]);
+
+      const nonFiniteRangePlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: Number.NaN }],
+          callbackRequired: true,
+        },
+        orderBy: [],
+        matches: matchesOnlySecondRow,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(nonFiniteRangePlan.keys).toStrictEqual(["2"]);
     }),
   );
 

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -254,17 +254,18 @@ export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStor
     const activeSubscriptions = state.subscribers.size;
     const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
     const status: TopicRuntimeHealth["status"] = closed ? "degraded" : "ready";
-
-    return {
+    const lastMutationAt = totals.lastMutationAt;
+    const rowsPerSecond = totals.rowsPerSecond;
+    const health: TopicStoreHealthView = {
       topic: store.topic,
       status,
       rowCount: totals.rowCount,
       liveRowCount: totals.rowCount,
       deletedRowCount: 0,
       version: totals.version,
-      lastMutationAt: totals.lastMutationAt,
+      lastMutationAt,
       mutationsPerSecond: totals.mutationsPerSecond,
-      rowsPerSecond: totals.rowsPerSecond,
+      rowsPerSecond,
       pendingMutationBatches: totals.pendingMutationBatches,
       activeViews,
       activeSubscriptions,
@@ -274,29 +275,30 @@ export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStor
       memoryBytes: 0,
       tombstoneCount: 0,
       compactionPending: false,
-    } satisfies TopicStoreHealthView;
+    };
+    return health;
   },
 );
 
 export const registerTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.add",
-)((permit: TopicStoreSubscriptionPermit, subscriber: LiveTopicSubscriber) =>
-  Effect.sync(() => {
+)(function (permit: TopicStoreSubscriptionPermit, subscriber: LiveTopicSubscriber) {
+  return Effect.sync(() => {
     const state = topicStoreState(permit.store);
     state.healthLedger.openSubscription(subscriber);
     state.subscribers.add(subscriber);
-  }),
-);
+  });
+});
 
 const unregisterTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.remove",
-)((store: TopicStore, subscriber: LiveTopicSubscriber) =>
-  Effect.sync(() => {
+)(function (store: TopicStore, subscriber: LiveTopicSubscriber) {
+  return Effect.sync(() => {
     const state = topicStoreState(store);
     state.healthLedger.closeSubscription(subscriber);
     state.subscribers.delete(subscriber);
-  }),
-);
+  });
+});
 
 const drainTopicStoreSubscribersForReset = (
   state: TopicStoreState,
@@ -311,17 +313,17 @@ const drainTopicStoreSubscribersForReset = (
   return closingSubscribers;
 };
 
-const drainTopicStoreSubscribersForClose = (
+function drainTopicStoreSubscribersForClose(
   state: TopicStoreState,
-): ReadonlyArray<LiveTopicSubscriber> => {
-  const closingSubscribers = [...state.subscribers];
+): ReadonlyArray<LiveTopicSubscriber> {
+  const closingSubscribers = Array.from(state.subscribers);
   for (const subscriber of closingSubscribers) {
     subscriber.closed = true;
     state.healthLedger.closeSubscription(subscriber);
   }
   state.subscribers.clear();
   return closingSubscribers;
-};
+}
 
 export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.queueDepth",


### PR DESCRIPTION
## Summary
- Replace row-map storage in ColumnarTopicStore with dense row slots plus per-field column arrays.
- Use column predicate plans as safe prefilter hints before the compiled predicate guard.
- Use swap-delete so delete-heavy topics keep scan work proportional to live rows.
- Add regression coverage for replace/delete/moved-row column copies, hostile direct scan plans, explicit handoff options, and normal topic-store close/reset paths.

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- vp run --no-cache column-live-view-engine#bench:raw-snapshot
- VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 ... vp run --no-cache column-live-view-engine#bench:raw-snapshot
- pnpm run ready
- 3-agent review loop: all reviewers reported no findings after fixes

## Benchmark Notes
100k row benchmark after this slice:
- equality filter + top-k sort mean ~10.13ms
- range filter + top-k sort mean ~1.04ms
- compound filter + top-k sort mean ~3.61ms
- filtered totalRows zero-row window mean ~2.56ms
- live subscription delta after publish mean ~10.26ms

1M directional benchmark:
- equality filter + top-k sort mean ~96.34ms
- range filter + top-k sort mean ~71.65ms
- compound filter + top-k sort mean ~153.15ms
- filtered totalRows zero-row window mean ~129.72ms
- live subscription delta after publish mean ~98.90ms

This creates the columnar seam and speeds predicate narrowing, but top-k still fully materializes/sorts matched rows and remains the next bottleneck.