### PR TITLE
Extract topic store lifecycle

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-lifecycle.ts
+++ b/packages/column-live-view-engine/src/topic-store-lifecycle.ts
@@ -1,0 +1,99 @@
+import type { StatusEvent } from "@view-server/config";
+import { Effect } from "effect";
+import { clearStoreRawQueryExecutions } from "./active-query";
+import { withTopicStoreNotification, withTopicStoreTransaction } from "./topic-store-mutation";
+import {
+  topicStoreReadModel,
+  topicStoreState,
+  type TopicStore,
+  type TopicStoreState,
+} from "./topic-store-state";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
+
+const resetStatusEvent = (store: TopicStore, subscriber: LiveTopicSubscriber): StatusEvent => ({
+  type: "status",
+  topic: store.topic,
+  queryId: subscriber.queryId,
+  status: "closed",
+  code: "SubscriptionClosed",
+  message: "Subscription closed because the engine reset.",
+});
+
+const engineClosedStatusEvent = (
+  store: TopicStore,
+  subscriber: LiveTopicSubscriber,
+): StatusEvent => ({
+  type: "status",
+  topic: store.topic,
+  queryId: subscriber.queryId,
+  status: "closed",
+  code: "SubscriptionClosed",
+  message: "Subscription closed because the engine closed.",
+});
+
+const drainTopicStoreSubscribersForReset = (
+  state: TopicStoreState,
+): ReadonlyArray<LiveTopicSubscriber> => {
+  state.storage.clear();
+  const closingSubscribers = [...state.subscribers];
+  for (const subscriber of closingSubscribers) {
+    subscriber.closed = true;
+  }
+  state.subscribers.clear();
+  state.healthLedger.reset();
+  return closingSubscribers;
+};
+
+const drainTopicStoreSubscribersForClose = (
+  state: TopicStoreState,
+): ReadonlyArray<LiveTopicSubscriber> => {
+  const closingSubscribers = [...state.subscribers];
+  for (const subscriber of closingSubscribers) {
+    subscriber.closed = true;
+    state.healthLedger.closeSubscription(subscriber);
+  }
+  state.subscribers.clear();
+  return closingSubscribers;
+};
+
+export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* (
+  store: TopicStore,
+) {
+  const state = topicStoreState(store);
+  yield* withTopicStoreNotification(
+    state,
+    withTopicStoreTransaction(
+      state,
+      Effect.gen(function* () {
+        const subscribers = yield* Effect.sync(() => {
+          return drainTopicStoreSubscribersForReset(state);
+        });
+        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
+        for (const subscriber of subscribers) {
+          yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
+        }
+      }),
+    ),
+  );
+});
+
+export const closeTopicStoreSubscriptions = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.closeSubscriptions",
+)(function* (store: TopicStore) {
+  const state = topicStoreState(store);
+  yield* withTopicStoreNotification(
+    state,
+    withTopicStoreTransaction(
+      state,
+      Effect.gen(function* () {
+        const subscribers = yield* Effect.sync(() => {
+          return drainTopicStoreSubscribersForClose(state);
+        });
+        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
+        for (const subscriber of subscribers) {
+          yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
+        }
+      }),
+    ),
+  );
+});

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,10 +1,8 @@
 import { Effect } from "effect";
-import type { StatusEvent } from "@view-server/config";
 import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
   activeStoreRawQueryExecutionCount,
-  clearStoreRawQueryExecutions,
   evaluateRawQuery,
   releaseMaterializedQueryExecution,
   releaseRawQueryExecution,
@@ -31,7 +29,6 @@ import {
   topicStoreRawQueryMetadata,
   topicStoreReadModel,
   topicStoreState,
-  type TopicStoreState,
   type TopicStoreSubscriptionPermit,
 } from "./topic-store-state";
 
@@ -44,6 +41,7 @@ export {
   publishTopicStoreRow,
   publishTopicStoreRows,
 } from "./topic-store-mutation";
+export { closeTopicStoreSubscriptions, resetTopicStore } from "./topic-store-lifecycle";
 export type { TopicStoreSubscriptionPermit } from "./topic-store-state";
 
 export const prepareTopicStoreRawQuery = Effect.fn(
@@ -146,27 +144,6 @@ export function acquireTopicStoreSubscription<
   );
 }
 
