### PR TITLE
Split protocol health codecs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,6 +128,18 @@ _Avoid_: Aggregate helper, groupBy validator, grouped query parser
 The Wire Protocol module that encodes and decodes grouped aggregate row values without precision loss, including bigint and BigDecimal aggregate envelopes.
 _Avoid_: Number helper, aggregate JSON helper, sum formatter
 
+**Health Summary Codec**:
+The Wire Protocol module that validates, encodes, and decodes the compact pushed health summary stream.
+_Avoid_: Health helper, summary JSON helper, status formatter
+
+**Health Topic Codec**:
+The Wire Protocol module that validates, encodes, and decodes the pushed per-topic health stream.
+_Avoid_: Topic health helper, health row parser, metrics formatter
+
+**Health Payload Codec**:
+The Wire Protocol module that validates full runtime health payloads against configured View Server Topics.
+_Avoid_: Health object checker, runtime health helper, admin health parser
+
 **View Server Provider**:
 The React provider that supplies a Live Client to hooks.
 _Avoid_: Runtime provider, in-memory provider when discussing the generic provider
@@ -176,6 +188,9 @@ _Avoid_: Browser write, send, emit
 - A **Raw Query Codec** protects Raw Query wire payloads from unknown fields, unsafe filters, and invalid windows.
 - A **Grouped Query Codec** protects Grouped Query wire payloads from invalid group fields, aggregate aliases, aggregate fields, grouped ordering, and invalid windows.
 - An **Aggregate Row Codec** protects grouped aggregate row values from JSON precision loss over the **Wire Protocol**.
+- A **Health Summary Codec** protects the compact health summary stream from impossible status combinations and unknown unhealthy topic names.
+- A **Health Topic Codec** protects the per-topic health stream from missing, duplicate, unknown, or mismatched topic rows.
+- A **Health Payload Codec** protects full runtime health payloads from missing or unknown configured topics.
 - A **View Server Provider** supplies a **Live Client** to React hooks.
 - A **View Server In-Memory Provider** supplies the same hook behavior through an **In-Memory View Server**.
 - A **Source Topic** is mapped into a **View Server Topic** through a **Mapping**.

--- a/packages/client/src/index.test-d.ts
+++ b/packages/client/src/index.test-d.ts
@@ -1,5 +1,9 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
-import { defineViewServerConfig } from "@view-server/config";
+import {
+  defineViewServerConfig,
+  VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+  VIEW_SERVER_HEALTH_TOPIC,
+} from "@view-server/config";
 import type {
   ViewServerHealth,
   ViewServerHealthSummaryRow,
@@ -8,6 +12,7 @@ import type {
   ViewServerTransportError,
 } from "@view-server/config";
 import type { Effect } from "effect";
+import type { Stream } from "effect";
 import { Schema } from "effect";
 import type { ViewServerLiveClient, ViewServerLiveSubscription } from "./index";
 
@@ -70,16 +75,55 @@ describe("client type contracts", () => {
     const details = client.subscribeHealth();
 
     expectTypeOf<Effect.Success<typeof summary>>().toEqualTypeOf<
-      ViewServerLiveSubscription<ViewServerHealthSummaryRow<typeof viewServer.topics>>
+      ViewServerLiveSubscription<
+        ViewServerHealthSummaryRow<typeof viewServer.topics>,
+        typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+        "summary"
+      >
     >();
     expectTypeOf<Effect.Error<typeof summary>>().toEqualTypeOf<
       ViewServerRuntimeError | ViewServerTransportError
     >();
     expectTypeOf<Effect.Success<typeof details>>().toEqualTypeOf<
-      ViewServerLiveSubscription<ViewServerHealthTopicRow<"orders">>
+      ViewServerLiveSubscription<
+        ViewServerHealthTopicRow<"orders">,
+        typeof VIEW_SERVER_HEALTH_TOPIC,
+        "orders"
+      >
     >();
     expectTypeOf<Effect.Error<typeof details>>().toEqualTypeOf<
       ViewServerRuntimeError | ViewServerTransportError
     >();
+
+    type SummaryEvent = Stream.Success<Effect.Success<typeof summary>["events"]>;
+    type SummarySnapshot = Extract<SummaryEvent, { readonly type: "snapshot" }>;
+    type SummaryDeltaOperation = Extract<
+      SummaryEvent,
+      { readonly type: "delta" }
+    >["operations"][number];
+    expectTypeOf<SummarySnapshot["keys"]>().toEqualTypeOf<readonly ["summary"]>();
+    expectTypeOf<SummarySnapshot["rows"][0]["id"]>().toEqualTypeOf<"summary">();
+    expectTypeOf<SummarySnapshot["totalRows"]>().toEqualTypeOf<1>();
+    expectTypeOf<
+      Extract<SummaryDeltaOperation, { readonly type: "insert" }>
+    >().toEqualTypeOf<never>();
+    expectTypeOf<
+      Extract<SummaryDeltaOperation, { readonly type: "remove" }>
+    >().toEqualTypeOf<never>();
+
+    type DetailEvent = Stream.Success<Effect.Success<typeof details>["events"]>;
+    type DetailSnapshot = Extract<DetailEvent, { readonly type: "snapshot" }>;
+    type DetailDeltaOperation = Extract<
+      DetailEvent,
+      { readonly type: "delta" }
+    >["operations"][number];
+    expectTypeOf<DetailSnapshot["keys"][number]>().toEqualTypeOf<"orders">();
+    expectTypeOf<DetailSnapshot["rows"][number]["id"]>().toEqualTypeOf<"orders">();
+    expectTypeOf<
+      Extract<DetailDeltaOperation, { readonly type: "insert" }>
+    >().toEqualTypeOf<never>();
+    expectTypeOf<
+      Extract<DetailDeltaOperation, { readonly type: "remove" }>
+    >().toEqualTypeOf<never>();
   });
 });

--- a/packages/client/src/live-client.ts
+++ b/packages/client/src/live-client.ts
@@ -9,6 +9,8 @@ import type {
   StatusEvent,
   TopicDefinitions,
   TopicRow,
+  VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+  VIEW_SERVER_HEALTH_TOPIC,
   ViewServerHealth,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
@@ -18,10 +20,96 @@ import type {
 import type { Effect, Stream } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
 
-export type ViewServerLiveEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
+type RowWithKey<Row, Key extends string> = string extends Key
+  ? Row
+  : Row extends { readonly id: string }
+    ? Row & { readonly id: Key }
+    : Row;
 
-export type ViewServerLiveSubscription<Row> = {
-  readonly events: Stream.Stream<ViewServerLiveEvent<Row>>;
+type TopicCanChangeCardinality<Topic extends string> = Topic extends
+  | typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC
+  | typeof VIEW_SERVER_HEALTH_TOPIC
+  ? false
+  : true;
+
+type TopicSnapshotEvent<Row, Topic extends string, Key extends string> = Omit<
+  SnapshotEvent<Row>,
+  "topic" | "keys" | "rows" | "totalRows"
+> & {
+  readonly topic: Topic;
+  readonly keys: Topic extends typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC
+    ? readonly ["summary"]
+    : ReadonlyArray<Key>;
+  readonly rows: Topic extends typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC
+    ? readonly [RowWithKey<Row, Key>]
+    : ReadonlyArray<Row>;
+  readonly totalRows: Topic extends typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC ? 1 : number;
+};
+
+type TopicInsertOperation<Row, Topic extends string, Key extends string> =
+  TopicCanChangeCardinality<Topic> extends true
+    ? Key extends string
+      ? {
+          readonly type: "insert";
+          readonly key: Key;
+          readonly row: RowWithKey<Row, Key>;
+          readonly index: number;
+        }
+      : never
+    : never;
+
+type TopicRemoveOperation<Topic extends string, Key extends string> =
+  TopicCanChangeCardinality<Topic> extends true
+    ? {
+        readonly type: "remove";
+        readonly key: Key;
+      }
+    : never;
+
+type TopicDeltaOperation<Row, Topic extends string, Key extends string> =
+  | TopicInsertOperation<Row, Topic, Key>
+  | (Key extends string
+      ? {
+          readonly type: "update";
+          readonly key: Key;
+          readonly row: RowWithKey<Row, Key>;
+          readonly index: number;
+        }
+      : never)
+  | {
+      readonly type: "move";
+      readonly key: Key;
+      readonly fromIndex: number;
+      readonly toIndex: number;
+    }
+  | TopicRemoveOperation<Topic, Key>;
+
+type TopicDeltaEvent<Row, Topic extends string, Key extends string> = Omit<
+  DeltaEvent<Row>,
+  "topic" | "operations" | "totalRows"
+> & {
+  readonly topic: Topic;
+  readonly operations: ReadonlyArray<TopicDeltaOperation<Row, Topic, Key>>;
+  readonly totalRows: Topic extends typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC ? 1 : number;
+};
+
+type TopicStatusEvent<Topic extends string> = StatusEvent & {
+  readonly topic: Topic;
+};
+
+export type ViewServerStatusEvent<Topic extends string = string> = TopicStatusEvent<Topic>;
+
+export type ViewServerLiveEvent<Row, Topic extends string = string, Key extends string = string> =
+  | TopicSnapshotEvent<Row, Topic, Key>
+  | TopicDeltaEvent<Row, Topic, Key>
+  | TopicStatusEvent<Topic>;
+
+export type ViewServerLiveSubscription<
+  Row,
+  Topic extends string = string,
+  Key extends string = string,
+> = {
+  readonly events: Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>>;
   readonly close: () => Effect.Effect<void, ViewServerTransportError>;
 };
 
@@ -39,11 +127,19 @@ export type ViewServerLiveClient<Topics extends TopicDefinitions> = {
     >;
   };
   readonly subscribeHealthSummary: () => Effect.Effect<
-    ViewServerLiveSubscription<ViewServerHealthSummaryRow<Topics>>,
+    ViewServerLiveSubscription<
+      ViewServerHealthSummaryRow<Topics>,
+      typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+      "summary"
+    >,
     ViewServerRuntimeError | ViewServerTransportError
   >;
   readonly subscribeHealth: () => Effect.Effect<
-    ViewServerLiveSubscription<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
+    ViewServerLiveSubscription<
+      ViewServerHealthTopicRow<Extract<keyof Topics, string>>,
+      typeof VIEW_SERVER_HEALTH_TOPIC,
+      Extract<keyof Topics, string>
+    >,
     ViewServerRuntimeError | ViewServerTransportError
   >;
   readonly health: AtomRef.ReadonlyRef<ViewServerHealth<Topics>>;

--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -23,9 +23,11 @@ import type * as Duration from "effect/Duration";
 import * as Http from "node:http";
 import {
   ViewServerRpcs,
+  ViewServerTrustedWireEventSchema,
   ViewServerWireRowSchema,
   viewServerDecodeHealth,
   type ViewServerRpcError,
+  type ViewServerTrustedWireEvent,
   type ViewServerWireEvent,
   type ViewServerWireHealth,
 } from "@view-server/protocol";
@@ -178,11 +180,22 @@ const snapshotEvent = (
   totalRows: rows.length,
 });
 
+const invalidTrustedEvent = (error: { readonly message: string }): ViewServerRpcError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidRow",
+  message: error.message,
+});
+
+const trustedEvent = (event: ViewServerWireEvent) =>
+  Schema.decodeUnknownEffect(ViewServerTrustedWireEventSchema)(event).pipe(
+    Effect.mapError(invalidTrustedEvent),
+  );
+
 const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(function* () {
   const path = "/rpc";
-  const events = yield* Queue.unbounded<ViewServerWireEvent>();
-  const healthSummaryEvents = yield* Queue.unbounded<ViewServerWireEvent>();
-  const healthTopicEvents = yield* Queue.unbounded<ViewServerWireEvent>();
+  const events = yield* Queue.unbounded<ViewServerTrustedWireEvent>();
+  const healthSummaryEvents = yield* Queue.unbounded<ViewServerTrustedWireEvent>();
+  const healthTopicEvents = yield* Queue.unbounded<ViewServerTrustedWireEvent>();
   let lastSubscribeQuery: unknown = undefined;
   let rows: ReadonlyArray<typeof ViewServerWireRowSchema.Type> = [];
   let activeSubscriptions = 0;
@@ -205,7 +218,9 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
             yield* Effect.sleep(healthDelay);
             return healthOverride ?? health(rows.length, activeSubscriptions);
           }),
