### PR TITLE
Extract protocol field filter codec

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,6 +112,10 @@ _Avoid_: Runtime client, publishing client
 The Effect RPC WebSocket protocol using NDJSON serialization and schema-aware JSON-safe encoding for configured topic rows and query values.
 _Avoid_: Raw WebSocket protocol, HTTP stream, SSE, MessagePack protocol
 
+**Field Filter Codec**:
+The Wire Protocol module that encodes and decodes schema-aware JSON-safe Raw Query filter values, including operator filters and structured-value fallback.
+_Avoid_: Filter helper, JSON helper, where encoder
+
 **View Server Provider**:
 The React provider that supplies a Live Client to hooks.
 _Avoid_: Runtime provider, in-memory provider when discussing the generic provider
@@ -156,6 +160,7 @@ _Avoid_: Browser write, send, emit
 - A **Live Client** can subscribe to **Live Queries** but cannot publish mutations.
 - A **Runtime Client** can publish mutations but is not exposed to browsers by the Real View Server.
 - A **Remote Browser Client** is a **Live Client** adapter for the **Wire Protocol**.
+- A **Field Filter Codec** protects the **Wire Protocol** from unsafe or incorrectly typed filter values.
 - A **View Server Provider** supplies a **Live Client** to React hooks.
 - A **View Server In-Memory Provider** supplies the same hook behavior through an **In-Memory View Server**.
 - A **Source Topic** is mapped into a **View Server Topic** through a **Mapping**.

--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -1,0 +1,206 @@
+import { viewServerSchemaFieldMetadata, type ViewServerRuntimeError } from "@view-server/config";
+import { Effect, Schema } from "effect";
+
+export type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
+
+export const filterOperatorKeys = new Set([
+  "eq",
+  "neq",
+  "in",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "startsWith",
+]);
+
+const rangeFilterOperatorKeys = new Set(["gt", "gte", "lt", "lte"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const isFilterObject = (value: unknown): value is Record<string, unknown> =>
+  isRecord(value) &&
+  Object.keys(value).length > 0 &&
+  Object.keys(value).every((key) => filterOperatorKeys.has(key));
+
+const invalidQuery = (topic: string, message: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidQuery",
+  message,
+  topic,
+});
+
+const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) =>
+      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
+    ),
+  );
+  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
+    Effect.mapError((error) =>
+      invalidQuery(topic, `Filter ${field} is not JSON-safe: ${error.message}`),
+    ),
+  );
+});
+
+const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) =>
+      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
+    ),
+  );
+});
+
+const encodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.encode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) =>
+      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
+    ),
+  );
+  if (typeof decoded !== "string") {
+    return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
+  }
+  return yield* Schema.decodeUnknownEffect(Schema.String)(value).pipe(
+    Effect.mapError((error) =>
+      invalidQuery(topic, `Invalid startsWith filter for ${field}: ${error.message}`),
+    ),
+  );
+});
+
+const decodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.decode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) =>
+      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
+    ),
+  );
+  if (typeof decoded !== "string") {
+    return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
+  }
+  return decoded;
+});
+
+const validateOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.validate")(
+  function* (
+    topic: string,
+    field: string,
+    schema: JsonFieldSchema,
+    value: Record<string, unknown>,
+  ) {
+    const metadata = viewServerSchemaFieldMetadata(schema);
+    if (metadata.isStructured) {
+      return;
+    }
+    const keys = Object.keys(value);
+    if (keys.includes("startsWith") && !metadata.isString) {
+      return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
+    }
+    if (keys.some((key) => rangeFilterOperatorKeys.has(key)) && !metadata.isNumeric) {
+      return yield* Effect.fail(
+        invalidQuery(topic, `Filter ${field} does not support range operators`),
+      );
+    }
+  },
+);
+
+const encodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.encode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: Record<string, unknown>,
+) {
+  yield* validateOperatorFilterValue(topic, field, schema, value);
+  const output: Record<string, Schema.Json> = {};
+  for (const [operator, operatorValue] of Object.entries(value)) {
+    if (operator === "in" && Array.isArray(operatorValue)) {
+      output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
+        encodeJsonFieldValue(topic, field, schema, entry),
+      );
+    } else if (operator === "startsWith") {
+      output[operator] = yield* encodeStringFilterValue(topic, field, schema, operatorValue);
+    } else {
+      output[operator] = yield* encodeJsonFieldValue(topic, field, schema, operatorValue);
+    }
+  }
+  return output;
+});
+
+const decodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.decode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: Record<string, unknown>,
+) {
+  yield* validateOperatorFilterValue(topic, field, schema, value);
+  const output: Record<string, unknown> = {};
+  for (const [operator, operatorValue] of Object.entries(value)) {
+    if (operator === "in" && Array.isArray(operatorValue)) {
+      output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
+        decodeJsonFieldValue(topic, field, schema, entry),
+      );
+    } else if (operator === "startsWith") {
+      output[operator] = yield* decodeStringFilterValue(topic, field, schema, operatorValue);
+    } else {
+      output[operator] = yield* decodeJsonFieldValue(topic, field, schema, operatorValue);
+    }
+  }
+  return output;
+});
+
+export const encodeFilterValue = Effect.fn("ViewServerProtocol.filter.encode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  if (!isFilterObject(value)) {
+    return yield* encodeJsonFieldValue(topic, field, schema, value);
+  }
+  return yield* Effect.matchEffect(encodeOperatorFilterValue(topic, field, schema, value), {
+    onFailure: (operatorError) =>
+      Effect.matchEffect(encodeJsonFieldValue(topic, field, schema, value), {
+        onFailure: () => Effect.fail(operatorError),
+        onSuccess: Effect.succeed,
+      }),
+    onSuccess: Effect.succeed,
+  });
+});
+
+export const decodeFilterValue = Effect.fn("ViewServerProtocol.filter.decode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  if (!isFilterObject(value)) {
+    return yield* decodeJsonFieldValue(topic, field, schema, value);
+  }
+  return yield* Effect.matchEffect(decodeOperatorFilterValue(topic, field, schema, value), {
+    onFailure: (operatorError) =>
+      Effect.matchEffect(decodeJsonFieldValue(topic, field, schema, value), {
+        onFailure: () => Effect.fail(operatorError),
+        onSuccess: Effect.succeed,
+      }),
+    onSuccess: Effect.succeed,
+  });
+});

