### PR TITLE
Extract grouped query plan module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,10 @@ _Avoid_: Query object, filter function
 The compiled internal representation of a Raw Query, including predicate hints, deterministic ordering, projection, cache keys, and window scan inputs.
 _Avoid_: Query object, filter callback, storage scan object
 
+**Grouped Query Plan**:
+The compiled internal representation of a Grouped Query, including group key calculation, aggregate definitions, ordering, window settings, and cache keys.
+_Avoid_: Grouped query object, aggregate config, groupBy helper
+
 **Health Ledger**:
 The owner of counters and sampled health state for mutations, subscriptions, queues, backpressure, ingestion, and transport pressure.
 _Avoid_: Health object builder, metrics dump
@@ -137,6 +141,7 @@ _Avoid_: Browser write, send, emit
 - A **Subscription** belongs to one **Live Query** and emits one **Snapshot** followed by zero or more **Deltas** and **Status Events**.
 - A **Column Live View Engine** owns one **Columnar Topic Store** per **View Server Topic**.
 - A **Raw Query Plan** is compiled once from a **Raw Query** before the **Columnar Topic Store** scans rows.
+- A **Grouped Query Plan** is compiled once from a **Grouped Query** before grouped full-scan or incremental execution.
 - An **Active Query** may serve many equivalent **Subscriptions**.
 - A **Live Client** can subscribe to **Live Queries** but cannot publish mutations.
 - A **Runtime Client** can publish mutations but is not exposed to browsers by the Real View Server.

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -4,8 +4,8 @@ import {
   recomputeIncrementalGroupState,
   updateAggregateState,
 } from "./grouped-aggregate-state";
-import type { RuntimeGroupedQuery } from "./grouped-query-decoder";
-import { groupKey, typedGroupedEvaluation } from "./grouped-query-evaluation";
+import { typedGroupedEvaluation } from "./grouped-query-evaluation";
+import type { GroupedQueryPlan } from "./grouped-query-plan";
 import {
   emptyGroupedEvaluation,
   groupedEvaluationFromEntries,
@@ -60,22 +60,22 @@ type IncrementalGroupedQueryBuildState =
       readonly state: IncrementalGroupedQueryState;
     };
 
-const evaluateIncrementalGroupedQuery = (
+const evaluateIncrementalGroupedQuery = <Row extends RowObject>(
   state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   version: number,
-): QueryEvaluation<RowObject> => groupedEvaluationFromGroups(state.groups.values(), query, version);
+): QueryEvaluation<RowObject> => groupedEvaluationFromGroups(state.groups.values(), plan, version);
 