-        "ViewServer.Subscribe": (payload) => {
+        "ViewServer.Subscribe": (
+          payload,
+        ): Stream.Stream<ViewServerTrustedWireEvent, ViewServerRpcError> => {
           lastSubscribeQuery = payload.query;
           if (payload.topic === VIEW_SERVER_HEALTH_SUMMARY_TOPIC) {
             if (healthSummaryError !== undefined) {
@@ -214,7 +229,9 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
             return Stream.unwrap(
               Effect.sync(() => {
                 activeSubscriptions += 1;
-                return Stream.succeed(snapshotEvent(payload.topic, healthSummaryRows)).pipe(
+                return Stream.fromEffect(
+                  trustedEvent(snapshotEvent(payload.topic, healthSummaryRows)),
+                ).pipe(
                   Stream.concat(Stream.fromQueue(healthSummaryEvents)),
                   Stream.ensuring(
                     Effect.sync(() => {
@@ -232,7 +249,9 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
             return Stream.unwrap(
               Effect.sync(() => {
                 activeSubscriptions += 1;
-                return Stream.succeed(snapshotEvent(payload.topic, healthTopicRows)).pipe(
+                return Stream.fromEffect(
+                  trustedEvent(snapshotEvent(payload.topic, healthTopicRows)),
+                ).pipe(
                   Stream.concat(Stream.fromQueue(healthTopicEvents)),
                   Stream.ensuring(
                     Effect.sync(() => {
@@ -292,7 +311,7 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
           return Stream.unwrap(
             Effect.sync(() => {
               activeSubscriptions += 1;
-              return Stream.succeed(snapshotEvent(payload.topic, rows)).pipe(
+              return Stream.fromEffect(trustedEvent(snapshotEvent(payload.topic, rows))).pipe(
                 Stream.concat(Stream.fromQueue(events)),
                 Stream.ensuring(
                   Effect.sync(() => {
@@ -331,16 +350,19 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
   return {
     activeSubscriptions: () => activeSubscriptions,
     close: runtime.disposeEffect,
-    emit: (event: ViewServerWireEvent) => Queue.offer(events, event),
-    emitHealthSummary: (event: ViewServerWireEvent) => Queue.offer(healthSummaryEvents, event),
-    emitHealthTopic: (event: ViewServerWireEvent) => Queue.offer(healthTopicEvents, event),
+    emit: (event: ViewServerWireEvent) =>
+      Effect.flatMap(trustedEvent(event), (trusted) => Queue.offer(events, trusted)),
+    emitHealthSummary: (event: ViewServerWireEvent) =>
+      Effect.flatMap(trustedEvent(event), (trusted) => Queue.offer(healthSummaryEvents, trusted)),
+    emitHealthTopic: (event: ViewServerWireEvent) =>
+      Effect.flatMap(trustedEvent(event), (trusted) => Queue.offer(healthTopicEvents, trusted)),
     emitInsert: (topic: string, row: typeof ViewServerWireRowSchema.Type) =>
       Effect.gen(function* () {
         rows = [...rows, row];
         const id = row["id"];
         const encodedKey = typeof id === "string" ? id : JSON.stringify(id);
         const key = encodedKey === undefined ? "undefined" : encodedKey;
-        yield* Queue.offer(events, {
+        const event = yield* trustedEvent({
           type: "delta",
           topic,
           queryId: "query-remote",
@@ -356,6 +378,7 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
           ],
           totalRows: rows.length,
         });
+        yield* Queue.offer(events, event);
       }),
     healthRequests: () => healthRequests,
     lastSubscribeQuery: () => lastSubscribeQuery,

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -8,7 +8,6 @@ import type {
   LiveQueryRow,
   PickRawFields,
   RawQuery,
-  StatusEvent,
   TopicDefinitions,
   TopicRow,
   ValidateLiveQuery,
@@ -25,10 +24,10 @@ import {
   viewServerDecodeHealthQuery,
   viewServerDecodeHealthSummaryEvent,
   viewServerDecodeHealthTopicEvent,
-  viewServerDecodeLiveEvent,
+  viewServerDecodeTrustedLiveEvent,
   viewServerEncodeLiveQuery,
   type ViewServerRpcError,
-  type ViewServerWireEvent,
+  type ViewServerTrustedWireEvent,
   type ViewServerWireHealth,
   type ViewServerWireLiveQuery,
 } from "@view-server/protocol";
@@ -39,6 +38,7 @@ import type {
   ViewServerLiveClient,
   ViewServerLiveEvent,
   ViewServerLiveSubscription,
+  ViewServerStatusEvent,
 } from "./live-client";
 import { makeRemoteHealthState } from "./remote-health";
 import { makeRemoteSubscription } from "./remote-subscription";
@@ -78,10 +78,10 @@ export const mapViewServerRemoteError = (
   return error;
 };
 
-const subscriptionFailureStatus = (
-  topic: string,
+const subscriptionFailureStatus = <Topic extends string>(
+  topic: Topic,
   error: ViewServerRemoteClientError,
-): StatusEvent => {
+): ViewServerStatusEvent<Topic> => {
   if (error.code === "BackpressureExceeded" || error.code === "SubscriptionClosed") {
     return {
       type: "status",
@@ -133,13 +133,13 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
   const healthRpc = (): Effect.Effect<ViewServerWireHealth, ViewServerRemoteClientError> =>
     rpc["ViewServer.Health"](undefined).pipe(Effect.mapError(mapViewServerRemoteError));
 
-  const subscribeRpc = <Row>(
-    topic: string,
+  const subscribeRpc = <Row, Topic extends string = string, Key extends string = string>(
+    topic: Topic,
     query: ViewServerWireLiveQuery,
     decodeEvent: (
-      event: ViewServerWireEvent,
-    ) => Effect.Effect<ViewServerLiveEvent<Row>, ViewServerRuntimeError>,
-  ): Stream.Stream<ViewServerLiveEvent<Row>, ViewServerRemoteClientError> =>
+      event: ViewServerTrustedWireEvent,
+    ) => Effect.Effect<ViewServerLiveEvent<Row, Topic, Key>, ViewServerRuntimeError>,
+  ): Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>, ViewServerRemoteClientError> =>
     rpc["ViewServer.Subscribe"](
       {
         topic,
@@ -162,9 +162,9 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     Effect.andThen(remoteHealth.markStopping),
   );
 
-  const streamToSubscription = <Row>(
-    topic: string,
-    source: Stream.Stream<ViewServerLiveEvent<Row>, ViewServerRemoteClientError>,
+  const streamToSubscription = <Row, Topic extends string = string, Key extends string = string>(
+    topic: Topic,
+    source: Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>, ViewServerRemoteClientError>,
     lifecycle: {
       readonly onOpen: Effect.Effect<void>;
       readonly onClose: Effect.Effect<void>;
@@ -173,7 +173,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
       onClose: Effect.void,
     },
   ) =>
-    makeRemoteSubscription({
+    makeRemoteSubscription<Row, ViewServerRemoteClientError, Topic, Key>({
       clientScope,
       failureStatus: subscriptionFailureStatus,
       lifecycle,
@@ -189,7 +189,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     type Row = LiveQueryRow<TopicRow<Topics, Topic>, Query>;
     const wireQuery = yield* viewServerEncodeLiveQuery(config, topic, query);
     const stream = subscribeRpc<Row>(topic, wireQuery, (event) =>
-      viewServerDecodeLiveEvent<Topics, Topic, Row>(config, topic, wireQuery, event),
+      viewServerDecodeTrustedLiveEvent<Topics, Topic, Row>(config, topic, wireQuery, event),
     );
     return yield* streamToSubscription(topic, stream, {
       onOpen: remoteHealth.updateSubscriptionCount(topic, 1),
@@ -240,12 +240,16 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     function* () {
       type Row = ViewServerHealthSummaryRow<Topics>;
       yield* viewServerDecodeHealthQuery(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, { select: ["id"] });
-      const stream = subscribeRpc<Row>(
+      const stream = subscribeRpc<Row, typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC, "summary">(
         VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
         { select: ["id"] },
-        (event) => viewServerDecodeHealthSummaryEvent(config, event),
+        (event) => viewServerDecodeHealthSummaryEvent<Topics>(config, event),
       );
-      const subscription = yield* streamToSubscription(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, stream);
+      const subscription = yield* streamToSubscription<
+        Row,
+        typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+        "summary"
+      >(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, stream);
       const events = subscription.events.pipe(Stream.tap(remoteHealth.updateHealthSummaryRef));
       return {
         events,
@@ -257,10 +261,18 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
   const subscribeHealth = Effect.fn("ViewServerClient.remote.health.subscribe")(function* () {
     type Row = ViewServerHealthTopicRow<Extract<keyof Topics, string>>;
     yield* viewServerDecodeHealthQuery(VIEW_SERVER_HEALTH_TOPIC, { select: ["id"] });
-    const stream = subscribeRpc<Row>(VIEW_SERVER_HEALTH_TOPIC, { select: ["id"] }, (event) =>
-      viewServerDecodeHealthTopicEvent(config, event),
+    const stream = subscribeRpc<
+      Row,
+      typeof VIEW_SERVER_HEALTH_TOPIC,
+      Extract<keyof Topics, string>
+    >(VIEW_SERVER_HEALTH_TOPIC, { select: ["id"] }, (event) =>
+      viewServerDecodeHealthTopicEvent<Topics>(config, event),
     );
-    const subscription = yield* streamToSubscription(VIEW_SERVER_HEALTH_TOPIC, stream);
+    const subscription = yield* streamToSubscription<
+      Row,
+      typeof VIEW_SERVER_HEALTH_TOPIC,
+      Extract<keyof Topics, string>
+    >(VIEW_SERVER_HEALTH_TOPIC, stream);
     const events = subscription.events.pipe(Stream.tap(remoteHealth.updateHealthTopicRef));
     return {
       events,

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -1,24 +1,32 @@
 import { Cause, Effect, Exit, Queue, Scope, Stream } from "effect";
 import { constant } from "effect/Function";
-import type { StatusEvent } from "@view-server/config";
-import type { ViewServerLiveEvent, ViewServerLiveSubscription } from "./live-client";
+import type {
+  ViewServerLiveEvent,
+  ViewServerLiveSubscription,
+  ViewServerStatusEvent,
+} from "./live-client";
 
 export type RemoteSubscriptionLifecycle = {
   readonly onOpen: Effect.Effect<void>;
   readonly onClose: Effect.Effect<void>;
 };
 
-export type RemoteSubscriptionOptions<Row, Error> = {
+export type RemoteSubscriptionOptions<
+  Row,
+  Error,
+  Topic extends string = string,
+  Key extends string = string,
+> = {
   readonly clientScope: Scope.Scope;
-  readonly failureStatus: (topic: string, error: Error) => StatusEvent;
+  readonly failureStatus: (topic: Topic, error: Error) => ViewServerStatusEvent<Topic>;
   readonly lifecycle?: RemoteSubscriptionLifecycle;
-  readonly source: Stream.Stream<ViewServerLiveEvent<Row>, Error>;
+  readonly source: Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>, Error>;
   readonly subscriptionBufferSize: number;
-  readonly topic: string;
+  readonly topic: Topic;
 };
 
 export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscription.make")(
-  function* <Row, Error>({
+  function* <Row, Error, Topic extends string = string, Key extends string = string>({
     clientScope,
     failureStatus,
     lifecycle = {
@@ -28,7 +36,7 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
     source,
     subscriptionBufferSize,
     topic,
-  }: RemoteSubscriptionOptions<Row, Error>) {
+  }: RemoteSubscriptionOptions<Row, Error, Topic, Key>) {
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         const scope = yield* Scope.fork(clientScope, "parallel");
@@ -38,7 +46,7 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
             const stream = source.pipe(
               Stream.catch((error) => Stream.make(failureStatus(topic, error))),
             );
-            const queue = yield* Queue.bounded<ViewServerLiveEvent<Row>, Cause.Done>(
+            const queue = yield* Queue.bounded<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(
               subscriptionBufferSize,
             );
             yield* Scope.addFinalizer(scope, lifecycle.onClose.pipe(Effect.ignore));
@@ -50,7 +58,7 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
             const subscription = {
               events: Stream.fromQueue(queue).pipe(Stream.ensuring(closeSubscription)),
               close: () => closeSubscription,
-            } satisfies ViewServerLiveSubscription<Row>;
+            } satisfies ViewServerLiveSubscription<Row, Topic, Key>;
             return subscription;
           }),
         ).pipe(Effect.onInterrupt(constant(closeSubscription)));

--- a/packages/config/src/health-contract.ts
+++ b/packages/config/src/health-contract.ts
@@ -5,7 +5,9 @@ export type TopicHealthStatus = "ready" | "degraded" | "starting";
 export type KafkaRegionStatus = "connected" | "disconnected" | "degraded" | "starting";
 export type KafkaTopicStatus = "ready" | "degraded" | "starting" | "stalled";
 export type ViewServerHealthConnectionStatus = "connecting" | "connected" | "disconnected";
-export type ViewServerHealthStatus = RuntimeStatus | ViewServerHealthConnectionStatus;
+export type ViewServerHealthStatus =
+  | RuntimeStatus
+  | Exclude<ViewServerHealthConnectionStatus, "connected">;
 
 export const VIEW_SERVER_HEALTH_SUMMARY_TOPIC = "__view_server_health_summary";
 export const VIEW_SERVER_HEALTH_TOPIC = "__view_server_health";

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -676,7 +676,7 @@ describe("public type surface", () => {
       ViewServerHealthTopicRow<"orders" | "trades" | "positions"> | undefined
     >();
     expectTypeOf<ViewServerHealthDetails<"orders">["status"]>().toEqualTypeOf<
-      "ready" | "degraded" | "starting" | "stopping" | "connecting" | "connected" | "disconnected"
+      "ready" | "degraded" | "starting" | "stopping" | "connecting" | "disconnected"
     >();
   });
 

--- a/packages/in-memory/src/live-client.ts
+++ b/packages/in-memory/src/live-client.ts
@@ -97,16 +97,16 @@ export const makeInMemoryLiveClient = Effect.fn("ViewServerInMemory.liveClient.m
       );
       const readonlyHealth = health.map((value) => value);
       const makeHealthSubscription = Effect.fn("ViewServerInMemory.health.subscribe")(function* <
-        Row extends { readonly id: string },
+        Topic extends typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC | typeof VIEW_SERVER_HEALTH_TOPIC,
+        Key extends string,
+        Row extends { readonly id: Key },
       >(
-        topic: typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC | typeof VIEW_SERVER_HEALTH_TOPIC,
-        queryId: string,
-        rowsFromHealth: (
+        snapshotFromHealth: (
           nextHealth: ViewServerHealth<Topics>,
           updatedAtNanos: bigint,
-        ) => ReadonlyArray<Row>,
+        ) => Extract<ViewServerLiveEvent<Row, Topic, Key>, { readonly type: "snapshot" }>,
       ) {
-        const queue = yield* Queue.bounded<ViewServerLiveEvent<Row>, Cause.Done>(64);
+        const queue = yield* Queue.bounded<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(64);
         const updates = yield* Queue.sliding<ViewServerHealth<Topics>, Cause.Done>(1);
         const subscription = { close: Effect.void };
         let closed = false;
@@ -114,16 +114,7 @@ export const makeInMemoryLiveClient = Effect.fn("ViewServerInMemory.liveClient.m
           nextHealth: ViewServerHealth<Topics>,
         ) {
           const updatedAtNanos = yield* Clock.currentTimeNanos;
-          const rows = rowsFromHealth(nextHealth, updatedAtNanos);
-          yield* Queue.offer(queue, {
-            type: "snapshot",
-            topic,
-            queryId,
-            version: nextHealth.version,
-            keys: rows.map((row) => row.id),
-            rows,
-            totalRows: rows.length,
-          });
+          yield* Queue.offer(queue, snapshotFromHealth(nextHealth, updatedAtNanos));
         });
         const unsubscribe = health.subscribe((nextHealth) => {
           Queue.offerUnsafe(updates, nextHealth);
@@ -164,19 +155,36 @@ export const makeInMemoryLiveClient = Effect.fn("ViewServerInMemory.liveClient.m
         subscribe,
         subscribeRuntime,
         subscribeHealthSummary: () =>
-          makeHealthSubscription<ViewServerHealthSummaryRow<Topics>>(
-            VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
-            "health-summary",
-            (nextHealth, updatedAtNanos) => [
-              viewServerHealthSummaryRowFromHealth(nextHealth, updatedAtNanos),
-            ],
-          ),
+          makeHealthSubscription<
+            typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+            "summary",
+            ViewServerHealthSummaryRow<Topics>
+          >((nextHealth, updatedAtNanos) => ({
+            type: "snapshot",
+            topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+            queryId: "health-summary",
+            version: nextHealth.version,
+            keys: ["summary"],
+            rows: [viewServerHealthSummaryRowFromHealth(nextHealth, updatedAtNanos)],
+            totalRows: 1,
+          })),
         subscribeHealth: () =>
-          makeHealthSubscription<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>(
-            VIEW_SERVER_HEALTH_TOPIC,
-            "health",
-            viewServerHealthTopicRowsFromHealth,
-          ),
+          makeHealthSubscription<
+            typeof VIEW_SERVER_HEALTH_TOPIC,
+            Extract<keyof Topics, string>,
+            ViewServerHealthTopicRow<Extract<keyof Topics, string>>
+          >((nextHealth, updatedAtNanos) => {
+            const rows = viewServerHealthTopicRowsFromHealth(nextHealth, updatedAtNanos);
+            return {
+              type: "snapshot",
+              topic: VIEW_SERVER_HEALTH_TOPIC,
+              queryId: "health",
+              version: nextHealth.version,
+              keys: rows.map((row) => row.id),
+              rows,
+              totalRows: rows.length,
+            };
+          }),
         health: readonlyHealth,
         close,
       };

--- a/packages/protocol/src/index.test-d.ts
+++ b/packages/protocol/src/index.test-d.ts
@@ -1,5 +1,34 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@view-server/config";
+import { Effect, Schema } from "effect";
 import type * as Protocol from "./index";
+import {
+  viewServerDecodeHealthSummaryEvent,
+  viewServerDecodeHealthTopicEvent,
+  viewServerDecodeTrustedLiveEvent,
+  viewServerEncodeHealthSummaryEvent,
+  viewServerEncodeHealthTopicEvent,
+} from "./index";
+
+const TypeOrder = Schema.Struct({
+  id: Schema.String,
+});
+
+const typeViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: TypeOrder,
+      key: "id",
+    },
+    trades: {
+      schema: TypeOrder,
+      key: "id",
+    },
+  },
+});
+
+declare const wireEvent: Protocol.ViewServerWireEvent;
+declare const trustedWireEvent: Protocol.ViewServerTrustedWireEvent;
 
 describe("@view-server/protocol type contract", () => {
   it("does not export transport-neutral live client contracts", () => {
@@ -13,5 +42,467 @@ describe("@view-server/protocol type contract", () => {
     expectTypeOf<Protocol.ViewServerLiveEvent<never>>().toBeNever();
     // @ts-expect-error live subscription contracts belong to @view-server/client.
     expectTypeOf<Protocol.ViewServerLiveSubscription<never>>().toBeNever();
+  });
+
+  it("types health event encoder inputs from configured topics", () => {
+    const validSummaryEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "snapshot",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      version: 1,
+      keys: ["summary"],
+      rows: [
+        {
+          id: "summary",
+          status: "degraded",
+          runtimeStatus: "degraded",
+          connectionStatus: "connected",
+          unhealthyTopics: ["orders"],
+          updatedAtNanos: 1n,
+          maxKafkaLag: 0n,
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(validSummaryEncode).not.toBeAny();
+
+    const invalidConnectedSummaryStatusEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "snapshot",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      version: 1,
+      keys: ["summary"],
+      rows: [
+        {
+          id: "summary",
+          // @ts-expect-error connected is a connectionStatus, not a merged health status.
+          status: "connected",
+          runtimeStatus: "ready",
+          connectionStatus: "connected",
+          unhealthyTopics: [],
+          updatedAtNanos: 1n,
+          maxKafkaLag: 0n,
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidConnectedSummaryStatusEncode).not.toBeAny();
+
+    const invalidSummaryEmptyRowsEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "snapshot",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      version: 1,
+      keys: ["summary"],
+      // @ts-expect-error health summary snapshots must contain exactly one row.
+      rows: [],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidSummaryEmptyRowsEncode).not.toBeAny();
+
+    const invalidSummaryTotalRowsEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "snapshot",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      version: 1,
+      keys: ["summary"],
+      rows: [
+        {
+          id: "summary",
+          status: "ready",
+          runtimeStatus: "ready",
+          connectionStatus: "connected",
+          unhealthyTopics: [],
+          updatedAtNanos: 1n,
+          maxKafkaLag: 0n,
+        },
+      ],
+      // @ts-expect-error health summary totalRows is always 1.
+      totalRows: 2,
+    });
+    expectTypeOf(invalidSummaryTotalRowsEncode).not.toBeAny();
+
+    const invalidSummaryTopicEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "status",
+      // @ts-expect-error health summary events must use the summary system topic.
+      topic: "__view_server_health",
+      queryId: "health-summary",
+      status: "ready",
+      code: "Ready",
+    });
+    expectTypeOf(invalidSummaryTopicEncode).not.toBeAny();
+
+    const invalidSummaryKeyEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "snapshot",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      version: 1,
+      // @ts-expect-error health summary snapshot keys are always summary.
+      keys: ["orders"],
+      rows: [
+        {
+          id: "summary",
+          status: "ready",
+          runtimeStatus: "ready",
+          connectionStatus: "connected",
+          unhealthyTopics: [],
+          updatedAtNanos: 1n,
+          maxKafkaLag: 0n,
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidSummaryKeyEncode).not.toBeAny();
+
+    const invalidSummaryDeltaKeyEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          type: "move",
+          // @ts-expect-error health summary delta keys are always summary.
+          key: "orders",
+          fromIndex: 0,
+          toIndex: 0,
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidSummaryDeltaKeyEncode).not.toBeAny();
+
+    const invalidSummaryEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "snapshot",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      version: 1,
+      keys: ["summary"],
+      rows: [
+        {
+          id: "summary",
+          status: "degraded",
+          runtimeStatus: "degraded",
+          connectionStatus: "connected",
+          // @ts-expect-error unknown unhealthy topics are rejected at compile time.
+          unhealthyTopics: ["missing"],
+          updatedAtNanos: 1n,
+          maxKafkaLag: 0n,
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidSummaryEncode).not.toBeAny();
+
+    const validTopicEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health",
+      queryId: "health-detail",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          type: "update",
+          key: "orders",
+          row: {
+            id: "orders",
+            status: "ready",
+            rowCount: 1,
+            liveRowCount: 1,
+            deletedRowCount: 0,
+            version: 1,
+            lastMutationAt: null,
+            mutationsPerSecond: 0,
+            rowsPerSecond: 0,
+            pendingMutationBatches: 0,
+            activeViews: 0,
+            activeSubscriptions: 0,
+            queuedEvents: 0,
+            maxQueueDepth: 0,
+            backpressureEvents: 0,
+            memoryBytes: 0,
+            tombstoneCount: 0,
+            compactionPending: false,
+            kafkaLag: 0n,
+            updatedAtNanos: 1n,
+          },
+          index: 0,
+        },
+      ],
+      totalRows: 2,
+    });
+    expectTypeOf(validTopicEncode).not.toBeAny();
+
+    const invalidTopicEventTopicEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "status",
+      // @ts-expect-error health detail events must use the detail system topic.
+      topic: "__view_server_health_summary",
+      queryId: "health-detail",
+      status: "ready",
+      code: "Ready",
+    });
+    expectTypeOf(invalidTopicEventTopicEncode).not.toBeAny();
+
+    const invalidTopicMoveKeyEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health",
+      queryId: "health-detail",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          type: "move",
+          // @ts-expect-error health detail operation keys must be configured topics.
+          key: "missing",
+          fromIndex: 0,
+          toIndex: 1,
+        },
+      ],
+      totalRows: 2,
+    });
+    expectTypeOf(invalidTopicMoveKeyEncode).not.toBeAny();
+
+    const mismatchedTopicDeltaRowEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health",
+      queryId: "health-detail",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          type: "update",
+          key: "orders",
+          row: {
+            // @ts-expect-error health detail operation row ids must match operation keys.
+            id: "trades",
+            status: "ready",
+            rowCount: 1,
+            liveRowCount: 1,
+            deletedRowCount: 0,
+            version: 1,
+            lastMutationAt: null,
+            mutationsPerSecond: 0,
+            rowsPerSecond: 0,
+            pendingMutationBatches: 0,
+            activeViews: 0,
+            activeSubscriptions: 0,
+            queuedEvents: 0,
+            maxQueueDepth: 0,
+            backpressureEvents: 0,
+            memoryBytes: 0,
+            tombstoneCount: 0,
+            compactionPending: false,
+            kafkaLag: 0n,
+            updatedAtNanos: 1n,
+          },
+          index: 0,
+        },
+      ],
+      totalRows: 2,
+    });
+    expectTypeOf(mismatchedTopicDeltaRowEncode).not.toBeAny();
+
+    const invalidTopicEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health",
+      queryId: "health-detail",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          type: "update",
+          key: "orders",
+          row: {
+            // @ts-expect-error unknown health topic rows are rejected at compile time.
+            id: "missing",
+            status: "ready",
+            rowCount: 1,
+            liveRowCount: 1,
+            deletedRowCount: 0,
+            version: 1,
+            lastMutationAt: null,
+            mutationsPerSecond: 0,
+            rowsPerSecond: 0,
+            pendingMutationBatches: 0,
+            activeViews: 0,
+            activeSubscriptions: 0,
+            queuedEvents: 0,
+            maxQueueDepth: 0,
+            backpressureEvents: 0,
+            memoryBytes: 0,
+            tombstoneCount: 0,
+            compactionPending: false,
+            kafkaLag: 0n,
+            updatedAtNanos: 1n,
+          },
+          index: 0,
+        },
+      ],
+      totalRows: 2,
+    });
+    expectTypeOf(invalidTopicEncode).not.toBeAny();
+
+    const invalidSummaryRemoveEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          // @ts-expect-error fixed-cardinality health summary deltas cannot remove the summary row.
+          type: "remove",
+          key: "summary",
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidSummaryRemoveEncode).not.toBeAny();
+
+    const invalidSummaryInsertEncode = viewServerEncodeHealthSummaryEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health_summary",
+      queryId: "health-summary",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          // @ts-expect-error fixed-cardinality health summary deltas cannot insert the summary row.
+          type: "insert",
+          key: "summary",
+          row: {
+            id: "summary",
+            status: "ready",
+            runtimeStatus: "ready",
+            connectionStatus: "connected",
+            unhealthyTopics: [],
+            updatedAtNanos: 1n,
+            maxKafkaLag: 0n,
+          },
+          index: 0,
+        },
+      ],
+      totalRows: 1,
+    });
+    expectTypeOf(invalidSummaryInsertEncode).not.toBeAny();
+
+    const invalidTopicRemoveEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health",
+      queryId: "health-detail",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          // @ts-expect-error fixed-cardinality health detail deltas cannot remove configured topics.
+          type: "remove",
+          key: "orders",
+        },
+      ],
+      totalRows: 2,
+    });
+    expectTypeOf(invalidTopicRemoveEncode).not.toBeAny();
+
+    const invalidTopicInsertEncode = viewServerEncodeHealthTopicEvent(typeViewServer, {
+      type: "delta",
+      topic: "__view_server_health",
+      queryId: "health-detail",
+      fromVersion: 1,
+      toVersion: 2,
+      operations: [
+        {
+          // @ts-expect-error fixed-cardinality health detail deltas cannot insert configured topics.
+          type: "insert",
+          key: "orders",
+          row: {
+            id: "orders",
+            status: "ready",
+            rowCount: 1,
+            liveRowCount: 1,
+            deletedRowCount: 0,
+            version: 1,
+            lastMutationAt: null,
+            mutationsPerSecond: 0,
+            rowsPerSecond: 0,
+            pendingMutationBatches: 0,
+            activeViews: 0,
+            activeSubscriptions: 0,
+            queuedEvents: 0,
+            maxQueueDepth: 0,
+            backpressureEvents: 0,
+            memoryBytes: 0,
+            tombstoneCount: 0,
+            compactionPending: false,
+            kafkaLag: 0n,
+            updatedAtNanos: 1n,
+          },
+          index: 0,
+        },
+      ],
+      totalRows: 2,
+    });
+    expectTypeOf(invalidTopicInsertEncode).not.toBeAny();
+  });
+
+  it("requires schema-validated event proof for trusted live event decoding", () => {
+    const validTrustedDecode = viewServerDecodeTrustedLiveEvent(
+      typeViewServer,
+      "orders",
+      { select: ["id"] },
+      trustedWireEvent,
+    );
+    expectTypeOf(validTrustedDecode).not.toBeAny();
+
+    const invalidTrustedDecode = viewServerDecodeTrustedLiveEvent(
+      typeViewServer,
+      "orders",
+      { select: ["id"] },
+      // @ts-expect-error trusted decoder requires ViewServerTrustedWireEvent.
+      wireEvent,
+    );
+    expectTypeOf(invalidTrustedDecode).not.toBeAny();
+  });
+
+  it("preserves health event decoder output generics", () => {
+    const summaryDecode = viewServerDecodeHealthSummaryEvent(typeViewServer, wireEvent);
+    type SummaryEvent = Effect.Success<typeof summaryDecode>;
+    type SummarySnapshot = Extract<SummaryEvent, { readonly type: "snapshot" }>;
+    type SummaryDeltaOperation = Extract<
+      SummaryEvent,
+      { readonly type: "delta" }
+    >["operations"][number];
+    expectTypeOf<SummarySnapshot["topic"]>().toEqualTypeOf<"__view_server_health_summary">();
+    expectTypeOf<SummarySnapshot["keys"]>().toEqualTypeOf<readonly ["summary"]>();
+    expectTypeOf<SummarySnapshot["rows"][0]["id"]>().toEqualTypeOf<"summary">();
+    expectTypeOf<SummarySnapshot["rows"][0]["unhealthyTopics"][number]>().toEqualTypeOf<
+      "orders" | "trades"
+    >();
+    expectTypeOf<SummarySnapshot["totalRows"]>().toEqualTypeOf<1>();
+    expectTypeOf<SummaryDeltaOperation["key"]>().toEqualTypeOf<"summary">();
+    expectTypeOf<
+      Extract<SummaryDeltaOperation, { readonly type: "insert" }>
+    >().toEqualTypeOf<never>();
+    expectTypeOf<
+      Extract<SummaryDeltaOperation, { readonly type: "remove" }>
+    >().toEqualTypeOf<never>();
+
+    const topicDecode = viewServerDecodeHealthTopicEvent(typeViewServer, wireEvent);
+    type TopicEvent = Effect.Success<typeof topicDecode>;
+    type TopicSnapshot = Extract<TopicEvent, { readonly type: "snapshot" }>;
+    type TopicDeltaOperation = Extract<
+      TopicEvent,
+      { readonly type: "delta" }
+    >["operations"][number];
+    expectTypeOf<TopicSnapshot["topic"]>().toEqualTypeOf<"__view_server_health">();
+    expectTypeOf<TopicSnapshot["keys"][number]>().toEqualTypeOf<"orders" | "trades">();
+    expectTypeOf<TopicSnapshot["rows"][number]["id"]>().toEqualTypeOf<"orders" | "trades">();
+    expectTypeOf<TopicDeltaOperation["key"]>().toEqualTypeOf<"orders" | "trades">();
+    expectTypeOf<
+      Extract<TopicDeltaOperation, { readonly type: "insert" }>
+    >().toEqualTypeOf<never>();
+    expectTypeOf<
+      Extract<TopicDeltaOperation, { readonly type: "remove" }>
+    >().toEqualTypeOf<never>();
   });
 });

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -16,6 +16,7 @@ import {
   ViewServerRuntimeErrorSchema,
   ViewServerSubscribePayloadSchema,
   ViewServerTransportErrorSchema,
+  ViewServerTrustedWireEventSchema,
   ViewServerWireEventSchema,
   ViewServerWireGroupedQuerySchema,
   ViewServerWireRawQuerySchema,
@@ -28,6 +29,7 @@ import {
   viewServerDecodeLiveEvent,
   viewServerDecodeLiveQuery,
   viewServerDecodeRawQuery,
+  viewServerDecodeTrustedLiveEvent,
   viewServerDecodeTopic,
   viewServerEncodeGroupedQuery,
   viewServerEncodeHealthSummaryEvent,
@@ -483,6 +485,18 @@ describe("@view-server/protocol", () => {
         code: "Ready",
       });
 
+      const malformedStatusEncode = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "ready",
+          // @ts-expect-error ready status events can only use the Ready code.
+          code: "InvalidRow",
+        }),
+      );
+      expect(malformedStatusEncode.message).toMatch(/Invalid event/);
+
       const snapshot = yield* viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
         type: "snapshot",
         topic: "orders",
@@ -525,6 +539,23 @@ describe("@view-server/protocol", () => {
       >(viewServer, "orders", idQuery, statusEvent);
       expect(decodedStatus).toStrictEqual(statusEvent);
 
+      const malformedStatusDecode = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
+          viewServer,
+          "orders",
+          idQuery,
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "query-0",
+            status: "ready",
+            // @ts-expect-error hostile wire status can use an invalid ready code.
+            code: "InvalidRow",
+          },
+        ),
+      );
+      expect(malformedStatusDecode.message).toMatch(/Invalid event/);
+
       const decodedSnapshot = yield* viewServerDecodeLiveEvent<
         typeof viewServer.topics,
         "orders",
@@ -538,6 +569,16 @@ describe("@view-server/protocol", () => {
         Pick<typeof Order.Type, "id">
       >(viewServer, "orders", idQuery, delta);
       expect(decodedDelta).toStrictEqual(delta);
+
+      const trustedSnapshot = yield* Schema.decodeUnknownEffect(ViewServerTrustedWireEventSchema)(
+        snapshot,
+      );
+      const decodedTrustedSnapshot = yield* viewServerDecodeTrustedLiveEvent<
+        typeof viewServer.topics,
+        "orders",
+        Pick<typeof Order.Type, "id">
+      >(viewServer, "orders", idQuery, trustedSnapshot);
+      expect(decodedTrustedSnapshot).toStrictEqual(snapshot);
 
       const decodedHealth = yield* viewServerDecodeHealth(viewServer, wireHealth);
       expect(decodedHealth.status).toBe("ready");
@@ -1026,7 +1067,7 @@ describe("@view-server/protocol", () => {
         maxKafkaLag: 45n,
       };
 
-      const summaryStatus = yield* viewServerEncodeHealthSummaryEvent({
+      const summaryStatus = yield* viewServerEncodeHealthSummaryEvent(viewServer, {
         type: "status",
         topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
         queryId: "health-summary",
@@ -1047,7 +1088,7 @@ describe("@view-server/protocol", () => {
       );
       expect(decodedSummaryStatus).toStrictEqual(summaryStatus);
 
-      const summarySnapshot = yield* viewServerEncodeHealthSummaryEvent({
+      const summarySnapshot = yield* viewServerEncodeHealthSummaryEvent(viewServer, {
         type: "snapshot",
         topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
         queryId: "health-summary",
@@ -1108,21 +1149,20 @@ describe("@view-server/protocol", () => {
       });
       expect(disconnectedSummary.type).toBe("snapshot");
 
-      const summaryDelta = yield* viewServerEncodeHealthSummaryEvent({
+      const summaryDelta = yield* viewServerEncodeHealthSummaryEvent(viewServer, {
         type: "delta",
         topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
         queryId: "health-summary",
         fromVersion: 1,
         toVersion: 2,
         operations: [
-          { type: "insert", key: "summary", row: summaryRow, index: 0 },
           {
             type: "update",
             key: "summary",
             row: { ...summaryRow, unhealthyTopics: [] },
             index: 0,
           },
-          { type: "remove", key: "summary" },
+          { type: "move", key: "summary", fromIndex: 0, toIndex: 0 },
         ],
         totalRows: 1,
       });
@@ -1137,14 +1177,13 @@ describe("@view-server/protocol", () => {
         fromVersion: 1,
         toVersion: 2,
         operations: [
-          { type: "insert", key: "summary", row: summaryRow, index: 0 },
           {
             type: "update",
             key: "summary",
             row: { ...summaryRow, unhealthyTopics: [] },
             index: 0,
           },
-          { type: "remove", key: "summary" },
+          { type: "move", key: "summary", fromIndex: 0, toIndex: 0 },
         ],
         totalRows: 1,
       });
@@ -1179,7 +1218,7 @@ describe("@view-server/protocol", () => {
         version: 0,
       };
 
-      const topicSnapshot = yield* viewServerEncodeHealthTopicEvent({
+      const topicSnapshot = yield* viewServerEncodeHealthTopicEvent(viewServer, {
         type: "snapshot",
         topic: VIEW_SERVER_HEALTH_TOPIC,
         queryId: "health-detail",
@@ -1226,19 +1265,17 @@ describe("@view-server/protocol", () => {
         totalRows: 2,
       });
 
-      const topicDelta = yield* viewServerEncodeHealthTopicEvent({
+      const topicDelta = yield* viewServerEncodeHealthTopicEvent(viewServer, {
         type: "delta",
         topic: VIEW_SERVER_HEALTH_TOPIC,
         queryId: "health-detail",
         fromVersion: 1,
         toVersion: 2,
         operations: [
-          { type: "insert", key: "orders", row: healthTopicRow, index: 0 },
           { type: "update", key: "orders", row: { ...healthTopicRow, rowCount: 11 }, index: 0 },
           { type: "move", key: "orders", fromIndex: 1, toIndex: 0 },
-          { type: "remove", key: "orders" },
         ],
-        totalRows: 1,
+        totalRows: 2,
       });
       expect(topicDelta).toStrictEqual({
         type: "delta",
@@ -1248,21 +1285,14 @@ describe("@view-server/protocol", () => {
         toVersion: 2,
         operations: [
           {
-            type: "insert",
-            key: "orders",
-            row: { ...healthTopicRow, kafkaLag: "7", updatedAtNanos: "456" },
-            index: 0,
-          },
-          {
             type: "update",
             key: "orders",
             row: { ...healthTopicRow, rowCount: 11, kafkaLag: "7", updatedAtNanos: "456" },
             index: 0,
           },
           { type: "move", key: "orders", fromIndex: 1, toIndex: 0 },
-          { type: "remove", key: "orders" },
         ],
-        totalRows: 1,
+        totalRows: 2,
       });
 
       const decodedTopicSnapshot = yield* viewServerDecodeHealthTopicEvent(
@@ -1287,12 +1317,10 @@ describe("@view-server/protocol", () => {
         fromVersion: 1,
         toVersion: 2,
         operations: [
-          { type: "insert", key: "orders", row: healthTopicRow, index: 0 },
           { type: "update", key: "orders", row: { ...healthTopicRow, rowCount: 11 }, index: 0 },
           { type: "move", key: "orders", fromIndex: 1, toIndex: 0 },
-          { type: "remove", key: "orders" },
         ],
-        totalRows: 1,
+        totalRows: 2,
       });
     }),
   );
@@ -2433,9 +2461,85 @@ describe("@view-server/protocol", () => {
         "Health payload references unknown topic: __view_server_health",
       );
 
+      const healthWithExtras = {
+        ...wireHealth,
+        extraRoot: "drop-me",
+        engine: {
+          topics: {
+            orders: { ...topicHealth, extraTopic: "drop-me" },
+            badjson: { ...topicHealth, rowCount: 0, liveRowCount: 0, extraTopic: "drop-me" },
+          },
+        },
+        transport: { ...wireHealth.transport, extraTransport: "drop-me" },
+      };
+      const normalizedHealth = yield* viewServerDecodeHealth(viewServer, healthWithExtras);
+      expect(Object.hasOwn(normalizedHealth, "extraRoot")).toBe(false);
+      expect(Object.hasOwn(normalizedHealth.transport, "extraTransport")).toBe(false);
+      expect(Object.hasOwn(normalizedHealth.engine.topics["orders"], "extraTopic")).toBe(false);
+
+      const malformedHealthStatus = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          // @ts-expect-error hostile runtime adapters can return malformed health status.
+          status: "broken",
+        }),
+      );
+      expect(malformedHealthStatus.message).toMatch(/Invalid health payload/);
+
+      const malformedHealthTransport = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          transport: {
+            ...wireHealth.transport,
+            // @ts-expect-error hostile runtime adapters can return malformed health counters.
+            activeClients: "1",
+          },
+        }),
+      );
+      expect(malformedHealthTransport.message).toMatch(/Invalid health payload/);
+
+      const validKafkaViewServerTopic = yield* viewServerDecodeHealth(viewServer, {
+        ...wireHealth,
+        kafka: {
+          regions: {},
+          topics: {
+            ordersSource: {
+              status: "ready",
+              sourceTopic: "orders-source",
+              viewServerTopic: "orders",
+              regions: {},
+            },
+          },
+        },
+      });
+      expect(validKafkaViewServerTopic.kafka?.topics["ordersSource"]?.viewServerTopic).toBe(
+        "orders",
+      );
+
+      const unknownKafkaViewServerTopic = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          kafka: {
+            regions: {},
+            topics: {
+              ordersSource: {
+                status: "ready",
+                sourceTopic: "orders-source",
+                viewServerTopic: "missing",
+                regions: {},
+              },
+            },
+          },
+        }),
+      );
+      expect(unknownKafkaViewServerTopic.message).toBe(
+        "Health payload references unknown topic: missing",
+      );
+
       const wrongSummaryEncodeTopic = yield* Effect.flip(
-        viewServerEncodeHealthSummaryEvent({
+        viewServerEncodeHealthSummaryEvent(viewServer, {
           type: "status",
+          // @ts-expect-error hostile callers can pass the wrong system topic.
           topic: VIEW_SERVER_HEALTH_TOPIC,
           queryId: "health-summary",
           status: "ready",
@@ -2445,6 +2549,30 @@ describe("@view-server/protocol", () => {
       expect(wrongSummaryEncodeTopic.message).toBe(
         "Received event for __view_server_health while subscribed to __view_server_health_summary",
       );
+
+      const malformedSummaryStatus = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "status",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          status: "ready",
+          // @ts-expect-error ready summary status can only use the Ready code.
+          code: "InvalidRow",
+        }),
+      );
+      expect(malformedSummaryStatus.message).toMatch(/Invalid event/);
+
+      const malformedDecodedSummaryStatus = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "status",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          status: "ready",
+          // @ts-expect-error hostile wire status can use an invalid ready code.
+          code: "InvalidRow",
+        }),
+      );
+      expect(malformedDecodedSummaryStatus.message).toMatch(/Invalid system event/);
 
       const wrongTopicDecodeTopic = yield* Effect.flip(
         viewServerDecodeHealthTopicEvent(viewServer, {
@@ -2473,6 +2601,30 @@ describe("@view-server/protocol", () => {
         status: "ready",
         code: "Ready",
       });
+
+      const malformedTopicStatus = yield* Effect.flip(
+        viewServerEncodeHealthTopicEvent(viewServer, {
+          type: "status",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          status: "ready",
+          // @ts-expect-error ready detail status can only use the Ready code.
+          code: "InvalidRow",
+        }),
+      );
+      expect(malformedTopicStatus.message).toMatch(/Invalid event/);
+
+      const malformedDecodedTopicStatus = yield* Effect.flip(
+        viewServerDecodeHealthTopicEvent(viewServer, {
+          type: "status",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          status: "ready",
+          // @ts-expect-error hostile wire status can use an invalid ready code.
+          code: "InvalidRow",
+        }),
+      );
+      expect(malformedDecodedTopicStatus.message).toMatch(/Invalid system event/);
 
       const invalidHealthSummaryRow = yield* Effect.flip(
         viewServerDecodeHealthSummaryEvent(viewServer, {
@@ -2582,6 +2734,29 @@ describe("@view-server/protocol", () => {
       );
       expect(wrongSummaryRowCount.message).toBe("Health summary must contain exactly one row");
 
+      const wrongSummaryTotalRows = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          version: 1,
+          keys: ["summary"],
+          rows: [
+            {
+              id: "summary",
+              status: "ready",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              unhealthyTopics: [],
+              updatedAtNanos: "1",
+              maxKafkaLag: "0",
+            },
+          ],
+          totalRows: 2,
+        }),
+      );
+      expect(wrongSummaryTotalRows.message).toBe("Health summary must contain exactly one row");
+
       const inconsistentSummaryStatus = yield* Effect.flip(
         viewServerDecodeHealthSummaryEvent(viewServer, {
           type: "snapshot",
@@ -2606,6 +2781,29 @@ describe("@view-server/protocol", () => {
       expect(inconsistentSummaryStatus.message).toBe(
         "Health summary status does not match runtime/connection status: ready != degraded",
       );
+
+      const connectedSummaryStatus = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          version: 1,
+          keys: ["summary"],
+          rows: [
+            {
+              id: "summary",
+              status: "connected",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              unhealthyTopics: [],
+              updatedAtNanos: "1",
+              maxKafkaLag: "0",
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(connectedSummaryStatus.message).toMatch(/Invalid system row/);
 
       const wrongSummaryDeltaKey = yield* Effect.flip(
         viewServerDecodeHealthSummaryEvent(viewServer, {
@@ -2730,7 +2928,7 @@ describe("@view-server/protocol", () => {
               updatedAtNanos: 1,
             },
           ],
-          totalRows: 3,
+          totalRows: 2,
         }),
       );
       expect(unknownDetailTopic.message).toBe("Health payload references unknown topic: missing");
@@ -2766,11 +2964,71 @@ describe("@view-server/protocol", () => {
               updatedAtNanos: "1",
             },
           ],
-          totalRows: 1,
+          totalRows: 2,
         }),
       );
       expect(partialDetailTopicSnapshot.message).toBe(
         "Health topic snapshot keys is missing topic: badjson",
+      );
+
+      const wrongDetailTopicSnapshotTotalRows = yield* Effect.flip(
+        viewServerDecodeHealthTopicEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          version: 1,
+          keys: ["orders", "badjson"],
+          rows: [
+            {
+              id: "orders",
+              status: "ready",
+              rowCount: 0,
+              liveRowCount: 0,
+              deletedRowCount: 0,
+              version: 0,
+              lastMutationAt: null,
+              mutationsPerSecond: 0,
+              rowsPerSecond: 0,
+              pendingMutationBatches: 0,
+              activeViews: 0,
+              activeSubscriptions: 0,
+              queuedEvents: 0,
+              maxQueueDepth: 0,
+              backpressureEvents: 0,
+              memoryBytes: 0,
+              tombstoneCount: 0,
+              compactionPending: false,
+              kafkaLag: "0",
+              updatedAtNanos: "1",
+            },
+            {
+              id: "badjson",
+              status: "ready",
+              rowCount: 0,
+              liveRowCount: 0,
+              deletedRowCount: 0,
+              version: 0,
+              lastMutationAt: null,
+              mutationsPerSecond: 0,
+              rowsPerSecond: 0,
+              pendingMutationBatches: 0,
+              activeViews: 0,
+              activeSubscriptions: 0,
+              queuedEvents: 0,
+              maxQueueDepth: 0,
+              backpressureEvents: 0,
+              memoryBytes: 0,
+              tombstoneCount: 0,
+              compactionPending: false,
+              kafkaLag: "0",
+              updatedAtNanos: "1",
+            },
+          ],
+          totalRows: 999,
+        }),
+      );
+      expect(wrongDetailTopicSnapshotTotalRows.message).toBe(
+        "Health topic snapshot totalRows must equal configured topic count: 999 != 2",
       );
 
       const duplicateDetailTopicKeys = yield* Effect.flip(
@@ -2968,7 +3226,7 @@ describe("@view-server/protocol", () => {
               updatedAtNanos: "1",
             },
           ],
-          totalRows: 3,
+          totalRows: 2,
         }),
       );
       expect(nonStringDetailTopic.message).toMatch(/Invalid system row/);
@@ -3009,7 +3267,7 @@ describe("@view-server/protocol", () => {
               index: 0,
             },
           ],
-          totalRows: 1,
+          totalRows: 2,
         }),
       );
       expect(nonStringDeltaDetailTopic.message).toMatch(/Invalid system row/);
@@ -3050,11 +3308,26 @@ describe("@view-server/protocol", () => {
               index: 0,
             },
           ],
-          totalRows: 1,
+          totalRows: 2,
         }),
       );
       expect(mismatchedDeltaDetailTopic.message).toBe(
         "Health topic delta key does not match row id: orders != badjson",
+      );
+
+      const wrongDetailTopicDeltaTotalRows = yield* Effect.flip(
+        viewServerDecodeHealthTopicEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "remove", key: "orders" }],
+          totalRows: 1,
+        }),
+      );
+      expect(wrongDetailTopicDeltaTotalRows.message).toBe(
+        "Health topic delta totalRows must equal configured topic count: 1 != 2",
       );
 
       const malformedHealthQuery = yield* Effect.flip(
@@ -3071,7 +3344,7 @@ describe("@view-server/protocol", () => {
       expect(extraHealthQueryKey.code).toBe("InvalidQuery");
 
       const invalidHealthSummaryEncodeRow = yield* Effect.flip(
-        viewServerEncodeHealthSummaryEvent({
+        viewServerEncodeHealthSummaryEvent(viewServer, {
           type: "snapshot",
           topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
           queryId: "health-summary",
@@ -3094,6 +3367,420 @@ describe("@view-server/protocol", () => {
         }),
       );
       expect(invalidHealthSummaryEncodeRow.message).toMatch(/Invalid system row/);
+
+      const missingHealthSummaryEncodeTopics = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          version: 1,
+          keys: ["summary"],
+          rows: [
+            // @ts-expect-error hostile callers can omit required system row values.
+            {
+              id: "summary",
+              status: "ready",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              updatedAtNanos: 1n,
+              maxKafkaLag: 0n,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(missingHealthSummaryEncodeTopics.message).toMatch(/Invalid system row/);
+
+      const invalidHealthSummaryEncodeKey = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          version: 1,
+          // @ts-expect-error hostile callers can pass invalid summary snapshot keys.
+          keys: ["not-summary"],
+          rows: [
+            {
+              id: "summary",
+              status: "ready",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              unhealthyTopics: [],
+              updatedAtNanos: 1n,
+              maxKafkaLag: 0n,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryEncodeKey.message).toBe(
+        "Health summary keys must be exactly: summary",
+      );
+
+      const unknownHealthSummaryEncodeTopic = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          version: 1,
+          keys: ["summary"],
+          rows: [
+            {
+              id: "summary",
+              status: "degraded",
+              runtimeStatus: "degraded",
+              connectionStatus: "connected",
+              // @ts-expect-error hostile callers can pass unknown unhealthy topics.
+              unhealthyTopics: ["missing"],
+              updatedAtNanos: 1n,
+              maxKafkaLag: 0n,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(unknownHealthSummaryEncodeTopic.message).toBe(
+        "Health payload references unknown topic: missing",
+      );
+
+      const invalidHealthSummaryEncodeRowId = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          version: 1,
+          keys: ["summary"],
+          rows: [
+            {
+              // @ts-expect-error hostile callers can pass invalid system row ids.
+              id: "not-summary",
+              status: "ready",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              unhealthyTopics: [],
+              updatedAtNanos: 1n,
+              maxKafkaLag: 0n,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryEncodeRowId.message).toMatch(/Invalid system row/);
+
+      const invalidHealthSummaryEncodeVersion = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          // @ts-expect-error hostile callers can pass malformed snapshot metadata.
+          version: "not-a-number",
+          keys: ["summary"],
+          rows: [
+            {
+              id: "summary",
+              status: "ready",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              unhealthyTopics: [],
+              updatedAtNanos: 1n,
+              maxKafkaLag: 0n,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryEncodeVersion.message).toMatch(/Invalid event/);
+
+      const invalidHealthSummaryEncodeDeltaKey = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "move",
+              // @ts-expect-error hostile callers can pass invalid summary delta keys.
+              key: "not-summary",
+              fromIndex: 0,
+              toIndex: 0,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryEncodeDeltaKey.message).toBe(
+        "Health summary delta key must be: summary",
+      );
+
+      const mismatchedHealthSummaryEncodeDeltaRow = yield* Effect.flip(
+        viewServerEncodeHealthSummaryEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "update",
+              key: "summary",
+              row: {
+                // @ts-expect-error hostile callers can pass invalid system row ids.
+                id: "not-summary",
+                status: "ready",
+                runtimeStatus: "ready",
+                connectionStatus: "connected",
+                unhealthyTopics: [],
+                updatedAtNanos: 1n,
+                maxKafkaLag: 0n,
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(mismatchedHealthSummaryEncodeDeltaRow.message).toMatch(/Invalid system row/);
+
+      const invalidHealthSummaryDecodeRemove = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "remove", key: "summary" }],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryDecodeRemove.message).toBe(
+        "Health summary delta cannot remove summary",
+      );
+
+      const invalidHealthSummaryDecodeInsert = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "insert",
+              key: "summary",
+              row: {
+                id: "summary",
+                status: "ready",
+                runtimeStatus: "ready",
+                connectionStatus: "connected",
+                unhealthyTopics: [],
+                updatedAtNanos: "1",
+                maxKafkaLag: "0",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryDecodeInsert.message).toBe(
+        "Health summary delta cannot insert summary",
+      );
+
+      const invalidHealthSummaryDecodeIndex = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "move", key: "summary", fromIndex: 0, toIndex: -1 }],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryDecodeIndex.message).toBe(
+        "Health summary move to index must be 0: -1",
+      );
+
+      const invalidHealthSummaryDecodeDeltaTopic = yield* Effect.flip(
+        viewServerDecodeHealthSummaryEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "health-summary",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "update",
+              key: "summary",
+              row: {
+                id: "summary",
+                status: "degraded",
+                runtimeStatus: "degraded",
+                connectionStatus: "connected",
+                unhealthyTopics: ["missing"],
+                updatedAtNanos: "1",
+                maxKafkaLag: "0",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidHealthSummaryDecodeDeltaTopic.message).toBe(
+        "Health payload references unknown topic: missing",
+      );
+
+      const encodedHealthTopicRow: ViewServerHealthTopicRow<"orders"> = {
+        id: "orders",
+        status: "ready",
+        rowCount: 0,
+        liveRowCount: 0,
+        deletedRowCount: 0,
+        version: 0,
+        lastMutationAt: null,
+        mutationsPerSecond: 0,
+        rowsPerSecond: 0,
+        pendingMutationBatches: 0,
+        activeViews: 0,
+        activeSubscriptions: 0,
+        queuedEvents: 0,
+        maxQueueDepth: 0,
+        backpressureEvents: 0,
+        memoryBytes: 0,
+        tombstoneCount: 0,
+        compactionPending: false,
+        kafkaLag: 0n,
+        updatedAtNanos: 1n,
+      };
+
+      const partialHealthTopicEncodeSnapshot = yield* Effect.flip(
+        viewServerEncodeHealthTopicEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          version: 1,
+          keys: ["orders"],
+          rows: [encodedHealthTopicRow],
+          totalRows: 2,
+        }),
+      );
+      expect(partialHealthTopicEncodeSnapshot.message).toBe(
+        "Health topic snapshot keys is missing topic: badjson",
+      );
+
+      const invalidHealthTopicEncodeVersion = yield* Effect.flip(
+        viewServerEncodeHealthTopicEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          // @ts-expect-error hostile callers can pass malformed snapshot metadata.
+          version: "not-a-number",
+          keys: ["orders", "badjson"],
+          rows: [encodedHealthTopicRow, { ...encodedHealthTopicRow, id: "badjson" }],
+          totalRows: 2,
+        }),
+      );
+      expect(invalidHealthTopicEncodeVersion.message).toMatch(/Invalid event/);
+
+      const mismatchedHealthTopicEncodeSnapshot = yield* Effect.flip(
+        viewServerEncodeHealthTopicEvent(viewServer, {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          version: 1,
+          keys: ["badjson", "orders"],
+          rows: [encodedHealthTopicRow, { ...encodedHealthTopicRow, id: "badjson" }],
+          totalRows: 2,
+        }),
+      );
+      expect(mismatchedHealthTopicEncodeSnapshot.message).toBe(
+        "Health topic snapshot key does not match row id: badjson != orders",
+      );
+
+      const mismatchedHealthTopicEncodeDelta = yield* Effect.flip(
+        viewServerEncodeHealthTopicEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "update",
+              key: "orders",
+              row: {
+                ...encodedHealthTopicRow,
+                // @ts-expect-error hostile callers can pass a valid but mismatched topic row id.
+                id: "badjson",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        }),
+      );
+      expect(mismatchedHealthTopicEncodeDelta.message).toBe(
+        "Health topic delta key does not match row id: orders != badjson",
+      );
+
+      const invalidHealthTopicDecodeRemove = yield* Effect.flip(
+        viewServerDecodeHealthTopicEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "remove", key: "orders" }],
+          totalRows: 2,
+        }),
+      );
+      expect(invalidHealthTopicDecodeRemove.message).toBe(
+        "Health topic delta cannot remove configured topic: orders",
+      );
+
+      const invalidHealthTopicDecodeInsert = yield* Effect.flip(
+        viewServerDecodeHealthTopicEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "insert",
+              key: "orders",
+              row: {
+                ...encodedHealthTopicRow,
+                kafkaLag: "0",
+                updatedAtNanos: "1",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        }),
+      );
+      expect(invalidHealthTopicDecodeInsert.message).toBe(
+        "Health topic delta cannot insert configured topic: orders",
+      );
+
+      const invalidHealthTopicDecodeIndex = yield* Effect.flip(
+        viewServerDecodeHealthTopicEvent(viewServer, {
+          type: "delta",
+          topic: VIEW_SERVER_HEALTH_TOPIC,
+          queryId: "health-detail",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "move", key: "orders", fromIndex: 99, toIndex: 0 }],
+          totalRows: 2,
+        }),
+      );
+      expect(invalidHealthTopicDecodeIndex.message).toBe(
+        "Health topic move from index must be within configured topic count: 99",
+      );
     }),
   );
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,13 +32,19 @@ export {
 } from "./protocol-query-codec";
 
 export {
+  ViewServerTrustedWireEventSchema,
   ViewServerWireRowSchema,
   type ViewServerWireRow,
   ViewServerWireEventSchema,
+  type ViewServerTrustedWireEvent,
   type ViewServerWireEvent,
 } from "./protocol-event-schema";
 
-export { viewServerEncodeLiveEvent, viewServerDecodeLiveEvent } from "./protocol-event-codec";
+export {
+  viewServerEncodeLiveEvent,
+  viewServerDecodeLiveEvent,
+  viewServerDecodeTrustedLiveEvent,
+} from "./protocol-event-codec";
 
 export {
   ViewServerHealthSchema,

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -6,7 +6,12 @@ import type {
   ViewServerRuntimeError,
 } from "@view-server/config";
 import { Effect, Schema } from "effect";
-import { type ViewServerWireEvent } from "./protocol-event-schema";
+import {
+  ViewServerTrustedWireEventSchema,
+  type ViewServerTrustedWireEvent,
+  ViewServerWireEventSchema,
+  type ViewServerWireEvent,
+} from "./protocol-event-schema";
 import type { ViewServerEventQuery } from "./protocol-query-schema";
 import {
   decodeGroupedRow,
@@ -18,8 +23,16 @@ import {
   isViewServerEventGroupedQuery,
 } from "./protocol-row-codec";
 
-export { ViewServerWireEventSchema, ViewServerWireRowSchema } from "./protocol-event-schema";
-export type { ViewServerWireEvent, ViewServerWireRow } from "./protocol-event-schema";
+export {
+  ViewServerTrustedWireEventSchema,
+  ViewServerWireEventSchema,
+  ViewServerWireRowSchema,
+} from "./protocol-event-schema";
+export type {
+  ViewServerTrustedWireEvent,
+  ViewServerWireEvent,
+  ViewServerWireRow,
+} from "./protocol-event-schema";
 
 export type ViewServerProtocolEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
 
@@ -30,7 +43,24 @@ const invalidRow = (topic: string, message: string): ViewServerRuntimeError => (
   topic,
 });
 
-const encodeStatusEvent = (event: StatusEvent): ViewServerWireEvent => event;
+const validateTrustedWireEvent = Effect.fn("ViewServerProtocol.event.trusted.validate")(function* (
+  topic: string,
+  event: ViewServerWireEvent,
+) {
+  return yield* Schema.decodeUnknownEffect(ViewServerTrustedWireEventSchema)(event).pipe(
+    Effect.mapError((error) => invalidRow(topic, `Invalid event: ${error.message}`)),
+  );
+});
+
+const encodeStatusEvent = Effect.fn("ViewServerProtocol.event.status.encode")(function* (
+  topic: string,
+  event: StatusEvent,
+) {
+  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(event).pipe(
+    Effect.mapError((error) => invalidRow(topic, `Invalid event: ${error.message}`)),
+  );
+  return yield* validateTrustedWireEvent(topic, wireEvent);
+});
 
 export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.encode")(function* <
   const Topics extends TopicDefinitions,
@@ -49,7 +79,7 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
     );
   }
   if (event.type === "status") {
-    return encodeStatusEvent(event);
+    return yield* encodeStatusEvent(expectedTopic, event);
   }
   if (event.type === "snapshot") {
     const rows = yield* Effect.forEach(event.rows, (row) => {
@@ -58,10 +88,11 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
       }
       return encodeProjectedRow(config, expectedTopic, new Set<string>(query.select), row);
     });
-    return {
+    const wireEvent = {
       ...event,
       rows,
     };
+    return yield* validateTrustedWireEvent(expectedTopic, wireEvent);
   }
   type WireDeltaOperation = Extract<
     ViewServerWireEvent,
@@ -81,10 +112,11 @@ export const viewServerEncodeLiveEvent = Effect.fn("ViewServerProtocol.event.enc
       operations.push(operation);
     }
   }
-  return {
+  const wireEvent = {
     ...event,
     operations,
   };
+  return yield* validateTrustedWireEvent(expectedTopic, wireEvent);
 });
 
 function typedLiveEvent<Row>(
@@ -96,7 +128,7 @@ function typedLiveEvent(
   return event;
 }
 
-export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.decode")(function* <
+const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValidated")(function* <
   const Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
   Row,
@@ -104,28 +136,28 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
   config: { readonly topics: Topics },
   expectedTopic: Topic,
   query: ViewServerEventQuery,
-  event: ViewServerWireEvent,
+  wireEvent: ViewServerWireEvent,
 ) {
-  if (event.topic !== expectedTopic) {
+  if (wireEvent.topic !== expectedTopic) {
     return yield* Effect.fail(
       invalidRow(
         expectedTopic,
-        `Received event for ${event.topic} while subscribed to ${expectedTopic}`,
+        `Received event for ${wireEvent.topic} while subscribed to ${expectedTopic}`,
       ),
     );
   }
-  if (event.type === "status") {
-    return typedLiveEvent<Row>(event);
+  if (wireEvent.type === "status") {
+    return typedLiveEvent<Row>(wireEvent);
   }
-  if (event.type === "snapshot") {
-    const rows = yield* Effect.forEach(event.rows, (row) => {
+  if (wireEvent.type === "snapshot") {
+    const rows = yield* Effect.forEach(wireEvent.rows, (row) => {
       if (isViewServerEventGroupedQuery(query)) {
         return decodeGroupedRow(config, expectedTopic, query, row);
       }
       return decodeProjectedRow(config, expectedTopic, new Set<string>(query.select), row);
     });
     return typedLiveEvent<Row>({
-      ...event,
+      ...wireEvent,
       rows,
     });
   }
@@ -134,7 +166,7 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
     { readonly type: "delta" }
   >["operations"][number];
   const operations: Array<DecodedDeltaOperation> = [];
-  for (const operation of event.operations) {
+  for (const operation of wireEvent.operations) {
     if (operation.type === "insert" || operation.type === "update") {
       const row = yield* isViewServerEventGroupedQuery(query)
         ? decodeGroupedRow(config, expectedTopic, query, operation.row)
@@ -148,10 +180,46 @@ export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.dec
     }
   }
   return typedLiveEvent<Row>({
-    ...event,
+    ...wireEvent,
     operations,
   });
 });
+
+export const viewServerDecodeLiveEvent = Effect.fn("ViewServerProtocol.event.decode")(function* <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  Row,
+>(
+  config: { readonly topics: Topics },
+  expectedTopic: Topic,
+  query: ViewServerEventQuery,
+  event: ViewServerWireEvent,
+) {
+  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(event).pipe(
+    Effect.mapError((error) => invalidRow(expectedTopic, `Invalid event: ${error.message}`)),
+  );
+  return yield* decodeValidatedLiveEvent<Topics, Topic, Row>(
+    config,
+    expectedTopic,
+    query,
+    wireEvent,
+  );
+});
+
+export const viewServerDecodeTrustedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeTrusted")(
+  function* <
+    const Topics extends TopicDefinitions,
+    Topic extends Extract<keyof Topics, string>,
+    Row,
+  >(
+    config: { readonly topics: Topics },
+    expectedTopic: Topic,
+    query: ViewServerEventQuery,
+    event: ViewServerTrustedWireEvent,
+  ) {
+    return yield* decodeValidatedLiveEvent<Topics, Topic, Row>(config, expectedTopic, query, event);
+  },
+);
 
 export const encodeSystemLiveEvent = Effect.fn("ViewServerProtocol.system.event.encode")(function* <
   Row,
@@ -169,16 +237,17 @@ export const encodeSystemLiveEvent = Effect.fn("ViewServerProtocol.system.event.
     );
   }
   if (event.type === "status") {
-    return encodeStatusEvent(event);
+    return yield* encodeStatusEvent(expectedTopic, event);
   }
   if (event.type === "snapshot") {
     const rows = yield* Effect.forEach(event.rows, (row) =>
       encodeSystemRow(expectedTopic, schema, row),
     );
-    return {
+    const wireEvent = {
       ...event,
       rows,
     };
+    return yield* validateTrustedWireEvent(expectedTopic, wireEvent);
   }
   type WireDeltaOperation = Extract<
     ViewServerWireEvent,
@@ -196,10 +265,11 @@ export const encodeSystemLiveEvent = Effect.fn("ViewServerProtocol.system.event.
       operations.push(operation);
     }
   }
-  return {
+  const wireEvent = {
     ...event,
     operations,
   };
+  return yield* validateTrustedWireEvent(expectedTopic, wireEvent);
 });
 
 export const decodeSystemLiveEvent = Effect.fn("ViewServerProtocol.system.event.decode")(function* <

--- a/packages/protocol/src/protocol-event-schema.ts
+++ b/packages/protocol/src/protocol-event-schema.ts
@@ -104,3 +104,9 @@ export const ViewServerWireEventSchema = Schema.Union([
 ]);
 
 export type ViewServerWireEvent = typeof ViewServerWireEventSchema.Type;
+
+export const ViewServerTrustedWireEventSchema = ViewServerWireEventSchema.pipe(
+  Schema.brand("ViewServerTrustedWireEvent"),
+);
+
+export type ViewServerTrustedWireEvent = typeof ViewServerTrustedWireEventSchema.Type;

--- a/packages/protocol/src/protocol-health-codec.ts
+++ b/packages/protocol/src/protocol-health-codec.ts
@@ -1,388 +1,34 @@
 import type {
   TopicDefinitions,
+  ViewServerConfig,
   ViewServerHealth,
-  ViewServerHealthSummaryRow,
-  ViewServerHealthTopicRow,
   ViewServerRuntimeError,
 } from "@view-server/config";
-import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import {
-  type ViewServerProtocolEvent as _ViewServerProtocolEvent,
-  type ViewServerWireEvent,
-  encodeSystemLiveEvent,
-  decodeSystemLiveEvent,
-} from "./protocol-event-codec";
-import {
-  ViewServerHealthSummaryRowSchema,
-  ViewServerHealthTopicRowSchema,
-  type ViewServerWireHealth,
-} from "./protocol-health-schema";
+  configuredTopicNames,
+  hasConfiguredTopic,
+  invalidHealthRow,
+} from "./protocol-health-common";
+import { ViewServerHealthSchema, type ViewServerWireHealth } from "./protocol-health-schema";
 
+export {
+  viewServerDecodeHealthSummaryEvent,
+  viewServerEncodeHealthSummaryEvent,
+} from "./protocol-health-summary-codec";
 export {
   ViewServerHealthSchema,
   ViewServerHealthSummaryRowSchema,
   ViewServerHealthTopicRowSchema,
 } from "./protocol-health-schema";
 export type { ViewServerWireHealth } from "./protocol-health-schema";
+export {
+  viewServerDecodeHealthTopicEvent,
+  viewServerEncodeHealthTopicEvent,
+} from "./protocol-health-topic-codec";
 
-type ViewServerProtocolEvent<Row> = _ViewServerProtocolEvent<Row>;
-
-const hasTopic = <Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  topic: string,
-): topic is Extract<keyof Topics, string> => Object.hasOwn(config.topics, topic);
-
-const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
-  _tag: "ViewServerRuntimeError",
-  code: "InvalidRow",
-  message,
-  topic,
-});
-
-const configuredTopicNames = <const Topics extends TopicDefinitions>(config: {
-  readonly topics: Topics;
-}): ReadonlyArray<string> => Object.keys(config.topics);
-
-const validateHealthTopicName = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  systemTopic: string,
-  topic: string,
-): Effect.Effect<string, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (!hasTopic(config, topic)) {
-      return yield* Effect.fail(
-        invalidRow(systemTopic, `Health payload references unknown topic: ${topic}`),
-      );
-    }
-    return topic;
-  });
-
-const validateNoDuplicateValues = (
-  systemTopic: string,
-  values: ReadonlyArray<string>,
-  message: string,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    const seen = new Set<string>();
-    for (const value of values) {
-      if (seen.has(value)) {
-        return yield* Effect.fail(invalidRow(systemTopic, `${message}: ${value}`));
-      }
-      seen.add(value);
-    }
-  });
-
-const validateExactSummaryKeys = (
-  systemTopic: string,
-  keys: ReadonlyArray<string>,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (keys.length !== 1 || keys[0] !== "summary") {
-      return yield* Effect.fail(
-        invalidRow(systemTopic, "Health summary keys must be exactly: summary"),
-      );
-    }
-  });
-
-const validateExactSummaryRowCount = (
-  systemTopic: string,
-  rowCount: number,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (rowCount !== 1) {
-      return yield* Effect.fail(
-        invalidRow(systemTopic, "Health summary must contain exactly one row"),
-      );
-    }
-  });
-
-const validateExactConfiguredTopicSet = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  systemTopic: string,
-  values: ReadonlyArray<string>,
-  label: string,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    yield* validateNoDuplicateValues(systemTopic, values, `${label} contains duplicate topic`);
-    const expected = configuredTopicNames(config);
-    for (const topic of expected) {
-      if (!values.includes(topic)) {
-        return yield* Effect.fail(invalidRow(systemTopic, `${label} is missing topic: ${topic}`));
-      }
-    }
-    for (const topic of values) {
-      yield* validateHealthTopicName(config, systemTopic, topic);
-    }
-  });
-
-const validateHealthSummaryRow = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  row: ViewServerHealthSummaryRow,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    const expectedStatus =
-      row.connectionStatus === "connected" ? row.runtimeStatus : row.connectionStatus;
-    if (row.status !== expectedStatus) {
-      return yield* Effect.fail(
-        invalidRow(
-          VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
-          `Health summary status does not match runtime/connection status: ${row.status} != ${expectedStatus}`,
-        ),
-      );
-    }
-    for (const topic of row.unhealthyTopics) {
-      yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_SUMMARY_TOPIC, topic);
-    }
-  });
-
-const validateHealthSummaryEvent = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow>,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (event.type === "snapshot") {
-      yield* validateExactSummaryKeys(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.keys);
-      yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.rows.length);
-      for (const row of event.rows) {
-        yield* validateHealthSummaryRow(config, row);
-      }
-      return;
-    }
-    if (event.type === "delta") {
-      for (const operation of event.operations) {
-        if (operation.type === "insert" || operation.type === "update") {
-          yield* validateHealthSummaryRow(config, operation.row);
-        }
-      }
-    }
-  });
-
-const validateHealthTopicRow = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  row: ViewServerHealthTopicRow,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, row.id);
-
-const validateHealthTopicEvent = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  event: ViewServerProtocolEvent<ViewServerHealthTopicRow>,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (event.type === "snapshot") {
-      yield* validateExactConfiguredTopicSet(
-        config,
-        VIEW_SERVER_HEALTH_TOPIC,
-        event.keys,
-        "Health topic snapshot keys",
-      );
-      const rowIds = event.rows.map((row) => row.id);
-      yield* validateExactConfiguredTopicSet(
-        config,
-        VIEW_SERVER_HEALTH_TOPIC,
-        rowIds,
-        "Health topic snapshot rows",
-      );
-      for (const key of event.keys) {
-        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, key);
-      }
-      for (const row of event.rows) {
-        yield* validateHealthTopicRow(config, row);
-      }
-      return;
-    }
-    if (event.type === "delta") {
-      for (const operation of event.operations) {
-        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, operation.key);
-        if (operation.type === "insert" || operation.type === "update") {
-          yield* validateHealthTopicRow(config, operation.row);
-        }
-      }
-    }
-  });
-
-const isStringArray = (value: unknown): value is ReadonlyArray<string> =>
-  Array.isArray(value) && value.every((entry) => typeof entry === "string");
-
-const validateWireHealthSummaryEvent = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  event: ViewServerWireEvent,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (event.type === "snapshot") {
-      yield* validateExactSummaryKeys(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.keys);
-      yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.rows.length);
-      for (const row of event.rows) {
-        const unhealthyTopics = row["unhealthyTopics"];
-        if (isStringArray(unhealthyTopics)) {
-          for (const topic of unhealthyTopics) {
-            yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_SUMMARY_TOPIC, topic);
-          }
-        }
-      }
-      return;
-    }
-    if (event.type === "delta") {
-      for (const operation of event.operations) {
-        if (operation.key !== "summary") {
-          return yield* Effect.fail(
-            invalidRow(
-              VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
-              "Health summary delta key must be: summary",
-            ),
-          );
-        }
-        if (operation.type === "insert" || operation.type === "update") {
-          const id = operation.row["id"];
-          if (typeof id === "string" && id !== operation.key) {
-            return yield* Effect.fail(
-              invalidRow(
-                VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
-                `Health summary delta key does not match row id: ${operation.key} != ${id}`,
-              ),
-            );
-          }
-          const unhealthyTopics = operation.row["unhealthyTopics"];
-          if (isStringArray(unhealthyTopics)) {
-            for (const topic of unhealthyTopics) {
-              yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_SUMMARY_TOPIC, topic);
-            }
-          }
-        }
-      }
-    }
-  });
-
-const validateWireHealthTopicEvent = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  event: ViewServerWireEvent,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  Effect.gen(function* () {
-    if (event.type === "snapshot") {
-      yield* validateExactConfiguredTopicSet(
-        config,
-        VIEW_SERVER_HEALTH_TOPIC,
-        event.keys,
-        "Health topic snapshot keys",
-      );
-      const rowIds: Array<string> = [];
-      for (const key of event.keys) {
-        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, key);
-      }
-      for (const [index, row] of event.rows.entries()) {
-        const id = row["id"];
-        if (typeof id === "string") {
-          const key = event.keys[index];
-          if (key !== undefined && key !== id) {
-            return yield* Effect.fail(
-              invalidRow(
-                VIEW_SERVER_HEALTH_TOPIC,
-                `Health topic snapshot key does not match row id: ${key} != ${id}`,
-              ),
-            );
-          }
-          rowIds.push(id);
-          yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, id);
-        }
-      }
-      yield* validateExactConfiguredTopicSet(
-        config,
-        VIEW_SERVER_HEALTH_TOPIC,
-        rowIds,
-        "Health topic snapshot rows",
-      );
-      return;
-    }
-    if (event.type === "delta") {
-      for (const operation of event.operations) {
-        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, operation.key);
-        if (operation.type === "insert" || operation.type === "update") {
-          const id = operation.row["id"];
-          if (typeof id === "string") {
-            if (id !== operation.key) {
-              return yield* Effect.fail(
-                invalidRow(
-                  VIEW_SERVER_HEALTH_TOPIC,
-                  `Health topic delta key does not match row id: ${operation.key} != ${id}`,
-                ),
-              );
-            }
-            yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, id);
-          }
-        }
-      }
-    }
-  });
-
-function typedHealthSummaryEvent<Topics extends TopicDefinitions>(
-  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow>,
-): ViewServerProtocolEvent<ViewServerHealthSummaryRow<Topics>>;
-function typedHealthSummaryEvent(
-  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow>,
-): ViewServerProtocolEvent<ViewServerHealthSummaryRow> {
-  return event;
-}
-
-function typedHealthTopicEvent<Topics extends TopicDefinitions>(
-  event: ViewServerProtocolEvent<ViewServerHealthTopicRow>,
-): ViewServerProtocolEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>;
-function typedHealthTopicEvent(
-  event: ViewServerProtocolEvent<ViewServerHealthTopicRow>,
-): ViewServerProtocolEvent<ViewServerHealthTopicRow> {
-  return event;
-}
-
-export const viewServerEncodeHealthSummaryEvent = Effect.fn(
-  "ViewServerProtocol.healthSummary.event.encode",
-)(function* (event: ViewServerProtocolEvent<ViewServerHealthSummaryRow>) {
-  return yield* encodeSystemLiveEvent(
-    VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
-    ViewServerHealthSummaryRowSchema,
-    event,
-  );
-});
-
-export const viewServerDecodeHealthSummaryEvent = Effect.fn(
-  "ViewServerProtocol.healthSummary.event.decode",
-)(function* <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  event: ViewServerWireEvent,
-) {
-  yield* validateWireHealthSummaryEvent(config, event);
-  const decoded = yield* decodeSystemLiveEvent(
-    VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
-    ViewServerHealthSummaryRowSchema,
-    event,
-  );
-  yield* validateHealthSummaryEvent(config, decoded);
-  return typedHealthSummaryEvent<Topics>(decoded);
-});
-
-export const viewServerEncodeHealthTopicEvent = Effect.fn(
-  "ViewServerProtocol.healthTopic.event.encode",
-)(function* (event: ViewServerProtocolEvent<ViewServerHealthTopicRow>) {
-  return yield* encodeSystemLiveEvent(
-    VIEW_SERVER_HEALTH_TOPIC,
-    ViewServerHealthTopicRowSchema,
-    event,
-  );
-});
-
-export const viewServerDecodeHealthTopicEvent = Effect.fn(
-  "ViewServerProtocol.healthTopic.event.decode",
-)(function* <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  event: ViewServerWireEvent,
-) {
-  yield* validateWireHealthTopicEvent(config, event);
-  const decoded = yield* decodeSystemLiveEvent(
-    VIEW_SERVER_HEALTH_TOPIC,
-    ViewServerHealthTopicRowSchema,
-    event,
-  );
-  yield* validateHealthTopicEvent(config, decoded);
-  return typedHealthTopicEvent<Topics>(decoded);
-});
+const invalidHealthPayload = (error: { readonly message: string }): ViewServerRuntimeError =>
+  invalidHealthRow("__view_server_health", `Invalid health payload: ${error.message}`);
 
 function typedHealth<Topics extends TopicDefinitions>(
   health: ViewServerWireHealth,
@@ -393,20 +39,38 @@ function typedHealth(health: ViewServerWireHealth): ViewServerWireHealth {
 
 export const viewServerDecodeHealth = Effect.fn("ViewServerProtocol.health.decode")(function* <
   const Topics extends TopicDefinitions,
->(config: { readonly topics: Topics }, health: ViewServerWireHealth) {
+>(config: ViewServerConfig<Topics>, health: ViewServerWireHealth) {
+  const encodedHealth = yield* Schema.encodeUnknownEffect(ViewServerHealthSchema)(health).pipe(
+    Effect.mapError(invalidHealthPayload),
+  );
+  const normalizedHealth = yield* Schema.decodeUnknownEffect(ViewServerHealthSchema)(
+    encodedHealth,
+  ).pipe(Effect.mapError(invalidHealthPayload));
   const configuredTopics = configuredTopicNames(config);
-  const healthTopics = Object.keys(health.engine.topics);
+  const healthTopics = Object.keys(normalizedHealth.engine.topics);
   for (const topic of configuredTopics) {
-    if (!Object.hasOwn(health.engine.topics, topic)) {
-      return yield* Effect.fail(invalidRow(topic, `Health payload is missing topic: ${topic}`));
-    }
-  }
-  for (const topic of healthTopics) {
-    if (!hasTopic(config, topic)) {
+    if (!Object.hasOwn(normalizedHealth.engine.topics, topic)) {
       return yield* Effect.fail(
-        invalidRow(topic, `Health payload references unknown topic: ${topic}`),
+        invalidHealthRow(topic, `Health payload is missing topic: ${topic}`),
       );
     }
   }
-  return typedHealth<Topics>(health);
+  for (const topic of healthTopics) {
+    if (!hasConfiguredTopic(config, topic)) {
+      return yield* Effect.fail(
+        invalidHealthRow(topic, `Health payload references unknown topic: ${topic}`),
+      );
+    }
+  }
+  for (const kafkaTopic of Object.values(normalizedHealth.kafka?.topics ?? {})) {
+    if (!hasConfiguredTopic(config, kafkaTopic.viewServerTopic)) {
+      return yield* Effect.fail(
+        invalidHealthRow(
+          kafkaTopic.viewServerTopic,
+          `Health payload references unknown topic: ${kafkaTopic.viewServerTopic}`,
+        ),
+      );
+    }
+  }
+  return typedHealth<Topics>(normalizedHealth);
 });

--- a/packages/protocol/src/protocol-health-common.ts
+++ b/packages/protocol/src/protocol-health-common.ts
@@ -1,0 +1,211 @@
+import type { StatusEvent, TopicDefinitions, ViewServerRuntimeError } from "@view-server/config";
+import { Effect } from "effect";
+import type {
+  ViewServerProtocolEvent as _ViewServerProtocolEvent,
+  ViewServerWireEvent,
+} from "./protocol-event-codec";
+
+export type ViewServerProtocolEvent<Row> = _ViewServerProtocolEvent<Row>;
+
+export type HealthStatusEvent<Topic extends string> = StatusEvent & {
+  readonly topic: Topic;
+};
+
+export type HealthSnapshotEvent<Topic extends string, Key extends string, Row> = {
+  readonly type: "snapshot";
+  readonly topic: Topic;
+  readonly queryId: string;
+  readonly version: number;
+  readonly keys: ReadonlyArray<Key>;
+  readonly rows: ReadonlyArray<Row>;
+  readonly totalRows: number;
+};
+
+type HealthUpdateOperation<Key extends string, Row> = Key extends string
+  ? {
+      readonly type: "update";
+      readonly key: Key;
+      readonly row: Row & { readonly id: Key };
+      readonly index: number;
+    }
+  : never;
+
+type HealthMoveOperation<Key extends string> = {
+  readonly type: "move";
+  readonly key: Key;
+  readonly fromIndex: number;
+  readonly toIndex: number;
+};
+
+export type HealthDeltaOperationInput<Key extends string, Row> =
+  | HealthUpdateOperation<Key, Row>
+  | HealthMoveOperation<Key>;
+
+export type HealthDeltaEvent<Topic extends string, Key extends string, Row> = {
+  readonly type: "delta";
+  readonly topic: Topic;
+  readonly queryId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly operations: ReadonlyArray<HealthDeltaOperationInput<Key, Row>>;
+  readonly totalRows: number;
+};
+
+export type HealthEvent<Topic extends string, Key extends string, Row> =
+  | HealthSnapshotEvent<Topic, Key, Row>
+  | HealthDeltaEvent<Topic, Key, Row>
+  | HealthStatusEvent<Topic>;
+
+export const hasConfiguredTopic = <Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  topic: string,
+): topic is Extract<keyof Topics, string> => Object.hasOwn(config.topics, topic);
+
+export const invalidHealthRow = (topic: string, message: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidRow",
+  message,
+  topic,
+});
+
+export const configuredTopicNames = <const Topics extends TopicDefinitions>(config: {
+  readonly topics: Topics;
+}): ReadonlyArray<string> => Object.keys(config.topics);
+
+export const validateHealthTopicName = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  systemTopic: string,
+  topic: string,
+): Effect.Effect<string, ViewServerRuntimeError> =>
+  validateHealthTopicNameEffect(config, systemTopic, topic);
+
+const validateHealthTopicNameEffect = Effect.fn("ViewServerProtocol.health.topicName.validate")(
+  function* <const Topics extends TopicDefinitions>(
+    config: { readonly topics: Topics },
+    systemTopic: string,
+    topic: string,
+  ) {
+    if (!hasConfiguredTopic(config, topic)) {
+      return yield* Effect.fail(
+        invalidHealthRow(systemTopic, `Health payload references unknown topic: ${topic}`),
+      );
+    }
+    return topic;
+  },
+);
+
+const validateNoDuplicateValues = (
+  systemTopic: string,
+  values: ReadonlyArray<string>,
+  message: string,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateNoDuplicateValuesEffect(systemTopic, values, message);
+
+const validateNoDuplicateValuesEffect = Effect.fn("ViewServerProtocol.health.duplicates.validate")(
+  function* (systemTopic: string, values: ReadonlyArray<string>, message: string) {
+    const seen = new Set<string>();
+    for (const value of values) {
+      if (seen.has(value)) {
+        return yield* Effect.fail(invalidHealthRow(systemTopic, `${message}: ${value}`));
+      }
+      seen.add(value);
+    }
+  },
+);
+
+export const validateExactSummaryKeys = (
+  systemTopic: string,
+  keys: ReadonlyArray<string>,
+): Effect.Effect<void, ViewServerRuntimeError> => validateExactSummaryKeysEffect(systemTopic, keys);
+
+const validateExactSummaryKeysEffect = Effect.fn("ViewServerProtocol.health.summaryKeys.validate")(
+  function* (systemTopic: string, keys: ReadonlyArray<string>) {
+    if (keys.length !== 1 || keys[0] !== "summary") {
+      return yield* Effect.fail(
+        invalidHealthRow(systemTopic, "Health summary keys must be exactly: summary"),
+      );
+    }
+  },
+);
+
+export const validateExactSummaryRowCount = (
+  systemTopic: string,
+  rowCount: number,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateExactSummaryRowCountEffect(systemTopic, rowCount);
+
+const validateExactSummaryRowCountEffect = Effect.fn(
+  "ViewServerProtocol.health.summaryRowCount.validate",
+)(function* (systemTopic: string, rowCount: number) {
+  if (rowCount !== 1) {
+    return yield* Effect.fail(
+      invalidHealthRow(systemTopic, "Health summary must contain exactly one row"),
+    );
+  }
+});
+
+export const validateExactConfiguredTopicSet = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  systemTopic: string,
+  values: ReadonlyArray<string>,
+  label: string,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateExactConfiguredTopicSetEffect(config, systemTopic, values, label);
+
+const validateExactConfiguredTopicSetEffect = Effect.fn(
+  "ViewServerProtocol.health.configuredTopicSet.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  systemTopic: string,
+  values: ReadonlyArray<string>,
+  label: string,
+) {
+  yield* validateNoDuplicateValues(systemTopic, values, `${label} contains duplicate topic`);
+  const expected = configuredTopicNames(config);
+  const actual = new Set(values);
+  for (const topic of expected) {
+    if (!actual.has(topic)) {
+      return yield* Effect.fail(
+        invalidHealthRow(systemTopic, `${label} is missing topic: ${topic}`),
+      );
+    }
+  }
+  for (const topic of values) {
+    yield* validateHealthTopicName(config, systemTopic, topic);
+  }
+});
+
+export const validateExactConfiguredTopicTotalRows = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  systemTopic: string,
+  totalRows: number,
+  label: string,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateExactConfiguredTopicTotalRowsEffect(config, systemTopic, totalRows, label);
+
+const validateExactConfiguredTopicTotalRowsEffect = Effect.fn(
+  "ViewServerProtocol.health.configuredTopicTotalRows.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  systemTopic: string,
+  totalRows: number,
+  label: string,
+) {
+  const expected = configuredTopicNames(config).length;
+  if (totalRows !== expected) {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        systemTopic,
+        `${label} totalRows must equal configured topic count: ${totalRows} != ${expected}`,
+      ),
+    );
+  }
+});
+
+export const isStringArray = (value: unknown): value is ReadonlyArray<string> =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string");
+
+export type HealthDeltaOperation = Extract<
+  ViewServerWireEvent,
+  { readonly type: "delta" }
+>["operations"][number];