-const resetStatusEvent = (store: TopicStore, subscriber: LiveTopicSubscriber): StatusEvent => ({
-  type: "status",
-  topic: store.topic,
-  queryId: subscriber.queryId,
-  status: "closed",
-  code: "SubscriptionClosed",
-  message: "Subscription closed because the engine reset.",
-});
-
-const engineClosedStatusEvent = (
-  store: TopicStore,
-  subscriber: LiveTopicSubscriber,
-): StatusEvent => ({
-  type: "status",
-  topic: store.topic,
-  queryId: subscriber.queryId,
-  status: "closed",
-  code: "SubscriptionClosed",
-  message: "Subscription closed because the engine closed.",
-});
-
 export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
   function* (store: TopicStore, closed: boolean) {
     const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
@@ -193,31 +170,6 @@ const unregisterTopicStoreSubscription = Effect.fn(
     state.subscribers.delete(subscriber);
   });
 });
-
-const drainTopicStoreSubscribersForReset = (
-  state: TopicStoreState,
-): ReadonlyArray<LiveTopicSubscriber> => {
-  state.storage.clear();
-  const closingSubscribers = [...state.subscribers];
-  for (const subscriber of closingSubscribers) {
-    subscriber.closed = true;
-  }
-  state.subscribers.clear();
-  state.healthLedger.reset();
-  return closingSubscribers;
-};
-
-function drainTopicStoreSubscribersForClose(
-  state: TopicStoreState,
-): ReadonlyArray<LiveTopicSubscriber> {
-  const closingSubscribers = Array.from(state.subscribers);
-  for (const subscriber of closingSubscribers) {
-    subscriber.closed = true;
-    state.healthLedger.closeSubscription(subscriber);
-  }
-  state.subscribers.clear();
-  return closingSubscribers;
-}
 
 export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.queueDepth",
@@ -272,47 +224,5 @@ export const closeBackpressuredTopicStoreSubscription = Effect.fn(
       yield* unregisterTopicStoreSubscription(store, subscriber);
       yield* finalize;
     }),
-  );
-});
-
-export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* (
-  store: TopicStore,
-) {
-  const state = topicStoreState(store);
-  yield* withTopicStoreNotification(
-    state,
-    withTopicStoreTransaction(
-      state,
-      Effect.gen(function* () {
-        const subscribers = yield* Effect.sync(() => {
-          return drainTopicStoreSubscribersForReset(topicStoreState(store));
-        });
-        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
-        for (const subscriber of subscribers) {
-          yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
-        }
-      }),
-    ),
-  );
-});
-
-export const closeTopicStoreSubscriptions = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.closeSubscriptions",
-)(function* (store: TopicStore) {
-  const state = topicStoreState(store);
-  yield* withTopicStoreNotification(
-    state,
-    withTopicStoreTransaction(
-      state,
-      Effect.gen(function* () {
-        const subscribers = yield* Effect.sync(() => {
-          return drainTopicStoreSubscribersForClose(topicStoreState(store));
-        });
-        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
-        for (const subscriber of subscribers) {
-          yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
-        }
-      }),
-    ),
   );
 });

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const engineSourceRoot = join(repoRoot, "packages", "column-live-view-engine", "src");
 const topicStoreFile = join(engineSourceRoot, "topic-store.ts");
+const topicStoreLifecycleFile = join(engineSourceRoot, "topic-store-lifecycle.ts");
 const topicStoreMutationFile = join(engineSourceRoot, "topic-store-mutation.ts");
 const topicStoreStateFile = join(engineSourceRoot, "topic-store-state.ts");
 
@@ -22,12 +23,17 @@ const restrictedTopicStoreHelpers = [
   {
     name: "topicStoreReadModel",
     pattern: /\btopicStoreReadModel\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreStateFile]),
+    allowedPaths: new Set([topicStoreFile, topicStoreLifecycleFile, topicStoreStateFile]),
   },
   {
     name: "topicStoreState",
     pattern: /\btopicStoreState\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreMutationFile, topicStoreStateFile]),
+    allowedPaths: new Set([
+      topicStoreFile,
+      topicStoreLifecycleFile,
+      topicStoreMutationFile,
+      topicStoreStateFile,
+    ]),
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

- Move TopicStore reset/close lifecycle behavior into `topic-store-lifecycle`.
- Keep `topic-store` as the stable facade by re-exporting reset/close functions.
- Keep lifecycle seam permissions helper-specific: lifecycle may use `topicStoreState` and `topicStoreReadModel`, but not raw metadata or subscription permit helpers.

## Validation

- `vp check --fix`
- `pnpm run check:internal-seams`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

Note: one `pnpm run ready` attempt hit a generated coverage `.tmp` race after tests were passing. Generated coverage folders were removed and the full `pnpm run ready` rerun passed.

## Review

- 3 local reviewer agents returned no findings.
