### PR TITLE
Batch client delta application

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -117,6 +117,556 @@ describe("@view-server/client", () => {
     });
   });
 
+  it("marks malformed snapshots stale", () => {
+    const previous = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 1,
+      keys: ["a"],
+      rows: [{ id: "a" }],
+      totalRows: 1,
+    });
+    const fractionalVersion = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 1.5,
+      keys: ["a"],
+      rows: [{ id: "a" }],
+      totalRows: 1,
+    });
+    const negativeTotalRows = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 1,
+      keys: ["a"],
+      rows: [{ id: "a" }],
+      totalRows: -1,
+    });
+    const totalRowsBelowWindow = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 1,
+      keys: ["a"],
+      rows: [{ id: "a" }],
+      totalRows: 0,
+    });
+    const mismatchedKeysAndRows = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 1,
+      keys: ["a", "b"],
+      rows: [{ id: "a" }],
+      totalRows: 2,
+    });
+    const duplicateKeys = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 1,
+      keys: ["a", "a"],
+      rows: [{ id: "a" }, { id: "a-copy" }],
+      totalRows: 2,
+    });
+    const invalidRefresh = applyEvent(previous, {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-snapshot",
+      version: 2,
+      keys: ["a"],
+      rows: [{ id: "a-refresh" }],
+      totalRows: -1,
+    });
+
+    expect(fractionalVersion).toMatchObject({
+      rows: [],
+      keys: [],
+      totalRows: 0,
+      version: 0,
+      status: "stale",
+      statusCode: "SnapshotStale",
+    });
+    expect(negativeTotalRows).toMatchObject({
+      rows: [],
+      keys: [],
+      totalRows: 0,
+      version: 0,
+      status: "stale",
+      statusCode: "SnapshotStale",
+    });
+    expect(totalRowsBelowWindow).toMatchObject({
+      rows: [],
+      keys: [],
+      totalRows: 0,
+      version: 0,
+      status: "stale",
+      statusCode: "SnapshotStale",
+    });
+    expect(mismatchedKeysAndRows).toMatchObject({
+      rows: [],
+      keys: [],
+      totalRows: 0,
+      version: 0,
+      status: "stale",
+      statusCode: "SnapshotStale",
+    });
+    expect(duplicateKeys).toMatchObject({
+      rows: [],
+      keys: [],
+      totalRows: 0,
+      version: 0,
+      status: "stale",
+      statusCode: "SnapshotStale",
+    });
+    expect(invalidRefresh).toMatchObject({
+      rows: [{ id: "a" }],
+      keys: ["a"],
+      totalRows: 1,
+      version: 1,
+      status: "stale",
+      statusCode: "SnapshotStale",
+    });
+  });
+
+  it("applies multi-operation deltas without mutating the previous state", () => {
+    const previous = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-batch",
+      version: 1,
+      keys: ["a", "b", "c"],
+      rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      totalRows: 3,
+    });
+    const previousRows = previous.rows;
+    const previousKeys = previous.keys;
+
+    const next = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-batch",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [
+        { type: "move", key: "c", fromIndex: 2, toIndex: 0 },
+        { type: "insert", key: "d", row: { id: "d" }, index: 2 },
+        { type: "update", key: "a", row: { id: "a-updated" }, index: 1 },
+        { type: "remove", key: "b" },
+      ],
+    });
+
+    expect(previous.rows).toBe(previousRows);
+    expect(previous.keys).toBe(previousKeys);
+    expect(previous.rows).toStrictEqual([{ id: "a" }, { id: "b" }, { id: "c" }]);
+    expect(previous.keys).toStrictEqual(["a", "b", "c"]);
+    expect(next.rows).toStrictEqual([{ id: "c" }, { id: "a-updated" }, { id: "d" }]);
+    expect(next.keys).toStrictEqual(["c", "a", "d"]);
+    expect(next.totalRows).toBe(3);
+    expect(next.version).toBe(2);
+  });
+
+  it("moves rows by key even when the row value is undefined", () => {
+    const previous = applyEvent(initialClientState<undefined>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-undefined-row",
+      version: 1,
+      keys: ["a", "b"],
+      rows: [undefined, undefined],
+      totalRows: 2,
+    });
+
+    const next = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-undefined-row",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 2,
+      operations: [{ type: "move", key: "b", fromIndex: 1, toIndex: 0 }],
+    });
+
+    expect(next.rows).toStrictEqual([undefined, undefined]);
+    expect(next.keys).toStrictEqual(["b", "a"]);
+    expect(next.status).toBe("ready");
+    expect(next.version).toBe(2);
+  });
+
+  it("marks the state stale when a delta cannot apply to the current snapshot", () => {
+    const previous = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      version: 1,
+      keys: ["a", "b", "c"],
+      rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      totalRows: 3,
+    });
+
+    const staleVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 0,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [],
+    });
+    const equalToVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 1,
+      totalRows: 3,
+      operations: [],
+    });
+    const backwardToVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 0,
+      totalRows: 3,
+      operations: [],
+    });
+    const fractionalToVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 1.5,
+      totalRows: 3,
+      operations: [],
+    });
+    const infiniteToVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: Number.POSITIVE_INFINITY,
+      totalRows: 3,
+      operations: [],
+    });
+    const nanFromVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: Number.NaN,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [],
+    });
+    const negativeFromVersion = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: -1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [],
+    });
+    const fractionalStateVersion = applyEvent(
+      {
+        ...previous,
+        version: 1.5,
+      },
+      {
+        type: "delta",
+        topic: "orders",
+        queryId: "query-invalid-delta",
+        fromVersion: 1.5,
+        toVersion: 2,
+        totalRows: 3,
+        operations: [],
+      },
+    );
+    const negativeDeltaTotalRows = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: -1,
+      operations: [],
+    });
+    const fractionalDeltaTotalRows = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 1.5,
+      operations: [],
+    });
+    const totalRowsBelowWindow = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 2,
+      operations: [],
+    });
+    const loadingStateDelta = applyEvent(initialClientState<{ readonly id: string }>(), {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 0,
+      toVersion: 1,
+      totalRows: 0,
+      operations: [],
+    });
+    const duplicateInsert = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 4,
+      operations: [{ type: "insert", key: "a", row: { id: "a-duplicate" }, index: 1 }],
+    });
+    const negativeInsert = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 4,
+      operations: [{ type: "insert", key: "d", row: { id: "d" }, index: -1 }],
+    });
+    const nanInsert = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 4,
+      operations: [{ type: "insert", key: "d", row: { id: "d" }, index: Number.NaN }],
+    });
+    const outOfRangeInsert = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 4,
+      operations: [{ type: "insert", key: "d", row: { id: "d" }, index: 4 }],
+    });
+    const mismatchedUpdate = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "update", key: "z", row: { id: "z" }, index: 1 }],
+    });
+    const fractionalUpdate = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "update", key: "b", row: { id: "b" }, index: 1.5 }],
+    });
+    const missingMoveSource = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "move", key: "missing", fromIndex: 99, toIndex: 0 }],
+    });
+    const mismatchedMoveKey = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "move", key: "z", fromIndex: 0, toIndex: 1 }],
+    });
+    const negativeMoveTarget = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "move", key: "a", fromIndex: 0, toIndex: -1 }],
+    });
+    const fractionalMoveSource = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "move", key: "a", fromIndex: 0.5, toIndex: 1 }],
+    });
+    const fractionalMoveTarget = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "move", key: "a", fromIndex: 0, toIndex: 1.5 }],
+    });
+    const outOfRangeMoveTarget = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 3,
+      operations: [{ type: "move", key: "a", fromIndex: 0, toIndex: 3 }],
+    });
+    const missingRemove = applyEvent(previous, {
+      type: "delta",
+      topic: "orders",
+      queryId: "query-invalid-delta",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 2,
+      operations: [{ type: "remove", key: "missing" }],
+    });
+
+    expect(staleVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(equalToVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(backwardToVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(fractionalToVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(infiniteToVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(nanFromVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(negativeFromVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(fractionalStateVersion).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1.5,
+    });
+    expect(negativeDeltaTotalRows).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(fractionalDeltaTotalRows).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(totalRowsBelowWindow).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(loadingStateDelta).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 0,
+    });
+    expect(duplicateInsert).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(negativeInsert).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(nanInsert).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(outOfRangeInsert).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(mismatchedUpdate).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(fractionalUpdate).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(missingMoveSource).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(mismatchedMoveKey).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(negativeMoveTarget).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(fractionalMoveSource).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(fractionalMoveTarget).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(outOfRangeMoveTarget).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+    expect(missingRemove).toMatchObject({
+      status: "stale",
+      statusCode: "SnapshotStale",
+      version: 1,
+    });
+  });
+
   it("maps async atom lifecycle states into live query results", () => {
     expect(liveQueryResultFromAsyncResult(AsyncResult.initial())).toMatchObject({
       status: "loading",

--- a/packages/client/src/live-query-state.ts
+++ b/packages/client/src/live-query-state.ts
@@ -29,54 +29,166 @@ export const liveQueryResult = <Row>(state: ClientState<Row>): LiveQueryResult<R
 });
 
 const applySnapshot = <Row>(
+  state: ClientState<Row>,
   event: Extract<ViewServerLiveEvent<Row>, { readonly type: "snapshot" }>,
-): ClientState<Row> => ({
-  rows: event.rows,
-  keys: event.keys,
-  totalRows: event.totalRows,
-  version: event.version,
-  status: "ready",
-  statusCode: "Ready",
-});
+): ClientState<Row> => {
+  if (!isValidSnapshotEvent(event)) {
+    return staleSnapshotState(state);
+  }
+  return {
+    rows: event.rows,
+    keys: event.keys,
+    totalRows: event.totalRows,
+    version: event.version,
+    status: "ready",
+    statusCode: "Ready",
+  };
+};
+
+const reindexKeys = (
+  keys: ReadonlyArray<string>,
+  keyIndexes: Map<string, number>,
+  startIndex: number,
+): void => {
+  for (let index = startIndex; index < keys.length; index += 1) {
+    keyIndexes.set(keys[index]!, index);
+  }
+};
+
+const isInsertIndex = (index: number, length: number): boolean =>
+  Number.isSafeInteger(index) && index >= 0 && index <= length;
+
+const isExistingIndex = (index: number, length: number): boolean =>
+  Number.isSafeInteger(index) && index >= 0 && index < length;
+
+const isNonNegativeSafeInteger = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0;
+
+const hasUniqueKeys = (keys: ReadonlyArray<string>): boolean => {
+  const seenKeys = new Set<string>();
+  for (const key of keys) {
+    if (seenKeys.has(key)) {
+      return false;
+    }
+    seenKeys.add(key);
+  }
+  return true;
+};
+
+const isValidSnapshotEvent = <Row>(
+  event: Extract<ViewServerLiveEvent<Row>, { readonly type: "snapshot" }>,
+): boolean =>
+  isNonNegativeSafeInteger(event.version) &&
+  isNonNegativeSafeInteger(event.totalRows) &&
+  event.totalRows >= event.rows.length &&
+  event.keys.length === event.rows.length &&
+  hasUniqueKeys(event.keys);
 
 const applyDeltaOperation = <Row>(
-  state: ClientState<Row>,
+  rows: Array<Row>,
+  keys: Array<string>,
+  keyIndexes: Map<string, number>,
   operation: DeltaEvent<Row>["operations"][number],
-): ClientState<Row> => {
+): boolean => {
   if (operation.type === "insert") {
-    const nextRows = state.rows.slice();
-    const nextKeys = state.keys.slice();
-    nextRows.splice(operation.index, 0, operation.row);
-    nextKeys.splice(operation.index, 0, operation.key);
-    return { ...state, rows: nextRows, keys: nextKeys };
+    if (!isInsertIndex(operation.index, keys.length) || keyIndexes.has(operation.key)) {
+      return false;
+    }
+    rows.splice(operation.index, 0, operation.row);
+    keys.splice(operation.index, 0, operation.key);
+    reindexKeys(keys, keyIndexes, operation.index);
+    return true;
   }
   if (operation.type === "update") {
-    const nextRows = state.rows.slice();
-    const nextKeys = state.keys.slice();
-    nextRows[operation.index] = operation.row;
-    nextKeys[operation.index] = operation.key;
-    return { ...state, rows: nextRows, keys: nextKeys };
+    if (!isExistingIndex(operation.index, keys.length)) {
+      return false;
+    }
+    const previousKey = keys[operation.index];
+    if (previousKey !== operation.key) {
+      return false;
+    }
+    rows[operation.index] = operation.row;
+    keyIndexes.set(operation.key, operation.index);
+    return true;
   }
   if (operation.type === "move") {
-    const nextRows = state.rows.slice();
-    const nextKeys = state.keys.slice();
-    nextRows.splice(operation.toIndex, 0, ...nextRows.splice(operation.fromIndex, 1));
-    nextKeys.splice(operation.toIndex, 0, ...nextKeys.splice(operation.fromIndex, 1));
-    return { ...state, rows: nextRows, keys: nextKeys };
+    if (
+      !isExistingIndex(operation.fromIndex, keys.length) ||
+      !isExistingIndex(operation.toIndex, keys.length)
+    ) {
+      return false;
+    }
+    const key = keys[operation.fromIndex];
+    if (key !== operation.key) {
+      return false;
+    }
+    const movedRows = rows.splice(operation.fromIndex, 1);
+    const movedKeys = keys.splice(operation.fromIndex, 1);
+    rows.splice(operation.toIndex, 0, ...movedRows);
+    keys.splice(operation.toIndex, 0, ...movedKeys);
+    reindexKeys(keys, keyIndexes, Math.min(operation.fromIndex, operation.toIndex));
+    return true;
   }
-  const nextRows = state.rows.filter((_row, index) => state.keys[index] !== operation.key);
-  const nextKeys = state.keys.filter((key) => key !== operation.key);
-  return { ...state, rows: nextRows, keys: nextKeys };
+  const index = keyIndexes.get(operation.key);
+  if (index === undefined) {
+    return false;
+  }
+  rows.splice(index, 1);
+  keys.splice(index, 1);
+  keyIndexes.delete(operation.key);
+  reindexKeys(keys, keyIndexes, index);
+  return true;
+};
+
+const staleDeltaState = <Row>(state: ClientState<Row>): ClientState<Row> => ({
+  ...state,
+  status: "stale",
+  statusCode: "SnapshotStale",
+  message: "Received an invalid delta; waiting for a fresh snapshot.",
+});
+
+const staleSnapshotState = <Row>(state: ClientState<Row>): ClientState<Row> => ({
+  ...state,
+  status: "stale",
+  statusCode: "SnapshotStale",
+  message: "Received an invalid snapshot; waiting for a fresh snapshot.",
+});
+
+const canApplyDeltaFromVersion = <Row>(
+  state: ClientState<Row>,
+  event: DeltaEvent<Row>,
+): boolean => {
+  if (state.status !== "ready") {
+    return false;
+  }
+  return (
+    isNonNegativeSafeInteger(state.version) &&
+    isNonNegativeSafeInteger(event.fromVersion) &&
+    isNonNegativeSafeInteger(event.toVersion) &&
+    isNonNegativeSafeInteger(event.totalRows) &&
+    state.version === event.fromVersion &&
+    event.toVersion > state.version
+  );
 };
 
 const applyDelta = <Row>(state: ClientState<Row>, event: DeltaEvent<Row>): ClientState<Row> => {
-  let nextState = state;
+  if (!canApplyDeltaFromVersion(state, event)) {
+    return staleDeltaState(state);
+  }
+  const rows = state.rows.slice();
+  const keys = state.keys.slice();
+  const keyIndexes = new Map(keys.map((key, index) => [key, index]));
   for (const operation of event.operations) {
-    nextState = applyDeltaOperation(nextState, operation);
+    if (!applyDeltaOperation(rows, keys, keyIndexes, operation)) {
+      return staleDeltaState(state);
+    }
+  }
+  if (event.totalRows < rows.length) {
+    return staleDeltaState(state);
   }
   return {
-    rows: nextState.rows,
-    keys: nextState.keys,
+    rows,
+    keys,
     totalRows: event.totalRows,
     version: event.toVersion,
     status: "ready",
@@ -99,7 +211,7 @@ export const applyEvent = <Row>(
   event: ViewServerLiveEvent<Row>,
 ): ClientState<Row> => {
   if (event.type === "snapshot") {
-    return applySnapshot(event);
+    return applySnapshot(state, event);
   }
   if (event.type === "delta") {
     return applyDelta(state, event);


### PR DESCRIPTION

## Summary
- Apply delta batches with one rows/keys clone and a per-batch key index instead of cloning/filtering per operation.
- Reject malformed snapshots/deltas by marking the existing client state stale instead of advancing to an impossible ready state.
- Add coverage for sequential operations, invalid metadata, malformed indices, duplicate keys, undefined row values, and totalRows/window invariants.

## Validation
- pnpm --filter @view-server/client run test
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan clean
- pnpm run ready

## Review loop
- 3 reviewer agents ran multiple rounds.
- Earlier findings around malformed deltas, numeric indices, version metadata, snapshot metadata, and totalRows invariants were fixed.
- Final round: 3/3 reviewers reported no findings.