--- a/packages/protocol/src/protocol-health-schema.ts
+++ b/packages/protocol/src/protocol-health-schema.ts
@@ -109,7 +109,6 @@ export const ViewServerHealthSummaryRowSchema: Schema.Codec<
     "starting",
     "stopping",
     "connecting",
-    "connected",
     "disconnected",
   ]),
   runtimeStatus: Schema.Literals(["ready", "degraded", "starting", "stopping"]),

--- a/packages/protocol/src/protocol-health-summary-codec.ts
+++ b/packages/protocol/src/protocol-health-summary-codec.ts
@@ -1,0 +1,272 @@
+import type {
+  TopicDefinitions,
+  ViewServerConfig,
+  ViewServerHealthSummaryRow,
+  ViewServerRuntimeError,
+} from "@view-server/config";
+import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC } from "@view-server/config";
+import { Effect, Schema } from "effect";
+import {
+  decodeSystemLiveEvent,
+  encodeSystemLiveEvent,
+  type ViewServerWireEvent,
+} from "./protocol-event-codec";
+import { ViewServerWireEventSchema } from "./protocol-event-schema";
+import {
+  type HealthDeltaOperationInput,
+  type HealthStatusEvent,
+  invalidHealthRow,
+  isStringArray,
+  validateExactSummaryKeys,
+  validateExactSummaryRowCount,
+  validateHealthTopicName,
+  type HealthDeltaOperation,
+  type ViewServerProtocolEvent,
+} from "./protocol-health-common";
+import { ViewServerHealthSummaryRowSchema } from "./protocol-health-schema";
+
+type ViewServerHealthSummarySnapshotEvent<Topics extends TopicDefinitions> = {
+  readonly type: "snapshot";
+  readonly topic: typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC;
+  readonly queryId: string;
+  readonly version: number;
+  readonly keys: readonly ["summary"];
+  readonly rows: readonly [ViewServerHealthSummaryRow<Topics>];
+  readonly totalRows: 1;
+};
+
+type ViewServerHealthSummaryDeltaEvent<Topics extends TopicDefinitions> = {
+  readonly type: "delta";
+  readonly topic: typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC;
+  readonly queryId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly operations: ReadonlyArray<
+    HealthDeltaOperationInput<"summary", ViewServerHealthSummaryRow<Topics>>
+  >;
+  readonly totalRows: 1;
+};
+
+type ViewServerHealthSummaryEvent<Topics extends TopicDefinitions> =
+  | HealthStatusEvent<typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC>
+  | ViewServerHealthSummarySnapshotEvent<Topics>
+  | ViewServerHealthSummaryDeltaEvent<Topics>;
+
+const validateHealthSummaryRow = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  row: ViewServerHealthSummaryRow<Topics>,
+): Effect.Effect<void, ViewServerRuntimeError> => validateHealthSummaryRowEffect(config, row);
+
+const validateHealthSummaryRowEffect = Effect.fn("ViewServerProtocol.healthSummary.row.validate")(
+  function* <const Topics extends TopicDefinitions>(
+    config: { readonly topics: Topics },
+    row: ViewServerHealthSummaryRow<Topics>,
+  ) {
+    const expectedStatus =
+      row.connectionStatus === "connected" ? row.runtimeStatus : row.connectionStatus;
+    if (row.status !== expectedStatus) {
+      return yield* Effect.fail(
+        invalidHealthRow(
+          VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          `Health summary status does not match runtime/connection status: ${row.status} != ${expectedStatus}`,
+        ),
+      );
+    }
+    for (const topic of row.unhealthyTopics) {
+      yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_SUMMARY_TOPIC, topic);
+    }
+  },
+);
+
+const validateHealthSummaryIndex = Effect.fn("ViewServerProtocol.healthSummary.index.validate")(
+  function* (index: number, label: string) {
+    if (index !== 0) {
+      return yield* Effect.fail(
+        invalidHealthRow(
+          VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          `Health summary ${label} index must be 0: ${index}`,
+        ),
+      );
+    }
+  },
+);
+
+const validateHealthSummaryEvent = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow<Topics>>,
+): Effect.Effect<void, ViewServerRuntimeError> => validateHealthSummaryEventEffect(config, event);
+
+const validateHealthSummaryEventEffect = Effect.fn(
+  "ViewServerProtocol.healthSummary.event.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow<Topics>>,
+) {
+  if (event.type === "snapshot") {
+    yield* validateExactSummaryKeys(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.keys);
+    yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.rows.length);
+    yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.totalRows);
+    for (const row of event.rows) {
+      yield* validateHealthSummaryRow(config, row);
+    }
+    return;
+  }
+  if (event.type === "delta") {
+    yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.totalRows);
+    for (const operation of event.operations) {
+      if (operation.type === "update") {
+        yield* validateHealthSummaryIndex(operation.index, "update");
+        yield* validateHealthSummaryRow(config, operation.row);
+      }
+      if (operation.type === "move") {
+        yield* validateHealthSummaryIndex(operation.fromIndex, "move from");
+        yield* validateHealthSummaryIndex(operation.toIndex, "move to");
+      }
+    }
+  }
+});
+
+const validateWireHealthSummaryDeltaOperation = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  operation: HealthDeltaOperation,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateWireHealthSummaryDeltaOperationEffect(config, operation);
+
+const validateWireHealthSummaryDeltaOperationEffect = Effect.fn(
+  "ViewServerProtocol.healthSummary.wireDeltaOperation.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  operation: HealthDeltaOperation,
+) {
+  if (operation.key !== "summary") {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+        "Health summary delta key must be: summary",
+      ),
+    );
+  }
+  if (operation.type === "remove") {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+        "Health summary delta cannot remove summary",
+      ),
+    );
+  }
+  if (operation.type === "insert") {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+        "Health summary delta cannot insert summary",
+      ),
+    );
+  }
+  if (operation.type === "update") {
+    yield* validateHealthSummaryIndex(operation.index, "update");
+    const id = operation.row["id"];
+    if (typeof id === "string" && id !== operation.key) {
+      return yield* Effect.fail(
+        invalidHealthRow(
+          VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          `Health summary delta key does not match row id: ${operation.key} != ${id}`,
+        ),
+      );
+    }
+    const unhealthyTopics = operation.row["unhealthyTopics"];
+    if (isStringArray(unhealthyTopics)) {
+      for (const topic of unhealthyTopics) {
+        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_SUMMARY_TOPIC, topic);
+      }
+    }
+  }
+  if (operation.type === "move") {
+    yield* validateHealthSummaryIndex(operation.fromIndex, "move from");
+    yield* validateHealthSummaryIndex(operation.toIndex, "move to");
+  }
+});
+
+const validateWireHealthSummaryEvent = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerWireEvent,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateWireHealthSummaryEventEffect(config, event);
+
+const validateWireHealthSummaryEventEffect = Effect.fn(
+  "ViewServerProtocol.healthSummary.wireEvent.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerWireEvent,
+) {
+  if (event.type === "snapshot") {
+    yield* validateExactSummaryKeys(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.keys);
+    yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.rows.length);
+    yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.totalRows);
+    for (const row of event.rows) {
+      const unhealthyTopics = row["unhealthyTopics"];
+      if (isStringArray(unhealthyTopics)) {
+        for (const topic of unhealthyTopics) {
+          yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_SUMMARY_TOPIC, topic);
+        }
+      }
+    }
+    return;
+  }
+  if (event.type === "delta") {
+    yield* validateExactSummaryRowCount(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, event.totalRows);
+    for (const operation of event.operations) {
+      yield* validateWireHealthSummaryDeltaOperation(config, operation);
+    }
+  }
+});
+
+function typedHealthSummaryEvent<Topics extends TopicDefinitions>(
+  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow>,
+): ViewServerHealthSummaryEvent<Topics>;
+function typedHealthSummaryEvent(
+  event: ViewServerProtocolEvent<ViewServerHealthSummaryRow>,
+): ViewServerProtocolEvent<ViewServerHealthSummaryRow> {
+  return event;
+}
+
+export const viewServerEncodeHealthSummaryEvent = Effect.fn(
+  "ViewServerProtocol.healthSummary.event.encode",
+)(function* <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  event: ViewServerHealthSummaryEvent<Topics>,
+) {
+  const encoded = yield* encodeSystemLiveEvent(
+    VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+    ViewServerHealthSummaryRowSchema,
+    event,
+  );
+  yield* validateWireHealthSummaryEvent(config, encoded);
+  const decoded = yield* decodeSystemLiveEvent(
+    VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+    ViewServerHealthSummaryRowSchema,
+    encoded,
+  );
+  yield* validateHealthSummaryEvent(config, typedHealthSummaryEvent<Topics>(decoded));
+  return encoded;
+});
+
+export const viewServerDecodeHealthSummaryEvent = Effect.fn(
+  "ViewServerProtocol.healthSummary.event.decode",
+)(function* <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  event: ViewServerWireEvent,
+) {
+  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(event).pipe(
+    Effect.mapError((error) =>
+      invalidHealthRow(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, `Invalid system event: ${error.message}`),
+    ),
+  );
+  yield* validateWireHealthSummaryEvent(config, wireEvent);
+  const decoded = yield* decodeSystemLiveEvent(
+    VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+    ViewServerHealthSummaryRowSchema,
+    wireEvent,
+  );
+  yield* validateHealthSummaryEvent(config, typedHealthSummaryEvent<Topics>(decoded));
+  return typedHealthSummaryEvent<Topics>(decoded);
+});

