### PR TITLE
Move topic store health collection

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-health.ts
+++ b/packages/column-live-view-engine/src/topic-store-health.ts
@@ -1,6 +1,8 @@
 import { Clock, Effect } from "effect";
 import type { TopicRuntimeHealth } from "@view-server/config";
+import { activeStoreRawQueryExecutionCount } from "./active-query";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
+import { TopicStore, topicStoreReadModel, topicStoreState } from "./topic-store-state";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 
 export type TopicStoreHealthView = {
@@ -29,6 +31,16 @@ export type TopicStoreHealthState = {
   readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
   readonly subscribers: ReadonlySet<LiveTopicSubscriber>;
   readonly topic: string;
+};
+
+const topicStoreHealthState = (store: TopicStore, activeViews: number): TopicStoreHealthState => {
+  const state = topicStoreState(store);
+  return {
+    activeViews,
+    healthLedger: state.healthLedger,
+    subscribers: state.subscribers,
+    topic: store.topic,
+  };
 };
 
 export const collectTopicStoreHealthView = Effect.fn(
@@ -68,3 +80,10 @@ export const collectTopicStoreHealthView = Effect.fn(
   };
   return health;
 });
+
+export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
+  function* (store: TopicStore, closed: boolean) {
+    const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
+    return yield* collectTopicStoreHealthView(topicStoreHealthState(store, activeViews), closed);
+  },
+);

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,12 +1,4 @@
-import { Effect } from "effect";
-import { activeStoreRawQueryExecutionCount } from "./active-query";
-import { collectTopicStoreHealthView, type TopicStoreHealthState } from "./topic-store-health";
-import {
-  TopicStore,
-  topicStoreRawQueryMetadata,
-  topicStoreReadModel,
-  topicStoreState,
-} from "./topic-store-state";
+import { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 
 export { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel };
 export {
@@ -33,21 +25,5 @@ export {
   releaseTopicStoreMaterializedQueryExecution,
   releaseTopicStoreRawQueryExecution,
 } from "./topic-store-query";
+export { collectTopicStoreHealth } from "./topic-store-health";
 export type { TopicStoreSubscriptionPermit } from "./topic-store-state";
-
-const topicStoreHealthState = (store: TopicStore, activeViews: number): TopicStoreHealthState => {
-  const state = topicStoreState(store);
-  return {
-    activeViews,
-    healthLedger: state.healthLedger,
-    subscribers: state.subscribers,
-    topic: store.topic,
-  };
-};
-
-export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
-  function* (store: TopicStore, closed: boolean) {
-    const activeViews = yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store));
-    return yield* collectTopicStoreHealthView(topicStoreHealthState(store, activeViews), closed);
-  },
-);

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const engineSourceRoot = join(repoRoot, "packages", "column-live-view-engine", "src");
 const topicStoreFile = join(engineSourceRoot, "topic-store.ts");
+const topicStoreHealthFile = join(engineSourceRoot, "topic-store-health.ts");
 const topicStoreLifecycleFile = join(engineSourceRoot, "topic-store-lifecycle.ts");
 const topicStoreMutationFile = join(engineSourceRoot, "topic-store-mutation.ts");
 const topicStoreQueryFile = join(engineSourceRoot, "topic-store-query.ts");
@@ -27,6 +28,7 @@ const restrictedTopicStoreHelpers = [
     pattern: /\btopicStoreReadModel\b/,
     allowedPaths: new Set([
       topicStoreFile,
+      topicStoreHealthFile,
       topicStoreLifecycleFile,
       topicStoreQueryFile,
       topicStoreStateFile,
@@ -37,6 +39,7 @@ const restrictedTopicStoreHelpers = [
     pattern: /\btopicStoreState\b/,
     allowedPaths: new Set([
       topicStoreFile,
+      topicStoreHealthFile,
       topicStoreLifecycleFile,
       topicStoreMutationFile,
       topicStoreStateFile,


### PR DESCRIPTION
## Summary

- Move TopicStore health collection implementation into `topic-store-health`.
- Keep `topic-store` as the stable facade by re-exporting health collection.
- Keep seam permissions helper-specific: health may use TopicStore state/read-model helpers, while other modules remain restricted.

## Validation

- `vp check --fix`
- `pnpm run check:internal-seams`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- 3 local reviewer agents returned no findings.
