### PR TITLE
Extract remote client health state

### DIFF
--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -24,12 +24,14 @@ import * as Http from "node:http";
 import {
   ViewServerRpcs,
   ViewServerWireRowSchema,
+  viewServerDecodeHealth,
   type ViewServerRpcError,
   type ViewServerWireEvent,
   type ViewServerWireHealth,
 } from "@view-server/protocol";
 import { makeViewServerClient } from "./remote";
 import { mapViewServerRemoteError } from "./remote-client";
+import { makeRemoteHealthState } from "./remote-health";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -390,6 +392,36 @@ describe("remote ViewServer client", () => {
       message: "socket closed",
     });
   });
+
+  it.effect("does not let late pushed health summary events overwrite stopping status", () =>
+    Effect.gen(function* () {
+      const initialHealth = yield* viewServerDecodeHealth(viewServer, health(0, 0));
+      const remoteHealth = makeRemoteHealthState(initialHealth);
+
+      yield* remoteHealth.markStopping;
+      yield* remoteHealth.updateHealthSummaryRef({
+        type: "snapshot",
+        topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+        queryId: "query-remote",
+        version: 1,
+        keys: ["summary"],
+        rows: [
+          {
+            id: "summary",
+            status: "ready",
+            runtimeStatus: "ready",
+            connectionStatus: "connected",
+            unhealthyTopics: [],
+            updatedAtNanos: 1n,
+            maxKafkaLag: 0n,
+          },
+        ],
+        totalRows: 1,
+      });
+
+      expect(remoteHealth.readonlyHealth.value.status).toBe("stopping");
+    }),
+  );
 
   it.live("subscribes, receives external live events, and closes over Effect RPC WebSocket", () =>
     Effect.gen(function* () {

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -9,12 +9,10 @@ import type {
   PickRawFields,
   RawQuery,
   StatusEvent,
-  TopicRuntimeHealth,
   TopicDefinitions,
   TopicRow,
   ValidateLiveQuery,
   ViewServerConfig,
-  ViewServerHealth,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
   ViewServerRuntimeError,
@@ -35,7 +33,6 @@ import {
   type ViewServerWireLiveQuery,
 } from "@view-server/protocol";
 import { Context, Effect, Exit, Layer, ManagedRuntime, Scope, Stream } from "effect";
-import { AtomRef } from "effect/unstable/reactivity";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import type {
@@ -43,6 +40,7 @@ import type {
   ViewServerLiveEvent,
   ViewServerLiveSubscription,
 } from "./live-client";
+import { makeRemoteHealthState } from "./remote-health";
 import { makeRemoteSubscription } from "./remote-subscription";
 
 export type ViewServerRemoteClientError = ViewServerRuntimeError | ViewServerTransportError;
@@ -69,38 +67,6 @@ const transportError = (error: Error): ViewServerTransportError => ({
   _tag: "ViewServerTransportError",
   code: "TransportError",
   message: error.message,
-});
-
-function typedHealthTopics<Topics extends TopicDefinitions>(
-  topics: Record<string, TopicRuntimeHealth>,
-): ViewServerHealth<Topics>["engine"]["topics"];
-function typedHealthTopics(
-  topics: Record<string, TopicRuntimeHealth>,
-): Record<string, TopicRuntimeHealth> {
-  return topics;
-}
-
-const topicHealthFromRow = (
-  existing: TopicRuntimeHealth,
-  row: ViewServerHealthTopicRow,
-): TopicRuntimeHealth => ({
-  status: row.status === "stopping" ? existing.status : row.status,
-  rowCount: row.rowCount,
-  liveRowCount: row.liveRowCount,
-  deletedRowCount: row.deletedRowCount,
-  version: row.version,
-  lastMutationAt: row.lastMutationAt,
-  mutationsPerSecond: row.mutationsPerSecond,
-  rowsPerSecond: row.rowsPerSecond,
-  pendingMutationBatches: row.pendingMutationBatches,
-  activeViews: row.activeViews,
-  activeSubscriptions: row.activeSubscriptions,
-  queuedEvents: row.queuedEvents,
-  maxQueueDepth: row.maxQueueDepth,
-  backpressureEvents: row.backpressureEvents,
-  memoryBytes: row.memoryBytes,
-  tombstoneCount: row.tombstoneCount,
-  compactionPending: row.compactionPending,
 });
 
 export const mapViewServerRemoteError = (
@@ -187,124 +153,13 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
   const initialHealth = yield* cleanupOnConstructionFailure(
     healthRpc().pipe(Effect.flatMap((next) => viewServerDecodeHealth(config, next))),
   );
-  const health = AtomRef.make(initialHealth);
+  const remoteHealth = makeRemoteHealthState(initialHealth);
   const subscriptionBufferSize = options.subscriptionBufferSize ?? 1_024;
   const clientScope = yield* Scope.make("parallel");
 
-  const updateHealthSummaryRef = (event: ViewServerLiveEvent<ViewServerHealthSummaryRow<Topics>>) =>
-    Effect.sync(() => {
-      const applySummaryRow = (row: ViewServerHealthSummaryRow<Topics>) => {
-        health.update((current) => ({
-          ...current,
-          status: row.runtimeStatus,
-        }));
-      };
-      if (event.type === "snapshot") {
-        for (const row of event.rows) {
-          applySummaryRow(row);
-        }
-      }
-      if (event.type === "delta") {
-        for (const operation of event.operations) {
-          if (operation.type === "insert" || operation.type === "update") {
-            applySummaryRow(operation.row);
-          }
-        }
-      }
-    });
-
-  const updateHealthTopicRef = (
-    event: ViewServerLiveEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
-  ) =>
-    Effect.sync(() => {
-      if (event.type === "snapshot") {
-        health.update((current) => {
-          const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
-          for (const row of event.rows) {
-            topics[row.id] = topicHealthFromRow(current.engine.topics[row.id], row);
-          }
-          return {
-            ...current,
-            engine: {
-              topics: typedHealthTopics<Topics>(topics),
-            },
-          };
-        });
-      }
-      if (event.type === "delta") {
-        health.update((current) => {
-          const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
-          for (const operation of event.operations) {
-            if (operation.type === "insert" || operation.type === "update") {
-              topics[operation.key] = topicHealthFromRow(
-                current.engine.topics[operation.row.id],
-                operation.row,
-              );
-            }
-          }
-          return {
-            ...current,
-            engine: {
-              topics: typedHealthTopics<Topics>(topics),
-            },
-          };
-        });
-      }
-    });
-
-  const updateLiveTopicHealth = <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    update: (current: TopicRuntimeHealth) => TopicRuntimeHealth,
-  ) =>
-    Effect.sync(() => {
-      health.update((current) => {
-        const topics: Record<string, TopicRuntimeHealth> = {
-          ...current.engine.topics,
-          [topic]: update(current.engine.topics[topic]),
-        };
-        return {
-          ...current,
-          engine: {
-            topics: typedHealthTopics<Topics>(topics),
-          },
-        };
-      });
-    });
-
-  const updateSubscriptionCount = <Topic extends Extract<keyof Topics, string>>(
-    topic: Topic,
-    delta: 1 | -1,
-  ) =>
-    Effect.gen(function* () {
-      yield* updateLiveTopicHealth(topic, (current) => {
-        const activeSubscriptions = Math.max(0, current.activeSubscriptions + delta);
-        return {
-          ...current,
-          activeSubscriptions,
-        };
-      });
-      yield* Effect.sync(() => {
-        health.update((current) => ({
-          ...current,
-          transport: {
-            ...current.transport,
-            activeStreams: Math.max(0, current.transport.activeStreams + delta),
-            activeSubscriptions: Math.max(0, current.transport.activeSubscriptions + delta),
-          },
-        }));
-      });
-    });
-
   const close = Scope.close(clientScope, Exit.void).pipe(
     Effect.andThen(managedRuntime.disposeEffect),
-    Effect.andThen(
-      Effect.sync(() => {
-        health.update((current) => ({
-          ...current,
-          status: "stopping",
-        }));
-      }),
-    ),
+    Effect.andThen(remoteHealth.markStopping),
   );
 
   const streamToSubscription = <Row>(
@@ -337,8 +192,8 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
       viewServerDecodeLiveEvent<Topics, Topic, Row>(config, topic, wireQuery, event),
     );
     return yield* streamToSubscription(topic, stream, {
-      onOpen: updateSubscriptionCount(topic, 1),
-      onClose: updateSubscriptionCount(topic, -1),
+      onOpen: remoteHealth.updateSubscriptionCount(topic, 1),
+      onClose: remoteHealth.updateSubscriptionCount(topic, -1),
     });
   });
 
@@ -391,7 +246,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
         (event) => viewServerDecodeHealthSummaryEvent(config, event),
       );
       const subscription = yield* streamToSubscription(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, stream);
-      const events = subscription.events.pipe(Stream.tap(updateHealthSummaryRef));
+      const events = subscription.events.pipe(Stream.tap(remoteHealth.updateHealthSummaryRef));
       return {
         events,
         close: subscription.close,
@@ -406,7 +261,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
       viewServerDecodeHealthTopicEvent(config, event),
     );
     const subscription = yield* streamToSubscription(VIEW_SERVER_HEALTH_TOPIC, stream);
-    const events = subscription.events.pipe(Stream.tap(updateHealthTopicRef));
+    const events = subscription.events.pipe(Stream.tap(remoteHealth.updateHealthTopicRef));
     return {
       events,
       close: subscription.close,
@@ -417,7 +272,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     subscribe,
     subscribeHealthSummary,
     subscribeHealth,
-    health: health.map((value) => value),
+    health: remoteHealth.readonlyHealth,
     close,
   };
 });