--- a/packages/protocol/src/protocol-health-topic-codec.ts
+++ b/packages/protocol/src/protocol-health-topic-codec.ts
@@ -1,0 +1,304 @@
+import type {
+  TopicDefinitions,
+  ViewServerConfig,
+  ViewServerHealthTopicRow,
+  ViewServerRuntimeError,
+} from "@view-server/config";
+import { VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
+import { Effect, Schema } from "effect";
+import {
+  decodeSystemLiveEvent,
+  encodeSystemLiveEvent,
+  type ViewServerWireEvent,
+} from "./protocol-event-codec";
+import { ViewServerWireEventSchema } from "./protocol-event-schema";
+import {
+  configuredTopicNames,
+  type HealthEvent,
+  invalidHealthRow,
+  validateExactConfiguredTopicTotalRows,
+  validateExactConfiguredTopicSet,
+  validateHealthTopicName,
+  type HealthDeltaOperation,
+  type ViewServerProtocolEvent,
+} from "./protocol-health-common";
+import { ViewServerHealthTopicRowSchema } from "./protocol-health-schema";
+
+type ViewServerHealthTopicEvent<Topics extends TopicDefinitions> = HealthEvent<
+  typeof VIEW_SERVER_HEALTH_TOPIC,
+  Extract<keyof Topics, string>,
+  ViewServerHealthTopicRow<Extract<keyof Topics, string>>
+>;
+
+const validateHealthTopicRow = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  row: ViewServerHealthTopicRow<Extract<keyof Topics, string>>,
+): Effect.Effect<void, ViewServerRuntimeError> => validateHealthTopicRowEffect(config, row);
+
+const validateHealthTopicRowEffect = Effect.fn("ViewServerProtocol.healthTopic.row.validate")(
+  function* <const Topics extends TopicDefinitions>(
+    config: { readonly topics: Topics },
+    row: ViewServerHealthTopicRow<Extract<keyof Topics, string>>,
+  ) {
+    yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, row.id);
+  },
+);
+
+const validateHealthTopicIndex = Effect.fn("ViewServerProtocol.healthTopic.index.validate")(
+  function* <const Topics extends TopicDefinitions>(
+    config: { readonly topics: Topics },
+    index: number,
+    label: string,
+  ) {
+    const topicCount = configuredTopicNames(config).length;
+    if (!Number.isInteger(index) || index < 0 || index >= topicCount) {
+      return yield* Effect.fail(
+        invalidHealthRow(
+          VIEW_SERVER_HEALTH_TOPIC,
+          `Health topic ${label} index must be within configured topic count: ${index}`,
+        ),
+      );
+    }
+  },
+);
+
+const validateHealthTopicEvent = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerProtocolEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
+): Effect.Effect<void, ViewServerRuntimeError> => validateHealthTopicEventEffect(config, event);
+
+const validateHealthTopicEventEffect = Effect.fn("ViewServerProtocol.healthTopic.event.validate")(
+  function* <const Topics extends TopicDefinitions>(
+    config: { readonly topics: Topics },
+    event: ViewServerProtocolEvent<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>,
+  ) {
+    if (event.type === "snapshot") {
+      yield* validateExactConfiguredTopicTotalRows(
+        config,
+        VIEW_SERVER_HEALTH_TOPIC,
+        event.totalRows,
+        "Health topic snapshot",
+      );
+      yield* validateExactConfiguredTopicSet(
+        config,
+        VIEW_SERVER_HEALTH_TOPIC,
+        event.keys,
+        "Health topic snapshot keys",
+      );
+      const rowIds = event.rows.map((row) => row.id);
+      yield* validateExactConfiguredTopicSet(
+        config,
+        VIEW_SERVER_HEALTH_TOPIC,
+        rowIds,
+        "Health topic snapshot rows",
+      );
+      for (const key of event.keys) {
+        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, key);
+      }
+      for (const row of event.rows) {
+        yield* validateHealthTopicRow(config, row);
+      }
+      return;
+    }
+    if (event.type === "delta") {
+      yield* validateExactConfiguredTopicTotalRows(
+        config,
+        VIEW_SERVER_HEALTH_TOPIC,
+        event.totalRows,
+        "Health topic delta",
+      );
+      for (const operation of event.operations) {
+        yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, operation.key);
+        if (operation.type === "update") {
+          yield* validateHealthTopicIndex(config, operation.index, "update");
+          yield* validateHealthTopicRow(config, operation.row);
+        }
+        if (operation.type === "move") {
+          yield* validateHealthTopicIndex(config, operation.fromIndex, "move from");
+          yield* validateHealthTopicIndex(config, operation.toIndex, "move to");
+        }
+      }
+    }
+  },
+);
+
+const validateWireHealthTopicSnapshotEvent = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: Extract<ViewServerWireEvent, { readonly type: "snapshot" }>,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateWireHealthTopicSnapshotEventEffect(config, event);
+
+const validateWireHealthTopicSnapshotEventEffect = Effect.fn(
+  "ViewServerProtocol.healthTopic.wireSnapshot.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: Extract<ViewServerWireEvent, { readonly type: "snapshot" }>,
+) {
+  yield* validateExactConfiguredTopicTotalRows(
+    config,
+    VIEW_SERVER_HEALTH_TOPIC,
+    event.totalRows,
+    "Health topic snapshot",
+  );
+  yield* validateExactConfiguredTopicSet(
+    config,
+    VIEW_SERVER_HEALTH_TOPIC,
+    event.keys,
+    "Health topic snapshot keys",
+  );
+  const rowIds: Array<string> = [];
+  for (const key of event.keys) {
+    yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, key);
+  }
+  for (const [index, row] of event.rows.entries()) {
+    const id = row["id"];
+    if (typeof id === "string") {
+      const key = event.keys[index];
+      if (key !== undefined && key !== id) {
+        return yield* Effect.fail(
+          invalidHealthRow(
+            VIEW_SERVER_HEALTH_TOPIC,
+            `Health topic snapshot key does not match row id: ${key} != ${id}`,
+          ),
+        );
+      }
+      rowIds.push(id);
+      yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, id);
+    }
+  }
+  yield* validateExactConfiguredTopicSet(
+    config,
+    VIEW_SERVER_HEALTH_TOPIC,
+    rowIds,
+    "Health topic snapshot rows",
+  );
+});
+
+const validateWireHealthTopicDeltaOperation = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  operation: HealthDeltaOperation,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  validateWireHealthTopicDeltaOperationEffect(config, operation);
+
+const validateWireHealthTopicDeltaOperationEffect = Effect.fn(
+  "ViewServerProtocol.healthTopic.wireDeltaOperation.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  operation: HealthDeltaOperation,
+) {
+  yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, operation.key);
+  if (operation.type === "remove") {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        VIEW_SERVER_HEALTH_TOPIC,
+        `Health topic delta cannot remove configured topic: ${operation.key}`,
+      ),
+    );
+  }
+  if (operation.type === "insert") {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        VIEW_SERVER_HEALTH_TOPIC,
+        `Health topic delta cannot insert configured topic: ${operation.key}`,
+      ),
+    );
+  }
+  if (operation.type === "update") {
+    yield* validateHealthTopicIndex(config, operation.index, "update");
+    const id = operation.row["id"];
+    if (typeof id === "string") {
+      if (id !== operation.key) {
+        return yield* Effect.fail(
+          invalidHealthRow(
+            VIEW_SERVER_HEALTH_TOPIC,
+            `Health topic delta key does not match row id: ${operation.key} != ${id}`,
+          ),
+        );
+      }
+      yield* validateHealthTopicName(config, VIEW_SERVER_HEALTH_TOPIC, id);
+    }
+  }
+  if (operation.type === "move") {
+    yield* validateHealthTopicIndex(config, operation.fromIndex, "move from");
+    yield* validateHealthTopicIndex(config, operation.toIndex, "move to");
+  }
+});
+
+const validateWireHealthTopicEvent = <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerWireEvent,
+): Effect.Effect<void, ViewServerRuntimeError> => validateWireHealthTopicEventEffect(config, event);
+
+const validateWireHealthTopicEventEffect = Effect.fn(
+  "ViewServerProtocol.healthTopic.wireEvent.validate",
+)(function* <const Topics extends TopicDefinitions>(
+  config: { readonly topics: Topics },
+  event: ViewServerWireEvent,
+) {
+  if (event.type === "snapshot") {
+    yield* validateWireHealthTopicSnapshotEvent(config, event);
+    return;
+  }
+  if (event.type === "delta") {
+    yield* validateExactConfiguredTopicTotalRows(
+      config,
+      VIEW_SERVER_HEALTH_TOPIC,
+      event.totalRows,
+      "Health topic delta",
+    );
+    for (const operation of event.operations) {
+      yield* validateWireHealthTopicDeltaOperation(config, operation);
+    }
+  }
+});
+
+function typedHealthTopicEvent<Topics extends TopicDefinitions>(
+  event: ViewServerProtocolEvent<ViewServerHealthTopicRow>,
+): ViewServerHealthTopicEvent<Topics>;
+function typedHealthTopicEvent(
+  event: ViewServerProtocolEvent<ViewServerHealthTopicRow>,
+): ViewServerProtocolEvent<ViewServerHealthTopicRow> {
+  return event;
+}
+
+export const viewServerEncodeHealthTopicEvent = Effect.fn(
+  "ViewServerProtocol.healthTopic.event.encode",
+)(function* <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  event: ViewServerHealthTopicEvent<Topics>,
+) {
+  const encoded = yield* encodeSystemLiveEvent(
+    VIEW_SERVER_HEALTH_TOPIC,
+    ViewServerHealthTopicRowSchema,
+    event,
+  );
+  yield* validateWireHealthTopicEvent(config, encoded);
+  const decoded = yield* decodeSystemLiveEvent(
+    VIEW_SERVER_HEALTH_TOPIC,
+    ViewServerHealthTopicRowSchema,
+    encoded,
+  );
+  yield* validateHealthTopicEvent(config, typedHealthTopicEvent<Topics>(decoded));
+  return encoded;
+});
+
+export const viewServerDecodeHealthTopicEvent = Effect.fn(
+  "ViewServerProtocol.healthTopic.event.decode",
+)(function* <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  event: ViewServerWireEvent,
+) {
+  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(event).pipe(
+    Effect.mapError((error) =>
+      invalidHealthRow(VIEW_SERVER_HEALTH_TOPIC, `Invalid system event: ${error.message}`),
+    ),
+  );
+  yield* validateWireHealthTopicEvent(config, wireEvent);
+  const decoded = yield* decodeSystemLiveEvent(
+    VIEW_SERVER_HEALTH_TOPIC,
+    ViewServerHealthTopicRowSchema,
+    wireEvent,
+  );
+  yield* validateHealthTopicEvent(config, typedHealthTopicEvent<Topics>(decoded));
+  return typedHealthTopicEvent<Topics>(decoded);
+});

