### PR TITLE
Extract protocol query schemas

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -15,6 +15,9 @@ export {
   type ViewServerWireLiveQuery,
   ViewServerWireRawQuerySchema,
   type ViewServerWireRawQuery,
+} from "./protocol-query-schema";
+
+export {
   viewServerDecodeHealthQuery,
   viewServerDecodeTopic,
   viewServerEncodeLiveQuery,

--- a/packages/protocol/src/protocol-query-codec.ts
+++ b/packages/protocol/src/protocol-query-codec.ts
@@ -11,111 +11,17 @@ import type {
 } from "@view-server/config";
 import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
+import {
+  LooseWireGroupedQuerySchema,
+  type LooseWireGroupedQuery,
+  LooseWireRawQuerySchema,
+  type LooseWireRawQuery,
+  ViewServerHealthQuerySchema,
+  type ViewServerWireGroupedQuery,
+  type ViewServerWireRawQuery,
+} from "./protocol-query-schema";
 
 type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
-
-export const ViewServerWireRawQuerySchema = Schema.Struct({
-  select: Schema.Array(Schema.String),
-  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Json)),
-  orderBy: Schema.optionalKey(
-    Schema.Array(
-      Schema.Struct({
-        field: Schema.String,
-        direction: Schema.Literals(["asc", "desc"]),
-      }),
-    ),
-  ),
-  offset: Schema.optionalKey(Schema.Number),
-  limit: Schema.optionalKey(Schema.Number),
-});
-
-export type ViewServerWireRawQuery = typeof ViewServerWireRawQuerySchema.Type;
-
-const ViewServerWireAggregateSchema = Schema.Union([
-  Schema.Struct({
-    aggFunc: Schema.Literal("count"),
-  }),
-  Schema.Struct({
-    aggFunc: Schema.Literals(["countDistinct", "sum", "avg", "min", "max"]),
-    field: Schema.String,
-  }),
-]);
-
-export const ViewServerWireGroupedQuerySchema = Schema.Struct({
-  groupBy: Schema.Array(Schema.String),
-  aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
-  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Json)),
-  orderBy: Schema.optionalKey(
-    Schema.Array(
-      Schema.Union([
-        Schema.Struct({
-          field: Schema.String,
-          direction: Schema.Literals(["asc", "desc"]),
-        }),
-        Schema.Struct({
-          aggregate: Schema.String,
-          direction: Schema.Literals(["asc", "desc"]),
-        }),
-      ]),
-    ),
-  ),
-  offset: Schema.optionalKey(Schema.Number),
-  limit: Schema.optionalKey(Schema.Number),
-});
-
-export type ViewServerWireGroupedQuery = typeof ViewServerWireGroupedQuerySchema.Type;
-export type ViewServerWireLiveQuery = ViewServerWireRawQuery | ViewServerWireGroupedQuery;
-
-export const ViewServerSubscribePayloadSchema = Schema.Struct({
-  topic: Schema.String,
-  // Keep this loose so excess query keys survive RPC decoding and can be rejected by strict query validation.
-  query: Schema.Record(Schema.String, Schema.Unknown),
-});
-
-export const ViewServerHealthQuerySchema = Schema.Struct({
-  select: Schema.Array(Schema.String),
-});
-
-const LooseWireRawQuerySchema = Schema.Struct({
-  select: Schema.Array(Schema.String),
-  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
-  orderBy: Schema.optionalKey(
-    Schema.Array(
-      Schema.Struct({
-        field: Schema.String,
-        direction: Schema.Literals(["asc", "desc"]),
-      }),
-    ),
-  ),
-  offset: Schema.optionalKey(Schema.Number),
-  limit: Schema.optionalKey(Schema.Number),
-});
-
-type LooseWireRawQuery = typeof LooseWireRawQuerySchema.Type;
-
-const LooseWireGroupedQuerySchema = Schema.Struct({
-  groupBy: Schema.Array(Schema.String),
-  aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
-  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
-  orderBy: Schema.optionalKey(
-    Schema.Array(
-      Schema.Union([
-        Schema.Struct({
-          field: Schema.String,
-          direction: Schema.Literals(["asc", "desc"]),
-        }),
-        Schema.Struct({
-          aggregate: Schema.String,
-          direction: Schema.Literals(["asc", "desc"]),
-        }),
-      ]),
-    ),
-  ),
-  offset: Schema.optionalKey(Schema.Number),
-  limit: Schema.optionalKey(Schema.Number),
-});
-
-type LooseWireGroupedQuery = typeof LooseWireGroupedQuerySchema.Type;
 
 type TrustedRawQuery<Row> = {
   readonly select: ReadonlyArray<FieldKey<Row>>;

--- a/packages/protocol/src/protocol-query-schema.ts
+++ b/packages/protocol/src/protocol-query-schema.ts
@@ -1,0 +1,104 @@
+import { Schema } from "effect";
+
+export const ViewServerWireRawQuerySchema = Schema.Struct({
+  select: Schema.Array(Schema.String),
+  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Json)),
+  orderBy: Schema.optionalKey(
+    Schema.Array(
+      Schema.Struct({
+        field: Schema.String,
+        direction: Schema.Literals(["asc", "desc"]),
+      }),
+    ),
+  ),
+  offset: Schema.optionalKey(Schema.Number),
+  limit: Schema.optionalKey(Schema.Number),
+});
+
+export type ViewServerWireRawQuery = typeof ViewServerWireRawQuerySchema.Type;
+
+export const ViewServerWireAggregateSchema = Schema.Union([
+  Schema.Struct({
+    aggFunc: Schema.Literal("count"),
+  }),
+  Schema.Struct({
+    aggFunc: Schema.Literals(["countDistinct", "sum", "avg", "min", "max"]),
+    field: Schema.String,
+  }),
+]);
+
+export const ViewServerWireGroupedQuerySchema = Schema.Struct({
+  groupBy: Schema.Array(Schema.String),
+  aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
+  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Json)),
+  orderBy: Schema.optionalKey(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          field: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+        Schema.Struct({
+          aggregate: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+      ]),
+    ),
+  ),
+  offset: Schema.optionalKey(Schema.Number),
+  limit: Schema.optionalKey(Schema.Number),
+});
+
+export type ViewServerWireGroupedQuery = typeof ViewServerWireGroupedQuerySchema.Type;
+export type ViewServerWireLiveQuery = ViewServerWireRawQuery | ViewServerWireGroupedQuery;
+
+export const ViewServerSubscribePayloadSchema = Schema.Struct({
+  topic: Schema.String,
+  // Keep this loose so excess query keys survive RPC decoding and can be rejected by strict query validation.
+  query: Schema.Record(Schema.String, Schema.Unknown),
+});
+
+export const ViewServerHealthQuerySchema = Schema.Struct({
+  select: Schema.Array(Schema.String),
+});
+
+export const LooseWireRawQuerySchema = Schema.Struct({
+  select: Schema.Array(Schema.String),
+  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
+  orderBy: Schema.optionalKey(
+    Schema.Array(
+      Schema.Struct({
+        field: Schema.String,
+        direction: Schema.Literals(["asc", "desc"]),
+      }),
+    ),
+  ),
+  offset: Schema.optionalKey(Schema.Number),
+  limit: Schema.optionalKey(Schema.Number),
+});
+
+export type LooseWireRawQuery = typeof LooseWireRawQuerySchema.Type;
+
+export const LooseWireGroupedQuerySchema = Schema.Struct({
+  groupBy: Schema.Array(Schema.String),
+  aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
+  where: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
+  orderBy: Schema.optionalKey(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          field: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+        Schema.Struct({
+          aggregate: Schema.String,
+          direction: Schema.Literals(["asc", "desc"]),
+        }),
+      ]),
+    ),
+  ),
+  offset: Schema.optionalKey(Schema.Number),
+  limit: Schema.optionalKey(Schema.Number),
+});
+
+export type LooseWireGroupedQuery = typeof LooseWireGroupedQuerySchema.Type;

