### PR TITLE
Extract aggregate row codec

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,10 @@ _Avoid_: Raw query helper, select validator, query parser
 The Wire Protocol module that validates, encodes, and decodes Grouped Query wire payloads, including aggregate alias safety, grouped ordering, and numeric aggregate rules.
 _Avoid_: Aggregate helper, groupBy validator, grouped query parser
 
+**Aggregate Row Codec**:
+The Wire Protocol module that encodes and decodes grouped aggregate row values without precision loss, including bigint and BigDecimal aggregate envelopes.
+_Avoid_: Number helper, aggregate JSON helper, sum formatter
+
 **View Server Provider**:
 The React provider that supplies a Live Client to hooks.
 _Avoid_: Runtime provider, in-memory provider when discussing the generic provider
@@ -171,6 +175,7 @@ _Avoid_: Browser write, send, emit
 - A **Field Filter Codec** protects the **Wire Protocol** from unsafe or incorrectly typed filter values.
 - A **Raw Query Codec** protects Raw Query wire payloads from unknown fields, unsafe filters, and invalid windows.
 - A **Grouped Query Codec** protects Grouped Query wire payloads from invalid group fields, aggregate aliases, aggregate fields, grouped ordering, and invalid windows.
+- An **Aggregate Row Codec** protects grouped aggregate row values from JSON precision loss over the **Wire Protocol**.
 - A **View Server Provider** supplies a **Live Client** to React hooks.
 - A **View Server In-Memory Provider** supplies the same hook behavior through an **In-Memory View Server**.
 - A **Source Topic** is mapped into a **View Server Topic** through a **Mapping**.

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -1771,6 +1771,49 @@ describe("@view-server/protocol", () => {
       );
       expect(nonJsonRow.message).toMatch(/Field id is not JSON-safe/);
 
+      const BadJsonAggregateRow = Schema.Struct({
+        id: Schema.String,
+        value: BadJsonField,
+      });
+      const badJsonAggregateViewServer = defineViewServerConfig({
+        topics: {
+          badAggregate: {
+            schema: BadJsonAggregateRow,
+            key: "id",
+          },
+        },
+      });
+      const badJsonAggregateQuery = yield* viewServerEncodeGroupedQuery(
+        badJsonAggregateViewServer,
+        "badAggregate",
+        {
+          groupBy: ["id"],
+          aggregates: {
+            badValue: { aggFunc: "min", field: "value" },
+          },
+        },
+      );
+      const nonJsonAggregate = yield* Effect.flip(
+        viewServerEncodeLiveEvent(
+          badJsonAggregateViewServer,
+          "badAggregate",
+          badJsonAggregateQuery,
+          {
+            type: "snapshot",
+            topic: "badAggregate",
+            queryId: "grouped-bad-aggregate",
+            version: 1,
+            keys: ["a"],
+            rows: [{ id: "a", badValue: "not-json-safe" }],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(nonJsonAggregate.code).toBe("InvalidRow");
+      expect(nonJsonAggregate.message).toBe(
+        "Field badValue is not JSON-safe: Expected JSON value, got Symbol(not-json)",
+      );
+
       const groupedQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
@@ -2053,6 +2096,32 @@ describe("@view-server/protocol", () => {
         "Aggregate rowCount must be a View Server aggregate envelope.",
       );
 
+      const numericBigIntEnvelope = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "bigint", value: 1 },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(numericBigIntEnvelope.message).toBe(
+        "Aggregate rowCount must be a View Server aggregate envelope.",
+      );
+
       const invalidGroupedBigInt = yield* Effect.flip(
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
           viewServer,
@@ -2100,6 +2169,32 @@ describe("@view-server/protocol", () => {
         ),
       );
       expect(invalidGroupedBigDecimal.message).toMatch(/Invalid aggregate averagePrice/);
+
+      const numericBigDecimalEnvelope = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+          viewServer,
+          "orders",
+          groupedQuery,
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "grouped-0",
+            version: 1,
+            keys: ["a"],
+            rows: [
+              {
+                id: "a",
+                rowCount: { _viewServerAggregate: "bigint", value: "1" },
+                averagePrice: { _viewServerAggregate: "bigdecimal", value: 1 },
+              },
+            ],
+            totalRows: 1,
+          },
+        ),
+      );
+      expect(numericBigDecimalEnvelope.message).toBe(
+        "Aggregate averagePrice must be a View Server aggregate envelope.",
+      );
 
       const wrongGroupedBigDecimalEnvelope = yield* Effect.flip(
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(

--- a/packages/protocol/src/protocol-aggregate-row-codec.ts
+++ b/packages/protocol/src/protocol-aggregate-row-codec.ts
@@ -1,0 +1,207 @@
+import type { TopicDefinitions, ViewServerRuntimeError } from "@view-server/config";
+import { viewServerSchemaFieldMetadata } from "@view-server/config";
+import { Effect, Schema } from "effect";
+import * as BigDecimal from "effect/BigDecimal";
+import type { ViewServerWireAggregate } from "./protocol-query-schema";
+
+const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidRow",
+  message,
+  topic,
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isBigIntFieldSchema = (schema: Schema.Codec<unknown>): boolean =>
+  viewServerSchemaFieldMetadata(schema).sumResultKind === "bigint";
+
+const bigintPattern = /^-?\d+$/;
+
+type AggregateEnvelope =
+  | {
+      readonly _viewServerAggregate: "bigint";
+      readonly value: string;
+    }
+  | {
+      readonly _viewServerAggregate: "bigdecimal";
+      readonly value: string;
+    }
+  | {
+      readonly _viewServerAggregate: "json";
+      readonly value: Schema.Json;
+    };
+
+const isAggregateEnvelope = (value: unknown): value is AggregateEnvelope =>
+  isRecord(value) &&
+  ((value["_viewServerAggregate"] === "bigint" && typeof value["value"] === "string") ||
+    (value["_viewServerAggregate"] === "bigdecimal" && typeof value["value"] === "string") ||
+    (value["_viewServerAggregate"] === "json" &&
+      Schema.decodeUnknownOption(Schema.Json)(value["value"])._tag === "Some"));
+
+const encodeJsonAggregateEnvelope = (value: Schema.Json): AggregateEnvelope => ({
+  _viewServerAggregate: "json",
+  value,
+});
+
+const encodeBigIntAggregateEnvelope = (value: bigint): AggregateEnvelope => ({
+  _viewServerAggregate: "bigint",
+  value: value.toString(),
+});
+
+const encodeBigDecimalAggregateEnvelope = (value: BigDecimal.BigDecimal): AggregateEnvelope => ({
+  _viewServerAggregate: "bigdecimal",
+  value: BigDecimal.format(value),
+});
+
+const decodeAggregateEnvelope = Effect.fn("ViewServerProtocol.row.aggregate.envelope.decode")(
+  function* (topic: string, field: string, value: unknown) {
+    if (!isAggregateEnvelope(value)) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Aggregate ${field} must be a View Server aggregate envelope.`),
+      );
+    }
+    return value;
+  },
+);
+
+const encodeAggregateJsonFieldValue = Effect.fn(
+  "ViewServerProtocol.row.aggregate.jsonField.encode",
+)(function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
+  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
+  );
+  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
+    Effect.mapError((error) =>
+      invalidRow(topic, `Field ${field} is not JSON-safe: ${error.message}`),
+    ),
+  );
+});
+
+const encodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.encode")(
+  function* (topic: string, field: string, value: unknown) {
+    if (typeof value !== "bigint") {
+      return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint.`));
+    }
+    return encodeBigIntAggregateEnvelope(value);
+  },
+);
+
+const decodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.decode")(
+  function* (topic: string, field: string, value: unknown) {
+    const envelope = yield* decodeAggregateEnvelope(topic, field, value);
+    if (envelope._viewServerAggregate !== "bigint" || !bigintPattern.test(envelope.value)) {
+      return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint envelope.`));
+    }
+    return BigInt(envelope.value);
+  },
+);
+
+const encodeBigDecimalAggregateValue = Effect.fn(
+  "ViewServerProtocol.row.aggregate.bigDecimal.encode",
+)(function* (topic: string, field: string, value: unknown) {
+  if (!BigDecimal.isBigDecimal(value)) {
+    return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a BigDecimal.`));
+  }
+  return encodeBigDecimalAggregateEnvelope(value);
+});
+
+const decodeBigDecimalAggregateValue = Effect.fn(
+  "ViewServerProtocol.row.aggregate.bigDecimal.decode",
+)(function* (topic: string, field: string, value: unknown) {
+  const envelope = yield* decodeAggregateEnvelope(topic, field, value);
+  if (envelope._viewServerAggregate !== "bigdecimal") {
+    return yield* Effect.fail(
+      invalidRow(topic, `Aggregate ${field} must be a BigDecimal envelope.`),
+    );
+  }
+  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(Schema.BigDecimal))(
+    envelope.value,
+  ).pipe(
+    Effect.mapError((error) => invalidRow(topic, `Invalid aggregate ${field}: ${error.message}`)),
+  );
+});
+
+const encodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.encode")(
+  function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
+    const encoded = yield* encodeAggregateJsonFieldValue(topic, field, schema, value);
+    return encodeJsonAggregateEnvelope(encoded);
+  },
+);
+
+const decodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.decode")(
+  function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
+    const envelope = yield* decodeAggregateEnvelope(topic, field, value);
+    if (envelope._viewServerAggregate !== "json") {
+      return yield* Effect.fail(
+        invalidRow(topic, `Aggregate ${field} must be a JSON aggregate envelope.`),
+      );
+    }
+    return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(envelope.value).pipe(
+      Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
+    );
+  },
+);
+
+const aggregateFieldSchema = Effect.fn("ViewServerProtocol.row.aggregate.fieldSchema")(function* <
+  const Topics extends TopicDefinitions,
+>(config: { readonly topics: Topics }, topic: Extract<keyof Topics, string>, field: string) {
+  const fieldSchema = config.topics[topic]!.schema.fields[field];
+  if (fieldSchema === undefined) {
+    return yield* Effect.fail(
+      invalidRow(topic, `Aggregate references unknown field for topic ${topic}: ${field}`),
+    );
+  }
+  return fieldSchema;
+});
+
+export const encodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.encode")(function* <
+  const Topics extends TopicDefinitions,
+>(
+  config: { readonly topics: Topics },
+  topic: Extract<keyof Topics, string>,
+  field: string,
+  aggregate: ViewServerWireAggregate,
+  value: unknown,
+) {
+  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
+    return yield* encodeBigIntAggregateValue(topic, field, value);
+  }
+  const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
+  if (aggregate.aggFunc === "avg") {
+    return yield* encodeBigDecimalAggregateValue(topic, field, value);
+  }
+  if (aggregate.aggFunc === "sum") {
+    if (isBigIntFieldSchema(fieldSchema)) {
+      return yield* encodeBigIntAggregateValue(topic, field, value);
+    }
+    return yield* encodeBigDecimalAggregateValue(topic, field, value);
+  }
+  return yield* encodeJsonAggregateValue(topic, field, fieldSchema, value);
+});
+
+export const decodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.decode")(function* <
+  const Topics extends TopicDefinitions,
+>(
+  config: { readonly topics: Topics },
+  topic: Extract<keyof Topics, string>,
+  field: string,
+  aggregate: ViewServerWireAggregate,
+  value: unknown,
+) {
+  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
+    return yield* decodeBigIntAggregateValue(topic, field, value);
+  }
+  const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
+  if (aggregate.aggFunc === "avg") {
+    return yield* decodeBigDecimalAggregateValue(topic, field, value);
+  }
+  if (aggregate.aggFunc === "sum") {
+    if (isBigIntFieldSchema(fieldSchema)) {
+      return yield* decodeBigIntAggregateValue(topic, field, value);
+    }
+    return yield* decodeBigDecimalAggregateValue(topic, field, value);
+  }
+  return yield* decodeJsonAggregateValue(topic, field, fieldSchema, value);
+});

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -1,13 +1,8 @@
 import type { TopicDefinitions, ViewServerRuntimeError } from "@view-server/config";