--- a/packages/protocol/src/protocol-rpc.ts
+++ b/packages/protocol/src/protocol-rpc.ts
@@ -5,7 +5,7 @@ import type {
 } from "@view-server/config";
 import { Rpc, RpcGroup } from "effect/unstable/rpc";
 import { Schema } from "effect";
-import { ViewServerWireEventSchema } from "./protocol-event-schema";
+import { ViewServerTrustedWireEventSchema } from "./protocol-event-schema";
 import { ViewServerHealthSchema } from "./protocol-health-schema";
 import { ViewServerSubscribePayloadSchema } from "./protocol-query-schema";
 
@@ -58,7 +58,7 @@ export const ViewServerRpcs = RpcGroup.make(
   }),
   Rpc.make("ViewServer.Subscribe", {
     payload: ViewServerSubscribePayloadSchema,
-    success: ViewServerWireEventSchema,
+    success: ViewServerTrustedWireEventSchema,
     error: ViewServerRpcErrorSchema,
     stream: true,
   }),

--- a/packages/react/src/index.test-d.ts
+++ b/packages/react/src/index.test-d.ts
@@ -246,7 +246,7 @@ describe("React type contracts", () => {
     expectTypeOf(health.rows[0]?.rowCount).toEqualTypeOf<number | undefined>();
     expectTypeOf(health.rows[0]?.id).toEqualTypeOf<"orders" | undefined>();
     expectTypeOf(healthSummary.status).toEqualTypeOf<
-      "ready" | "degraded" | "starting" | "stopping" | "connecting" | "connected" | "disconnected"
+      "ready" | "degraded" | "starting" | "stopping" | "connecting" | "disconnected"
     >();
     expectTypeOf(provider).toEqualTypeOf<ReactNode>();
     expectTypeOf(clientProvider).toEqualTypeOf<ReactNode>();

--- a/packages/server/src/health-route.ts
+++ b/packages/server/src/health-route.ts
@@ -1,4 +1,5 @@
-import type { TopicDefinitions } from "@view-server/config";
+import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
+import { viewServerDecodeHealth } from "@view-server/protocol";
 import { Effect } from "effect";
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
 import type { ViewServerWebSocketServerInput } from "./server-types";
@@ -15,6 +16,7 @@ const jsonResponse = (status: number, value: unknown): HttpServerResponse.HttpSe
   });
 
 export const makeViewServerHealthRoute = <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
   input: ViewServerWebSocketServerInput<Topics>,
   path: `/${string}`,
 ) =>