--- a/packages/protocol/src/protocol-rpc.ts
+++ b/packages/protocol/src/protocol-rpc.ts
@@ -7,7 +7,7 @@ import { Rpc, RpcGroup } from "effect/unstable/rpc";
 import { Schema } from "effect";
 import { ViewServerWireEventSchema } from "./protocol-event-codec";
 import { ViewServerHealthSchema } from "./protocol-health-codec";
-import { ViewServerSubscribePayloadSchema } from "./protocol-query-codec";
+import { ViewServerSubscribePayloadSchema } from "./protocol-query-schema";
 
 export const ViewServerBackpressureErrorSchema: Schema.Codec<ViewServerBackpressureError> =
   Schema.TaggedStruct("ViewServerBackpressureError", {
@@ -66,4 +66,4 @@ export const ViewServerRpcs = RpcGroup.make(
 
 export type ViewServerRpcError = typeof ViewServerRpcErrorSchema.Type;
 
-export { ViewServerHealthQuerySchema } from "./protocol-query-codec";
+export { ViewServerHealthQuerySchema } from "./protocol-query-schema";


### PR DESCRIPTION
## Summary

- Move query wire and loose schema declarations into `protocol-query-schema`.
- Keep the public `@view-server/protocol` Interface unchanged through the package barrel.
- Make RPC schema-only dependencies import from the schema Module instead of query codec behavior.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/protocol run test`
- `pnpm run check:package-exports`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- Local self-review completed.
- 3-agent review was attempted, but subagents hit account usage limits before returning findings.
