### PR TITLE
Extract raw query metadata

### DIFF
--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -1,12 +1,16 @@
-import { viewServerSchemaFieldMetadata, type FieldKey, type OrderBy } from "@view-server/config";
-import { Effect, Schema, SchemaAST } from "effect";
+import type { FieldKey, OrderBy } from "@view-server/config";
+import { Effect, Schema } from "effect";
 import { format as formatBigDecimal, isBigDecimal, normalize, Order } from "effect/BigDecimal";
+import {
+  rawQueryCompilerMetadata,
+  type RangeValueKind,
+  type RawQueryCompilerMetadata,
+} from "./raw-query-metadata";
 import {
   cloneRecord,
   cloneUnknown,
   fieldValue,
   isPlainRecord,
-  isRecord,
   scalarEqualityKey,
   type ScalarEqualityKeyValue,
   valuesEqual,
@@ -15,6 +19,9 @@ import type { TopicRawOrderByPlan, TopicRawPredicatePlan, TopicRowEntry } from "
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");
+
+export { rawQueryCompilerMetadata };
+export type { RawQueryCompilerMetadata };
 
 export class InvalidQueryError extends Schema.TaggedErrorClass<InvalidQueryError>()(
   "InvalidQueryError",
@@ -33,21 +40,6 @@ export type RuntimeRawQuery = {
   }>;
   readonly offset?: number;
   readonly limit?: number;
-};
-
-type SchemaWithFields = Schema.Decoder<object> & {
-  readonly fields: Record<string, unknown>;
-};
-
-export type RawQueryCompilerMetadata = {
-  readonly fieldNames: ReadonlySet<string>;
-  readonly fieldMetadata: ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>>;
-  readonly structuredFieldNames: ReadonlySet<string>;
-  readonly structuredObjectFieldNames: ReadonlySet<string>;
-  readonly stringFieldNames: ReadonlySet<string>;
-  readonly numericFieldNames: ReadonlySet<string>;
-  readonly bigintFieldNames: ReadonlySet<string>;
-  readonly rangeValueKinds: ReadonlyMap<string, ReadonlySet<RangeValueKind>>;
 };
 
 export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject> = {
@@ -88,8 +80,6 @@ type FilterObject = {
   readonly lte?: unknown;
   readonly startsWith?: string;
 };
-
-type RangeValueKind = "number" | "bigint" | "bigDecimal";
 
 const rawQueryKeys = new Set(["where", "orderBy", "offset", "limit", "select"]);
 const filterOperatorKeys = new Set(["eq", "neq", "in", "gt", "gte", "lt", "lte", "startsWith"]);
@@ -139,175 +129,6 @@ const isQueryValueSafe = (value: unknown, active: WeakSet<object> = new WeakSet(
   }
   return false;
 };
-
-const isSchemaWithFields = (schema: Schema.Decoder<object>): schema is SchemaWithFields =>
-  "fields" in schema && isRecord(schema.fields);
-
-const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
-  if (!isRecord(schema)) {
-    return undefined;
-  }
-  const ast = schema["ast"];
-  return SchemaAST.isAST(ast) ? ast : undefined;
-};
-
-const isBigDecimalAst = (ast: SchemaAST.AST): boolean =>
-  SchemaAST.isDeclaration(ast) &&
-  isRecord(ast.annotations?.["typeConstructor"]) &&
-  ast.annotations["typeConstructor"]["_tag"] === "effect/BigDecimal";
-
-const rangeValueKindsAst = (ast: SchemaAST.AST): ReadonlySet<RangeValueKind> => {
-  if (SchemaAST.isNumber(ast)) {
-    return new Set(["number"]);
-  }
-  if (SchemaAST.isBigInt(ast)) {
-    return new Set(["bigint"]);
-  }
-  if (isBigDecimalAst(ast)) {
-    return new Set(["bigDecimal"]);
-  }
-  if (SchemaAST.isLiteral(ast)) {
-    if (typeof ast.literal === "number") {
-      return new Set(["number"]);
-    }
-    if (typeof ast.literal === "bigint") {
-      return new Set(["bigint"]);
-    }
-    return new Set();
-  }
-  if (!SchemaAST.isUnion(ast) || ast.types.length === 0) {
-    return new Set();
-  }
-  const kinds = new Set<RangeValueKind>();
-  for (const member of ast.types) {
-    for (const kind of rangeValueKindsAst(member)) {
-      kinds.add(kind);
-    }
-  }
-  return kinds;
-};
-
-const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
-  isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
-
-const schemaFieldMetadata = (
-  schema: Schema.Decoder<object>,
-): ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Map();
-  }
-
-  const fields = new Map<string, ReturnType<typeof viewServerSchemaFieldMetadata>>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    fields.set(field, viewServerSchemaFieldMetadata(fieldSchema));
-  }
-  return fields;
-};
-
-const schemaNumericFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Set();
-  }
-
-  const fields = new Set<string>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    if (!viewServerSchemaFieldMetadata(fieldSchema).isNumeric) {
-      continue;
-    }
-    fields.add(field);
-  }
-  return fields;
-};
-
-const schemaBigintFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Set();
-  }
-
-  const fields = new Set<string>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    if (viewServerSchemaFieldMetadata(fieldSchema).isPureBigInt) {
-      fields.add(field);
-    }
-  }
-  return fields;
-};
-
-const schemaRangeValueKinds = (
-  schema: Schema.Decoder<object>,
-): ReadonlyMap<string, ReadonlySet<RangeValueKind>> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Map();
-  }
-
-  const fields = new Map<string, ReadonlySet<RangeValueKind>>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    const ast = schemaAst(fieldSchema);
-    if (ast === undefined) {
-      continue;
-    }
-    const kinds = rangeValueKindsAst(ast);
-    if (kinds.size > 0) {
-      fields.set(field, kinds);
-    }
-  }
-  return fields;
-};
-
-const schemaStringFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Set();
-  }
-
-  const fields = new Set<string>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    if (viewServerSchemaFieldMetadata(fieldSchema).isString) {
-      fields.add(field);
-    }
-  }
-  return fields;
-};
-
-const schemaStructuredFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Set();
-  }
-
-  const fields = new Set<string>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    if (viewServerSchemaFieldMetadata(fieldSchema).isStructured) {
-      fields.add(field);
-    }
-  }
-  return fields;
-};
-
-const schemaStructuredObjectFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
-  if (!isSchemaWithFields(schema)) {
-    return new Set();
-  }
-
-  const fields = new Set<string>();
-  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
-    if (viewServerSchemaFieldMetadata(fieldSchema).isStructuredObject) {
-      fields.add(field);
-    }
-  }
-  return fields;
-};
-
-export const rawQueryCompilerMetadata = (
-  schema: Schema.Decoder<object>,
-): RawQueryCompilerMetadata => ({
-  fieldNames: schemaFieldNames(schema),
-  fieldMetadata: schemaFieldMetadata(schema),
-  structuredFieldNames: schemaStructuredFieldNames(schema),
-  structuredObjectFieldNames: schemaStructuredObjectFieldNames(schema),
-  stringFieldNames: schemaStringFieldNames(schema),
-  numericFieldNames: schemaNumericFieldNames(schema),
-  bigintFieldNames: schemaBigintFieldNames(schema),
-  rangeValueKinds: schemaRangeValueKinds(schema),
-});
 
 const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")((
   topic: string,

