### PR TITLE
Extract topic row preparation

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -45,19 +45,20 @@ import {
   rawQueryCompilerMetadata,
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
-import { cloneRow, fieldValue, isPlainRecord, scalarEqualityKey, valuesEqual } from "./row-values";
+import { fieldValue, scalarEqualityKey, valuesEqual } from "./row-values";
 import { TopicRowChangeJournal } from "./topic-row-change-journal";
+import {
+  prepareTopicPatch,
+  prepareTopicRow,
+  type InvalidRowErrorFactory,
+  type PreparedTopicRow,
+  type TopicRowPreparationContext,
+} from "./topic-row-preparation";
 
 type RowObject = object;
 
-type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
 type ColumnValues = Array<unknown>;
 const maxBoundedRawWindowEnd = 1_024;
-
-export type PreparedTopicRow = {
-  readonly key: string;
-  readonly row: object;
-};
 
 export class ColumnarTopicStore {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
@@ -68,14 +69,21 @@ export class ColumnarTopicStore {
   private readonly columns = new Map<string, ColumnValues>();
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
   private readonly rowChangeJournal = new TopicRowChangeJournal<object>();
+  private readonly rowPreparation: TopicRowPreparationContext;
   private versionValue = 0;
 
   constructor(
     readonly topic: string,
-    private readonly schema: Schema.Decoder<object>,
-    private readonly keyField: string,
+    schema: Schema.Decoder<object>,
+    keyField: string,
   ) {
     this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
+    this.rowPreparation = {
+      fieldNames: this.rawQueryMetadata.fieldNames,
+      keyField,
+      schema,
+      topic,
+    };
     for (const field of this.rawQueryMetadata.fieldNames) {
       this.columns.set(field, []);
     }
@@ -540,12 +548,7 @@ export class ColumnarTopicStore {
     Error,
     Row extends RowObject,
   >(this: ColumnarTopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
-    const decoded = yield* this.decodeRow(row, invalidRow);
-    const key = yield* this.rowKey(decoded, invalidRow);
-    return {
-      key,
-      row: decoded,
-    } satisfies PreparedTopicRow;
+    return yield* prepareTopicRow(this.rowPreparation, row, invalidRow);
   });
 
   prepareRows = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.rows.prepare")(function* <
@@ -564,65 +567,13 @@ export class ColumnarTopicStore {
     patch: Patch,
     invalidRow: InvalidRowErrorFactory<Error>,
   ) {
-    yield* this.validatePatchKeys(patch, invalidRow);
-    const current = this.rowForKey(key);
-    if (current === undefined) {
-      return yield* Effect.fail(invalidRow(this.topic, `Cannot patch missing key: ${key}`));
-    }
-    const decoded = yield* this.decodeRow({ ...current, ...patch }, invalidRow);
-    const decodedKey = yield* this.rowKey(decoded, invalidRow);
-    if (decodedKey !== key) {
-      return yield* Effect.fail(invalidRow(this.topic, "Patch must not change the row key."));
-    }
-    return {
+    return yield* prepareTopicPatch(
+      this.rowPreparation,
       key,
-      row: decoded,
-    } satisfies PreparedTopicRow;
-  });
-
-  private decodeRow = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.decode")(function* <
-    Error,
-  >(this: ColumnarTopicStore, row: RowObject, invalidRow: InvalidRowErrorFactory<Error>) {
-    return yield* Effect.try({
-      try: () => {
-        const decoded = Schema.decodeUnknownSync(this.schema)(row);
-        return cloneRow(decoded);
-      },
-      catch: (cause) => invalidRow(this.topic, String(cause)),
-    });
-  });
-
-  private rowKey = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.key")(function* <Error>(
-    this: ColumnarTopicStore,
-    row: RowObject,
-    invalidRow: InvalidRowErrorFactory<Error>,
-  ) {
-    const key = fieldValue(row, this.keyField);
-    if (typeof key !== "string") {
-      return yield* Effect.fail(
-        invalidRow(this.topic, `Key field ${this.keyField} must decode to a string.`),
-      );
-    }
-    return key;
-  });
-
-  private validatePatchKeys = Effect.fn(
-    "ColumnLiveViewEngine.columnarTopicStore.patchKeys.validate",
-  )(function* <Error>(
-    this: ColumnarTopicStore,
-    patch: unknown,
-    invalidRow: InvalidRowErrorFactory<Error>,
-  ) {
-    if (!isPlainRecord(patch)) {
-      return yield* Effect.fail(invalidRow(this.topic, "Patch must be a plain object."));
-    }
-    for (const key of Reflect.ownKeys(patch)) {
-      if (typeof key !== "string" || !this.rawQueryMetadata.fieldNames.has(key)) {
-        return yield* Effect.fail(
-          invalidRow(this.topic, `Patch contains unknown field: ${String(key)}.`),
-        );
-      }
-    }
+      this.rowForKey(key),
+      patch,
+      invalidRow,
+    );
   });
 
   private writeSlot(slot: number, prepared: PreparedTopicRow): void {

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -1,0 +1,101 @@
+import { Effect, Schema } from "effect";
+import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
+
+type RowObject = object;
+
+export type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
+
+export type PreparedTopicRow = {
+  readonly key: string;
+  readonly row: object;
+};
+
+export type TopicRowPreparationContext = {
+  readonly fieldNames: ReadonlySet<string>;
+  readonly keyField: string;
+  readonly schema: Schema.Decoder<object>;
+  readonly topic: string;
+};
+
+const decodeTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decode")(function* <Error>(
+  context: TopicRowPreparationContext,
+  row: RowObject,
+  invalidRow: InvalidRowErrorFactory<Error>,
+) {
+  return yield* Effect.try({
+    try: () => {
+      const decoded = Schema.decodeUnknownSync(context.schema)(row);
+      return cloneRow(decoded);
+    },
+    catch: (cause) => invalidRow(context.topic, String(cause)),
+  });
+});
+
+const topicRowKey = Effect.fn("ColumnLiveViewEngine.topicRow.key")(function* <Error>(
+  context: TopicRowPreparationContext,
+  row: RowObject,
+  invalidRow: InvalidRowErrorFactory<Error>,
+) {
+  const key = fieldValue(row, context.keyField);
+  if (typeof key !== "string") {
+    return yield* Effect.fail(
+      invalidRow(context.topic, `Key field ${context.keyField} must decode to a string.`),
+    );
+  }
+  return key;
+});
+
+const validateTopicPatchKeys = Effect.fn("ColumnLiveViewEngine.topicRow.patchKeys.validate")(
+  function* <Error>(
+    context: TopicRowPreparationContext,
+    patch: unknown,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) {
+    if (!isPlainRecord(patch)) {
+      return yield* Effect.fail(invalidRow(context.topic, "Patch must be a plain object."));
+    }
+    for (const key of Reflect.ownKeys(patch)) {
+      if (typeof key !== "string" || !context.fieldNames.has(key)) {
+        return yield* Effect.fail(
+          invalidRow(context.topic, `Patch contains unknown field: ${String(key)}.`),
+        );
+      }
+    }
+  },
+);
+
+export const prepareTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.prepare")(function* <
+  Error,
+  Row extends RowObject,
+>(context: TopicRowPreparationContext, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
+  const decoded = yield* decodeTopicRow(context, row, invalidRow);
+  const key = yield* topicRowKey(context, decoded, invalidRow);
+  return {
+    key,
+    row: decoded,
+  } satisfies PreparedTopicRow;
+});
+
+export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.prepare")(
+  function* <Patch extends Partial<RowObject>, Error>(
+    context: TopicRowPreparationContext,
+    key: string,
+    current: RowObject | undefined,
+    patch: Patch,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) {
+    yield* validateTopicPatchKeys(context, patch, invalidRow);
+    if (current === undefined) {
+      return yield* Effect.fail(invalidRow(context.topic, `Cannot patch missing key: ${key}`));
+    }
+    const decoded = yield* decodeTopicRow(context, { ...current, ...patch }, invalidRow);
+    const decodedKey = yield* topicRowKey(context, decoded, invalidRow);
+    if (decodedKey !== key) {
+      return yield* Effect.fail(invalidRow(context.topic, "Patch must not change the row key."));
+    }
+    return {
+      key,
+      row: decoded,
+    } satisfies PreparedTopicRow;
+  },
+);

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -1,11 +1,11 @@
 import { Clock, Effect, Semaphore } from "effect";
