### PR TITLE
Localize active query execution registry

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -2,8 +2,11 @@ import { fromStringUnsafe } from "effect/BigDecimal";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Option, Schema } from "effect";
 import {
+  acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
   activeStoreRawQueryExecutionCount,
+  createActiveQueryRegistry,
+  releaseMaterializedQueryExecution,
   releaseRawQueryExecution,
 } from "./active-query";
 import { prepareRawQuery } from "./raw-query-compiler";
@@ -119,6 +122,91 @@ describe("column-live-view-engine active query execution", () => {
       expect(afterRefcountExhausted.initial("query-d").totalRows).toBe(2);
       expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
       yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+    }),
+  );
+
+  it.effect("keeps execution caches local to the active query registry", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "registry-isolation",
+        Schema.Struct({
+          id: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", score: 1 }, invalidRow);
+
+      const compiled = yield* prepareRawQuery(
+        "registry-isolation",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          orderBy: [{ field: "score", direction: "desc" }],
+        },
+      );
+      const readModel = topicStoreReadModel(store);
+      const isolatedReadModel = {
+        ...readModel,
+        activeQueries: createActiveQueryRegistry(),
+      };
+
+      yield* acquireRawQueryExecution(readModel, compiled);
+      yield* acquireRawQueryExecution(isolatedReadModel, compiled);
+
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
+
+      yield* releaseRawQueryExecution(readModel, compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
+
+      yield* releaseRawQueryExecution(isolatedReadModel, compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(0);
+    }),
+  );
+
+  it.effect("keeps materialized execution caches local to the active query registry", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "materialized-registry-isolation",
+        Schema.Struct({
+          id: Schema.String,
+        }),
+        "id",
+        () => {},
+      );
+      const readModel = topicStoreReadModel(store);
+      const isolatedReadModel = {
+        ...readModel,
+        activeQueries: createActiveQueryRegistry(),
+      };
+
+      const emptyEvaluation = (version: number) => ({
+        rows: [],
+        keys: [],
+        window: [],
+        totalRows: 0,
+        version,
+      });
+
+      yield* acquireMaterializedQueryExecution(readModel, "grouped", () =>
+        emptyEvaluation(readModel.version()),
+      );
+      yield* acquireMaterializedQueryExecution(isolatedReadModel, "grouped", () =>
+        emptyEvaluation(isolatedReadModel.version()),
+      );
+
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
+
+      yield* releaseMaterializedQueryExecution(readModel, "grouped");
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
+
+      yield* releaseMaterializedQueryExecution(isolatedReadModel, "grouped");
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(0);
     }),
   );
 

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -13,7 +13,7 @@ type RowObject = object;
 
 export type ActiveQueryStoreState = TopicRowScan<object> &
   TopicRawWindowScan<object> & {
-    readonly identity: object;
+    readonly activeQueries: ActiveQueryRegistry;
     readonly topic: string;
   };
 
@@ -66,11 +66,15 @@ type ActiveMaterializedQueryExecution = {
   readonly latest: () => QueryEvaluation<object>;
 };
 
-type QueryExecutionCache = WeakMap<object, Map<string, RawQueryExecutionSlot>>;
-type MaterializedQueryExecutionCache = WeakMap<object, Map<string, MaterializedQueryExecutionSlot>>;
+export type ActiveQueryRegistry = {
+  readonly raw: Map<string, RawQueryExecutionSlot>;
+  readonly materialized: Map<string, MaterializedQueryExecutionSlot>;
+};
 
-const activeQueryExecutionCache: QueryExecutionCache = new WeakMap();
-const activeMaterializedQueryExecutionCache: MaterializedQueryExecutionCache = new WeakMap();
+export const createActiveQueryRegistry = (): ActiveQueryRegistry => ({
+  raw: new Map(),
+  materialized: new Map(),
+});
 
 type QueryCacheToken = readonly ["raw", string, string];
 type QueryWindowCacheToken = readonly ["window", string, string];
