### PR TITLE
Index scalar in predicate filters

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -14,7 +14,7 @@ import {
   rawQueryCompilerMetadata,
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
-import { cloneRow, fieldValue, isPlainRecord, valuesEqual } from "./row-values";
+import { cloneRow, fieldValue, isPlainRecord, scalarEqualityKey, valuesEqual } from "./row-values";
 import { isBigDecimal, Order as orderBigDecimal } from "effect/BigDecimal";
 
 type RowObject = object;
@@ -665,6 +665,10 @@ export class ColumnarTopicStore {
       return !valuesEqual(value, filter.value);
     }
     if (filter.operator === "in") {
+      if (filter.valueKeys !== undefined) {
+        const key = scalarEqualityKey(value);
+        return key !== undefined && filter.valueKeys.has(key);
+      }
       return filter.values.some((candidate) => valuesEqual(value, candidate));
     }
     if (filter.operator === "startsWith") {

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -38,7 +38,7 @@ import {
   stableQueryValueString,
 } from "./raw-query-compiler";
 import { evaluateCompiledGroupedQuery, prepareGroupedQuery } from "./grouped-query-compiler";
-import { cloneRecord, cloneRow, fieldValue, rowsEqual } from "./row-values";
+import { cloneRecord, cloneRow, fieldValue, rowsEqual, scalarEqualityKey } from "./row-values";
 import {
   acquireTopicStoreSubscription,
   closeBackpressuredTopicStoreSubscription,
@@ -1651,6 +1651,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
                   field: "status",
                   operator: "in",
                   values: ["open", "closed"],
+                  valueKeys: new Set(["string:4:open", "string:6:closed"]),
                 },
                 {
                   field: "price",
@@ -1718,6 +1719,128 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expect(evaluation.rows).toStrictEqual([]);
       expect(evaluation.totalRows).toBe(0);
       expect(evaluation.version).toBe(11);
+    }),
+  );
+
+  it.effect("passes indexed scalar in predicate keys to the storage scan interface", () =>
+    Effect.gen(function* () {
+      const matchedPrice = fromStringUnsafe("1.0");
+      const positionCompiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id"],
+          where: {
+            active: {
+              in: [true],
+            },
+            quantity: {
+              in: [20n],
+            },
+            price: {
+              in: [matchedPrice],
+            },
+          },
+        },
+      );
+
+      const positionEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [
+                {
+                  field: "active",
+                  operator: "in",
+                  values: [true],
+                  valueKeys: new Set(["boolean:true"]),
+                },
+                {
+                  field: "quantity",
+                  operator: "in",
+                  values: [20n],
+                  valueKeys: new Set(["bigint:20"]),
+                },
+                {
+                  field: "price",
+                  operator: "in",
+                  values: [matchedPrice],
+                  valueKeys: new Set(["bigDecimal:1"]),
+                },
+              ],
+              callbackRequired: false,
+              callbackSkippable: true,
+            });
+            expect(plan.matches(position("matched", "AAPL", 20n, "1", true))).toBe(true);
+            expect(plan.matches(position("wrong-active", "AAPL", 20n, "1", false))).toBe(false);
+            expect(plan.matches(position("wrong-quantity", "AAPL", 21n, "1", true))).toBe(false);
+            expect(plan.matches(position("wrong-price", "AAPL", 20n, "2", true))).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 3,
+        },
+        positionCompiled,
+      );
+
+      expect(positionEvaluation.keys).toStrictEqual([]);
+      expect(positionEvaluation.rows).toStrictEqual([]);
+      expect(positionEvaluation.totalRows).toBe(0);
+      expect(positionEvaluation.version).toBe(3);
+
+      const NullableMetric = Schema.Struct({
+        id: Schema.String,
+        note: Schema.NullOr(Schema.String),
+      });
+      const nullableCompiled = yield* prepareRawQuery<object, object>(
+        "nullableMetrics",
+        rawQueryCompilerMetadata(NullableMetric),
+        {
+          select: ["id"],
+          where: {
+            note: {
+              in: [null, "x"],
+            },
+          },
+        },
+      );
+
+      const nullableEvaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [
+                {
+                  field: "note",
+                  operator: "in",
+                  values: [null, "x"],
+                  valueKeys: new Set(["null", "string:1:x"]),
+                },
+              ],
+              callbackRequired: false,
+              callbackSkippable: true,
+            });
+            expect(plan.matches({ id: "null", note: null })).toBe(true);
+            expect(plan.matches({ id: "x", note: "x" })).toBe(true);
+            expect(plan.matches({ id: "y", note: "y" })).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 4,
+        },
+        nullableCompiled,
+      );
+
+      expect(nullableEvaluation.keys).toStrictEqual([]);
+      expect(nullableEvaluation.rows).toStrictEqual([]);
+      expect(nullableEvaluation.totalRows).toBe(0);
+      expect(nullableEvaluation.version).toBe(4);
     }),
   );
 
