### PR TITLE
Extract topic store query

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-query.ts
+++ b/packages/column-live-view-engine/src/topic-store-query.ts
@@ -1,0 +1,88 @@
+import { Effect } from "effect";
+import {
+  acquireMaterializedQueryExecution,
+  acquireRawQueryExecution,
+  evaluateRawQuery,
+  releaseMaterializedQueryExecution,
+  releaseRawQueryExecution,
+} from "./active-query";
+import {
+  evaluateCompiledGroupedQuery,
+  prepareGroupedQuery,
+  type CompiledGroupedQuery,
+} from "./grouped-query-compiler";
+import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
+import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
+import type { QueryEvaluation } from "./query-result";
+import {
+  topicStoreRawQueryMetadata,
+  topicStoreReadModel,
+  type TopicStore,
+} from "./topic-store-state";
+
+type RowObject = object;
+
+export const prepareTopicStoreRawQuery = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.raw.prepare",
+)(function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
+  return yield* prepareRawQuery<object, ResultRow>(
+    store.topic,
+    topicStoreRawQueryMetadata(store),
+    query,
+  );
+});
+
+export const prepareTopicStoreGroupedQuery = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.grouped.prepare",
+)(function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
+  return yield* prepareGroupedQuery<object, ResultRow>(
+    store.topic,
+    topicStoreRawQueryMetadata(store),
+    query,
+  );
+});
+
+export const evaluateTopicStoreRawQuery = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledRawQuery<object, ResultRow>,
+): QueryEvaluation<ResultRow> => evaluateRawQuery(topicStoreReadModel(store), compiled);
+
+export const evaluateTopicStoreGroupedQuery = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledGroupedQuery<object, ResultRow>,
+): QueryEvaluation<ResultRow> => evaluateCompiledGroupedQuery(topicStoreReadModel(store), compiled);
+
+export const acquireTopicStoreRawQueryExecution = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.raw.acquire",
+)(function* <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledRawQuery<object, ResultRow>,
+) {
+  return yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+});
+
+export const releaseTopicStoreRawQueryExecution = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledRawQuery<object, ResultRow>,
+): Effect.Effect<void> => releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+
+export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.query.materialized.acquire",
+)(function* <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledGroupedQuery<object, ResultRow>,
+) {
+  const readModel = topicStoreReadModel(store);
+  return yield* acquireMaterializedQueryExecution(
+    readModel,
+    compiled.cacheKey,
+    (releaseRetainedChanges) =>
+      makeIncrementalGroupedQueryExecution(readModel, compiled, releaseRetainedChanges),
+  );
+});
+
+export const releaseTopicStoreMaterializedQueryExecution = <ResultRow extends RowObject>(
+  store: TopicStore,
+  compiled: CompiledGroupedQuery<object, ResultRow>,
+): Effect.Effect<void> =>
+  releaseMaterializedQueryExecution(topicStoreReadModel(store), compiled.cacheKey);

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,20 +1,5 @@
 import { Effect } from "effect";
