### PR TITLE
Bound raw fallback window scans

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -67,6 +67,7 @@ const noOrderedRangeBounds: OrderedRangeBounds = {
   lower: undefined,
   upper: undefined,
 };
+const maxBoundedRawWindowEnd = 1_024;
 
 export type PreparedTopicRow = {
   readonly key: string;
@@ -189,28 +190,10 @@ export class ColumnarTopicStore {
       return this.scanRawWindowOrderedSlots(plan, orderedWindow);
     }
 
-    const compareSlots = this.rawWindowSlotComparator(plan);
-    if (compareSlots !== undefined) {
-      return this.scanRawWindowSlots(plan, compareSlots);
-    }
-
-    const filtered: Array<TopicRowEntry<object>> = [];
-    for (let slot = 0; slot < this.slots.length; slot += 1) {
-      const entry = this.slots[slot]!;
-      if (this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-        filtered.push(entry);
-      }
-    }
-    const ordered = filtered.toSorted(plan.compare);
-    const window = ordered.slice(
-      plan.offset,
-      plan.limit === undefined ? undefined : plan.offset + plan.limit,
-    );
-    return {
-      keys: window.map((entry) => entry.key),
-      window,
-      totalRows: filtered.length,
-    };
+    const compareSlots =
+      this.rawWindowSlotComparator(plan) ??
+      ((left, right) => plan.compare(this.slots[left]!, this.slots[right]!));
+    return this.scanRawWindowSlots(plan, compareSlots);
   }
 
   private scanRawWindowOrderedSlots(
@@ -246,6 +229,11 @@ export class ColumnarTopicStore {
     plan: TopicRawWindowScanPlan<object>,
     compareSlots: (left: number, right: number) => number,
   ): TopicRawWindowScanResult<object> {
+    const boundedWindowEnd = boundedRawWindowEnd(plan);
+    if (boundedWindowEnd !== undefined) {
+      return this.scanRawWindowBoundedSlots(plan, compareSlots, boundedWindowEnd);
+    }
+
     let totalRows = 0;
     const filteredSlots: Array<number> = [];
     for (let slot = 0; slot < this.slots.length; slot += 1) {
@@ -264,6 +252,39 @@ export class ColumnarTopicStore {
       plan.limit === undefined ? undefined : plan.offset + plan.limit,
     );
     const window = windowSlots.map((slot) => this.slots[slot]!);
+    return {
+      keys: window.map((entry) => entry.key),
+      window,
+      totalRows,
+    };
+  }
+
+  private scanRawWindowBoundedSlots(
+    plan: TopicRawWindowScanPlan<object>,
+    compareSlots: (left: number, right: number) => number,
+    windowEnd: number,
+  ): TopicRawWindowScanResult<object> {
+    let totalRows = 0;
+    const windowSlots: Array<number> = [];
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      const entry = this.slots[slot]!;
+      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+        continue;
+      }
+      totalRows += 1;
+      if (windowSlots.length < windowEnd) {
+        const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+        windowSlots.splice(insertAt, 0, slot);
+        continue;
+      }
+      const worstSlot = windowSlots[windowSlots.length - 1]!;
+      if (compareSlots(slot, worstSlot) < 0) {
+        const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+        windowSlots.splice(insertAt, 0, slot);
+        windowSlots.pop();
+      }
+    }
+    const window = windowSlots.slice(plan.offset).map((slot) => this.slots[slot]!);
     return {
       keys: window.map((entry) => entry.key),
       window,
@@ -747,6 +768,20 @@ const compareRangeColumnValue = (left: unknown, right: unknown): number | undefi
 const orderedSlotIndexKey = (orderBy: ReadonlyArray<TopicRawOrderByPlan>): string => {
   const order = orderBy[0]!;
   return `${order.field.length}:${order.field}:${order.direction}`;
+};
+
+const boundedRawWindowEnd = (plan: TopicRawWindowScanPlan<object>): number | undefined => {
+  if (plan.limit === undefined || plan.limit <= 0) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(plan.offset) || plan.offset < 0 || !Number.isSafeInteger(plan.limit)) {
+    return undefined;
+  }
+  const windowEnd = plan.offset + plan.limit;
+  if (!Number.isSafeInteger(windowEnd) || windowEnd > maxBoundedRawWindowEnd) {
+    return undefined;
+  }
+  return windowEnd;
 };
 
 const orderedSlotIndexInsertionPoint = (

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -212,6 +212,14 @@ const rowField = (row: object, field: string): unknown => {
 const rowIds = (rows: ReadonlyArray<object>): ReadonlyArray<unknown> =>
   rows.map((row) => rowField(row, "id"));
 
+const numericRowField = (row: object, field: string): number => {
+  const value = fieldValue(row, field);
+  if (typeof value === "number") {
+    return value;
+  }
+  throw new Error(`Expected numeric row field ${field}.`);
+};
+
 const normalizeDecimalFields = <Row extends object>(
   rows: ReadonlyArray<Row>,
 ): ReadonlyArray<Record<string, unknown>> =>
@@ -3969,6 +3977,87 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(zeroLimitPlan.keys).toStrictEqual([]);
       expect(zeroLimitPlan.totalRows).toBe(2);
+
+      const unsafeWindowEndPlan = readModel.scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByKey,
+        offset: Number.MAX_SAFE_INTEGER,
+        limit: 1,
+      });
+      expect(unsafeWindowEndPlan.keys).toStrictEqual([]);
+      expect(unsafeWindowEndPlan.totalRows).toBe(2);
+    }),
+  );
+
+  it.effect("uses bounded fallback scans for finite windows with stable row-key ties", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(store, order("d", "open", 20, 4), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("b", "open", 10, 2), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("a", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("c", "open", 10, 3), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("e", "open", 30, 5), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const compareByPriceThenKey = (
+        left: { readonly key: string; readonly row: object },
+        right: { readonly key: string; readonly row: object },
+      ) => {
+        const priceComparison =
+          numericRowField(left.row, "price") - numericRowField(right.row, "price");
+        if (priceComparison !== 0) {
+          return priceComparison;
+        }
+        return left.key.localeCompare(right.key);
+      };
+
+      const readModel = topicStoreReadModel(store);
+      const boundedWindow = readModel.scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 1,
+        limit: 3,
+      });
+
+      expect(boundedWindow.keys).toStrictEqual(["b", "c", "d"]);
+      expect(boundedWindow.window.map((entry) => entry.key)).toStrictEqual(["b", "c", "d"]);
+      expect(rowIds(boundedWindow.window.map((entry) => entry.row))).toStrictEqual(["b", "c", "d"]);
+      expect(boundedWindow.totalRows).toBe(5);
+
+      const cappedLargeWindow = readModel.scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 1_024,
+        limit: 1,
+      });
+
+      expect(cappedLargeWindow.keys).toStrictEqual([]);
+      expect(cappedLargeWindow.window).toStrictEqual([]);
+      expect(cappedLargeWindow.totalRows).toBe(5);
     }),
   );
 


### PR DESCRIPTION
## Summary
- route fallback raw scans through slot comparators so row entries are not materialized before ordering
- add a bounded sorted slot accumulator for small finite windows where offset plus limit is at most 1024
- preserve full-sort fallback for unbounded, invalid, hostile, or large/deep windows
- add coverage for positive offsets, stable row-key tie ordering, key/window alignment, unsafe window ends, and capped large finite windows

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan
- pnpm run ready
- 3/3 reviewer agents clean after blocker fixes