### PR TITLE
Add exact column predicate scan path

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -15,6 +15,7 @@ import {
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord, valuesEqual } from "./row-values";
+import { isBigDecimal, Order as orderBigDecimal } from "effect/BigDecimal";
 
 type RowObject = object;
 
@@ -196,7 +197,7 @@ export class ColumnarTopicStore {
     const filtered: Array<TopicRowEntry<object>> = [];
     for (let slot = 0; slot < this.slots.length; slot += 1) {
       const entry = this.slots[slot]!;
-      if (this.slotMayMatchFilters(slot, plan.predicate.filters) && plan.matches(entry.row)) {
+      if (this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
         filtered.push(entry);
       }
     }
@@ -223,7 +224,7 @@ export class ColumnarTopicStore {
       for (let slotIndex = span.startIndex; slotIndex < span.endIndex; slotIndex += 1) {
         const slot = orderedWindow.slots[slotIndex]!;
         const entry = this.slots[slot]!;
-        if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
+        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
           continue;
         }
         const matchIndex = totalRows;
@@ -249,7 +250,7 @@ export class ColumnarTopicStore {
     const filteredSlots: Array<number> = [];
     for (let slot = 0; slot < this.slots.length; slot += 1) {
       const entry = this.slots[slot]!;
-      if (!this.slotMayMatchFilters(slot, plan.predicate.filters) || !plan.matches(entry.row)) {
+      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
         continue;
       }
       totalRows += 1;
@@ -284,7 +285,7 @@ export class ColumnarTopicStore {
       return undefined;
     }
     const orderField = storageOrderBy[0]!.field;
-    if (plan.predicate.callbackRequired) {
+    if (plan.predicate.callbackSkippable !== true) {
       return undefined;
     }
     if (!predicateFiltersAreOrderedIndexAdmissible(plan.predicate.filters, orderField)) {
@@ -597,19 +598,36 @@ export class ColumnarTopicStore {
     return this.slots[slot]!.row;
   }
 
+  private slotMatchesPredicatePlan(
+    slot: number,
+    plan: TopicRawWindowScanPlan<object>,
+    row: object,
+  ): boolean {
+    const exact = plan.predicate.callbackSkippable === true;
+    if (!this.slotMayMatchFilters(slot, plan.predicate.filters, exact)) {
+      return false;
+    }
+    return exact || plan.matches(row);
+  }
+
   private slotMayMatchFilters(
     slot: number,
     filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+    exact: boolean,
   ): boolean {
     for (const filter of filters) {
-      if (!this.slotMayMatchFilter(slot, filter)) {
+      if (!this.slotMayMatchFilter(slot, filter, exact)) {
         return false;
       }
     }
     return true;
   }
 
-  private slotMayMatchFilter(slot: number, filter: TopicRawPredicateFilterPlan): boolean {
+  private slotMayMatchFilter(
+    slot: number,
+    filter: TopicRawPredicateFilterPlan,
+    exact: boolean,
+  ): boolean {
     const column = this.columns.get(filter.field);
     if (column === undefined) {
       return true;
@@ -620,6 +638,9 @@ export class ColumnarTopicStore {
       return valuesEqual(value, filter.value);
     }
     if (filter.operator === "neq") {
+      if (exact) {
+        return columnValueDoesNotEqual(value, filter.value);
+      }
       return !valuesEqual(value, filter.value);
     }
     if (filter.operator === "in") {
@@ -630,6 +651,26 @@ export class ColumnarTopicStore {
         return true;
       }
       return typeof value === "string" && value.startsWith(filter.value);
+    }
+
+    if (exact && !isComparableRangeValue(filter.value)) {
+      return true;
+    }
+    if (exact) {
+      const exactComparison = compareExactRangeColumnValue(value, filter.value);
+      if (exactComparison === undefined) {
+        return false;
+      }
+      if (filter.operator === "gt") {
+        return exactComparison > 0;
+      }
+      if (filter.operator === "gte") {
+        return exactComparison >= 0;
+      }
+      if (filter.operator === "lt") {
+        return exactComparison < 0;
+      }
+      return exactComparison <= 0;
     }
 
     const comparison = compareRangeColumnValue(value, filter.value);
@@ -648,6 +689,44 @@ export class ColumnarTopicStore {
     return comparison <= 0;
   }
 }
+
+const isComparableRangeValue = (value: unknown): boolean =>
+  (typeof value === "number" && Number.isFinite(value)) ||
+  typeof value === "bigint" ||
+  isBigDecimal(value);
+
+const compareExactRangeColumnValue = (left: unknown, right: unknown): number | undefined => {
+  if (typeof left === "number" && typeof right === "number") {
+    if (!Number.isFinite(left) || !Number.isFinite(right)) {
+      return undefined;
+    }
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (typeof left === "bigint" && typeof right === "bigint") {
+    if (left === right) {
+      return 0;
+    }
+    return left < right ? -1 : 1;
+  }
+  if (isBigDecimal(left) && isBigDecimal(right)) {
+    return orderBigDecimal(left, right);
+  }
+  return undefined;
+};
+
+const columnValueDoesNotEqual = (value: unknown, notEqual: unknown): boolean => {
+  return equalityComparableValues(value, notEqual) && !valuesEqual(value, notEqual);
+};
+
+const equalityComparableValues = (left: unknown, right: unknown): boolean => {
+  if (isBigDecimal(left) || isBigDecimal(right)) {
+    return isBigDecimal(left) && isBigDecimal(right);
+  }
+  if (typeof left === "number" || typeof right === "number") {
+    return typeof left === "number" && typeof right === "number" && Number.isFinite(right);
+  }
+  return typeof left === typeof right;
+};
 
 const compareRangeColumnValue = (left: unknown, right: unknown): number | undefined => {
   if (typeof left === "number" && typeof right === "number") {

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -1480,6 +1480,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
                 },
               ],
               callbackRequired: false,
+              callbackSkippable: true,
             });
             expect(plan.orderBy).toStrictEqual([
               {
@@ -1680,6 +1681,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
                 },
               ],
               callbackRequired: false,
+              callbackSkippable: true,
             });
             expect(plan.orderBy).toStrictEqual([
               {
@@ -1753,6 +1755,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
                 },
               ],
               callbackRequired: false,
+              callbackSkippable: true,
             });
             expect(plan.matches(position("aapl", "AAPL", 20n, "10"))).toBe(true);
             expect(plan.matches(position("goog", "GOOG", 1n, "10"))).toBe(false);
@@ -1813,6 +1816,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
                 },
               ],
               callbackRequired: false,
+              callbackSkippable: true,
             });
             return {
               keys: [],
@@ -1863,6 +1867,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches(order("open", "open", 10, 1))).toBe(false);
             return {
@@ -1904,6 +1909,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches(order("open", "open", 10, 1))).toBe(false);
             return {
@@ -1940,6 +1946,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches(position("bad", "BAD", 10n, "10"))).toBe(false);
             return {
@@ -1976,6 +1983,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches(position("bad-price", "BAD", 10n, "10"))).toBe(false);
             return {
@@ -2012,6 +2020,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches(position("active", "ACT", 10n, "10", true))).toBe(false);
             expect(plan.matches(position("inactive", "INA", 10n, "10", false))).toBe(true);
@@ -2053,6 +2062,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches({ id: "number", amount: 2 })).toBe(true);
             expect(plan.matches({ id: "bigint", amount: 2n })).toBe(false);
@@ -2099,6 +2109,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
             expect(plan.predicate).toStrictEqual({
               filters: [],
               callbackRequired: true,
+              callbackSkippable: false,
             });
             expect(plan.matches(instrument("1", "xnys", 1, ["equity"]))).toBe(false);
             expect(plan.matches(instrument("2", "xlon", 2, ["equity"]))).toBe(false);
@@ -2919,6 +2930,28 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expect(evaluation.totalRows).toBe(0);
     }),
   );