-import {
-  acquireMaterializedQueryExecution,
-  acquireRawQueryExecution,
-  activeStoreRawQueryExecutionCount,
-  evaluateRawQuery,
-  releaseMaterializedQueryExecution,
-  releaseRawQueryExecution,
-} from "./active-query";
-import {
-  evaluateCompiledGroupedQuery,
-  prepareGroupedQuery,
-  type CompiledGroupedQuery,
-} from "./grouped-query-compiler";
-import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
-import { prepareRawQuery, type CompiledRawQuery } from "./raw-query-compiler";
-import type { QueryEvaluation } from "./query-result";
+import { activeStoreRawQueryExecutionCount } from "./active-query";
 import { collectTopicStoreHealthView, type TopicStoreHealthState } from "./topic-store-health";
 import {
   TopicStore,
@@ -22,8 +7,6 @@ import {
   topicStoreReadModel,
   topicStoreState,
 } from "./topic-store-state";
-
-type RowObject = object;
 
 export { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel };
 export {
@@ -40,75 +23,17 @@ export {
   registerTopicStoreSubscription,
   trackTopicStoreSubscriptionQueueDepth,
 } from "./topic-store-subscription";
+export {
+  acquireTopicStoreMaterializedQueryExecution,
+  acquireTopicStoreRawQueryExecution,
+  evaluateTopicStoreGroupedQuery,
+  evaluateTopicStoreRawQuery,
+  prepareTopicStoreGroupedQuery,
+  prepareTopicStoreRawQuery,
+  releaseTopicStoreMaterializedQueryExecution,
+  releaseTopicStoreRawQueryExecution,
+} from "./topic-store-query";
 export type { TopicStoreSubscriptionPermit } from "./topic-store-state";
-
-export const prepareTopicStoreRawQuery = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.query.raw.prepare",
-)(function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
-  return yield* prepareRawQuery<object, ResultRow>(
-    store.topic,
-    topicStoreState(store).storage.rawQueryMetadata,
-    query,
-  );
-});
-
-export const prepareTopicStoreGroupedQuery = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.query.grouped.prepare",
-)(function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
-  return yield* prepareGroupedQuery<object, ResultRow>(
-    store.topic,
-    topicStoreState(store).storage.rawQueryMetadata,
-    query,
-  );
-});
-
-export const evaluateTopicStoreRawQuery = <ResultRow extends RowObject>(
-  store: TopicStore,
-  compiled: CompiledRawQuery<object, ResultRow>,
-): QueryEvaluation<ResultRow> =>
-  evaluateRawQuery(topicStoreState(store).storage.readModel, compiled);
-
-export const evaluateTopicStoreGroupedQuery = <ResultRow extends RowObject>(
-  store: TopicStore,
-  compiled: CompiledGroupedQuery<object, ResultRow>,
-): QueryEvaluation<ResultRow> =>
-  evaluateCompiledGroupedQuery(topicStoreState(store).storage.readModel, compiled);
-
-export const acquireTopicStoreRawQueryExecution = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.query.raw.acquire",
-)(function* <ResultRow extends RowObject>(
-  store: TopicStore,
-  compiled: CompiledRawQuery<object, ResultRow>,
-) {
-  return yield* acquireRawQueryExecution(topicStoreState(store).storage.readModel, compiled);
-});
-
-export const releaseTopicStoreRawQueryExecution = <ResultRow extends RowObject>(
-  store: TopicStore,
-  compiled: CompiledRawQuery<object, ResultRow>,
-): Effect.Effect<void> =>
-  releaseRawQueryExecution(topicStoreState(store).storage.readModel, compiled);
-
-export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
-  "ColumnLiveViewEngine.topicStore.query.materialized.acquire",
-)(function* <ResultRow extends RowObject>(
-  store: TopicStore,
-  compiled: CompiledGroupedQuery<object, ResultRow>,
-) {
-  const readModel = topicStoreState(store).storage.readModel;
-  return yield* acquireMaterializedQueryExecution(
-    readModel,
-    compiled.cacheKey,
-    (releaseRetainedChanges) =>
-      makeIncrementalGroupedQueryExecution(readModel, compiled, releaseRetainedChanges),
-  );
-});
-
-export const releaseTopicStoreMaterializedQueryExecution = <ResultRow extends RowObject>(
-  store: TopicStore,
-  compiled: CompiledGroupedQuery<object, ResultRow>,
-): Effect.Effect<void> =>
-  releaseMaterializedQueryExecution(topicStoreState(store).storage.readModel, compiled.cacheKey);
 
 const topicStoreHealthState = (store: TopicStore, activeViews: number): TopicStoreHealthState => {
   const state = topicStoreState(store);

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -7,6 +7,7 @@ const engineSourceRoot = join(repoRoot, "packages", "column-live-view-engine", "
 const topicStoreFile = join(engineSourceRoot, "topic-store.ts");
 const topicStoreLifecycleFile = join(engineSourceRoot, "topic-store-lifecycle.ts");
 const topicStoreMutationFile = join(engineSourceRoot, "topic-store-mutation.ts");
+const topicStoreQueryFile = join(engineSourceRoot, "topic-store-query.ts");
 const topicStoreStateFile = join(engineSourceRoot, "topic-store-state.ts");
 const topicStoreSubscriptionFile = join(engineSourceRoot, "topic-store-subscription.ts");
 
@@ -19,12 +20,17 @@ const restrictedTopicStoreHelpers = [
   {
     name: "topicStoreRawQueryMetadata",
     pattern: /\btopicStoreRawQueryMetadata\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreStateFile]),
+    allowedPaths: new Set([topicStoreFile, topicStoreQueryFile, topicStoreStateFile]),
   },
   {
     name: "topicStoreReadModel",
     pattern: /\btopicStoreReadModel\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreLifecycleFile, topicStoreStateFile]),
+    allowedPaths: new Set([
+      topicStoreFile,
+      topicStoreLifecycleFile,
+      topicStoreQueryFile,
+      topicStoreStateFile,
+    ]),
   },
   {
     name: "topicStoreState",


### PR DESCRIPTION
## Summary

- Move TopicStore raw/grouped query helper behavior into `topic-store-query`.
- Keep `topic-store` as the stable facade by re-exporting query helpers.
- Keep seam permissions helper-specific: query may use read-model/raw-metadata helpers, but not raw TopicStore state or subscription permits.

## Validation

- `vp check --fix`
- `pnpm run check:internal-seams`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- 3 local reviewer agents returned no findings.
