### PR TITLE
Add bounded incremental grouped execution

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -191,12 +191,14 @@ describe("column-live-view-engine active query execution", () => {
         version,
       });
 
-      yield* acquireMaterializedQueryExecution(readModel, "grouped", () =>
-        emptyEvaluation(readModel.version()),
-      );
-      yield* acquireMaterializedQueryExecution(isolatedReadModel, "grouped", () =>
-        emptyEvaluation(isolatedReadModel.version()),
-      );
+      yield* acquireMaterializedQueryExecution(readModel, "grouped", () => ({
+        incremental: false,
+        latest: () => emptyEvaluation(readModel.version()),
+      }));
+      yield* acquireMaterializedQueryExecution(isolatedReadModel, "grouped", () => ({
+        incremental: false,
+        latest: () => emptyEvaluation(isolatedReadModel.version()),
+      }));
 
       expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
       expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -14,6 +14,8 @@ type RowObject = object;
 export type ActiveQueryStoreState = TopicRowScan<object> &
   TopicRawWindowScan<object> & {
     readonly activeQueries: ActiveQueryRegistry;
+    readonly releaseChanges: () => void;
+    readonly retainChanges: () => void;
     readonly topic: string;
   };
 
@@ -55,6 +57,7 @@ type RawQueryExecutionWindowSlot = {
 
 type MaterializedQueryExecutionSlot = {
   readonly execution: ActiveMaterializedQueryExecution;
+  readonly releaseRetainedChanges: () => void;
   refs: number;
 };
 
@@ -63,7 +66,13 @@ type ActiveQueryBaseEvaluation<Row extends RowObject> = TopicRawWindowScanResult
 };
 
 type ActiveMaterializedQueryExecution = {
+  readonly incremental: boolean;
   readonly latest: () => QueryEvaluation<object>;
+};
+
+export type MaterializedQueryExecution<ResultRow extends RowObject> = {
+  readonly incremental: boolean;
+  readonly latest: () => QueryEvaluation<ResultRow>;
 };
 
 export type ActiveQueryRegistry = {
@@ -392,7 +401,7 @@ export const acquireMaterializedQueryExecution = Effect.fn(
 )(function <ResultRow extends RowObject>(
   store: ActiveQueryStoreState,
   cacheKey: string,
-  evaluate: () => QueryEvaluation<ResultRow>,
+  makeExecution: (releaseRetainedChanges: () => void) => MaterializedQueryExecution<ResultRow>,
 ) {
   return Effect.sync(() => {
     const map = getActiveMaterializedQueryMap(store);
@@ -403,24 +412,22 @@ export const acquireMaterializedQueryExecution = Effect.fn(
       return leaseMaterializedQueryExecution<ResultRow>(store, entry.execution);
     }
 
-    let snapshot = {
-      evaluation: evaluate(),
-      version: store.version(),
+    let retainedChanges = false;
+    const releaseRetainedChanges = () => {
+      if (!retainedChanges) {
+        return;
+      }
+      retainedChanges = false;
+      store.releaseChanges();
     };
-    const execution: ActiveMaterializedQueryExecution = {
-      latest: () => {
-        const storeVersion = store.version();
-        if (snapshot.version !== storeVersion) {
-          snapshot = {
-            evaluation: evaluate(),
-            version: storeVersion,
-          };
-        }
-        return snapshot.evaluation;
-      },
-    };
+    const execution = makeExecution(releaseRetainedChanges);
+    if (execution.incremental) {
+      retainedChanges = true;
+      store.retainChanges();
+    }
     map.set(cacheKey, {
       execution,
+      releaseRetainedChanges,
       refs: 1,
     });
     return leaseMaterializedQueryExecution<ResultRow>(store, execution);
@@ -441,6 +448,7 @@ export const releaseMaterializedQueryExecution = Effect.fn(
       entry.refs -= 1;
       return undefined;
     }
+    entry.releaseRetainedChanges();
     map.delete(cacheKey);
     return undefined;
   }),
@@ -451,6 +459,9 @@ export const clearStoreRawQueryExecutions = Effect.fn(
 )((store: ActiveQueryStoreState) =>
   Effect.sync(() => {
     store.activeQueries.raw.clear();
+    for (const entry of store.activeQueries.materialized.values()) {
+      entry.releaseRetainedChanges();
+    }
     store.activeQueries.materialized.clear();
   }),
 );

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -5,6 +5,8 @@ import type {
   TopicRawPredicateFilterPlan,
   TopicRawWindowScanPlan,
   TopicRawWindowScanResult,
+  TopicRowChange,
+  TopicRowChangeBatch,
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
@@ -82,6 +84,8 @@ const noOrderedRangeBounds: OrderedRangeBounds = {
 const maxBoundedRawWindowEnd = 1_024;
 const maxPredicateCandidateSampleSlots = 4_096;
 const maxTransientPredicateCandidateSlots = 65_536;
+const maxRowChangeJournalEntries = 65_536;
+const maxRowChangeJournalVersions = 1_024;
 
 export type PreparedTopicRow = {
   readonly key: string;
@@ -96,6 +100,12 @@ export class ColumnarTopicStore {
   private readonly keyToSlot = new Map<string, number>();
   private readonly columns = new Map<string, ColumnValues>();
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
+  private pendingRowChanges: Array<TopicRowChange<object>> = [];
+  private pendingRowChangesOverflowed = false;
+  private readonly rowChangeJournal: Array<TopicRowChangeBatch<object>> = [];
+  private rowChangeJournalChangeCount = 0;
+  private rowChangeJournalInvalidBeforeVersion = 0;
+  private rowChangeJournalRefs = 0;
   private versionValue = 0;
 
   constructor(
@@ -110,6 +120,9 @@ export class ColumnarTopicStore {
     this.readModel = {
       activeQueries: createActiveQueryRegistry(),
       topic,
+      changesSince: (version) => this.changesSince(version),
+      releaseChanges: () => this.releaseChanges(),
+      retainChanges: () => this.retainChanges(),
       scanRows: (visitor) => this.scanRows(visitor),
       scanRawWindow: (plan) => this.scanRawWindow(plan),
       version: () => this.versionValue,
@@ -126,6 +139,21 @@ export class ColumnarTopicStore {
 
   advanceVersion(): number {
     this.versionValue += 1;
+    if (this.rowChangeJournalRefs > 0) {
+      if (this.pendingRowChangesOverflowed) {
+        this.pendingRowChanges = [];
+        this.pendingRowChangesOverflowed = false;
+        return this.versionValue;
+      }
+      const changes = this.pendingRowChanges;
+      this.rowChangeJournal.push({
+        changes,
+        version: this.versionValue,
+      });
+      this.pendingRowChanges = [];
+      this.rowChangeJournalChangeCount += changes.length;
+      this.trimRowChangeJournal();
+    }
     return this.versionValue;
   }
 
@@ -133,6 +161,7 @@ export class ColumnarTopicStore {
     this.slots.length = 0;
     this.keyToSlot.clear();
     this.orderedSlotIndexes.clear();
+    this.clearRowChangeJournal();
     for (const column of this.columns.values()) {
       column.length = 0;
     }
@@ -142,7 +171,13 @@ export class ColumnarTopicStore {
   setPrepared(prepared: PreparedTopicRow): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
+      const previous = this.slots[existingSlot]!.row;
       this.writeSlot(existingSlot, prepared);
+      this.recordRowChange({
+        key: prepared.key,
+        previous,
+        next: prepared.row,
+      });
       this.orderedSlotIndexes.clear();
       return;
     }
@@ -150,6 +185,11 @@ export class ColumnarTopicStore {
     const slot = this.slots.length;
     this.keyToSlot.set(prepared.key, slot);
     this.writeSlot(slot, prepared);
+    this.recordRowChange({
+      key: prepared.key,
+      previous: undefined,
+      next: prepared.row,
+    });
     this.insertSlotIntoOrderedIndexes(slot);
   }
 
@@ -176,6 +216,7 @@ export class ColumnarTopicStore {
     this.orderedSlotIndexes.clear();
     const lastSlot = this.slots.length - 1;
     const lastEntry = this.slots[lastSlot]!;
+    const previous = this.slots[slot]!.row;
     this.keyToSlot.delete(key);
     if (slot !== lastSlot) {
       this.slots[slot] = lastEntry;
@@ -188,13 +229,43 @@ export class ColumnarTopicStore {
     for (const column of this.columns.values()) {
       column.pop();
     }
+    this.recordRowChange({
+      key,
+      previous,
+      next: undefined,
+    });
     return 1;
+  }
+
+  changesSince(version: number): ReadonlyArray<TopicRowChangeBatch<object>> | undefined {
+    if (version === this.versionValue) {
+      return [];
+    }
+    if (this.rowChangeJournalRefs === 0 || version < 0 || version > this.versionValue) {
+      return undefined;
+    }
+    if (version < this.rowChangeJournalInvalidBeforeVersion) {
+      return undefined;
+    }
+    const firstBatch = this.rowChangeJournal[0]!;
+    if (version < firstBatch.version - 1) {
+      return undefined;
+    }
+    const batches: Array<TopicRowChangeBatch<object>> = [];
+    for (const batch of this.rowChangeJournal) {
+      if (batch.version > version) {
+        batches.push(batch);
+      }
+    }
+    return batches;
   }
 
   scanRows(visitor: TopicRowVisitor<object>): void {
     for (let slot = 0; slot < this.slots.length; slot += 1) {
       const entry = this.slots[slot]!;
-      visitor(entry.key, entry.row);
+      if (visitor(entry.key, entry.row) === false) {
+        break;
+      }
     }
   }
 
@@ -769,13 +840,73 @@ export class ColumnarTopicStore {
   private setPreparedWithoutIndexMaintenance(prepared: PreparedTopicRow): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
+      const previous = this.slots[existingSlot]!.row;
       this.writeSlot(existingSlot, prepared);
+      this.recordRowChange({
+        key: prepared.key,
+        previous,
+        next: prepared.row,
+      });
       return;
     }
 
     const slot = this.slots.length;
     this.keyToSlot.set(prepared.key, slot);
     this.writeSlot(slot, prepared);
+    this.recordRowChange({
+      key: prepared.key,
+      previous: undefined,
+      next: prepared.row,
+    });
+  }
+
+  private clearRowChangeJournal(): void {
+    this.pendingRowChanges = [];
+    this.pendingRowChangesOverflowed = false;
+    this.rowChangeJournal.length = 0;
+    this.rowChangeJournalChangeCount = 0;
+    this.rowChangeJournalInvalidBeforeVersion = this.versionValue;
+  }
+
+  private invalidateRowChangeJournal(invalidBeforeVersion: number): void {
+    this.clearRowChangeJournal();
+    this.rowChangeJournalInvalidBeforeVersion = invalidBeforeVersion;
+  }
+
+  private recordRowChange(change: TopicRowChange<object>): void {
+    if (this.rowChangeJournalRefs === 0 || this.pendingRowChangesOverflowed) {
+      return;
+    }
+    if (this.pendingRowChanges.length + 1 > maxRowChangeJournalEntries) {
+      this.invalidateRowChangeJournal(this.versionValue + 1);
+      this.pendingRowChangesOverflowed = true;
+      return;
+    }
+    this.pendingRowChanges.push(change);
+  }
+
+  private releaseChanges(): void {
+    this.rowChangeJournalRefs = Math.max(0, this.rowChangeJournalRefs - 1);
+    if (this.rowChangeJournalRefs === 0) {
+      this.clearRowChangeJournal();
+    }
+  }
+
+  private retainChanges(): void {
+    this.rowChangeJournalRefs += 1;
+    if (this.rowChangeJournalRefs === 1) {
+      this.clearRowChangeJournal();
+    }
+  }
+
+  private trimRowChangeJournal(): void {
+    while (this.rowChangeJournal.length > maxRowChangeJournalVersions) {
+      const removed = this.rowChangeJournal.shift()!;
+      this.rowChangeJournalChangeCount -= removed.changes.length;
+    }
+    if (this.rowChangeJournalChangeCount > maxRowChangeJournalEntries) {
+      this.invalidateRowChangeJournal(this.versionValue);
+    }
   }
 
   private rowForKey(key: string): object | undefined {

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -15,7 +15,7 @@ import {
 import { compareQueryValue, stableQueryValueString } from "./raw-query-compiler";
 import { cloneUnknown, fieldValue, isPlainRecord } from "./row-values";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
-import type { TopicRowScan } from "./row-scan";
+import type { TopicRowChangeBatch, TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 
@@ -95,6 +95,19 @@ type GroupState = {
   readonly row: Record<string, unknown>;
   readonly aggregates: Record<string, AggregateState>;
 };
+
+type IncrementalGroupState = GroupState & {
+  readonly members: Map<string, RowObject>;
+};
+
+export type IncrementalGroupedQueryExecution<ResultRow extends RowObject> = {
+  readonly incremental: boolean;
+  readonly latest: () => QueryEvaluation<ResultRow>;
+};
+
+const maxIncrementalGroupedMembers = 65_536;
+const maxIncrementalGroupedMembersPerGroup = 4_096;
+const maxIncrementalGroupedGroups = 8_192;
 
 const groupedQueryKeys = new Set([
   "groupBy",
@@ -272,6 +285,40 @@ const newGroupState = (
   };
 };
 
+const newIncrementalGroupState = (
+  key: string,
+  groupBy: ReadonlyArray<string>,
+  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+  row: RowObject,
+): IncrementalGroupState => ({
+  ...newGroupState(key, groupBy, aggregates, row),
+  members: new Map(),
+});
+
+const resetAggregateStates = (
+  group: GroupState,
+  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+): void => {
+  for (const key of Object.keys(group.aggregates)) {
+    delete group.aggregates[key];
+  }
+  for (const [alias, aggregate] of Object.entries(aggregates)) {
+    group.aggregates[alias] = emptyAggregateState(aggregate);
+  }
+};
+
+const recomputeIncrementalGroupState = (
+  group: IncrementalGroupState,
+  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+): void => {
+  resetAggregateStates(group, aggregates);
+  for (const row of group.members.values()) {
+    for (const [alias, aggregate] of Object.entries(aggregates)) {
+      updateAggregateState(group.aggregates[alias]!, aggregate, row);
+    }
+  }
+};
+
 const finalizeGroup = (group: GroupState): StoredRowOf<RowObject> => {
   const row: Record<string, unknown> = { ...group.row };
   for (const [alias, state] of Object.entries(group.aggregates)) {
@@ -296,6 +343,28 @@ const compareGroupedRows = (
     }
   }
   return Number(left.key > right.key) - Number(left.key < right.key);
+};
+
+const groupedEvaluationFromEntries = (
+  entries: ReadonlyArray<StoredRowOf<RowObject>>,
+  query: RuntimeGroupedQuery,
+  version: number,
+): QueryEvaluation<RowObject> => {
+  const ordered = entries.toSorted((left, right) =>
+    compareGroupedRows(left, right, query.orderBy ?? []),
+  );
+  const offset = query.offset ?? 0;
+  const window = ordered.slice(
+    offset,
+    query.limit === undefined ? undefined : offset + query.limit,
+  );
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: window.map((entry) => entry.key),
+    window,
+    totalRows: ordered.length,
+    version,
+  };
 };
 
 const decodeGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.decode")((
@@ -607,20 +676,303 @@ const evaluateGroupedRows = <Row extends RowObject>(
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
   });
-  const ordered = Array.from(groups.values(), finalizeGroup).toSorted((left, right) =>
-    compareGroupedRows(left, right, query.orderBy ?? []),
+  return groupedEvaluationFromEntries(
+    Array.from(groups.values(), finalizeGroup),
+    query,
+    store.version(),
   );
-  const offset = query.offset ?? 0;
-  const window = ordered.slice(
-    offset,
-    query.limit === undefined ? undefined : offset + query.limit,
-  );
+};
+
+type IncrementalGroupedQueryState = {
+  readonly groups: Map<string, IncrementalGroupState>;
+  evaluation: QueryEvaluation<RowObject>;
+  memberCount: number;
+  version: number;
+};
+
+type IncrementalGroupedQueryBuildState =
+  | {
+      readonly admitted: false;
+    }
+  | {
+      readonly admitted: true;
+      readonly state: IncrementalGroupedQueryState;
+    };
+
+const evaluateIncrementalGroupedQuery = (
+  groups: ReadonlyMap<string, IncrementalGroupState>,
+  query: RuntimeGroupedQuery,
+  version: number,
+): QueryEvaluation<RowObject> =>
+  groupedEvaluationFromEntries(Array.from(groups.values(), finalizeGroup), query, version);
+
+const clearIncrementalGroupedQueryState = (
+  state: IncrementalGroupedQueryState,
+  query: RuntimeGroupedQuery,
+  version: number,
+): void => {
+  state.groups.clear();
+  state.evaluation = groupedEvaluationFromEntries([], query, version);
+  state.memberCount = 0;
+  state.version = version;
+};
+
+const buildIncrementalGroupedQueryState = <Row extends RowObject>(
+  store: TopicRowScan<Row>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+): IncrementalGroupedQueryBuildState => {
+  const groups = new Map<string, IncrementalGroupState>();
+  let memberCount = 0;
+  let admitted = true;
+  store.scanRows((key, row) => {
+    if (!admitted) {
+      return undefined;
+    }
+    if (!matches(row)) {
+      return undefined;
+    }
+    const groupedKey = groupKey(query.groupBy, row);
+    let group = groups.get(groupedKey);
+    if (group === undefined) {
+      group = newIncrementalGroupState(groupedKey, query.groupBy, query.aggregates, row);
+      groups.set(groupedKey, group);
+    }
+    group.members.set(key, row);
+    memberCount += 1;
+    if (
+      memberCount > maxIncrementalGroupedMembers ||
+      group.members.size > maxIncrementalGroupedMembersPerGroup ||
+      groups.size > maxIncrementalGroupedGroups
+    ) {
+      groups.clear();
+      admitted = false;
+      return false;
+    }
+    for (const [alias, aggregate] of Object.entries(query.aggregates)) {
+      updateAggregateState(group.aggregates[alias]!, aggregate, row);
+    }
+    return undefined;
+  });
+  if (!admitted) {
+    return {
+      admitted: false,
+    };
+  }
+  const version = store.version();
   return {
-    rows: window.map((entry) => entry.row),
-    keys: window.map((entry) => entry.key),
-    window,
-    totalRows: ordered.length,
+    admitted: true,
+    state: {
+      groups,
+      evaluation: evaluateIncrementalGroupedQuery(groups, query, version),
+      memberCount,
+      version,
+    },
+  };
+};
+
+const removeIncrementalGroupedMember = <Row extends RowObject>(
+  groups: Map<string, IncrementalGroupState>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  key: string,
+  row: Row,
+  dirtyGroups: Set<IncrementalGroupState>,
+): boolean => {
+  if (!matches(row)) {
+    return false;
+  }
+  const groupedKey = groupKey(query.groupBy, row);
+  const group = groups.get(groupedKey);
+  if (group === undefined) {
+    return false;
+  }
+  const removed = group.members.delete(key);
+  if (!removed) {
+    return false;
+  }
+  if (group.members.size === 0) {
+    groups.delete(groupedKey);
+    dirtyGroups.delete(group);
+    return true;
+  }
+  dirtyGroups.add(group);
+  return true;
+};
+
+type UpsertIncrementalGroupedMemberResult = {
+  readonly groupSize: number;
+  readonly inserted: boolean;
+};
+
+const upsertIncrementalGroupedMember = <Row extends RowObject>(
+  groups: Map<string, IncrementalGroupState>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  key: string,
+  row: Row,
+  dirtyGroups: Set<IncrementalGroupState>,
+): UpsertIncrementalGroupedMemberResult | undefined => {
+  if (!matches(row)) {
+    return undefined;
+  }
+  const groupedKey = groupKey(query.groupBy, row);
+  let group = groups.get(groupedKey);
+  if (group === undefined) {
+    group = newIncrementalGroupState(groupedKey, query.groupBy, query.aggregates, row);
+    groups.set(groupedKey, group);
+  }
+  const inserted = !group.members.has(key);
+  group.members.set(key, row);
+  dirtyGroups.add(group);
+  return {
+    groupSize: group.members.size,
+    inserted,
+  };
+};
+
+const applyIncrementalGroupedQueryBatch = <Row extends RowObject>(
+  state: IncrementalGroupedQueryState,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  batch: TopicRowChangeBatch<Row>,
+  dirtyGroups: Set<IncrementalGroupState>,
+): boolean => {
+  for (const change of batch.changes) {
+    if (change.previous !== undefined) {
+      const removed = removeIncrementalGroupedMember(
+        state.groups,
+        query,
+        matches,
+        change.key,
+        change.previous,
+        dirtyGroups,
+      );
+      if (removed) {
+        state.memberCount -= 1;
+      }
+    }
+    if (change.next !== undefined) {
+      const upserted = upsertIncrementalGroupedMember(
+        state.groups,
+        query,
+        matches,
+        change.key,
+        change.next,
+        dirtyGroups,
+      );
+      if (upserted === undefined) {
+        continue;
+      }
+      if (upserted.groupSize > maxIncrementalGroupedMembersPerGroup) {
+        return false;
+      }
+      if (state.groups.size > maxIncrementalGroupedGroups) {
+        return false;
+      }
+      if (upserted.inserted) {
+        state.memberCount += 1;
+        if (state.memberCount > maxIncrementalGroupedMembers) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+};
+
+const applyIncrementalGroupedQueryBatches = <Row extends RowObject>(
+  state: IncrementalGroupedQueryState,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
+): boolean => {
+  const dirtyGroups = new Set<IncrementalGroupState>();
+  for (const batch of batches) {
+    if (!applyIncrementalGroupedQueryBatch(state, query, matches, batch, dirtyGroups)) {
+      state.groups.clear();
+      state.memberCount = 0;
+      return false;
+    }
+    state.version = batch.version;
+  }
+  for (const group of dirtyGroups) {
+    recomputeIncrementalGroupState(group, query.aggregates);
+  }
+  state.evaluation = evaluateIncrementalGroupedQuery(state.groups, query, state.version);
+  return true;
+};
+
+const makeFallbackGroupedQueryExecution = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRowScan<Row>,
+  compiled: CompiledGroupedQuery<Row, ResultRow>,
+): IncrementalGroupedQueryExecution<ResultRow> => {
+  let snapshot = {
+    evaluation: compiled.evaluate(store),
     version: store.version(),
+  };
+  return {
+    incremental: false,
+    latest: () => {
+      const storeVersion = store.version();
+      if (snapshot.version !== storeVersion) {
+        snapshot = {
+          evaluation: compiled.evaluate(store),
+          version: storeVersion,
+        };
+      }
+      return snapshot.evaluation;
+    },
+  };
+};
+
+export const makeIncrementalGroupedQueryExecution = <
+  Row extends RowObject,
+  ResultRow extends RowObject,
+>(
+  store: TopicRowScan<Row>,
+  compiled: CompiledGroupedQuery<Row, ResultRow>,
+  releaseRetainedChanges: () => void,
+): IncrementalGroupedQueryExecution<ResultRow> => {
+  let build = buildIncrementalGroupedQueryState(store, compiled.query, compiled.matches);
+  if (!build.admitted) {
+    return makeFallbackGroupedQueryExecution(store, compiled);
+  }
+  let state = build.state;
+  let fallback: IncrementalGroupedQueryExecution<ResultRow> | undefined;
+  const activateFallback = (): IncrementalGroupedQueryExecution<ResultRow> => {
+    clearIncrementalGroupedQueryState(state, compiled.query, store.version());
+    const nextFallback = makeFallbackGroupedQueryExecution(store, compiled);
+    fallback = nextFallback;
+    releaseRetainedChanges();
+    return nextFallback;
+  };
+  return {
+    get incremental() {
+      return fallback === undefined;
+    },
+    latest: () => {
+      if (fallback !== undefined) {
+        return fallback.latest();
+      }
+      const storeVersion = store.version();
+      if (state.version === storeVersion) {
+        return typedEvaluation<ResultRow>(state.evaluation);
+      }
+      const batches = store.changesSince(state.version);
+      if (batches === undefined) {
+        build = buildIncrementalGroupedQueryState(store, compiled.query, compiled.matches);
+        if (!build.admitted) {
+          return activateFallback().latest();
+        }
+        state = build.state;
+        return typedEvaluation<ResultRow>(state.evaluation);
+      }
+      if (!applyIncrementalGroupedQueryBatches(state, compiled.query, compiled.matches, batches)) {
+        return activateFallback().latest();
+      }
+      return typedEvaluation<ResultRow>(state.evaluation);
+    },
   };
 };
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -20,10 +20,12 @@ import {
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
 } from "./index";
+import { ColumnarTopicStore } from "./columnar-topic-store";
 import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
   activeStoreRawQueryExecutionCount,
+  clearStoreRawQueryExecutions,
   evaluateRawQuery,
   releaseMaterializedQueryExecution,
 } from "./active-query";
@@ -37,8 +39,13 @@ import {
   rawQueryCompilerMetadata,
   stableQueryValueString,
 } from "./raw-query-compiler";
-import { evaluateCompiledGroupedQuery, prepareGroupedQuery } from "./grouped-query-compiler";
+import {
+  evaluateCompiledGroupedQuery,
+  makeIncrementalGroupedQueryExecution,
+  prepareGroupedQuery,
+} from "./grouped-query-compiler";
 import { cloneRecord, cloneRow, fieldValue, rowsEqual, scalarEqualityKey } from "./row-values";
+import type { TopicRowChangeBatch } from "./row-scan";
 import {
   acquireTopicStoreSubscription,
   closeBackpressuredTopicStoreSubscription,
@@ -1461,6 +1468,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       );
       const evaluation = evaluateCompiledGroupedQuery(
         {
+          changesSince: () => [],
           scanRows: (visitor) => {
             for (const [key, row] of rows) {
               visitor(key, row);
@@ -1476,6 +1484,412 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           totalQuantity: "3",
         },
       ]);
+    }),
+  );
+
+  it.effect("applies incremental grouped change batches without rescanning rows", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const rows = new Map<string, object>([
+        ["1", order("1", "open", 10, 1, "emea")],
+        ["2", order("2", "open", 20, 2, "amer")],
+      ]);
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          where: {
+            region: "emea",
+          },
+          orderBy: [{ field: "status", direction: "asc" }],
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 1n }]);
+      expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 1n }]);
+      expect(scanCount).toBe(1);
+
+      const ignored = order("3", "closed", 30, 3, "amer");
+      const inserted = order("4", "closed", 40, 4, "emea");
+      rows.set("3", ignored);
+      rows.set("4", inserted);
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [
+            {
+              key: "ignored-old",
+              previous: order("ignored-old", "open", 5, 5, "amer"),
+              next: undefined,
+            },
+            {
+              key: "missing-old-group",
+              previous: order("missing-old-group", "cancelled", 5, 5, "emea"),
+              next: undefined,
+            },
+            {
+              key: "missing-open-member",
+              previous: order("missing-open-member", "open", 5, 5, "emea"),
+              next: undefined,
+            },
+            {
+              key: "1",
+              previous: undefined,
+              next: order("1", "open", 15, 6, "emea"),
+            },
+            { key: "3", previous: undefined, next: ignored },
+            { key: "4", previous: undefined, next: inserted },
+          ],
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([
+        { status: "closed", rowCount: 1n },
+        { status: "open", rowCount: 1n },
+      ]);
+      expect(scanCount).toBe(1);
+    }),
+  );
+
+  it.effect("uses fallback grouped execution when incremental admission is too broad", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      const scanCounts: Array<number> = [];
+      const rows = new Map<string, object>(
+        Array.from({ length: 65_537 }, (_value, index) => [
+          `row-${index}`,
+          order(`row-${index}`, "open", index, index),
+        ]),
+      );
+      const store = {
+        changesSince: () => [],
+        scanRows: (visitor: (key: string, row: object) => false | void) => {
+          let scanCount = 0;
+          for (const [key, row] of rows) {
+            scanCount += 1;
+            if (visitor(key, row) === false) {
+              break;
+            }
+          }
+          scanCounts.push(scanCount);
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+      expect(execution.incremental).toBe(false);
+      expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 65_537n }]);
+      expect(scanCounts).toStrictEqual([4_097, 65_537]);
+
+      rows.set("closed", order("closed", "closed", 1, 65_538));
+      version = 1;
+      expect(execution.latest().rows).toStrictEqual([
+        { status: "closed", rowCount: 1n },
+        { status: "open", rowCount: 65_537n },
+      ]);
+    }),
+  );
+
+  it.effect(
+    "switches grouped execution to fallback when an incremental batch exceeds admission",
+    () =>
+      Effect.gen(function* () {
+        let version = 0;
+        let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+        const rows = new Map<string, object>();
+        const store = {
+          changesSince: () => batches,
+          scanRows: (visitor: (key: string, row: object) => void) => {
+            for (const [key, row] of rows) {
+              visitor(key, row);
+            }
+          },
+          version: () => version,
+        };
+        const compiled = yield* prepareGroupedQuery<object, object>(
+          "orders",
+          rawQueryCompilerMetadata(Order),
+          {
+            groupBy: ["status"],
+            aggregates: {
+              rowCount: { aggFunc: "count" },
+            },
+          },
+        );
+        const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+        expect(execution.incremental).toBe(true);
+
+        const changes = Array.from({ length: 65_537 }, (_value, index) => {
+          const row = order(`row-${index}`, "open", index, index);
+          rows.set(row.id, row);
+          return {
+            key: row.id,
+            previous: undefined,
+            next: row,
+          };
+        });
+        version = 1;
+        batches = [{ changes, version }];
+
+        expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 65_537n }]);
+        expect(execution.incremental).toBe(false);
+        rows.set("closed", order("closed", "closed", 1, 65_538));
+        version = 2;
+        batches = [];
+        expect(execution.latest().rows).toStrictEqual([
+          { status: "closed", rowCount: 1n },
+          { status: "open", rowCount: 65_537n },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "switches grouped execution to fallback when incremental batches exceed total admission",
+    () =>
+      Effect.gen(function* () {
+        let version = 0;
+        let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+        const rows = new Map<string, object>();
+        const store = {
+          changesSince: () => batches,
+          scanRows: (visitor: (key: string, row: object) => false | void) => {
+            for (const [key, row] of rows) {
+              if (visitor(key, row) === false) {
+                break;
+              }
+            }
+          },
+          version: () => version,
+        };
+        const compiled = yield* prepareGroupedQuery<object, object>(
+          "positions",
+          rawQueryCompilerMetadata(Position),
+          {
+            groupBy: ["symbol"],
+            aggregates: {
+              rowCount: { aggFunc: "count" },
+            },
+          },
+        );
+        const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+        expect(execution.incremental).toBe(true);
+
+        const changes = Array.from({ length: 65_537 }, (_value, index) => {
+          const row = position(`row-${index}`, `symbol-${index % 8_192}`, 1n, "1");
+          rows.set(row.id, row);
+          return {
+            key: row.id,
+            previous: undefined,
+            next: row,
+          };
+        });
+        version = 1;
+        batches = [{ changes, version }];
+
+        expect(execution.latest().totalRows).toBe(8_192);
+        expect(execution.incremental).toBe(false);
+      }),
+  );
+
+  it.effect(
+    "switches grouped execution to fallback when incremental batches exceed group admission",
+    () =>
+      Effect.gen(function* () {
+        let version = 0;
+        let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+        const rows = new Map<string, object>();
+        const store = {
+          changesSince: () => batches,
+          scanRows: (visitor: (key: string, row: object) => false | void) => {
+            for (const [key, row] of rows) {
+              if (visitor(key, row) === false) {
+                break;
+              }
+            }
+          },
+          version: () => version,
+        };
+        const compiled = yield* prepareGroupedQuery<object, object>(
+          "positions",
+          rawQueryCompilerMetadata(Position),
+          {
+            groupBy: ["symbol"],
+            aggregates: {
+              rowCount: { aggFunc: "count" },
+            },
+          },
+        );
+        const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+        expect(execution.incremental).toBe(true);
+
+        const changes = Array.from({ length: 8_193 }, (_value, index) => {
+          const row = position(`group-row-${index}`, `group-symbol-${index}`, 1n, "1");
+          rows.set(row.id, row);
+          return {
+            key: row.id,
+            previous: undefined,
+            next: row,
+          };
+        });
+        version = 1;
+        batches = [{ changes, version }];
+
+        expect(execution.latest().totalRows).toBe(8_193);
+        expect(execution.incremental).toBe(false);
+      }),
+  );
+
+  it.effect("falls back to a grouped rebuild when the row-change journal is unavailable", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      const rows = new Map<string, object>([["1", order("1", "open", 10, 1)]]);
+      const store = {
+        changesSince: () => undefined,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          orderBy: [{ field: "status", direction: "asc" }],
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 1n }]);
+      rows.set("2", order("2", "closed", 20, 2));
+      version = 1;
+
+      expect(execution.latest().rows).toStrictEqual([
+        { status: "closed", rowCount: 1n },
+        { status: "open", rowCount: 1n },
+      ]);
+      expect(scanCount).toBe(2);
+    }),
+  );
+
+  it.effect("uses fallback when a grouped rebuild after a missed journal exceeds admission", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      const rows = new Map<string, object>([["initial", order("initial", "open", 1, 1)]]);
+      const store = {
+        changesSince: () => undefined,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+      expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 1n }]);
+
+      for (let index = 0; index < 65_537; index += 1) {
+        const row = order(`wide-${index}`, "closed", index, index);
+        rows.set(row.id, row);
+      }
+      version = 1;
+
+      expect(execution.latest().rows).toStrictEqual([
+        { status: "closed", rowCount: 65_537n },
+        { status: "open", rowCount: 1n },
+      ]);
+      rows.set("cancelled", order("cancelled", "cancelled", 1, 65_538));
+      version = 2;
+      expect(execution.latest().rows).toStrictEqual([
+        { status: "cancelled", rowCount: 1n },
+        { status: "closed", rowCount: 65_537n },
+        { status: "open", rowCount: 1n },
+      ]);
+    }),
+  );
+
+  it.effect("rebuilds a real grouped execution after its row-change journal window is missed", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      yield* publishTopicStoreRow(store, order("initial", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      const readModel = topicStoreReadModel(store);
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          orderBy: [{ field: "status", direction: "asc" }],
+        },
+      );
+      const execution = yield* acquireMaterializedQueryExecution(
+        readModel,
+        "missed-real-journal",
+        () => makeIncrementalGroupedQueryExecution(readModel, compiled, () => {}),
+      );
+      const cursor = execution.createCursor();
+
+      for (let index = 0; index < 1_025; index += 1) {
+        yield* publishTopicStoreRow(
+          store,
+          order(`late-${index}`, "closed", index, index),
+          (topic, message) => InvalidRowError.make({ topic, message }),
+        );
+      }
+
+      const next = yield* execution.next("missed-real-journal-query", cursor);
+      expect(Option.isSome(next)).toBe(true);
+      expect(expectDefined(Option.getOrUndefined(next)).totalRows).toBe(2);
+
+      yield* releaseMaterializedQueryExecution(readModel, "missed-real-journal");
     }),
   );
 
