### PR TITLE
Use column slot ordering for raw scans

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -124,6 +124,7 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
     where: compiled.query.where,
     predicate: compiled.predicate.plan,
     orderBy: compiled.ordering.plan,
+    storageOrderBy: compiled.ordering.plan,
     matches: compiled.predicate.matches,
     compare: compiled.ordering.compare,
     offset: compiled.window.offset,

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -7,7 +7,11 @@ import type {
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
-import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
+import {
+  compareQueryValue,
+  rawQueryCompilerMetadata,
+  type RawQueryCompilerMetadata,
+} from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord, valuesEqual } from "./row-values";
 
 type RowObject = object;
@@ -118,6 +122,11 @@ export class ColumnarTopicStore {
   }
 
   scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
+    const compareSlots = this.rawWindowSlotComparator(plan);
+    if (compareSlots !== undefined) {
+      return this.scanRawWindowSlots(plan, compareSlots);
+    }
+
     const filtered: Array<TopicRowEntry<object>> = [];
     for (let slot = 0; slot < this.slots.length; slot += 1) {
       const entry = this.slots[slot]!;
@@ -134,6 +143,62 @@ export class ColumnarTopicStore {
       keys: window.map((entry) => entry.key),
       window,
       totalRows: filtered.length,
+    };
+  }
+
+  private scanRawWindowSlots(
+    plan: TopicRawWindowScanPlan<object>,
+    compareSlots: (left: number, right: number) => number,
+  ): TopicRawWindowScanResult<object> {
+    let totalRows = 0;
+    const filteredSlots: Array<number> = [];
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      const entry = this.slots[slot]!;
+      if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
+        continue;
+      }
+      totalRows += 1;
+      if (plan.limit !== 0) {
+        filteredSlots.push(slot);
+      }
+    }
+    filteredSlots.sort(compareSlots);
+    const windowSlots = filteredSlots.slice(
+      plan.offset,
+      plan.limit === undefined ? undefined : plan.offset + plan.limit,
+    );
+    const window = windowSlots.map((slot) => this.slots[slot]!);
+    return {
+      keys: window.map((entry) => entry.key),
+      window,
+      totalRows,
+    };
+  }
+
+  private rawWindowSlotComparator(
+    plan: TopicRawWindowScanPlan<object>,
+  ): ((left: number, right: number) => number) | undefined {
+    const storageOrderBy = plan.storageOrderBy;
+    if (storageOrderBy === undefined) {
+      return undefined;
+    }
+    for (const order of storageOrderBy) {
+      if (!this.columns.has(order.field)) {
+        return undefined;
+      }
+    }
+
+    return (left, right) => {
+      for (const order of storageOrderBy) {
+        const column = this.columns.get(order.field)!;
+        const comparison = compareQueryValue(column[left], column[right]);
+        if (comparison !== undefined && comparison !== 0) {
+          return order.direction === "asc" ? comparison : -comparison;
+        }
+      }
+      const leftKey = this.slots[left]!.key;
+      const rightKey = this.slots[right]!.key;
+      return Number(leftKey > rightKey) - Number(leftKey < rightKey);
     };
   }
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -451,6 +451,52 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
+  it.effect("returns exact totalRows while windowing a sorted raw snapshot", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      yield* engine.publishMany("orders", [
+        order("a", "open", 1, 1),
+        order("b", "open", 8, 2),
+        order("c", "open", 3, 3),
+        order("d", "open", 10, 4),
+        order("e", "open", 5, 5),
+        order("f", "open", 7, 6),
+        order("g", "open", 2, 7),
+        order("h", "closed", 99, 8),
+      ]);
+
+      const windowed = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        offset: 2,
+        limit: 3,
+      });
+
+      expect(windowed.rows).toStrictEqual([
+        { id: "f", price: 7 },
+        { id: "e", price: 5 },
+        { id: "c", price: 3 },
+      ]);
+      expect(windowed.totalRows).toBe(7);
+
+      const countOnly = yield* engine.snapshot("orders", {
+        select: ["id"],
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 0,
+      });
+
+      expect(countOnly.rows).toStrictEqual([]);
+      expect(countOnly.totalRows).toBe(7);
+    }),
+  );
+
   it.effect("does not expose stored row objects through snapshots", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();
@@ -961,7 +1007,8 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     Effect.gen(function* () {
       const rows = [
         { key: "closed", row: order("closed", "closed", 1, 1) },
-        { key: "open-high", row: order("open-high", "open", 20, 3) },
+        { key: "open-z", row: order("open-z", "open", 20, 3) },
+        { key: "open-a", row: order("open-a", "open", 20, 4) },
         { key: "open-low", row: order("open-low", "open", 10, 2) },
       ];
       const compiled = yield* prepareRawQuery<object, object>(
@@ -1019,10 +1066,14 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         compiled,
       );
 
-      expect(evaluation.keys).toStrictEqual(["open-high", "open-low"]);
+      expect(evaluation.keys).toStrictEqual(["open-a", "open-z", "open-low"]);
       expect(evaluation.rows).toStrictEqual([
         {
-          id: "open-high",
+          id: "open-a",
+          price: 20,
+        },
+        {
+          id: "open-z",
           price: 20,
         },
         {
@@ -1030,8 +1081,76 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           price: 10,
         },
       ]);
-      expect(evaluation.totalRows).toBe(2);
+      expect(evaluation.totalRows).toBe(3);
       expect(evaluation.version).toBe(7);
+    }),
+  );
+
+  it.effect("passes scalar ordering semantics to custom storage scanners", () =>
+    Effect.gen(function* () {
+      const active = { key: "active", row: position("active", "AAPL", 1n, "1", true) };
+      const activeTie = { key: "active-tie", row: position("active-tie", "AAPL", 1n, "1", true) };
+      const inactive = { key: "inactive", row: position("inactive", "AAPL", 1n, "1", false) };
+      const orderRows = [
+        { key: "closed", row: order("closed", "closed", 1, 1) },
+        { key: "open-high", row: order("open-high", "open", 20, 2) },
+        { key: "open-low", row: order("open-low", "open", 10, 3) },
+      ];
+      const booleanCompiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id"],
+          orderBy: [{ field: "active", direction: "asc" }],
+        },
+      );
+      const orderCompiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "price", direction: "asc" }],
+        },
+      );
+
+      const booleanEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.compare(active, inactive)).toBe(1);
+            expect(plan.compare(inactive, active)).toBe(-1);
+            expect(plan.compare(active, activeTie)).toBe(-1);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 1,
+        },
+        booleanCompiled,
+      );
+      const orderEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            const filtered = orderRows.filter((entry) => plan.matches(entry.row));
+            const ordered = filtered.toSorted(plan.compare);
+            return {
+              keys: ordered.map((entry) => entry.key),
+              window: ordered,
+              totalRows: filtered.length,
+            };
+          },
+          version: () => 2,
+        },
+        orderCompiled,
+      );
+
+      expect(booleanEvaluation.totalRows).toBe(0);
+      expect(orderEvaluation.keys).toStrictEqual(["open-low", "open-high"]);
+      expect(orderEvaluation.version).toBe(2);
     }),
   );
 
