### PR TITLE
Extract topic slot predicate matching

### DIFF
--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -8,16 +8,9 @@ import type {
 } from "./row-scan";
 import type {
   TopicRawOrderByPlan,
-  TopicRawPredicateFilterPlan,
   TopicRawWindowScanPlan,
   TopicRawWindowScanResult,
 } from "./raw-window-scan";
-import {
-  columnValueDoesNotEqual,
-  compareExactRangeColumnValue,
-  compareRangeColumnValue,
-  isComparableRangeValue,
-} from "./topic-range-value";
 import {
   selectedPredicateCandidateFilter,
   type PredicateCandidateFilter,
@@ -45,7 +38,7 @@ import {
   rawQueryCompilerMetadata,
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
-import { fieldValue, scalarEqualityKey, valuesEqual } from "./row-values";
+import { fieldValue } from "./row-values";
 import { TopicRowChangeJournal } from "./topic-row-change-journal";
 import {
   prepareTopicPatch,
@@ -54,6 +47,7 @@ import {
   type PreparedTopicRow,
   type TopicRowPreparationContext,
 } from "./topic-row-preparation";
+import { slotMatchesRawPredicatePlan } from "./topic-slot-predicate";
 
 type RowObject = object;
 
@@ -246,7 +240,7 @@ export class ColumnarTopicStore {
           continue;
         }
         const entry = this.slots[slot]!;
-        if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+        if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, this.columns)) {
           continue;
         }
         const matchIndex = totalRows;
@@ -284,7 +278,7 @@ export class ColumnarTopicStore {
         continue;
       }
       const entry = this.slots[slot]!;
-      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+      if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, this.columns)) {
         continue;
       }
       totalRows += 1;
@@ -318,7 +312,7 @@ export class ColumnarTopicStore {
         continue;
       }
       const entry = this.slots[slot]!;
-      if (!this.slotMatchesPredicatePlan(slot, plan, entry.row)) {
+      if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, this.columns)) {
         continue;
       }
       totalRows += 1;
@@ -636,101 +630,6 @@ export class ColumnarTopicStore {
       return undefined;
     }
     return this.slots[slot]!.row;
