### PR TITLE
Extract active raw query execution

### DIFF
--- a/packages/column-live-view-engine/src/active-materialized-query.ts
+++ b/packages/column-live-view-engine/src/active-materialized-query.ts
@@ -130,3 +130,7 @@ export const clearMaterializedQueryExecutions = Effect.fn(
     map.clear();
   }),
 );
+
+export const activeMaterializedQueryExecutionCount = Effect.fn(
+  "ColumnLiveViewEngine.activeQuery.materialized.countStore",
+)((store: ActiveQueryStoreState) => Effect.sync(() => getActiveMaterializedQueryMap(store).size));

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -1,16 +1,23 @@
 import { Effect, Option } from "effect";
 import type { DeltaEvent, SnapshotEvent } from "@view-server/config";
-import {
-  stableQueryValueString,
-  type CompiledRawQuery,
-  type RuntimeRawQuery,
-} from "./raw-query-compiler";
-import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
-import type { TopicRawWindowScan, TopicRawWindowScanResult } from "./raw-window-scan";
+import type { TopicRawWindowScan } from "./raw-window-scan";
 import type { TopicRowScan } from "./row-scan";
+import {
+  activeRawQueryExecutionCount,
+  clearRawQueryExecutions,
+  type RawQueryExecutionSlot,
+} from "./active-raw-query";
 import type { MaterializedQueryExecutionSlot } from "./active-materialized-query";