+
+  it.effect("keeps optional not-equal semantics aligned with public raw snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("missing-note", "open", 10, 1),
+        { ...order("matched-note", "open", 20, 2), note: "hello" },
+        { ...order("other-note", "open", 30, 3), note: "bye" },
+      ]);
+
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id"],
+        where: {
+          note: { neq: "bye" },
+        },
+        orderBy: [{ field: "id", direction: "asc" }],
+      });
+
+      expect(rowIds(snapshot.rows)).toStrictEqual(["matched-note"]);
+      expect(snapshot.totalRows).toBe(1);
+    }),
+  );
 });
 
 describe("ColumnLiveViewEngine subscriptions", () => {
@@ -3663,6 +3696,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         predicate: {
           filters: [],
           callbackRequired: false,
+          callbackSkippable: true,
         },
         orderBy: [{ field: "price", direction: "asc" }],
         storageOrderBy: [{ field: "missing", direction: "asc" }],
@@ -3764,6 +3798,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
             { field: "price", operator: "lt", value: 30 },
           ],
           callbackRequired: false,
+          callbackSkippable: true,
         },
         orderBy: [{ field: "price", direction: "asc" }],
         storageOrderBy: [{ field: "price", direction: "asc" }],
@@ -3779,6 +3814,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         predicate: {
           filters: [{ field: "price", operator: "gt", value: "10" }],
           callbackRequired: false,
+          callbackSkippable: true,
         },
         orderBy: [{ field: "price", direction: "asc" }],
         storageOrderBy: [{ field: "price", direction: "asc" }],