@@ -22,6 +24,7 @@ export const makeViewServerHealthRoute = <const Topics extends TopicDefinitions>
     "GET",
     path,
     input.runtime.health().pipe(
+      Effect.flatMap((health) => viewServerDecodeHealth(config, health)),
       Effect.match({
         onFailure: (error) => jsonResponse(500, error),
         onSuccess: (health) => jsonResponse(health.status === "ready" ? 200 : 503, health),

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -277,6 +277,47 @@ describe("@view-server/server", () => {
     }),
   );
 
+  it.live("returns 500 when runtime health is semantically invalid", () =>
+    Effect.gen(function* () {
+      const inMemory = createInMemoryViewServer(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: {
+          ...inMemory.client,
+          health: () =>
+            Effect.succeed({
+              ...baseHealth,
+              kafka: {
+                regions: {},
+                topics: {
+                  source_orders: {
+                    status: "ready",
+                    sourceTopic: "source_orders",
+                    viewServerTopic: "missing",
+                    regions: {},
+                  },
+                },
+              },
+            }),
+        },
+      });
+
+      const health = yield* fetchJson(server.healthUrl);
+
+      expect(health.response.status).toBe(500);
+      expect(health.value).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        message: "Health payload references unknown topic: missing",
+        topic: "missing",
+      });
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
   it.live("returns 503 for degraded health and serializes bigint fields", () =>
     Effect.gen(function* () {
       const inMemory = createInMemoryViewServer(viewServer);
@@ -971,6 +1012,45 @@ describe("@view-server/server", () => {
       expect(client.health.value.engine.topics.orders.rowCount).toBe(123);
 
       yield* client.close;
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("rejects semantically invalid runtime health over unary RPC", () =>
+    Effect.gen(function* () {
+      const inMemory = createInMemoryViewServer(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: {
+          ...inMemory.client,
+          health: () =>
+            Effect.succeed({
+              ...baseHealth,
+              kafka: {
+                regions: {},
+                topics: {
+                  source_orders: {
+                    status: "ready",
+                    sourceTopic: "source_orders",
+                    viewServerTopic: "missing",
+                    regions: {},
+                  },
+                },
+              },
+            }),
+        },
+      });
+      const raw = yield* makeRawRpcClient(server.url);
+
+      const invalidHealth = yield* Effect.flip(raw.rpc["ViewServer.Health"]()).pipe(
+        Effect.flatMap(Schema.decodeUnknownEffect(ViewServerRpcErrorSchema)),
+      );
+      expect(invalidHealth.code).toBe("InvalidRow");
+      expect(invalidHealth.message).toBe("Health payload references unknown topic: missing");
+
+      yield* raw.close;
       yield* server.close;
       yield* inMemory.close;
     }),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,7 +38,7 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   const healthPath = options.healthPath ?? "/health";
   const protocol = RpcServer.layerProtocolWebsocket({ path }).pipe(Layer.provide(HttpRouter.layer));
   const handlers = ViewServerRpcs.toLayer(makeViewServerRpcHandlers(config, input));
-  const healthRoute = makeViewServerHealthRoute(input, healthPath);
+  const healthRoute = makeViewServerHealthRoute(config, input, healthPath);
   const httpApp = Layer.merge(protocol, healthRoute);
   const rpcLayer = RpcServer.layer(ViewServerRpcs, {
     disableFatalDefects: true,

--- a/packages/server/src/rpc-handlers.ts
+++ b/packages/server/src/rpc-handlers.ts
@@ -2,6 +2,7 @@ import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@vie
 import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
 import {
   ViewServerRpcs,
+  viewServerDecodeHealth,
   viewServerDecodeHealthQuery,
   viewServerDecodeLiveQuery,
   viewServerDecodeTopic,
@@ -17,7 +18,11 @@ export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>
   input: ViewServerWebSocketServerInput<Topics>,
 ) => {
   return ViewServerRpcs.of({
-    "ViewServer.Health": () => input.runtime.health(),
+    "ViewServer.Health": () =>
+      Effect.gen(function* () {
+        const health = yield* input.runtime.health();
+        return yield* viewServerDecodeHealth(config, health);
+      }),
     "ViewServer.Subscribe": (payload) =>
       Stream.unwrap(
         Effect.gen(function* () {
@@ -25,7 +30,9 @@ export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>
             yield* viewServerDecodeHealthQuery(payload.topic, payload.query);
             const subscription = yield* input.liveClient.subscribeHealthSummary();
             return subscription.events.pipe(
-              Stream.mapEffect(viewServerEncodeHealthSummaryEvent),
+              Stream.mapEffect((event) =>
+                viewServerEncodeHealthSummaryEvent<Topics>(config, event),
+              ),
               Stream.ensuring(subscription.close().pipe(Effect.ignore)),
             );
           }
@@ -33,7 +40,7 @@ export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>
             yield* viewServerDecodeHealthQuery(payload.topic, payload.query);
             const subscription = yield* input.liveClient.subscribeHealth();
             return subscription.events.pipe(
-              Stream.mapEffect(viewServerEncodeHealthTopicEvent),
+              Stream.mapEffect((event) => viewServerEncodeHealthTopicEvent<Topics>(config, event)),
               Stream.ensuring(subscription.close().pipe(Effect.ignore)),
             );
           }


### PR DESCRIPTION
## Summary
- Split protocol health validation into common, summary, and topic codec modules.
- Harden health payload/event decoding with exact configured-topic validation and fixed-cardinality summary/detail semantics.
- Brand trusted RPC wire events so the fast trusted decoder requires schema/RPC validation proof.

## Validation
- pnpm run ready
- pnpm --filter @view-server/protocol run test
- pnpm --filter @view-server/client run test
- pnpm --filter @view-server/server run test
- pnpm --filter @view-server/react run test
- pnpm run check:package-exports
- pnpm run check:internal-seams
- forbidden-pattern scan clean

## Review
- 3 read-only subagent reviews: no findings