-import { clearMaterializedQueryExecutions } from "./active-materialized-query";
+import {
+  activeMaterializedQueryExecutionCount,
+  clearMaterializedQueryExecutions,
+} from "./active-materialized-query";
+export {
+  acquireRawQueryExecution,
+  evaluateRawQuery,
+  releaseRawQueryExecution,
+} from "./active-raw-query";
 export {
   acquireMaterializedQueryExecution,
   releaseMaterializedQueryExecution,
@@ -48,25 +55,6 @@ export type LiveQueryExecution<ResultRow extends RowObject> = {
 
 export type RawQueryExecution<ResultRow extends RowObject> = LiveQueryExecution<ResultRow>;
 
-type ActiveQueryBaseExecution = {
-  readonly latest: () => ActiveQueryBaseEvaluation<object>;
-};
-
-type RawQueryExecutionSlot = {
-  readonly execution: ActiveQueryBaseExecution;
-  readonly windows: Map<string, RawQueryExecutionWindowSlot>;
-  refs: number;
-};
-
-type RawQueryExecutionWindowSlot = {
-  readonly window: CompiledRawQuery<object, object>["window"];
-  refs: number;
-};
-
-type ActiveQueryBaseEvaluation<Row extends RowObject> = TopicRawWindowScanResult<Row> & {
-  readonly version: number;
-};
-
 export type ActiveQueryRegistry = {
   readonly raw: Map<string, RawQueryExecutionSlot>;
   readonly materialized: Map<string, MaterializedQueryExecutionSlot>;
@@ -77,287 +65,12 @@ export const createActiveQueryRegistry = (): ActiveQueryRegistry => ({
   materialized: new Map(),
 });
 
-type QueryCacheToken = readonly ["raw", string, string];
-type QueryWindowCacheToken = readonly ["window", string, string];
-
-const queryCacheKey = (query: RuntimeRawQuery): string => {
-  const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
-    query.orderBy === undefined ? [] : query.orderBy.map((entry) => [entry.field, entry.direction]);
-  const token: QueryCacheToken = [
-    "raw",
-    query.where === undefined ? "" : stableQueryValueString(query.where),
-    stableQueryValueString(orderBy),
-  ];
-  return JSON.stringify(token);
-};
-
-const queryWindowCacheKey = (window: CompiledRawQuery<object, object>["window"]): string => {
-  const token: QueryWindowCacheToken = [
-    "window",
-    stableQueryValueString(window.offset),
-    stableQueryValueString(window.limit ?? null),
-  ];
-  return JSON.stringify(token);
-};
-
-const getActiveQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryExecutionSlot> => {
-  return store.activeQueries.raw;
-};
-
-const getActiveQueryEntry = <ResultRow extends RowObject>(
-  store: ActiveQueryStoreState,
-  compiled: CompiledRawQuery<object, ResultRow>,
-): {
-  map: Map<string, RawQueryExecutionSlot>;
-  key: string;
-} => {
-  const key = queryCacheKey(compiled.query);
-  const map = getActiveQueryMap(store);
-  return { map, key };
-};
-
-const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: TopicRawWindowScan<Row> & { readonly version: () => number },
-  compiled: CompiledRawQuery<Row, ResultRow>,
-  queryWindow: CompiledRawQuery<Row, ResultRow>["window"] = compiled.window,
-): ActiveQueryBaseEvaluation<Row> => {
-  const version = store.version();
-  const scanResult = store.scanRawWindow({
-    predicate: compiled.predicate.plan,
-    orderBy: compiled.ordering.plan,
-    storageOrderBy: compiled.ordering.plan,
-    matches: compiled.predicate.matches,
-    compare: compiled.ordering.compare,
-    offset: queryWindow.offset,
-    limit: queryWindow.limit,
-  });
-  return {
-    ...scanResult,
-    version,
-  };
-};
-
-const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
-  compiled: CompiledRawQuery<Row, ResultRow>,
-  evaluation: ActiveQueryBaseEvaluation<Row>,
-): QueryEvaluation<ResultRow> => {
-  const window = evaluation.window.map((entry) => ({
-    key: entry.key,
-    row: compiled.projection.project(entry.row),
-  }));
-
-  return {
-    rows: window.map((entry) => entry.row),
-    keys: evaluation.keys,
-    window,
-    totalRows: evaluation.totalRows,
-    version: evaluation.version,
-  };
-};
-
-const projectWindowEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
-  compiled: CompiledRawQuery<Row, ResultRow>,
-  evaluation: ActiveQueryBaseEvaluation<Row>,
-): QueryEvaluation<ResultRow> => {
-  const end =
-    compiled.window.limit === undefined
-      ? undefined
-      : compiled.window.offset + compiled.window.limit;
-  const sourceWindow = evaluation.window.slice(compiled.window.offset, end);
-  const window = sourceWindow.map((entry) => ({
-    key: entry.key,
-    row: compiled.projection.project(entry.row),
-  }));
-
-  return {
-    rows: window.map((entry) => entry.row),
-    keys: window.map((entry) => entry.key),
-    window,
-    totalRows: evaluation.totalRows,
-    version: evaluation.version,
-  };
-};
-
-export const evaluateRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
-  store: TopicRawWindowScan<Row> & { readonly version: () => number },
-  compiled: CompiledRawQuery<Row, ResultRow>,
-): QueryEvaluation<ResultRow> =>
-  projectBaseEvaluation(compiled, evaluateBaseQuery(store, compiled));
-
-const leaseRawQueryExecution = <ResultRow extends RowObject>(
-  store: ActiveQueryStoreState,
-  execution: ActiveQueryBaseExecution,
-  compiled: CompiledRawQuery<object, ResultRow>,
-): RawQueryExecution<ResultRow> => {
-  const latestEvaluation = () => projectWindowEvaluation(compiled, execution.latest());
-
-  return {
-    initial: (queryId) => snapshotEvent(store, queryId, latestEvaluation()),
-    createCursor: () => ({
-      evaluation: latestEvaluation(),
-    }),
-    next: (queryId, cursor) =>
-      Effect.sync(() => {
-        const previous = cursor.evaluation;
-        const next = latestEvaluation();
-        const operations = deltaOperations(previous, next);
-        if (operations.length === 0 && previous.totalRows === next.totalRows) {
-          return Option.none();
-        }
-        cursor.evaluation = next;
-        return Option.some(deltaEvent(store, queryId, previous.version, next, operations));
-      }),
-  };
-};
-
-const baseWindowForActiveWindows = (
-  windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
-): CompiledRawQuery<object, object>["window"] => {
-  let limit = 0;
-  for (const { window } of windows.values()) {
-    if (window.limit === undefined) {
-      return {
-        offset: 0,
-        limit: undefined,
-      };
-    }
-    const windowEnd = window.limit === 0 ? 0 : window.offset + window.limit;
-    limit = Math.max(limit, windowEnd);
-  }
-  return {
-    offset: 0,
-    limit,
-  };
-};
-
-const acquireRawQueryWindow = (
-  windows: Map<string, RawQueryExecutionWindowSlot>,
-  window: CompiledRawQuery<object, object>["window"],
-): void => {
-  const key = queryWindowCacheKey(window);
-  const existing = windows.get(key);
-  if (existing !== undefined) {
-    existing.refs += 1;
-    return;
-  }
-  windows.set(key, {
-    window,
-    refs: 1,
-  });
-};
-
-const releaseRawQueryWindow = (
-  windows: Map<string, RawQueryExecutionWindowSlot>,
-  window: CompiledRawQuery<object, object>["window"],
-): boolean => {
-  const key = queryWindowCacheKey(window);
-  const existing = windows.get(key);
-  if (existing === undefined) {
-    return false;
-  }
-  if (existing.refs > 1) {
-    existing.refs -= 1;
-    return true;
-  }
-  windows.delete(key);
-  return true;
-};
-
-export const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.make")(
-  (
-    store: ActiveQueryStoreState,
-    canonicalCompiled: CompiledRawQuery<object, object>,
-    windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
-  ) =>
-    Effect.sync(() => {
-      let baseWindow = baseWindowForActiveWindows(windows);
-      let snapshot = {
-        evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
-        version: store.version(),
-      };
-
-      const latest = () => {
-        const storeVersion = store.version();
-        const nextBaseWindow = baseWindowForActiveWindows(windows);
-        if (
-          snapshot.version !== storeVersion ||
-          nextBaseWindow.offset !== baseWindow.offset ||
-          nextBaseWindow.limit !== baseWindow.limit
-        ) {
-          baseWindow = nextBaseWindow;
-          snapshot = {
-            evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
-            version: storeVersion,
-          };
-        }
-        return snapshot.evaluation;
-      };
-
-      return {
-        latest,
-      };
-    }),
-);
-
-export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.acquire")(
-  function* <ResultRow extends RowObject>(
-    store: ActiveQueryStoreState,
-    compiled: CompiledRawQuery<object, ResultRow>,
-  ) {
-    const { map, key } = getActiveQueryEntry(store, compiled);
-    const existing = map.get(key);
-    if (existing !== undefined) {
-      const entry = existing;
-      entry.refs += 1;
-      acquireRawQueryWindow(entry.windows, compiled.window);
-      return leaseRawQueryExecution(store, entry.execution, compiled);
-    }
-
-    const windows = new Map<string, RawQueryExecutionWindowSlot>();
-    acquireRawQueryWindow(windows, compiled.window);
-    const execution = yield* makeRawQueryExecution(store, compiled, windows);
-    map.set(key, {
-      execution,
-      windows,
-      refs: 1,
-    });
-    return leaseRawQueryExecution(store, execution, compiled);
-  },
-);
-
-export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.release")(
-  <ResultRow extends RowObject>(
-    store: ActiveQueryStoreState,
-    compiled: CompiledRawQuery<object, ResultRow>,
-  ) =>
-    Effect.sync(() => {
-      const { map, key } = getActiveQueryEntry(store, compiled);
-      const existing = map.get(key);
-      if (existing === undefined) {
-        return undefined;
-      }
-      const entry = existing;
-      if (!releaseRawQueryWindow(entry.windows, compiled.window)) {
-        return undefined;
-      }
-      if (entry.refs > 1) {
-        entry.refs -= 1;
-        entry.execution.latest();
-        return undefined;
-      }
-      map.delete(key);
-      return undefined;
-    }),
-);
-
 export const clearStoreRawQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.clearStore",
 )((store: ActiveQueryStoreState) =>
   Effect.uninterruptible(
     Effect.gen(function* () {
-      yield* Effect.sync(() => {
-        store.activeQueries.raw.clear();
-      });
+      yield* clearRawQueryExecutions(store);
       yield* clearMaterializedQueryExecutions(store);
     }),
   ),
@@ -366,5 +79,9 @@ export const clearStoreRawQueryExecutions = Effect.fn(
 export const activeStoreRawQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.countStore",
 )((store: ActiveQueryStoreState) =>
-  Effect.sync(() => store.activeQueries.raw.size + store.activeQueries.materialized.size),
+  Effect.gen(function* () {
+    const rawCount = yield* activeRawQueryExecutionCount(store);
+    const materializedCount = yield* activeMaterializedQueryExecutionCount(store);
+    return rawCount + materializedCount;
+  }),
 );

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -1,0 +1,316 @@
+import { Effect, Option } from "effect";
+import type { DeltaEvent } from "@view-server/config";
+import type { ActiveQueryStoreState, RawQueryExecution } from "./active-query";
+import {
+  stableQueryValueString,
+  type CompiledRawQuery,
+  type RuntimeRawQuery,
+} from "./raw-query-compiler";
+import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
+import type { QueryEvaluation } from "./query-result";
+import type { TopicRawWindowScan, TopicRawWindowScanResult } from "./raw-window-scan";
+
+type RowObject = object;
+
+type ActiveQueryBaseExecution = {
+  readonly latest: () => ActiveQueryBaseEvaluation<object>;
+};
+
+export type RawQueryExecutionSlot = {
+  readonly execution: ActiveQueryBaseExecution;
+  readonly windows: Map<string, RawQueryExecutionWindowSlot>;
+  refs: number;
+};
+
+type RawQueryExecutionWindowSlot = {
+  readonly window: CompiledRawQuery<object, object>["window"];
+  refs: number;
+};
+
+type ActiveQueryBaseEvaluation<Row extends RowObject> = TopicRawWindowScanResult<Row> & {
+  readonly version: number;
+};
+
+type QueryCacheToken = readonly ["raw", string, string];
+type QueryWindowCacheToken = readonly ["window", string, string];
+
+const queryCacheKey = (query: RuntimeRawQuery): string => {
+  const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
+    query.orderBy === undefined ? [] : query.orderBy.map((entry) => [entry.field, entry.direction]);
+  const token: QueryCacheToken = [
+    "raw",
+    query.where === undefined ? "" : stableQueryValueString(query.where),
+    stableQueryValueString(orderBy),
+  ];
+  return JSON.stringify(token);
+};
+
+const queryWindowCacheKey = (window: CompiledRawQuery<object, object>["window"]): string => {
+  const token: QueryWindowCacheToken = [
+    "window",
+    stableQueryValueString(window.offset),
+    stableQueryValueString(window.limit ?? null),
+  ];
+  return JSON.stringify(token);
+};
+
+const getActiveRawQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryExecutionSlot> => {
+  return store.activeQueries.raw;
+};
+
+const getActiveRawQueryEntry = <ResultRow extends RowObject>(
+  store: ActiveQueryStoreState,
+  compiled: CompiledRawQuery<object, ResultRow>,
+): {
+  map: Map<string, RawQueryExecutionSlot>;
+  key: string;
+} => {
+  const key = queryCacheKey(compiled.query);
+  const map = getActiveRawQueryMap(store);
+  return { map, key };
+};
+
+const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRawWindowScan<Row> & { readonly version: () => number },
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  queryWindow: CompiledRawQuery<Row, ResultRow>["window"] = compiled.window,
+): ActiveQueryBaseEvaluation<Row> => {
+  const version = store.version();
+  const scanResult = store.scanRawWindow({
+    predicate: compiled.predicate.plan,
+    orderBy: compiled.ordering.plan,
+    storageOrderBy: compiled.ordering.plan,
+    matches: compiled.predicate.matches,
+    compare: compiled.ordering.compare,
+    offset: queryWindow.offset,
+    limit: queryWindow.limit,
+  });
+  return {
+    ...scanResult,
+    version,
+  };
+};
+
+const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  evaluation: ActiveQueryBaseEvaluation<Row>,
+): QueryEvaluation<ResultRow> => {
+  const window = evaluation.window.map((entry) => ({
+    key: entry.key,
+    row: compiled.projection.project(entry.row),
+  }));
+
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: evaluation.keys,
+    window,
+    totalRows: evaluation.totalRows,
+    version: evaluation.version,
+  };
+};
+
+const projectWindowEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  evaluation: ActiveQueryBaseEvaluation<Row>,
+): QueryEvaluation<ResultRow> => {
+  const end =
+    compiled.window.limit === undefined
+      ? undefined
+      : compiled.window.offset + compiled.window.limit;
+  const sourceWindow = evaluation.window.slice(compiled.window.offset, end);
+  const window = sourceWindow.map((entry) => ({
+    key: entry.key,
+    row: compiled.projection.project(entry.row),
+  }));
+
+  return {
+    rows: window.map((entry) => entry.row),
+    keys: window.map((entry) => entry.key),
+    window,
+    totalRows: evaluation.totalRows,
+    version: evaluation.version,
+  };
+};
+
+export const evaluateRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRawWindowScan<Row> & { readonly version: () => number },
+  compiled: CompiledRawQuery<Row, ResultRow>,
+): QueryEvaluation<ResultRow> =>
+  projectBaseEvaluation(compiled, evaluateBaseQuery(store, compiled));
+
+const leaseRawQueryExecution = <ResultRow extends RowObject>(
+  store: ActiveQueryStoreState,
+  execution: ActiveQueryBaseExecution,
+  compiled: CompiledRawQuery<object, ResultRow>,
+): RawQueryExecution<ResultRow> => {
+  const latestEvaluation = () => projectWindowEvaluation(compiled, execution.latest());
+
+  return {
+    initial: (queryId) => snapshotEvent(store, queryId, latestEvaluation()),
+    createCursor: () => ({
+      evaluation: latestEvaluation(),
+    }),
+    next: (queryId, cursor): Effect.Effect<Option.Option<DeltaEvent<ResultRow>>> =>
+      Effect.sync(() => {
+        const previous = cursor.evaluation;
+        const next = latestEvaluation();
+        const operations = deltaOperations(previous, next);
+        if (operations.length === 0 && previous.totalRows === next.totalRows) {
+          return Option.none();
+        }
+        cursor.evaluation = next;
+        return Option.some(deltaEvent(store, queryId, previous.version, next, operations));
+      }),
+  };
+};
+
+const baseWindowForActiveWindows = (
+  windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
+): CompiledRawQuery<object, object>["window"] => {
+  let limit = 0;
+  for (const { window } of windows.values()) {
+    if (window.limit === undefined) {
+      return {
+        offset: 0,
+        limit: undefined,
+      };
+    }
+    const windowEnd = window.limit === 0 ? 0 : window.offset + window.limit;
+    limit = Math.max(limit, windowEnd);
+  }
+  return {
+    offset: 0,
+    limit,
+  };
+};
+
+const acquireRawQueryWindow = (
+  windows: Map<string, RawQueryExecutionWindowSlot>,
+  window: CompiledRawQuery<object, object>["window"],
+): void => {
+  const key = queryWindowCacheKey(window);
+  const existing = windows.get(key);
+  if (existing !== undefined) {
+    existing.refs += 1;
+    return;
+  }
+  windows.set(key, {
+    window,
+    refs: 1,
+  });
+};
+
+const releaseRawQueryWindow = (
+  windows: Map<string, RawQueryExecutionWindowSlot>,
+  window: CompiledRawQuery<object, object>["window"],
+): boolean => {
+  const key = queryWindowCacheKey(window);
+  const existing = windows.get(key);
+  if (existing === undefined) {
+    return false;
+  }
+  if (existing.refs > 1) {
+    existing.refs -= 1;
+    return true;
+  }
+  windows.delete(key);
+  return true;
+};
+
+const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.make")(
+  (
+    store: ActiveQueryStoreState,
+    canonicalCompiled: CompiledRawQuery<object, object>,
+    windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
+  ) =>
+    Effect.sync(() => {
+      let baseWindow = baseWindowForActiveWindows(windows);
+      let snapshot = {
+        evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
+        version: store.version(),
+      };
+
+      const latest = () => {
+        const storeVersion = store.version();
+        const nextBaseWindow = baseWindowForActiveWindows(windows);
+        if (
+          snapshot.version !== storeVersion ||
+          nextBaseWindow.offset !== baseWindow.offset ||
+          nextBaseWindow.limit !== baseWindow.limit
+        ) {
+          baseWindow = nextBaseWindow;
+          snapshot = {
+            evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
+            version: storeVersion,
+          };
+        }
+        return snapshot.evaluation;
+      };
+
+      return {
+        latest,
+      };
+    }),
+);
+
+export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.acquire")(
+  function* <ResultRow extends RowObject>(
+    store: ActiveQueryStoreState,
+    compiled: CompiledRawQuery<object, ResultRow>,
+  ) {
+    const { map, key } = getActiveRawQueryEntry(store, compiled);
+    const existing = map.get(key);
+    if (existing !== undefined) {
+      const entry = existing;
+      entry.refs += 1;
+      acquireRawQueryWindow(entry.windows, compiled.window);
+      return leaseRawQueryExecution(store, entry.execution, compiled);
+    }
+
+    const windows = new Map<string, RawQueryExecutionWindowSlot>();
+    acquireRawQueryWindow(windows, compiled.window);
+    const execution = yield* makeRawQueryExecution(store, compiled, windows);
+    map.set(key, {
+      execution,
+      windows,
+      refs: 1,
+    });
+    return leaseRawQueryExecution(store, execution, compiled);
+  },
+);
+
+export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.release")(
+  <ResultRow extends RowObject>(
+    store: ActiveQueryStoreState,
+    compiled: CompiledRawQuery<object, ResultRow>,
+  ) =>
+    Effect.sync(() => {
+      const { map, key } = getActiveRawQueryEntry(store, compiled);
+      const existing = map.get(key);
+      if (existing === undefined) {
+        return undefined;
+      }
+      const entry = existing;
+      if (!releaseRawQueryWindow(entry.windows, compiled.window)) {
+        return undefined;
+      }
+      if (entry.refs > 1) {
+        entry.refs -= 1;
+        entry.execution.latest();
+        return undefined;
+      }
+      map.delete(key);
+      return undefined;
+    }),
+);
+
+export const clearRawQueryExecutions = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.clearStore")(
+  (store: ActiveQueryStoreState) =>
+    Effect.sync(() => {
+      getActiveRawQueryMap(store).clear();
+    }),
+);
+
+export const activeRawQueryExecutionCount = Effect.fn(
+  "ColumnLiveViewEngine.activeQuery.raw.countStore",
+)((store: ActiveQueryStoreState) => Effect.sync(() => getActiveRawQueryMap(store).size));


### PR DESCRIPTION
## Summary

- Move raw active-query execution mechanics into `active-raw-query`.
- Keep `active-query` focused on shared contracts, registry creation, and combined clear/count delegation.
- Add raw/materialized count helpers so the shared registry module does not inspect execution maps directly.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:effect`
- `pnpm run ready` (first run hit Vitest coverage temp-file ENOENT after tests passed; clean rerun passed end to end)
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- 3 local reviewer agents: no findings.
