### PR TITLE
Share raw active queries across windows

### DIFF
--- a/packages/client/src/live-client.ts
+++ b/packages/client/src/live-client.ts
@@ -16,7 +16,7 @@ import type {
   ViewServerTransportError,
 } from "@view-server/config";
 import type { Effect, Stream } from "effect";
-import type * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import type { AtomRef } from "effect/unstable/reactivity";
 
 export type ViewServerLiveEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
 

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -35,7 +35,7 @@ import {
   type ViewServerWireLiveQuery,
 } from "@view-server/protocol";
 import { Context, Effect, Exit, Layer, ManagedRuntime, Scope, Stream } from "effect";
-import * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import { AtomRef } from "effect/unstable/reactivity";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import type {

--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -1,6 +1,6 @@
 import { fromStringUnsafe } from "effect/BigDecimal";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 import {
   acquireRawQueryExecution,
   activeStoreRawQueryExecutionCount,
@@ -176,6 +176,318 @@ describe("column-live-view-engine active query execution", () => {
       yield* releaseRawQueryExecution(topicStoreReadModel(store), idOnly);
       yield* releaseRawQueryExecution(topicStoreReadModel(store), idAndScore);
       expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
+    }),
+  );
+
+  it.effect("shares base evaluation across different windows", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-sharing",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const firstWindow = yield* prepareRawQuery(
+        "window-sharing",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 0,
+          limit: 1,
+        },
+      );
+      const secondWindow = yield* prepareRawQuery(
+        "window-sharing",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 1,
+          limit: 1,
+        },
+      );
+
+      const firstExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        firstWindow,
+      );
+      expect(firstExecution.initial("first").rows).toStrictEqual([{ id: "c", score: 3 }]);
+
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      expect(firstExecution.initial("first-after-unknown-release").rows).toStrictEqual([
+        { id: "c", score: 3 },
+      ]);
+
+      const secondExecution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        secondWindow,
+      );
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      expect(secondExecution.initial("second").rows).toStrictEqual([{ id: "b" }]);
+
+      const firstCursor = firstExecution.createCursor();
+      const secondCursor = secondExecution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const firstDelta = yield* firstExecution.next("first", firstCursor);
+      const secondDelta = yield* secondExecution.next("second", secondCursor);
+      expect(Option.getOrThrow(firstDelta)).toStrictEqual({
+        type: "delta",
+        topic: "window-sharing",
+        queryId: "first",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: "c",
+          },
+          {
+            type: "insert",
+            key: "d",
+            row: {
+              id: "d",
+              score: 4,
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 4,
+      });
+      expect(Option.getOrThrow(secondDelta)).toStrictEqual({
+        type: "delta",
+        topic: "window-sharing",
+        queryId: "second",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: "b",
+          },
+          {
+            type: "insert",
+            key: "c",
+            row: {
+              id: "c",
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 4,
+      });
+
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstWindow);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      expect(secondExecution.initial("second-after-release").rows).toStrictEqual([{ id: "c" }]);
+
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
+
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
+    }),
+  );
+
+  it.effect("shrinks shared base windows immediately when larger windows release", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-shrink",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const wideWindow = yield* prepareRawQuery(
+        "window-shrink",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 0,
+          limit: 3,
+        },
+      );
+      const narrowWindow = yield* prepareRawQuery(
+        "window-shrink",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 1,
+          limit: 1,
+        },
+      );
+
+      const wideExecution = yield* acquireRawQueryExecution(observedReadModel, wideWindow);
+      expect(wideExecution.initial("wide").keys).toStrictEqual(["d", "c", "b"]);
+
+      const narrowExecution = yield* acquireRawQueryExecution(observedReadModel, narrowWindow);
+      expect(narrowExecution.initial("narrow").keys).toStrictEqual(["c"]);
+
+      yield* releaseRawQueryExecution(observedReadModel, wideWindow);
+      expect(scanLimits).toStrictEqual([3, 2]);
+      expect(narrowExecution.initial("narrow-after-shrink").keys).toStrictEqual(["c"]);
+
+      yield* releaseRawQueryExecution(observedReadModel, narrowWindow);
+    }),
+  );
+
+  it.effect("compacts unbounded shared base windows when unbounded windows release", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-unbounded",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const boundedWindow = yield* prepareRawQuery(
+        "window-unbounded",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 1,
+          limit: 1,
+        },
+      );
+      const unboundedWindow = yield* prepareRawQuery(
+        "window-unbounded",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+        },
+      );
+
+      const boundedExecution = yield* acquireRawQueryExecution(observedReadModel, boundedWindow);
+      expect(boundedExecution.initial("bounded").keys).toStrictEqual(["b"]);
+
+      const unboundedExecution = yield* acquireRawQueryExecution(
+        observedReadModel,
+        unboundedWindow,
+      );
+      expect(unboundedExecution.initial("unbounded").keys).toStrictEqual(["c", "b", "a"]);
+
+      yield* releaseRawQueryExecution(observedReadModel, unboundedWindow);
+      expect(scanLimits).toStrictEqual([2, undefined, 2]);
+      expect(boundedExecution.initial("bounded-after-compact").keys).toStrictEqual(["b"]);
+
+      yield* releaseRawQueryExecution(observedReadModel, boundedWindow);
+    }),
+  );
+
+  it.effect("does not expand shared base rows for zero-limit windows", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-zero-limit",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const zeroWindow = yield* prepareRawQuery(
+        "window-zero-limit",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 10,
+          limit: 0,
+        },
+      );
+
+      const zeroExecution = yield* acquireRawQueryExecution(observedReadModel, zeroWindow);
+      const initial = zeroExecution.initial("zero");
+      expect(scanLimits).toStrictEqual([0]);
+      expect(initial.rows).toStrictEqual([]);
+      expect(initial.keys).toStrictEqual([]);
+      expect(initial.totalRows).toBe(2);
+
+      yield* releaseRawQueryExecution(observedReadModel, zeroWindow);
     }),
   );
 

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -44,6 +44,12 @@ type ActiveQueryBaseExecution = {
 
 type RawQueryExecutionSlot = {
   readonly execution: ActiveQueryBaseExecution;
+  readonly windows: Map<string, RawQueryExecutionWindowSlot>;
+  refs: number;
+};
+
+type RawQueryExecutionWindowSlot = {
+  readonly window: CompiledRawQuery<object, object>["window"];
   refs: number;
 };
 
@@ -66,7 +72,8 @@ type MaterializedQueryExecutionCache = WeakMap<object, Map<string, MaterializedQ
 const activeQueryExecutionCache: QueryExecutionCache = new WeakMap();
 const activeMaterializedQueryExecutionCache: MaterializedQueryExecutionCache = new WeakMap();
 
-type QueryCacheToken = readonly ["raw", string, string, string, string];
+type QueryCacheToken = readonly ["raw", string, string];
+type QueryWindowCacheToken = readonly ["window", string, string];
 
 const queryCacheKey = (query: RuntimeRawQuery): string => {
   const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
@@ -75,8 +82,15 @@ const queryCacheKey = (query: RuntimeRawQuery): string => {
     "raw",
     query.where === undefined ? "" : stableQueryValueString(query.where),
     stableQueryValueString(orderBy),
-    stableQueryValueString(query.offset ?? null),
-    stableQueryValueString(query.limit ?? null),
+  ];
+  return JSON.stringify(token);
+};
+
+const queryWindowCacheKey = (window: CompiledRawQuery<object, object>["window"]): string => {
+  const token: QueryWindowCacheToken = [
+    "window",
+    stableQueryValueString(window.offset),
+    stableQueryValueString(window.limit ?? null),
   ];
   return JSON.stringify(token);
 };
@@ -118,20 +132,21 @@ const getActiveQueryEntry = <ResultRow extends RowObject>(
 const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   store: TopicRawWindowScan<Row> & { readonly version: () => number },
   compiled: CompiledRawQuery<Row, ResultRow>,
+  queryWindow: CompiledRawQuery<Row, ResultRow>["window"] = compiled.window,
 ): ActiveQueryBaseEvaluation<Row> => {
   const version = store.version();
-  const window = store.scanRawWindow({
+  const scanResult = store.scanRawWindow({
     where: compiled.query.where,
     predicate: compiled.predicate.plan,
     orderBy: compiled.ordering.plan,
     storageOrderBy: compiled.ordering.plan,
     matches: compiled.predicate.matches,
     compare: compiled.ordering.compare,
-    offset: compiled.window.offset,
-    limit: compiled.window.limit,
+    offset: queryWindow.offset,
+    limit: queryWindow.limit,
   });
   return {
-    ...window,
+    ...scanResult,
     version,
   };
 };
@@ -154,6 +169,29 @@ const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObjec
   };
 };
 
+const projectWindowEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  evaluation: ActiveQueryBaseEvaluation<Row>,
+): QueryEvaluation<ResultRow> => {
+  const end =
+    compiled.window.limit === undefined
+      ? undefined
+      : compiled.window.offset + compiled.window.limit;
+  const sourceWindow = evaluation.window.slice(compiled.window.offset, end);
+  const window = sourceWindow.map((entry) => ({
+    key: entry.key,
+    row: compiled.projection.project(entry.row),
+  }));
+
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: window.map((entry) => entry.key),
+    window,
+    totalRows: evaluation.totalRows,
+    version: evaluation.version,
+  };
+};
+
 export const evaluateRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
   store: TopicRawWindowScan<Row> & { readonly version: () => number },
   compiled: CompiledRawQuery<Row, ResultRow>,
