### PR TITLE
Move topic store mutations behind mutation module

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -3,7 +3,7 @@ import type { ColumnarTopicStore } from "./columnar-topic-store";
 import type { InvalidRowErrorFactory, PreparedTopicRow } from "./topic-row-preparation";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
-import type { TopicStore } from "./topic-store";
+import { topicStoreState, type TopicStore } from "./topic-store-state";
 
 type RowObject = object;
 
@@ -141,6 +141,55 @@ export const runTopicStoreMutationTransaction = Effect.fn(
         }),
       );
       yield* notifyTopicStoreSubscribers(state, store, subscribers);
+    }),
+  );
+});
+
+export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.publish")(function* <
+  Error,
+  Row extends RowObject,
+>(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
+  const state = topicStoreState(store);
+  const prepared = yield* state.storage.prepareRow(row, invalidRow);
+  yield* runTopicStoreMutationTransaction(state, store, (mutation) =>
+    Effect.sync(() => {
+      return mutation.publishPrepared(prepared);
+    }),
+  );
+});
+
+export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.publishMany")(
+  function* <Error, Row extends RowObject>(
+    store: TopicStore,
+    rows: ReadonlyArray<Row>,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) {
+    const state = topicStoreState(store);
+    const preparedRows = yield* state.storage.prepareRows(rows, invalidRow);
+    yield* runTopicStoreMutationTransaction(state, store, (mutation) =>
+      Effect.sync(() => {
+        return mutation.publishPreparedMany(preparedRows);
+      }),
+    );
+  },
+);
+
+export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.patch")(function* <
+  Patch extends Partial<RowObject>,
+  Error,
+>(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
+  yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
+    mutation.patch(key, patch, invalidRow),
+  );
+});
+
+export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.delete")(function* (
+  store: TopicStore,
+  key: string,
+) {
+  yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
+    Effect.sync(() => {
+      return mutation.delete(key);
     }),
   );
 });

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -15,14 +15,9 @@ import {
   type CompiledGroupedQuery,
 } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
-import {
-  runTopicStoreMutationTransaction,
-  withTopicStoreNotification,
-  withTopicStoreTransaction,
-} from "./topic-store-mutation";
+import { withTopicStoreNotification, withTopicStoreTransaction } from "./topic-store-mutation";
 import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
 import type { QueryEvaluation } from "./query-result";
-import type { InvalidRowErrorFactory } from "./topic-row-preparation";
 import {
   acquireSubscriptionHandoff,
   type MarkAcquiredSubscription,
@@ -43,6 +38,12 @@ import {
 type RowObject = object;
 
 export { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel };
+export {
+  deleteTopicStoreRow,
+  patchTopicStoreRow,
+  publishTopicStoreRow,
+  publishTopicStoreRows,
+} from "./topic-store-mutation";
 export type { TopicStoreSubscriptionPermit } from "./topic-store-state";
 
 export const prepareTopicStoreRawQuery = Effect.fn(
@@ -313,52 +314,5 @@ export const closeTopicStoreSubscriptions = Effect.fn(
         }
       }),
     ),