-import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
-import * as BigDecimal from "effect/BigDecimal";
+import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
-import type {
-  ViewServerEventGroupedQuery,
-  ViewServerEventQuery,
-  ViewServerWireAggregate,
-} from "./protocol-query-schema";
+import type { ViewServerEventGroupedQuery, ViewServerEventQuery } from "./protocol-query-schema";
 
 const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",
@@ -16,63 +11,9 @@ const invalidRow = (topic: string, message: string): ViewServerRuntimeError => (
   topic,
 });
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isBigIntFieldSchema = (schema: Schema.Codec<unknown>): boolean =>
-  viewServerSchemaFieldMetadata(schema).sumResultKind === "bigint";
-
 export const isViewServerEventGroupedQuery = (
   query: ViewServerEventQuery,
 ): query is ViewServerEventGroupedQuery => "groupBy" in query;
-
-const bigintPattern = /^-?\d+$/;
-
-type AggregateEnvelope =
-  | {
-      readonly _viewServerAggregate: "bigint";
-      readonly value: string;
-    }
-  | {
-      readonly _viewServerAggregate: "bigdecimal";
-      readonly value: string;
-    }
-  | {
-      readonly _viewServerAggregate: "json";
-      readonly value: Schema.Json;
-    };
-
-const isAggregateEnvelope = (value: unknown): value is AggregateEnvelope =>
-  isRecord(value) &&
-  (value["_viewServerAggregate"] === "bigint" ||
-    value["_viewServerAggregate"] === "bigdecimal" ||
-    value["_viewServerAggregate"] === "json");
-
-const encodeJsonAggregateEnvelope = (value: Schema.Json): AggregateEnvelope => ({
-  _viewServerAggregate: "json",
-  value,
-});
-
-const encodeBigIntAggregateEnvelope = (value: bigint): AggregateEnvelope => ({
-  _viewServerAggregate: "bigint",
-  value: value.toString(),
-});
-
-const encodeBigDecimalAggregateEnvelope = (value: BigDecimal.BigDecimal): AggregateEnvelope => ({
-  _viewServerAggregate: "bigdecimal",
-  value: BigDecimal.format(value),
-});
-
-const decodeAggregateEnvelope = Effect.fn("ViewServerProtocol.row.aggregate.envelope.decode")(
-  function* (topic: string, field: string, value: unknown) {
-    if (!isAggregateEnvelope(value)) {
-      return yield* Effect.fail(
-        invalidRow(topic, `Aggregate ${field} must be a View Server aggregate envelope.`),
-      );
-    }
-    return value;
-  },
-);
 
 const encodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.encode")(function* (
   topic: string,
