### PR TITLE
Extract protocol event schemas

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -36,9 +36,9 @@ export {
   type ViewServerWireRow,
   ViewServerWireEventSchema,
   type ViewServerWireEvent,
-  viewServerEncodeLiveEvent,
-  viewServerDecodeLiveEvent,
-} from "./protocol-event-codec";
+} from "./protocol-event-schema";
+
+export { viewServerEncodeLiveEvent, viewServerDecodeLiveEvent } from "./protocol-event-codec";
 
 export {
   ViewServerHealthSchema,

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -8,6 +8,14 @@ import type {
 import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
+import {
+  type ViewServerWireEvent,
+  ViewServerWireRowSchema,
+  type ViewServerWireRow,
+} from "./protocol-event-schema";
+
+export { ViewServerWireEventSchema, ViewServerWireRowSchema } from "./protocol-event-schema";
+export type { ViewServerWireEvent, ViewServerWireRow } from "./protocol-event-schema";
 
 export type ViewServerProtocolEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
 
@@ -30,109 +38,6 @@ type ViewServerEventGroupedQuery = {
 };
 
 type ViewServerEventQuery = ViewServerEventRawQuery | ViewServerEventGroupedQuery;
-
-export const ViewServerWireRowSchema: Schema.Codec<Schema.JsonObject> = Schema.Record(
-  Schema.String,
-  Schema.Json,
-);
-export type ViewServerWireRow = typeof ViewServerWireRowSchema.Type;
-
-const SnapshotEventSchema = Schema.Struct({
-  type: Schema.Literal("snapshot"),
-  topic: Schema.String,
-  queryId: Schema.String,
-  version: Schema.Number,
-  keys: Schema.Array(Schema.String),
-  rows: Schema.Array(ViewServerWireRowSchema),
-  totalRows: Schema.Number,
-});
-
-const DeltaOperationSchema = Schema.Union([
-  Schema.Struct({
-    type: Schema.Literal("insert"),
-    key: Schema.String,
-    row: ViewServerWireRowSchema,
-    index: Schema.Number,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("update"),
-    key: Schema.String,
-    row: ViewServerWireRowSchema,
-    index: Schema.Number,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("move"),
-    key: Schema.String,
-    fromIndex: Schema.Number,
-    toIndex: Schema.Number,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("remove"),
-    key: Schema.String,
-  }),
-]);
-
-const DeltaEventSchema = Schema.Struct({
-  type: Schema.Literal("delta"),
-  topic: Schema.String,
-  queryId: Schema.String,
-  fromVersion: Schema.Number,
-  toVersion: Schema.Number,
-  operations: Schema.Array(DeltaOperationSchema),
-  totalRows: Schema.Number,
-});
-
-const StatusEventSchema: Schema.Codec<StatusEvent> = Schema.Union([
-  Schema.Struct({
-    type: Schema.Literal("status"),
-    topic: Schema.String,
-    queryId: Schema.String,
-    status: Schema.Literal("ready"),
-    code: Schema.Literal("Ready"),
-    message: Schema.optionalKey(Schema.String),
-  }),
-  Schema.Struct({
-    type: Schema.Literal("status"),
-    topic: Schema.String,
-    queryId: Schema.String,
-    status: Schema.Literal("stale"),
-    code: Schema.Literals(["SnapshotStale", "BackpressureExceeded"]),
-    message: Schema.optionalKey(Schema.String),
-  }),
-  Schema.Struct({
-    type: Schema.Literal("status"),
-    topic: Schema.String,
-    queryId: Schema.String,
-    status: Schema.Literal("closed"),
-    code: Schema.Literals(["SubscriptionClosed", "BackpressureExceeded"]),
-    message: Schema.optionalKey(Schema.String),
-  }),
-  Schema.Struct({
-    type: Schema.Literal("status"),
-    topic: Schema.String,
-    queryId: Schema.String,
-    status: Schema.Literal("error"),
-    code: Schema.Literals([
-      "TransportError",
-      "BackpressureExceeded",
-      "InvalidTopic",
-      "InvalidRow",
-      "InvalidQuery",
-      "UnsupportedQuery",
-      "RuntimeUnavailable",
-      "RuntimeResetFailed",
-    ]),
-    message: Schema.optionalKey(Schema.String),
-  }),
-]);
-
-export const ViewServerWireEventSchema = Schema.Union([
-  SnapshotEventSchema,
-  DeltaEventSchema,
-  StatusEventSchema,
-]);
-
-export type ViewServerWireEvent = typeof ViewServerWireEventSchema.Type;
 
 const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",

--- a/packages/protocol/src/protocol-event-schema.ts
+++ b/packages/protocol/src/protocol-event-schema.ts
@@ -1,0 +1,106 @@
+import type { StatusEvent } from "@view-server/config";
+import { Schema } from "effect";
+
+export const ViewServerWireRowSchema: Schema.Codec<Schema.JsonObject> = Schema.Record(
+  Schema.String,
+  Schema.Json,
+);
+
+export type ViewServerWireRow = typeof ViewServerWireRowSchema.Type;
+
+const SnapshotEventSchema = Schema.Struct({
+  type: Schema.Literal("snapshot"),
+  topic: Schema.String,
+  queryId: Schema.String,
+  version: Schema.Number,
+  keys: Schema.Array(Schema.String),
+  rows: Schema.Array(ViewServerWireRowSchema),
+  totalRows: Schema.Number,
+});
+
+const DeltaOperationSchema = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("insert"),
+    key: Schema.String,
+    row: ViewServerWireRowSchema,
+    index: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("update"),
+    key: Schema.String,
+    row: ViewServerWireRowSchema,
+    index: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("move"),
+    key: Schema.String,
+    fromIndex: Schema.Number,
+    toIndex: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("remove"),
+    key: Schema.String,
+  }),
+]);
+
+const DeltaEventSchema = Schema.Struct({
+  type: Schema.Literal("delta"),
+  topic: Schema.String,
+  queryId: Schema.String,
+  fromVersion: Schema.Number,
+  toVersion: Schema.Number,
+  operations: Schema.Array(DeltaOperationSchema),
+  totalRows: Schema.Number,
+});
+
+const StatusEventSchema: Schema.Codec<StatusEvent> = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("status"),
+    topic: Schema.String,
+    queryId: Schema.String,
+    status: Schema.Literal("ready"),
+    code: Schema.Literal("Ready"),
+    message: Schema.optionalKey(Schema.String),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("status"),
+    topic: Schema.String,
+    queryId: Schema.String,
+    status: Schema.Literal("stale"),
+    code: Schema.Literals(["SnapshotStale", "BackpressureExceeded"]),
+    message: Schema.optionalKey(Schema.String),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("status"),
+    topic: Schema.String,
+    queryId: Schema.String,
+    status: Schema.Literal("closed"),
+    code: Schema.Literals(["SubscriptionClosed", "BackpressureExceeded"]),
+    message: Schema.optionalKey(Schema.String),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("status"),
+    topic: Schema.String,
+    queryId: Schema.String,
+    status: Schema.Literal("error"),
+    code: Schema.Literals([
+      "TransportError",
+      "BackpressureExceeded",
+      "InvalidTopic",
+      "InvalidRow",
+      "InvalidQuery",
+      "UnsupportedQuery",
+      "RuntimeUnavailable",
+      "RuntimeResetFailed",
+    ]),
+    message: Schema.optionalKey(Schema.String),
+  }),
+]);
+
+export const ViewServerWireEventSchema = Schema.Union([
+  SnapshotEventSchema,
+  DeltaEventSchema,
+  StatusEventSchema,
+]);
+
+export type ViewServerWireEvent = typeof ViewServerWireEventSchema.Type;

--- a/packages/protocol/src/protocol-rpc.ts
+++ b/packages/protocol/src/protocol-rpc.ts
@@ -5,7 +5,7 @@ import type {
 } from "@view-server/config";
 import { Rpc, RpcGroup } from "effect/unstable/rpc";
 import { Schema } from "effect";
-import { ViewServerWireEventSchema } from "./protocol-event-codec";
+import { ViewServerWireEventSchema } from "./protocol-event-schema";
 import { ViewServerHealthSchema } from "./protocol-health-codec";
 import { ViewServerSubscribePayloadSchema } from "./protocol-query-schema";
 


### PR DESCRIPTION
## Summary

- Move event wire row/event schema declarations into `protocol-event-schema`.
- Keep the public `@view-server/protocol` Interface unchanged through the package barrel.
- Make RPC schema-only dependencies import from the event schema Module instead of event codec behavior.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/protocol run test`
- `pnpm run check:package-exports`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- Local self-review completed.
- 3-agent review is currently unavailable because subagents hit account usage limits.
