### PR TITLE
Move event query types to query schema

### DIFF
--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -7,6 +7,7 @@ import type {
 } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import { type ViewServerWireEvent } from "./protocol-event-schema";
+import type { ViewServerEventQuery } from "./protocol-query-schema";
 import {
   decodeGroupedRow,
   decodeProjectedRow,
@@ -15,7 +16,6 @@ import {
   encodeProjectedRow,
   encodeSystemRow,
   isViewServerEventGroupedQuery,
-  type ViewServerEventQuery,
 } from "./protocol-row-codec";
 
 export { ViewServerWireEventSchema, ViewServerWireRowSchema } from "./protocol-event-schema";

--- a/packages/protocol/src/protocol-query-schema.ts
+++ b/packages/protocol/src/protocol-query-schema.ts
@@ -27,6 +27,8 @@ export const ViewServerWireAggregateSchema = Schema.Union([
   }),
 ]);
 
+export type ViewServerWireAggregate = typeof ViewServerWireAggregateSchema.Type;
+
 export const ViewServerWireGroupedQuerySchema = Schema.Struct({
   groupBy: Schema.Array(Schema.String),
   aggregates: Schema.Record(Schema.String, ViewServerWireAggregateSchema),
@@ -51,6 +53,13 @@ export const ViewServerWireGroupedQuerySchema = Schema.Struct({
 
 export type ViewServerWireGroupedQuery = typeof ViewServerWireGroupedQuerySchema.Type;
 export type ViewServerWireLiveQuery = ViewServerWireRawQuery | ViewServerWireGroupedQuery;
+
+export type ViewServerEventRawQuery = Pick<ViewServerWireRawQuery, "select">;
+export type ViewServerEventGroupedQuery = Pick<
+  ViewServerWireGroupedQuery,
+  "groupBy" | "aggregates"
+>;
+export type ViewServerEventQuery = ViewServerEventRawQuery | ViewServerEventGroupedQuery;
 
 export const ViewServerSubscribePayloadSchema = Schema.Struct({
   topic: Schema.String,

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -3,26 +3,11 @@ import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
-
-export type ViewServerEventRawQuery = {
-  readonly select: ReadonlyArray<string>;
-};
-
-export type ViewServerEventGroupedAggregate =
-  | {
-      readonly aggFunc: "count";
-    }
-  | {
-      readonly aggFunc: "countDistinct" | "sum" | "avg" | "min" | "max";
-      readonly field: string;
-    };
-
-export type ViewServerEventGroupedQuery = {
-  readonly groupBy: ReadonlyArray<string>;
-  readonly aggregates: Readonly<Record<string, ViewServerEventGroupedAggregate>>;
-};
-
-export type ViewServerEventQuery = ViewServerEventRawQuery | ViewServerEventGroupedQuery;
+import type {
+  ViewServerEventGroupedQuery,
+  ViewServerEventQuery,
+  ViewServerWireAggregate,
+} from "./protocol-query-schema";
 
 const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",
@@ -248,7 +233,7 @@ const encodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.encode"
   config: { readonly topics: Topics },
   topic: Extract<keyof Topics, string>,
   field: string,
-  aggregate: ViewServerEventGroupedAggregate,
+  aggregate: ViewServerWireAggregate,
   value: unknown,
 ) {
   if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
@@ -273,7 +258,7 @@ const decodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.decode"
   config: { readonly topics: Topics },
   topic: Extract<keyof Topics, string>,
   field: string,
-  aggregate: ViewServerEventGroupedAggregate,
+  aggregate: ViewServerWireAggregate,
   value: unknown,
 ) {
   if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {


### PR DESCRIPTION
## Summary

- Move event query helper types into `protocol-query-schema`, where query shape ownership belongs.
- Make row/event codecs consume query-schema types instead of defining local query shapes.
- Preserve runtime behavior and public wire exports.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/protocol run test`
- `pnpm run check:package-exports`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId

## Review

- Local self-review completed.
- 3-agent review is currently unavailable because subagents hit account usage limits.