@@ -148,133 +89,6 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
     );
   }
   return output;
-});
-
-const encodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.encode")(
-  function* (topic: string, field: string, value: unknown) {
-    if (typeof value !== "bigint") {
-      return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint.`));
-    }
-    return encodeBigIntAggregateEnvelope(value);
-  },
-);
-
-const decodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.decode")(
-  function* (topic: string, field: string, value: unknown) {
-    const envelope = yield* decodeAggregateEnvelope(topic, field, value);
-    if (envelope._viewServerAggregate !== "bigint" || !bigintPattern.test(envelope.value)) {
-      return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint envelope.`));
-    }
-    return BigInt(envelope.value);
-  },
-);
-
-const encodeBigDecimalAggregateValue = Effect.fn(
-  "ViewServerProtocol.row.aggregate.bigDecimal.encode",
-)(function* (topic: string, field: string, value: unknown) {
-  if (!BigDecimal.isBigDecimal(value)) {
-    return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a BigDecimal.`));
-  }
-  return encodeBigDecimalAggregateEnvelope(value);
-});
-
-const decodeBigDecimalAggregateValue = Effect.fn(
-  "ViewServerProtocol.row.aggregate.bigDecimal.decode",
-)(function* (topic: string, field: string, value: unknown) {
-  const envelope = yield* decodeAggregateEnvelope(topic, field, value);
-  if (envelope._viewServerAggregate !== "bigdecimal") {
-    return yield* Effect.fail(
-      invalidRow(topic, `Aggregate ${field} must be a BigDecimal envelope.`),
-    );
-  }
-  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(Schema.BigDecimal))(
-    envelope.value,
-  ).pipe(
-    Effect.mapError((error) => invalidRow(topic, `Invalid aggregate ${field}: ${error.message}`)),
-  );
-});
-
-const encodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.encode")(
-  function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
-    const encoded = yield* encodeEventJsonFieldValue(topic, field, schema, value);
-    return encodeJsonAggregateEnvelope(encoded);
-  },
-);
-
-const decodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.decode")(
-  function* (topic: string, field: string, schema: Schema.Codec<unknown>, value: unknown) {
-    const envelope = yield* decodeAggregateEnvelope(topic, field, value);
-    if (envelope._viewServerAggregate !== "json") {
-      return yield* Effect.fail(
-        invalidRow(topic, `Aggregate ${field} must be a JSON aggregate envelope.`),
-      );
-    }
-    return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(envelope.value).pipe(
-      Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
-    );
-  },
-);
-
-const aggregateFieldSchema = Effect.fn("ViewServerProtocol.row.aggregate.fieldSchema")(function* <
-  const Topics extends TopicDefinitions,
->(config: { readonly topics: Topics }, topic: Extract<keyof Topics, string>, field: string) {
-  const fieldSchema = config.topics[topic]!.schema.fields[field];
-  if (fieldSchema === undefined) {
-    return yield* Effect.fail(
-      invalidRow(topic, `Aggregate references unknown field for topic ${topic}: ${field}`),
-    );
-  }
-  return fieldSchema;
-});
-
-const encodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.encode")(function* <
-  const Topics extends TopicDefinitions,
->(
-  config: { readonly topics: Topics },
-  topic: Extract<keyof Topics, string>,
-  field: string,
-  aggregate: ViewServerWireAggregate,
-  value: unknown,
-) {
-  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
-    return yield* encodeBigIntAggregateValue(topic, field, value);
-  }
-  const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
-  if (aggregate.aggFunc === "avg") {
-    return yield* encodeBigDecimalAggregateValue(topic, field, value);
-  }
-  if (aggregate.aggFunc === "sum") {
-    if (isBigIntFieldSchema(fieldSchema)) {
-      return yield* encodeBigIntAggregateValue(topic, field, value);
-    }
-    return yield* encodeBigDecimalAggregateValue(topic, field, value);
-  }
-  return yield* encodeJsonAggregateValue(topic, field, fieldSchema, value);
-});
-
-const decodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.decode")(function* <
-  const Topics extends TopicDefinitions,
->(
-  config: { readonly topics: Topics },
-  topic: Extract<keyof Topics, string>,
-  field: string,
-  aggregate: ViewServerWireAggregate,
-  value: unknown,
-) {
-  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
-    return yield* decodeBigIntAggregateValue(topic, field, value);
-  }
-  const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
-  if (aggregate.aggFunc === "avg") {
-    return yield* decodeBigDecimalAggregateValue(topic, field, value);
-  }
-  if (aggregate.aggFunc === "sum") {
-    if (isBigIntFieldSchema(fieldSchema)) {
-      return yield* decodeBigIntAggregateValue(topic, field, value);
-    }
-    return yield* decodeBigDecimalAggregateValue(topic, field, value);
-  }
-  return yield* decodeJsonAggregateValue(topic, field, fieldSchema, value);
 });
 
 export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode")(function* <


### PR DESCRIPTION
## Summary
- extract grouped aggregate envelope encode/decode into protocol-aggregate-row-codec
- keep protocol-row-codec focused on projected/grouped/system row orchestration
- make aggregate envelopes stricter so bigint and BigDecimal payloads must be strings
- add hostile wire tests for non-string aggregate envelopes and JSON-unsafe aggregate source values
- document Aggregate Row Codec in CONTEXT.md

## Validation
- vp check --fix packages/protocol/src/protocol-aggregate-row-codec.ts packages/protocol/src/protocol-row-codec.ts packages/protocol/src/index.test.ts CONTEXT.md
- pnpm --filter @view-server/protocol run test
- pnpm exec effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict
- pnpm run check:package-exports
- pnpm run check:internal-seams
- git diff --check
- forbidden-pattern scan
- pnpm run ready

## Review
- 3 local reviewers found a real malformed aggregate envelope bug plus the new-file staging risk.
- Fixed the envelope validation, added regression tests, renamed the duplicate span.
- Second review round found no remaining code issues; only the staging risk, now addressed in this PR.