@@ -3809,6 +3845,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         predicate: {
           filters: [{ field: "price", operator: "eq", value: "20" }],
           callbackRequired: false,
+          callbackSkippable: true,
         },
         orderBy: [{ field: "price", direction: "asc" }],
         storageOrderBy: [{ field: "price", direction: "asc" }],
@@ -3854,6 +3891,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         predicate: {
           filters: [{ field: "price", operator: "in", values: [20, "30"] }],
           callbackRequired: false,
+          callbackSkippable: true,
         },
         orderBy: [{ field: "price", direction: "asc" }],
         storageOrderBy: [{ field: "price", direction: "asc" }],
@@ -3931,6 +3969,312 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(zeroLimitPlan.keys).toStrictEqual([]);
       expect(zeroLimitPlan.totalRows).toBe(2);
+    }),
+  );
+
+  it.effect("skips row callbacks for complete column predicate plans", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(store, order("missing-note", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        store,
+        { ...order("matched-note", "open", 20, 2), note: "hello" },
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        store,
+        { ...order("other-note", "open", 30, 3), note: "bye" },
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const callbackSkipped = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "note", operator: "startsWith", value: "he" }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete column predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(callbackSkipped.keys).toStrictEqual(["matched-note"]);
+      expect(callbackSkipped.totalRows).toBe(1);
+
+      const optionalNotEqual = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "note", operator: "neq", value: "bye" }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete optional not-equal predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(optionalNotEqual.keys).toStrictEqual(["matched-note"]);
+      expect(optionalNotEqual.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("keeps optional column values out of exact range scans without row callbacks", () =>
+    Effect.gen(function* () {
+      const OptionalPrice = Schema.Struct({
+        id: Schema.String,
+        price: Schema.optionalKey(Schema.Finite),
+      });
+      const store = new TopicStore("optional-prices", OptionalPrice, "id", () => {});
+      yield* publishTopicStoreRow(store, { id: "missing" }, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, { id: "cheap", price: 5 }, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, { id: "expensive", price: 20 }, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const callbackSkipped = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: 10 }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete range predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(callbackSkipped.keys).toStrictEqual(["expensive"]);
+      expect(callbackSkipped.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("uses bigint range hints conservatively for manual plans", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("positions", Position, "id", () => {});
+      yield* publishTopicStoreRow(store, position("low", "AAPL", 5n, "10"), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, position("equal", "AAPL", 10n, "10"), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, position("high", "AAPL", 20n, "10"), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const rangeHinted = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "quantity", operator: "gt", value: 10n }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(rangeHinted.keys).toStrictEqual(["high"]);
+      expect(rangeHinted.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("handles exact not-equal column predicates without row callbacks", () =>
+    Effect.gen(function* () {
+      const orderStore = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(orderStore, order("cheap", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(orderStore, order("excluded", "open", 20, 2), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(orderStore, order("expensive", "open", 30, 3), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const orderReadModel = topicStoreReadModel(orderStore);
+      const exactNumberNotEqual = orderReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "neq", value: 20 }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("exact numeric not-equal predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+      expect(exactNumberNotEqual.keys).toStrictEqual(["cheap", "expensive"]);
+      expect(exactNumberNotEqual.totalRows).toBe(2);
+
+      const manualRangeHint = orderReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: 10 }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+      expect(manualRangeHint.keys).toStrictEqual(["excluded", "expensive"]);
+      expect(manualRangeHint.totalRows).toBe(2);
+
+      const manualNotEqualHint = orderReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "neq", value: 20 }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+      expect(manualNotEqualHint.keys).toStrictEqual(["cheap", "expensive"]);
+      expect(manualNotEqualHint.totalRows).toBe(2);
+
+      const manualGreaterThanOrEqualHint = orderReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "gte", value: 20 }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+      expect(manualGreaterThanOrEqualHint.keys).toStrictEqual(["excluded", "expensive"]);
+      expect(manualGreaterThanOrEqualHint.totalRows).toBe(2);
+
+      const manualLessThanHint = orderReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "lt", value: 30 }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+      expect(manualLessThanHint.keys).toStrictEqual(["cheap", "excluded"]);
+      expect(manualLessThanHint.totalRows).toBe(2);
+
+      const manualLessThanOrEqualHint = orderReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "lte", value: 20 }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+      expect(manualLessThanOrEqualHint.keys).toStrictEqual(["cheap", "excluded"]);
+      expect(manualLessThanOrEqualHint.totalRows).toBe(2);
+
+      const positionStore = new TopicStore("positions", Position, "id", () => {});
+      yield* publishTopicStoreRow(
+        positionStore,
+        position("drop", "DROP", 20n, "10"),
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        positionStore,
+        position("excluded-price", "AAPL", 20n, "99"),
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        positionStore,
+        position("excluded-quantity", "AAPL", 10n, "10"),
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        positionStore,
+        position("keep", "AAPL", 20n, "10"),
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+
+      const positionReadModel = topicStoreReadModel(positionStore);
+      const exactMixedNotEqual = positionReadModel.scanRawWindow({
+        predicate: {
+          filters: [
+            { field: "symbol", operator: "neq", value: "DROP" },
+            { field: "quantity", operator: "neq", value: 10n },
+            { field: "price", operator: "neq", value: fromStringUnsafe("99") },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("exact mixed not-equal predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(exactMixedNotEqual.keys).toStrictEqual(["keep"]);
+      expect(exactMixedNotEqual.totalRows).toBe(1);
+
+      const LooseNumber = Schema.Struct({
+        id: Schema.String,
+        value: Schema.Number,
+      });
+      const looseNumberStore = new TopicStore("loose-numbers", LooseNumber, "id", () => {});
+      yield* publishTopicStoreRow(
+        looseNumberStore,
+        { id: "nan", value: Number.NaN },
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(looseNumberStore, { id: "real", value: 20 }, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const looseNumberReadModel = topicStoreReadModel(looseNumberStore);
+      const exactFiniteRange = looseNumberReadModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "value", operator: "gt", value: 10 }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("exact finite range predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(exactFiniteRange.keys).toStrictEqual(["real"]);
+      expect(exactFiniteRange.totalRows).toBe(1);
     }),
   );
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -1037,6 +1037,7 @@ const compilePredicatePlan = (
     return {
       filters: [],
       callbackRequired: false,
+      callbackSkippable: true,
     };
   }
 
@@ -1050,6 +1051,7 @@ const compilePredicatePlan = (
   return {
     filters,
     callbackRequired,
+    callbackSkippable: !callbackRequired,
   };
 };
 

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -36,6 +36,11 @@ export type TopicRawPredicatePlan = {
    * `filters`, for example structured fields or malformed runtime filters.
    */
   readonly callbackRequired: boolean;
+  /**
+   * True when the compiler proved that `filters` fully represent `matches`.
+   * Hand-written plans omit this and stay guarded by the row callback.
+   */
+  readonly callbackSkippable?: boolean;
 };
 
 export type TopicRawWindowScanPlan<Row extends RowObject> = {


### PR DESCRIPTION
## Summary
- Add compiler-owned callbackSkippable predicate plans so storage can skip row callbacks only when filters fully represent the raw predicate.
- Teach ColumnarTopicStore exact column scans to evaluate eq/neq/in/startsWith/range predicates without row callbacks while preserving conservative fallback for hand-written plans.
- Add public snapshot and storage-seam tests for optional neq semantics, exact range behavior, manual fallback, and callback skipping.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan clean
- pnpm run ready

## Review
- 3 local review agents completed after fixes: no findings.
