### PR TITLE
Deepen topic store mutation context

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -3184,6 +3184,20 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("applies disjoint patches cumulatively against the latest row state", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("a", "open", 10, 1));
+
+      yield* engine.patch("orders", "a", { status: "closed" });
+      yield* engine.patch("orders", "a", { price: 99 });
+
+      const fresh = yield* engine.snapshot("orders", { select: orderSelect });
+      expect(fresh.version).toBe(3);
+      expect(fresh.rows).toStrictEqual([order("a", "closed", 99, 1)]);
+    }),
+  );
+
   it.effect("idempotent subscription close removes active subscribers from health", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -5,7 +5,7 @@ import {
   clearStoreRawQueryExecutions,
   type ActiveQueryStoreState,
 } from "./active-query";
-import { ColumnarTopicStore } from "./columnar-topic-store";
+import { ColumnarTopicStore, type PreparedTopicRow } from "./columnar-topic-store";
 import { createTopicHealthLedger } from "./topic-health-ledger";
 import type { RawQueryCompilerMetadata } from "./raw-query-compiler";
 import {
@@ -53,6 +53,17 @@ type TopicStoreState = {
   readonly notificationSemaphore: Semaphore.Semaphore;
   readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
   readonly onCommit: () => void;
+};
+
+type TopicStoreMutationContext = {
+  readonly publishPrepared: (prepared: PreparedTopicRow) => number;
+  readonly publishPreparedMany: (preparedRows: ReadonlyArray<PreparedTopicRow>) => number;
+  readonly patch: <Patch extends Partial<RowObject>, Error>(
+    key: string,
+    patch: Patch,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) => Effect.Effect<number, Error>;
+  readonly delete: (key: string) => number;
 };
 
 const topicStoreStates = new WeakMap<TopicStore, TopicStoreState>();
@@ -182,6 +193,24 @@ const recordTopicStoreMutation = (
   return subscribersToNotify;
 };
 
+const topicStoreMutationContext = (state: TopicStoreState): TopicStoreMutationContext => ({
+  publishPrepared: (prepared) => {
+    state.storage.setPrepared(prepared);
+    return 1;
+  },
+  publishPreparedMany: (preparedRows) => {
+    state.storage.setPreparedMany(preparedRows);
+    return preparedRows.length;
+  },
+  patch: (key, patch, invalidRow) =>
+    Effect.gen(function* () {
+      const prepared = yield* state.storage.preparePatch(key, patch, invalidRow);
+      state.storage.setPrepared(prepared);
+      return 1;
+    }),
+  delete: (key) => state.storage.delete(key),
+});
+
 const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.notify")(function* (
   store: TopicStore,
   subscribers: ReadonlyArray<LiveTopicSubscriber>,
@@ -202,7 +231,7 @@ const runTopicStoreMutationTransaction = Effect.fn(
   "ColumnLiveViewEngine.topicStore.mutationTransaction",
 )(function* <Error, Requirements>(
   store: TopicStore,
-  mutate: (state: TopicStoreState) => Effect.Effect<number, Error, Requirements>,
+  mutate: (mutation: TopicStoreMutationContext) => Effect.Effect<number, Error, Requirements>,
 ) {
   yield* withTopicStoreMutationBatch(
     store,
@@ -211,7 +240,7 @@ const runTopicStoreMutationTransaction = Effect.fn(
         store,
         Effect.gen(function* () {
           const state = topicStoreState(store);
-          const rowsChanged = yield* mutate(state);
+          const rowsChanged = yield* mutate(topicStoreMutationContext(state));
           const occurredAt = yield* Clock.currentTimeMillis;
           return recordTopicStoreMutation(state, rowsChanged, occurredAt);
         }),
@@ -424,10 +453,9 @@ export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.p
   Row extends RowObject,
 >(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
   const prepared = yield* topicStoreState(store).storage.prepareRow(row, invalidRow);
-  yield* runTopicStoreMutationTransaction(store, (state) =>
+  yield* runTopicStoreMutationTransaction(store, (mutation) =>
     Effect.sync(() => {
-      state.storage.setPrepared(prepared);
-      return 1;
+      return mutation.publishPrepared(prepared);
     }),
   );
 });
@@ -439,10 +467,9 @@ export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.
     invalidRow: InvalidRowErrorFactory<Error>,
   ) {
     const preparedRows = yield* topicStoreState(store).storage.prepareRows(rows, invalidRow);
-    yield* runTopicStoreMutationTransaction(store, (state) =>
+    yield* runTopicStoreMutationTransaction(store, (mutation) =>
       Effect.sync(() => {
-        state.storage.setPreparedMany(preparedRows);
-        return preparedRows.length;
+        return mutation.publishPreparedMany(preparedRows);
       }),
     );
   },
@@ -452,12 +479,8 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
   Patch extends Partial<RowObject>,
   Error,
 >(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
-  yield* runTopicStoreMutationTransaction(store, (state) =>
-    Effect.gen(function* () {
-      const prepared = yield* state.storage.preparePatch(key, patch, invalidRow);
-      state.storage.setPrepared(prepared);
-      return 1;
-    }),
+  yield* runTopicStoreMutationTransaction(store, (mutation) =>
+    mutation.patch(key, patch, invalidRow),
   );
 });
 
@@ -465,9 +488,9 @@ export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.de
   store: TopicStore,
   key: string,
 ) {
-  yield* runTopicStoreMutationTransaction(store, (state) =>
+  yield* runTopicStoreMutationTransaction(store, (mutation) =>
     Effect.sync(() => {
-      return state.storage.delete(key);
+      return mutation.delete(key);
     }),
   );
 });


### PR DESCRIPTION
## Summary
- Route TopicStore mutation transactions through a private behavior-only mutation context instead of exposing raw TopicStoreState to mutation lambdas.
- Keep patch prepare/write atomic inside the mutation context so callers cannot split stale-read-sensitive behavior.
- Add deterministic engine coverage for cumulative disjoint patches against the latest row state.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- source-only forbidden-pattern scan
- pnpm run ready

## Review
- 3 read-only reviewer agents completed final review with no findings.
- Residual note: the new patch test is intentionally sequential; transaction atomicity is enforced by the private mutation context rather than a fragile scheduler race test.