### PR TITLE
Add range predicate candidate scans

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -33,6 +33,7 @@ type OrderedRawWindowSpan = {
 };
 
 type OrderedRawWindow = {
+  readonly candidateExcludedField: string;
   readonly limit: number;
   readonly slots: ReadonlyArray<number>;
   readonly spans: ReadonlyArray<OrderedRawWindowSpan>;
@@ -48,11 +49,16 @@ type OrderedRangeBounds = {
   readonly upper: OrderedRangeBound | undefined;
 };
 
-type ScalarCandidateSlots = ReadonlyArray<number>;
-type ScalarCandidateFilter = {
+type PredicateCandidateSlots = ReadonlyArray<number>;
+type PredicateCandidateFilter = {
   readonly column: ColumnValues;
+  readonly matches: (value: unknown) => boolean;
   readonly sampleMatches: number;
-  readonly valueKeys: ReadonlySet<string>;
+};
+
+type PredicateCandidateSample = {
+  readonly sampleMatches: number;
+  readonly sampleSize: number;
 };
 
 type TopicRawRangePredicateFilterPlan = TopicRawPredicateFilterPlan & {
@@ -75,8 +81,8 @@ const noOrderedRangeBounds: OrderedRangeBounds = {
   upper: undefined,
 };
 const maxBoundedRawWindowEnd = 1_024;
-const maxScalarCandidateSampleSlots = 4_096;
-const maxTransientScalarCandidateSlots = 65_536;
+const maxPredicateCandidateSampleSlots = 4_096;
+const maxTransientPredicateCandidateSlots = 65_536;
 
 export type PreparedTopicRow = {
   readonly key: string;
@@ -199,7 +205,10 @@ export class ColumnarTopicStore {
       const candidateSlots =
         plan.predicate.callbackSkippable === true &&
         orderedRawWindowSlotCount(orderedWindow) * 2 > this.slots.length
-          ? this.scalarPredicateCandidateSlots(plan.predicate.filters)
+          ? this.predicateCandidateSlots(
+              plan.predicate.filters,
+              orderedWindow.candidateExcludedField,
+            )
           : undefined;
       return this.scanRawWindowOrderedSlots(plan, orderedWindow, candidateSlots);
     }
@@ -213,7 +222,7 @@ export class ColumnarTopicStore {
   private scanRawWindowOrderedSlots(
     plan: TopicRawWindowScanPlan<object>,
     orderedWindow: OrderedRawWindow,
-    candidateSlots: ScalarCandidateSlots | undefined,
+    candidateSlots: PredicateCandidateSlots | undefined,
   ): TopicRawWindowScanResult<object> {
     if (candidateSlots !== undefined && candidateSlots.length === 0) {
       return {
@@ -258,7 +267,7 @@ export class ColumnarTopicStore {
   ): TopicRawWindowScanResult<object> {
     const candidateSlots =
       plan.predicate.callbackSkippable === true
-        ? this.scalarPredicateCandidateSlots(plan.predicate.filters)
+        ? this.predicateCandidateSlots(plan.predicate.filters)
         : undefined;
     const boundedWindowEnd = boundedRawWindowEnd(plan);
     if (boundedWindowEnd !== undefined) {
@@ -307,7 +316,7 @@ export class ColumnarTopicStore {
     plan: TopicRawWindowScanPlan<object>,
     compareSlots: (left: number, right: number) => number,
     windowEnd: number,
-    candidateSlots: ScalarCandidateSlots | undefined,
+    candidateSlots: PredicateCandidateSlots | undefined,
   ): TopicRawWindowScanResult<object> {
     let totalRows = 0;
     const windowSlots: Array<number> = [];
@@ -358,12 +367,16 @@ export class ColumnarTopicStore {
     };
   }
 
-  private scalarPredicateCandidateSlots(
+  private predicateCandidateSlots(
     filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
-  ): ScalarCandidateSlots | undefined {
-    let selectedFilter: ScalarCandidateFilter | undefined;
+    excludedField?: string,
+  ): PredicateCandidateSlots | undefined {
+    let selectedFilter: PredicateCandidateFilter | undefined;
     for (const filter of filters) {
-      const candidateFilter = this.scalarPredicateFilter(filter);
+      if (filter.field === excludedField) {
+        continue;
+      }
+      const candidateFilter = this.predicateCandidateFilter(filter);
       if (candidateFilter === undefined) {
         continue;
       }
@@ -377,12 +390,12 @@ export class ColumnarTopicStore {
     if (selectedFilter === undefined) {
       return undefined;
     }
-    return this.scalarColumnCandidateSlots(selectedFilter.column, selectedFilter.valueKeys);
+    return this.predicateColumnCandidateSlots(selectedFilter.column, selectedFilter.matches);
   }
 
-  private scalarPredicateFilter(
+  private predicateCandidateFilter(
     filter: TopicRawPredicateFilterPlan,
-  ): ScalarCandidateFilter | undefined {
+  ): PredicateCandidateFilter | undefined {
     if (filter.operator === "eq") {
       const key = scalarEqualityKey(filter.value);
       if (key === undefined) {
@@ -394,68 +407,113 @@ export class ColumnarTopicStore {
       }
       return this.scalarColumnCandidateFilter(column, new Set([key]));
     }
-    if (filter.operator !== "in" || filter.valueKeys === undefined) {
+    if (filter.operator === "in" && filter.valueKeys !== undefined) {
+      const column = this.columns.get(filter.field);
+      if (column === undefined) {
+        return undefined;
+      }
+      return this.scalarColumnCandidateFilter(column, filter.valueKeys);
+    }
+    if (!isRangeFilterPlan(filter) || !isComparableRangeValue(filter.value)) {
       return undefined;
     }
     const column = this.columns.get(filter.field);
     if (column === undefined) {
       return undefined;
     }
-    return this.scalarColumnCandidateFilter(column, filter.valueKeys);
+    return this.rangeColumnCandidateFilter(column, filter.operator, filter.value);
   }
 
   private scalarColumnCandidateFilter(
     column: ColumnValues,
     valueKeys: ReadonlySet<string>,
-  ): ScalarCandidateFilter | undefined {
-    const sampleMatches = this.scalarColumnSampleMatchCount(column, valueKeys);
-    if (sampleMatches === undefined) {
+  ): PredicateCandidateFilter | undefined {
+    const matches = (value: unknown) => {
+      const key = scalarEqualityKey(value);
+      return key !== undefined && valueKeys.has(key);
+    };
+    return this.predicateColumnCandidateFilter(column, matches);
+  }
+
+  private rangeColumnCandidateFilter(
+    column: ColumnValues,
+    operator: TopicRawRangePredicateFilterPlan["operator"],
+    value: unknown,
+  ): PredicateCandidateFilter | undefined {
+    const matches = (columnValue: unknown) => {
+      const comparison = compareExactRangeColumnValue(columnValue, value);
+      return comparison !== undefined && rangeComparisonMatches(operator, comparison);
+    };
+    return this.predicateColumnCandidateFilter(column, matches);
+  }
+
+  private predicateColumnCandidateFilter(
+    column: ColumnValues,
+    matches: (value: unknown) => boolean,
+  ): PredicateCandidateFilter | undefined {
+    const sample = this.predicateColumnCandidateSample(column, matches);
+    if (sample === undefined) {
       return undefined;
     }
     return {
       column,
-      sampleMatches,
-      valueKeys,
+      matches,
+      sampleMatches: sample.sampleMatches,
     };
   }
 
-  private scalarColumnCandidateSlots(
+  private predicateColumnCandidateSlots(
     column: ColumnValues,
-    valueKeys: ReadonlySet<string>,
-  ): ScalarCandidateSlots | undefined {
-    const maxSlots = scalarCandidateSlotLimit(this.slots.length);
+    matches: (value: unknown) => boolean,
+  ): PredicateCandidateSlots | undefined {
+    const maxSlots = predicateCandidateSlotLimit(this.slots.length);
+    const densityCheckInterval = predicateCandidateMaterializationDensityCheckInterval(
+      this.slots.length,
+    );
     const slots: Array<number> = [];
     for (let slot = 0; slot < this.slots.length; slot += 1) {
-      const key = scalarEqualityKey(column[slot]);
-      if (key === undefined || !valueKeys.has(key)) {
-        continue;
+      const scannedSlots = slot + 1;
+      if (matches(column[slot])) {
+        slots.push(slot);
+        if (slots.length > maxSlots) {
+          return undefined;
+        }
       }
-      slots.push(slot);
-      if (slots.length > maxSlots) {
+      if (
+        scannedSlots >= densityCheckInterval &&
+        scannedSlots % densityCheckInterval === 0 &&
+        predicateCandidateSampleExceedsSlotLimit(slots.length, scannedSlots, this.slots.length)
+      ) {
         return undefined;
       }
     }
     return slots;
   }
 
-  private scalarColumnSampleMatchCount(
+  private predicateColumnCandidateSample(
     column: ColumnValues,
-    valueKeys: ReadonlySet<string>,
-  ): number | undefined {
-    const sampleSize = Math.min(this.slots.length, maxScalarCandidateSampleSlots);
-    const maxMatches = scalarCandidateSampleMatchLimit(sampleSize);
-    let matches = 0;
-    for (let slot = 0; slot < sampleSize; slot += 1) {
-      const key = scalarEqualityKey(column[slot]);
-      if (key === undefined || !valueKeys.has(key)) {
+    matches: (value: unknown) => boolean,
+  ): PredicateCandidateSample | undefined {
+    const sampleSize = Math.min(this.slots.length, maxPredicateCandidateSampleSlots);
+    const maxMatches = predicateCandidateSampleMatchLimit(sampleSize);
+    let matchCount = 0;
+    for (let sampleIndex = 0; sampleIndex < sampleSize; sampleIndex += 1) {
+      const slot = predicateCandidateSampleSlot(this.slots.length, sampleSize, sampleIndex);
+      if (!matches(column[slot])) {
         continue;
       }
-      matches += 1;
-      if (matches > maxMatches) {
+      matchCount += 1;
+      if (matchCount > maxMatches) {
         return undefined;
       }
     }
-    return matches;
+    if (predicateCandidateSampleExceedsSlotLimit(matchCount, sampleSize, this.slots.length)) {
+      return undefined;
+    }
+    return {
+      sampleMatches: matchCount,
+      sampleSize,
+    };
   }
 
   private rawWindowOrderedWindow(
@@ -489,6 +547,7 @@ export class ColumnarTopicStore {
     );
     if (rangeBounds !== undefined && rangeBoundsAreEmpty(rangeBounds)) {
       return {
+        candidateExcludedField: orderField,
         limit: plan.limit,
         slots: [],
         spans: [],
@@ -504,6 +563,7 @@ export class ColumnarTopicStore {
     const existing = this.orderedSlotIndexes.get(indexKey);
     if (existing !== undefined) {
       return {
+        candidateExcludedField: orderField,
         limit: plan.limit,
         slots: existing.slots,
         spans: this.orderedSlotIndexSpans(existing, seekBounds, equalityValues),
@@ -517,6 +577,7 @@ export class ColumnarTopicStore {
       slots,
     });
     return {
+      candidateExcludedField: orderField,
       limit: plan.limit,
       slots,
       spans: this.orderedSlotIndexSpans(
@@ -905,6 +966,22 @@ const compareExactRangeColumnValue = (left: unknown, right: unknown): number | u
   return undefined;
 };
 
+const rangeComparisonMatches = (
+  operator: TopicRawRangePredicateFilterPlan["operator"],
+  comparison: number,
+): boolean => {
+  if (operator === "gt") {
+    return comparison > 0;
+  }
+  if (operator === "gte") {
+    return comparison >= 0;
+  }
+  if (operator === "lt") {
+    return comparison < 0;
+  }
+  return comparison <= 0;
+};
+
 const columnValueDoesNotEqual = (value: unknown, notEqual: unknown): boolean => {
   return equalityComparableValues(value, notEqual) && !valuesEqual(value, notEqual);
 };
@@ -962,11 +1039,44 @@ const orderedRawWindowSlotCount = (window: OrderedRawWindow): number => {
   return count;
 };
 
-const scalarCandidateSlotLimit = (rowCount: number): number =>
-  Math.min(maxTransientScalarCandidateSlots, Math.floor(rowCount / 2));
+const predicateCandidateSlotLimit = (rowCount: number): number =>
+  Math.min(maxTransientPredicateCandidateSlots, Math.floor(rowCount / 2));
 
-const scalarCandidateSampleMatchLimit = (sampleSize: number): number =>
+const predicateCandidateSampleMatchLimit = (sampleSize: number): number =>
   Math.max(8, Math.floor(sampleSize / 8));
+
+const predicateCandidateMaterializationDensityCheckInterval = (rowCount: number): number => {
+  if (rowCount <= maxPredicateCandidateSampleSlots) {
+    return rowCount;
+  }
+  return Math.max(
+    maxPredicateCandidateSampleSlots,
+    Math.min(Math.floor(rowCount / 4), predicateCandidateSlotLimit(rowCount) * 2),
+  );
+};
+
+const predicateCandidateSampleSlot = (
+  rowCount: number,
+  sampleSize: number,
+  sampleIndex: number,
+): number => {
+  if (sampleSize <= 1) {
+    return 0;
+  }
+  return Math.round((sampleIndex * (rowCount - 1)) / (sampleSize - 1));
+};
+
+const predicateCandidateSampleExceedsSlotLimit = (
+  sampleMatches: number,
+  sampleSize: number,
+  rowCount: number,
+): boolean => {
+  return (
+    sampleMatches > 0 &&
+    sampleSize > 0 &&
+    sampleMatches * rowCount > predicateCandidateSlotLimit(rowCount) * sampleSize
+  );
+};
 
 const orderedSlotIndexInsertionPoint = (
   slots: ReadonlyArray<number>,

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -49,7 +49,6 @@ type OrderedRangeBounds = {
   readonly upper: OrderedRangeBound | undefined;
 };
 
-type PredicateCandidateSlots = ReadonlyArray<number>;
 type PredicateCandidateFilter = {
   readonly column: ColumnValues;
   readonly matches: (value: unknown) => boolean;
@@ -202,15 +201,15 @@ export class ColumnarTopicStore {
   scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
     const orderedWindow = this.rawWindowOrderedWindow(plan);
     if (orderedWindow !== undefined) {
-      const candidateSlots =
+      const candidateFilter =
         plan.predicate.callbackSkippable === true &&
         orderedRawWindowSlotCount(orderedWindow) * 2 > this.slots.length
-          ? this.predicateCandidateSlots(
+          ? this.selectedPredicateCandidateFilter(
               plan.predicate.filters,
               orderedWindow.candidateExcludedField,
             )
           : undefined;
-      return this.scanRawWindowOrderedSlots(plan, orderedWindow, candidateSlots);
+      return this.scanRawWindowOrderedSlots(plan, orderedWindow, candidateFilter);
     }
 
     const compareSlots =
@@ -222,24 +221,18 @@ export class ColumnarTopicStore {
   private scanRawWindowOrderedSlots(
     plan: TopicRawWindowScanPlan<object>,
     orderedWindow: OrderedRawWindow,
-    candidateSlots: PredicateCandidateSlots | undefined,
+    candidateFilter: PredicateCandidateFilter | undefined,
   ): TopicRawWindowScanResult<object> {
-    if (candidateSlots !== undefined && candidateSlots.length === 0) {
-      return {
-        keys: [],
-        window: [],
-        totalRows: 0,
-      };
-    }
     let totalRows = 0;
     const windowSlots: Array<number> = [];
     const windowEnd = plan.offset + orderedWindow.limit;
-    const candidateSlotSet =
-      candidateSlots === undefined ? undefined : new Set<number>(candidateSlots);
     for (const span of orderedWindow.spans) {
       for (let slotIndex = span.startIndex; slotIndex < span.endIndex; slotIndex += 1) {
         const slot = orderedWindow.slots[slotIndex]!;
-        if (candidateSlotSet !== undefined && !candidateSlotSet.has(slot)) {
+        if (
+          candidateFilter !== undefined &&
+          !candidateFilter.matches(candidateFilter.column[slot])
+        ) {
           continue;
         }
         const entry = this.slots[slot]!;
@@ -265,38 +258,28 @@ export class ColumnarTopicStore {
     plan: TopicRawWindowScanPlan<object>,
     compareSlots: (left: number, right: number) => number,
   ): TopicRawWindowScanResult<object> {
-    const candidateSlots =
+    const candidateFilter =
       plan.predicate.callbackSkippable === true
-        ? this.predicateCandidateSlots(plan.predicate.filters)
+        ? this.selectedPredicateCandidateFilter(plan.predicate.filters)
         : undefined;
     const boundedWindowEnd = boundedRawWindowEnd(plan);
     if (boundedWindowEnd !== undefined) {
-      return this.scanRawWindowBoundedSlots(plan, compareSlots, boundedWindowEnd, candidateSlots);
+      return this.scanRawWindowBoundedSlots(plan, compareSlots, boundedWindowEnd, candidateFilter);
     }
 
     let totalRows = 0;
     const filteredSlots: Array<number> = [];
-    if (candidateSlots !== undefined) {
-      for (const slot of candidateSlots) {
-        const entry = this.slots[slot]!;
-        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-          continue;
-        }
-        totalRows += 1;
-        if (plan.limit !== 0) {
-          filteredSlots.push(slot);
-        }
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      if (candidateFilter !== undefined && !candidateFilter.matches(candidateFilter.column[slot])) {
+        continue;
       }
-    } else {
-      for (let slot = 0; slot < this.slots.length; slot += 1) {
-        const entry = this.slots[slot]!;
-        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-          continue;
-        }
-        totalRows += 1;
-        if (plan.limit !== 0) {
-          filteredSlots.push(slot);
-        }
+      const entry = this.slots[slot]!;
+      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+        continue;
+      }
+      totalRows += 1;
+      if (plan.limit !== 0) {
+        filteredSlots.push(slot);
       }
     }
     filteredSlots.sort(compareSlots);
@@ -316,47 +299,29 @@ export class ColumnarTopicStore {
     plan: TopicRawWindowScanPlan<object>,
     compareSlots: (left: number, right: number) => number,
     windowEnd: number,
-    candidateSlots: PredicateCandidateSlots | undefined,
+    candidateFilter: PredicateCandidateFilter | undefined,
   ): TopicRawWindowScanResult<object> {
     let totalRows = 0;
     const windowSlots: Array<number> = [];
-    if (candidateSlots !== undefined) {
-      for (const slot of candidateSlots) {
-        const entry = this.slots[slot]!;
-        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-          continue;
-        }
-        totalRows += 1;
-        if (windowSlots.length < windowEnd) {
-          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
-          windowSlots.splice(insertAt, 0, slot);
-          continue;
-        }
-        const worstSlot = windowSlots[windowSlots.length - 1]!;
-        if (compareSlots(slot, worstSlot) < 0) {
-          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
-          windowSlots.splice(insertAt, 0, slot);
-          windowSlots.pop();
-        }
+    for (let slot = 0; slot < this.slots.length; slot += 1) {
+      if (candidateFilter !== undefined && !candidateFilter.matches(candidateFilter.column[slot])) {
+        continue;
       }
-    } else {
-      for (let slot = 0; slot < this.slots.length; slot += 1) {
-        const entry = this.slots[slot]!;
-        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
-          continue;
-        }
-        totalRows += 1;
-        if (windowSlots.length < windowEnd) {
-          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
-          windowSlots.splice(insertAt, 0, slot);
-          continue;
-        }
-        const worstSlot = windowSlots[windowSlots.length - 1]!;
-        if (compareSlots(slot, worstSlot) < 0) {
-          const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
-          windowSlots.splice(insertAt, 0, slot);
-          windowSlots.pop();
-        }
+      const entry = this.slots[slot]!;
+      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+        continue;
+      }
+      totalRows += 1;
+      if (windowSlots.length < windowEnd) {
+        const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+        windowSlots.splice(insertAt, 0, slot);
+        continue;
+      }
+      const worstSlot = windowSlots[windowSlots.length - 1]!;
+      if (compareSlots(slot, worstSlot) < 0) {
+        const insertAt = orderedSlotIndexInsertionPoint(windowSlots, slot, compareSlots);
+        windowSlots.splice(insertAt, 0, slot);
+        windowSlots.pop();
       }
     }
     const window = windowSlots.slice(plan.offset).map((slot) => this.slots[slot]!);
@@ -367,10 +332,10 @@ export class ColumnarTopicStore {
     };
   }
 
-  private predicateCandidateSlots(
+  private selectedPredicateCandidateFilter(
     filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
     excludedField?: string,
-  ): PredicateCandidateSlots | undefined {
+  ): PredicateCandidateFilter | undefined {
     let selectedFilter: PredicateCandidateFilter | undefined;
     for (const filter of filters) {
       if (filter.field === excludedField) {
@@ -390,7 +355,7 @@ export class ColumnarTopicStore {
     if (selectedFilter === undefined) {
       return undefined;
     }
-    return this.predicateColumnCandidateSlots(selectedFilter.column, selectedFilter.matches);
+    return selectedFilter;
   }
 
   private predicateCandidateFilter(
@@ -455,39 +420,14 @@ export class ColumnarTopicStore {
     if (sample === undefined) {
       return undefined;
     }
+    if (sample.sampleMatches === 0 && sample.sampleSize < this.slots.length) {
+      return undefined;
+    }
     return {
       column,
       matches,
       sampleMatches: sample.sampleMatches,
     };
-  }
-
-  private predicateColumnCandidateSlots(
-    column: ColumnValues,
-    matches: (value: unknown) => boolean,
-  ): PredicateCandidateSlots | undefined {
-    const maxSlots = predicateCandidateSlotLimit(this.slots.length);
-    const densityCheckInterval = predicateCandidateMaterializationDensityCheckInterval(
-      this.slots.length,
-    );
-    const slots: Array<number> = [];
-    for (let slot = 0; slot < this.slots.length; slot += 1) {
-      const scannedSlots = slot + 1;
-      if (matches(column[slot])) {
-        slots.push(slot);
-        if (slots.length > maxSlots) {
-          return undefined;
-        }
-      }
-      if (
-        scannedSlots >= densityCheckInterval &&
-        scannedSlots % densityCheckInterval === 0 &&
-        predicateCandidateSampleExceedsSlotLimit(slots.length, scannedSlots, this.slots.length)
-      ) {
-        return undefined;
-      }
-    }
-    return slots;
   }
 
   private predicateColumnCandidateSample(
@@ -1044,16 +984,6 @@ const predicateCandidateSlotLimit = (rowCount: number): number =>
 
 const predicateCandidateSampleMatchLimit = (sampleSize: number): number =>
   Math.max(8, Math.floor(sampleSize / 8));
-
-const predicateCandidateMaterializationDensityCheckInterval = (rowCount: number): number => {
-  if (rowCount <= maxPredicateCandidateSampleSlots) {
-    return rowCount;
-  }
-  return Math.max(
-    maxPredicateCandidateSampleSlots,
-    Math.min(Math.floor(rowCount / 4), predicateCandidateSlotLimit(rowCount) * 2),
-  );
-};
 
 const predicateCandidateSampleSlot = (
   rowCount: number,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -4406,6 +4406,172 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(initialPriceCountOnly.keys).toStrictEqual([]);
       expect(initialPriceCountOnly.totalRows).toBe(1);
 
+      const initialRangeGreaterThan = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gt",
+              value: 30,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete range gt predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(initialRangeGreaterThan.keys).toStrictEqual(["cold", "noted"]);
+
+      const initialRangeGreaterThanOrEqual = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gte",
+              value: 40,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete range gte predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(initialRangeGreaterThanOrEqual.keys).toStrictEqual(["cold", "noted"]);
+
+      const initialRangeLessThan = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "lt",
+              value: 20,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete range lt predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(initialRangeLessThan.keys).toStrictEqual(["cheap"]);
+
+      const initialRangeLessThanOrEqual = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "lte",
+              value: 10,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete range lte predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(initialRangeLessThanOrEqual.keys).toStrictEqual(["cheap"]);
+
+      const initialRangeCountOnly = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gt",
+              value: 30,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete range count-only predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: 0,
+      });
+      expect(initialRangeCountOnly.keys).toStrictEqual([]);
+      expect(initialRangeCountOnly.totalRows).toBe(2);
+
+      const rangeCandidateRejectedBySecondFilter = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gt",
+              value: 30,
+            },
+            {
+              field: "status",
+              operator: "in",
+              values: ["open"],
+              valueKeys: new Set(["string:4:open"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("compound range candidate predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(rangeCandidateRejectedBySecondFilter.keys).toStrictEqual(["noted"]);
+
+      const rangeCandidateRejectedByIncompatibleSecondFilter = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gt",
+              value: 30,
+            },
+            {
+              field: "note",
+              operator: "gt",
+              value: 30,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("incompatible compound range predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(rangeCandidateRejectedByIncompatibleSecondFilter.keys).toStrictEqual([]);
+
       const partialPriceBuckets = readModel.scanRawWindow({
         predicate: {
           filters: [
@@ -4658,6 +4824,28 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(newPriceBucket.keys).toStrictEqual(["other"]);
 
+      const insertedRangeMatches = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gte",
+              value: 50,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("range candidate scans should not call row callbacks after append");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(insertedRangeMatches.keys).toStrictEqual(["cold", "missing-note"]);
+
       const smallerCandidateWins = readModel.scanRawWindow({
         predicate: {
           filters: [
@@ -4790,7 +4978,62 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         "other",
       ]);
 
+      const missingFieldRange = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "missing",
+              operator: "gt",
+              value: 1,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(missingFieldRange.keys).toStrictEqual([
+        "also-matched",
+        "cheap",
+        "cold",
+        "matched",
+        "missing-note",
+        "noted",
+        "other",
+      ]);
+
       yield* deleteTopicStoreRow(store, "other");
+
+      const afterDeleteRangeMatch = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gte",
+              value: 30,
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("range candidate scans after delete should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(afterDeleteRangeMatch.keys).toStrictEqual([
+        "cold",
+        "matched",
+        "missing-note",
+        "noted",
+      ]);
 
       const afterDeletePriceMatch = readModel.scanRawWindow({
         predicate: {
@@ -4875,18 +5118,23 @@ describe("ColumnLiveViewEngine subscriptions", () => {
   it.effect("keeps optional column values out of exact range scans without row callbacks", () =>
     Effect.gen(function* () {
       const OptionalPrice = Schema.Struct({
+        group: Schema.String,
         id: Schema.String,
         price: Schema.optionalKey(Schema.Finite),
       });
       const store = new TopicStore("optional-prices", OptionalPrice, "id", () => {});
-      yield* publishTopicStoreRow(store, { id: "missing" }, (topic, message) =>
+      yield* publishTopicStoreRow(store, { group: "candidate", id: "missing" }, (topic, message) =>
         InvalidRowError.make({ topic, message }),
       );
-      yield* publishTopicStoreRow(store, { id: "cheap", price: 5 }, (topic, message) =>
-        InvalidRowError.make({ topic, message }),
+      yield* publishTopicStoreRow(
+        store,
+        { group: "other", id: "cheap", price: 5 },
+        (topic, message) => InvalidRowError.make({ topic, message }),
       );
-      yield* publishTopicStoreRow(store, { id: "expensive", price: 20 }, (topic, message) =>
-        InvalidRowError.make({ topic, message }),
+      yield* publishTopicStoreRow(
+        store,
+        { group: "other", id: "expensive", price: 20 },
+        (topic, message) => InvalidRowError.make({ topic, message }),
       );
 
       const readModel = topicStoreReadModel(store);
@@ -4907,6 +5155,122 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       expect(callbackSkipped.keys).toStrictEqual(["expensive"]);
       expect(callbackSkipped.totalRows).toBe(1);
+
+      const scalarCandidateRejectedByMissingRangeValue = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "group",
+              operator: "in",
+              values: ["candidate"],
+              valueKeys: new Set(["string:9:candidate"]),
+            },
+            { field: "price", operator: "gt", value: 0 },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("missing optional range values should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(scalarCandidateRejectedByMissingRangeValue.keys).toStrictEqual([]);
+      expect(scalarCandidateRejectedByMissingRangeValue.totalRows).toBe(0);
+    }),
+  );
+
+  it.effect("falls back when stratified samples underestimate predicate candidate size", () =>
+    Effect.gen(function* () {
+      const SkewedRow = Schema.Struct({
+        id: Schema.String,
+        status: Schema.String,
+      });
+      const rowCount = 20_000;
+      const sampleSize = 4_096;
+      const sampledSlots = new Set(
+        Array.from({ length: sampleSize }, (_value, sampleIndex) =>
+          Math.round((sampleIndex * (rowCount - 1)) / (sampleSize - 1)),
+        ),
+      );
+      const rows = Array.from({ length: rowCount }, (_value, index) => ({
+        id: `row-${index.toString().padStart(5, "0")}`,
+        status: sampledSlots.has(index) ? "skip" : "match",
+      }));
+      const store = new TopicStore("skewed", SkewedRow, "id", () => {});
+      yield* publishTopicStoreRows(store, rows, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const fallbackResult = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "status", operator: "eq", value: "match" }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete skewed predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: 0,
+      });
+
+      expect(fallbackResult.keys).toStrictEqual([]);
+      expect(fallbackResult.totalRows).toBe(rowCount - sampledSlots.size);
+    }),
+  );
+
+  it.effect("falls back when materialized predicate candidates exceed the transient cap", () =>
+    Effect.gen(function* () {
+      const SkewedRow = Schema.Struct({
+        id: Schema.String,
+        status: Schema.String,
+      });
+      const rowCount = 270_000;
+      const matchingPrefixRows = 70_000;
+      const sampleSize = 4_096;
+      const sampledSlots = new Set(
+        Array.from({ length: sampleSize }, (_value, sampleIndex) =>
+          Math.round((sampleIndex * (rowCount - 1)) / (sampleSize - 1)),
+        ),
+      );
+      const rows = Array.from({ length: rowCount }, (_value, index) => ({
+        id: `row-${index.toString().padStart(6, "0")}`,
+        status: index < matchingPrefixRows && !sampledSlots.has(index) ? "match" : "skip",
+      }));
+      const expectedTotalRows =
+        matchingPrefixRows -
+        Array.from(sampledSlots).filter((slot) => slot < matchingPrefixRows).length;
+      const store = new TopicStore("candidate-cap", SkewedRow, "id", () => {});
+      yield* publishTopicStoreRows(store, rows, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const readModel = topicStoreReadModel(store);
+      const fallbackResult = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "status", operator: "eq", value: "match" }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("complete capped candidate predicates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: 0,
+      });
+
+      expect(fallbackResult.keys).toStrictEqual([]);
+      expect(fallbackResult.totalRows).toBe(expectedTotalRows);
     }),
   );
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -5227,53 +5227,6 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
-  it.effect("falls back when materialized predicate candidates exceed the transient cap", () =>
-    Effect.gen(function* () {
-      const SkewedRow = Schema.Struct({
-        id: Schema.String,
-        status: Schema.String,
-      });
-      const rowCount = 270_000;
-      const matchingPrefixRows = 70_000;
-      const sampleSize = 4_096;
-      const sampledSlots = new Set(
-        Array.from({ length: sampleSize }, (_value, sampleIndex) =>
-          Math.round((sampleIndex * (rowCount - 1)) / (sampleSize - 1)),
-        ),
-      );
-      const rows = Array.from({ length: rowCount }, (_value, index) => ({
-        id: `row-${index.toString().padStart(6, "0")}`,
-        status: index < matchingPrefixRows && !sampledSlots.has(index) ? "match" : "skip",
-      }));
-      const expectedTotalRows =
-        matchingPrefixRows -
-        Array.from(sampledSlots).filter((slot) => slot < matchingPrefixRows).length;
-      const store = new TopicStore("candidate-cap", SkewedRow, "id", () => {});
-      yield* publishTopicStoreRows(store, rows, (topic, message) =>
-        InvalidRowError.make({ topic, message }),
-      );
-
-      const readModel = topicStoreReadModel(store);
-      const fallbackResult = readModel.scanRawWindow({
-        predicate: {
-          filters: [{ field: "status", operator: "eq", value: "match" }],
-          callbackRequired: false,
-          callbackSkippable: true,
-        },
-        orderBy: [],
-        matches: () => {
-          throw new Error("complete capped candidate predicates should not call row callbacks");
-        },
-        compare: (left, right) => left.key.localeCompare(right.key),
-        offset: 0,
-        limit: 0,
-      });
-
-      expect(fallbackResult.keys).toStrictEqual([]);
-      expect(fallbackResult.totalRows).toBe(expectedTotalRows);
-    }),
-  );
-
   it.effect("uses bigint range hints conservatively for manual plans", () =>
     Effect.gen(function* () {
       const store = new TopicStore("positions", Position, "id", () => {});

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -346,6 +346,27 @@ describe(`raw snapshot and delta engine benchmark: ${profile.rowCount} rows`, ()
   );
 
   bench(
+    "selective range filter + fallback top-k sort",
+    async () => {
+      const priceDomainSize = Math.min(profile.rowCount, 1_000_000);
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: ["id", "price", "region", "updatedAt"],
+          where: {
+            price: { gte: Math.max(0, priceDomainSize - 100) },
+          },
+          orderBy: [
+            { field: "updatedAt", direction: "desc" },
+            { field: "id", direction: "asc" },
+          ],
+          limit: 100,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
     "compound filter + top-k sort",
     async () => {
       await Effect.runPromise(


### PR DESCRIPTION
## Summary
- Add transient candidate scans for exact range predicates (`gt`/`gte`/`lt`/`lte`) alongside scalar `eq`/`in` candidates.
- Use deterministic stratified sampling plus projected/cap checks to avoid broad predicate materialization, and skip duplicate candidate work when an ordered-window seek already constrains the same field.
- Extend engine tests for range operators, append/delete/reset freshness, optional/missing values, skew/cap fallback, and add a selective range fallback top-k benchmark.

## Validation
- `vp check --fix`
- `pnpm run check:effect`
- forbidden-pattern scan clean
- `git diff --check`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run ready`

## Review Notes
- First-pass review findings addressed: delete/slot compaction coverage, capped benchmark threshold, stratified sampling, projected candidate rejection, ordered seek-field exclusion, and skew/cap fallback coverage.