@@ -2456,6 +2870,160 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       health = yield* engine.health();
       expect(health.topics.orders.activeViews).toBe(0);
       expect(health.topics.orders.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("updates grouped subscriptions incrementally across moves and deletes", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("1", "open", 10, 1, "emea"),
+        order("2", "open", 20, 2, "amer"),
+        order("3", "closed", 5, 3, "emea"),
+      ]);
+      const query = {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          distinctRegions: { aggFunc: "countDistinct", field: "region" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+          averagePrice: { aggFunc: "avg", field: "price" },
+          minUpdatedAt: { aggFunc: "min", field: "updatedAt" },
+          maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      } satisfies {
+        readonly groupBy: readonly ["status"];
+        readonly aggregates: {
+          readonly rowCount: { readonly aggFunc: "count" };
+          readonly distinctRegions: {
+            readonly aggFunc: "countDistinct";
+            readonly field: "region";
+          };
+          readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+          readonly averagePrice: { readonly aggFunc: "avg"; readonly field: "price" };
+          readonly minUpdatedAt: { readonly aggFunc: "min"; readonly field: "updatedAt" };
+          readonly maxUpdatedAt: { readonly aggFunc: "max"; readonly field: "updatedAt" };
+        };
+        readonly orderBy: readonly [{ readonly field: "status"; readonly direction: "asc" }];
+      };
+
+      const subscription = yield* engine.subscribe("orders", query);
+      const read = yield* makeEventReader(subscription);
+      const snapshot = firstEvent(yield* read(1));
+      expectSnapshotEvent(snapshot);
+      let state = stateFromSnapshot(snapshot);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "closed",
+          rowCount: 1n,
+          distinctRegions: 1n,
+          totalPrice: "5",
+          averagePrice: "5",
+          minUpdatedAt: 3,
+          maxUpdatedAt: 3,
+        },
+        {
+          status: "open",
+          rowCount: 2n,
+          distinctRegions: 2n,
+          totalPrice: "30",
+          averagePrice: "15",
+          minUpdatedAt: 1,
+          maxUpdatedAt: 2,
+        },
+      ]);
+
+      yield* engine.patch("orders", "2", {
+        status: "closed",
+        price: 30,
+        region: "emea",
+        updatedAt: 4,
+      });
+      const movedDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(movedDelta);
+      state = applyDelta(state, movedDelta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "closed",
+          rowCount: 2n,
+          distinctRegions: 1n,
+          totalPrice: "35",
+          averagePrice: "17.5",
+          minUpdatedAt: 3,
+          maxUpdatedAt: 4,
+        },
+        {
+          status: "open",
+          rowCount: 1n,
+          distinctRegions: 1n,
+          totalPrice: "10",
+          averagePrice: "10",
+          minUpdatedAt: 1,
+          maxUpdatedAt: 1,
+        },
+      ]);
+
+      yield* engine.delete("orders", "1");
+      const deleteDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(deleteDelta);
+      state = applyDelta(state, deleteDelta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "closed",
+          rowCount: 2n,
+          distinctRegions: 1n,
+          totalPrice: "35",
+          averagePrice: "17.5",
+          minUpdatedAt: 3,
+          maxUpdatedAt: 4,
+        },
+      ]);
+
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("converges grouped subscriptions for duplicate-key publishMany batches", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("same", "open", 1, 1, "emea"));
+      const query = {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      } satisfies {
+        readonly groupBy: readonly ["status"];
+        readonly aggregates: {
+          readonly rowCount: { readonly aggFunc: "count" };
+          readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+        };
+        readonly orderBy: readonly [{ readonly field: "status"; readonly direction: "asc" }];
+      };
+
+      const subscription = yield* engine.subscribe("orders", query);
+      const read = yield* makeEventReader(subscription);
+      let state = stateFromSnapshot(firstEvent(yield* read(1)));
+
+      yield* engine.publishMany("orders", [
+        order("same", "closed", 2, 2, "emea"),
+        order("same", "open", 3, 3, "emea"),
+        order("same", "closed", 4, 4, "emea"),
+        order("other", "open", 10, 10, "amer"),
+      ]);
+
+      const delta = firstEvent(yield* read(1));
+      expectDeltaEvent(delta);
+      state = applyDelta(state, delta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        { status: "closed", rowCount: 1n, totalPrice: "4" },
+        { status: "open", rowCount: 1n, totalPrice: "10" },
+      ]);
+
+      yield* subscription.close();
     }),
   );
 
