### PR TITLE
Extract topic store state

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-state.ts
+++ b/packages/column-live-view-engine/src/topic-store-state.ts
@@ -1,0 +1,58 @@
+import { Schema, Semaphore } from "effect";
+import type { ActiveQueryStoreState } from "./active-query";
+import { ColumnarTopicStore } from "./columnar-topic-store";
+import { createTopicHealthLedger } from "./topic-health-ledger";
+import type { TopicStoreMutationState } from "./topic-store-mutation";
+import type { RawQueryCompilerMetadata } from "./raw-query-compiler";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
+
+const topicStoreSubscriptionPermitBrand: unique symbol = Symbol("TopicStoreSubscriptionPermit");
+
+export type TopicStoreSubscriptionPermit = {
+  readonly [topicStoreSubscriptionPermitBrand]: true;
+  readonly store: TopicStore;
+};
+
+export type TopicStoreState = TopicStoreMutationState;
+
+const topicStoreStates = new WeakMap<TopicStore, TopicStoreState>();
+
+export class TopicStore {
+  declare private readonly topicStoreBrand: void;
+
+  constructor(
+    readonly topic: string,
+    schema: Schema.Decoder<object>,
+    keyField: string,
+    onCommit: () => void,
+  ) {
+    const storage = new ColumnarTopicStore(topic, schema, keyField);
+    const subscribers = new Set<LiveTopicSubscriber>();
+    const state: TopicStoreState = {
+      storage,
+      subscribers,
+      mutationSemaphore: Semaphore.makeUnsafe(1),
+      notificationSemaphore: Semaphore.makeUnsafe(1),
+      healthLedger: createTopicHealthLedger(),
+      onCommit,
+    };
+    topicStoreStates.set(this, state);
+  }
+}
+
+export const topicStoreState = (store: TopicStore): TopicStoreState => {
+  return topicStoreStates.get(store)!;
+};
+
+export const makeTopicStoreSubscriptionPermit = (
+  store: TopicStore,
+): TopicStoreSubscriptionPermit => ({
+  [topicStoreSubscriptionPermitBrand]: true,
+  store,
+});
+
+export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerMetadata =>
+  topicStoreState(store).storage.rawQueryMetadata;
+
+export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
+  topicStoreState(store).storage.readModel;

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema, Semaphore } from "effect";
+import { Effect } from "effect";
 import type { StatusEvent } from "@view-server/config";
 import {
   acquireMaterializedQueryExecution,
@@ -8,27 +8,19 @@ import {
   evaluateRawQuery,
   releaseMaterializedQueryExecution,
   releaseRawQueryExecution,
-  type ActiveQueryStoreState,
 } from "./active-query";
-import { ColumnarTopicStore } from "./columnar-topic-store";
 import {
   evaluateCompiledGroupedQuery,
   prepareGroupedQuery,
   type CompiledGroupedQuery,
 } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
-import { createTopicHealthLedger } from "./topic-health-ledger";
 import {
   runTopicStoreMutationTransaction,
   withTopicStoreNotification,
   withTopicStoreTransaction,
-  type TopicStoreMutationState,
 } from "./topic-store-mutation";
-import {
-  prepareRawQuery,
-  type CompiledRawQuery,
-  type RawQueryCompilerMetadata,
-} from "./raw-query-compiler";
+import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
 import type { QueryEvaluation } from "./query-result";
 import type { InvalidRowErrorFactory } from "./topic-row-preparation";
 import {
@@ -38,52 +30,20 @@ import {
 } from "./subscription-handoff";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 import { collectTopicStoreHealthView, type TopicStoreHealthState } from "./topic-store-health";
+import {
+  makeTopicStoreSubscriptionPermit,
+  TopicStore,
+  topicStoreRawQueryMetadata,
+  topicStoreReadModel,
+  topicStoreState,
+  type TopicStoreState,
+  type TopicStoreSubscriptionPermit,
+} from "./topic-store-state";
 
 type RowObject = object;
 
-const topicStoreSubscriptionPermitBrand: unique symbol = Symbol("TopicStoreSubscriptionPermit");
-
-export type TopicStoreSubscriptionPermit = {
-  readonly [topicStoreSubscriptionPermitBrand]: true;
-  readonly store: TopicStore;
-};
-
-type TopicStoreState = TopicStoreMutationState;
-
-const topicStoreStates = new WeakMap<TopicStore, TopicStoreState>();
-
-export class TopicStore {
-  declare private readonly topicStoreBrand: void;
-
-  constructor(
-    readonly topic: string,
-    schema: Schema.Decoder<object>,
-    keyField: string,
-    onCommit: () => void,
-  ) {
-    const storage = new ColumnarTopicStore(topic, schema, keyField);
-    const subscribers = new Set<LiveTopicSubscriber>();
-    const state: TopicStoreState = {
-      storage,
-      subscribers,
-      mutationSemaphore: Semaphore.makeUnsafe(1),
-      notificationSemaphore: Semaphore.makeUnsafe(1),
-      healthLedger: createTopicHealthLedger(),
-      onCommit,
-    };
-    topicStoreStates.set(this, state);
-  }
-}
-
-const topicStoreState = (store: TopicStore): TopicStoreState => {
-  return topicStoreStates.get(store)!;
-};
-
-export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerMetadata =>
-  topicStoreState(store).storage.rawQueryMetadata;
-
-export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
-  topicStoreState(store).storage.readModel;
+export { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel };
+export type { TopicStoreSubscriptionPermit } from "./topic-store-state";
 
 export const prepareTopicStoreRawQuery = Effect.fn(
   "ColumnLiveViewEngine.topicStore.query.raw.prepare",
@@ -179,13 +139,7 @@ export function acquireTopicStoreSubscription<
     (markAcquired: (subscription: Subscription) => Effect.Effect<void>) =>
       withTopicStoreTransaction(
         topicStoreState(store),
-        acquire(
-          {
-            [topicStoreSubscriptionPermitBrand]: true,
-            store,
-          },
-          markAcquired,
-        ),
+        acquire(makeTopicStoreSubscriptionPermit(store), markAcquired),
       ),
     options,
   );

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const engineSourceRoot = join(repoRoot, "packages", "column-live-view-engine", "src");
-const restrictedTopicStoreHelpers = /\b(topicStoreReadModel|topicStoreRawQueryMetadata)\b/;
+const restrictedTopicStoreHelpers =
+  /\b(makeTopicStoreSubscriptionPermit|topicStoreRawQueryMetadata|topicStoreReadModel|topicStoreState)\b/;
 
 const sourceFiles = (directory: string): ReadonlyArray<string> => {
   const entries = readdirSync(directory, { withFileTypes: true });
@@ -28,7 +29,8 @@ const isTestFile = (path: string): boolean =>
   path.endsWith(".test.ts") || path.endsWith(".test-d.ts");
 
 const isAllowedTopicStoreOwner = (path: string): boolean =>
-  path === join(engineSourceRoot, "topic-store.ts");
+  path === join(engineSourceRoot, "topic-store.ts") ||
+  path === join(engineSourceRoot, "topic-store-state.ts");
 
 const violations: Array<string> = [];
 
@@ -48,7 +50,7 @@ for (const path of sourceFiles(engineSourceRoot)) {
 if (violations.length > 0) {
   throw new Error(
     [
-      "Production engine modules must not use topicStoreReadModel or topicStoreRawQueryMetadata.",
+      "Production engine modules must not use restricted TopicStore state helpers.",
       "Route query/read-model behavior through TopicStore helper operations instead.",
       ...violations.map((path) => `- ${path}`),
     ].join("\n"),


### PR DESCRIPTION
## Summary

- Move TopicStore construction/state storage and subscription permit branding into `topic-store-state`.
- Keep `topic-store` public exports stable while it delegates raw state access to the new state Module.
- Tighten `check:internal-seams` so direct TopicStore state/permit helpers stay restricted to owner Modules.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:internal-seams`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- 3 local reviewer agents returned no findings after the seam-checker fix.