-  }
-
-  private slotMatchesPredicatePlan(
-    slot: number,
-    plan: TopicRawWindowScanPlan<object>,
-    row: object,
-  ): boolean {
-    const exact = plan.predicate.callbackSkippable === true;
-    if (!this.slotMayMatchFilters(slot, plan.predicate.filters, exact)) {
-      return false;
-    }
-    return exact || plan.matches(row);
-  }
-
-  private slotMayMatchFilters(
-    slot: number,
-    filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
-    exact: boolean,
-  ): boolean {
-    for (const filter of filters) {
-      if (!this.slotMayMatchFilter(slot, filter, exact)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private slotMayMatchFilter(
-    slot: number,
-    filter: TopicRawPredicateFilterPlan,
-    exact: boolean,
-  ): boolean {
-    const column = this.columns.get(filter.field);
-    if (column === undefined) {
-      return true;
-    }
-    const value = column[slot];
-
-    if (filter.operator === "eq") {
-      return valuesEqual(value, filter.value);
-    }
-    if (filter.operator === "neq") {
-      if (exact) {
-        return columnValueDoesNotEqual(value, filter.value);
-      }
-      return !valuesEqual(value, filter.value);
-    }
-    if (filter.operator === "in") {
-      if (filter.valueKeys !== undefined) {
-        const key = scalarEqualityKey(value);
-        return key !== undefined && filter.valueKeys.has(key);
-      }
-      return filter.values.some((candidate) => valuesEqual(value, candidate));
-    }
-    if (filter.operator === "startsWith") {
-      if (typeof filter.value !== "string") {
-        return true;
-      }
-      return typeof value === "string" && value.startsWith(filter.value);
-    }
-
-    if (exact && !isComparableRangeValue(filter.value)) {
-      return true;
-    }
-    if (exact) {
-      const exactComparison = compareExactRangeColumnValue(value, filter.value);
-      if (exactComparison === undefined) {
-        return false;
-      }
-      if (filter.operator === "gt") {
-        return exactComparison > 0;
-      }
-      if (filter.operator === "gte") {
-        return exactComparison >= 0;
-      }
-      if (filter.operator === "lt") {
-        return exactComparison < 0;
-      }
-      return exactComparison <= 0;
-    }
-
-    const comparison = compareRangeColumnValue(value, filter.value);
-    if (comparison === undefined) {
-      return true;
-    }
-    if (filter.operator === "gt") {
-      return comparison > 0;
-    }
-    if (filter.operator === "gte") {
-      return comparison >= 0;
-    }
-    if (filter.operator === "lt") {
-      return comparison < 0;
-    }
-    return comparison <= 0;
   }
 }
 

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -1,0 +1,109 @@
+import type { TopicRawPredicateFilterPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
+import { scalarEqualityKey, valuesEqual } from "./row-values";
+import {
+  columnValueDoesNotEqual,
+  compareExactRangeColumnValue,
+  compareRangeColumnValue,
+  isComparableRangeValue,
+} from "./topic-range-value";
+
+type RowObject = object;
+type ColumnValues = ReadonlyArray<unknown>;
+
+export const slotMatchesRawPredicatePlan = <Row extends RowObject>(
+  slot: number,
+  plan: TopicRawWindowScanPlan<Row>,
+  row: Row,
+  columns: ReadonlyMap<string, ColumnValues>,
+): boolean => {
+  const exact = plan.predicate.callbackSkippable === true;
+  if (!slotMayMatchFilters(slot, plan.predicate.filters, columns, exact)) {
+    return false;
+  }
+  return exact || plan.matches(row);
+};
+
+const slotMayMatchFilters = (
+  slot: number,
+  filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
+  columns: ReadonlyMap<string, ColumnValues>,
+  exact: boolean,
+): boolean => {
+  for (const filter of filters) {
+    if (!slotMayMatchFilter(slot, filter, columns, exact)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const slotMayMatchFilter = (
+  slot: number,
+  filter: TopicRawPredicateFilterPlan,
+  columns: ReadonlyMap<string, ColumnValues>,
+  exact: boolean,
+): boolean => {
+  const column = columns.get(filter.field);
+  if (column === undefined) {
+    return true;
+  }
+  const value = column[slot];
+
+  if (filter.operator === "eq") {
+    return valuesEqual(value, filter.value);
+  }
+  if (filter.operator === "neq") {
+    if (exact) {
+      return columnValueDoesNotEqual(value, filter.value);
+    }
+    return !valuesEqual(value, filter.value);
+  }
+  if (filter.operator === "in") {
+    if (filter.valueKeys !== undefined) {
+      const key = scalarEqualityKey(value);
+      return key !== undefined && filter.valueKeys.has(key);
+    }
+    return filter.values.some((candidate) => valuesEqual(value, candidate));
+  }
+  if (filter.operator === "startsWith") {
+    if (typeof filter.value !== "string") {
+      return true;
+    }
+    return typeof value === "string" && value.startsWith(filter.value);
+  }
+
+  if (exact && !isComparableRangeValue(filter.value)) {
+    return true;
+  }
+  if (exact) {
+    const exactComparison = compareExactRangeColumnValue(value, filter.value);
+    if (exactComparison === undefined) {
+      return false;
+    }
+    if (filter.operator === "gt") {
+      return exactComparison > 0;
+    }
+    if (filter.operator === "gte") {
+      return exactComparison >= 0;
+    }
+    if (filter.operator === "lt") {
+      return exactComparison < 0;
+    }
+    return exactComparison <= 0;
+  }
+
+  const comparison = compareRangeColumnValue(value, filter.value);
+  if (comparison === undefined) {
+    return true;
+  }
+  if (filter.operator === "gt") {
+    return comparison > 0;
+  }
+  if (filter.operator === "gte") {
+    return comparison >= 0;
+  }
+  if (filter.operator === "lt") {
+    return comparison < 0;
+  }
+  return comparison <= 0;
+};


### PR DESCRIPTION
## Summary

- Move slot-level raw predicate filtering from ColumnarTopicStore into a focused topic-slot-predicate Module.
- Keep ColumnarTopicStore focused on slot/index/journal behavior while predicate pushdown has a dedicated implementation seam.
- Preserve exact/callback predicate semantics by passing slot, plan, row, and column map unchanged.

## Validation

- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- git diff --check
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- pnpm run ready

## Review

- 3 local reviewer agents: no findings.