@@ -3734,19 +4302,235 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("acquires topic-store subscriptions through the permit handoff", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      let closed = false;
+      const subscription = yield* acquireTopicStoreSubscription(store, (permit, markAcquired) =>
+        Effect.gen(function* () {
+          expect(permit.store).toBe(store);
+          const acquired = {
+            close: () =>
+              Effect.sync(() => {
+                closed = true;
+              }),
+          };
+          yield* markAcquired(acquired);
+          return acquired;
+        }),
+      );
+
+      yield* subscription.close();
+      expect(closed).toBe(true);
+    }),
+  );
+
+  it.effect("exposes bounded row-change batches for active query catch-up", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      const readModel = topicStoreReadModel(store);
+      expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
+      expect(readModel.changesSince(-1)).toBeUndefined();
+      expect(readModel.changesSince(1)).toBeUndefined();
+
+      yield* publishTopicStoreRow(store, order("initial", "open", 10, 1), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      expect(readModel.changesSince(0)).toBeUndefined();
+
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+        },
+      );
+      const execution = yield* acquireMaterializedQueryExecution(readModel, "journal-bounds", () =>
+        makeIncrementalGroupedQueryExecution(readModel, compiled, () => {}),
+      );
+      expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
+
+      yield* publishTopicStoreRow(store, order("first-active", "open", 11, 2), (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+      expect(readModel.changesSince(1)).toStrictEqual([
+        {
+          version: 2,
+          changes: [
+            {
+              key: "first-active",
+              previous: undefined,
+              next: order("first-active", "open", 11, 2),
+            },
+          ],
+        },
+      ]);
+
+      for (let index = 0; index < 1_025; index += 1) {
+        yield* publishTopicStoreRow(
+          store,
+          order(`journal-${index}`, "open", index, index),
+          (topic, message) => InvalidRowError.make({ topic, message }),
+        );
+      }
+
+      expect(readModel.version()).toBe(1_027);
+      expect(readModel.changesSince(0)).toBeUndefined();
+      expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
+      yield* releaseMaterializedQueryExecution(readModel, "journal-bounds");
+      expect(readModel.changesSince(readModel.version() - 1)).toBeUndefined();
+      const cursor = execution.createCursor();
+      const unchanged = yield* execution.next("released-journal", cursor);
+      expect(Option.isNone(unchanged)).toBe(true);
+    }),
+  );
+
+  it.effect("clears retained row-change journals on active execution clear and overflow", () =>
+    Effect.gen(function* () {
+      const storage = new ColumnarTopicStore("orders", Order, "id");
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+        },
+      );
+      yield* acquireMaterializedQueryExecution(storage.readModel, "overflow-journal", () =>
+        makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
+      );
+      yield* acquireMaterializedQueryExecution(storage.readModel, "overflow-journal-second", () =>
+        makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
+      );
+      yield* releaseMaterializedQueryExecution(storage.readModel, "overflow-journal-second");
+      expect(storage.readModel.changesSince(storage.version)).toStrictEqual([]);
+
+      const baseVersion = storage.version;
+      storage.setPreparedMany(
+        Array.from({ length: 65_537 }, (_value, index) => ({
+          key: `row-${index}`,
+          row: order(`row-${index}`, "open", index, index),
+        })),
+      );
+      storage.advanceVersion();
+      expect(storage.readModel.changesSince(baseVersion)).toBeUndefined();
+
+      const recoveredVersion = storage.version;
+      storage.setPrepared({
+        key: "after-overflow",
+        row: order("after-overflow", "closed", 1, 1),
+      });
+      storage.advanceVersion();
+      expect(storage.readModel.changesSince(recoveredVersion)).toStrictEqual([
+        {
+          version: recoveredVersion + 1,
+          changes: [
+            {
+              key: "after-overflow",
+              previous: undefined,
+              next: order("after-overflow", "closed", 1, 1),
+            },
+          ],
+        },
+      ]);
+
+      const multiVersionOverflowStart = storage.version;
+      for (let batchIndex = 0; batchIndex < 257; batchIndex += 1) {
+        storage.setPreparedMany(
+          Array.from({ length: 256 }, (_value, rowIndex) => {
+            const key = `multi-version-${batchIndex}-${rowIndex}`;
+            return {
+              key,
+              row: order(key, "open", rowIndex, rowIndex),
+            };
+          }),
+        );
+        storage.advanceVersion();
+      }
+      expect(storage.readModel.changesSince(multiVersionOverflowStart)).toBeUndefined();
+
+      yield* clearStoreRawQueryExecutions(storage.readModel);
+      expect(yield* activeStoreRawQueryExecutionCount(storage.readModel)).toBe(0);
+      storage.setPrepared({
+        key: "after-clear",
+        row: order("after-clear", "open", 1, 1),
+      });
+      const afterClearVersion = storage.version;
+      storage.advanceVersion();
+      expect(storage.readModel.changesSince(afterClearVersion)).toBeUndefined();
+
+      const fallbackStorage = new ColumnarTopicStore("orders", Order, "id");
+      fallbackStorage.setPreparedMany(
+        Array.from({ length: 65_537 }, (_value, index) => ({
+          key: `fallback-${index}`,
+          row: order(`fallback-${index}`, "open", index, index),
+        })),
+      );
+      fallbackStorage.advanceVersion();
+      yield* acquireMaterializedQueryExecution(fallbackStorage.readModel, "fallback-clear", () =>
+        makeIncrementalGroupedQueryExecution(fallbackStorage.readModel, compiled, () => {}),
+      );
+      yield* clearStoreRawQueryExecutions(fallbackStorage.readModel);
+      expect(yield* activeStoreRawQueryExecutionCount(fallbackStorage.readModel)).toBe(0);
+    }),
+  );
+
+  it.effect("releases retained row-change journals after grouped fallback demotion", () =>
+    Effect.gen(function* () {
+      const storage = new ColumnarTopicStore("orders", Order, "id");
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+        },
+      );
+      const execution = yield* acquireMaterializedQueryExecution(
+        storage.readModel,
+        "demoted-grouped-journal",
+        (releaseRetainedChanges) =>
+          makeIncrementalGroupedQueryExecution(storage.readModel, compiled, releaseRetainedChanges),
+      );
+      const cursor = execution.createCursor();
+
+      storage.setPreparedMany(
+        Array.from({ length: 65_537 }, (_value, index) => ({
+          key: `row-${index}`,
+          row: order(`row-${index}`, "open", index, index),
+        })),
+      );
+      storage.advanceVersion();
+      yield* execution.next("demoted-grouped-journal", cursor);
+
+      const demotedVersion = storage.version;
+      storage.setPrepared({
+        key: "after-demotion",
+        row: order("after-demotion", "closed", 1, 1),
+      });
+      storage.advanceVersion();
+      expect(storage.readModel.changesSince(demotedVersion)).toBeUndefined();
+
+      yield* releaseMaterializedQueryExecution(storage.readModel, "demoted-grouped-journal");
+    }),
+  );
+
   it.effect("drains subscribers and storage on normal topic-store reset", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});
       let resetStatusCount = 0;