--- a/packages/client/src/remote-health.ts
+++ b/packages/client/src/remote-health.ts
@@ -1,0 +1,181 @@
+import type {
+  TopicDefinitions,
+  TopicRuntimeHealth,
+  ViewServerHealth,
+  ViewServerHealthSummaryRow,
+  ViewServerHealthTopicRow,
+} from "@view-server/config";
+import { Effect } from "effect";
+import { AtomRef } from "effect/unstable/reactivity";
+import type { ViewServerLiveEvent } from "./live-client";
+
+function typedHealthTopics<Topics extends TopicDefinitions>(
+  topics: Record<string, TopicRuntimeHealth>,
+): ViewServerHealth<Topics>["engine"]["topics"];
+function typedHealthTopics(
+  topics: Record<string, TopicRuntimeHealth>,
+): Record<string, TopicRuntimeHealth> {
+  return topics;
+}
+
+const topicHealthFromRow = (
+  existing: TopicRuntimeHealth,
+  row: ViewServerHealthTopicRow,
+): TopicRuntimeHealth => ({
+  status: row.status === "stopping" ? existing.status : row.status,
+  rowCount: row.rowCount,
+  liveRowCount: row.liveRowCount,
+  deletedRowCount: row.deletedRowCount,
+  version: row.version,
+  lastMutationAt: row.lastMutationAt,
+  mutationsPerSecond: row.mutationsPerSecond,
+  rowsPerSecond: row.rowsPerSecond,
+  pendingMutationBatches: row.pendingMutationBatches,
+  activeViews: row.activeViews,
+  activeSubscriptions: row.activeSubscriptions,
+  queuedEvents: row.queuedEvents,
+  maxQueueDepth: row.maxQueueDepth,
+  backpressureEvents: row.backpressureEvents,
+  memoryBytes: row.memoryBytes,
+  tombstoneCount: row.tombstoneCount,
+  compactionPending: row.compactionPending,
+});
+
+export type RemoteHealthState<Topics extends TopicDefinitions> = {
+  readonly readonlyHealth: AtomRef.ReadonlyRef<ViewServerHealth<Topics>>;
+  readonly markStopping: Effect.Effect<void>;
+  readonly updateHealthSummaryRef: (
+    event: ViewServerLiveEvent<ViewServerHealthSummaryRow<Topics>>,
+  ) => Effect.Effect<void>;
+  readonly updateHealthTopicRef: (
+    event: ViewServerLiveEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
+  ) => Effect.Effect<void>;
+  readonly updateSubscriptionCount: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    delta: 1 | -1,
+  ) => Effect.Effect<void>;
+};
+
+export const makeRemoteHealthState = <const Topics extends TopicDefinitions>(
+  initialHealth: ViewServerHealth<Topics>,
+): RemoteHealthState<Topics> => {
+  const health = AtomRef.make(initialHealth);
+  const updateHealthSummaryRef = (event: ViewServerLiveEvent<ViewServerHealthSummaryRow<Topics>>) =>
+    Effect.sync(() => {
+      const applySummaryRow = (row: ViewServerHealthSummaryRow<Topics>) => {
+        health.update((current) => ({
+          ...current,
+          status: current.status === "stopping" ? "stopping" : row.runtimeStatus,
+        }));
+      };
+      if (event.type === "snapshot") {
+        for (const row of event.rows) {
+          applySummaryRow(row);
+        }
+      }
+      if (event.type === "delta") {
+        for (const operation of event.operations) {
+          if (operation.type === "insert" || operation.type === "update") {
+            applySummaryRow(operation.row);
+          }
+        }
+      }
+    });
+
+  const updateHealthTopicRef = (
+    event: ViewServerLiveEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
+  ) =>
+    Effect.sync(() => {
+      if (event.type === "snapshot") {
+        health.update((current) => {
+          const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
+          for (const row of event.rows) {
+            topics[row.id] = topicHealthFromRow(current.engine.topics[row.id], row);
+          }
+          return {
+            ...current,
+            engine: {
+              topics: typedHealthTopics<Topics>(topics),
+            },
+          };
+        });
+      }
+      if (event.type === "delta") {
+        health.update((current) => {
+          const topics: Record<string, TopicRuntimeHealth> = { ...current.engine.topics };
+          for (const operation of event.operations) {
+            if (operation.type === "insert" || operation.type === "update") {
+              topics[operation.key] = topicHealthFromRow(
+                current.engine.topics[operation.row.id],
+                operation.row,
+              );
+            }
+          }
+          return {
+            ...current,
+            engine: {
+              topics: typedHealthTopics<Topics>(topics),
+            },
+          };
+        });
+      }
+    });
+
+  const updateLiveTopicHealth = <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    update: (current: TopicRuntimeHealth) => TopicRuntimeHealth,
+  ) =>
+    Effect.sync(() => {
+      health.update((current) => {
+        const topics: Record<string, TopicRuntimeHealth> = {
+          ...current.engine.topics,
+          [topic]: update(current.engine.topics[topic]),
+        };
+        return {
+          ...current,
+          engine: {
+            topics: typedHealthTopics<Topics>(topics),
+          },
+        };
+      });
+    });
+
+  const updateSubscriptionCount = <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    delta: 1 | -1,
+  ) =>
+    Effect.gen(function* () {
+      yield* updateLiveTopicHealth(topic, (current) => {
+        const activeSubscriptions = Math.max(0, current.activeSubscriptions + delta);
+        return {
+          ...current,
+          activeSubscriptions,
+        };
+      });
+      yield* Effect.sync(() => {
+        health.update((current) => ({
+          ...current,
+          transport: {
+            ...current.transport,
+            activeStreams: Math.max(0, current.transport.activeStreams + delta),
+            activeSubscriptions: Math.max(0, current.transport.activeSubscriptions + delta),
+          },
+        }));
+      });
+    });
+
+  const markStopping = Effect.sync(() => {
+    health.update((current) => ({
+      ...current,
+      status: "stopping",
+    }));
+  });
+
+  return {
+    readonlyHealth: health.map((value) => value),
+    markStopping,
+    updateHealthSummaryRef,
+    updateHealthTopicRef,
+    updateSubscriptionCount,
+  };
+};


### PR DESCRIPTION
## Summary

- Move Remote Browser Client health ref update logic into a focused internal `RemoteHealthState` Module.
- Keep the public Live Client Interface and Effect RPC WebSocket wire behavior unchanged.
- Add a regression so late pushed health summary events cannot revive `stopping` status after close.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/client run test`
- `pnpm run check:package-exports`
- `pnpm run check:internal-seams`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- 3-agent review, fix, and second 3-agent review all clean
