### PR TITLE
Split server internal modules

### DIFF
--- a/packages/server/src/health-route.ts
+++ b/packages/server/src/health-route.ts
@@ -1,0 +1,30 @@
+import type { TopicDefinitions } from "@view-server/config";
+import { Effect } from "effect";
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
+import type { ViewServerWebSocketServerInput } from "./server-types";
+
+const jsonStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, nextValue: unknown) =>
+    typeof nextValue === "bigint" ? nextValue.toString() : nextValue,
+  );
+
+const jsonResponse = (status: number, value: unknown): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.text(jsonStringify(value), {
+    status,
+    contentType: "application/json",
+  });
+
+export const makeViewServerHealthRoute = <const Topics extends TopicDefinitions>(
+  input: ViewServerWebSocketServerInput<Topics>,
+  path: `/${string}`,
+) =>
+  HttpRouter.add(
+    "GET",
+    path,
+    input.runtime.health().pipe(
+      Effect.match({
+        onFailure: (error) => jsonResponse(500, error),
+        onSuccess: (health) => jsonResponse(health.status === "ready" ? 200 : 503, health),
+      }),
+    ),
+  );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,129 +1,27 @@
 import { NodeHttpServer } from "@effect/platform-node";
-import type {
-  TopicDefinitions,
-  ViewServerConfig,
-  ViewServerHealth,
-  ViewServerRuntimeClient,
-} from "@view-server/config";
-import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
-import type { ViewServerRuntimeLiveClient } from "@view-server/client";
-import {
-  ViewServerRpcs,
-  viewServerDecodeHealthQuery,
-  viewServerDecodeLiveQuery,
-  viewServerDecodeTopic,
-  viewServerEncodeHealthSummaryEvent,
-  viewServerEncodeHealthTopicEvent,
-  viewServerEncodeLiveEvent,
-} from "@view-server/protocol";
-import { Context, Effect, Layer, ManagedRuntime, Stream } from "effect";
-import { HttpRouter, HttpServer, HttpServerError, HttpServerResponse } from "effect/unstable/http";
+import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
+import { ViewServerRpcs } from "@view-server/protocol";
+import { Context, Effect, Layer, ManagedRuntime } from "effect";
+import { HttpRouter, HttpServer, HttpServerError } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 import * as Http from "node:http";
+import { makeViewServerHealthRoute } from "./health-route";
+import { makeViewServerRpcHandlers } from "./rpc-handlers";
+import type {
+  Jsonify,
+  ViewServerHealthHttpJson,
+  ViewServerWebSocketServer,
+  ViewServerWebSocketServerInput,
+  ViewServerWebSocketServerOptions,
+} from "./server-types";
 
