### PR TITLE
Extract protocol health schemas

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -45,6 +45,9 @@ export {
   type ViewServerWireHealth,
   ViewServerHealthSummaryRowSchema,
   ViewServerHealthTopicRowSchema,
+} from "./protocol-health-schema";
+
+export {
   viewServerEncodeHealthSummaryEvent,
   viewServerDecodeHealthSummaryEvent,
   viewServerEncodeHealthTopicEvent,

--- a/packages/protocol/src/protocol-health-codec.ts
+++ b/packages/protocol/src/protocol-health-codec.ts
@@ -1,163 +1,32 @@
 import type {
   TopicDefinitions,
-  TopicRuntimeHealth,
-  TransportHealth,
   ViewServerHealth,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
   ViewServerRuntimeError,
 } from "@view-server/config";
 import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
-import { Effect, Schema } from "effect";
+import { Effect } from "effect";
 import {
   type ViewServerProtocolEvent as _ViewServerProtocolEvent,
   type ViewServerWireEvent,
   encodeSystemLiveEvent,
   decodeSystemLiveEvent,
 } from "./protocol-event-codec";
+import {
+  ViewServerHealthSummaryRowSchema,
+  ViewServerHealthTopicRowSchema,
+  type ViewServerWireHealth,
+} from "./protocol-health-schema";
+
+export {
+  ViewServerHealthSchema,
+  ViewServerHealthSummaryRowSchema,
+  ViewServerHealthTopicRowSchema,
+} from "./protocol-health-schema";
+export type { ViewServerWireHealth } from "./protocol-health-schema";
 
 type ViewServerProtocolEvent<Row> = _ViewServerProtocolEvent<Row>;
-
-const StringOrNull = Schema.NullOr(Schema.String);
-const NumberOrNull = Schema.NullOr(Schema.Number);
-const BigIntString = Schema.BigIntFromString;
-
-const TopicRuntimeHealthSchema: Schema.Codec<TopicRuntimeHealth> = Schema.Struct({
-  status: Schema.Literals(["ready", "degraded", "starting"]),
-  rowCount: Schema.Number,
-  liveRowCount: Schema.Number,
-  deletedRowCount: Schema.Number,
-  version: Schema.Number,
-  lastMutationAt: NumberOrNull,
-  mutationsPerSecond: Schema.Number,
-  rowsPerSecond: Schema.Number,
-  pendingMutationBatches: Schema.Number,
-  activeViews: Schema.Number,
-  activeSubscriptions: Schema.Number,
-  queuedEvents: Schema.Number,
-  maxQueueDepth: Schema.Number,
-  backpressureEvents: Schema.Number,
-  memoryBytes: Schema.Number,
-  tombstoneCount: Schema.Number,
-  compactionPending: Schema.Boolean,
-});
-
-const TransportHealthSchema: Schema.Codec<TransportHealth> = Schema.Struct({
-  activeClients: Schema.Number,
-  activeStreams: Schema.Number,
-  activeSubscriptions: Schema.Number,
-  messagesPerSecond: Schema.Number,
-  bytesPerSecond: Schema.Number,
-  queuedMessages: Schema.Number,
-  queuedBytes: Schema.Number,
-  droppedClients: Schema.Number,
-  backpressureEvents: Schema.Number,
-  reconnects: Schema.Number,
-  lastError: StringOrNull,
-});
-
-export const ViewServerHealthSchema = Schema.Struct({
-  status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
-  version: Schema.Number,
-  uptimeMs: Schema.Number,
-  engine: Schema.Struct({
-    topics: Schema.Record(Schema.String, TopicRuntimeHealthSchema),
-  }),
-  kafka: Schema.optionalKey(
-    Schema.Struct({
-      regions: Schema.Record(
-        Schema.String,
-        Schema.Struct({
-          status: Schema.Literals(["connected", "disconnected", "degraded", "starting"]),
-          brokers: Schema.String,
-          lastConnectedAt: NumberOrNull,
-          lastError: StringOrNull,
-        }),
-      ),
-      topics: Schema.Record(
-        Schema.String,
-        Schema.Struct({
-          status: Schema.Literals(["ready", "degraded", "starting", "stalled"]),
-          sourceTopic: Schema.String,
-          viewServerTopic: Schema.String,
-          regions: Schema.Record(
-            Schema.String,
-            Schema.Struct({
-              connected: Schema.Boolean,
-              assignedPartitions: Schema.Number,
-              messagesPerSecond: Schema.Number,
-              bytesPerSecond: Schema.Number,
-              decodedMessagesPerSecond: Schema.Number,
-              decodeFailuresPerSecond: Schema.Number,
-              lastMessageAt: NumberOrNull,
-              lastCommitAt: NumberOrNull,
-              consumerLagMessages: Schema.NullOr(BigIntString),
-              consumerLagMs: NumberOrNull,
-              lagSampledAt: NumberOrNull,
-              highWatermarkOffset: StringOrNull,
-              committedOffset: StringOrNull,
-              lastError: StringOrNull,
-            }),
-          ),
-        }),
-      ),
-    }),
-  ),
-  transport: TransportHealthSchema,
-});
-
-export type ViewServerWireHealth = typeof ViewServerHealthSchema.Type;
-
-export const ViewServerHealthSummaryRowSchema: Schema.Codec<
-  ViewServerHealthSummaryRow,
-  unknown,
-  never,
-  never
-> = Schema.Struct({
-  id: Schema.Literal("summary"),
-  status: Schema.Literals([
-    "ready",
-    "degraded",
-    "starting",
-    "stopping",
-    "connecting",
-    "connected",
-    "disconnected",
-  ]),
-  runtimeStatus: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
-  connectionStatus: Schema.Literals(["connecting", "connected", "disconnected"]),
-  unhealthyTopics: Schema.Array(Schema.String),
-  updatedAtNanos: BigIntString,
-  maxKafkaLag: BigIntString,
-});
-
-export const ViewServerHealthTopicRowSchema: Schema.Codec<
-  ViewServerHealthTopicRow,
-  unknown,
-  never,
-  never
-> = Schema.Struct({
-  id: Schema.String,
-  status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
-  rowCount: Schema.Number,
-  liveRowCount: Schema.Number,
-  deletedRowCount: Schema.Number,
-  version: Schema.Number,
-  lastMutationAt: NumberOrNull,
-  mutationsPerSecond: Schema.Number,
-  rowsPerSecond: Schema.Number,
-  pendingMutationBatches: Schema.Number,
-  activeViews: Schema.Number,
-  activeSubscriptions: Schema.Number,
-  queuedEvents: Schema.Number,
-  maxQueueDepth: Schema.Number,
-  backpressureEvents: Schema.Number,
-  memoryBytes: Schema.Number,
-  tombstoneCount: Schema.Number,
-  compactionPending: Schema.Boolean,
-  kafkaLag: BigIntString,
-  updatedAtNanos: BigIntString,
-});
 
 const hasTopic = <Topics extends TopicDefinitions>(
   config: { readonly topics: Topics },

--- a/packages/protocol/src/protocol-health-schema.ts
+++ b/packages/protocol/src/protocol-health-schema.ts
@@ -1,0 +1,148 @@
+import type {
+  TopicRuntimeHealth,
+  TransportHealth,
+  ViewServerHealthSummaryRow,
+  ViewServerHealthTopicRow,
+} from "@view-server/config";
+import { Schema } from "effect";
+
+const StringOrNull = Schema.NullOr(Schema.String);
+const NumberOrNull = Schema.NullOr(Schema.Number);
+const BigIntString = Schema.BigIntFromString;
+
+const TopicRuntimeHealthSchema: Schema.Codec<TopicRuntimeHealth> = Schema.Struct({
+  status: Schema.Literals(["ready", "degraded", "starting"]),
+  rowCount: Schema.Number,
+  liveRowCount: Schema.Number,
+  deletedRowCount: Schema.Number,
+  version: Schema.Number,
+  lastMutationAt: NumberOrNull,
+  mutationsPerSecond: Schema.Number,
+  rowsPerSecond: Schema.Number,
+  pendingMutationBatches: Schema.Number,
+  activeViews: Schema.Number,
+  activeSubscriptions: Schema.Number,
+  queuedEvents: Schema.Number,
+  maxQueueDepth: Schema.Number,
+  backpressureEvents: Schema.Number,
+  memoryBytes: Schema.Number,
+  tombstoneCount: Schema.Number,
+  compactionPending: Schema.Boolean,
+});
+
+const TransportHealthSchema: Schema.Codec<TransportHealth> = Schema.Struct({
+  activeClients: Schema.Number,
+  activeStreams: Schema.Number,
+  activeSubscriptions: Schema.Number,
+  messagesPerSecond: Schema.Number,
+  bytesPerSecond: Schema.Number,
+  queuedMessages: Schema.Number,
+  queuedBytes: Schema.Number,
+  droppedClients: Schema.Number,
+  backpressureEvents: Schema.Number,
+  reconnects: Schema.Number,
+  lastError: StringOrNull,
+});
+
+export const ViewServerHealthSchema = Schema.Struct({
+  status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
+  version: Schema.Number,
+  uptimeMs: Schema.Number,
+  engine: Schema.Struct({
+    topics: Schema.Record(Schema.String, TopicRuntimeHealthSchema),
+  }),
+  kafka: Schema.optionalKey(
+    Schema.Struct({
+      regions: Schema.Record(
+        Schema.String,
+        Schema.Struct({
+          status: Schema.Literals(["connected", "disconnected", "degraded", "starting"]),
+          brokers: Schema.String,
+          lastConnectedAt: NumberOrNull,
+          lastError: StringOrNull,
+        }),
+      ),
+      topics: Schema.Record(
+        Schema.String,
+        Schema.Struct({
+          status: Schema.Literals(["ready", "degraded", "starting", "stalled"]),
+          sourceTopic: Schema.String,
+          viewServerTopic: Schema.String,
+          regions: Schema.Record(
+            Schema.String,
+            Schema.Struct({
+              connected: Schema.Boolean,
+              assignedPartitions: Schema.Number,
+              messagesPerSecond: Schema.Number,
+              bytesPerSecond: Schema.Number,
+              decodedMessagesPerSecond: Schema.Number,
+              decodeFailuresPerSecond: Schema.Number,
+              lastMessageAt: NumberOrNull,
+              lastCommitAt: NumberOrNull,
+              consumerLagMessages: Schema.NullOr(BigIntString),
+              consumerLagMs: NumberOrNull,
+              lagSampledAt: NumberOrNull,
+              highWatermarkOffset: StringOrNull,
+              committedOffset: StringOrNull,
+              lastError: StringOrNull,
+            }),
+          ),
+        }),
+      ),
+    }),
+  ),
+  transport: TransportHealthSchema,
+});
+
+export type ViewServerWireHealth = typeof ViewServerHealthSchema.Type;
+
+export const ViewServerHealthSummaryRowSchema: Schema.Codec<
+  ViewServerHealthSummaryRow,
+  unknown,
+  never,
+  never
+> = Schema.Struct({
+  id: Schema.Literal("summary"),
+  status: Schema.Literals([
+    "ready",
+    "degraded",
+    "starting",
+    "stopping",
+    "connecting",
+    "connected",
+    "disconnected",
+  ]),
+  runtimeStatus: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
+  connectionStatus: Schema.Literals(["connecting", "connected", "disconnected"]),
+  unhealthyTopics: Schema.Array(Schema.String),
+  updatedAtNanos: BigIntString,
+  maxKafkaLag: BigIntString,
+});
+
+export const ViewServerHealthTopicRowSchema: Schema.Codec<
+  ViewServerHealthTopicRow,
+  unknown,
+  never,
+  never
+> = Schema.Struct({
+  id: Schema.String,
+  status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
+  rowCount: Schema.Number,
+  liveRowCount: Schema.Number,
+  deletedRowCount: Schema.Number,
+  version: Schema.Number,
+  lastMutationAt: NumberOrNull,
+  mutationsPerSecond: Schema.Number,
+  rowsPerSecond: Schema.Number,
+  pendingMutationBatches: Schema.Number,
+  activeViews: Schema.Number,
+  activeSubscriptions: Schema.Number,
+  queuedEvents: Schema.Number,
+  maxQueueDepth: Schema.Number,
+  backpressureEvents: Schema.Number,
+  memoryBytes: Schema.Number,
+  tombstoneCount: Schema.Number,
+  compactionPending: Schema.Boolean,
+  kafkaLag: BigIntString,
+  updatedAtNanos: BigIntString,
+});

--- a/packages/protocol/src/protocol-rpc.ts
+++ b/packages/protocol/src/protocol-rpc.ts
@@ -6,7 +6,7 @@ import type {
 import { Rpc, RpcGroup } from "effect/unstable/rpc";
 import { Schema } from "effect";
 import { ViewServerWireEventSchema } from "./protocol-event-schema";
-import { ViewServerHealthSchema } from "./protocol-health-codec";
+import { ViewServerHealthSchema } from "./protocol-health-schema";
 import { ViewServerSubscribePayloadSchema } from "./protocol-query-schema";
 
 export const ViewServerBackpressureErrorSchema: Schema.Codec<ViewServerBackpressureError> =


### PR DESCRIPTION
## Summary

- Move health wire schema declarations into `protocol-health-schema`.
- Keep the public `@view-server/protocol` Interface unchanged through the package barrel.
- Make RPC schema-only dependencies import from the health schema Module instead of health codec behavior.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/protocol run test`
- `pnpm run check:package-exports`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- Local self-review completed.
- 3-agent review is currently unavailable because subagents hit account usage limits.