-const clearIncrementalGroupedQueryState = (
+const clearIncrementalGroupedQueryState = <Row extends RowObject>(
   state: IncrementalGroupedQueryState,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   version: number,
 ): void => {
   state.groups.clear();
   state.evaluation =
     state.mode === "countOnly"
       ? emptyGroupedEvaluation(0, version)
-      : groupedEvaluationFromEntries([], query, version);
+      : groupedEvaluationFromEntries([], plan, version);
   if (state.mode === "materialized") {
     state.memberCount = 0;
   }
@@ -84,7 +84,7 @@ const clearIncrementalGroupedQueryState = (
 
 const buildCountOnlyIncrementalGroupedQueryState = <Row extends RowObject>(
   store: TopicRowScan<Row>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
 ): IncrementalGroupedQueryBuildState => {
   const groups = new Map<string, CountOnlyIncrementalGroupState>();
@@ -96,7 +96,7 @@ const buildCountOnlyIncrementalGroupedQueryState = <Row extends RowObject>(
     if (!matches(row)) {
       return undefined;
     }
-    const groupedKey = groupKey(query.groupBy, row);
+    const groupedKey = plan.groupKey(row);
     let group = groups.get(groupedKey);
     if (group === undefined) {
       group = newZeroLimitIncrementalGroupState(groupedKey);
@@ -129,7 +129,7 @@ const buildCountOnlyIncrementalGroupedQueryState = <Row extends RowObject>(
 
 const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
   store: TopicRowScan<Row>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
 ): IncrementalGroupedQueryBuildState => {
   const groups = new Map<string, MaterializedIncrementalGroupState>();
@@ -142,10 +142,10 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
     if (!matches(row)) {
       return undefined;
     }
-    const groupedKey = groupKey(query.groupBy, row);
+    const groupedKey = plan.groupKey(row);
     let group = groups.get(groupedKey);
     if (group === undefined) {
-      group = newIncrementalGroupState(groupedKey, query.groupBy, query.aggregates, row);
+      group = newIncrementalGroupState(groupedKey, plan.groupBy, plan.aggregates, row);
       groups.set(groupedKey, group);
     }
     group.members.set(key, row);
@@ -159,7 +159,7 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
       admitted = false;
       return false;
     }
-    for (const [alias, aggregate] of Object.entries(query.aggregates)) {
+    for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
     return undefined;
@@ -173,7 +173,7 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
   const state: IncrementalGroupedQueryState = {
     mode: "materialized",
     groups,
-    evaluation: groupedEvaluationFromGroups(groups.values(), query, version),
+    evaluation: groupedEvaluationFromGroups(groups.values(), plan, version),
     memberCount,
     version,
   };
@@ -185,16 +185,16 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
 
 const buildIncrementalGroupedQueryState = <Row extends RowObject>(
   store: TopicRowScan<Row>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
 ): IncrementalGroupedQueryBuildState =>
-  query.limit === 0
-    ? buildCountOnlyIncrementalGroupedQueryState(store, query, matches)
-    : buildMaterializedIncrementalGroupedQueryState(store, query, matches);
+  plan.zeroLimit
+    ? buildCountOnlyIncrementalGroupedQueryState(store, plan, matches)
+    : buildMaterializedIncrementalGroupedQueryState(store, plan, matches);
 
 const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   groups: Map<string, MaterializedIncrementalGroupState>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   key: string,
   row: Row,
@@ -203,7 +203,7 @@ const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   if (!matches(row)) {
     return false;
   }
-  const groupedKey = groupKey(query.groupBy, row);
+  const groupedKey = plan.groupKey(row);
   const group = groups.get(groupedKey);
   if (group === undefined) {
     return false;
@@ -223,14 +223,14 @@ const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
 
 const removeCountOnlyIncrementalGroupedMember = <Row extends RowObject>(
   groups: Map<string, CountOnlyIncrementalGroupState>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   row: Row,
 ): boolean => {
   if (!matches(row)) {
     return false;
   }
-  const groupedKey = groupKey(query.groupBy, row);
+  const groupedKey = plan.groupKey(row);
   const group = groups.get(groupedKey);
   if (group === undefined) {
     return false;
@@ -249,7 +249,7 @@ type UpsertIncrementalGroupedMemberResult = {
 
 const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   groups: Map<string, MaterializedIncrementalGroupState>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   key: string,
   row: Row,
@@ -258,10 +258,10 @@ const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   if (!matches(row)) {
     return undefined;
   }
-  const groupedKey = groupKey(query.groupBy, row);
+  const groupedKey = plan.groupKey(row);
   let group = groups.get(groupedKey);
   if (group === undefined) {
-    group = newIncrementalGroupState(groupedKey, query.groupBy, query.aggregates, row);
+    group = newIncrementalGroupState(groupedKey, plan.groupBy, plan.aggregates, row);
     groups.set(groupedKey, group);
   }
   const inserted = !group.members.has(key);
@@ -275,14 +275,14 @@ const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
 
 const upsertCountOnlyIncrementalGroupedMember = <Row extends RowObject>(
   groups: Map<string, CountOnlyIncrementalGroupState>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   row: Row,
 ): boolean => {
   if (!matches(row)) {
     return false;
   }
-  const groupedKey = groupKey(query.groupBy, row);
+  const groupedKey = plan.groupKey(row);
   let group = groups.get(groupedKey);
   if (group === undefined) {
     group = newZeroLimitIncrementalGroupState(groupedKey);
@@ -294,7 +294,7 @@ const upsertCountOnlyIncrementalGroupedMember = <Row extends RowObject>(
 
 const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
   state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   batch: TopicRowChangeBatch<Row>,
   dirtyGroups: Set<MaterializedIncrementalGroupState>,
@@ -303,7 +303,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
     if (change.previous !== undefined) {
       const removed = removeMaterializedIncrementalGroupedMember(
         state.groups,
-        query,
+        plan,
         matches,
         change.key,
         change.previous,
@@ -316,7 +316,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
     if (change.next !== undefined) {
       const upserted = upsertMaterializedIncrementalGroupedMember(
         state.groups,
-        query,
+        plan,
         matches,
         change.key,
         change.next,
@@ -344,18 +344,18 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
 
 const applyCountOnlyIncrementalGroupedQueryBatch = <Row extends RowObject>(
   state: Extract<IncrementalGroupedQueryState, { readonly mode: "countOnly" }>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   batch: TopicRowChangeBatch<Row>,
 ): boolean => {
   for (const change of batch.changes) {
     if (change.previous !== undefined) {
-      removeCountOnlyIncrementalGroupedMember(state.groups, query, matches, change.previous);
+      removeCountOnlyIncrementalGroupedMember(state.groups, plan, matches, change.previous);
     }
     if (change.next !== undefined) {
       const inserted = upsertCountOnlyIncrementalGroupedMember(
         state.groups,
-        query,
+        plan,
         matches,
         change.next,
       );
@@ -372,13 +372,13 @@ const applyCountOnlyIncrementalGroupedQueryBatch = <Row extends RowObject>(
 
 const applyMaterializedIncrementalGroupedQueryBatches = <Row extends RowObject>(
   state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
 ): boolean => {
   const dirtyGroups = new Set<MaterializedIncrementalGroupState>();
   for (const batch of batches) {
-    if (!applyMaterializedIncrementalGroupedQueryBatch(state, query, matches, batch, dirtyGroups)) {
+    if (!applyMaterializedIncrementalGroupedQueryBatch(state, plan, matches, batch, dirtyGroups)) {
       state.groups.clear();
       state.memberCount = 0;
       return false;
@@ -386,20 +386,20 @@ const applyMaterializedIncrementalGroupedQueryBatches = <Row extends RowObject>(
     state.version = batch.version;
   }
   for (const group of dirtyGroups) {
-    recomputeIncrementalGroupState(group, query.aggregates);
+    recomputeIncrementalGroupState(group, plan.aggregates);
   }
-  state.evaluation = evaluateIncrementalGroupedQuery(state, query, state.version);
+  state.evaluation = evaluateIncrementalGroupedQuery(state, plan, state.version);
   return true;
 };
 
 const applyCountOnlyIncrementalGroupedQueryBatches = <Row extends RowObject>(
   state: Extract<IncrementalGroupedQueryState, { readonly mode: "countOnly" }>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
 ): boolean => {
   for (const batch of batches) {
-    if (!applyCountOnlyIncrementalGroupedQueryBatch(state, query, matches, batch)) {
+    if (!applyCountOnlyIncrementalGroupedQueryBatch(state, plan, matches, batch)) {
       state.groups.clear();
       return false;
     }
@@ -411,14 +411,14 @@ const applyCountOnlyIncrementalGroupedQueryBatches = <Row extends RowObject>(
 
 const applyIncrementalGroupedQueryBatches = <Row extends RowObject>(
   state: IncrementalGroupedQueryState,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
 ): boolean => {
   if (state.mode === "countOnly") {
-    return applyCountOnlyIncrementalGroupedQueryBatches(state, query, matches, batches);
+    return applyCountOnlyIncrementalGroupedQueryBatches(state, plan, matches, batches);
   }
-  return applyMaterializedIncrementalGroupedQueryBatches(state, query, matches, batches);
+  return applyMaterializedIncrementalGroupedQueryBatches(state, plan, matches, batches);
 };
 
 const makeFallbackGroupedQueryExecution = <Row extends RowObject, ResultRow extends RowObject>(
@@ -452,14 +452,14 @@ export const makeIncrementalGroupedQueryExecution = <
   compiled: CompiledGroupedQuery<Row, ResultRow>,
   releaseRetainedChanges: () => void,
 ): IncrementalGroupedQueryExecution<ResultRow> => {
-  let build = buildIncrementalGroupedQueryState(store, compiled.query, compiled.matches);
+  let build = buildIncrementalGroupedQueryState(store, compiled.plan, compiled.matches);
   if (!build.admitted) {
     return makeFallbackGroupedQueryExecution(store, compiled);
   }
   let state = build.state;
   let fallback: IncrementalGroupedQueryExecution<ResultRow> | undefined;
   const activateFallback = (): IncrementalGroupedQueryExecution<ResultRow> => {
-    clearIncrementalGroupedQueryState(state, compiled.query, store.version());
+    clearIncrementalGroupedQueryState(state, compiled.plan, store.version());
     const nextFallback = makeFallbackGroupedQueryExecution(store, compiled);
     fallback = nextFallback;
     releaseRetainedChanges();
@@ -479,14 +479,14 @@ export const makeIncrementalGroupedQueryExecution = <
       }
       const batches = store.changesSince(state.version);
       if (batches === undefined) {
-        build = buildIncrementalGroupedQueryState(store, compiled.query, compiled.matches);
+        build = buildIncrementalGroupedQueryState(store, compiled.plan, compiled.matches);
         if (!build.admitted) {
           return activateFallback().latest();
         }
         state = build.state;
         return typedGroupedEvaluation<ResultRow>(state.evaluation);
       }
-      if (!applyIncrementalGroupedQueryBatches(state, compiled.query, compiled.matches, batches)) {
+      if (!applyIncrementalGroupedQueryBatches(state, compiled.plan, compiled.matches, batches)) {
         return activateFallback().latest();
       }
       return typedGroupedEvaluation<ResultRow>(state.evaluation);

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -1,10 +1,7 @@
 import { Effect } from "effect";
 import { decodeGroupedQuery, type RuntimeGroupedQuery } from "./grouped-query-decoder";
-import {
-  evaluateGroupedRows,
-  groupedCacheKey,
-  typedGroupedEvaluation,
-} from "./grouped-query-evaluation";
+import { evaluateGroupedRows, typedGroupedEvaluation } from "./grouped-query-evaluation";
+import { makeGroupedQueryPlan, type GroupedQueryPlan } from "./grouped-query-plan";
 import { type RawQueryCompilerMetadata, prepareRawQuery } from "./raw-query-compiler";
 import type { QueryEvaluation } from "./query-result";
 import type { TopicRowScan } from "./row-scan";
@@ -14,7 +11,7 @@ type RowObject = object;
 export type { RuntimeGroupedQuery };
 
 export type CompiledGroupedQuery<Row extends RowObject, ResultRow extends RowObject> = {
-  readonly query: RuntimeGroupedQuery;
+  readonly plan: GroupedQueryPlan<Row>;
   readonly cacheKey: string;
   readonly matches: (row: Row) => boolean;
   readonly evaluate: (store: TopicRowScan<Row>) => QueryEvaluation<ResultRow>;
@@ -32,12 +29,13 @@ export const prepareGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.
       ...(decoded.where === undefined ? {} : { where: decoded.where }),
     });
     const { matches } = rawFilter.plan.predicate;
+    const plan = makeGroupedQueryPlan<Row>(decoded);
     return {
-      query: decoded,
-      cacheKey: groupedCacheKey(decoded),
+      plan,
+      cacheKey: plan.cacheKey,
       matches,
       evaluate: (store) =>
-        typedGroupedEvaluation<ResultRow>(evaluateGroupedRows(store, decoded, matches)),
+        typedGroupedEvaluation<ResultRow>(evaluateGroupedRows(store, plan, matches)),
     } satisfies CompiledGroupedQuery<Row, ResultRow>;
   },
 );

--- a/packages/column-live-view-engine/src/grouped-query-decoder.ts
+++ b/packages/column-live-view-engine/src/grouped-query-decoder.ts
@@ -1,18 +1,11 @@
 import { Effect } from "effect";
 import type { RuntimeGroupedAggregate } from "./grouped-aggregate-state";
-import type { RuntimeGroupedOrderBy } from "./grouped-window-evaluation";
+import type { GroupedQueryPlanInput, RuntimeGroupedOrderBy } from "./grouped-query-plan";
 import { InvalidQueryError, isDenseArray } from "./raw-query-decoder";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 import { isPlainRecord } from "./row-values";
 
-export type RuntimeGroupedQuery = {
-  readonly groupBy: ReadonlyArray<string>;
-  readonly aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>;
-  readonly where?: Record<string, unknown>;
-  readonly orderBy?: ReadonlyArray<RuntimeGroupedOrderBy>;
-  readonly offset?: number;
-  readonly limit?: number;
-};
+export type RuntimeGroupedQuery = GroupedQueryPlanInput;
 
 const groupedQueryKeys = new Set([
   "groupBy",

--- a/packages/column-live-view-engine/src/grouped-query-evaluation.ts
+++ b/packages/column-live-view-engine/src/grouped-query-evaluation.ts
@@ -1,28 +1,10 @@
 import { type GroupState, newGroupState, updateAggregateState } from "./grouped-aggregate-state";
-import type { RuntimeGroupedQuery } from "./grouped-query-decoder";
+import type { GroupedQueryPlan } from "./grouped-query-plan";
 import { emptyGroupedEvaluation, groupedEvaluationFromGroups } from "./grouped-window-evaluation";
-import { stableQueryValueString } from "./query-value";
-import { fieldValue } from "./row-values";
 import type { QueryEvaluation } from "./query-result";
 import type { TopicRowScan } from "./row-scan";
 
 type RowObject = object;
-
-export const groupedCacheKey = (query: RuntimeGroupedQuery): string =>
-  stableQueryValueString([
-    "grouped",
-    query.groupBy,
-    Object.entries(query.aggregates).toSorted(
-      ([left], [right]) => Number(left > right) - Number(left < right),
-    ),
-    query.where === undefined ? [] : stableQueryValueString(query.where),
-    query.orderBy ?? [],
-    query.offset ?? null,
-    query.limit ?? null,
-  ]);
-
-export const groupKey = (groupBy: ReadonlyArray<string>, row: RowObject): string =>
-  stableQueryValueString(groupBy.map((field) => [field, fieldValue(row, field)]));
 
 export function typedGroupedEvaluation<ResultRow extends RowObject>(
   evaluation: QueryEvaluation<RowObject>,
@@ -35,13 +17,13 @@ export function typedGroupedEvaluation(
 
 const evaluateZeroLimitGroupedRows = <Row extends RowObject>(
   store: TopicRowScan<Row>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
 ): QueryEvaluation<RowObject> => {
   const groupKeys = new Set<string>();
   store.scanRows((_key, row) => {
     if (matches(row)) {
-      groupKeys.add(groupKey(query.groupBy, row));
+      groupKeys.add(plan.groupKey(row));
     }
   });
   return emptyGroupedEvaluation(groupKeys.size, store.version());
@@ -49,26 +31,26 @@ const evaluateZeroLimitGroupedRows = <Row extends RowObject>(
 
 export const evaluateGroupedRows = <Row extends RowObject>(
   store: TopicRowScan<Row>,
-  query: RuntimeGroupedQuery,
+  plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
 ): QueryEvaluation<RowObject> => {
-  if (query.limit === 0) {
-    return evaluateZeroLimitGroupedRows(store, query, matches);
+  if (plan.zeroLimit) {
+    return evaluateZeroLimitGroupedRows(store, plan, matches);
   }
   const groups = new Map<string, GroupState>();
   store.scanRows((_key, row) => {
     if (!matches(row)) {
       return;
     }
-    const key = groupKey(query.groupBy, row);
+    const key = plan.groupKey(row);
     let group = groups.get(key);
     if (group === undefined) {
-      group = newGroupState(key, query.groupBy, query.aggregates, row);
+      group = newGroupState(key, plan.groupBy, plan.aggregates, row);
       groups.set(key, group);
     }
-    for (const [alias, aggregate] of Object.entries(query.aggregates)) {
+    for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
   });
-  return groupedEvaluationFromGroups(groups.values(), query, store.version());
+  return groupedEvaluationFromGroups(groups.values(), plan, store.version());
 };

--- a/packages/column-live-view-engine/src/grouped-query-plan.ts
+++ b/packages/column-live-view-engine/src/grouped-query-plan.ts
@@ -1,0 +1,71 @@
+import type { RuntimeGroupedAggregate } from "./grouped-aggregate-state";
+import { stableQueryValueString } from "./query-value";
+import { fieldValue } from "./row-values";
+
+type RowObject = object;
+
+export type RuntimeGroupedOrderBy =
+  | {
+      readonly field: string;
+      readonly direction: "asc" | "desc";
+    }
+  | {
+      readonly aggregate: string;
+      readonly direction: "asc" | "desc";
+    };
+
+export type GroupedQueryPlanInput = {
+  readonly groupBy: ReadonlyArray<string>;
+  readonly aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>;
+  readonly where?: Record<string, unknown>;
+  readonly orderBy?: ReadonlyArray<RuntimeGroupedOrderBy>;
+  readonly offset?: number;
+  readonly limit?: number;
+};
+
+export type GroupedQueryPlan<Row extends RowObject> = {
+  readonly query: GroupedQueryPlanInput;
+  readonly cacheKey: string;
+  readonly groupBy: ReadonlyArray<string>;
+  readonly aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>;
+  readonly orderBy: ReadonlyArray<RuntimeGroupedOrderBy>;
+  readonly offset: number;
+  readonly limit: number | undefined;
+  readonly zeroLimit: boolean;
+  readonly groupKey: (row: Row) => string;
+};
+
+const groupedQueryPlanCacheKey = (query: GroupedQueryPlanInput): string =>
+  stableQueryValueString([
+    "grouped",
+    query.groupBy,
+    Object.entries(query.aggregates).toSorted(
+      ([left], [right]) => Number(left > right) - Number(left < right),
+    ),
+    query.where === undefined ? [] : stableQueryValueString(query.where),
+    query.orderBy ?? [],
+    query.offset ?? null,
+    query.limit ?? null,
+  ]);
+
+const groupedQueryPlanGroupKey = <Row extends RowObject>(
+  groupBy: ReadonlyArray<string>,
+  row: Row,
+): string => stableQueryValueString(groupBy.map((field) => [field, fieldValue(row, field)]));
+
+export const makeGroupedQueryPlan = <Row extends RowObject>(
+  query: GroupedQueryPlanInput,
+): GroupedQueryPlan<Row> => {
+  const groupBy = [...query.groupBy];
+  return {
+    query,
+    cacheKey: groupedQueryPlanCacheKey(query),
+    groupBy,
+    aggregates: query.aggregates,
+    orderBy: query.orderBy === undefined ? [] : [...query.orderBy],
+    offset: query.offset ?? 0,
+    limit: query.limit,
+    zeroLimit: query.limit === 0,
+    groupKey: (row) => groupedQueryPlanGroupKey(groupBy, row),
+  };
+};

--- a/packages/column-live-view-engine/src/grouped-window-evaluation.ts
+++ b/packages/column-live-view-engine/src/grouped-window-evaluation.ts
@@ -3,27 +3,12 @@ import {
   finalizeGroup,
   type GroupState,
 } from "./grouped-aggregate-state";
+import type { GroupedQueryPlan, RuntimeGroupedOrderBy } from "./grouped-query-plan";
 import { compareQueryValue } from "./raw-query-compiler";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
 import { fieldValue } from "./row-values";
 
 type RowObject = object;
-
-export type RuntimeGroupedOrderBy =
-  | {
-      readonly field: string;
-      readonly direction: "asc" | "desc";
-    }
-  | {
-      readonly aggregate: string;
-      readonly direction: "asc" | "desc";
-    };
-
-type RuntimeGroupedWindowQuery = {
-  readonly orderBy?: ReadonlyArray<RuntimeGroupedOrderBy>;
-  readonly offset?: number;
-  readonly limit?: number;
-};
 
 type BoundedGroupEntry = {
   group: GroupState;
@@ -48,11 +33,13 @@ const compareGroupedRows = (
   return Number(left.key > right.key) - Number(left.key < right.key);
 };
 
-const groupedWindowEnd = (query: RuntimeGroupedWindowQuery): number | undefined => {
-  if (query.limit === undefined) {
+const groupedWindowEnd = <Row extends RowObject>(
+  plan: GroupedQueryPlan<Row>,
+): number | undefined => {
+  if (plan.limit === undefined) {
     return undefined;
   }
-  const windowEnd = (query.offset ?? 0) + query.limit;
+  const windowEnd = plan.offset + plan.limit;
   if (!Number.isSafeInteger(windowEnd) || windowEnd > maxBoundedGroupedWindowEnd) {
     return undefined;
   }
@@ -211,13 +198,13 @@ const retainBoundedGroup = (
   return nextScratchOrderValues;
 };
 
-const boundedGroupedEvaluationFromGroups = (
+const boundedGroupedEvaluationFromGroups = <Row extends RowObject>(
   groups: Iterable<GroupState>,
-  query: RuntimeGroupedWindowQuery,
+  plan: GroupedQueryPlan<Row>,
   version: number,
   windowEnd: number,
 ): QueryEvaluation<RowObject> => {
-  const orderBy = query.orderBy ?? [];
+  const orderBy = plan.orderBy;
   const retainedGroups: Array<BoundedGroupEntry> = [];
   let scratchOrderValues: Array<unknown> = [];
   let totalRows = 0;
@@ -233,7 +220,7 @@ const boundedGroupedEvaluationFromGroups = (
   }
   const window = retainedGroups
     .toSorted((left, right) => compareBoundedGroupEntries(left, right, orderBy))
-    .slice(query.offset ?? 0)
+    .slice(plan.offset)
     .map((entry) => finalizeGroup(entry.group));
   return {
     rows: window.map((entry) => entry.row),
@@ -255,31 +242,26 @@ export const emptyGroupedEvaluation = (
   version,
 });
 
-export const groupedEvaluationFromGroups = (
+export const groupedEvaluationFromGroups = <Row extends RowObject>(
   groups: Iterable<GroupState>,
-  query: RuntimeGroupedWindowQuery,
+  plan: GroupedQueryPlan<Row>,
   version: number,
 ): QueryEvaluation<RowObject> => {
-  const windowEnd = groupedWindowEnd(query);
+  const windowEnd = groupedWindowEnd(plan);
   if (windowEnd !== undefined) {
-    return boundedGroupedEvaluationFromGroups(groups, query, version, windowEnd);
+    return boundedGroupedEvaluationFromGroups(groups, plan, version, windowEnd);
   }
-  return groupedEvaluationFromEntries(Array.from(groups, finalizeGroup), query, version);
+  return groupedEvaluationFromEntries(Array.from(groups, finalizeGroup), plan, version);
 };
 
-export const groupedEvaluationFromEntries = (
+export const groupedEvaluationFromEntries = <Row extends RowObject>(
   entries: ReadonlyArray<StoredRowOf<RowObject>>,
-  query: RuntimeGroupedWindowQuery,
+  plan: GroupedQueryPlan<Row>,
   version: number,
 ): QueryEvaluation<RowObject> => {
-  const ordered = entries.toSorted((left, right) =>
-    compareGroupedRows(left, right, query.orderBy ?? []),
-  );
-  const offset = query.offset ?? 0;
-  const window = ordered.slice(
-    offset,
-    query.limit === undefined ? undefined : offset + query.limit,
-  );
+  const ordered = entries.toSorted((left, right) => compareGroupedRows(left, right, plan.orderBy));
+  const offset = plan.offset;
+  const window = ordered.slice(offset, plan.limit === undefined ? undefined : offset + plan.limit);
   return {
     rows: window.map((entry) => entry.row),
     keys: window.map((entry) => entry.key),


### PR DESCRIPTION
## Summary

- Add an internal Grouped Query Plan Module for grouped cache keys, group keys, aggregate definitions, order/window settings, and zero-limit mode.
- Make grouped compilation produce a single plan object consumed by full-scan and incremental grouped execution.
- Move grouped order-by typing out of window evaluation so the decoder no longer depends on the window Module.
- Add Grouped Query Plan vocabulary to CONTEXT.md.

## Validation

- `vp check --fix ...`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:package-exports`
- `pnpm run check:internal-seams`
- `pnpm run check:effect`
- `pnpm run ready`
- `git diff --check`
- forbidden-pattern scan
- 3-agent review clean