@@ -96,25 +100,13 @@ const queryWindowCacheKey = (window: CompiledRawQuery<object, object>["window"])
 };
 
 const getActiveQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryExecutionSlot> => {
-  const existing = activeQueryExecutionCache.get(store.identity);
-  if (existing !== undefined) {
-    return existing;
-  }
-  const created = new Map<string, RawQueryExecutionSlot>();
-  activeQueryExecutionCache.set(store.identity, created);
-  return created;
+  return store.activeQueries.raw;
 };
 
 const getActiveMaterializedQueryMap = (
   store: ActiveQueryStoreState,
 ): Map<string, MaterializedQueryExecutionSlot> => {
-  const existing = activeMaterializedQueryExecutionCache.get(store.identity);
-  if (existing !== undefined) {
-    return existing;
-  }
-  const created = new Map<string, MaterializedQueryExecutionSlot>();
-  activeMaterializedQueryExecutionCache.set(store.identity, created);
-  return created;
+  return store.activeQueries.materialized;
 };
 
 const getActiveQueryEntry = <ResultRow extends RowObject>(
@@ -391,9 +383,6 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
         return undefined;
       }
       map.delete(key);
-      if (map.size === 0) {
-        activeQueryExecutionCache.delete(store.identity);
-      }
       return undefined;
     }),
 );
@@ -442,9 +431,9 @@ export const releaseMaterializedQueryExecution = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.materialized.release",
 )((store: ActiveQueryStoreState, cacheKey: string) =>
   Effect.sync(() => {
-    const map = activeMaterializedQueryExecutionCache.get(store.identity);
-    const existing = map?.get(cacheKey);
-    if (existing === undefined || map === undefined) {
+    const map = getActiveMaterializedQueryMap(store);
+    const existing = map.get(cacheKey);
+    if (existing === undefined) {
       return undefined;
     }
     const entry = existing;
@@ -453,9 +442,6 @@ export const releaseMaterializedQueryExecution = Effect.fn(
       return undefined;
     }
     map.delete(cacheKey);
-    if (map.size === 0) {
-      activeMaterializedQueryExecutionCache.delete(store.identity);
-    }
     return undefined;
   }),
 );
@@ -464,17 +450,13 @@ export const clearStoreRawQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.clearStore",
 )((store: ActiveQueryStoreState) =>
   Effect.sync(() => {
-    activeQueryExecutionCache.delete(store.identity);
-    activeMaterializedQueryExecutionCache.delete(store.identity);
+    store.activeQueries.raw.clear();
+    store.activeQueries.materialized.clear();
   }),
 );
 
 export const activeStoreRawQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.countStore",
 )((store: ActiveQueryStoreState) =>
-  Effect.sync(
-    () =>
-      (activeQueryExecutionCache.get(store.identity)?.size ?? 0) +
-      (activeMaterializedQueryExecutionCache.get(store.identity)?.size ?? 0),
-  ),
+  Effect.sync(() => store.activeQueries.raw.size + store.activeQueries.materialized.size),
 );

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema } from "effect";
-import type { ActiveQueryStoreState } from "./active-query";
+import { createActiveQueryRegistry, type ActiveQueryStoreState } from "./active-query";
 import type {
   TopicRawOrderByPlan,
   TopicRawPredicateFilterPlan,
@@ -92,7 +92,7 @@ export class ColumnarTopicStore {
       this.columns.set(field, []);
     }
     this.readModel = {
-      identity: this,
+      activeQueries: createActiveQueryRegistry(),
       topic,
       scanRows: (visitor) => this.scanRows(visitor),
       scanRawWindow: (plan) => this.scanRawWindow(plan),


### PR DESCRIPTION
## What changed
- Replaced hidden module-level active-query WeakMap caches with an explicit per-read-model ActiveQueryRegistry.
- ColumnarTopicStore now owns the active query registry through its read model.
- Raw and materialized active-query acquire/release/clear/count paths now operate on the store-owned registry maps.
- Removed the stale read-model identity field.
- Added raw and materialized registry isolation regressions.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan for casts/asserts/Testing Library/coverage ignores/etc
- vp run column-live-view-engine#build
- pnpm run ready

## Review
- 3 local reviewer agents found no blockers on the final diff.