### PR TITLE
Extract raw window scan contract

### DIFF
--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -7,7 +7,8 @@ import {
 } from "./raw-query-compiler";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
-import type { TopicRawWindowScan, TopicRawWindowScanResult, TopicRowScan } from "./row-scan";
+import type { TopicRawWindowScan, TopicRawWindowScanResult } from "./raw-window-scan";
+import type { TopicRowScan } from "./row-scan";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -1,15 +1,17 @@
 import { Effect, Schema } from "effect";
 import { createActiveQueryRegistry, type ActiveQueryStoreState } from "./active-query";
 import type {
-  TopicRawOrderByPlan,
-  TopicRawPredicateFilterPlan,
-  TopicRawWindowScanPlan,
-  TopicRawWindowScanResult,
   TopicRowChange,
   TopicRowChangeBatch,
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
+import type {
+  TopicRawOrderByPlan,
+  TopicRawPredicateFilterPlan,
+  TopicRawWindowScanPlan,
+  TopicRawWindowScanResult,
+} from "./raw-window-scan";
 import {
   columnValueDoesNotEqual,
   compareExactRangeColumnValue,

--- a/packages/column-live-view-engine/src/raw-predicate-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-compiler.ts
@@ -9,7 +9,7 @@ import {
   type ScalarEqualityKeyValue,
   valuesEqual,
 } from "./row-values";
-import type { TopicRawPredicatePlan } from "./row-scan";
+import type { TopicRawPredicatePlan } from "./raw-window-scan";
 
 type RowObject = object;
 

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -14,7 +14,8 @@ import {
 } from "./raw-query-decoder";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-metadata";
 import { cloneUnknown, fieldValue } from "./row-values";
-import type { TopicRawOrderByPlan, TopicRowEntry } from "./row-scan";
+import type { TopicRawOrderByPlan } from "./raw-window-scan";
+import type { TopicRowEntry } from "./row-scan";
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");

--- a/packages/column-live-view-engine/src/raw-window-scan.ts
+++ b/packages/column-live-view-engine/src/raw-window-scan.ts
@@ -1,0 +1,64 @@
+import type { TopicRowEntry } from "./row-scan";
+
+type RowObject = object;
+
+export type TopicRawOrderByPlan = {
+  readonly field: string;
+  readonly direction: "asc" | "desc";
+};
+
+export type TopicRawPredicateFilterPlan =
+  | {
+      readonly field: string;
+      readonly operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "startsWith";
+      readonly value: unknown;
+    }
+  | {
+      readonly field: string;
+      readonly operator: "in";
+      readonly values: ReadonlyArray<unknown>;
+      readonly valueKeys?: ReadonlySet<string>;
+    };
+
+export type TopicRawPredicatePlan = {
+  /**
+   * Safe scalar hints that storage can use to narrow a raw scan.
+   * `matches` remains the correctness guard unless an adapter implements a
+   * proven equivalent for every emitted hint.
+   */
+  readonly filters: ReadonlyArray<TopicRawPredicateFilterPlan>;
+  /**
+   * True when the compiler intentionally omitted part of the predicate from
+   * `filters`, for example structured fields or malformed runtime filters.
+   */
+  readonly callbackRequired: boolean;
+  /**
+   * True when the compiler proved that `filters` fully represent `matches`.
+   * Hand-written plans omit this and stay guarded by the row callback.
+   */
+  readonly callbackSkippable?: boolean;
+};
+
+export type TopicRawWindowScanPlan<Row extends RowObject> = {
+  readonly predicate: TopicRawPredicatePlan;
+  readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
+  /**
+   * Compiler-proven ordering hint for storage pushdown. `compare` remains the
+   * source of truth for custom scan plans unless this hint is present.
+   */
+  readonly storageOrderBy?: ReadonlyArray<TopicRawOrderByPlan>;
+  readonly matches: (row: Row) => boolean;
+  readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
+  readonly offset: number;
+  readonly limit: number | undefined;
+};
+
+export type TopicRawWindowScanResult<Row extends RowObject> = {
+  readonly keys: ReadonlyArray<string>;
+  readonly window: ReadonlyArray<TopicRowEntry<Row>>;
+  readonly totalRows: number;
+};
+
+export type TopicRawWindowScan<Row extends RowObject> = {
+  readonly scanRawWindow: (plan: TopicRawWindowScanPlan<Row>) => TopicRawWindowScanResult<Row>;
+};

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -18,69 +18,8 @@ export type TopicRowChangeBatch<Row extends RowObject> = {
   readonly version: number;
 };
 
-export type TopicRawOrderByPlan = {
-  readonly field: string;
-  readonly direction: "asc" | "desc";
-};
-
-export type TopicRawPredicateFilterPlan =
-  | {
-      readonly field: string;
-      readonly operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "startsWith";
-      readonly value: unknown;
-    }
-  | {
-      readonly field: string;
-      readonly operator: "in";
-      readonly values: ReadonlyArray<unknown>;
-      readonly valueKeys?: ReadonlySet<string>;
-    };
-
-export type TopicRawPredicatePlan = {
-  /**
-   * Safe scalar hints that storage can use to narrow a raw scan.
-   * `matches` remains the correctness guard unless an adapter implements a
-   * proven equivalent for every emitted hint.
-   */
-  readonly filters: ReadonlyArray<TopicRawPredicateFilterPlan>;
-  /**
-   * True when the compiler intentionally omitted part of the predicate from
-   * `filters`, for example structured fields or malformed runtime filters.
-   */
-  readonly callbackRequired: boolean;
-  /**
-   * True when the compiler proved that `filters` fully represent `matches`.
-   * Hand-written plans omit this and stay guarded by the row callback.
-   */
-  readonly callbackSkippable?: boolean;
-};
-
-export type TopicRawWindowScanPlan<Row extends RowObject> = {
-  readonly predicate: TopicRawPredicatePlan;
-  readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
-  /**
-   * Compiler-proven ordering hint for storage pushdown. `compare` remains the
-   * source of truth for custom scan plans unless this hint is present.
-   */
-  readonly storageOrderBy?: ReadonlyArray<TopicRawOrderByPlan>;
-  readonly matches: (row: Row) => boolean;
-  readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
-  readonly offset: number;
-  readonly limit: number | undefined;
-};
-
-export type TopicRawWindowScanResult<Row extends RowObject> = {
-  readonly keys: ReadonlyArray<string>;
-  readonly window: ReadonlyArray<TopicRowEntry<Row>>;
-  readonly totalRows: number;
-};
-
 export type TopicRowScan<Row extends RowObject> = {
   readonly changesSince: (version: number) => ReadonlyArray<TopicRowChangeBatch<Row>> | undefined;
   readonly scanRows: (visitor: TopicRowVisitor<Row>) => void;
   readonly version: () => number;
-};
-
-export type TopicRawWindowScan<Row extends RowObject> = {
-  readonly scanRawWindow: (plan: TopicRawWindowScanPlan<Row>) => TopicRawWindowScanResult<Row>;
 };

--- a/packages/column-live-view-engine/src/topic-ordered-window.ts
+++ b/packages/column-live-view-engine/src/topic-ordered-window.ts
@@ -1,4 +1,4 @@
-import type { TopicRawOrderByPlan, TopicRawPredicateFilterPlan } from "./row-scan";
+import type { TopicRawOrderByPlan, TopicRawPredicateFilterPlan } from "./raw-window-scan";
 import {
   compareQueryValue,
   isRangePlanValue,

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-filter.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-filter.ts
@@ -1,4 +1,4 @@
-import type { TopicRawPredicateFilterPlan } from "./row-scan";
+import type { TopicRawPredicateFilterPlan } from "./raw-window-scan";
 import { scalarEqualityKey } from "./row-values";
 import {
   compareExactRangeColumnValue,


### PR DESCRIPTION
## Summary\n\n- Move raw predicate/order/window scan plan contracts into a focused raw-window-scan Module.\n- Keep row-scan focused on row entries, row visitors, and row change batches.\n- Update engine/storage/query modules to import the raw scan contract directly.\n\n## Validation\n\n- vp check --fix\n- pnpm --filter @view-server/column-live-view-engine run test\n- pnpm run check:effect\n- git diff --check\n- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId\n- pnpm run ready\n\n## Review\n\n- 3 local reviewer agents: no findings after staging the new Module.\n