@@ -3017,6 +3136,10 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       const compareByKey = (left: { readonly key: string }, right: { readonly key: string }) =>
         left.key.localeCompare(right.key);
+      const compareByKeyDescending = (
+        left: { readonly key: string },
+        right: { readonly key: string },
+      ) => right.key.localeCompare(left.key);
       const matchesOnlySecondRow = (row: object) => fieldValue(row, "id") === "2";
       const missingColumn = readModel.scanRawWindow({
         where: undefined,
@@ -3031,6 +3154,64 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         limit: undefined,
       });
       expect(missingColumn.keys).toStrictEqual(["2"]);
+
+      const missingOrderColumn = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "missing", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(missingOrderColumn.keys).toStrictEqual(["3", "2"]);
+
+      const existingOrderColumnCustomCompare = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(existingOrderColumnCustomCompare.keys).toStrictEqual(["3", "2"]);
+
+      const invalidStorageOrderColumn = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "missing", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(invalidStorageOrderColumn.keys).toStrictEqual(["3", "2"]);
+
+      const missingOrderColumnLimitedMisses = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "missing", direction: "asc" }],
+        matches: matchesOnlySecondRow,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: 1,
+      });
+      expect(missingOrderColumnLimitedMisses.keys).toStrictEqual(["2"]);
+      expect(missingOrderColumnLimitedMisses.totalRows).toBe(1);
 
       const invalidStartsWithPlan = readModel.scanRawWindow({
         where: undefined,
@@ -3073,6 +3254,21 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         limit: undefined,
       });
       expect(nonFiniteRangePlan.keys).toStrictEqual(["2"]);
+
+      const zeroLimitPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 0,
+      });
+      expect(zeroLimitPlan.keys).toStrictEqual([]);
+      expect(zeroLimitPlan.totalRows).toBe(2);
     }),
   );
 

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -42,6 +42,11 @@ export type TopicRawWindowScanPlan<Row extends RowObject> = {
   readonly where: Readonly<Record<string, unknown>> | undefined;
   readonly predicate: TopicRawPredicatePlan;
   readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
+  /**
+   * Compiler-proven ordering hint for storage pushdown. `compare` remains the
+   * source of truth for custom scan plans unless this hint is present.
+   */
+  readonly storageOrderBy?: ReadonlyArray<TopicRawOrderByPlan>;
   readonly matches: (row: Row) => boolean;
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
   readonly offset: number;


### PR DESCRIPTION
## Summary
- add a compiler-proven storageOrderBy hint for raw scan plans
- use column arrays to sort matched slot numbers for compiler-produced raw scans
- preserve plan.compare for custom/direct scan callers unless the storage hint is present
- add regressions for sorted windows, custom comparator fallback, malformed storage hints, zero-limit exact totalRows, and comparator semantics

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready
- forbidden-pattern scan in packages/column-live-view-engine/src: clean
- 3-agent review loop: clean after one fix iteration

## Benchmarks
100k current:
- equality top-k mean 8.42ms
- range top-k mean 0.98ms
- compound top-k mean 3.87ms
- zero-row totalRows mean 2.53ms
- live delta after publish mean 8.62ms

1M current:
- equality top-k mean 84.97ms
- range top-k mean 63.06ms
- compound top-k mean 142.23ms
- zero-row totalRows mean 118.20ms
- live delta after publish mean 86.59ms

Same-host main 1M baseline:
- equality 106.23ms
- range 82.29ms
- compound 167.11ms
- zero-row totalRows 130.87ms
- live delta 99.72ms

## Residual risk
This still sorts all matching slots. It reduces row materialization/object access, but it is not bounded top-k yet.