### PR TITLE
Add ordered raw slot index fast path

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 import type { ActiveQueryStoreState } from "./active-query";
 import type {
+  TopicRawOrderByPlan,
   TopicRawPredicateFilterPlan,
   TopicRawWindowScanPlan,
   TopicRawWindowScanResult,
@@ -19,6 +20,16 @@ type RowObject = object;
 type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
 type ColumnValues = Array<unknown>;
 
+type OrderedSlotIndex = {
+  readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
+  readonly slots: Array<number>;
+};
+
+type OrderedRawWindow = {
+  readonly limit: number;
+  readonly slots: ReadonlyArray<number>;
+};
+
 export type PreparedTopicRow = {
   readonly key: string;
   readonly row: object;
@@ -31,6 +42,7 @@ export class ColumnarTopicStore {
   private readonly slots: Array<TopicRowEntry<object>> = [];
   private readonly keyToSlot = new Map<string, number>();
   private readonly columns = new Map<string, ColumnValues>();
+  private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
   private versionValue = 0;
 
   constructor(
@@ -67,6 +79,7 @@ export class ColumnarTopicStore {
   clear(): void {
     this.slots.length = 0;
     this.keyToSlot.clear();
+    this.orderedSlotIndexes.clear();
     for (const column of this.columns.values()) {
       column.length = 0;
     }
@@ -77,15 +90,25 @@ export class ColumnarTopicStore {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
       this.writeSlot(existingSlot, prepared);
+      this.orderedSlotIndexes.clear();
       return;
     }
 
     const slot = this.slots.length;
     this.keyToSlot.set(prepared.key, slot);
     this.writeSlot(slot, prepared);
+    this.insertSlotIntoOrderedIndexes(slot);
   }
 
   setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
+    if (preparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
+      this.orderedSlotIndexes.clear();
+      for (const prepared of preparedRows) {
+        this.setPreparedWithoutIndexMaintenance(prepared);
+      }
+      return;
+    }
+
     for (const prepared of preparedRows) {
       this.setPrepared(prepared);
     }
@@ -97,6 +120,7 @@ export class ColumnarTopicStore {
       return 0;
     }
 
+    this.orderedSlotIndexes.clear();
     const lastSlot = this.slots.length - 1;
     const lastEntry = this.slots[lastSlot]!;
     this.keyToSlot.delete(key);
@@ -122,6 +146,11 @@ export class ColumnarTopicStore {
   }
 
   scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
+    const orderedWindow = this.rawWindowOrderedWindow(plan);
+    if (orderedWindow !== undefined) {
+      return this.scanRawWindowOrderedSlots(plan, orderedWindow);
+    }
+
     const compareSlots = this.rawWindowSlotComparator(plan);
     if (compareSlots !== undefined) {
       return this.scanRawWindowSlots(plan, compareSlots);
@@ -143,6 +172,32 @@ export class ColumnarTopicStore {
       keys: window.map((entry) => entry.key),
       window,
       totalRows: filtered.length,
+    };
+  }
+
+  private scanRawWindowOrderedSlots(
+    plan: TopicRawWindowScanPlan<object>,
+    orderedWindow: OrderedRawWindow,
+  ): TopicRawWindowScanResult<object> {
+    let totalRows = 0;
+    const windowSlots: Array<number> = [];
+    const windowEnd = plan.offset + orderedWindow.limit;
+    for (const slot of orderedWindow.slots) {
+      const entry = this.slots[slot]!;
+      if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
+        continue;
+      }
+      const matchIndex = totalRows;
+      totalRows += 1;
+      if (matchIndex >= plan.offset && matchIndex < windowEnd) {
+        windowSlots.push(slot);
+      }
+    }
+    const window = windowSlots.map((slot) => this.slots[slot]!);
+    return {
+      keys: window.map((entry) => entry.key),
+      window,
+      totalRows,
     };
   }
 
@@ -175,6 +230,50 @@ export class ColumnarTopicStore {
     };
   }
 
+  private rawWindowOrderedWindow(
+    plan: TopicRawWindowScanPlan<object>,
+  ): OrderedRawWindow | undefined {
+    const storageOrderBy = plan.storageOrderBy;
+    if (
+      plan.limit === undefined ||
+      !Number.isSafeInteger(plan.limit) ||
+      plan.limit <= 0 ||
+      storageOrderBy === undefined ||
+      storageOrderBy.length !== 1
+    ) {
+      return undefined;
+    }
+    if (
+      plan.predicate.callbackRequired ||
+      !predicateFiltersAreOrderedIndexAdmissible(plan.predicate.filters)
+    ) {
+      return undefined;
+    }
+    if (!this.storageOrderByFieldsExist(storageOrderBy)) {
+      return undefined;
+    }
+
+    const indexKey = orderedSlotIndexKey(storageOrderBy);
+    const existing = this.orderedSlotIndexes.get(indexKey);
+    if (existing !== undefined) {
+      return {
+        limit: plan.limit,
+        slots: existing.slots,
+      };
+    }
+
+    const slots = Array.from({ length: this.slots.length }, (_value, slot) => slot);
+    slots.sort((left, right) => this.compareSlotsByStorageOrder(left, right, storageOrderBy));
+    this.orderedSlotIndexes.set(indexKey, {
+      orderBy: storageOrderBy,
+      slots,
+    });
+    return {
+      limit: plan.limit,
+      slots,
+    };
+  }
+
   private rawWindowSlotComparator(
     plan: TopicRawWindowScanPlan<object>,
   ): ((left: number, right: number) => number) | undefined {
@@ -182,24 +281,39 @@ export class ColumnarTopicStore {
     if (storageOrderBy === undefined) {
       return undefined;
     }
-    for (const order of storageOrderBy) {
-      if (!this.columns.has(order.field)) {
-        return undefined;
-      }
+    if (!this.storageOrderByFieldsExist(storageOrderBy)) {
+      return undefined;
     }
 
     return (left, right) => {
-      for (const order of storageOrderBy) {
-        const column = this.columns.get(order.field)!;
-        const comparison = compareQueryValue(column[left], column[right]);
-        if (comparison !== undefined && comparison !== 0) {
-          return order.direction === "asc" ? comparison : -comparison;
-        }
-      }
-      const leftKey = this.slots[left]!.key;
-      const rightKey = this.slots[right]!.key;
-      return Number(leftKey > rightKey) - Number(leftKey < rightKey);
+      return this.compareSlotsByStorageOrder(left, right, storageOrderBy);
     };
+  }
+
+  private compareSlotsByStorageOrder(
+    left: number,
+    right: number,
+    storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>,
+  ): number {
+    for (const order of storageOrderBy) {
+      const column = this.columns.get(order.field)!;
+      const comparison = compareQueryValue(column[left], column[right]);
+      if (comparison !== undefined && comparison !== 0) {
+        return order.direction === "asc" ? comparison : -comparison;
+      }
+    }
+    const leftKey = this.slots[left]!.key;
+    const rightKey = this.slots[right]!.key;
+    return Number(leftKey > rightKey) - Number(leftKey < rightKey);
+  }
+
+  private storageOrderByFieldsExist(storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>): boolean {
+    for (const order of storageOrderBy) {
+      if (!this.columns.has(order.field)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   prepareRow = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.prepare")(function* <
@@ -301,6 +415,27 @@ export class ColumnarTopicStore {
     }
   }
 
+  private insertSlotIntoOrderedIndexes(slot: number): void {
+    for (const index of this.orderedSlotIndexes.values()) {
+      const insertAt = orderedSlotIndexInsertionPoint(index.slots, slot, (left, right) =>
+        this.compareSlotsByStorageOrder(left, right, index.orderBy),
+      );
+      index.slots.splice(insertAt, 0, slot);
+    }
+  }
+
+  private setPreparedWithoutIndexMaintenance(prepared: PreparedTopicRow): void {
+    const existingSlot = this.keyToSlot.get(prepared.key);
+    if (existingSlot !== undefined) {
+      this.writeSlot(existingSlot, prepared);
+      return;
+    }
+
+    const slot = this.slots.length;
+    this.keyToSlot.set(prepared.key, slot);
+    this.writeSlot(slot, prepared);
+  }
+
   private rowForKey(key: string): object | undefined {
     const slot = this.keyToSlot.get(key);
     if (slot === undefined) {
@@ -375,4 +510,38 @@ const compareRangeColumnValue = (left: unknown, right: unknown): number | undefi
     return left < right ? -1 : 1;
   }
   return undefined;
+};
+
+const orderedSlotIndexKey = (orderBy: ReadonlyArray<TopicRawOrderByPlan>): string => {
+  const order = orderBy[0]!;
+  return `${order.field.length}:${order.field}:${order.direction}`;
+};
+
+const orderedSlotIndexInsertionPoint = (
+  slots: ReadonlyArray<number>,
+  slot: number,
+  compareSlots: (left: number, right: number) => number,
+): number => {
+  let low = 0;
+  let high = slots.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (compareSlots(slots[middle]!, slot) <= 0) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+};
+
+const predicateFiltersAreOrderedIndexAdmissible = (
+  filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+): boolean => {
+  for (const filter of filters) {
+    if (filter.operator !== "eq" && filter.operator !== "in") {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -494,6 +494,87 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
 
       expect(countOnly.rows).toStrictEqual([]);
       expect(countOnly.totalRows).toBe(7);
+
+      yield* engine.publish("orders", order("bb", "open", 8, 9));
+
+      const afterTieAppend = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 4,
+      });
+
+      expect(afterTieAppend.rows).toStrictEqual([
+        { id: "d", price: 10 },
+        { id: "b", price: 8 },
+        { id: "bb", price: 8 },
+        { id: "f", price: 7 },
+      ]);
+      expect(afterTieAppend.totalRows).toBe(8);
+
+      yield* engine.publish("orders", order("f", "open", 11, 10));
+
+      const afterReplace = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 4,
+      });
+
+      expect(afterReplace.rows).toStrictEqual([
+        { id: "f", price: 11 },
+        { id: "d", price: 10 },
+        { id: "b", price: 8 },
+        { id: "bb", price: 8 },
+      ]);
+      expect(afterReplace.totalRows).toBe(8);
+
+      yield* engine.publishMany("orders", [
+        order("f", "open", 12, 11),
+        order("i", "open", 9, 12),
+        order("j", "open", 0, 13),
+      ]);
+
+      const afterAppend = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 5,
+      });
+
+      expect(afterAppend.rows).toStrictEqual([
+        { id: "f", price: 12 },
+        { id: "d", price: 10 },
+        { id: "i", price: 9 },
+        { id: "b", price: 8 },
+        { id: "bb", price: 8 },
+      ]);
+      expect(afterAppend.totalRows).toBe(10);
+
+      yield* engine.delete("orders", "d");
+
+      const afterDelete = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          status: "open",
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 4,
+      });
+
+      expect(afterDelete.rows).toStrictEqual([
+        { id: "f", price: 12 },
+        { id: "i", price: 9 },
+        { id: "b", price: 8 },
+        { id: "bb", price: 8 },
+      ]);
+      expect(afterDelete.totalRows).toBe(9);
     }),
   );
 
