### PR TITLE
Add bounded grouped window evaluation

### DIFF
--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -96,8 +96,13 @@ type GroupState = {
   readonly aggregates: Record<string, AggregateState>;
 };
 
-type IncrementalGroupState = GroupState & {
+type MaterializedIncrementalGroupState = GroupState & {
   readonly members: Map<string, RowObject>;
+};
+
+type CountOnlyIncrementalGroupState = {
+  readonly key: string;
+  count: number;
 };
 
 export type IncrementalGroupedQueryExecution<ResultRow extends RowObject> = {
@@ -108,6 +113,7 @@ export type IncrementalGroupedQueryExecution<ResultRow extends RowObject> = {
 const maxIncrementalGroupedMembers = 65_536;
 const maxIncrementalGroupedMembersPerGroup = 4_096;
 const maxIncrementalGroupedGroups = 8_192;
+const maxBoundedGroupedWindowEnd = 1_024;
 
 const groupedQueryKeys = new Set([
   "groupBy",
@@ -261,6 +267,22 @@ const aggregateStateValue = (state: AggregateState): unknown => {
   return cloneUnknown(state.value);
 };
 
+const aggregateStateCompareValue = (state: AggregateState): unknown => {
+  if (state.aggFunc === "count") {
+    return state.count;
+  }
+  if (state.aggFunc === "countDistinct") {
+    return state.count;
+  }
+  if (state.aggFunc === "sum") {
+    return state.resultKind === "bigint" ? state.bigintTotal : state.decimalTotal;
+  }
+  if (state.aggFunc === "avg") {
+    return state.count === 0n ? fromBigInt(0n) : divideUnsafe(state.total, fromBigInt(state.count));
+  }
+  return state.value;
+};
+
 const groupKey = (groupBy: ReadonlyArray<string>, row: RowObject): string =>
   stableQueryValueString(groupBy.map((field) => [field, fieldValue(row, field)]));
 
@@ -290,9 +312,14 @@ const newIncrementalGroupState = (
   groupBy: ReadonlyArray<string>,
   aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
   row: RowObject,
-): IncrementalGroupState => ({
+): MaterializedIncrementalGroupState => ({
   ...newGroupState(key, groupBy, aggregates, row),
   members: new Map(),
+});
+
+const newZeroLimitIncrementalGroupState = (key: string): CountOnlyIncrementalGroupState => ({
+  key,
+  count: 0,
 });
 
 const resetAggregateStates = (
@@ -308,7 +335,7 @@ const resetAggregateStates = (
 };
 
 const recomputeIncrementalGroupState = (
-  group: IncrementalGroupState,
+  group: MaterializedIncrementalGroupState,
   aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
 ): void => {
   resetAggregateStates(group, aggregates);
@@ -343,6 +370,246 @@ const compareGroupedRows = (
     }
   }
   return Number(left.key > right.key) - Number(left.key < right.key);
+};
+
+type BoundedGroupEntry = {
+  group: GroupState;
+  orderValues: Array<unknown>;
+};
+
+const emptyBoundedGroupOrderValues: Array<unknown> = [];
+
+const groupedWindowEnd = (query: RuntimeGroupedQuery): number | undefined => {
+  if (query.limit === undefined) {
+    return undefined;
+  }
+  const windowEnd = (query.offset ?? 0) + query.limit;
+  if (!Number.isSafeInteger(windowEnd) || windowEnd > maxBoundedGroupedWindowEnd) {
+    return undefined;
+  }
+  return windowEnd;
+};
+
+const writeGroupOrderValues = (
+  target: Array<unknown>,
+  group: GroupState,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): Array<unknown> => {
+  target.length = 0;
+  for (const order of orderBy) {
+    target.push(
+      "field" in order
+        ? fieldValue(group.row, order.field)
+        : aggregateStateCompareValue(group.aggregates[order.aggregate]!),
+    );
+  }
+  return target;
+};
+
+const newBoundedGroupEntry = (
+  group: GroupState,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): BoundedGroupEntry => {
+  if (orderBy.length === 0) {
+    return {
+      group,
+      orderValues: emptyBoundedGroupOrderValues,
+    };
+  }
+  return {
+    group,
+    orderValues: writeGroupOrderValues([], group, orderBy),
+  };
+};
+
+const compareBoundedGroupEntries = (
+  left: BoundedGroupEntry,
+  right: BoundedGroupEntry,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): number => {
+  for (let index = 0; index < orderBy.length; index += 1) {
+    const order = orderBy[index]!;
+    const comparison = compareQueryValue(left.orderValues[index], right.orderValues[index]);
+    if (comparison !== 0) {
+      return order.direction === "asc" ? comparison : -comparison;
+    }
+  }
+  return Number(left.group.key > right.group.key) - Number(left.group.key < right.group.key);
+};
+
+const compareGroupToBoundedGroupEntry = (
+  group: GroupState,
+  orderValues: ReadonlyArray<unknown>,
+  right: BoundedGroupEntry,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): number => {
+  for (let index = 0; index < orderBy.length; index += 1) {
+    const order = orderBy[index]!;
+    const comparison = compareQueryValue(orderValues[index], right.orderValues[index]);
+    if (comparison !== 0) {
+      return order.direction === "asc" ? comparison : -comparison;
+    }
+  }
+  return Number(group.key > right.group.key) - Number(group.key < right.group.key);
+};
+
+const boundedGroupEntryIsWorse = (
+  left: BoundedGroupEntry,
+  right: BoundedGroupEntry,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): boolean => compareBoundedGroupEntries(left, right, orderBy) > 0;
+
+const swapBoundedGroupEntries = (
+  groups: Array<BoundedGroupEntry>,
+  left: number,
+  right: number,
+): void => {
+  const leftGroup = groups[left]!;
+  groups[left] = groups[right]!;
+  groups[right] = leftGroup;
+};
+
+const siftWorstBoundedGroupEntryUp = (
+  groups: Array<BoundedGroupEntry>,
+  index: number,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): void => {
+  let current = index;
+  while (current > 0) {
+    const parent = (current - 1) >>> 1;
+    if (!boundedGroupEntryIsWorse(groups[current]!, groups[parent]!, orderBy)) {
+      return;
+    }
+    swapBoundedGroupEntries(groups, current, parent);
+    current = parent;
+  }
+};
+
+const siftWorstBoundedGroupEntryDown = (
+  groups: Array<BoundedGroupEntry>,
+  index: number,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+): void => {
+  let current = index;
+  while (true) {
+    const left = current * 2 + 1;
+    const right = left + 1;
+    let worst = current;
+    if (left < groups.length && boundedGroupEntryIsWorse(groups[left]!, groups[worst]!, orderBy)) {
+      worst = left;
+    }
+    if (
+      right < groups.length &&
+      boundedGroupEntryIsWorse(groups[right]!, groups[worst]!, orderBy)
+    ) {
+      worst = right;
+    }
+    if (worst === current) {
+      return;
+    }
+    swapBoundedGroupEntries(groups, current, worst);
+    current = worst;
+  }
+};
+
+const retainBoundedGroup = (
+  groups: Array<BoundedGroupEntry>,
+  group: GroupState,
+  orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+  windowEnd: number,
+  scratchOrderValues: Array<unknown>,
+): Array<unknown> => {
+  if (groups.length < windowEnd) {
+    groups.push(newBoundedGroupEntry(group, orderBy));
+    siftWorstBoundedGroupEntryUp(groups, groups.length - 1, orderBy);
+    return scratchOrderValues;
+  }
+  const worstGroup = groups[0]!;
+  const candidateOrderValues =
+    orderBy.length === 0
+      ? emptyBoundedGroupOrderValues
+      : writeGroupOrderValues(scratchOrderValues, group, orderBy);
+  if (compareGroupToBoundedGroupEntry(group, candidateOrderValues, worstGroup, orderBy) >= 0) {
+    return scratchOrderValues;
+  }
+  const nextScratchOrderValues =
+    worstGroup.orderValues === emptyBoundedGroupOrderValues
+      ? scratchOrderValues
+      : worstGroup.orderValues;
+  worstGroup.group = group;
+  worstGroup.orderValues = candidateOrderValues;
+  siftWorstBoundedGroupEntryDown(groups, 0, orderBy);
+  return nextScratchOrderValues;
+};
+
+const boundedGroupedEvaluationFromGroups = (
+  groups: Iterable<GroupState>,
+  query: RuntimeGroupedQuery,
+  version: number,
+  windowEnd: number,
+): QueryEvaluation<RowObject> => {
+  const orderBy = query.orderBy ?? [];
+  const retainedGroups: Array<BoundedGroupEntry> = [];
+  let scratchOrderValues: Array<unknown> = [];
+  let totalRows = 0;
+  for (const group of groups) {
+    totalRows += 1;
+    scratchOrderValues = retainBoundedGroup(
+      retainedGroups,
+      group,
+      orderBy,
+      windowEnd,
+      scratchOrderValues,
+    );
+  }
+  const window = retainedGroups
+    .toSorted((left, right) => compareBoundedGroupEntries(left, right, orderBy))
+    .slice(query.offset ?? 0)
+    .map((entry) => finalizeGroup(entry.group));
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: window.map((entry) => entry.key),
+    window,
+    totalRows,
+    version,
+  };
+};
+
+const emptyGroupedEvaluation = (
+  totalRows: number,
+  version: number,
+): QueryEvaluation<RowObject> => ({
+  rows: [],
+  keys: [],
+  window: [],
+  totalRows,
+  version,
+});
+
+const evaluateZeroLimitGroupedRows = <Row extends RowObject>(
+  store: TopicRowScan<Row>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+): QueryEvaluation<RowObject> => {
+  const groupKeys = new Set<string>();
+  store.scanRows((_key, row) => {
+    if (matches(row)) {
+      groupKeys.add(groupKey(query.groupBy, row));
+    }
+  });
+  return emptyGroupedEvaluation(groupKeys.size, store.version());
+};
+
+const groupedEvaluationFromGroups = (
+  groups: Iterable<GroupState>,
+  query: RuntimeGroupedQuery,
+  version: number,
+): QueryEvaluation<RowObject> => {
+  const windowEnd = groupedWindowEnd(query);
+  if (windowEnd !== undefined) {
+    return boundedGroupedEvaluationFromGroups(groups, query, version, windowEnd);
+  }
+  return groupedEvaluationFromEntries(Array.from(groups, finalizeGroup), query, version);
 };
 
 const groupedEvaluationFromEntries = (
@@ -661,6 +928,9 @@ const evaluateGroupedRows = <Row extends RowObject>(
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
 ): QueryEvaluation<RowObject> => {
+  if (query.limit === 0) {
+    return evaluateZeroLimitGroupedRows(store, query, matches);
+  }
   const groups = new Map<string, GroupState>();
   store.scanRows((_key, row) => {
     if (!matches(row)) {
@@ -676,19 +946,23 @@ const evaluateGroupedRows = <Row extends RowObject>(
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
   });
-  return groupedEvaluationFromEntries(
-    Array.from(groups.values(), finalizeGroup),
-    query,
-    store.version(),
-  );
+  return groupedEvaluationFromGroups(groups.values(), query, store.version());
 };
 
-type IncrementalGroupedQueryState = {
-  readonly groups: Map<string, IncrementalGroupState>;
-  evaluation: QueryEvaluation<RowObject>;
-  memberCount: number;
-  version: number;
-};
+type IncrementalGroupedQueryState =
+  | {
+      readonly mode: "materialized";
+      readonly groups: Map<string, MaterializedIncrementalGroupState>;
+      evaluation: QueryEvaluation<RowObject>;
+      memberCount: number;
+      version: number;
+    }
+  | {
+      readonly mode: "countOnly";
+      readonly groups: Map<string, CountOnlyIncrementalGroupState>;
+      evaluation: QueryEvaluation<RowObject>;
+      version: number;
+    };
 
 type IncrementalGroupedQueryBuildState =
   | {
@@ -700,11 +974,10 @@ type IncrementalGroupedQueryBuildState =
     };
 
 const evaluateIncrementalGroupedQuery = (
-  groups: ReadonlyMap<string, IncrementalGroupState>,
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
   query: RuntimeGroupedQuery,
   version: number,
-): QueryEvaluation<RowObject> =>
-  groupedEvaluationFromEntries(Array.from(groups.values(), finalizeGroup), query, version);
+): QueryEvaluation<RowObject> => groupedEvaluationFromGroups(state.groups.values(), query, version);
 
 const clearIncrementalGroupedQueryState = (
   state: IncrementalGroupedQueryState,
@@ -712,17 +985,67 @@ const clearIncrementalGroupedQueryState = (
   version: number,
 ): void => {
   state.groups.clear();
-  state.evaluation = groupedEvaluationFromEntries([], query, version);
-  state.memberCount = 0;
+  state.evaluation =
+    state.mode === "countOnly"
+      ? emptyGroupedEvaluation(0, version)
+      : groupedEvaluationFromEntries([], query, version);
+  if (state.mode === "materialized") {
+    state.memberCount = 0;
+  }
   state.version = version;
 };
 
-const buildIncrementalGroupedQueryState = <Row extends RowObject>(
+const buildCountOnlyIncrementalGroupedQueryState = <Row extends RowObject>(
   store: TopicRowScan<Row>,
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
 ): IncrementalGroupedQueryBuildState => {
-  const groups = new Map<string, IncrementalGroupState>();
+  const groups = new Map<string, CountOnlyIncrementalGroupState>();
+  let admitted = true;
+  store.scanRows((_key, row) => {
+    if (!admitted) {
+      return undefined;
+    }
+    if (!matches(row)) {
+      return undefined;
+    }
+    const groupedKey = groupKey(query.groupBy, row);
+    let group = groups.get(groupedKey);
+    if (group === undefined) {
+      group = newZeroLimitIncrementalGroupState(groupedKey);
+      groups.set(groupedKey, group);
+    }
+    group.count += 1;
+    if (groups.size > maxIncrementalGroupedGroups) {
+      groups.clear();
+      admitted = false;
+      return false;
+    }
+    return undefined;
+  });
+  if (!admitted) {
+    return {
+      admitted: false,
+    };
+  }
+  const version = store.version();
+  return {
+    admitted: true,
+    state: {
+      mode: "countOnly",
+      groups,
+      evaluation: emptyGroupedEvaluation(groups.size, version),
+      version,
+    },
+  };
+};
+
+const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
+  store: TopicRowScan<Row>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+): IncrementalGroupedQueryBuildState => {
+  const groups = new Map<string, MaterializedIncrementalGroupState>();
   let memberCount = 0;
   let admitted = true;
   store.scanRows((key, row) => {
@@ -760,24 +1083,35 @@ const buildIncrementalGroupedQueryState = <Row extends RowObject>(
     };
   }
   const version = store.version();
+  const state: IncrementalGroupedQueryState = {
+    mode: "materialized",
+    groups,
+    evaluation: groupedEvaluationFromGroups(groups.values(), query, version),
+    memberCount,
+    version,
+  };
   return {
     admitted: true,
-    state: {
-      groups,
-      evaluation: evaluateIncrementalGroupedQuery(groups, query, version),
-      memberCount,
-      version,
-    },
+    state,
   };
 };
 
-const removeIncrementalGroupedMember = <Row extends RowObject>(
-  groups: Map<string, IncrementalGroupState>,
+const buildIncrementalGroupedQueryState = <Row extends RowObject>(
+  store: TopicRowScan<Row>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+): IncrementalGroupedQueryBuildState =>
+  query.limit === 0
+    ? buildCountOnlyIncrementalGroupedQueryState(store, query, matches)
+    : buildMaterializedIncrementalGroupedQueryState(store, query, matches);
+
+const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+  groups: Map<string, MaterializedIncrementalGroupState>,
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
   key: string,
   row: Row,
-  dirtyGroups: Set<IncrementalGroupState>,
+  dirtyGroups: Set<MaterializedIncrementalGroupState>,
 ): boolean => {
   if (!matches(row)) {
     return false;
@@ -800,18 +1134,39 @@ const removeIncrementalGroupedMember = <Row extends RowObject>(
   return true;
 };
 
+const removeCountOnlyIncrementalGroupedMember = <Row extends RowObject>(
+  groups: Map<string, CountOnlyIncrementalGroupState>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  row: Row,
+): boolean => {
+  if (!matches(row)) {
+    return false;
+  }
+  const groupedKey = groupKey(query.groupBy, row);
+  const group = groups.get(groupedKey);
+  if (group === undefined) {
+    return false;
+  }
+  group.count -= 1;
+  if (group.count === 0) {
+    groups.delete(groupedKey);
+  }
+  return true;
+};
+
 type UpsertIncrementalGroupedMemberResult = {
   readonly groupSize: number;
   readonly inserted: boolean;
 };
 
-const upsertIncrementalGroupedMember = <Row extends RowObject>(
-  groups: Map<string, IncrementalGroupState>,
+const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+  groups: Map<string, MaterializedIncrementalGroupState>,
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
   key: string,
   row: Row,
-  dirtyGroups: Set<IncrementalGroupState>,
+  dirtyGroups: Set<MaterializedIncrementalGroupState>,
 ): UpsertIncrementalGroupedMemberResult | undefined => {
   if (!matches(row)) {
     return undefined;
@@ -831,16 +1186,35 @@ const upsertIncrementalGroupedMember = <Row extends RowObject>(
   };
 };
 
-const applyIncrementalGroupedQueryBatch = <Row extends RowObject>(
-  state: IncrementalGroupedQueryState,
+const upsertCountOnlyIncrementalGroupedMember = <Row extends RowObject>(
+  groups: Map<string, CountOnlyIncrementalGroupState>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  row: Row,
+): boolean => {
+  if (!matches(row)) {
+    return false;
+  }
+  const groupedKey = groupKey(query.groupBy, row);
+  let group = groups.get(groupedKey);
+  if (group === undefined) {
+    group = newZeroLimitIncrementalGroupState(groupedKey);
+    groups.set(groupedKey, group);
+  }
+  group.count += 1;
+  return true;
+};
+
+const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
   batch: TopicRowChangeBatch<Row>,
-  dirtyGroups: Set<IncrementalGroupState>,
+  dirtyGroups: Set<MaterializedIncrementalGroupState>,
 ): boolean => {
   for (const change of batch.changes) {
     if (change.previous !== undefined) {
-      const removed = removeIncrementalGroupedMember(
+      const removed = removeMaterializedIncrementalGroupedMember(
         state.groups,
         query,
         matches,
@@ -853,7 +1227,7 @@ const applyIncrementalGroupedQueryBatch = <Row extends RowObject>(
       }
     }
     if (change.next !== undefined) {
-      const upserted = upsertIncrementalGroupedMember(
+      const upserted = upsertMaterializedIncrementalGroupedMember(
         state.groups,
         query,
         matches,
@@ -881,15 +1255,43 @@ const applyIncrementalGroupedQueryBatch = <Row extends RowObject>(
   return true;
 };
 
-const applyIncrementalGroupedQueryBatches = <Row extends RowObject>(
-  state: IncrementalGroupedQueryState,
+const applyCountOnlyIncrementalGroupedQueryBatch = <Row extends RowObject>(
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "countOnly" }>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  batch: TopicRowChangeBatch<Row>,
+): boolean => {
+  for (const change of batch.changes) {
+    if (change.previous !== undefined) {
+      removeCountOnlyIncrementalGroupedMember(state.groups, query, matches, change.previous);
+    }
+    if (change.next !== undefined) {
+      const inserted = upsertCountOnlyIncrementalGroupedMember(
+        state.groups,
+        query,
+        matches,
+        change.next,
+      );
+      if (!inserted) {
+        continue;
+      }
+      if (state.groups.size > maxIncrementalGroupedGroups) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+const applyMaterializedIncrementalGroupedQueryBatches = <Row extends RowObject>(
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
   query: RuntimeGroupedQuery,
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
 ): boolean => {
-  const dirtyGroups = new Set<IncrementalGroupState>();
+  const dirtyGroups = new Set<MaterializedIncrementalGroupState>();
   for (const batch of batches) {
-    if (!applyIncrementalGroupedQueryBatch(state, query, matches, batch, dirtyGroups)) {
+    if (!applyMaterializedIncrementalGroupedQueryBatch(state, query, matches, batch, dirtyGroups)) {
       state.groups.clear();
       state.memberCount = 0;
       return false;
@@ -899,8 +1301,37 @@ const applyIncrementalGroupedQueryBatches = <Row extends RowObject>(
   for (const group of dirtyGroups) {
     recomputeIncrementalGroupState(group, query.aggregates);
   }
-  state.evaluation = evaluateIncrementalGroupedQuery(state.groups, query, state.version);
+  state.evaluation = evaluateIncrementalGroupedQuery(state, query, state.version);
   return true;
+};
+
+const applyCountOnlyIncrementalGroupedQueryBatches = <Row extends RowObject>(
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "countOnly" }>,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
+): boolean => {
+  for (const batch of batches) {
+    if (!applyCountOnlyIncrementalGroupedQueryBatch(state, query, matches, batch)) {
+      state.groups.clear();
+      return false;
+    }
+    state.version = batch.version;
+  }
+  state.evaluation = emptyGroupedEvaluation(state.groups.size, state.version);
+  return true;
+};
+
+const applyIncrementalGroupedQueryBatches = <Row extends RowObject>(
+  state: IncrementalGroupedQueryState,
+  query: RuntimeGroupedQuery,
+  matches: (row: Row) => boolean,
+  batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
+): boolean => {
+  if (state.mode === "countOnly") {
+    return applyCountOnlyIncrementalGroupedQueryBatches(state, query, matches, batches);
+  }
+  return applyMaterializedIncrementalGroupedQueryBatches(state, query, matches, batches);
 };
 
 const makeFallbackGroupedQueryExecution = <Row extends RowObject, ResultRow extends RowObject>(

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -1445,6 +1445,399 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
+  it.effect("evaluates bounded grouped windows without changing ordered aggregate results", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, object>(
+        Array.from({ length: 1_100 }, (_value, index) => [
+          `row-${index}`,
+          position(`row-${index}`, `symbol-${index}`, BigInt(index), "1"),
+        ]),
+      );
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            totalQuantity: { aggFunc: "sum", field: "quantity" },
+          },
+          orderBy: [{ aggregate: "totalQuantity", direction: "desc" }],
+          offset: 2,
+          limit: 3,
+        },
+      );
+      const evaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            for (const [key, row] of rows) {
+              visitor(key, row);
+            }
+          },
+          version: () => 1,
+        },
+        compiled,
+      );
+
+      expect(normalizeDecimalAndBigIntFields(evaluation.rows)).toStrictEqual([
+        {
+          symbol: "symbol-1097",
+          totalQuantity: "1097",
+        },
+        {
+          symbol: "symbol-1096",
+          totalQuantity: "1096",
+        },
+        {
+          symbol: "symbol-1095",
+          totalQuantity: "1095",
+        },
+      ]);
+      expect(evaluation.keys).toStrictEqual([
+        '["array",[["array",[["string","symbol"],["string","symbol-1097"]]]]]',
+        '["array",[["array",[["string","symbol"],["string","symbol-1096"]]]]]',
+        '["array",[["array",[["string","symbol"],["string","symbol-1095"]]]]]',
+      ]);
+      expect(evaluation.totalRows).toBe(1_100);
+    }),
+  );
+
+  it.effect("keeps grouped total rows for zero-limit windows", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, object>([
+        ["1", position("1", "AAPL", 10n, "1")],
+        ["2", position("2", "MSFT", 20n, "1")],
+      ]);
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          where: {
+            symbol: "AAPL",
+          },
+          orderBy: [{ field: "symbol", direction: "asc" }],
+          offset: 10_000,
+          limit: 0,
+        },
+      );
+      const evaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            for (const [key, row] of rows) {
+              visitor(key, row);
+            }
+          },
+          version: () => 1,
+        },
+        compiled,
+      );
+
+      expect(evaluation.rows).toStrictEqual([]);
+      expect(evaluation.keys).toStrictEqual([]);
+      expect(evaluation.totalRows).toBe(1);
+    }),
+  );
+
+  it.effect("compares bounded grouped windows by avg, max, and stable group key", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, object>([
+        ["a-1", position("a-1", "AAPL", 0n, "1")],
+        ["a-2", position("a-2", "AAPL", 20n, "1")],
+        ["m-1", position("m-1", "MSFT", 5n, "1")],
+        ["m-2", position("m-2", "MSFT", 15n, "1")],
+        ["z-1", position("z-1", "ZZZZ", 1n, "1")],
+      ]);
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            averageQuantity: { aggFunc: "avg", field: "quantity" },
+            maxQuantity: { aggFunc: "max", field: "quantity" },
+          },
+          orderBy: [
+            { aggregate: "averageQuantity", direction: "asc" },
+            { aggregate: "maxQuantity", direction: "desc" },
+          ],
+          limit: 3,
+        },
+      );
+      const evaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            for (const [key, row] of rows) {
+              visitor(key, row);
+            }
+          },
+          version: () => 1,
+        },
+        compiled,
+      );
+
+      expect(normalizeDecimalAndBigIntFields(evaluation.rows)).toStrictEqual([
+        {
+          averageQuantity: "1",
+          maxQuantity: "1",
+          symbol: "ZZZZ",
+        },
+        {
+          averageQuantity: "10",
+          maxQuantity: "20",
+          symbol: "AAPL",
+        },
+        {
+          averageQuantity: "10",
+          maxQuantity: "15",
+          symbol: "MSFT",
+        },
+      ]);
+
+      const tiedCount = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      const tiedEvaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            visitor("b", position("b", "BBBB", 1n, "1"));
+            visitor("a", position("a", "AAAA", 1n, "1"));
+          },
+          version: () => 1,
+        },
+        tiedCount,
+      );
+      expect(tiedEvaluation.rows).toStrictEqual([
+        {
+          rowCount: 1n,
+          symbol: "AAAA",
+        },
+        {
+          rowCount: 1n,
+          symbol: "BBBB",
+        },
+      ]);
+
+      const tiedSingleCount = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+          limit: 1,
+        },
+      );
+      const tiedSingleEvaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            visitor("b", position("b", "BBBB", 1n, "1"));
+            visitor("a", position("a", "AAAA", 1n, "1"));
+          },
+          version: () => 1,
+        },
+        tiedSingleCount,
+      );
+      expect(tiedSingleEvaluation.rows).toStrictEqual([
+        {
+          rowCount: 1n,
+          symbol: "AAAA",
+        },
+      ]);
+
+      const distinctCount = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            distinctPrices: { aggFunc: "countDistinct", field: "price" },
+          },
+          orderBy: [{ aggregate: "distinctPrices", direction: "desc" }],
+          limit: 1,
+        },
+      );
+      const distinctEvaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            visitor("a-1", position("a-1", "AAPL", 1n, "1"));
+            visitor("a-2", position("a-2", "AAPL", 1n, "2"));
+            visitor("m-1", position("m-1", "MSFT", 1n, "1"));
+          },
+          version: () => 1,
+        },
+        distinctCount,
+      );
+      expect(distinctEvaluation.rows).toStrictEqual([
+        {
+          distinctPrices: 2n,
+          symbol: "AAPL",
+        },
+      ]);
+
+      const fieldOrder = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          orderBy: [{ field: "symbol", direction: "desc" }],
+          limit: 1,
+        },
+      );
+      const fieldOrderEvaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            visitor("a", position("a", "AAAA", 1n, "1"));
+            visitor("b", position("b", "BBBB", 1n, "1"));
+          },
+          version: () => 1,
+        },
+        fieldOrder,
+      );
+      expect(fieldOrderEvaluation.rows).toStrictEqual([
+        {
+          rowCount: 1n,
+          symbol: "BBBB",
+        },
+      ]);
+
+      const defaultOrder = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          limit: 1,
+        },
+      );
+      const defaultOrderEvaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            visitor("b", position("b", "BBBB", 1n, "1"));
+            visitor("a", position("a", "AAAA", 1n, "1"));
+          },
+          version: () => 1,
+        },
+        defaultOrder,
+      );
+      expect(defaultOrderEvaluation.rows).toStrictEqual([
+        {
+          rowCount: 1n,
+          symbol: "AAAA",
+        },
+      ]);
+
+      const PositionForCompiler = Schema.Struct({
+        id: Schema.String,
+        quantity: Schema.BigInt,
+        symbol: Schema.String,
+      });
+      const zeroAverage = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(PositionForCompiler),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            averageQuantity: { aggFunc: "avg", field: "quantity" },
+          },
+          orderBy: [{ aggregate: "averageQuantity", direction: "asc" }],
+          limit: 1,
+        },
+      );
+      const zeroAverageEvaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            visitor("bad", { id: "bad", quantity: "not-a-bigint", symbol: "BAD" });
+            visitor("good", { id: "good", quantity: 10n, symbol: "GOOD" });
+          },
+          version: () => 1,
+        },
+        zeroAverage,
+      );
+      expect(normalizeDecimalAndBigIntFields(zeroAverageEvaluation.rows)).toStrictEqual([
+        {
+          averageQuantity: "0",
+          symbol: "BAD",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("uses full grouped ordering when requested grouped window is too large", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, object>(
+        Array.from({ length: 1_100 }, (_value, index) => [
+          `row-${index}`,
+          position(`row-${index}`, `symbol-${index}`, BigInt(index), "1"),
+        ]),
+      );
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            totalQuantity: { aggFunc: "sum", field: "quantity" },
+          },
+          orderBy: [{ aggregate: "totalQuantity", direction: "desc" }],
+          limit: 1_025,
+        },
+      );
+      const evaluation = evaluateCompiledGroupedQuery(
+        {
+          changesSince: () => [],
+          scanRows: (visitor) => {
+            for (const [key, row] of rows) {
+              visitor(key, row);
+            }
+          },
+          version: () => 1,
+        },
+        compiled,
+      );
+
+      expect(normalizeDecimalAndBigIntFields(evaluation.rows.slice(0, 2))).toStrictEqual([
+        {
+          symbol: "symbol-1099",
+          totalQuantity: "1099",
+        },
+        {
+          symbol: "symbol-1098",
+          totalQuantity: "1098",
+        },
+      ]);
+      expect(evaluation.rows.length).toBe(1_025);
+      expect(evaluation.totalRows).toBe(1_100);
+    }),
+  );
+
   it.effect("ignores malformed runtime values for bigint grouped sums", () =>
     Effect.gen(function* () {
       const PositionForCompiler = Schema.Struct({
@@ -1566,6 +1959,255 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         { status: "open", rowCount: 1n },
       ]);
       expect(scanCount).toBe(1);
+    }),
+  );
+
+  it.effect("tracks incremental zero-limit grouped counts without aggregate windows", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const retainedCustomer = {
+        ...order("1-extra", "open", 15, 4, "emea"),
+        customerId: "customer-1",
+      };
+      const rows = new Map<string, object>([
+        ["1", order("1", "open", 10, 1, "emea")],
+        ["1-extra", retainedCustomer],
+        ["2", order("2", "open", 20, 2, "amer")],
+      ]);
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["customerId"],
+          aggregates: {
+            totalPrice: { aggFunc: "sum", field: "price" },
+          },
+          where: {
+            region: "emea",
+          },
+          offset: 10_000,
+          limit: 0,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(1);
+      expect(scanCount).toBe(1);
+
+      rows.delete("1-extra");
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [{ key: "1-extra", previous: retainedCustomer, next: undefined }],
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(1);
+      expect(scanCount).toBe(1);
+
+      const inserted = order("3", "closed", 30, 3, "emea");
+      rows.set("3", inserted);
+      version = 2;
+      batches = [
+        {
+          version,
+          changes: [{ key: "3", previous: undefined, next: inserted }],
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(2);
+      expect(scanCount).toBe(1);
+
+      rows.delete("3");
+      version = 3;
+      batches = [
+        {
+          version,
+          changes: [{ key: "3", previous: inserted, next: undefined }],
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(1);
+      expect(scanCount).toBe(1);
+
+      rows.set("3", inserted);
+      version = 4;
+      batches = [
+        {
+          version,
+          changes: [
+            {
+              key: "missing-zero-limit",
+              previous: order("missing-zero-limit", "open", 1, 1, "emea"),
+              next: undefined,
+            },
+            {
+              key: "ignored-zero-limit",
+              previous: undefined,
+              next: order("ignored-zero-limit", "open", 1, 1, "amer"),
+            },
+            {
+              key: "ignored-zero-limit-previous",
+              previous: order("ignored-zero-limit-previous", "open", 1, 1, "amer"),
+              next: undefined,
+            },
+          ],
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(1);
+      expect(scanCount).toBe(1);
+
+      version = 5;
+      batches = [
+        {
+          version,
+          changes: [{ key: "3", previous: undefined, next: inserted }],
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(2);
+      expect(scanCount).toBe(1);
+
+      const repeatedGroupChanges = Array.from({ length: 4_097 }, (_value, index) => {
+        const repeated = {
+          ...order(`repeat-${index}`, "open", index, index, "emea"),
+          customerId: "customer-3",
+        };
+        rows.set(`repeat-${index}`, repeated);
+        return {
+          key: `repeat-${index}`,
+          previous: undefined,
+          next: repeated,
+        };
+      });
+      version = 6;
+      batches = [
+        {
+          version,
+          changes: repeatedGroupChanges,
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(2);
+      expect(execution.incremental).toBe(true);
+      expect(scanCount).toBe(1);
+
+      const overflowChanges = Array.from({ length: 8_193 }, (_value, index) => {
+        const overflow = order(`overflow-${index}`, "open", index, index, "emea");
+        rows.set(`overflow-${index}`, overflow);
+        return {
+          key: `overflow-${index}`,
+          previous: undefined,
+          next: overflow,
+        };
+      });
+      version = 7;
+      batches = [
+        {
+          version,
+          changes: overflowChanges,
+        },
+      ];
+
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(8_195);
+      expect(execution.incremental).toBe(false);
+      expect(scanCount).toBe(2);
+    }),
+  );
+
+  it.effect("falls back when materialized grouped admission is ignored by the row scanner", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, object>(
+        Array.from({ length: 4_098 }, (_value, index) => [
+          `row-${index}`,
+          order(`row-${index}`, "open", index, index),
+        ]),
+      );
+      const store = {
+        changesSince: () => [],
+        scanRows: (visitor: (key: string, row: object) => false | void) => {
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => 0,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(execution.incremental).toBe(false);
+      expect(execution.latest().rows).toStrictEqual([{ status: "open", rowCount: 4_098n }]);
+    }),
+  );
+
+  it.effect("falls back when count-only grouped admission is ignored by the row scanner", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, object>([
+        ["ignored", order("ignored", "open", 1, 1, "amer")],
+        ...Array.from({ length: 8_194 }, (_value, index): [string, object] => {
+          const key = `row-${index}`;
+          return [key, order(key, "open", index, index, "emea")];
+        }),
+      ]);
+      const store = {
+        changesSince: () => [],
+        scanRows: (visitor: (key: string, row: object) => false | void) => {
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => 0,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["customerId"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          where: {
+            region: "emea",
+          },
+          limit: 0,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(execution.incremental).toBe(false);
+      expect(execution.latest().rows).toStrictEqual([]);
+      expect(execution.latest().totalRows).toBe(8_194);
     }),
   );
 


### PR DESCRIPTION
## Summary
- add bounded grouped window evaluation for grouped queries where offset + limit is <= 1024
- keep full grouped ordering fallback for larger windows
- make grouped limit: 0 use count-only incremental state without row clones, aggregate state, or member maps
- add grouped tests for bounded ordering, zero-limit totals, count-only incremental updates, and fallback admission paths

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- git diff --check
- forbidden-pattern scan clean
- pnpm run ready
- 3 local reviewer agents clean