@@ -4117,6 +4240,77 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("uses indexed scalar in predicate filters without row callbacks", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(store, order("cheap", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("matched", "open", 20, 2), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("expensive", "open", 30, 3), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        store,
+        { ...order("noted", "open", 40, 4), note: "hello" },
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const indexedNumberIn = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("indexed numeric in predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(indexedNumberIn.keys).toStrictEqual(["matched"]);
+      expect(indexedNumberIn.totalRows).toBe(1);
+
+      const indexedOptionalIn = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "note",
+              operator: "in",
+              values: ["hello"],
+              valueKeys: new Set(["string:5:hello"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("indexed optional in predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(indexedOptionalIn.keys).toStrictEqual(["noted"]);
+      expect(indexedOptionalIn.totalRows).toBe(1);
+    }),
+  );
+
   it.effect("keeps optional column values out of exact range scans without row callbacks", () =>
     Effect.gen(function* () {
       const OptionalPrice = Schema.Struct({
@@ -5192,6 +5386,19 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 });
 
 describe("ColumnLiveViewEngine validation and health", () => {
+  it("encodes scalar equality keys deterministically", () => {
+    expect(scalarEqualityKey(null)).toBe("null");
+    expect(scalarEqualityKey("open")).toBe("string:4:open");
+    expect(scalarEqualityKey(false)).toBe("boolean:false");
+    expect(scalarEqualityKey(true)).toBe("boolean:true");
+    expect(scalarEqualityKey(1n)).toBe("bigint:1");
+    expect(scalarEqualityKey(-0)).toBe("number:-0");
+    expect(scalarEqualityKey(Number.NaN)).toBe("number:NaN");
+    expect(scalarEqualityKey(Number.POSITIVE_INFINITY)).toBe("number:Infinity");
+    expect(scalarEqualityKey(fromStringUnsafe("1.0"))).toBe("bigDecimal:1");
+    expect(scalarEqualityKey({ value: "open" })).toBeUndefined();
+  });
+
   it("encodes primitive and unsupported query values deterministically", () => {
     function namedFilter() {
       return "ignored";

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -7,6 +7,8 @@ import {
   fieldValue,
   isPlainRecord,
   isRecord,
+  scalarEqualityKey,
+  type ScalarEqualityKeyValue,
   valuesEqual,
 } from "./row-values";
 import type { TopicRawOrderByPlan, TopicRawPredicatePlan, TopicRowEntry } from "./row-scan";
@@ -855,7 +857,7 @@ const rangeValueKind = (value: unknown): RangeValueKind | undefined => {
   return undefined;
 };
 
-const isScalarPlanValue = (value: unknown): boolean =>
+const isScalarPlanValue = (value: unknown): value is ScalarEqualityKeyValue =>
   value === null ||
   typeof value === "string" ||
   typeof value === "boolean" ||
@@ -873,7 +875,8 @@ export const isRangePlanValue = (
   return kind !== undefined && fieldKinds?.size === 1 && fieldKinds.has(kind);
 };
 
-const isEqualityPlanValue = (value: unknown): boolean => isScalarPlanValue(value);
+const isEqualityPlanValue = (value: unknown): value is ScalarEqualityKeyValue =>
+  isScalarPlanValue(value);
 
 const isNotEqualPlanValue = (
   field: string,
@@ -892,10 +895,18 @@ const isNotEqualPlanValue = (
   return false;
 };
 
-const isInPlanValues = (value: unknown): value is ReadonlyArray<unknown> =>
+const isInPlanValues = (value: unknown): value is ReadonlyArray<ScalarEqualityKeyValue> =>
   Array.isArray(value) &&
   isDenseArray(value) &&
   value.every((candidate) => isEqualityPlanValue(candidate));
+
+const scalarEqualityKeys = (values: ReadonlyArray<ScalarEqualityKeyValue>): ReadonlySet<string> => {
+  const keys = new Set<string>();
+  for (const value of values) {
+    keys.add(scalarEqualityKey(value));
+  }
+  return keys;
+};
 
 type PredicateFieldPlan = {
   readonly filters: TopicRawPredicatePlan["filters"];
@@ -959,10 +970,12 @@ const predicateFilterPlans = (
   }
   if ("in" in filter) {
     if (isInPlanValues(filter["in"])) {
+      const values = [...filter["in"]];
       plans.push({
         field,
         operator: "in",
-        values: [...filter["in"]],
+        values,
+        valueKeys: scalarEqualityKeys(values),
       });
     } else {
       callbackRequired = true;

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -22,6 +22,7 @@ export type TopicRawPredicateFilterPlan =
       readonly field: string;
       readonly operator: "in";
       readonly values: ReadonlyArray<unknown>;
+      readonly valueKeys?: ReadonlySet<string>;
     };
 
 export type TopicRawPredicatePlan = {

--- a/packages/column-live-view-engine/src/row-values.ts
+++ b/packages/column-live-view-engine/src/row-values.ts
@@ -1,6 +1,14 @@
-import { equals, isBigDecimal } from "effect/BigDecimal";
+import {
+  equals,
+  format as formatBigDecimal,
+  isBigDecimal,
+  normalize,
+  type BigDecimal,
+} from "effect/BigDecimal";
 
 type RowObject = object;
+
+export type ScalarEqualityKeyValue = null | string | boolean | bigint | number | BigDecimal;
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -80,6 +88,30 @@ export const valuesEqual = (left: unknown, right: unknown): boolean => {
   }
   return Object.is(left, right);
 };
+
+export function scalarEqualityKey(value: ScalarEqualityKeyValue): string;
+export function scalarEqualityKey(value: unknown): string | undefined;
+export function scalarEqualityKey(value: unknown): string | undefined {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return `string:${value.length}:${value}`;
+  }
+  if (typeof value === "boolean") {
+    return `boolean:${value ? "true" : "false"}`;
+  }
+  if (typeof value === "bigint") {
+    return `bigint:${value.toString()}`;
+  }
+  if (typeof value === "number") {
+    return `number:${Object.is(value, -0) ? "-0" : value.toString()}`;
+  }
+  if (isBigDecimal(value)) {
+    return `bigDecimal:${formatBigDecimal(normalize(value))}`;
+  }
+  return undefined;
+}
 
 export const rowsEqual = <Row extends RowObject>(left: Row, right: Row): boolean => {
   const rightKeys = new Set(Object.keys(right));


### PR DESCRIPTION
## Summary
- add deterministic scalar equality keys for row equality values
- attach precomputed valueKeys to compiler-generated scalar in predicate filters
- use Set.has for keyed in predicates in columnar scans while preserving valuesEqual fallback for manual plans without valueKeys
- cover string, number, boolean, bigint, BigDecimal, null, -0, NaN, Infinity, and optional-field behavior

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan
- pnpm run ready
- 3/3 reviewer agents clean