### PR TITLE
Extract topic store health module

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-health.ts
+++ b/packages/column-live-view-engine/src/topic-store-health.ts
@@ -1,0 +1,70 @@
+import { Clock, Effect } from "effect";
+import type { TopicRuntimeHealth } from "@view-server/config";
+import type { createTopicHealthLedger } from "./topic-health-ledger";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
+
+export type TopicStoreHealthView = {
+  readonly topic: string;
+  readonly status: "ready" | "degraded";
+  readonly rowCount: number;
+  readonly liveRowCount: number;
+  readonly deletedRowCount: number;
+  readonly version: number;
+  readonly lastMutationAt: number | null;
+  readonly mutationsPerSecond: number;
+  readonly rowsPerSecond: number;
+  readonly pendingMutationBatches: number;
+  readonly activeViews: number;
+  readonly activeSubscriptions: number;
+  readonly queuedEvents: number;
+  readonly maxQueueDepth: number;
+  readonly backpressureEvents: number;
+  readonly memoryBytes: number;
+  readonly tombstoneCount: number;
+  readonly compactionPending: boolean;
+};
+
+export type TopicStoreHealthState = {
+  readonly activeViews: number;
+  readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
+  readonly subscribers: ReadonlySet<LiveTopicSubscriber>;
+  readonly topic: string;
+};
+
+export const collectTopicStoreHealthView = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.healthView.collect",
+)(function* (state: TopicStoreHealthState, closed: boolean) {
+  const totals = state.healthLedger.snapshot(yield* Clock.currentTimeMillis);
+  let queuedEvents = 0;
+
+  for (const subscriber of state.subscribers) {
+    const currentQueuedEvents = yield* subscriber.queuedEvents;
+    queuedEvents += currentQueuedEvents;
+  }
+
+  const activeSubscriptions = state.subscribers.size;
+  const status: TopicRuntimeHealth["status"] = closed ? "degraded" : "ready";
+  const lastMutationAt = totals.lastMutationAt;
+  const rowsPerSecond = totals.rowsPerSecond;
+  const health: TopicStoreHealthView = {
+    topic: state.topic,
+    status,
+    rowCount: totals.rowCount,
+    liveRowCount: totals.rowCount,
+    deletedRowCount: 0,
+    version: totals.version,
+    lastMutationAt,
+    mutationsPerSecond: totals.mutationsPerSecond,
+    rowsPerSecond,
+    pendingMutationBatches: totals.pendingMutationBatches,
+    activeViews: state.activeViews,
+    activeSubscriptions,
+    queuedEvents,
+    maxQueueDepth: totals.maxQueueDepth,
+    backpressureEvents: totals.backpressureEvents,
+    memoryBytes: 0,
+    tombstoneCount: 0,
+    compactionPending: false,
+  };
+  return health;
+});

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,5 +1,5 @@
-import { Clock, Effect, Schema, Semaphore } from "effect";
-import type { StatusEvent, TopicRuntimeHealth } from "@view-server/config";
+import { Effect, Schema, Semaphore } from "effect";
+import type { StatusEvent } from "@view-server/config";
 import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
@@ -37,6 +37,7 @@ import {
   type SubscriptionHandoffOptions,
 } from "./subscription-handoff";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
+import { collectTopicStoreHealthView, type TopicStoreHealthState } from "./topic-store-health";
 
 type RowObject = object;
 
@@ -45,27 +46,6 @@ const topicStoreSubscriptionPermitBrand: unique symbol = Symbol("TopicStoreSubsc
 export type TopicStoreSubscriptionPermit = {
   readonly [topicStoreSubscriptionPermitBrand]: true;
   readonly store: TopicStore;
-};
-
-export type TopicStoreHealthView = {
-  readonly topic: string;
-  readonly status: "ready" | "degraded";
-  readonly rowCount: number;
-  readonly liveRowCount: number;
-  readonly deletedRowCount: number;
-  readonly version: number;
-  readonly lastMutationAt: number | null;
-  readonly mutationsPerSecond: number;
-  readonly rowsPerSecond: number;
-  readonly pendingMutationBatches: number;
-  readonly activeViews: number;
-  readonly activeSubscriptions: number;
-  readonly queuedEvents: number;
-  readonly maxQueueDepth: number;
-  readonly backpressureEvents: number;
-  readonly memoryBytes: number;
-  readonly tombstoneCount: number;
-  readonly compactionPending: boolean;
 };
 
 type TopicStoreState = TopicStoreMutationState;
@@ -173,6 +153,16 @@ export const releaseTopicStoreMaterializedQueryExecution = <ResultRow extends Ro
 ): Effect.Effect<void> =>
   releaseMaterializedQueryExecution(topicStoreState(store).storage.readModel, compiled.cacheKey);
 
+const topicStoreHealthState = (store: TopicStore, activeViews: number): TopicStoreHealthState => {
+  const state = topicStoreState(store);
+  return {
+    activeViews,
+    healthLedger: state.healthLedger,
+    subscribers: state.subscribers,
+    topic: store.topic,
+  };
+};
+
 export function acquireTopicStoreSubscription<
   Subscription extends { readonly close: () => Effect.Effect<void, never> },
   Error,
@@ -224,41 +214,8 @@ const engineClosedStatusEvent = (
 
 export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
   function* (store: TopicStore, closed: boolean) {
-    const state = topicStoreState(store);
-    const totals = state.healthLedger.snapshot(yield* Clock.currentTimeMillis);
-    let queuedEvents = 0;
-
-    for (const subscriber of state.subscribers) {
-      const currentQueuedEvents = yield* subscriber.queuedEvents;
-      queuedEvents += currentQueuedEvents;
-    }
-
-    const activeSubscriptions = state.subscribers.size;
     const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
-    const status: TopicRuntimeHealth["status"] = closed ? "degraded" : "ready";
-    const lastMutationAt = totals.lastMutationAt;
-    const rowsPerSecond = totals.rowsPerSecond;
-    const health: TopicStoreHealthView = {
-      topic: store.topic,
-      status,
-      rowCount: totals.rowCount,
-      liveRowCount: totals.rowCount,
-      deletedRowCount: 0,
-      version: totals.version,
-      lastMutationAt,
-      mutationsPerSecond: totals.mutationsPerSecond,
-      rowsPerSecond,
-      pendingMutationBatches: totals.pendingMutationBatches,
-      activeViews,
-      activeSubscriptions,
-      queuedEvents,
-      maxQueueDepth: totals.maxQueueDepth,
-      backpressureEvents: totals.backpressureEvents,
-      memoryBytes: 0,
-      tombstoneCount: 0,
-      compactionPending: false,
-    };
-    return health;
+    return yield* collectTopicStoreHealthView(topicStoreHealthState(store, activeViews), closed);
   },
 );
 


### PR DESCRIPTION
## Summary

- Move topic store health view construction into a focused topic-store-health Module.
- Keep TopicStore as the state owner with a narrow store-based wrapper.
- Preserve existing health semantics while improving Locality before runtime/Kafka health grows.

## Validation

- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- pnpm run ready

## Review

- 3 local reviewer agents: no findings.