+      let resetStatus: StatusEvent | undefined;
       const subscriber: LiveTopicSubscriber = {
         topic: "orders",
         queryId: "query-normal-reset",
         notify: () => Effect.void,
         queuedEvents: Effect.succeed(0),
         end: Effect.void,
-        closeWithStatus: () =>
+        closeWithStatus: (event) =>
           Effect.sync(() => {
             resetStatusCount += 1;
+            resetStatus = event;
           }),
         maxQueueDepth: 0,
         backpressureEvents: 0,
@@ -3762,6 +4546,14 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       const health = yield* collectTopicStoreHealth(store, false);
       expect(resetStatusCount).toBe(1);
+      expect(expectDefined(resetStatus)).toStrictEqual({
+        type: "status",
+        topic: "orders",
+        queryId: "query-normal-reset",
+        status: "closed",
+        code: "SubscriptionClosed",
+        message: "Subscription closed because the engine reset.",
+      });
       expect(health.status).toBe("ready");
       expect(health.rowCount).toBe(0);
       expect(health.activeSubscriptions).toBe(0);
@@ -5558,18 +6350,25 @@ describe("ColumnLiveViewEngine subscriptions", () => {
           version: readModel.version(),
         };
       };
+      const makeExecution = () => {
+        const evaluation = evaluate();
+        return {
+          incremental: false,
+          latest: () => evaluation,
+        };
+      };
 
       const execution = yield* acquireMaterializedQueryExecution(
         readModel,
         "empty-materialized",
-        evaluate,
+        makeExecution,
       );
       const cursor = execution.createCursor();
       const unchanged = yield* execution.next("query-unchanged", cursor);
 
       expect(Option.isNone(unchanged)).toBe(true);
       expect(evaluationCount).toBe(1);
-      yield* acquireMaterializedQueryExecution(readModel, "second-materialized", evaluate);
+      yield* acquireMaterializedQueryExecution(readModel, "second-materialized", makeExecution);
       expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(2);
       yield* releaseMaterializedQueryExecution(readModel, "empty-materialized");
       expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -5,7 +5,18 @@ export type TopicRowEntry<Row extends RowObject> = {
   readonly row: Row;
 };
 
-export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => void;
+export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => false | void;
+
+export type TopicRowChange<Row extends RowObject> = {
+  readonly key: string;
+  readonly next: Row | undefined;
+  readonly previous: Row | undefined;
+};
+
+export type TopicRowChangeBatch<Row extends RowObject> = {
+  readonly changes: ReadonlyArray<TopicRowChange<Row>>;
+  readonly version: number;
+};
 
 export type TopicRawOrderByPlan = {
   readonly field: string;
@@ -65,6 +76,7 @@ export type TopicRawWindowScanResult<Row extends RowObject> = {
 };
 
 export type TopicRowScan<Row extends RowObject> = {
+  readonly changesSince: (version: number) => ReadonlyArray<TopicRowChangeBatch<Row>> | undefined;
   readonly scanRows: (visitor: TopicRowVisitor<Row>) => void;
   readonly version: () => number;
 };

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -13,6 +13,7 @@ import {
 import { ColumnarTopicStore, type PreparedTopicRow } from "./columnar-topic-store";
 import {
   evaluateCompiledGroupedQuery,
+  makeIncrementalGroupedQueryExecution,
   prepareGroupedQuery,
   type CompiledGroupedQuery,
 } from "./grouped-query-compiler";
@@ -170,8 +171,11 @@ export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
   compiled: CompiledGroupedQuery<object, ResultRow>,
 ) {
   const readModel = topicStoreState(store).storage.readModel;
-  return yield* acquireMaterializedQueryExecution(readModel, compiled.cacheKey, () =>
-    evaluateCompiledGroupedQuery(readModel, compiled),
+  return yield* acquireMaterializedQueryExecution(
+    readModel,
+    compiled.cacheKey,
+    (releaseRetainedChanges) =>
+      makeIncrementalGroupedQueryExecution(readModel, compiled, releaseRetainedChanges),
   );
 });
 


### PR DESCRIPTION
## Summary
- add retained row-change journals for active materialized grouped executions, with immediate invalidation on oversized pending batches and bounded version/change retention
- add incremental grouped execution with dirty-group recompute, fallback demotion, mandatory retained-journal release finalizer, and admission caps for total members, members per group, and group count
- allow row scans to short-circuit so failed incremental admission does not scan the full table before fallback
- add regression coverage for grouped moves/deletes, duplicate-key batches, journal miss/fallback, journal overflow/recovery, demotion cleanup, and admission caps

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- git diff --check
- forbidden-pattern scan for casts/testing-library/act/flushSync/toEqual/coverage ignores
- pnpm run ready

## Review
- three-agent review cycle completed
- final pass: two clean reviews; one low-risk follow-up noted for ordered grouped window indexes, global active grouped query budgets, and byte-based journal budgets