-  );
-});
-
-export const publishTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.publish")(function* <
-  Error,
-  Row extends RowObject,
->(store: TopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
-  const prepared = yield* topicStoreState(store).storage.prepareRow(row, invalidRow);
-  yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
-    Effect.sync(() => {
-      return mutation.publishPrepared(prepared);
-    }),
-  );
-});
-
-export const publishTopicStoreRows = Effect.fn("ColumnLiveViewEngine.topicStore.publishMany")(
-  function* <Error, Row extends RowObject>(
-    store: TopicStore,
-    rows: ReadonlyArray<Row>,
-    invalidRow: InvalidRowErrorFactory<Error>,
-  ) {
-    const preparedRows = yield* topicStoreState(store).storage.prepareRows(rows, invalidRow);
-    yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
-      Effect.sync(() => {
-        return mutation.publishPreparedMany(preparedRows);
-      }),
-    );
-  },
-);
-
-export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.patch")(function* <
-  Patch extends Partial<RowObject>,
-  Error,
->(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
-  yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
-    mutation.patch(key, patch, invalidRow),
-  );
-});
-
-export const deleteTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.delete")(function* (
-  store: TopicStore,
-  key: string,
-) {
-  yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
-    Effect.sync(() => {
-      return mutation.delete(key);
-    }),
   );
 });

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -4,8 +4,32 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const engineSourceRoot = join(repoRoot, "packages", "column-live-view-engine", "src");
-const restrictedTopicStoreHelpers =
-  /\b(makeTopicStoreSubscriptionPermit|topicStoreRawQueryMetadata|topicStoreReadModel|topicStoreState)\b/;
+const topicStoreFile = join(engineSourceRoot, "topic-store.ts");
+const topicStoreMutationFile = join(engineSourceRoot, "topic-store-mutation.ts");
+const topicStoreStateFile = join(engineSourceRoot, "topic-store-state.ts");
+
+const restrictedTopicStoreHelpers = [
+  {
+    name: "makeTopicStoreSubscriptionPermit",
+    pattern: /\bmakeTopicStoreSubscriptionPermit\b/,
+    allowedPaths: new Set([topicStoreFile, topicStoreStateFile]),
+  },
+  {
+    name: "topicStoreRawQueryMetadata",
+    pattern: /\btopicStoreRawQueryMetadata\b/,
+    allowedPaths: new Set([topicStoreFile, topicStoreStateFile]),
+  },
+  {
+    name: "topicStoreReadModel",
+    pattern: /\btopicStoreReadModel\b/,
+    allowedPaths: new Set([topicStoreFile, topicStoreStateFile]),
+  },
+  {
+    name: "topicStoreState",
+    pattern: /\btopicStoreState\b/,
+    allowedPaths: new Set([topicStoreFile, topicStoreMutationFile, topicStoreStateFile]),
+  },
+] as const;
 
 const sourceFiles = (directory: string): ReadonlyArray<string> => {
   const entries = readdirSync(directory, { withFileTypes: true });
@@ -28,23 +52,20 @@ const sourceFiles = (directory: string): ReadonlyArray<string> => {
 const isTestFile = (path: string): boolean =>
   path.endsWith(".test.ts") || path.endsWith(".test-d.ts");
 
-const isAllowedTopicStoreOwner = (path: string): boolean =>
-  path === join(engineSourceRoot, "topic-store.ts") ||
-  path === join(engineSourceRoot, "topic-store-state.ts");
-
 const violations: Array<string> = [];
 
 for (const path of sourceFiles(engineSourceRoot)) {
-  if (isTestFile(path) || isAllowedTopicStoreOwner(path)) {
+  if (isTestFile(path)) {
     continue;
   }
 
   const contents = readFileSync(path, "utf8");
-  if (!restrictedTopicStoreHelpers.test(contents)) {
-    continue;
+  for (const helper of restrictedTopicStoreHelpers) {
+    if (helper.allowedPaths.has(path) || !helper.pattern.test(contents)) {
+      continue;
+    }
+    violations.push(`${relative(repoRoot, path)} uses ${helper.name}`);
   }
-
-  violations.push(relative(repoRoot, path));
 }
 
 if (violations.length > 0) {


### PR DESCRIPTION
## Summary

- Move TopicStore publish/publishMany/patch/delete implementations into `topic-store-mutation`.
- Keep `topic-store` as the stable facade by re-exporting the write helpers.
- Tighten `check:internal-seams` with helper-specific allowlists so `topic-store-mutation` may use only `topicStoreState`, not read-model/metadata/permit helpers.

## Validation

- `vp check --fix`
- `pnpm run check:internal-seams`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- 3 local reviewer agents found one seam-checker allowlist issue.
- Fixed with helper-specific allowlists.
- 3 local reviewer agents returned no findings after the fix.
