### PR TITLE
Add ordered raw range seek

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -10,6 +10,7 @@ import type {
 } from "./row-scan";
 import {
   compareQueryValue,
+  isRangePlanValue,
   rawQueryCompilerMetadata,
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
@@ -26,8 +27,30 @@ type OrderedSlotIndex = {
 };
 
 type OrderedRawWindow = {
+  readonly endIndex: number;
   readonly limit: number;
   readonly slots: ReadonlyArray<number>;
+  readonly startIndex: number;
+};
+
+type OrderedRangeBound = {
+  readonly exclusive: boolean;
+  readonly value: unknown;
+};
+
+type OrderedRangeBounds = {
+  readonly lower: OrderedRangeBound | undefined;
+  readonly upper: OrderedRangeBound | undefined;
+};
+
+type TopicRawRangePredicateFilterPlan = TopicRawPredicateFilterPlan & {
+  readonly operator: "gt" | "gte" | "lt" | "lte";
+  readonly value: unknown;
+};
+
+const noOrderedRangeBounds: OrderedRangeBounds = {
+  lower: undefined,
+  upper: undefined,
 };
 
 export type PreparedTopicRow = {
@@ -182,7 +205,12 @@ export class ColumnarTopicStore {
     let totalRows = 0;
     const windowSlots: Array<number> = [];
     const windowEnd = plan.offset + orderedWindow.limit;
-    for (const slot of orderedWindow.slots) {
+    for (
+      let slotIndex = orderedWindow.startIndex;
+      slotIndex < orderedWindow.endIndex;
+      slotIndex += 1
+    ) {
+      const slot = orderedWindow.slots[slotIndex]!;
       const entry = this.slots[slot]!;
       if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
         continue;
@@ -243,22 +271,40 @@ export class ColumnarTopicStore {
     ) {
       return undefined;
     }
-    if (
-      plan.predicate.callbackRequired ||
-      !predicateFiltersAreOrderedIndexAdmissible(plan.predicate.filters)
-    ) {
+    const orderField = storageOrderBy[0]!.field;
+    if (plan.predicate.callbackRequired) {
+      return undefined;
+    }
+    if (!predicateFiltersAreOrderedIndexAdmissible(plan.predicate.filters, orderField)) {
       return undefined;
     }
     if (!this.storageOrderByFieldsExist(storageOrderBy)) {
       return undefined;
     }
 
+    const rangeBounds = orderedRangeBoundsForField(
+      plan.predicate.filters,
+      orderField,
+      this.rawQueryMetadata,
+    );
+    if (rangeBounds !== undefined && rangeBoundsAreEmpty(rangeBounds)) {
+      return {
+        endIndex: 0,
+        limit: plan.limit,
+        slots: [],
+        startIndex: 0,
+      };
+    }
+    const seekBounds = rangeBounds ?? noOrderedRangeBounds;
     const indexKey = orderedSlotIndexKey(storageOrderBy);
     const existing = this.orderedSlotIndexes.get(indexKey);
     if (existing !== undefined) {
+      const bounds = this.orderedSlotIndexBounds(existing, seekBounds);
       return {
+        endIndex: bounds.endIndex,
         limit: plan.limit,
         slots: existing.slots,
+        startIndex: bounds.startIndex,
       };
     }
 
@@ -268,9 +314,12 @@ export class ColumnarTopicStore {
       orderBy: storageOrderBy,
       slots,
     });
+    const bounds = this.orderedSlotIndexBounds({ orderBy: storageOrderBy, slots }, seekBounds);
     return {
+      endIndex: bounds.endIndex,
       limit: plan.limit,
       slots,
+      startIndex: bounds.startIndex,
     };
   }
 
@@ -298,7 +347,7 @@ export class ColumnarTopicStore {
     for (const order of storageOrderBy) {
       const column = this.columns.get(order.field)!;
       const comparison = compareQueryValue(column[left], column[right]);
-      if (comparison !== undefined && comparison !== 0) {
+      if (comparison !== 0) {
         return order.direction === "asc" ? comparison : -comparison;
       }
     }
@@ -314,6 +363,68 @@ export class ColumnarTopicStore {
       }
     }
     return true;
+  }
+
+  private orderedSlotIndexBounds(
+    index: OrderedSlotIndex,
+    rangeBounds: OrderedRangeBounds,
+  ): { readonly startIndex: number; readonly endIndex: number } {
+    const order = index.orderBy[0]!;
+    const column = this.columns.get(order.field)!;
+    if (order.direction === "asc") {
+      const startIndex =
+        rangeBounds.lower === undefined
+          ? 0
+          : orderedSlotBoundIndex(
+              index.slots,
+              column,
+              rangeBounds.lower.value,
+              rangeBounds.lower.exclusive
+                ? (comparison) => comparison > 0
+                : (comparison) => comparison >= 0,
+            );
+      const endIndex =
+        rangeBounds.upper === undefined
+          ? index.slots.length
+          : orderedSlotBoundIndex(
+              index.slots,
+              column,
+              rangeBounds.upper.value,
+              rangeBounds.upper.exclusive
+                ? (comparison) => comparison >= 0
+                : (comparison) => comparison > 0,
+            );
+      return {
+        endIndex: Math.max(startIndex, endIndex),
+        startIndex,
+      };
+    }
+    const startIndex =
+      rangeBounds.upper === undefined
+        ? 0
+        : orderedSlotBoundIndex(
+            index.slots,
+            column,
+            rangeBounds.upper.value,
+            rangeBounds.upper.exclusive
+              ? (comparison) => comparison < 0
+              : (comparison) => comparison <= 0,
+          );
+    const endIndex =
+      rangeBounds.lower === undefined
+        ? index.slots.length
+        : orderedSlotBoundIndex(
+            index.slots,
+            column,
+            rangeBounds.lower.value,
+            rangeBounds.lower.exclusive
+              ? (comparison) => comparison <= 0
+              : (comparison) => comparison < 0,
+          );
+    return {
+      endIndex: Math.max(startIndex, endIndex),
+      startIndex,
+    };
   }
 
   prepareRow = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.prepare")(function* <
@@ -537,11 +648,149 @@ const orderedSlotIndexInsertionPoint = (
 
 const predicateFiltersAreOrderedIndexAdmissible = (
   filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+  orderField: string,
 ): boolean => {
   for (const filter of filters) {
-    if (filter.operator !== "eq" && filter.operator !== "in") {
-      return false;
+    if (filter.operator === "eq" || filter.operator === "in") {
+      continue;
     }
+    if (isRangeFilterPlan(filter) && filter.field === orderField) {
+      continue;
+    }
+    return false;
   }
   return true;
+};
+
+const orderedRangeBoundsForField = (
+  filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+  field: string,
+  metadata: RawQueryCompilerMetadata,
+): OrderedRangeBounds | undefined => {
+  let lower: OrderedRangeBound | undefined;
+  let upper: OrderedRangeBound | undefined;
+  for (const filter of filters) {
+    if (filter.field !== field || !isRangeFilterPlan(filter)) {
+      continue;
+    }
+    if (!isRangePlanValue(field, filter.value, metadata)) {
+      return undefined;
+    }
+    switch (filter.operator) {
+      case "gt": {
+        lower = strongerLowerBound(lower, {
+          exclusive: true,
+          value: filter.value,
+        });
+        break;
+      }
+      case "gte": {
+        lower = strongerLowerBound(lower, {
+          exclusive: false,
+          value: filter.value,
+        });
+        break;
+      }
+      case "lt": {
+        upper = strongerUpperBound(upper, {
+          exclusive: true,
+          value: filter.value,
+        });
+        break;
+      }
+      case "lte": {
+        upper = strongerUpperBound(upper, {
+          exclusive: false,
+          value: filter.value,
+        });
+        break;
+      }
+    }
+  }
+  return {
+    lower,
+    upper,
+  };
+};
+
+const strongerLowerBound = (
+  current: OrderedRangeBound | undefined,
+  candidate: OrderedRangeBound,
+): OrderedRangeBound => {
+  if (current === undefined) {
+    return candidate;
+  }
+  const comparison = compareOrderedRangeValue(candidate.value, current.value);
+  if (comparison > 0) {
+    return candidate;
+  }
+  if (comparison === 0 && candidate.exclusive && !current.exclusive) {
+    return candidate;
+  }
+  return current;
+};
+
+const strongerUpperBound = (
+  current: OrderedRangeBound | undefined,
+  candidate: OrderedRangeBound,
+): OrderedRangeBound => {
+  if (current === undefined) {
+    return candidate;
+  }
+  const comparison = compareOrderedRangeValue(candidate.value, current.value);
+  if (comparison < 0) {
+    return candidate;
+  }
+  if (comparison === 0 && candidate.exclusive && !current.exclusive) {
+    return candidate;
+  }
+  return current;
+};
+
+const rangeBoundsAreEmpty = (bounds: OrderedRangeBounds): boolean => {
+  if (bounds.lower === undefined || bounds.upper === undefined) {
+    return false;
+  }
+  const comparison = compareOrderedRangeValue(bounds.lower.value, bounds.upper.value);
+  if (comparison > 0) {
+    return true;
+  }
+  return comparison === 0 && (bounds.lower.exclusive || bounds.upper.exclusive);
+};
+
+const orderedSlotBoundIndex = (
+  slots: ReadonlyArray<number>,
+  column: ColumnValues,
+  value: unknown,
+  predicate: (comparison: number) => boolean,
+): number => {
+  let low = 0;
+  let high = slots.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    const comparison = compareOrderedRangeValue(column[slots[middle]!], value);
+    if (predicate(comparison)) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return low;
+};
+
+const compareOrderedRangeValue = (left: unknown, right: unknown): number =>
+  compareQueryValue(left, right);
+
+const isRangeFilterPlan = (
+  filter: TopicRawPredicateFilterPlan,
+): filter is TopicRawRangePredicateFilterPlan => {
+  if (
+    filter.operator === "gt" ||
+    filter.operator === "gte" ||
+    filter.operator === "lt" ||
+    filter.operator === "lte"
+  ) {
+    return true;
+  }
+  return false;
 };

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -224,7 +224,7 @@ const updateAggregateState = (
     return;
   }
   const comparison = compareQueryValue(value, state.value);
-  if (comparison === undefined || comparison === 0) {
+  if (comparison === 0) {
     return;
   }
   if ((state.aggFunc === "min" && comparison < 0) || (state.aggFunc === "max" && comparison > 0)) {
@@ -291,7 +291,7 @@ const compareGroupedRows = (
   for (const order of orderBy) {
     const field = "field" in order ? order.field : order.aggregate;
     const comparison = compareQueryValue(fieldValue(left.row, field), fieldValue(right.row, field));
-    if (comparison !== undefined && comparison !== 0) {
+    if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
   }

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -578,6 +578,219 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
+  it.effect("uses ordered range seeks for raw snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      yield* engine.publishMany("orders", [
+        order("a", "open", 1, 1),
+        order("b", "open", 2, 2),
+        order("c", "open", 3, 3),
+        order("d", "open", 4, 4),
+        order("e", "open", 5, 5),
+        order("f", "open", 6, 6),
+        order("g", "open", 7, 7),
+        order("h", "open", 8, 8),
+        order("z", "closed", 99, 9),
+      ]);
+
+      const ascendingInclusive = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gte: 3 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        offset: 1,
+        limit: 2,
+      });
+
+      expect(ascendingInclusive.rows).toStrictEqual([
+        { id: "d", price: 4 },
+        { id: "e", price: 5 },
+      ]);
+      expect(ascendingInclusive.totalRows).toBe(7);
+
+      const ascendingExclusive = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gt: 3, lt: 7 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(ascendingExclusive.rows).toStrictEqual([
+        { id: "d", price: 4 },
+        { id: "e", price: 5 },
+        { id: "f", price: 6 },
+      ]);
+      expect(ascendingExclusive.totalRows).toBe(3);
+
+      const strongerDifferentBounds = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gt: 3, gte: 4, lt: 8, lte: 6 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(strongerDifferentBounds.rows).toStrictEqual([
+        { id: "d", price: 4 },
+        { id: "e", price: 5 },
+        { id: "f", price: 6 },
+      ]);
+      expect(strongerDifferentBounds.totalRows).toBe(3);
+
+      const strongerEqualBounds = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gte: 3, gt: 3, lte: 6, lt: 6 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(strongerEqualBounds.rows).toStrictEqual([
+        { id: "d", price: 4 },
+        { id: "e", price: 5 },
+      ]);
+      expect(strongerEqualBounds.totalRows).toBe(2);
+
+      const descendingInclusive = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { lte: 6 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        offset: 1,
+        limit: 2,
+      });
+
+      expect(descendingInclusive.rows).toStrictEqual([
+        { id: "e", price: 5 },
+        { id: "d", price: 4 },
+      ]);
+      expect(descendingInclusive.totalRows).toBe(6);
+
+      const descendingExclusive = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { lt: 6 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 2,
+      });
+
+      expect(descendingExclusive.rows).toStrictEqual([
+        { id: "e", price: 5 },
+        { id: "d", price: 4 },
+      ]);
+      expect(descendingExclusive.totalRows).toBe(5);
+
+      const descendingLowerBound = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gt: 3 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 2,
+      });
+
+      expect(descendingLowerBound.rows).toStrictEqual([
+        { id: "z", price: 99 },
+        { id: "h", price: 8 },
+      ]);
+      expect(descendingLowerBound.totalRows).toBe(6);
+
+      const descendingLowerInclusive = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gte: 6 },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        limit: 4,
+      });
+
+      expect(descendingLowerInclusive.rows).toStrictEqual([
+        { id: "z", price: 99 },
+        { id: "h", price: 8 },
+        { id: "g", price: 7 },
+        { id: "f", price: 6 },
+      ]);
+      expect(descendingLowerInclusive.totalRows).toBe(4);
+
+      const exactInclusiveRange = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gte: 4, lte: 4 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 2,
+      });
+
+      expect(exactInclusiveRange.rows).toStrictEqual([{ id: "d", price: 4 }]);
+      expect(exactInclusiveRange.totalRows).toBe(1);
+
+      const impossibleRange = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gt: 4, lte: 4 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 5,
+      });
+
+      expect(impossibleRange.rows).toStrictEqual([]);
+      expect(impossibleRange.totalRows).toBe(0);
+
+      const invertedRange = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gt: 7, lt: 4 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 5,
+      });
+
+      expect(invertedRange.rows).toStrictEqual([]);
+      expect(invertedRange.totalRows).toBe(0);
+
+      const nonOrderFieldRange = yield* engine.snapshot("orders", {
+        select: ["id", "price", "updatedAt"],
+        where: {
+          price: { gte: 4 },
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        limit: 2,
+      });
+
+      expect(nonOrderFieldRange.rows).toStrictEqual([
+        { id: "z", price: 99, updatedAt: 9 },
+        { id: "h", price: 8, updatedAt: 8 },
+      ]);
+      expect(nonOrderFieldRange.totalRows).toBe(6);
+
+      yield* engine.publish("orders", order("i", "open", 9, 10));
+
+      const afterAppend = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gte: 8 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 3,
+      });
+
+      expect(afterAppend.rows).toStrictEqual([
+        { id: "h", price: 8 },
+        { id: "i", price: 9 },
+        { id: "z", price: 99 },
+      ]);
+      expect(afterAppend.totalRows).toBe(3);
+    }),
+  );
+
   it.effect("does not expose stored row objects through snapshots", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();
@@ -3364,6 +3577,59 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(infiniteLimitPlan.keys).toStrictEqual(["2", "3"]);
       expect(infiniteLimitPlan.totalRows).toBe(2);
+
+      const callbackRequiredStorageOrderPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: matchesOnlySecondRow,
+        compare: compareByKeyDescending,
+        offset: 0,
+        limit: 10,
+      });
+      expect(callbackRequiredStorageOrderPlan.keys).toStrictEqual(["2"]);
+      expect(callbackRequiredStorageOrderPlan.totalRows).toBe(1);
+
+      const manuallyOrderedEqualExclusiveBounds = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [
+            { field: "price", operator: "gte", value: 20 },
+            { field: "price", operator: "gt", value: 20 },
+            { field: "price", operator: "lte", value: 30 },
+            { field: "price", operator: "lt", value: 30 },
+          ],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(manuallyOrderedEqualExclusiveBounds.keys).toStrictEqual([]);
+      expect(manuallyOrderedEqualExclusiveBounds.totalRows).toBe(0);
+
+      const unsafeRangeHintPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: "10" }],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(unsafeRangeHintPlan.keys).toStrictEqual(["2", "3"]);
+      expect(unsafeRangeHintPlan.totalRows).toBe(2);
 
       const missingOrderColumnLimitedMisses = readModel.scanRawWindow({
         where: undefined,

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -694,7 +694,7 @@ const compareByStableString = (left: unknown, right: unknown): number => {
   return Number(leftString > rightString) - Number(leftString < rightString);
 };
 
-export const compareQueryValue = (left: unknown, right: unknown): number | undefined => {
+export const compareQueryValue = (left: unknown, right: unknown): number => {
   const leftRank = valueRank(left);
   const rightRank = valueRank(right);
   if (leftRank !== rightRank) {
@@ -863,7 +863,7 @@ const isScalarPlanValue = (value: unknown): boolean =>
   isBigDecimal(value) ||
   (typeof value === "number" && Number.isFinite(value));
 
-const isRangePlanValue = (
+export const isRangePlanValue = (
   field: string,
   value: unknown,
   metadata: RawQueryCompilerMetadata,
@@ -1089,7 +1089,7 @@ const compareRows = <Row extends RowObject>(
       fieldValue(left.row, order.field),
       fieldValue(right.row, order.field),
     );
-    if (comparison !== undefined && comparison !== 0) {
+    if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
   }


### PR DESCRIPTION
## Summary
- add range-aware binary seek bounds for cached single-field ordered raw slot indexes
- keep exact totalRows by scanning bounded candidates and still calling plan.matches
- disable seek bounds for unsafe direct/custom range hints and fall back to full ordered scan
- short-circuit proven-empty ranges before sorting/caching an ordered index

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready
- forbidden-pattern scan on column-live-view-engine/src
- 3-agent review cycle: no findings

## Benchmarks
100k rows raw snapshot bench:
- range filter + top-k sort mean 0.0327ms
- equality filter + top-k sort mean 7.2619ms
- live subscription delta after publish mean 7.7517ms

1M rows raw snapshot bench:
- range filter + top-k sort mean 52.7069ms
- equality filter + top-k sort mean 71.2323ms
- compound filter + top-k sort mean 145.05ms
