### PR TITLE
Extract raw predicate plan module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,10 @@ _Avoid_: Query object, filter function
 The compiled internal representation of a Raw Query, including predicate hints, deterministic ordering, projection, cache keys, and window scan inputs.
 _Avoid_: Query object, filter callback, storage scan object
 
+**Raw Predicate Plan**:
+The storage-admissible predicate hint set compiled from a Raw Query, including exact scalar filters and whether row callback evaluation is still required.
+_Avoid_: Filter helper, where object, matcher callback
+
 **Grouped Query Plan**:
 The compiled internal representation of a Grouped Query, including group key calculation, aggregate definitions, ordering, window settings, and cache keys.
 _Avoid_: Grouped query object, aggregate config, groupBy helper
@@ -141,6 +145,7 @@ _Avoid_: Browser write, send, emit
 - A **Subscription** belongs to one **Live Query** and emits one **Snapshot** followed by zero or more **Deltas** and **Status Events**.
 - A **Column Live View Engine** owns one **Columnar Topic Store** per **View Server Topic**.
 - A **Raw Query Plan** is compiled once from a **Raw Query** before the **Columnar Topic Store** scans rows.
+- A **Raw Predicate Plan** is part of a **Raw Query Plan** and lets storage narrow scans without replacing the correctness callback unless it is proven exact.
 - A **Grouped Query Plan** is compiled once from a **Grouped Query** before grouped full-scan or incremental execution.
 - An **Active Query** may serve many equivalent **Subscriptions**.
 - A **Live Client** can subscribe to **Live Queries** but cannot publish mutations.

--- a/packages/column-live-view-engine/src/raw-predicate-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-compiler.ts
@@ -1,32 +1,19 @@
 import { isBigDecimal } from "effect/BigDecimal";
 import { compareFilterValue } from "./query-value";
