### PR TITLE
Add scalar predicate candidate scans

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -48,6 +48,13 @@ type OrderedRangeBounds = {
   readonly upper: OrderedRangeBound | undefined;
 };
 
+type ScalarCandidateSlots = ReadonlyArray<number>;
+type ScalarCandidateFilter = {
+  readonly column: ColumnValues;
+  readonly sampleMatches: number;
+  readonly valueKeys: ReadonlySet<string>;
+};
+
 type TopicRawRangePredicateFilterPlan = TopicRawPredicateFilterPlan & {
   readonly operator: "gt" | "gte" | "lt" | "lte";
   readonly value: unknown;
@@ -68,6 +75,8 @@ const noOrderedRangeBounds: OrderedRangeBounds = {
   upper: undefined,
 };
 const maxBoundedRawWindowEnd = 1_024;
+const maxScalarCandidateSampleSlots = 4_096;
+const maxTransientScalarCandidateSlots = 65_536;
 
 export type PreparedTopicRow = {
   readonly key: string;
@@ -187,7 +196,12 @@ export class ColumnarTopicStore {
   scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
     const orderedWindow = this.rawWindowOrderedWindow(plan);
     if (orderedWindow !== undefined) {
-      return this.scanRawWindowOrderedSlots(plan, orderedWindow);
+      const candidateSlots =
+        plan.predicate.callbackSkippable === true &&
+        orderedRawWindowSlotCount(orderedWindow) * 2 > this.slots.length
+          ? this.scalarPredicateCandidateSlots(plan.predicate.filters)
+          : undefined;
+      return this.scanRawWindowOrderedSlots(plan, orderedWindow, candidateSlots);
     }
 
     const compareSlots =
@@ -199,13 +213,26 @@ export class ColumnarTopicStore {
   private scanRawWindowOrderedSlots(
     plan: TopicRawWindowScanPlan<object>,
     orderedWindow: OrderedRawWindow,
+    candidateSlots: ScalarCandidateSlots | undefined,
   ): TopicRawWindowScanResult<object> {
+    if (candidateSlots !== undefined && candidateSlots.length === 0) {
+      return {
+        keys: [],
+        window: [],
+        totalRows: 0,
+      };
+    }
     let totalRows = 0;
     const windowSlots: Array<number> = [];
     const windowEnd = plan.offset + orderedWindow.limit;
+    const candidateSlotSet =
+      candidateSlots === undefined ? undefined : new Set<number>(candidateSlots);
     for (const span of orderedWindow.spans) {
       for (let slotIndex = span.startIndex; slotIndex < span.endIndex; slotIndex += 1) {
         const slot = orderedWindow.slots[slotIndex]!;
+        if (candidateSlotSet !== undefined && !candidateSlotSet.has(slot)) {
+          continue;
+        }
         const entry = this.slots[slot]!;
         if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
           continue;
@@ -229,21 +256,38 @@ export class ColumnarTopicStore {
     plan: TopicRawWindowScanPlan<object>,
     compareSlots: (left: number, right: number) => number,
   ): TopicRawWindowScanResult<object> {
+    const candidateSlots =
+      plan.predicate.callbackSkippable === true
+        ? this.scalarPredicateCandidateSlots(plan.predicate.filters)
+        : undefined;
     const boundedWindowEnd = boundedRawWindowEnd(plan);
     if (boundedWindowEnd !== undefined) {
-      return this.scanRawWindowBoundedSlots(plan, compareSlots, boundedWindowEnd);
+      return this.scanRawWindowBoundedSlots(plan, compareSlots, boundedWindowEnd, candidateSlots);
     }
 
     let totalRows = 0;
     const filteredSlots: Array<number> = [];
-    for (let slot = 0; slot < this.slots.length; slot += 1) {
-      const entry = this.slots[slot]!;
-      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-        continue;
+    if (candidateSlots !== undefined) {
+      for (const slot of candidateSlots) {
+        const entry = this.slots[slot]!;
+        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+          continue;
+        }
+        totalRows += 1;
+        if (plan.limit !== 0) {
+          filteredSlots.push(slot);
+        }
       }
-      totalRows += 1;
-      if (plan.limit !== 0) {
-        filteredSlots.push(slot);
+    } else {
+      for (let slot = 0; slot < this.slots.length; slot += 1) {
+        const entry = this.slots[slot]!;
+        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+          continue;
+        }
+        totalRows += 1;
+        if (plan.limit !== 0) {
+          filteredSlots.push(slot);
+        }
       }
     }
     filteredSlots.sort(compareSlots);
@@ -263,25 +307,47 @@ export class ColumnarTopicStore {
     plan: TopicRawWindowScanPlan<object>,
     compareSlots: (left: number, right: number) => number,
     windowEnd: number,
+    candidateSlots: ScalarCandidateSlots | undefined,
   ): TopicRawWindowScanResult<object> {
     let totalRows = 0;
     const windowSlots: Array<number> = [];
-    for (let slot = 0; slot < this.slots.length; slot += 1) {
-      const entry = this.slots[slot]!;
-      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-        continue;
+    if (candidateSlots !== undefined) {
+      for (const slot of candidateSlots) {
+        const entry = this.slots[slot]!;
+        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+          continue;
+        }
+        totalRows += 1;
+        if (windowSlots.length < windowEnd) {
+          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+          windowSlots.splice(insertAt, 0, slot);
+          continue;
+        }
+        const worstSlot = windowSlots[windowSlots.length - 1]!;
+        if (compareSlots(slot, worstSlot) < 0) {
+          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+          windowSlots.splice(insertAt, 0, slot);
+          windowSlots.pop();
+        }
       }
-      totalRows += 1;
-      if (windowSlots.length < windowEnd) {
-        const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
-        windowSlots.splice(insertAt, 0, slot);
-        continue;
-      }
-      const worstSlot = windowSlots[windowSlots.length - 1]!;
-      if (compareSlots(slot, worstSlot) < 0) {
-        const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
-        windowSlots.splice(insertAt, 0, slot);
-        windowSlots.pop();
+    } else {
+      for (let slot = 0; slot < this.slots.length; slot += 1) {
+        const entry = this.slots[slot]!;
+        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+          continue;
+        }
+        totalRows += 1;
+        if (windowSlots.length < windowEnd) {
+          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+          windowSlots.splice(insertAt, 0, slot);
+          continue;
+        }
+        const worstSlot = windowSlots[windowSlots.length - 1]!;
+        if (compareSlots(slot, worstSlot) < 0) {
+          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+          windowSlots.splice(insertAt, 0, slot);
+          windowSlots.pop();
+        }
       }
     }
     const window = windowSlots.slice(plan.offset).map((slot) => this.slots[slot]!);
@@ -290,6 +356,106 @@ export class ColumnarTopicStore {
       window,
       totalRows,
     };
+  }
+
+  private scalarPredicateCandidateSlots(
+    filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+  ): ScalarCandidateSlots | undefined {
+    let selectedFilter: ScalarCandidateFilter | undefined;
+    for (const filter of filters) {
+      const candidateFilter = this.scalarPredicateFilter(filter);
+      if (candidateFilter === undefined) {
+        continue;
+      }
+      if (
+        selectedFilter === undefined ||
+        candidateFilter.sampleMatches < selectedFilter.sampleMatches
+      ) {
+        selectedFilter = candidateFilter;
+      }
+    }
+    if (selectedFilter === undefined) {
+      return undefined;
+    }
+    return this.scalarColumnCandidateSlots(selectedFilter.column, selectedFilter.valueKeys);
+  }
+
+  private scalarPredicateFilter(
+    filter: TopicRawPredicateFilterPlan,
+  ): ScalarCandidateFilter | undefined {
+    if (filter.operator === "eq") {
+      const key = scalarEqualityKey(filter.value);
+      if (key === undefined) {
+        return undefined;
+      }
+      const column = this.columns.get(filter.field);
+      if (column === undefined) {
+        return undefined;
+      }
+      return this.scalarColumnCandidateFilter(column, new Set([key]));
+    }
+    if (filter.operator !== "in" || filter.valueKeys === undefined) {
+      return undefined;
+    }
+    const column = this.columns.get(filter.field);
+    if (column === undefined) {
+      return undefined;
+    }
+    return this.scalarColumnCandidateFilter(column, filter.valueKeys);
+  }
+
+  private scalarColumnCandidateFilter(
+    column: ColumnValues,
+    valueKeys: ReadonlySet<string>,
+  ): ScalarCandidateFilter | undefined {
+    const sampleMatches = this.scalarColumnSampleMatchCount(column, valueKeys);
+    if (sampleMatches === undefined) {
+      return undefined;
+    }
+    return {
+      column,
+      sampleMatches,
+      valueKeys,
+    };
+  }
+
+  private scalarColumnCandidateSlots(
+    column: ColumnValues,
+    valueKeys: ReadonlySet<string>,
+  ): ScalarCandidateSlots | undefined {
+    const maxSlots = scalarCandidateSlotLimit(this.slots.length);
+    const slots: Array<number> = [];
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      const key = scalarEqualityKey(column[slot]);
+      if (key === undefined || !valueKeys.has(key)) {
+        continue;
+      }
+      slots.push(slot);
+      if (slots.length > maxSlots) {
+        return undefined;
+      }
+    }
+    return slots;
+  }
+
+  private scalarColumnSampleMatchCount(
+    column: ColumnValues,
+    valueKeys: ReadonlySet<string>,
+  ): number | undefined {
+    const sampleSize = Math.min(this.slots.length, maxScalarCandidateSampleSlots);
+    const maxMatches = scalarCandidateSampleMatchLimit(sampleSize);
+    let matches = 0;
+    for (let slot = 0; slot < sampleSize; slot += 1) {
+      const key = scalarEqualityKey(column[slot]);
+      if (key === undefined || !valueKeys.has(key)) {
+        continue;
+      }
+      matches += 1;
+      if (matches > maxMatches) {
+        return undefined;
+      }
+    }
+    return matches;
   }
 
   private rawWindowOrderedWindow(
@@ -787,6 +953,20 @@ const boundedRawWindowEnd = (plan: TopicRawWindowScanPlan<object>): number | und
   }
   return windowEnd;
 };
+
+const orderedRawWindowSlotCount = (window: OrderedRawWindow): number => {
+  let count = 0;
+  for (const span of window.spans) {
+    count += span.endIndex - span.startIndex;
+  }
+  return count;
+};
+
+const scalarCandidateSlotLimit = (rowCount: number): number =>
+  Math.min(maxTransientScalarCandidateSlots, Math.floor(rowCount / 2));
+
+const scalarCandidateSampleMatchLimit = (sampleSize: number): number =>
+  Math.max(8, Math.floor(sampleSize / 8));
 
 const orderedSlotIndexInsertionPoint = (
   slots: ReadonlyArray<number>,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -46,6 +46,7 @@ import {
   collectTopicStoreHealth,
   deleteTopicStoreRow,
   publishTopicStoreRow,
+  publishTopicStoreRows,
   registerTopicStoreSubscription,
   resetTopicStore,
   TopicStore,
@@ -617,6 +618,32 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         { id: "e", price: 5 },
       ]);
       expect(ascendingInclusive.totalRows).toBe(7);
+
+      const scalarFilteredOrderedWindow = yield* engine.snapshot("orders", {
+        select: ["id", "price", "status"],
+        where: {
+          status: "closed",
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 1,
+      });
+
+      expect(scalarFilteredOrderedWindow.rows).toStrictEqual([
+        { id: "z", price: 99, status: "closed" },
+      ]);
+      expect(scalarFilteredOrderedWindow.totalRows).toBe(1);
+
+      const scalarFilteredEmptyOrderedWindow = yield* engine.snapshot("orders", {
+        select: ["id", "customerId", "price"],
+        where: {
+          customerId: "missing-customer",
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 1,
+      });
+
+      expect(scalarFilteredEmptyOrderedWindow.rows).toStrictEqual([]);
+      expect(scalarFilteredEmptyOrderedWindow.totalRows).toBe(0);
 
       const numericEquality = yield* engine.snapshot("orders", {
         select: ["id", "price"],
@@ -4257,7 +4284,6 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         { ...order("noted", "open", 40, 4), note: "hello" },
         (topic, message) => InvalidRowError.make({ topic, message }),
       );
-
       const readModel = topicStoreReadModel(store);
       const indexedNumberIn = readModel.scanRawWindow({
         predicate: {
@@ -4308,6 +4334,541 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       expect(indexedOptionalIn.keys).toStrictEqual(["noted"]);
       expect(indexedOptionalIn.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("uses scalar predicate candidate scans across row mutations", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(store, order("cheap", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("matched", "open", 20, 2), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(
+        store,
+        { ...order("noted", "open", 40, 4), note: "hello" },
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("cold", "closed", 99, 9), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const compareByKey = (left: { readonly key: string }, right: { readonly key: string }) =>
+        left.key.localeCompare(right.key);
+
+      const initialPriceMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete scalar in predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(initialPriceMatch.keys).toStrictEqual(["matched"]);
+
+      const initialPriceCountOnly = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete scalar count-only predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: 0,
+      });
+      expect(initialPriceCountOnly.keys).toStrictEqual([]);
+      expect(initialPriceCountOnly.totalRows).toBe(1);
+
+      const partialPriceBuckets = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20, 999],
+              valueKeys: new Set(["number:20", "number:999"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("missing scalar buckets should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(partialPriceBuckets.keys).toStrictEqual(["matched"]);
+
+      const stableTieWindow = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20, 10],
+              valueKeys: new Set(["number:20", "number:10"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete scalar in tie windows should not call row callbacks");
+        },
+        compare: () => 0,
+        offset: 0,
+        limit: 1,
+      });
+      expect(stableTieWindow.keys).toStrictEqual(["cheap"]);
+
+      const boundedCandidateRejectedBySecondFilter = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["closed"],
+              valueKeys: new Set(["string:6:closed"]),
+            },
+            {
+              field: "price",
+              operator: "in",
+              values: [10, 20],
+              valueKeys: new Set(["number:10", "number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("bounded scalar candidate scans should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: 1,
+      });
+      expect(boundedCandidateRejectedBySecondFilter.keys).toStrictEqual([]);
+
+      const boundedCandidateReplacement = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [10, 20],
+              valueKeys: new Set(["number:10", "number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("bounded scalar candidate top-k scans should not call row callbacks");
+        },
+        compare: (left, right) => right.key.localeCompare(left.key),
+        offset: 0,
+        limit: 1,
+      });
+      expect(boundedCandidateReplacement.keys).toStrictEqual(["matched"]);
+
+      const notedMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "note",
+              operator: "in",
+              values: ["hello"],
+              valueKeys: new Set(["string:5:hello"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete optional scalar in predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(notedMatch.keys).toStrictEqual(["noted"]);
+
+      const closedStatusMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["closed"],
+              valueKeys: new Set(["string:6:closed"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("selective status predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(closedStatusMatch.keys).toStrictEqual(["cold"]);
+
+      const sameSizeCandidateMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["closed"],
+              valueKeys: new Set(["string:6:closed"]),
+            },
+            {
+              field: "note",
+              operator: "in",
+              values: ["hello"],
+              valueKeys: new Set(["string:5:hello"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("same-size scalar candidates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(sameSizeCandidateMatch.keys).toStrictEqual([]);
+
+      const broadStatusMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["open"],
+              valueKeys: new Set(["string:4:open"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("broad complete scalar predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(broadStatusMatch.keys).toStrictEqual(["cheap", "matched", "noted"]);
+
+      yield* publishTopicStoreRow(store, order("also-matched", "open", 20, 3), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("other", "open", 30, 5), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      yield* publishTopicStoreRow(store, order("missing-note", "open", 50, 6), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const insertedPriceMatches = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("scalar candidate scans should not call row callbacks after append");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(insertedPriceMatches.keys).toStrictEqual(["also-matched", "matched"]);
+
+      const newPriceBucket = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [30],
+              valueKeys: new Set(["number:30"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("new scalar candidate buckets should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(newPriceBucket.keys).toStrictEqual(["other"]);
+
+      const smallerCandidateWins = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["open"],
+              valueKeys: new Set(["string:4:open"]),
+            },
+            {
+              field: "price",
+              operator: "eq",
+              value: 20,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete scalar predicate candidates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(smallerCandidateWins.keys).toStrictEqual(["also-matched", "matched"]);
+
+      yield* publishTopicStoreRow(store, order("matched", "open", 30, 7), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const rebuiltPriceMatches = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("scalar candidate scans should not call row callbacks after replace");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(rebuiltPriceMatches.keys).toStrictEqual(["also-matched"]);
+
+      const manualObjectEquality = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "eq",
+              value: { price: 20 },
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(manualObjectEquality.keys).toStrictEqual([]);
+
+      const missingFieldEq = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "missing",
+              operator: "eq",
+              value: "anything",
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(missingFieldEq.keys).toStrictEqual([
+        "also-matched",
+        "cheap",
+        "cold",
+        "matched",
+        "missing-note",
+        "noted",
+        "other",
+      ]);
+
+      const missingFieldIn = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "missing",
+              operator: "in",
+              values: ["anything"],
+              valueKeys: new Set(["string:8:anything"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(missingFieldIn.keys).toStrictEqual([
+        "also-matched",
+        "cheap",
+        "cold",
+        "matched",
+        "missing-note",
+        "noted",
+        "other",
+      ]);
+
+      yield* deleteTopicStoreRow(store, "other");
+
+      const afterDeletePriceMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "eq",
+              value: 30,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("scalar candidate scans after delete should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(afterDeletePriceMatch.keys).toStrictEqual(["matched"]);
+
+      yield* publishTopicStoreRows(
+        store,
+        [order("bulk-a", "open", 20, 8), order("bulk-b", "closed", 60, 9)],
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+
+      const afterBulkPriceMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error(
+            "scalar candidate scans after bulk publish should not call row callbacks",
+          );
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(afterBulkPriceMatch.keys).toStrictEqual(["also-matched", "bulk-a"]);
+
+      yield* resetTopicStore(store);
+
+      const afterResetPriceMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("scalar candidate scans after reset should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(afterResetPriceMatch.keys).toStrictEqual([]);
     }),
   );
 

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -273,6 +273,26 @@ describe(`raw snapshot and delta engine benchmark: ${profile.rowCount} rows`, ()
   );
 
   bench(
+    "selective equality filter + fallback top-k sort",
+    async () => {
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: ["id", "price", "status", "updatedAt"],
+          where: {
+            price: { eq: Math.floor(profile.rowCount / 2) % 1_000_000 },
+          },
+          orderBy: [
+            { field: "updatedAt", direction: "desc" },
+            { field: "id", direction: "asc" },
+          ],
+          limit: 50,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
     "ordered equality filter + indexed seek",
     async () => {
       await Effect.runPromise(


### PR DESCRIPTION
## Summary
- add transient scalar candidate scans for exact raw eq/in predicates
- gate candidate planning with sampling and cap materialization to avoid broad-filter memory/time regressions
- keep fallback scans as plain numeric loops and add fallback top-k benchmark coverage

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- forbidden-pattern scan clean
- pnpm run ready

## Review
- 3-agent review loop completed after fixes
- final focused 3-agent review found no blocking or non-blocking findings
