### PR TITLE
Route query execution through topic store

### DIFF
--- a/packages/column-live-view-engine/src/index.ts
+++ b/packages/column-live-view-engine/src/index.ts
@@ -175,7 +175,7 @@ class InMemoryColumnLiveViewEngine<
       function* (this: InMemoryColumnLiveViewEngine<Topics>) {
         yield* this.ensureOpen();
         const store = yield* this.getStore(topic);
-        return yield* snapshotExecutableQuery<ResultRow>(topic, store, query);
+        return yield* snapshotExecutableQuery<ResultRow>(store, query);
       },
     )();
 

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -1,22 +1,17 @@
 import { Effect } from "effect";
 import { makeLiveSubscription } from "./live-subscription";
-import {
-  acquireMaterializedQueryExecution,
-  acquireRawQueryExecution,
-  evaluateRawQuery,
-  releaseMaterializedQueryExecution,
-  releaseRawQueryExecution,
-} from "./active-query";
-import {
-  evaluateCompiledGroupedQuery,
-  prepareGroupedQuery,
-  type CompiledGroupedQuery,
-} from "./grouped-query-compiler";
-import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
+import type { CompiledGroupedQuery } from "./grouped-query-compiler";
+import type { CompiledRawQuery } from "./raw-query-compiler";
 import { liveQueryResult, type QueryEvaluation } from "./query-result";
 import {
-  topicStoreRawQueryMetadata,
-  topicStoreReadModel,
+  acquireTopicStoreMaterializedQueryExecution,
+  acquireTopicStoreRawQueryExecution,
+  evaluateTopicStoreGroupedQuery,
+  evaluateTopicStoreRawQuery,
+  prepareTopicStoreGroupedQuery,
+  prepareTopicStoreRawQuery,
+  releaseTopicStoreMaterializedQueryExecution,
+  releaseTopicStoreRawQueryExecution,
   type TopicStore,
   type TopicStoreSubscriptionPermit,
 } from "./topic-store";
@@ -40,23 +35,15 @@ export const isGroupedQuery = (query: unknown): boolean =>
   ("groupBy" in query || "aggregates" in query);
 
 export const prepareExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.prepare")(
-  function* <ResultRow extends RowObject>(topic: string, store: TopicStore, query: unknown) {
+  function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
     if (isGroupedQuery(query)) {
-      const compiled = yield* prepareGroupedQuery<object, ResultRow>(
-        topic,
-        topicStoreRawQueryMetadata(store),
-        query,
-      );
+      const compiled = yield* prepareTopicStoreGroupedQuery<ResultRow>(store, query);
       return {
         kind: "grouped",
         compiled,
       } satisfies ExecutableQuery<ResultRow>;
     }
-    const compiled = yield* prepareRawQuery<object, ResultRow>(
-      topic,
-      topicStoreRawQueryMetadata(store),
-      query,
-    );
+    const compiled = yield* prepareTopicStoreRawQuery<ResultRow>(store, query);
     return {
       kind: "raw",
       compiled,
@@ -69,12 +56,12 @@ export const evaluateExecutableQuery = <ResultRow extends RowObject>(
   executable: ExecutableQuery<ResultRow>,
 ): QueryEvaluation<ResultRow> =>
   executable.kind === "raw"
-    ? evaluateRawQuery(topicStoreReadModel(store), executable.compiled)
-    : evaluateCompiledGroupedQuery(topicStoreReadModel(store), executable.compiled);
+    ? evaluateTopicStoreRawQuery(store, executable.compiled)
+    : evaluateTopicStoreGroupedQuery(store, executable.compiled);
 
 export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.snapshot")(
-  function* <ResultRow extends RowObject>(topic: string, store: TopicStore, query: unknown) {
-    const executable = yield* prepareExecutableQuery<ResultRow>(topic, store, query);
+  function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
+    const executable = yield* prepareExecutableQuery<ResultRow>(store, query);
     return liveQueryResult(evaluateExecutableQuery(store, executable));
   },
 );
@@ -89,31 +76,28 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
     },
   ) {
     const { store } = input.permit;
-    const { topic } = store;
-    const executable = yield* prepareExecutableQuery<ResultRow>(topic, store, query);
-    const storeReadModel = topicStoreReadModel(store);
+    const executable = yield* prepareExecutableQuery<ResultRow>(store, query);
     if (executable.kind === "raw") {
-      const execution = yield* acquireRawQueryExecution(storeReadModel, executable.compiled);
+      const execution = yield* acquireTopicStoreRawQueryExecution(store, executable.compiled);
       return yield* makeLiveSubscription({
         permit: input.permit,
         queryId: input.queryId,
         execution,
         queueCapacity: input.queueCapacity,
-        release: releaseRawQueryExecution(storeReadModel, executable.compiled),
+        release: releaseTopicStoreRawQueryExecution(store, executable.compiled),
       });
     }
 
-    const execution = yield* acquireMaterializedQueryExecution(
-      storeReadModel,
-      executable.compiled.cacheKey,
-      () => evaluateCompiledGroupedQuery(storeReadModel, executable.compiled),
+    const execution = yield* acquireTopicStoreMaterializedQueryExecution(
+      store,
+      executable.compiled,
     );
     return yield* makeLiveSubscription({
       permit: input.permit,
       queryId: input.queryId,
       execution,
       queueCapacity: input.queueCapacity,
-      release: releaseMaterializedQueryExecution(storeReadModel, executable.compiled.cacheKey),
+      release: releaseTopicStoreMaterializedQueryExecution(store, executable.compiled),
     });
   },
 );

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,13 +1,28 @@
 import { Clock, Effect, Schema, Semaphore } from "effect";
 import type { StatusEvent, TopicRuntimeHealth } from "@view-server/config";
 import {
+  acquireMaterializedQueryExecution,
+  acquireRawQueryExecution,
   activeStoreRawQueryExecutionCount,
   clearStoreRawQueryExecutions,
+  evaluateRawQuery,
+  releaseMaterializedQueryExecution,
+  releaseRawQueryExecution,
   type ActiveQueryStoreState,
 } from "./active-query";
 import { ColumnarTopicStore, type PreparedTopicRow } from "./columnar-topic-store";