-type ViewServerServerRuntime<Topics extends TopicDefinitions> = Pick<
-  ViewServerRuntimeClient<Topics>,
-  "health"
->;
-
-export type ViewServerWebSocketServerInput<Topics extends TopicDefinitions> = {
-  readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
-  readonly runtime: ViewServerServerRuntime<Topics>;
+export type {
+  Jsonify,
+  ViewServerHealthHttpJson,
+  ViewServerWebSocketServer,
+  ViewServerWebSocketServerInput,
+  ViewServerWebSocketServerOptions,
 };
-
-export type ViewServerWebSocketServerOptions = {
-  readonly host?: string;
-  readonly port?: number;
-  readonly path?: `/${string}`;
-  readonly healthPath?: `/${string}`;
-};
-
-export type ViewServerWebSocketServer = {
-  readonly url: string;
-  readonly healthUrl: string;
-  readonly close: Effect.Effect<void>;
-};
-
-export type Jsonify<T> = T extends bigint
-  ? string
-  : T extends string | number | boolean | null
-    ? T
-    : T extends ReadonlyArray<infer Item>
-      ? ReadonlyArray<Jsonify<Item>>
-      : T extends object
-        ? { readonly [Key in keyof T]: Jsonify<T[Key]> }
-        : never;
-
-export type ViewServerHealthHttpJson<Topics extends TopicDefinitions = TopicDefinitions> = Jsonify<
-  ViewServerHealth<Topics>
->;
-
-const jsonStringify = (value: unknown): string =>
-  JSON.stringify(value, (_key, nextValue: unknown) =>
-    typeof nextValue === "bigint" ? nextValue.toString() : nextValue,
-  );
-
-const jsonResponse = (status: number, value: unknown): HttpServerResponse.HttpServerResponse =>
-  HttpServerResponse.text(jsonStringify(value), {
-    status,
-    contentType: "application/json",
-  });
-
-const makeHandlers = <const Topics extends TopicDefinitions>(
-  config: ViewServerConfig<Topics>,
-  input: ViewServerWebSocketServerInput<Topics>,
-) => {
-  return ViewServerRpcs.of({
-    "ViewServer.Health": () => input.runtime.health(),
-    "ViewServer.Subscribe": (payload) =>
-      Stream.unwrap(
-        Effect.gen(function* () {
-          if (payload.topic === VIEW_SERVER_HEALTH_SUMMARY_TOPIC) {
-            yield* viewServerDecodeHealthQuery(payload.topic, payload.query);
-            const subscription = yield* input.liveClient.subscribeHealthSummary();
-            return subscription.events.pipe(
-              Stream.mapEffect(viewServerEncodeHealthSummaryEvent),
-              Stream.ensuring(subscription.close().pipe(Effect.ignore)),
-            );
-          }
-          if (payload.topic === VIEW_SERVER_HEALTH_TOPIC) {
-            yield* viewServerDecodeHealthQuery(payload.topic, payload.query);
-            const subscription = yield* input.liveClient.subscribeHealth();
-            return subscription.events.pipe(
-              Stream.mapEffect(viewServerEncodeHealthTopicEvent),
-              Stream.ensuring(subscription.close().pipe(Effect.ignore)),
-            );
-          }
-          const topic = yield* viewServerDecodeTopic(config, payload.topic);
-          const query = yield* viewServerDecodeLiveQuery<Topics, typeof topic>(
-            config,
-            topic,
-            payload.query,
-          );
-          const subscription = yield* input.liveClient.subscribeRuntime(topic, query);
-          return subscription.events.pipe(
-            Stream.mapEffect((event) => viewServerEncodeLiveEvent(config, topic, query, event)),
-            Stream.ensuring(subscription.close().pipe(Effect.ignore)),
-          );
-        }),
-      ),
-  });
-};
-
-const makeHealthRoute = <const Topics extends TopicDefinitions>(
-  input: ViewServerWebSocketServerInput<Topics>,
-  path: `/${string}`,
-) =>
-  HttpRouter.add(
-    "GET",
-    path,
-    input.runtime.health().pipe(
-      Effect.match({
-        onFailure: (error) => jsonResponse(500, error),
-        onSuccess: (health) => jsonResponse(health.status === "ready" ? 200 : 503, health),
-      }),
-    ),
-  );
 
 export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
@@ -139,8 +37,8 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   const path = options.path ?? "/rpc";
   const healthPath = options.healthPath ?? "/health";
   const protocol = RpcServer.layerProtocolWebsocket({ path }).pipe(Layer.provide(HttpRouter.layer));
-  const handlers = ViewServerRpcs.toLayer(makeHandlers(config, input));
-  const healthRoute = makeHealthRoute(input, healthPath);
+  const handlers = ViewServerRpcs.toLayer(makeViewServerRpcHandlers(config, input));
+  const healthRoute = makeViewServerHealthRoute(input, healthPath);
   const httpApp = Layer.merge(protocol, healthRoute);
   const rpcLayer = RpcServer.layer(ViewServerRpcs, {
     disableFatalDefects: true,

--- a/packages/server/src/rpc-handlers.ts
+++ b/packages/server/src/rpc-handlers.ts
@@ -1,0 +1,54 @@
+import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
+import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
+import {
+  ViewServerRpcs,
+  viewServerDecodeHealthQuery,
+  viewServerDecodeLiveQuery,
+  viewServerDecodeTopic,
+  viewServerEncodeHealthSummaryEvent,
+  viewServerEncodeHealthTopicEvent,
+  viewServerEncodeLiveEvent,
+} from "@view-server/protocol";
+import { Effect, Stream } from "effect";
+import type { ViewServerWebSocketServerInput } from "./server-types";
+
+export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  input: ViewServerWebSocketServerInput<Topics>,
+) => {
+  return ViewServerRpcs.of({
+    "ViewServer.Health": () => input.runtime.health(),
+    "ViewServer.Subscribe": (payload) =>
+      Stream.unwrap(
+        Effect.gen(function* () {
+          if (payload.topic === VIEW_SERVER_HEALTH_SUMMARY_TOPIC) {
+            yield* viewServerDecodeHealthQuery(payload.topic, payload.query);
+            const subscription = yield* input.liveClient.subscribeHealthSummary();
+            return subscription.events.pipe(
+              Stream.mapEffect(viewServerEncodeHealthSummaryEvent),
+              Stream.ensuring(subscription.close().pipe(Effect.ignore)),
+            );
+          }
+          if (payload.topic === VIEW_SERVER_HEALTH_TOPIC) {
+            yield* viewServerDecodeHealthQuery(payload.topic, payload.query);
+            const subscription = yield* input.liveClient.subscribeHealth();
+            return subscription.events.pipe(
+              Stream.mapEffect(viewServerEncodeHealthTopicEvent),
+              Stream.ensuring(subscription.close().pipe(Effect.ignore)),
+            );
+          }
+          const topic = yield* viewServerDecodeTopic(config, payload.topic);
+          const query = yield* viewServerDecodeLiveQuery<Topics, typeof topic>(
+            config,
+            topic,
+            payload.query,
+          );
+          const subscription = yield* input.liveClient.subscribeRuntime(topic, query);
+          return subscription.events.pipe(
+            Stream.mapEffect((event) => viewServerEncodeLiveEvent(config, topic, query, event)),
+            Stream.ensuring(subscription.close().pipe(Effect.ignore)),
+          );
+        }),
+      ),
+  });
+};

--- a/packages/server/src/server-types.ts
+++ b/packages/server/src/server-types.ts
@@ -1,0 +1,44 @@
+import type { ViewServerRuntimeLiveClient } from "@view-server/client";
+import type {
+  TopicDefinitions,
+  ViewServerHealth,
+  ViewServerRuntimeClient,
+} from "@view-server/config";
+import type { Effect } from "effect";
+
+export type ViewServerServerRuntime<Topics extends TopicDefinitions> = Pick<
+  ViewServerRuntimeClient<Topics>,
+  "health"
+>;
+
+export type ViewServerWebSocketServerInput<Topics extends TopicDefinitions> = {
+  readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
+  readonly runtime: ViewServerServerRuntime<Topics>;
+};
+
+export type ViewServerWebSocketServerOptions = {
+  readonly host?: string;
+  readonly port?: number;
+  readonly path?: `/${string}`;
+  readonly healthPath?: `/${string}`;
+};
+
+export type ViewServerWebSocketServer = {
+  readonly url: string;
+  readonly healthUrl: string;
+  readonly close: Effect.Effect<void>;
+};
+
+export type Jsonify<T> = T extends bigint
+  ? string
+  : T extends string | number | boolean | null
+    ? T
+    : T extends ReadonlyArray<infer Item>
+      ? ReadonlyArray<Jsonify<Item>>
+      : T extends object
+        ? { readonly [Key in keyof T]: Jsonify<T[Key]> }
+        : never;
+
+export type ViewServerHealthHttpJson<Topics extends TopicDefinitions = TopicDefinitions> = Jsonify<
+  ViewServerHealth<Topics>
+>;


### PR DESCRIPTION
## Summary

- Move server HTTP health route behavior into a focused internal Module.
- Move Effect RPC subscribe/health handlers into a focused internal Module.
- Move server contract types into a type-only Module while re-exporting the same public Interface from `index.ts`.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/server run test`
- `pnpm run check:package-exports`
- `pnpm run check:internal-seams`
- `pnpm run check:effect`
- `pnpm run ready`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- 3-agent review clean
