### PR TITLE
Guard topic store read model seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 
 - Keep Modules deep. If deleting a module makes complexity disappear, it is probably pass-through and should not exist.
 - Use real Seams only where there are multiple Implementations or a clear near-term Adapter boundary.
+- Production engine modules must not import `topicStoreReadModel` or `topicStoreRawQueryMetadata`. Route read-model/query behavior through TopicStore helper operations so Columnar Topic Store internals stay local to the TopicStore Module.
 - Keep package direction clean:
   - config/contracts: public types and pure contracts.
   - column live view engine: query compilation, store, snapshots, deltas, subscriptions, engine health.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "check:effect": "effect-language-service diagnostics --project packages/config/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/client/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/in-memory/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/server/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/react/tsconfig.json --format text --strict",
+    "check:internal-seams": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/node-ambient.d.ts scripts/check-internal-seams.ts && node --experimental-strip-types scripts/check-internal-seams.ts",
     "check:package-exports": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/check-package-exports.ts && node --experimental-strip-types scripts/check-package-exports.ts",
-    "ready": "vp run -r build && pnpm run check:package-exports && vp check && pnpm run check:effect && vp run -r test",
+    "ready": "vp run -r build && pnpm run check:package-exports && pnpm run check:internal-seams && vp check && pnpm run check:effect && vp run -r test",
     "prepare": "vp config && effect-language-service patch"
   },
   "devDependencies": {

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const engineSourceRoot = join(repoRoot, "packages", "column-live-view-engine", "src");
+const restrictedTopicStoreHelpers = /\b(topicStoreReadModel|topicStoreRawQueryMetadata)\b/;
+
+const sourceFiles = (directory: string): ReadonlyArray<string> => {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const files: Array<string> = [];
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...sourceFiles(path));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(path);
+    }
+  }
+
+  return files;
+};
+
+const isTestFile = (path: string): boolean =>
+  path.endsWith(".test.ts") || path.endsWith(".test-d.ts");
+
+const isAllowedTopicStoreOwner = (path: string): boolean =>
+  path === join(engineSourceRoot, "topic-store.ts");
+
+const violations: Array<string> = [];
+
+for (const path of sourceFiles(engineSourceRoot)) {
+  if (isTestFile(path) || isAllowedTopicStoreOwner(path)) {
+    continue;
+  }
+
+  const contents = readFileSync(path, "utf8");
+  if (!restrictedTopicStoreHelpers.test(contents)) {
+    continue;
+  }
+
+  violations.push(relative(repoRoot, path));
+}
+
+if (violations.length > 0) {
+  throw new Error(
+    [
+      "Production engine modules must not use topicStoreReadModel or topicStoreRawQueryMetadata.",
+      "Route query/read-model behavior through TopicStore helper operations instead.",
+      ...violations.map((path) => `- ${path}`),
+    ].join("\n"),
+  );
+}

--- a/scripts/node-ambient.d.ts
+++ b/scripts/node-ambient.d.ts
@@ -1,0 +1,24 @@
+declare module "node:fs" {
+  export type Dirent = {
+    readonly name: string;
+    readonly isDirectory: () => boolean;
+    readonly isFile: () => boolean;
+  };
+
+  export function readdirSync(
+    path: string,
+    options: { readonly withFileTypes: true },
+  ): Array<Dirent>;
+
+  export function readFileSync(path: string, encoding: "utf8"): string;
+}
+
+declare module "node:path" {
+  export function dirname(path: string): string;
+  export function join(...paths: ReadonlyArray<string>): string;
+  export function relative(from: string, to: string): string;
+}
+
+declare module "node:url" {
+  export function fileURLToPath(url: string): string;
+}


### PR DESCRIPTION
## What changed
- Added a check:internal-seams guard that prevents production column-live-view-engine source files from using topicStoreReadModel or topicStoreRawQueryMetadata outside topic-store.ts.
- Wired the guard into pnpm run ready.
- Documented the TopicStore read-model seam rule in AGENTS.md.
- Added minimal Node ambient declarations so the guard script is typechecked without adding @types/node.

## Validation
- pnpm run check:internal-seams
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan for casts/asserts/Testing Library/coverage ignores/etc
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run ready

## Review
- 3 local reviewer agents found no blockers.
- Residual accepted risk: the guard is intentionally lexical and scoped to current .ts engine source files.