--- a/packages/protocol/src/protocol-query-codec.ts
+++ b/packages/protocol/src/protocol-query-codec.ts
@@ -12,6 +12,11 @@ import type {
 import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import {
+  decodeFilterValue,
+  encodeFilterValue,
+  type JsonFieldSchema,
+} from "./protocol-field-filter-codec";
+import {
   LooseWireGroupedQuerySchema,
   type LooseWireGroupedQuery,
   LooseWireRawQuerySchema,
@@ -20,8 +25,6 @@ import {
   type ViewServerWireGroupedQuery,
   type ViewServerWireRawQuery,
 } from "./protocol-query-schema";
-
-type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
 
 type TrustedRawQuery<Row> = {
   readonly select: ReadonlyArray<FieldKey<Row>>;
@@ -48,8 +51,6 @@ export type ViewServerValidatedLiveQuery<Row> =
   | ViewServerValidatedRawQuery<Row>
   | ViewServerValidatedGroupedQuery<Row>;
 
-const filterOperatorKeys = new Set(["eq", "neq", "in", "gt", "gte", "lt", "lte", "startsWith"]);
-const rangeFilterOperatorKeys = new Set(["gt", "gte", "lt", "lte"]);
 const dangerousRecordKeys = new Set(["__proto__", "prototype", "constructor"]);
 
 const strictParseOptions = {
@@ -62,11 +63,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isNumericFieldSchema = (schema: JsonFieldSchema | undefined): boolean => {
   return schema !== undefined && viewServerSchemaFieldMetadata(schema).isNumeric;
 };
-
-const isFilterObject = (value: unknown): value is Record<string, unknown> =>
-  isRecord(value) &&
-  Object.keys(value).length > 0 &&
-  Object.keys(value).every((key) => filterOperatorKeys.has(key));
 
 const isGroupedQueryInput = (query: unknown): query is { readonly groupBy: unknown } =>
   isRecord(query) && Object.hasOwn(query, "groupBy");
@@ -154,180 +150,6 @@ export const viewServerDecodeHealthQuery = Effect.fn("ViewServerProtocol.healthQ
     return decoded;
   },
 );
-
-const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Filter ${field} is not JSON-safe: ${error.message}`),
-    ),
-  );
-});
-
-const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-});
-
-const encodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.encode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-  if (typeof decoded !== "string") {
-    return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
-  }
-  return yield* Schema.decodeUnknownEffect(Schema.String)(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid startsWith filter for ${field}: ${error.message}`),
-    ),
-  );
-});
-
-const decodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.decode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-  if (typeof decoded !== "string") {
-    return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
-  }
-  return decoded;
-});
-
-const validateOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.validate")(
-  function* (
-    topic: string,
-    field: string,
-    schema: JsonFieldSchema,
-    value: Record<string, unknown>,
-  ) {
-    const metadata = viewServerSchemaFieldMetadata(schema);
-    if (metadata.isStructured) {
-      return;
-    }
-    const keys = Object.keys(value);
-    if (keys.includes("startsWith") && !metadata.isString) {
-      return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
-    }
-    if (keys.some((key) => rangeFilterOperatorKeys.has(key)) && !metadata.isNumeric) {
-      return yield* Effect.fail(
-        invalidQuery(topic, `Filter ${field} does not support range operators`),
-      );
-    }
-  },
-);
-
-const encodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.encode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: Record<string, unknown>,
-) {
-  yield* validateOperatorFilterValue(topic, field, schema, value);
-  const output: Record<string, Schema.Json> = {};
-  for (const [operator, operatorValue] of Object.entries(value)) {
-    if (operator === "in" && Array.isArray(operatorValue)) {
-      output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
-        encodeJsonFieldValue(topic, field, schema, entry),
-      );
-    } else if (operator === "startsWith") {
-      output[operator] = yield* encodeStringFilterValue(topic, field, schema, operatorValue);
-    } else {
-      output[operator] = yield* encodeJsonFieldValue(topic, field, schema, operatorValue);
-    }
-  }
-  return output;
-});
-
-const decodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.decode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: Record<string, unknown>,
-) {
-  yield* validateOperatorFilterValue(topic, field, schema, value);
-  const output: Record<string, unknown> = {};
-  for (const [operator, operatorValue] of Object.entries(value)) {
-    if (operator === "in" && Array.isArray(operatorValue)) {
-      output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
-        decodeJsonFieldValue(topic, field, schema, entry),
-      );
-    } else if (operator === "startsWith") {
-      output[operator] = yield* decodeStringFilterValue(topic, field, schema, operatorValue);
-    } else {
-      output[operator] = yield* decodeJsonFieldValue(topic, field, schema, operatorValue);
-    }
-  }
-  return output;
-});
-
-const encodeFilterValue = Effect.fn("ViewServerProtocol.filter.encode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  if (!isFilterObject(value)) {
-    return yield* encodeJsonFieldValue(topic, field, schema, value);
-  }
-  return yield* Effect.matchEffect(encodeOperatorFilterValue(topic, field, schema, value), {
-    onFailure: (operatorError) =>
-      Effect.matchEffect(encodeJsonFieldValue(topic, field, schema, value), {
-        onFailure: () => Effect.fail(operatorError),
-        onSuccess: Effect.succeed,
-      }),
-    onSuccess: Effect.succeed,
-  });
-});
-
-const decodeFilterValue = Effect.fn("ViewServerProtocol.filter.decode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  if (!isFilterObject(value)) {
-    return yield* decodeJsonFieldValue(topic, field, schema, value);
-  }
-  return yield* Effect.matchEffect(decodeOperatorFilterValue(topic, field, schema, value), {
-    onFailure: (operatorError) =>
-      Effect.matchEffect(decodeJsonFieldValue(topic, field, schema, value), {
-        onFailure: () => Effect.fail(operatorError),
-        onSuccess: Effect.succeed,
-      }),
-    onSuccess: Effect.succeed,
-  });
-});
 
 const encodeWhere = Effect.fn("ViewServerProtocol.query.where.encode")(function* <
   const Topics extends TopicDefinitions,


### PR DESCRIPTION
## Summary

- Add a Wire Protocol Field Filter Codec Module for schema-aware JSON-safe filter value encode/decode.
- Move operator detection, startsWith/range validation, JSON-safe field encode/decode, operator filter encode/decode, and structured-value fallback out of protocol-query-codec.
- Keep protocol-query-codec focused on raw/grouped query shape validation and where-field delegation.
- Add Field Filter Codec vocabulary to CONTEXT.md.

## Validation

- `vp check --fix ...`
- `pnpm --filter @view-server/protocol run test`
- `pnpm run check:package-exports`
- `pnpm run check:internal-seams`
- strict Effect LSP for protocol
- `pnpm run ready`
- `git diff --check`
- forbidden-pattern scan
- 3-agent review clean after staging the new file
