### PR TITLE
Extract topic store subscription

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-subscription.ts
+++ b/packages/column-live-view-engine/src/topic-store-subscription.ts
@@ -1,0 +1,112 @@
+import { Effect } from "effect";
+import {
+  acquireSubscriptionHandoff,
+  type MarkAcquiredSubscription,
+  type SubscriptionHandoffOptions,
+} from "./subscription-handoff";
+import type { LiveTopicSubscriber } from "./topic-subscriber";
+import { withTopicStoreNotification, withTopicStoreTransaction } from "./topic-store-mutation";
+import {
+  makeTopicStoreSubscriptionPermit,
+  topicStoreState,
+  type TopicStore,
+  type TopicStoreSubscriptionPermit,
+} from "./topic-store-state";
+
+export function acquireTopicStoreSubscription<
+  Subscription extends { readonly close: () => Effect.Effect<void, never> },
+  Error,
+  Requirements,
+>(
+  store: TopicStore,
+  acquire: (
+    permit: TopicStoreSubscriptionPermit,
+    markAcquired: MarkAcquiredSubscription<Subscription>,
+  ) => Effect.Effect<Subscription, Error, Requirements>,
+  options: SubscriptionHandoffOptions = {},
+): Effect.Effect<Subscription, Error, Requirements> {
+  return acquireSubscriptionHandoff(
+    (markAcquired: (subscription: Subscription) => Effect.Effect<void>) =>
+      withTopicStoreTransaction(
+        topicStoreState(store),
+        acquire(makeTopicStoreSubscriptionPermit(store), markAcquired),
+      ),
+    options,
+  );
+}
+
+export const registerTopicStoreSubscription = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.add",
+)(function (permit: TopicStoreSubscriptionPermit, subscriber: LiveTopicSubscriber) {
+  return Effect.sync(() => {
+    const state = topicStoreState(permit.store);
+    state.healthLedger.openSubscription(subscriber);
+    state.subscribers.add(subscriber);
+  });
+});
+
+const unregisterTopicStoreSubscription = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.remove",
+)(function (store: TopicStore, subscriber: LiveTopicSubscriber) {
+  return Effect.sync(() => {
+    const state = topicStoreState(store);
+    state.healthLedger.closeSubscription(subscriber);
+    state.subscribers.delete(subscriber);
+  });
+});
+
+export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.queueDepth",
+)((store: TopicStore, subscriber: LiveTopicSubscriber, queueDepth: number) =>
+  Effect.sync(() => {
+    topicStoreState(store).healthLedger.updateQueueDepth(subscriber, queueDepth);
+    subscriber.maxQueueDepth = Math.max(subscriber.maxQueueDepth, queueDepth);
+  }),
+);
+
+const reportTopicStoreSubscriptionBackpressure = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.backpressure",
+)((store: TopicStore, subscriber: LiveTopicSubscriber) =>
+  Effect.sync(() => {
+    topicStoreState(store).healthLedger.markBackpressure(subscriber);
+    subscriber.backpressureEvents += 1;
+  }),
+);
+
+export const closeTopicStoreSubscription = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.close",
+)(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
+  const state = topicStoreState(store);
+  yield* withTopicStoreNotification(
+    state,
+    withTopicStoreTransaction(
+      state,
+      Effect.gen(function* () {
+        if (subscriber.closed) {
+          return;
+        }
+        subscriber.closed = true;
+        yield* unregisterTopicStoreSubscription(store, subscriber);
+        yield* finalize;
+      }),
+    ),
+  );
+});
+
+export const closeBackpressuredTopicStoreSubscription = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.subscribe.closeBackpressured",
+)(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
+  const state = topicStoreState(store);
+  yield* withTopicStoreTransaction(
+    state,
+    Effect.gen(function* () {
+      if (subscriber.closed) {
+        return;
+      }
+      subscriber.closed = true;
+      yield* reportTopicStoreSubscriptionBackpressure(store, subscriber);
+      yield* unregisterTopicStoreSubscription(store, subscriber);
+      yield* finalize;
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -13,23 +13,14 @@ import {
   type CompiledGroupedQuery,
 } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
-import { withTopicStoreNotification, withTopicStoreTransaction } from "./topic-store-mutation";
 import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
 import type { QueryEvaluation } from "./query-result";
-import {
-  acquireSubscriptionHandoff,
-  type MarkAcquiredSubscription,
-  type SubscriptionHandoffOptions,
-} from "./subscription-handoff";
-import type { LiveTopicSubscriber } from "./topic-subscriber";
 import { collectTopicStoreHealthView, type TopicStoreHealthState } from "./topic-store-health";
 import {
-  makeTopicStoreSubscriptionPermit,
   TopicStore,
   topicStoreRawQueryMetadata,
   topicStoreReadModel,
   topicStoreState,
-  type TopicStoreSubscriptionPermit,
 } from "./topic-store-state";
 
 type RowObject = object;
@@ -42,6 +33,13 @@ export {
   publishTopicStoreRows,
 } from "./topic-store-mutation";
 export { closeTopicStoreSubscriptions, resetTopicStore } from "./topic-store-lifecycle";
+export {
+  acquireTopicStoreSubscription,
+  closeBackpressuredTopicStoreSubscription,
+  closeTopicStoreSubscription,
+  registerTopicStoreSubscription,
+  trackTopicStoreSubscriptionQueueDepth,
+} from "./topic-store-subscription";
 export type { TopicStoreSubscriptionPermit } from "./topic-store-state";
 
 export const prepareTopicStoreRawQuery = Effect.fn(
@@ -122,107 +120,9 @@ const topicStoreHealthState = (store: TopicStore, activeViews: number): TopicSto
   };
 };
 
-export function acquireTopicStoreSubscription<
-  Subscription extends { readonly close: () => Effect.Effect<void, never> },
-  Error,
-  Requirements,
->(
-  store: TopicStore,
-  acquire: (
-    permit: TopicStoreSubscriptionPermit,
-    markAcquired: MarkAcquiredSubscription<Subscription>,
-  ) => Effect.Effect<Subscription, Error, Requirements>,
-  options: SubscriptionHandoffOptions = {},
-): Effect.Effect<Subscription, Error, Requirements> {
-  return acquireSubscriptionHandoff(
-    (markAcquired: (subscription: Subscription) => Effect.Effect<void>) =>
-      withTopicStoreTransaction(
-        topicStoreState(store),
-        acquire(makeTopicStoreSubscriptionPermit(store), markAcquired),
-      ),
-    options,
-  );
-}
-
 export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
   function* (store: TopicStore, closed: boolean) {
     const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
     return yield* collectTopicStoreHealthView(topicStoreHealthState(store, activeViews), closed);
   },
 );
-
-export const registerTopicStoreSubscription = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.subscribe.add",
-)(function (permit: TopicStoreSubscriptionPermit, subscriber: LiveTopicSubscriber) {
-  return Effect.sync(() => {
-    const state = topicStoreState(permit.store);
-    state.healthLedger.openSubscription(subscriber);
-    state.subscribers.add(subscriber);
-  });
-});
-
-const unregisterTopicStoreSubscription = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.subscribe.remove",
-)(function (store: TopicStore, subscriber: LiveTopicSubscriber) {
-  return Effect.sync(() => {
-    const state = topicStoreState(store);
-    state.healthLedger.closeSubscription(subscriber);
-    state.subscribers.delete(subscriber);
-  });
-});
-
-export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.subscribe.queueDepth",
-)((store: TopicStore, subscriber: LiveTopicSubscriber, queueDepth: number) =>
-  Effect.sync(() => {
-    topicStoreState(store).healthLedger.updateQueueDepth(subscriber, queueDepth);
-    subscriber.maxQueueDepth = Math.max(subscriber.maxQueueDepth, queueDepth);
-  }),
-);
-
-const reportTopicStoreSubscriptionBackpressure = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.subscribe.backpressure",
-)((store: TopicStore, subscriber: LiveTopicSubscriber) =>
-  Effect.sync(() => {
-    topicStoreState(store).healthLedger.markBackpressure(subscriber);
-    subscriber.backpressureEvents += 1;
-  }),
-);
-
-export const closeTopicStoreSubscription = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.subscribe.close",
-)(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
-  const state = topicStoreState(store);
-  yield* withTopicStoreNotification(
-    state,
-    withTopicStoreTransaction(
-      state,
-      Effect.gen(function* () {
-        if (subscriber.closed) {
-          return;
-        }
-        subscriber.closed = true;
-        yield* unregisterTopicStoreSubscription(store, subscriber);
-        yield* finalize;
-      }),
-    ),
-  );
-});
-
-export const closeBackpressuredTopicStoreSubscription = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.subscribe.closeBackpressured",
-)(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
-  const state = topicStoreState(store);
-  yield* withTopicStoreTransaction(
-    state,
-    Effect.gen(function* () {
-      if (subscriber.closed) {
-        return;
-      }
-      subscriber.closed = true;
-      yield* reportTopicStoreSubscriptionBackpressure(store, subscriber);
-      yield* unregisterTopicStoreSubscription(store, subscriber);
-      yield* finalize;
-    }),
-  );
-});

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -8,12 +8,13 @@ const topicStoreFile = join(engineSourceRoot, "topic-store.ts");
 const topicStoreLifecycleFile = join(engineSourceRoot, "topic-store-lifecycle.ts");
 const topicStoreMutationFile = join(engineSourceRoot, "topic-store-mutation.ts");
 const topicStoreStateFile = join(engineSourceRoot, "topic-store-state.ts");
+const topicStoreSubscriptionFile = join(engineSourceRoot, "topic-store-subscription.ts");
 
 const restrictedTopicStoreHelpers = [
   {
     name: "makeTopicStoreSubscriptionPermit",
     pattern: /\bmakeTopicStoreSubscriptionPermit\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreStateFile]),
+    allowedPaths: new Set([topicStoreFile, topicStoreStateFile, topicStoreSubscriptionFile]),
   },
   {
     name: "topicStoreRawQueryMetadata",
@@ -33,6 +34,7 @@ const restrictedTopicStoreHelpers = [
       topicStoreLifecycleFile,
       topicStoreMutationFile,
       topicStoreStateFile,
+      topicStoreSubscriptionFile,
     ]),
   },
 ] as const;


### PR DESCRIPTION
## Summary

- Move TopicStore subscription acquisition/register/close/backpressure/queue-depth behavior into `topic-store-subscription`.
- Keep `topic-store` as the stable facade by re-exporting subscription helpers.
- Keep seam permissions helper-specific: subscription may use `makeTopicStoreSubscriptionPermit` and `topicStoreState`, but not read-model/raw-metadata helpers.

## Validation

- `vp check --fix`
- `pnpm run check:internal-seams`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- 3 local reviewer agents returned no findings.