@@ -165,7 +203,7 @@ const leaseRawQueryExecution = <ResultRow extends RowObject>(
   execution: ActiveQueryBaseExecution,
   compiled: CompiledRawQuery<object, ResultRow>,
 ): RawQueryExecution<ResultRow> => {
-  const latestEvaluation = () => projectBaseEvaluation(compiled, execution.latest());
+  const latestEvaluation = () => projectWindowEvaluation(compiled, execution.latest());
 
   return {
     initial: (queryId) => snapshotEvent(store, queryId, latestEvaluation()),
@@ -218,19 +256,83 @@ function typedQueryEvaluation(evaluation: QueryEvaluation<object>): QueryEvaluat
   return evaluation;
 }
 
+const baseWindowForActiveWindows = (
+  windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
+): CompiledRawQuery<object, object>["window"] => {
+  let limit = 0;
+  for (const { window } of windows.values()) {
+    if (window.limit === undefined) {
+      return {
+        offset: 0,
+        limit: undefined,
+      };
+    }
+    const windowEnd = window.limit === 0 ? 0 : window.offset + window.limit;
+    limit = Math.max(limit, windowEnd);
+  }
+  return {
+    offset: 0,
+    limit,
+  };
+};
+
+const acquireRawQueryWindow = (
+  windows: Map<string, RawQueryExecutionWindowSlot>,
+  window: CompiledRawQuery<object, object>["window"],
+): void => {
+  const key = queryWindowCacheKey(window);
+  const existing = windows.get(key);
+  if (existing !== undefined) {
+    existing.refs += 1;
+    return;
+  }
+  windows.set(key, {
+    window,
+    refs: 1,
+  });
+};
+
+const releaseRawQueryWindow = (
+  windows: Map<string, RawQueryExecutionWindowSlot>,
+  window: CompiledRawQuery<object, object>["window"],
+): boolean => {
+  const key = queryWindowCacheKey(window);
+  const existing = windows.get(key);
+  if (existing === undefined) {
+    return false;
+  }
+  if (existing.refs > 1) {
+    existing.refs -= 1;
+    return true;
+  }
+  windows.delete(key);
+  return true;
+};
+
 export const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.make")(
-  (store: ActiveQueryStoreState, canonicalCompiled: CompiledRawQuery<object, object>) =>
+  (
+    store: ActiveQueryStoreState,
+    canonicalCompiled: CompiledRawQuery<object, object>,
+    windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
+  ) =>
     Effect.sync(() => {
+      let baseWindow = baseWindowForActiveWindows(windows);
       let snapshot = {
-        evaluation: evaluateBaseQuery(store, canonicalCompiled),
+        evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
         version: store.version(),
       };
 
       const latest = () => {
         const storeVersion = store.version();
-        if (snapshot.version !== storeVersion) {
+        const nextBaseWindow = baseWindowForActiveWindows(windows);
+        if (
+          snapshot.version !== storeVersion ||
+          nextBaseWindow.offset !== baseWindow.offset ||
+          nextBaseWindow.limit !== baseWindow.limit
+        ) {
+          baseWindow = nextBaseWindow;
           snapshot = {
-            evaluation: evaluateBaseQuery(store, canonicalCompiled),
+            evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
             version: storeVersion,
           };
         }
@@ -253,12 +355,16 @@ export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
     if (existing !== undefined) {
       const entry = existing;
       entry.refs += 1;
+      acquireRawQueryWindow(entry.windows, compiled.window);
       return leaseRawQueryExecution(store, entry.execution, compiled);
     }
 
-    const execution = yield* makeRawQueryExecution(store, compiled);
+    const windows = new Map<string, RawQueryExecutionWindowSlot>();
+    acquireRawQueryWindow(windows, compiled.window);
+    const execution = yield* makeRawQueryExecution(store, compiled, windows);
     map.set(key, {
       execution,
+      windows,
       refs: 1,
     });
     return leaseRawQueryExecution(store, execution, compiled);
@@ -277,8 +383,12 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
         return undefined;
       }
       const entry = existing;
+      if (!releaseRawQueryWindow(entry.windows, compiled.window)) {
+        return undefined;
+      }
       if (entry.refs > 1) {
         entry.refs -= 1;
+        entry.execution.latest();
         return undefined;
       }
       map.delete(key);

--- a/packages/in-memory/src/health.ts
+++ b/packages/in-memory/src/health.ts
@@ -5,7 +5,7 @@ import type {
 } from "@view-server/column-live-view-engine";
 import type { ViewServerHealth } from "@view-server/config";
 import { Effect } from "effect";
-import type * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import type { AtomRef } from "effect/unstable/reactivity";
 
 type EngineHealthReader<Topics extends DecodableTopicDefinitions> = {
   readonly health: () => Effect.Effect<ColumnLiveViewEngineHealth<Topics>, never>;

--- a/packages/in-memory/src/index.test.ts
+++ b/packages/in-memory/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import type { ColumnLiveViewEngineHealth } from "@view-server/column-live-view-engine";
 import { defineViewServerConfig } from "@view-server/config";
 import { Deferred, Effect, Fiber, Schema, Stream } from "effect";
-import * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import { AtomRef } from "effect/unstable/reactivity";
 import { healthFromEngine, makeHealthRefreshScheduler, readHealth } from "./health";
 import { createInMemoryViewServer, makeInMemoryViewServer } from "./index";
 

--- a/packages/in-memory/src/index.ts
+++ b/packages/in-memory/src/index.ts
@@ -34,7 +34,7 @@ import {
   viewServerHealthTopicRowsFromHealth,
 } from "@view-server/config";
 import { Cause, Clock, Effect, Queue, Stream } from "effect";
-import * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import { AtomRef } from "effect/unstable/reactivity";
 import { healthFromEngine, makeHealthRefreshScheduler, readHealth, refreshHealth } from "./health";
 
 export type { DecodableTopicDefinitions } from "@view-server/column-live-view-engine";

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -4,7 +4,7 @@ import { libraryPack } from "../../vite.pack";
 
 export default defineConfig({
   optimizeDeps: {
-    include: ["effect/Function"],
+    include: ["effect/Function", "effect/unstable/reactivity"],
   },
   test: {
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -21,7 +21,7 @@ import {
   Stream,
 } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
-import * as AtomRef from "effect/unstable/reactivity/AtomRef";
+import { AtomRef } from "effect/unstable/reactivity";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import { makeViewServerWebSocketServer } from "./index";


### PR DESCRIPTION
## Summary
- share raw active-query executions by physical query shape instead of per window
- track active window refcounts and materialize one shared base prefix window for subscribers
- project each subscriber's own window/select from the shared base evaluation
- compact cached base windows on release, including shrink, unbounded release, and zero-limit cases
- fix AtomRef imports to use the available reactivity barrel and add React optimizeDeps for that barrel

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- pnpm run ready
- forbidden-pattern scan for casts, Testing Library, act, flushSync, toEqual, coverage ignores: clean

## Review
- 3 local reviewer agents: no findings after fixes
- residual risks noted: deep offsets still require prefix materialization by design; route-churn benchmarks should watch close-path compaction cost