+import {
+  evaluateCompiledGroupedQuery,
+  prepareGroupedQuery,
+  type CompiledGroupedQuery,
+} from "./grouped-query-compiler";
 import { createTopicHealthLedger } from "./topic-health-ledger";
-import type { RawQueryCompilerMetadata } from "./raw-query-compiler";
+import {
+  prepareRawQuery,
+  type CompiledRawQuery,
+  type RawQueryCompilerMetadata,
+} from "./raw-query-compiler";
+import type { QueryEvaluation } from "./query-result";
 import {
   acquireSubscriptionHandoff,
   type MarkAcquiredSubscription,
@@ -100,6 +115,71 @@ export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerM
 
 export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
   topicStoreState(store).storage.readModel;
+
+export const prepareTopicStoreRawQuery = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.raw.prepare",
+)(function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
+  return yield* prepareRawQuery<object, ResultRow>(
+    store.topic,
+    topicStoreState(store).storage.rawQueryMetadata,
+    query,
+  );
+});
+
+export const prepareTopicStoreGroupedQuery = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.grouped.prepare",
+)(function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
+  return yield* prepareGroupedQuery<object, ResultRow>(
+    store.topic,
+    topicStoreState(store).storage.rawQueryMetadata,
+    query,
+  );
+});
+
+export const evaluateTopicStoreRawQuery = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledRawQuery<object, ResultRow>,
+): QueryEvaluation<ResultRow> =>
+  evaluateRawQuery(topicStoreState(store).storage.readModel, compiled);
+
+export const evaluateTopicStoreGroupedQuery = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledGroupedQuery<object, ResultRow>,
+): QueryEvaluation<ResultRow> =>
+  evaluateCompiledGroupedQuery(topicStoreState(store).storage.readModel, compiled);
+
+export const acquireTopicStoreRawQueryExecution = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.raw.acquire",
+)(function* <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledRawQuery<object, ResultRow>,
+) {
+  return yield* acquireRawQueryExecution(topicStoreState(store).storage.readModel, compiled);
+});
+
+export const releaseTopicStoreRawQueryExecution = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledRawQuery<object, ResultRow>,
+): Effect.Effect<void> =>
+  releaseRawQueryExecution(topicStoreState(store).storage.readModel, compiled);
+
+export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.materialized.acquire",
+)(function* <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledGroupedQuery<object, ResultRow>,
+) {
+  const readModel = topicStoreState(store).storage.readModel;
+  return yield* acquireMaterializedQueryExecution(readModel, compiled.cacheKey, () =>
+    evaluateCompiledGroupedQuery(readModel, compiled),
+  );
+});
+
+export const releaseTopicStoreMaterializedQueryExecution = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledGroupedQuery<object, ResultRow>,
+): Effect.Effect<void> =>
+  releaseMaterializedQueryExecution(topicStoreState(store).storage.readModel, compiled.cacheKey);
 
 const withTopicStoreTransaction = Effect.fn("ColumnLiveViewEngine.topicStore.transaction")(
   function* <Success, Error, Requirements>(


### PR DESCRIPTION
## Summary
- Add TopicStore query helpers for raw/grouped prepare, evaluate, acquire, and release paths.
- Route query-execution through those helpers so production query execution no longer pulls raw query metadata or active-query read-model internals directly.
- Keep snapshot and subscription behavior unchanged while making TopicStore the locality boundary for ColumnarTopicStore/read-model access.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- source-only forbidden-pattern scan
- pnpm run ready

## Review
- 3 read-only reviewer agents completed final review with no findings.
- Residual note: old internal read-model/metadata exports still exist for tests/internal modules; this PR removes the production query-execution dependency on them.