-import type { ColumnarTopicStore, PreparedTopicRow } from "./columnar-topic-store";
+import type { ColumnarTopicStore } from "./columnar-topic-store";
+import type { InvalidRowErrorFactory, PreparedTopicRow } from "./topic-row-preparation";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 import type { TopicStore } from "./topic-store";
 
 type RowObject = object;
-type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
 
 export type TopicStoreMutationState = {
   readonly storage: ColumnarTopicStore;

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -30,6 +30,7 @@ import {
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
 import type { QueryEvaluation } from "./query-result";
+import type { InvalidRowErrorFactory } from "./topic-row-preparation";
 import {
   acquireSubscriptionHandoff,
   type MarkAcquiredSubscription,
@@ -39,7 +40,6 @@ import type { LiveTopicSubscriber } from "./topic-subscriber";
 
 type RowObject = object;
 
-type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
 const topicStoreSubscriptionPermitBrand: unique symbol = Symbol("TopicStoreSubscriptionPermit");
 
 export type TopicStoreSubscriptionPermit = {


### PR DESCRIPTION
## Summary\n\n- Move row decode, row-key validation, patch-key validation, and prepared-row contract into a focused topic-row-preparation Module.\n- Keep ColumnarTopicStore focused on storage/index/journal behavior while delegating row preparation at the mutation boundary.\n- Preserve bulk prepareRows per-row ColumnarTopicStore span continuity by keeping bulk orchestration in the store.\n\n## Validation\n\n- vp check --fix\n- pnpm --filter @view-server/column-live-view-engine run test\n- pnpm run check:effect\n- git diff --check\n- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId\n- pnpm run ready\n\n## Review\n\n- 3 local reviewer agents, then second pass after preserving bulk row-preparation span continuity: no findings.\n