### PR TITLE
Extract raw query plan module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,10 @@ _Avoid_: Map wrapper, row array, topic state bag
 The engine-side representation of a compiled Live Query that can evaluate snapshots and deltas and may be shared by equivalent subscriptions.
 _Avoid_: Query object, filter function
 
+**Raw Query Plan**:
+The compiled internal representation of a Raw Query, including predicate hints, deterministic ordering, projection, cache keys, and window scan inputs.
+_Avoid_: Query object, filter callback, storage scan object
+
 **Health Ledger**:
 The owner of counters and sampled health state for mutations, subscriptions, queues, backpressure, ingestion, and transport pressure.
 _Avoid_: Health object builder, metrics dump
@@ -132,6 +136,7 @@ _Avoid_: Browser write, send, emit
 - A **Grouped Query** returns group fields plus aggregate aliases.
 - A **Subscription** belongs to one **Live Query** and emits one **Snapshot** followed by zero or more **Deltas** and **Status Events**.
 - A **Column Live View Engine** owns one **Columnar Topic Store** per **View Server Topic**.
+- A **Raw Query Plan** is compiled once from a **Raw Query** before the **Columnar Topic Store** scans rows.
 - An **Active Query** may serve many equivalent **Subscriptions**.
 - A **Live Client** can subscribe to **Live Queries** but cannot publish mutations.
 - A **Runtime Client** can publish mutations but is not exposed to browsers by the Real View Server.

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -1,11 +1,12 @@
 import { Effect, Option } from "effect";
 import type { DeltaEvent } from "@view-server/config";
 import type { ActiveQueryStoreState, RawQueryExecution } from "./active-query";
+import type { CompiledRawQuery } from "./raw-query-compiler";
 import {
-  stableQueryValueString,
-  type CompiledRawQuery,
-  type RuntimeRawQuery,
-} from "./raw-query-compiler";
+  rawQueryPlanWindow,
+  rawQueryWindowScanPlan,
+  type RawQueryPlanWindow,
+} from "./raw-query-plan";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
 import type { TopicRawWindowScan, TopicRawWindowScanResult } from "./raw-window-scan";
