### PR TITLE
Extract topic row change journal

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -17,6 +17,7 @@ import {
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
 import { cloneRow, fieldValue, isPlainRecord, scalarEqualityKey, valuesEqual } from "./row-values";
+import { TopicRowChangeJournal } from "./topic-row-change-journal";
 import { isBigDecimal, Order as orderBigDecimal } from "effect/BigDecimal";
 
 type RowObject = object;
@@ -84,8 +85,6 @@ const noOrderedRangeBounds: OrderedRangeBounds = {
 const maxBoundedRawWindowEnd = 1_024;
 const maxPredicateCandidateSampleSlots = 4_096;
 const maxTransientPredicateCandidateSlots = 65_536;
-const maxRowChangeJournalEntries = 65_536;
-const maxRowChangeJournalVersions = 1_024;
 
 export type PreparedTopicRow = {
   readonly key: string;
@@ -100,12 +99,7 @@ export class ColumnarTopicStore {
   private readonly keyToSlot = new Map<string, number>();
   private readonly columns = new Map<string, ColumnValues>();
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
-  private pendingRowChanges: Array<TopicRowChange<object>> = [];
-  private pendingRowChangesOverflowed = false;
-  private readonly rowChangeJournal: Array<TopicRowChangeBatch<object>> = [];
-  private rowChangeJournalChangeCount = 0;
-  private rowChangeJournalInvalidBeforeVersion = 0;
-  private rowChangeJournalRefs = 0;
+  private readonly rowChangeJournal = new TopicRowChangeJournal<object>();
   private versionValue = 0;
 
   constructor(
@@ -139,21 +133,7 @@ export class ColumnarTopicStore {
 
   advanceVersion(): number {
     this.versionValue += 1;
-    if (this.rowChangeJournalRefs > 0) {
-      if (this.pendingRowChangesOverflowed) {
-        this.pendingRowChanges = [];
-        this.pendingRowChangesOverflowed = false;
-        return this.versionValue;
-      }
-      const changes = this.pendingRowChanges;
-      this.rowChangeJournal.push({
-        changes,
-        version: this.versionValue,
-      });
-      this.pendingRowChanges = [];
-      this.rowChangeJournalChangeCount += changes.length;
-      this.trimRowChangeJournal();
-    }
+    this.rowChangeJournal.commit(this.versionValue);
     return this.versionValue;
   }
 
@@ -161,7 +141,7 @@ export class ColumnarTopicStore {
     this.slots.length = 0;
     this.keyToSlot.clear();
     this.orderedSlotIndexes.clear();
-    this.clearRowChangeJournal();
+    this.rowChangeJournal.clear(this.versionValue);
     for (const column of this.columns.values()) {
       column.length = 0;
     }
@@ -238,26 +218,7 @@ export class ColumnarTopicStore {
   }
 
   changesSince(version: number): ReadonlyArray<TopicRowChangeBatch<object>> | undefined {
-    if (version === this.versionValue) {
-      return [];
-    }
-    if (this.rowChangeJournalRefs === 0 || version < 0 || version > this.versionValue) {
-      return undefined;
-    }
-    if (version < this.rowChangeJournalInvalidBeforeVersion) {
-      return undefined;
-    }
-    const firstBatch = this.rowChangeJournal[0]!;
-    if (version < firstBatch.version - 1) {
-      return undefined;
-    }
-    const batches: Array<TopicRowChangeBatch<object>> = [];
-    for (const batch of this.rowChangeJournal) {
-      if (batch.version > version) {
-        batches.push(batch);
-      }
-    }
-    return batches;
+    return this.rowChangeJournal.changesSince(version, this.versionValue);
   }
 
   scanRows(visitor: TopicRowVisitor<object>): void {
@@ -860,53 +821,16 @@ export class ColumnarTopicStore {
     });
   }
 
-  private clearRowChangeJournal(): void {
-    this.pendingRowChanges = [];
-    this.pendingRowChangesOverflowed = false;
-    this.rowChangeJournal.length = 0;
-    this.rowChangeJournalChangeCount = 0;
-    this.rowChangeJournalInvalidBeforeVersion = this.versionValue;
-  }
-
-  private invalidateRowChangeJournal(invalidBeforeVersion: number): void {
-    this.clearRowChangeJournal();
-    this.rowChangeJournalInvalidBeforeVersion = invalidBeforeVersion;
-  }
-
   private recordRowChange(change: TopicRowChange<object>): void {
-    if (this.rowChangeJournalRefs === 0 || this.pendingRowChangesOverflowed) {
-      return;
-    }
-    if (this.pendingRowChanges.length + 1 > maxRowChangeJournalEntries) {
-      this.invalidateRowChangeJournal(this.versionValue + 1);
-      this.pendingRowChangesOverflowed = true;
-      return;
-    }
-    this.pendingRowChanges.push(change);
+    this.rowChangeJournal.record(change, this.versionValue);
   }
 
   private releaseChanges(): void {
-    this.rowChangeJournalRefs = Math.max(0, this.rowChangeJournalRefs - 1);
-    if (this.rowChangeJournalRefs === 0) {
-      this.clearRowChangeJournal();
-    }
+    this.rowChangeJournal.release(this.versionValue);
   }
 
   private retainChanges(): void {
-    this.rowChangeJournalRefs += 1;
-    if (this.rowChangeJournalRefs === 1) {
-      this.clearRowChangeJournal();
-    }
-  }
-
-  private trimRowChangeJournal(): void {
-    while (this.rowChangeJournal.length > maxRowChangeJournalVersions) {
-      const removed = this.rowChangeJournal.shift()!;
-      this.rowChangeJournalChangeCount -= removed.changes.length;
-    }
-    if (this.rowChangeJournalChangeCount > maxRowChangeJournalEntries) {
-      this.invalidateRowChangeJournal(this.versionValue);
-    }
+    this.rowChangeJournal.retain(this.versionValue);
   }
 
   private rowForKey(key: string): object | undefined {

--- a/packages/column-live-view-engine/src/topic-row-change-journal.ts
+++ b/packages/column-live-view-engine/src/topic-row-change-journal.ts
@@ -1,0 +1,109 @@
+import type { TopicRowChange, TopicRowChangeBatch } from "./row-scan";
+
+type RowObject = object;
+
+const maxRowChangeJournalEntries = 65_536;
+const maxRowChangeJournalVersions = 1_024;
+
+export class TopicRowChangeJournal<Row extends RowObject> {
+  private pendingChanges: Array<TopicRowChange<Row>> = [];
+  private pendingChangesOverflowed = false;
+  private readonly batches: Array<TopicRowChangeBatch<Row>> = [];
+  private changeCount = 0;
+  private invalidBeforeVersion = 0;
+  private refs = 0;
+
+  changesSince(
+    version: number,
+    currentVersion: number,
+  ): ReadonlyArray<TopicRowChangeBatch<Row>> | undefined {
+    if (version === currentVersion) {
+      return [];
+    }
+    if (this.refs === 0 || version < 0 || version > currentVersion) {
+      return undefined;
+    }
+    if (version < this.invalidBeforeVersion) {
+      return undefined;
+    }
+    const firstBatch = this.batches[0]!;
+    if (version < firstBatch.version - 1) {
+      return undefined;
+    }
+    const batches: Array<TopicRowChangeBatch<Row>> = [];
+    for (const batch of this.batches) {
+      if (batch.version > version) {
+        batches.push(batch);
+      }
+    }
+    return batches;
+  }
+
+  clear(currentVersion: number): void {
+    this.pendingChanges = [];
+    this.pendingChangesOverflowed = false;
+    this.batches.length = 0;
+    this.changeCount = 0;
+    this.invalidBeforeVersion = currentVersion;
+  }
+
+  commit(currentVersion: number): void {
+    if (this.refs === 0) {
+      return;
+    }
+    if (this.pendingChangesOverflowed) {
+      this.pendingChanges = [];
+      this.pendingChangesOverflowed = false;
+      return;
+    }
+    const changes = this.pendingChanges;
+    this.batches.push({
+      changes,
+      version: currentVersion,
+    });
+    this.pendingChanges = [];
+    this.changeCount += changes.length;
+    this.trim(currentVersion);
+  }
+
+  record(change: TopicRowChange<Row>, currentVersion: number): void {
+    if (this.refs === 0 || this.pendingChangesOverflowed) {
+      return;
+    }
+    if (this.pendingChanges.length + 1 > maxRowChangeJournalEntries) {
+      this.invalidate(currentVersion + 1);
+      this.pendingChangesOverflowed = true;
+      return;
+    }
+    this.pendingChanges.push(change);
+  }
+
+  release(currentVersion: number): void {
+    this.refs = Math.max(0, this.refs - 1);
+    if (this.refs === 0) {
+      this.clear(currentVersion);
+    }
+  }
+
+  retain(currentVersion: number): void {
+    this.refs += 1;
+    if (this.refs === 1) {
+      this.clear(currentVersion);
+    }
+  }
+
+  private invalidate(invalidBeforeVersion: number): void {
+    this.clear(invalidBeforeVersion);
+    this.invalidBeforeVersion = invalidBeforeVersion;
+  }
+
+  private trim(currentVersion: number): void {
+    while (this.batches.length > maxRowChangeJournalVersions) {
+      const removed = this.batches.shift()!;
+      this.changeCount -= removed.changes.length;
+    }
+    if (this.changeCount > maxRowChangeJournalEntries) {
+      this.invalidate(currentVersion);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract retained row-change history into a focused TopicRowChangeJournal module
- leave ColumnarTopicStore responsible for storage, row mutation, indexes, and scans
- preserve version commit, overflow invalidation, retain/release, and changesSince behavior

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- git diff --check
- forbidden-pattern scan for casts, Testing Library, act, flushSync, toEqual, coverage ignores
- pnpm run ready