@@ -3197,6 +3278,92 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         limit: undefined,
       });
       expect(invalidStorageOrderColumn.keys).toStrictEqual(["3", "2"]);
+
+      const invalidStorageOrderColumnLimited = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "missing", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: 1,
+      });
+      expect(invalidStorageOrderColumnLimited.keys).toStrictEqual(["3"]);
+      expect(invalidStorageOrderColumnLimited.totalRows).toBe(2);
+
+      const multiFieldStorageOrderZeroLimit = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [
+          { field: "price", direction: "asc" },
+          { field: "updatedAt", direction: "desc" },
+        ],
+        storageOrderBy: [
+          { field: "price", direction: "asc" },
+          { field: "updatedAt", direction: "desc" },
+        ],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 0,
+      });
+      expect(multiFieldStorageOrderZeroLimit.keys).toStrictEqual([]);
+      expect(multiFieldStorageOrderZeroLimit.totalRows).toBe(2);
+
+      const negativeLimitPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: -1,
+      });
+      expect(negativeLimitPlan.keys).toStrictEqual(["2"]);
+      expect(negativeLimitPlan.totalRows).toBe(2);
+
+      const nanLimitPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: Number.NaN,
+      });
+      expect(nanLimitPlan.keys).toStrictEqual([]);
+      expect(nanLimitPlan.totalRows).toBe(2);
+
+      const infiniteLimitPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: Number.POSITIVE_INFINITY,
+      });
+      expect(infiniteLimitPlan.keys).toStrictEqual(["2", "3"]);
+      expect(infiniteLimitPlan.totalRows).toBe(2);
 
       const missingOrderColumnLimitedMisses = readModel.scanRawWindow({
         where: undefined,


### PR DESCRIPTION
## Summary
- add a cached ordered-slot index fast path for finite raw top-k scans
- admit the fast path only for positive safe-integer limits, one compiler-proven order field, no callback-required predicates, and eq/in filters
- keep exact totalRows semantics while avoiding full matched-row sort/materialization for admitted windows
- invalidate ordered indexes on replacement/delete/clear and clear them once for multi-row batches to avoid O(batch * rows) splice pressure
- add lifecycle tests for append tie-breaks, replacement, batch invalidation, delete invalidation, and hostile invalid limits

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test: 110 passed, 100% statements/branches/functions/lines
- pnpm run check:effect: 0 errors, 0 warnings, 0 messages
- pnpm run ready
- forbidden-pattern scan clean for casts, toEqual, assert, coverage ignores, Testing Library, act, flushSync, test ids, and Date usage

## Benchmarks
100k rows, local serial run:
- equality filter + top-k sort mean 8.27ms
- range filter + top-k sort mean 0.97ms
- compound filter + top-k sort mean 3.79ms
- filtered totalRows zero-row mean 2.73ms
- live subscription delta after publish mean 7.87ms

1M rows, local serial run:
- equality filter + top-k sort mean 78.15ms
- range filter + top-k sort mean 60.97ms
- compound filter + top-k sort mean 145.06ms
- filtered totalRows zero-row mean 118.61ms
- live subscription delta after publish mean 81.89ms

Three local review agents completed final pass with no findings.