### PR TITLE
Add ordered raw equality seek

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -26,11 +26,15 @@ type OrderedSlotIndex = {
   readonly slots: Array<number>;
 };
 
-type OrderedRawWindow = {
+type OrderedRawWindowSpan = {
   readonly endIndex: number;
+  readonly startIndex: number;
+};
+
+type OrderedRawWindow = {
   readonly limit: number;
   readonly slots: ReadonlyArray<number>;
-  readonly startIndex: number;
+  readonly spans: ReadonlyArray<OrderedRawWindowSpan>;
 };
 
 type OrderedRangeBound = {
@@ -46,6 +50,16 @@ type OrderedRangeBounds = {
 type TopicRawRangePredicateFilterPlan = TopicRawPredicateFilterPlan & {
   readonly operator: "gt" | "gte" | "lt" | "lte";
   readonly value: unknown;
+};
+
+type TopicRawEqualityPredicateFilterPlan = TopicRawPredicateFilterPlan & {
+  readonly operator: "eq";
+  readonly value: unknown;
+};
+
+type TopicRawInPredicateFilterPlan = TopicRawPredicateFilterPlan & {
+  readonly operator: "in";
+  readonly values: ReadonlyArray<unknown>;
 };
 
 const noOrderedRangeBounds: OrderedRangeBounds = {
@@ -205,20 +219,18 @@ export class ColumnarTopicStore {
     let totalRows = 0;
     const windowSlots: Array<number> = [];
     const windowEnd = plan.offset + orderedWindow.limit;
-    for (
-      let slotIndex = orderedWindow.startIndex;
-      slotIndex < orderedWindow.endIndex;
-      slotIndex += 1
-    ) {
-      const slot = orderedWindow.slots[slotIndex]!;
-      const entry = this.slots[slot]!;
-      if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
-        continue;
-      }
-      const matchIndex = totalRows;
-      totalRows += 1;
-      if (matchIndex >= plan.offset && matchIndex < windowEnd) {
-        windowSlots.push(slot);
+    for (const span of orderedWindow.spans) {
+      for (let slotIndex = span.startIndex; slotIndex < span.endIndex; slotIndex += 1) {
+        const slot = orderedWindow.slots[slotIndex]!;
+        const entry = this.slots[slot]!;
+        if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
+          continue;
+        }
+        const matchIndex = totalRows;
+        totalRows += 1;
+        if (matchIndex >= plan.offset && matchIndex < windowEnd) {
+          windowSlots.push(slot);
+        }
       }
     }
     const window = windowSlots.map((slot) => this.slots[slot]!);
@@ -289,22 +301,24 @@ export class ColumnarTopicStore {
     );
     if (rangeBounds !== undefined && rangeBoundsAreEmpty(rangeBounds)) {
       return {
-        endIndex: 0,
         limit: plan.limit,
         slots: [],
-        startIndex: 0,
+        spans: [],
       };
     }
     const seekBounds = rangeBounds ?? noOrderedRangeBounds;
+    const equalityValues = orderedEqualityValuesForField(
+      plan.predicate.filters,
+      orderField,
+      this.rawQueryMetadata,
+    );
     const indexKey = orderedSlotIndexKey(storageOrderBy);
     const existing = this.orderedSlotIndexes.get(indexKey);
     if (existing !== undefined) {
-      const bounds = this.orderedSlotIndexBounds(existing, seekBounds);
       return {
-        endIndex: bounds.endIndex,
         limit: plan.limit,
         slots: existing.slots,
-        startIndex: bounds.startIndex,
+        spans: this.orderedSlotIndexSpans(existing, seekBounds, equalityValues),
       };
     }
 
@@ -314,12 +328,14 @@ export class ColumnarTopicStore {
       orderBy: storageOrderBy,
       slots,
     });
-    const bounds = this.orderedSlotIndexBounds({ orderBy: storageOrderBy, slots }, seekBounds);
     return {
-      endIndex: bounds.endIndex,
       limit: plan.limit,
       slots,
-      startIndex: bounds.startIndex,
+      spans: this.orderedSlotIndexSpans(
+        { orderBy: storageOrderBy, slots },
+        seekBounds,
+        equalityValues,
+      ),
     };
   }
 
@@ -365,10 +381,36 @@ export class ColumnarTopicStore {
     return true;
   }
 
+  private orderedSlotIndexSpans(
+    index: OrderedSlotIndex,
+    rangeBounds: OrderedRangeBounds,
+    equalityValues: ReadonlyArray<unknown> | undefined,
+  ): ReadonlyArray<OrderedRawWindowSpan> {
+    if (equalityValues === undefined) {
+      return [this.orderedSlotIndexBounds(index, rangeBounds)];
+    }
+    const seekValues = distinctOrderedEqualityValues(equalityValues).filter((value) =>
+      equalityValueSatisfiesRangeBounds(value, rangeBounds),
+    );
+    const spans = seekValues.map((value) =>
+      this.orderedSlotIndexBounds(index, {
+        lower: {
+          exclusive: false,
+          value,
+        },
+        upper: {
+          exclusive: false,
+          value,
+        },
+      }),
+    );
+    return orderedWindowSpansInIndexOrder(spans);
+  }
+
   private orderedSlotIndexBounds(
     index: OrderedSlotIndex,
     rangeBounds: OrderedRangeBounds,
-  ): { readonly startIndex: number; readonly endIndex: number } {
+  ): OrderedRawWindowSpan {
     const order = index.orderBy[0]!;
     const column = this.columns.get(order.field)!;
     if (order.direction === "asc") {
@@ -662,6 +704,68 @@ const predicateFiltersAreOrderedIndexAdmissible = (
   return true;
 };
 
+const orderedEqualityValuesForField = (
+  filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+  field: string,
+  metadata: RawQueryCompilerMetadata,
+): ReadonlyArray<unknown> | undefined => {
+  let values: ReadonlyArray<unknown> = [];
+  let hasEqualityFilter = false;
+  let hasSafeEqualityFilter = false;
+  let hasUnsafeEqualityFilter = false;
+  let hasEmptyInFilter = false;
+  for (const filter of filters) {
+    if (filter.field !== field || !isEqualityFilterPlan(filter)) {
+      continue;
+    }
+    hasEqualityFilter = true;
+    const nextValues: Array<unknown> = [];
+    if (filter.operator === "eq") {
+      if (isEqualitySeekPlanValue(field, filter.value, metadata)) {
+        nextValues.push(filter.value);
+      } else {
+        hasUnsafeEqualityFilter = true;
+      }
+    } else if (filter.values.length === 0) {
+      hasEmptyInFilter = true;
+    } else {
+      for (const value of filter.values) {
+        if (isEqualitySeekPlanValue(field, value, metadata)) {
+          nextValues.push(value);
+        } else {
+          hasUnsafeEqualityFilter = true;
+        }
+      }
+    }
+    if (nextValues.length > 0) {
+      if (!hasSafeEqualityFilter) {
+        values = nextValues;
+        hasSafeEqualityFilter = true;
+      } else {
+        values = intersectOrderedEqualityValues(values, nextValues);
+      }
+    }
+  }
+  if (hasEmptyInFilter) {
+    return [];
+  }
+  if (hasUnsafeEqualityFilter || !hasEqualityFilter) {
+    return undefined;
+  }
+  return values;
+};
+
+const isEqualitySeekPlanValue = (
+  field: string,
+  value: unknown,
+  metadata: RawQueryCompilerMetadata,
+): boolean => {
+  if (metadata.stringFieldNames.has(field)) {
+    return typeof value === "string";
+  }
+  return isRangePlanValue(field, value, metadata);
+};
+
 const orderedRangeBoundsForField = (
   filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
   field: string,
@@ -778,8 +882,81 @@ const orderedSlotBoundIndex = (
   return low;
 };
 
+const orderedWindowSpansInIndexOrder = (
+  spans: ReadonlyArray<OrderedRawWindowSpan>,
+): ReadonlyArray<OrderedRawWindowSpan> => {
+  return spans
+    .filter((span) => span.startIndex < span.endIndex)
+    .toSorted((left, right) => left.startIndex - right.startIndex);
+};
+
+const distinctOrderedEqualityValues = (values: ReadonlyArray<unknown>): ReadonlyArray<unknown> => {
+  const sorted = values.toSorted(compareOrderedRangeValue);
+  const distinct: Array<unknown> = [];
+  for (const value of sorted) {
+    const previous = distinct.at(-1);
+    if (previous === undefined || compareOrderedRangeValue(previous, value) !== 0) {
+      distinct.push(value);
+    }
+  }
+  return distinct;
+};
+
+const intersectOrderedEqualityValues = (
+  leftValues: ReadonlyArray<unknown>,
+  rightValues: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> => {
+  const left = distinctOrderedEqualityValues(leftValues);
+  const right = distinctOrderedEqualityValues(rightValues);
+  const intersection: Array<unknown> = [];
+  let rightIndex = 0;
+  for (const leftValue of left) {
+    while (
+      rightIndex < right.length &&
+      compareOrderedRangeValue(right[rightIndex]!, leftValue) < 0
+    ) {
+      rightIndex += 1;
+    }
+    if (
+      rightIndex < right.length &&
+      compareOrderedRangeValue(right[rightIndex]!, leftValue) === 0
+    ) {
+      intersection.push(leftValue);
+    }
+  }
+  return intersection;
+};
+
+const equalityValueSatisfiesRangeBounds = (
+  value: unknown,
+  rangeBounds: OrderedRangeBounds,
+): boolean => {
+  if (rangeBounds.lower !== undefined) {
+    const comparison = compareOrderedRangeValue(value, rangeBounds.lower.value);
+    if (comparison < 0 || (comparison === 0 && rangeBounds.lower.exclusive)) {
+      return false;
+    }
+  }
+  if (rangeBounds.upper !== undefined) {
+    const comparison = compareOrderedRangeValue(value, rangeBounds.upper.value);
+    if (comparison > 0 || (comparison === 0 && rangeBounds.upper.exclusive)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 const compareOrderedRangeValue = (left: unknown, right: unknown): number =>
   compareQueryValue(left, right);
+
+const isEqualityFilterPlan = (
+  filter: TopicRawPredicateFilterPlan,
+): filter is TopicRawEqualityPredicateFilterPlan | TopicRawInPredicateFilterPlan => {
+  if (filter.operator === "eq" || filter.operator === "in") {
+    return true;
+  }
+  return false;
+};
 
 const isRangeFilterPlan = (
   filter: TopicRawPredicateFilterPlan,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -610,6 +610,136 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       ]);
       expect(ascendingInclusive.totalRows).toBe(7);
 
+      const numericEquality = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { eq: 5 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(numericEquality.rows).toStrictEqual([{ id: "e", price: 5 }]);
+      expect(numericEquality.totalRows).toBe(1);
+
+      const numericInAscending = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { in: [8, 2, 99, 2] },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(numericInAscending.rows).toStrictEqual([
+        { id: "b", price: 2 },
+        { id: "h", price: 8 },
+        { id: "z", price: 99 },
+      ]);
+      expect(numericInAscending.totalRows).toBe(3);
+
+      const numericInDescending = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { in: [8, 2, 99, 2] },
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        offset: 1,
+        limit: 1,
+      });
+
+      expect(numericInDescending.rows).toStrictEqual([{ id: "h", price: 8 }]);
+      expect(numericInDescending.totalRows).toBe(3);
+
+      const emptyIn = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { in: [] },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(emptyIn.rows).toStrictEqual([]);
+      expect(emptyIn.totalRows).toBe(0);
+
+      const stringEquality = yield* engine.snapshot("orders", {
+        select: ["id", "status"],
+        where: {
+          status: { eq: "closed" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(stringEquality.rows).toStrictEqual([{ id: "z", status: "closed" }]);
+      expect(stringEquality.totalRows).toBe(1);
+
+      const stringIn = yield* engine.snapshot("orders", {
+        select: ["id", "customerId"],
+        where: {
+          customerId: { in: ["customer-h", "customer-b", "customer-z", "customer-b"] },
+        },
+        orderBy: [{ field: "customerId", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(stringIn.rows).toStrictEqual([
+        { id: "b", customerId: "customer-b" },
+        { id: "h", customerId: "customer-h" },
+        { id: "z", customerId: "customer-z" },
+      ]);
+      expect(stringIn.totalRows).toBe(3);
+
+      const numericInWithRange = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { in: [2, 5, 8, 99, 2], gte: 5, lt: 99 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        offset: 1,
+        limit: 1,
+      });
+
+      expect(numericInWithRange.rows).toStrictEqual([{ id: "h", price: 8 }]);
+      expect(numericInWithRange.totalRows).toBe(2);
+
+      const equalityInIntersection = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { eq: 5, in: [2, 5, 8] },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(equalityInIntersection.rows).toStrictEqual([{ id: "e", price: 5 }]);
+      expect(equalityInIntersection.totalRows).toBe(1);
+
+      const contradictoryEqualityInIntersection = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { eq: 5, in: [2, 8] },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(contradictoryEqualityInIntersection.rows).toStrictEqual([]);
+      expect(contradictoryEqualityInIntersection.totalRows).toBe(0);
+
+      const equalityOutsideRange = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { eq: 5, gt: 5 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(equalityOutsideRange.rows).toStrictEqual([]);
+      expect(equalityOutsideRange.totalRows).toBe(0);
+
       const ascendingExclusive = yield* engine.snapshot("orders", {
         select: ["id", "price"],
         where: {
@@ -771,7 +901,24 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       ]);
       expect(nonOrderFieldRange.totalRows).toBe(6);
 
-      yield* engine.publish("orders", order("i", "open", 9, 10));
+      yield* engine.publish("orders", order("hh", "open", 8, 10));
+
+      const duplicateEqualityValue = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { eq: 8 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(duplicateEqualityValue.rows).toStrictEqual([
+        { id: "h", price: 8 },
+        { id: "hh", price: 8 },
+      ]);
+      expect(duplicateEqualityValue.totalRows).toBe(2);
+
+      yield* engine.publish("orders", order("i", "open", 9, 11));
 
       const afterAppend = yield* engine.snapshot("orders", {
         select: ["id", "price"],
@@ -784,10 +931,10 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
 
       expect(afterAppend.rows).toStrictEqual([
         { id: "h", price: 8 },
+        { id: "hh", price: 8 },
         { id: "i", price: 9 },
-        { id: "z", price: 99 },
       ]);
-      expect(afterAppend.totalRows).toBe(3);
+      expect(afterAppend.totalRows).toBe(4);
     }),
   );
 
@@ -2430,6 +2577,17 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       });
       expect(rowIds(symbolOrdered.rows)).toStrictEqual(["position-3", "position-4"]);
 
+      const decimalEqualityOrdered = yield* engine.snapshot("positions", {
+        select: ["id"],
+        where: {
+          price: { eq: fromStringUnsafe("1.00") },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+      expect(rowIds(decimalEqualityOrdered.rows)).toStrictEqual(["position-3", "position-4"]);
+      expect(decimalEqualityOrdered.totalRows).toBe(2);
+
       const quantityOrdered = yield* engine.snapshot("positions", {
         select: ["id"],
         orderBy: [{ field: "quantity", direction: "asc" }],
@@ -2440,6 +2598,17 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         "position-4",
         "position-2",
       ]);
+
+      const bigintEqualityOrdered = yield* engine.snapshot("positions", {
+        select: ["id"],
+        where: {
+          quantity: { eq: 10n },
+        },
+        orderBy: [{ field: "quantity", direction: "asc" }],
+        limit: 10,
+      });
+      expect(rowIds(bigintEqualityOrdered.rows)).toStrictEqual(["position-1", "position-4"]);
+      expect(bigintEqualityOrdered.totalRows).toBe(2);
 
       const booleanNotEqual = yield* engine.snapshot("positions", {
         select: ["id"],
@@ -3630,6 +3799,86 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(unsafeRangeHintPlan.keys).toStrictEqual(["2", "3"]);
       expect(unsafeRangeHintPlan.totalRows).toBe(2);
+
+      const equalityHintPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "eq", value: 20 }],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(equalityHintPlan.keys).toStrictEqual(["2"]);
+      expect(equalityHintPlan.totalRows).toBe(1);
+
+      const unsafeEqualityHintPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "eq", value: "20" }],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(unsafeEqualityHintPlan.keys).toStrictEqual([]);
+      expect(unsafeEqualityHintPlan.totalRows).toBe(0);
+
+      const duplicateInHintPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "in", values: [20, 20, 30] }],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(duplicateInHintPlan.keys).toStrictEqual(["2", "3"]);
+      expect(duplicateInHintPlan.totalRows).toBe(2);
+
+      const emptyInHintPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "in", values: [] }],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(emptyInHintPlan.keys).toStrictEqual([]);
+      expect(emptyInHintPlan.totalRows).toBe(0);
+
+      const unsafeMixedInHintPlan = readModel.scanRawWindow({
+        where: undefined,
+        predicate: {
+          filters: [{ field: "price", operator: "in", values: [20, "30"] }],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(unsafeMixedInHintPlan.keys).toStrictEqual(["2"]);
+      expect(unsafeMixedInHintPlan.totalRows).toBe(1);
 
       const missingOrderColumnLimitedMisses = readModel.scanRawWindow({
         where: undefined,

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -273,6 +273,42 @@ describe(`raw snapshot and delta engine benchmark: ${profile.rowCount} rows`, ()
   );
 
   bench(
+    "ordered equality filter + indexed seek",
+    async () => {
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: ["id", "price", "status", "updatedAt"],
+          where: {
+            price: { eq: Math.floor(profile.rowCount / 2) % 1_000_000 },
+          },
+          orderBy: [{ field: "price", direction: "asc" }],
+          limit: 50,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
+    "ordered in filter + indexed seek",
+    async () => {
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: ["id", "price", "status", "updatedAt"],
+          where: {
+            price: {
+              in: [100, Math.floor(profile.rowCount / 2) % 1_000_000, profile.rowCount - 1],
+            },
+          },
+          orderBy: [{ field: "price", direction: "asc" }],
+          limit: 50,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
     "range filter + top-k sort",
     async () => {
       await Effect.runPromise(


### PR DESCRIPTION
## Summary
- Adds ordered raw window seek spans for safe eq/in predicates on the same single storage order field.
- Dedupes equality values, intersects them with range bounds, and intersects multiple equality predicates before binary seeking.
- Keeps slotMayMatchFilters and plan.matches as final safety gates for exact totalRows and hostile/direct plans.
- Adds regression coverage for numeric/string/BigInt/BigDecimal equality seeks, range+in intersection, duplicate equality values, empty in, descending order, and unsafe direct hints.
- Adds raw snapshot benchmark cases for ordered equality/in indexed seek.

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready
- 3-agent review cycle completed; final reviewers reported no findings. One pre-final benchmark naming/equality-union finding was fixed before this PR.

## Benchmark notes
Local raw snapshot benchmark showed indexed equality/in seek in the ~0.03-0.04ms class at 100k/1M rows, versus full equality-filtered sort in ~7.5ms/76ms. Treat as local directional benchmark data.