--- a/packages/column-live-view-engine/src/raw-query-metadata.ts
+++ b/packages/column-live-view-engine/src/raw-query-metadata.ts
@@ -1,0 +1,189 @@
+import { viewServerSchemaFieldMetadata } from "@view-server/config";
+import { Schema, SchemaAST } from "effect";
+import { isRecord } from "./row-values";
+
+type SchemaWithFields = Schema.Decoder<object> & {
+  readonly fields: Record<string, unknown>;
+};
+
+export type RangeValueKind = "number" | "bigint" | "bigDecimal";
+
+export type RawQueryCompilerMetadata = {
+  readonly fieldNames: ReadonlySet<string>;
+  readonly fieldMetadata: ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>>;
+  readonly structuredFieldNames: ReadonlySet<string>;
+  readonly structuredObjectFieldNames: ReadonlySet<string>;
+  readonly stringFieldNames: ReadonlySet<string>;
+  readonly numericFieldNames: ReadonlySet<string>;
+  readonly bigintFieldNames: ReadonlySet<string>;
+  readonly rangeValueKinds: ReadonlyMap<string, ReadonlySet<RangeValueKind>>;
+};
+
+const isSchemaWithFields = (schema: Schema.Decoder<object>): schema is SchemaWithFields =>
+  "fields" in schema && isRecord(schema.fields);
+
+const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
+  if (!isRecord(schema)) {
+    return undefined;
+  }
+  const ast = schema["ast"];
+  return SchemaAST.isAST(ast) ? ast : undefined;
+};
+
+const isBigDecimalAst = (ast: SchemaAST.AST): boolean =>
+  SchemaAST.isDeclaration(ast) &&
+  isRecord(ast.annotations?.["typeConstructor"]) &&
+  ast.annotations["typeConstructor"]["_tag"] === "effect/BigDecimal";
+
+const rangeValueKindsAst = (ast: SchemaAST.AST): ReadonlySet<RangeValueKind> => {
+  if (SchemaAST.isNumber(ast)) {
+    return new Set(["number"]);
+  }
+  if (SchemaAST.isBigInt(ast)) {
+    return new Set(["bigint"]);
+  }
+  if (isBigDecimalAst(ast)) {
+    return new Set(["bigDecimal"]);
+  }
+  if (SchemaAST.isLiteral(ast)) {
+    if (typeof ast.literal === "number") {
+      return new Set(["number"]);
+    }
+    if (typeof ast.literal === "bigint") {
+      return new Set(["bigint"]);
+    }
+    return new Set();
+  }
+  if (!SchemaAST.isUnion(ast) || ast.types.length === 0) {
+    return new Set();
+  }
+  const kinds = new Set<RangeValueKind>();
+  for (const member of ast.types) {
+    for (const kind of rangeValueKindsAst(member)) {
+      kinds.add(kind);
+    }
+  }
+  return kinds;
+};
+
+const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
+  isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
+
+const schemaFieldMetadata = (
+  schema: Schema.Decoder<object>,
+): ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Map();
+  }
+
+  const fields = new Map<string, ReturnType<typeof viewServerSchemaFieldMetadata>>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    fields.set(field, viewServerSchemaFieldMetadata(fieldSchema));
+  }
+  return fields;
+};
+
+const schemaNumericFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (!viewServerSchemaFieldMetadata(fieldSchema).isNumeric) {
+      continue;
+    }
+    fields.add(field);
+  }
+  return fields;
+};
+
+const schemaBigintFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isPureBigInt) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+const schemaRangeValueKinds = (
+  schema: Schema.Decoder<object>,
+): ReadonlyMap<string, ReadonlySet<RangeValueKind>> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Map();
+  }
+
+  const fields = new Map<string, ReadonlySet<RangeValueKind>>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    const ast = schemaAst(fieldSchema);
+    if (ast === undefined) {
+      continue;
+    }
+    const kinds = rangeValueKindsAst(ast);
+    if (kinds.size > 0) {
+      fields.set(field, kinds);
+    }
+  }
+  return fields;
+};
+
+const schemaStringFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isString) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+const schemaStructuredFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isStructured) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+const schemaStructuredObjectFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    if (viewServerSchemaFieldMetadata(fieldSchema).isStructuredObject) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
+export const rawQueryCompilerMetadata = (
+  schema: Schema.Decoder<object>,
+): RawQueryCompilerMetadata => ({
+  fieldNames: schemaFieldNames(schema),
+  fieldMetadata: schemaFieldMetadata(schema),
+  structuredFieldNames: schemaStructuredFieldNames(schema),
+  structuredObjectFieldNames: schemaStructuredObjectFieldNames(schema),
+  stringFieldNames: schemaStringFieldNames(schema),
+  numericFieldNames: schemaNumericFieldNames(schema),
+  bigintFieldNames: schemaBigintFieldNames(schema),
+  rangeValueKinds: schemaRangeValueKinds(schema),
+});


### PR DESCRIPTION
## Summary

- Extract raw query schema/field metadata construction into a focused internal Module.
- Preserve the existing raw-query-compiler public re-export for RawQueryCompilerMetadata and rawQueryCompilerMetadata.
- Keep raw-query-compiler focused on query decoding, predicate/order/projection/window compilation.

## Validation

- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- git diff --check
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- pnpm run ready