@@ -23,35 +24,12 @@ export type RawQueryExecutionSlot = {
 };
 
 type RawQueryExecutionWindowSlot = {
-  readonly window: CompiledRawQuery<object, object>["window"];
+  readonly window: RawQueryPlanWindow;
   refs: number;
 };
 
 type ActiveQueryBaseEvaluation<Row extends RowObject> = TopicRawWindowScanResult<Row> & {
   readonly version: number;
-};
-
-type QueryCacheToken = readonly ["raw", string, string];
-type QueryWindowCacheToken = readonly ["window", string, string];
-
-const queryCacheKey = (query: RuntimeRawQuery): string => {
-  const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
-    query.orderBy === undefined ? [] : query.orderBy.map((entry) => [entry.field, entry.direction]);
-  const token: QueryCacheToken = [
-    "raw",
-    query.where === undefined ? "" : stableQueryValueString(query.where),
-    stableQueryValueString(orderBy),
-  ];
-  return JSON.stringify(token);
-};
-
-const queryWindowCacheKey = (window: CompiledRawQuery<object, object>["window"]): string => {
-  const token: QueryWindowCacheToken = [
-    "window",
-    stableQueryValueString(window.offset),
-    stableQueryValueString(window.limit ?? null),
-  ];
-  return JSON.stringify(token);
 };
 
 const getActiveRawQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryExecutionSlot> => {
@@ -65,7 +43,7 @@ const getActiveRawQueryEntry = <ResultRow extends RowObject>(
   map: Map<string, RawQueryExecutionSlot>;
   key: string;
 } => {
-  const key = queryCacheKey(compiled.query);
+  const key = compiled.plan.queryCacheKey;
   const map = getActiveRawQueryMap(store);
   return { map, key };
 };
@@ -73,18 +51,10 @@ const getActiveRawQueryEntry = <ResultRow extends RowObject>(
 const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   store: TopicRawWindowScan<Row> & { readonly version: () => number },
   compiled: CompiledRawQuery<Row, ResultRow>,
-  queryWindow: CompiledRawQuery<Row, ResultRow>["window"] = compiled.window,
+  queryWindow: RawQueryPlanWindow = compiled.plan.window,
 ): ActiveQueryBaseEvaluation<Row> => {
   const version = store.version();
-  const scanResult = store.scanRawWindow({
-    predicate: compiled.predicate.plan,
-    orderBy: compiled.ordering.plan,
-    storageOrderBy: compiled.ordering.plan,
-    matches: compiled.predicate.matches,
-    compare: compiled.ordering.compare,
-    offset: queryWindow.offset,
-    limit: queryWindow.limit,
-  });
+  const scanResult = store.scanRawWindow(rawQueryWindowScanPlan(compiled.plan, queryWindow));
   return {
     ...scanResult,
     version,
@@ -97,7 +67,7 @@ const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObjec
 ): QueryEvaluation<ResultRow> => {
   const window = evaluation.window.map((entry) => ({
     key: entry.key,
-    row: compiled.projection.project(entry.row),
+    row: compiled.plan.project(entry.row),
   }));
 
   return {
@@ -114,13 +84,13 @@ const projectWindowEvaluation = <Row extends RowObject, ResultRow extends RowObj
   evaluation: ActiveQueryBaseEvaluation<Row>,
 ): QueryEvaluation<ResultRow> => {
   const end =
-    compiled.window.limit === undefined
+    compiled.plan.window.limit === undefined
       ? undefined
-      : compiled.window.offset + compiled.window.limit;
-  const sourceWindow = evaluation.window.slice(compiled.window.offset, end);
+      : compiled.plan.window.offset + compiled.plan.window.limit;
+  const sourceWindow = evaluation.window.slice(compiled.plan.window.offset, end);
   const window = sourceWindow.map((entry) => ({
     key: entry.key,
-    row: compiled.projection.project(entry.row),
+    row: compiled.plan.project(entry.row),
   }));
 
   return {
@@ -166,29 +136,23 @@ const leaseRawQueryExecution = <ResultRow extends RowObject>(
 
 const baseWindowForActiveWindows = (
   windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
-): CompiledRawQuery<object, object>["window"] => {
+): RawQueryPlanWindow => {
   let limit = 0;
   for (const { window } of windows.values()) {
     if (window.limit === undefined) {
-      return {
-        offset: 0,
-        limit: undefined,
-      };
+      return rawQueryPlanWindow(0, undefined);
     }
     const windowEnd = window.limit === 0 ? 0 : window.offset + window.limit;
     limit = Math.max(limit, windowEnd);
   }
-  return {
-    offset: 0,
-    limit,
-  };
+  return rawQueryPlanWindow(0, limit);
 };
 
 const acquireRawQueryWindow = (
   windows: Map<string, RawQueryExecutionWindowSlot>,
-  window: CompiledRawQuery<object, object>["window"],
+  window: RawQueryPlanWindow,
 ): void => {
-  const key = queryWindowCacheKey(window);
+  const key = window.cacheKey;
   const existing = windows.get(key);
   if (existing !== undefined) {
     existing.refs += 1;
@@ -202,9 +166,9 @@ const acquireRawQueryWindow = (
 
 const releaseRawQueryWindow = (
   windows: Map<string, RawQueryExecutionWindowSlot>,
-  window: CompiledRawQuery<object, object>["window"],
+  window: RawQueryPlanWindow,
 ): boolean => {
-  const key = queryWindowCacheKey(window);
+  const key = window.cacheKey;
   const existing = windows.get(key);
   if (existing === undefined) {
     return false;
@@ -263,12 +227,12 @@ export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
     if (existing !== undefined) {
       const entry = existing;
       entry.refs += 1;
-      acquireRawQueryWindow(entry.windows, compiled.window);
+      acquireRawQueryWindow(entry.windows, compiled.plan.window);
       return leaseRawQueryExecution(store, entry.execution, compiled);
     }
 
     const windows = new Map<string, RawQueryExecutionWindowSlot>();
-    acquireRawQueryWindow(windows, compiled.window);
+    acquireRawQueryWindow(windows, compiled.plan.window);
     const execution = yield* makeRawQueryExecution(store, compiled, windows);
     map.set(key, {
       execution,
@@ -291,7 +255,7 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
         return undefined;
       }
       const entry = existing;
-      if (!releaseRawQueryWindow(entry.windows, compiled.window)) {
+      if (!releaseRawQueryWindow(entry.windows, compiled.plan.window)) {
         return undefined;
       }
       if (entry.refs > 1) {

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -31,7 +31,7 @@ export const prepareGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.
       select: decoded.groupBy,
       ...(decoded.where === undefined ? {} : { where: decoded.where }),
     });
-    const { matches } = rawFilter.predicate;
+    const { matches } = rawFilter.plan.predicate;
     return {
       query: decoded,
       cacheKey: groupedCacheKey(decoded),

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -1,11 +1,7 @@
-import type { FieldKey, OrderBy } from "@view-server/config";
 import { Effect } from "effect";
 import { compareQueryValue, stableQueryValueString } from "./query-value";
-import {
-  compileRawPredicate,
-  isRangePlanValue,
-  type CompiledRawPredicate,
-} from "./raw-predicate-compiler";
+import { isRangePlanValue, type CompiledRawPredicate } from "./raw-predicate-compiler";
+import { makeRawQueryPlan, type RawQueryPlan } from "./raw-query-plan";
 import {
   decodeRawQuery,
   InvalidQueryError,
@@ -13,9 +9,6 @@ import {
   validateRuntimeQuery,
 } from "./raw-query-decoder";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-metadata";
-import { cloneUnknown, fieldValue } from "./row-values";
-import type { TopicRawOrderByPlan } from "./raw-window-scan";
-import type { TopicRowEntry } from "./row-scan";
 
 type RowObject = object;
 const compiledRawQueryBrand: unique symbol = Symbol("CompiledRawQuery");
@@ -29,113 +22,20 @@ export type { RawQueryCompilerMetadata, RuntimeRawQuery };
 export type CompiledRawQuery<Row extends RowObject, ResultRow extends RowObject> = {
   readonly [compiledRawQueryBrand]: true;
   readonly query: RuntimeRawQuery;
-  readonly predicate: CompiledRawPredicate<Row>;
-  readonly ordering: CompiledRawOrdering<Row>;
-  readonly projection: CompiledRawProjection<Row, ResultRow>;
-  readonly window: CompiledRawWindow;
+  readonly plan: RawQueryPlan<Row, ResultRow>;
 };
 
 export type { CompiledRawPredicate };
-
-export type CompiledRawOrdering<Row extends RowObject> = {
-  readonly plan: ReadonlyArray<TopicRawOrderByPlan>;
-  readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
-};
-
-export type CompiledRawProjection<Row extends RowObject, ResultRow extends RowObject> = {
-  readonly project: (row: Row) => ResultRow;
-};
-
-export type CompiledRawWindow = {
-  readonly offset: number;
-  readonly limit: number | undefined;
-};
-
-const compareRows = <Row extends RowObject>(
-  left: TopicRowEntry<Row>,
-  right: TopicRowEntry<Row>,
-  orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
-): number => {
-  for (const order of orderBy) {
-    const comparison = compareQueryValue(
-      fieldValue(left.row, order.field),
-      fieldValue(right.row, order.field),
-    );
-    if (comparison !== 0) {
-      return order.direction === "asc" ? comparison : -comparison;
-    }
-  }
-  return Number(left.key > right.key) - Number(left.key < right.key);
-};
-
-const projectRow = (
-  row: RowObject,
-  select: ReadonlyArray<FieldKey<Record<string, unknown>>>,
-): RowObject => {
-  const projected: Record<string, unknown> = {};
-  for (const field of select) {
-    projected[field] = cloneUnknown(fieldValue(row, field));
-  }
-  return projected;
-};
-
-function projectCompiledRow<ResultRow extends RowObject>(
-  row: RowObject,
-  select: ReadonlyArray<FieldKey<Record<string, unknown>>>,
-): ResultRow;
-function projectCompiledRow(
-  row: RowObject,
-  select: ReadonlyArray<FieldKey<Record<string, unknown>>>,
-): RowObject {
-  return projectRow(row, select);
-}
-
-const compileProjection = <Row extends RowObject, ResultRow extends RowObject>(
-  select: ReadonlyArray<string>,
-): CompiledRawProjection<Row, ResultRow> => {
-  const selectedFields = [...select];
-  return {
-    project: (row) => projectCompiledRow(row, selectedFields),
-  };
-};
-
-const compileOrdering = <Row extends RowObject>(
-  orderBy: ReadonlyArray<OrderBy<Record<string, unknown>>>,
-): CompiledRawOrdering<Row> => ({
-  plan: [...orderBy],
-  compare: (left, right) => compareRows(left, right, orderBy),
-});
-
-const compileWindow = (query: RuntimeRawQuery): CompiledRawWindow => ({
-  offset: query.offset ?? 0,
-  limit: query.limit,
-});
-
-const compileRawQueryParts = <Row extends RowObject, ResultRow extends RowObject>(
-  metadata: RawQueryCompilerMetadata,
-  query: RuntimeRawQuery,
-): Pick<CompiledRawQuery<Row, ResultRow>, "predicate" | "ordering" | "projection" | "window"> => {
-  const orderBy = query.orderBy ?? [];
-  return {
-    predicate: compileRawPredicate(metadata, query.where),
-    ordering: compileOrdering(orderBy),
-    projection: compileProjection(query.select),
-    window: compileWindow(query),
-  };
-};
 
 const compileRawQuery = <Row extends RowObject, ResultRow extends RowObject>(
   metadata: RawQueryCompilerMetadata,
   query: RuntimeRawQuery,
 ): CompiledRawQuery<Row, ResultRow> => {
-  const parts = compileRawQueryParts<Row, ResultRow>(metadata, query);
+  const plan = makeRawQueryPlan<Row, ResultRow>(metadata, query);
   return {
     [compiledRawQueryBrand]: true,
     query,
-    predicate: parts.predicate,
-    ordering: parts.ordering,
-    projection: parts.projection,
-    window: parts.window,
+    plan,
   };
 };
 

--- a/packages/column-live-view-engine/src/raw-query-plan.ts
+++ b/packages/column-live-view-engine/src/raw-query-plan.ts
@@ -1,0 +1,126 @@
+import { compareQueryValue, stableQueryValueString } from "./query-value";
+import { compileRawPredicate, type CompiledRawPredicate } from "./raw-predicate-compiler";
+import type { RuntimeRawQuery } from "./raw-query-decoder";
+import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+import type { TopicRawOrderByPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
+import type { TopicRowEntry } from "./row-scan";
+import { cloneUnknown, fieldValue } from "./row-values";
+
+type RowObject = object;
+
+type QueryCacheToken = readonly ["raw", string, string];
+type QueryWindowCacheToken = readonly ["window", string, string];
+
+export type RawQueryPlanWindow = {
+  readonly cacheKey: string;
+  readonly offset: number;
+  readonly limit: number | undefined;
+};
+
+export type RawQueryPlan<Row extends RowObject, ResultRow extends RowObject> = {
+  readonly queryCacheKey: string;
+  readonly selectedFields: ReadonlyArray<string>;
+  readonly predicate: CompiledRawPredicate<Row>;
+  readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
+  readonly storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>;
+  readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
+  readonly project: (row: Row) => ResultRow;
+  readonly window: RawQueryPlanWindow;
+};
+
+const rawQueryShapeCacheKey = (query: RuntimeRawQuery): string => {
+  const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
+    query.orderBy === undefined ? [] : query.orderBy.map((entry) => [entry.field, entry.direction]);
+  const token: QueryCacheToken = [
+    "raw",
+    query.where === undefined ? "" : stableQueryValueString(query.where),
+    stableQueryValueString(orderBy),
+  ];
+  return JSON.stringify(token);
+};
+
+const rawQueryWindowCacheKey = (offset: number, limit: number | undefined): string => {
+  const token: QueryWindowCacheToken = [
+    "window",
+    stableQueryValueString(offset),
+    stableQueryValueString(limit ?? null),
+  ];
+  return JSON.stringify(token);
+};
+
+export const rawQueryPlanWindow = (
+  offset: number,
+  limit: number | undefined,
+): RawQueryPlanWindow => ({
+  cacheKey: rawQueryWindowCacheKey(offset, limit),
+  offset,
+  limit,
+});
+
+const rawQueryPlanWindowFromQuery = (query: RuntimeRawQuery): RawQueryPlanWindow =>
+  rawQueryPlanWindow(query.offset ?? 0, query.limit);
+
+const compareRows = <Row extends RowObject>(
+  left: TopicRowEntry<Row>,
+  right: TopicRowEntry<Row>,
+  orderBy: ReadonlyArray<TopicRawOrderByPlan>,
+): number => {
+  for (const order of orderBy) {
+    const comparison = compareQueryValue(
+      fieldValue(left.row, order.field),
+      fieldValue(right.row, order.field),
+    );
+    if (comparison !== 0) {
+      return order.direction === "asc" ? comparison : -comparison;
+    }
+  }
+  return Number(left.key > right.key) - Number(left.key < right.key);
+};
+
+const projectRow = (row: RowObject, select: ReadonlyArray<string>): RowObject => {
+  const projected: Record<string, unknown> = {};
+  for (const field of select) {
+    projected[field] = cloneUnknown(fieldValue(row, field));
+  }
+  return projected;
+};
+
+function projectCompiledRow<ResultRow extends RowObject>(
+  row: RowObject,
+  select: ReadonlyArray<string>,
+): ResultRow;
+function projectCompiledRow(row: RowObject, select: ReadonlyArray<string>): RowObject {
+  return projectRow(row, select);
+}
+
+export const makeRawQueryPlan = <Row extends RowObject, ResultRow extends RowObject>(
+  metadata: RawQueryCompilerMetadata,
+  query: RuntimeRawQuery,
+): RawQueryPlan<Row, ResultRow> => {
+  const orderBy = query.orderBy ?? [];
+  const selectedFields = [...query.select];
+  const predicate = compileRawPredicate<Row>(metadata, query.where);
+  return {
+    queryCacheKey: rawQueryShapeCacheKey(query),
+    selectedFields,
+    predicate,
+    orderBy,
+    storageOrderBy: orderBy,
+    compare: (left, right) => compareRows(left, right, orderBy),
+    project: (row) => projectCompiledRow(row, selectedFields),
+    window: rawQueryPlanWindowFromQuery(query),
+  };
+};
+
+export const rawQueryWindowScanPlan = <Row extends RowObject, ResultRow extends RowObject>(
+  plan: RawQueryPlan<Row, ResultRow>,
+  window: RawQueryPlanWindow,
+): TopicRawWindowScanPlan<Row> => ({
+  predicate: plan.predicate.plan,
+  orderBy: plan.orderBy,
+  storageOrderBy: plan.storageOrderBy,
+  matches: plan.predicate.matches,
+  compare: plan.compare,
+  offset: window.offset,
+  limit: window.limit,
+});


### PR DESCRIPTION
## Summary

- Add an internal Raw Query Plan Module for predicate hints, deterministic ordering, projection, cache keys, and scan-plan construction.
- Make raw query compilation produce a single plan object instead of separate predicate/order/projection/window pieces.
- Update active raw query execution and grouped query filtering to consume the plan Interface.
- Add Raw Query Plan vocabulary to CONTEXT.md.

## Validation

- `vp check --fix CONTEXT.md packages/column-live-view-engine/src/raw-query-plan.ts packages/column-live-view-engine/src/raw-query-compiler.ts packages/column-live-view-engine/src/active-raw-query.ts packages/column-live-view-engine/src/grouped-query-compiler.ts`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:package-exports`
- `pnpm run check:internal-seams`
- `pnpm run check:effect`
- `pnpm run ready`
- `git diff --check`
- forbidden-pattern scan for casts/assert/toEqual/coverage ignores/Testing Library/act/flushSync/getByTestId
- 3-agent review clean