-import { filterOperatorKeys, isDenseArray, type RuntimeRawQuery } from "./raw-query-decoder";
-import type { RangeValueKind, RawQueryCompilerMetadata } from "./raw-query-metadata";
+import { isDenseArray, type RuntimeRawQuery } from "./raw-query-decoder";
 import {
-  fieldValue,
-  isPlainRecord,
-  scalarEqualityKey,
-  type ScalarEqualityKeyValue,
-  valuesEqual,
-} from "./row-values";
-import type { TopicRawPredicatePlan } from "./raw-window-scan";
+  isOperatorFilterObject,
+  predicateFilterPlans,
+  type TopicRawPredicatePlan,
+} from "./raw-predicate-plan";
+import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+import { fieldValue, isPlainRecord, valuesEqual } from "./row-values";
 
 type RowObject = object;
 
 export type CompiledRawPredicate<Row extends RowObject> = {
   readonly plan: TopicRawPredicatePlan;
   readonly matches: (row: Row) => boolean;
-};
-
-type FilterObject = {
-  readonly eq?: unknown;
-  readonly neq?: unknown;
-  readonly in?: ReadonlyArray<unknown>;
-  readonly gt?: unknown;
-  readonly gte?: unknown;
-  readonly lt?: unknown;
-  readonly lte?: unknown;
-  readonly startsWith?: string;
 };
 
 const isEqualityComparable = (left: unknown, right: unknown): boolean => {
@@ -39,11 +26,6 @@ const isEqualityComparable = (left: unknown, right: unknown): boolean => {
   return typeof left === typeof right;
 };
 
-const isOperatorFilterObject = (filter: Record<string, unknown>): filter is FilterObject => {
-  const keys = Object.keys(filter);
-  return keys.length > 0 && keys.every((key) => filterOperatorKeys.has(key));
-};
-
 const includesValue = (values: ReadonlyArray<unknown>, value: unknown): boolean => {
   for (const candidate of values) {
     if (valuesEqual(value, candidate)) {
@@ -51,75 +33,6 @@ const includesValue = (values: ReadonlyArray<unknown>, value: unknown): boolean 
     }
   }
   return false;
-};
-
-const rangeValueKind = (value: unknown): RangeValueKind | undefined => {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return "number";
-  }
-  if (typeof value === "bigint") {
-    return "bigint";
-  }
-  if (isBigDecimal(value)) {
-    return "bigDecimal";
-  }
-  return undefined;
-};
-
-const isScalarPlanValue = (value: unknown): value is ScalarEqualityKeyValue =>
-  value === null ||
-  typeof value === "string" ||
-  typeof value === "boolean" ||
-  typeof value === "bigint" ||
-  isBigDecimal(value) ||
-  (typeof value === "number" && Number.isFinite(value));
-
-export const isRangePlanValue = (
-  field: string,
-  value: unknown,
-  metadata: RawQueryCompilerMetadata,
-): boolean => {
-  const kind = rangeValueKind(value);
-  const fieldKinds = metadata.rangeValueKinds.get(field);
-  return kind !== undefined && fieldKinds?.size === 1 && fieldKinds.has(kind);
-};
-
-const isEqualityPlanValue = (value: unknown): value is ScalarEqualityKeyValue =>
-  isScalarPlanValue(value);
-
-const isNotEqualPlanValue = (
-  field: string,
-  value: unknown,
-  metadata: RawQueryCompilerMetadata,
-): boolean => {
-  if (!isEqualityPlanValue(value)) {
-    return false;
-  }
-  if (metadata.numericFieldNames.has(field)) {
-    return isRangePlanValue(field, value, metadata);
-  }
-  if (metadata.stringFieldNames.has(field)) {
-    return typeof value === "string";
-  }
-  return false;
-};
-
-const isInPlanValues = (value: unknown): value is ReadonlyArray<ScalarEqualityKeyValue> =>
-  Array.isArray(value) &&
-  isDenseArray(value) &&
-  value.every((candidate) => isEqualityPlanValue(candidate));
-
-const scalarEqualityKeys = (values: ReadonlyArray<ScalarEqualityKeyValue>): ReadonlySet<string> => {
-  const keys = new Set<string>();
-  for (const value of values) {
-    keys.add(scalarEqualityKey(value));
-  }
-  return keys;
-};
-
-type PredicateFieldPlan = {
-  readonly filters: TopicRawPredicatePlan["filters"];
-  readonly callbackRequired: boolean;
 };
 
 type CompiledRawPredicateClause = {
@@ -130,135 +43,6 @@ type CompiledRawPredicateClause = {
 type CompiledRawPredicateParts = {
   readonly clauses: ReadonlyArray<CompiledRawPredicateClause>;
   readonly plan: TopicRawPredicatePlan;
-};
-
-const predicateFilterPlans = (
-  field: string,
-  filter: unknown,
-  metadata: RawQueryCompilerMetadata,
-): PredicateFieldPlan => {
-  if (metadata.structuredFieldNames.has(field) || filter === undefined) {
-    return {
-      filters: [],
-      callbackRequired: true,
-    };
-  }
-  if (!isPlainRecord(filter) || isBigDecimal(filter)) {
-    if (!isScalarPlanValue(filter)) {
-      return {
-        filters: [],
-        callbackRequired: true,
-      };
-    }
-    return {
-      filters: [
-        {
-          field,
-          operator: "eq",
-          value: filter,
-        },
-      ],
-      callbackRequired: false,
-    };
-  }
-
-  const operatorKeys = Object.keys(filter).filter((key) => filterOperatorKeys.has(key));
-  let callbackRequired = operatorKeys.length === 0;
-  const plans: Array<TopicRawPredicatePlan["filters"][number]> = [];
-  if ("eq" in filter) {
-    if (isEqualityPlanValue(filter["eq"])) {
-      plans.push({
-        field,
-        operator: "eq",
-        value: filter["eq"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("neq" in filter) {
-    if (isNotEqualPlanValue(field, filter["neq"], metadata)) {
-      plans.push({
-        field,
-        operator: "neq",
-        value: filter["neq"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("in" in filter) {
-    if (isInPlanValues(filter["in"])) {
-      const values = [...filter["in"]];
-      plans.push({
-        field,
-        operator: "in",
-        values,
-        valueKeys: scalarEqualityKeys(values),
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("gt" in filter) {
-    if (isRangePlanValue(field, filter["gt"], metadata)) {
-      plans.push({
-        field,
-        operator: "gt",
-        value: filter["gt"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("gte" in filter) {
-    if (isRangePlanValue(field, filter["gte"], metadata)) {
-      plans.push({
-        field,
-        operator: "gte",
-        value: filter["gte"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("lt" in filter) {
-    if (isRangePlanValue(field, filter["lt"], metadata)) {
-      plans.push({
-        field,
-        operator: "lt",
-        value: filter["lt"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("lte" in filter) {
-    if (isRangePlanValue(field, filter["lte"], metadata)) {
-      plans.push({
-        field,
-        operator: "lte",
-        value: filter["lte"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  if ("startsWith" in filter) {
-    if (typeof filter["startsWith"] === "string") {
-      plans.push({
-        field,
-        operator: "startsWith",
-        value: filter["startsWith"],
-      });
-    } else {
-      callbackRequired = true;
-    }
-  }
-  return {
-    filters: plans,
-    callbackRequired,
-  };
 };
 
 const isStructuredQueryValue = (value: unknown): boolean =>

--- a/packages/column-live-view-engine/src/raw-predicate-plan.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-plan.ts
@@ -1,0 +1,250 @@
+import { isBigDecimal } from "effect/BigDecimal";
+import { filterOperatorKeys, isDenseArray } from "./raw-query-decoder";
+import type { RangeValueKind, RawQueryCompilerMetadata } from "./raw-query-metadata";
+import { isPlainRecord, scalarEqualityKey, type ScalarEqualityKeyValue } from "./row-values";
+
+export type TopicRawPredicateFilterPlan =
+  | {
+      readonly field: string;
+      readonly operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "startsWith";
+      readonly value: unknown;
+    }
+  | {
+      readonly field: string;
+      readonly operator: "in";
+      readonly values: ReadonlyArray<unknown>;
+      readonly valueKeys?: ReadonlySet<string>;
+    };
+
+export type TopicRawPredicatePlan = {
+  /**
+   * Safe scalar hints that storage can use to narrow a raw scan.
+   * `matches` remains the correctness guard unless an adapter implements a
+   * proven equivalent for every emitted hint.
+   */
+  readonly filters: ReadonlyArray<TopicRawPredicateFilterPlan>;
+  /**
+   * True when the compiler intentionally omitted part of the predicate from
+   * `filters`, for example structured fields or malformed runtime filters.
+   */
+  readonly callbackRequired: boolean;
+  /**
+   * True when the compiler proved that `filters` fully represent `matches`.
+   * Hand-written plans omit this and stay guarded by the row callback.
+   */
+  readonly callbackSkippable?: boolean;
+};
+
+export type PredicateFieldPlan = {
+  readonly filters: TopicRawPredicatePlan["filters"];
+  readonly callbackRequired: boolean;
+};
+
+type FilterObject = {
+  readonly eq?: unknown;
+  readonly neq?: unknown;
+  readonly in?: ReadonlyArray<unknown>;
+  readonly gt?: unknown;
+  readonly gte?: unknown;
+  readonly lt?: unknown;
+  readonly lte?: unknown;
+  readonly startsWith?: string;
+};
+
+const rangeValueKind = (value: unknown): RangeValueKind | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return "number";
+  }
+  if (typeof value === "bigint") {
+    return "bigint";
+  }
+  if (isBigDecimal(value)) {
+    return "bigDecimal";
+  }
+  return undefined;
+};
+
+const isScalarPlanValue = (value: unknown): value is ScalarEqualityKeyValue =>
+  value === null ||
+  typeof value === "string" ||
+  typeof value === "boolean" ||
+  typeof value === "bigint" ||
+  isBigDecimal(value) ||
+  (typeof value === "number" && Number.isFinite(value));
+
+export const isRangePlanValue = (
+  field: string,
+  value: unknown,
+  metadata: RawQueryCompilerMetadata,
+): boolean => {
+  const kind = rangeValueKind(value);
+  const fieldKinds = metadata.rangeValueKinds.get(field);
+  return kind !== undefined && fieldKinds?.size === 1 && fieldKinds.has(kind);
+};
+
+const isEqualityPlanValue = (value: unknown): value is ScalarEqualityKeyValue =>
+  isScalarPlanValue(value);
+
+const isNotEqualPlanValue = (
+  field: string,
+  value: unknown,
+  metadata: RawQueryCompilerMetadata,
+): boolean => {
+  if (!isEqualityPlanValue(value)) {
+    return false;
+  }
+  if (metadata.numericFieldNames.has(field)) {
+    return isRangePlanValue(field, value, metadata);
+  }
+  if (metadata.stringFieldNames.has(field)) {
+    return typeof value === "string";
+  }
+  return false;
+};
+
+const isInPlanValues = (value: unknown): value is ReadonlyArray<ScalarEqualityKeyValue> =>
+  Array.isArray(value) &&
+  isDenseArray(value) &&
+  value.every((candidate) => isEqualityPlanValue(candidate));
+
+const scalarEqualityKeys = (values: ReadonlyArray<ScalarEqualityKeyValue>): ReadonlySet<string> => {
+  const keys = new Set<string>();
+  for (const value of values) {
+    keys.add(scalarEqualityKey(value));
+  }
+  return keys;
+};
+
+export const isOperatorFilterObject = (filter: Record<string, unknown>): filter is FilterObject => {
+  const keys = Object.keys(filter);
+  return keys.length > 0 && keys.every((key) => filterOperatorKeys.has(key));
+};
+
+export const predicateFilterPlans = (
+  field: string,
+  filter: unknown,
+  metadata: RawQueryCompilerMetadata,
+): PredicateFieldPlan => {
+  if (metadata.structuredFieldNames.has(field) || filter === undefined) {
+    return {
+      filters: [],
+      callbackRequired: true,
+    };
+  }
+  if (!isPlainRecord(filter) || isBigDecimal(filter)) {
+    if (!isScalarPlanValue(filter)) {
+      return {
+        filters: [],
+        callbackRequired: true,
+      };
+    }
+    return {
+      filters: [
+        {
+          field,
+          operator: "eq",
+          value: filter,
+        },
+      ],
+      callbackRequired: false,
+    };
+  }
+
+  const operatorKeys = Object.keys(filter).filter((key) => filterOperatorKeys.has(key));
+  let callbackRequired = operatorKeys.length === 0;
+  const plans: Array<TopicRawPredicatePlan["filters"][number]> = [];
+  if ("eq" in filter) {
+    if (isEqualityPlanValue(filter["eq"])) {
+      plans.push({
+        field,
+        operator: "eq",
+        value: filter["eq"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("neq" in filter) {
+    if (isNotEqualPlanValue(field, filter["neq"], metadata)) {
+      plans.push({
+        field,
+        operator: "neq",
+        value: filter["neq"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("in" in filter) {
+    if (isInPlanValues(filter["in"])) {
+      const values = [...filter["in"]];
+      plans.push({
+        field,
+        operator: "in",
+        values,
+        valueKeys: scalarEqualityKeys(values),
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("gt" in filter) {
+    if (isRangePlanValue(field, filter["gt"], metadata)) {
+      plans.push({
+        field,
+        operator: "gt",
+        value: filter["gt"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("gte" in filter) {
+    if (isRangePlanValue(field, filter["gte"], metadata)) {
+      plans.push({
+        field,
+        operator: "gte",
+        value: filter["gte"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("lt" in filter) {
+    if (isRangePlanValue(field, filter["lt"], metadata)) {
+      plans.push({
+        field,
+        operator: "lt",
+        value: filter["lt"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("lte" in filter) {
+    if (isRangePlanValue(field, filter["lte"], metadata)) {
+      plans.push({
+        field,
+        operator: "lte",
+        value: filter["lte"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  if ("startsWith" in filter) {
+    if (typeof filter["startsWith"] === "string") {
+      plans.push({
+        field,
+        operator: "startsWith",
+        value: filter["startsWith"],
+      });
+    } else {
+      callbackRequired = true;
+    }
+  }
+  return {
+    filters: plans,
+    callbackRequired,
+  };
+};

--- a/packages/column-live-view-engine/src/raw-query-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { compareQueryValue, stableQueryValueString } from "./query-value";
-import { isRangePlanValue, type CompiledRawPredicate } from "./raw-predicate-compiler";
+import type { CompiledRawPredicate } from "./raw-predicate-compiler";
+import { isRangePlanValue } from "./raw-predicate-plan";
 import { makeRawQueryPlan, type RawQueryPlan } from "./raw-query-plan";
 import {
   decodeRawQuery,

--- a/packages/column-live-view-engine/src/raw-window-scan.ts
+++ b/packages/column-live-view-engine/src/raw-window-scan.ts
@@ -1,3 +1,4 @@
+import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { TopicRowEntry } from "./row-scan";
 
 type RowObject = object;
@@ -5,38 +6,6 @@ type RowObject = object;
 export type TopicRawOrderByPlan = {
   readonly field: string;
   readonly direction: "asc" | "desc";
-};
-
-export type TopicRawPredicateFilterPlan =
-  | {
-      readonly field: string;
-      readonly operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "startsWith";
-      readonly value: unknown;
-    }
-  | {
-      readonly field: string;
-      readonly operator: "in";
-      readonly values: ReadonlyArray<unknown>;
-      readonly valueKeys?: ReadonlySet<string>;
-    };
-
-export type TopicRawPredicatePlan = {
-  /**
-   * Safe scalar hints that storage can use to narrow a raw scan.
-   * `matches` remains the correctness guard unless an adapter implements a
-   * proven equivalent for every emitted hint.
-   */
-  readonly filters: ReadonlyArray<TopicRawPredicateFilterPlan>;
-  /**
-   * True when the compiler intentionally omitted part of the predicate from
-   * `filters`, for example structured fields or malformed runtime filters.
-   */
-  readonly callbackRequired: boolean;
-  /**
-   * True when the compiler proved that `filters` fully represent `matches`.
-   * Hand-written plans omit this and stay guarded by the row callback.
-   */
-  readonly callbackSkippable?: boolean;
 };
 
 export type TopicRawWindowScanPlan<Row extends RowObject> = {

--- a/packages/column-live-view-engine/src/topic-ordered-window.ts
+++ b/packages/column-live-view-engine/src/topic-ordered-window.ts
@@ -1,4 +1,5 @@
-import type { TopicRawOrderByPlan, TopicRawPredicateFilterPlan } from "./raw-window-scan";
+import type { TopicRawPredicateFilterPlan } from "./raw-predicate-plan";
+import type { TopicRawOrderByPlan } from "./raw-window-scan";
 import {
   compareQueryValue,
   isRangePlanValue,

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-filter.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-filter.ts
@@ -1,4 +1,4 @@
-import type { TopicRawPredicateFilterPlan } from "./raw-window-scan";
+import type { TopicRawPredicateFilterPlan } from "./raw-predicate-plan";
 import { scalarEqualityKey } from "./row-values";
 import {
   compareExactRangeColumnValue,

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -1,4 +1,5 @@
-import type { TopicRawPredicateFilterPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
+import type { TopicRawPredicateFilterPlan } from "./raw-predicate-plan";
+import type { TopicRawWindowScanPlan } from "./raw-window-scan";
 import { scalarEqualityKey, valuesEqual } from "./row-values";
 import {
   columnValueDoesNotEqual,


### PR DESCRIPTION
## Summary

- Add an internal Raw Predicate Plan Module for storage-admissible raw predicate hints, predicate filter plan types, and range/equality admissibility.
- Keep raw predicate compilation focused on matcher callback semantics while consuming the predicate plan Module.
- Move predicate plan ownership out of raw-window-scan and update storage consumers to depend on raw-predicate-plan directly.
- Add Raw Predicate Plan vocabulary to CONTEXT.md.

## Validation

- `vp check --fix ...`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run check:package-exports`
- `pnpm run check:internal-seams`
- strict Effect LSP for column-live-view-engine
- `pnpm run ready`
- `git diff --check`
- forbidden-pattern scan
- 3-agent review clean after staging the new file
