### PR TITLE
Split runtime internal modules

### DIFF
--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -129,6 +129,45 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("forwards runtime options to the in-memory runtime and websocket server", () =>
+    Effect.gen(function* () {
+      type RuntimeDependencies = ViewServerRuntimeDependencies<typeof viewServer.topics>;
+      let inMemoryOptions: Parameters<RuntimeDependencies["makeInMemory"]>[1] | undefined;
+      let serverOptions: Parameters<RuntimeDependencies["makeServer"]>[2] | undefined;
+      const dependencies: RuntimeDependencies = {
+        makeInMemory: (config, options) => {
+          inMemoryOptions = options;
+          return makeInMemoryViewServer(config, options);
+        },
+        makeServer: (_config, _input, options) => {
+          serverOptions = options;
+          return Effect.succeed({
+            url: "ws://127.0.0.1:0/custom-rpc",
+            healthUrl: "http://127.0.0.1:0/custom-health",
+            close: Effect.void,
+          });
+        },
+      };
+
+      const runtime = yield* makeViewServerRuntimeWithDependencies(dependencies, viewServer, {
+        host: "0.0.0.0",
+        websocketPort: 1234,
+        rpcPath: "/custom-rpc",
+        healthPath: "/custom-health",
+        subscriptionQueueCapacity: 7,
+      });
+
+      expect(inMemoryOptions).toStrictEqual({ subscriptionQueueCapacity: 7 });
+      expect(serverOptions).toStrictEqual({
+        host: "0.0.0.0",
+        port: 1234,
+        path: "/custom-rpc",
+        healthPath: "/custom-health",
+      });
+      yield* runtime.close;
+    }),
+  );
+
   it.live(
     "releases the in-memory runtime when server startup fails before returning a runtime",
     () =>

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -1,72 +1,24 @@
-import type { ViewServerLiveClient } from "@view-server/client";
-import type {
-  RowSchema,
-  TopicDefinitions,
-  ViewServerConfig,
-  ViewServerHealth,
-  ViewServerRuntimeClient,
-  ViewServerRuntimeError,
-} from "@view-server/config";
-import {
-  makeInMemoryViewServer,
-  type ViewServerInMemoryInstance,
-  type ViewServerInMemoryOptions,
-} from "@view-server/in-memory";
-import {
-  makeViewServerWebSocketServer,
-  type ViewServerWebSocketServer,
-  type ViewServerWebSocketServerInput,
-  type ViewServerWebSocketServerOptions,
-} from "@view-server/server";
-import { Effect, Exit, type Schema } from "effect";
+import type { ViewServerConfig } from "@view-server/config";
+import { Effect, Exit } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
+import {
+  makeDefaultRuntimeDependencies,
+  type ViewServerRuntimeDependencies,
+} from "./runtime-dependencies";
+import { resolveViewServerRuntimeOptions } from "./runtime-options";
+import type {
+  ViewServerRuntime,
+  ViewServerRuntimeOptions,
+  ViewServerRuntimeTopicDefinitions,
+} from "./runtime-types";
 
-export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
-  Record<
-    string,
-    {
-      readonly schema: RowSchema & Schema.Decoder<object>;
-      readonly key: string;
-    }
-  >;
-
-type RuntimeHttpPath = `/${string}`;
-
-export type ViewServerRuntimeOptions = {
-  readonly host?: string;
-  readonly websocketPort?: number;
-  readonly rpcPath?: RuntimeHttpPath;
-  readonly healthPath?: RuntimeHttpPath;
-  readonly subscriptionQueueCapacity?: number;
+export { makeDefaultRuntimeDependencies };
+export type {
+  ViewServerRuntime,
+  ViewServerRuntimeDependencies,
+  ViewServerRuntimeOptions,
+  ViewServerRuntimeTopicDefinitions,
 };
-
-export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> = {
-  readonly url: string;
-  readonly healthUrl: string;
-  readonly client: ViewServerRuntimeClient<Topics>;
-  readonly liveClient: ViewServerLiveClient<Topics>;
-  readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
-  readonly close: Effect.Effect<void>;
-};
-
-export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicDefinitions> = {
-  readonly makeInMemory: (
-    config: ViewServerConfig<Topics>,
-    options: ViewServerInMemoryOptions,
-  ) => Effect.Effect<ViewServerInMemoryInstance<Topics>>;
-  readonly makeServer: (
-    config: ViewServerConfig<Topics>,
-    input: ViewServerWebSocketServerInput<Topics>,
-    options: ViewServerWebSocketServerOptions,
-  ) => Effect.Effect<ViewServerWebSocketServer, HttpServerError.ServeError>;
-};
-
-export const makeDefaultRuntimeDependencies = <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(): ViewServerRuntimeDependencies<Topics> => ({
-  makeInMemory: makeInMemoryViewServer,
-  makeServer: makeViewServerWebSocketServer,
-});
 
 export const makeViewServerRuntimeWithDependencies: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
@@ -81,16 +33,7 @@ export const makeViewServerRuntimeWithDependencies: <
   config: ViewServerConfig<Topics>,
   options: ViewServerRuntimeOptions = {},
 ) {
-  const inMemoryOptions =
-    options.subscriptionQueueCapacity === undefined
-      ? {}
-      : { subscriptionQueueCapacity: options.subscriptionQueueCapacity };
-  const serverOptions = {
-    ...(options.host === undefined ? {} : { host: options.host }),
-    ...(options.websocketPort === undefined ? {} : { port: options.websocketPort }),
-    ...(options.rpcPath === undefined ? {} : { path: options.rpcPath }),
-    ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
-  };
+  const { inMemoryOptions, serverOptions } = resolveViewServerRuntimeOptions(options);
   const inMemory = yield* dependencies.makeInMemory(config, inMemoryOptions);
   const server = yield* dependencies
     .makeServer(

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -1,0 +1,34 @@
+import type { ViewServerConfig } from "@view-server/config";
+import {
+  makeInMemoryViewServer,
+  type ViewServerInMemoryInstance,
+  type ViewServerInMemoryOptions,
+} from "@view-server/in-memory";
+import {
+  makeViewServerWebSocketServer,
+  type ViewServerWebSocketServer,
+  type ViewServerWebSocketServerInput,
+  type ViewServerWebSocketServerOptions,
+} from "@view-server/server";
+import type { Effect } from "effect";
+import type { HttpServerError } from "effect/unstable/http";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly makeInMemory: (
+    config: ViewServerConfig<Topics>,
+    options: ViewServerInMemoryOptions,
+  ) => Effect.Effect<ViewServerInMemoryInstance<Topics>>;
+  readonly makeServer: (
+    config: ViewServerConfig<Topics>,
+    input: ViewServerWebSocketServerInput<Topics>,
+    options: ViewServerWebSocketServerOptions,
+  ) => Effect.Effect<ViewServerWebSocketServer, HttpServerError.ServeError>;
+};
+
+export const makeDefaultRuntimeDependencies = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(): ViewServerRuntimeDependencies<Topics> => ({
+  makeInMemory: makeInMemoryViewServer,
+  makeServer: makeViewServerWebSocketServer,
+});

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -1,0 +1,27 @@
+import type { ViewServerInMemoryOptions } from "@view-server/in-memory";
+import type { ViewServerWebSocketServerOptions } from "@view-server/server";
+import type { ViewServerRuntimeOptions } from "./runtime-types";
+
+export type ResolvedViewServerRuntimeOptions = {
+  readonly inMemoryOptions: ViewServerInMemoryOptions;
+  readonly serverOptions: ViewServerWebSocketServerOptions;
+};
+
+export const resolveViewServerRuntimeOptions = (
+  options: ViewServerRuntimeOptions,
+): ResolvedViewServerRuntimeOptions => {
+  const inMemoryOptions =
+    options.subscriptionQueueCapacity === undefined
+      ? {}
+      : { subscriptionQueueCapacity: options.subscriptionQueueCapacity };
+  const serverOptions = {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.websocketPort === undefined ? {} : { port: options.websocketPort }),
+    ...(options.rpcPath === undefined ? {} : { path: options.rpcPath }),
+    ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
+  };
+  return {
+    inMemoryOptions,
+    serverOptions,
+  };
+};

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -1,0 +1,37 @@
+import type { ViewServerLiveClient } from "@view-server/client";
+import type {
+  RowSchema,
+  TopicDefinitions,
+  ViewServerHealth,
+  ViewServerRuntimeClient,
+  ViewServerRuntimeError,
+} from "@view-server/config";
+import type { Effect, Schema } from "effect";
+
+export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
+  Record<
+    string,
+    {
+      readonly schema: RowSchema & Schema.Decoder<object>;
+      readonly key: string;
+    }
+  >;
+
+type RuntimeHttpPath = `/${string}`;
+
+export type ViewServerRuntimeOptions = {
+  readonly host?: string;
+  readonly websocketPort?: number;
+  readonly rpcPath?: RuntimeHttpPath;
+  readonly healthPath?: RuntimeHttpPath;
+  readonly subscriptionQueueCapacity?: number;
+};
+
+export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly url: string;
+  readonly healthUrl: string;
+  readonly client: ViewServerRuntimeClient<Topics>;
+  readonly liveClient: ViewServerLiveClient<Topics>;
+  readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
+  readonly close: Effect.Effect<void>;
+};


### PR DESCRIPTION
## Summary

- Move runtime contract types into a focused internal Module.
- Move default runtime dependencies into a focused internal Module.
- Move runtime option normalization into a focused internal Module while preserving runtime lifecycle assembly.
- Add a dependency-injected regression proving runtime options are forwarded to in-memory and websocket dependencies.

## Validation

- `vp check --fix packages/runtime/src/index.test.ts packages/runtime/src/internal.ts packages/runtime/src/runtime-types.ts packages/runtime/src/runtime-dependencies.ts packages/runtime/src/runtime-options.ts`
- `pnpm --filter @view-server/runtime run test`
- `pnpm run ready`
- `git diff --check`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- 3-agent review clean
