### PR TITLE
Add raw predicate index benchmark

### DIFF
--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "vp pack",
+    "bench:raw-predicate-index": "vp test bench src/raw-predicate-index.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-predicate-index.json",
     "bench:raw-snapshot": "vp test bench src/raw-snapshot.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-snapshot.json",
     "test": "vp test run --coverage --typecheck"
   },

--- a/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
@@ -6,7 +6,10 @@ import { rawQueryCompilerMetadata } from "./raw-query-compiler";
 import { fieldValue, scalarEqualityKey } from "./row-values";
 import type { TopicRowEntry } from "./row-scan";
 import type { TopicRawWindowScanPlan } from "./raw-window-scan";
-import { createScalarPredicateIndexes } from "./topic-predicate-candidate-index";
+import {
+  createScalarPredicateIndexes,
+  selectedPredicateCandidateSlots,
+} from "./topic-predicate-candidate-index";
 import { scanTopicRawWindow, type TopicRawWindowScanState } from "./topic-raw-window-scanner";
 
 declare const process: {
@@ -30,9 +33,16 @@ type PredicateBenchState = {
 type RowCallbackCounter = {
   count: number;
 };
+type CandidateExpectation = {
+  readonly allowScalarIndexBuild: boolean;
+  readonly exactRangeCandidates: boolean;
+  readonly excludedField: string;
+  readonly expectedSlots: ReadonlyArray<number> | undefined;
+};
 type BenchmarkCase = {
   readonly name: string;
   readonly counter: RowCallbackCounter;
+  readonly candidateExpectation: CandidateExpectation;
   readonly expectedCallbackCount: number;
   readonly expectedKeys: ReadonlyArray<string>;
   readonly expectedTotalRows: number;
@@ -40,11 +50,12 @@ type BenchmarkCase = {
 };
 
 const defaultRowCount = 100_000;
-const minimumRowCount = 100;
+const minimumRowCount = 101;
 const defaultBenchmarkTimeMs = 250;
 const defaultIterations = 5;
 const defaultWarmupIterations = 0;
 const defaultWarmupTimeMs = 0;
+const noExcludedField = "__view_server_bench_no_excluded_field__";
 
 const positiveIntegerFromEnv = (name: string, fallback: number): number => {
   const raw = process.env[name];
@@ -205,6 +216,12 @@ const orderKeysFromRange = (startInclusive: number, endExclusive: number): Reado
     (_value, index) => `order-${startInclusive + index}`,
   );
 
+const slotIndexesFromRange = (
+  startInclusive: number,
+  endExclusive: number,
+): ReadonlyArray<number> =>
+  Array.from({ length: endExclusive - startInclusive }, (_value, index) => startInclusive + index);
+
 const scalarKey = (value: string): string => {
   const key = scalarEqualityKey(value);
   if (key === undefined) {
@@ -235,11 +252,31 @@ const selectiveScalarCounter: RowCallbackCounter = { count: 0 };
 const multiKeyCounter: RowCallbackCounter = { count: 0 };
 const broadRejectedCounter: RowCallbackCounter = { count: 0 };
 
+const assertCandidateExpectation = (
+  state: TopicRawWindowScanState,
+  filters: TopicRawWindowScanPlan<object>["predicate"]["filters"],
+  expectation: CandidateExpectation,
+): void => {
+  const candidateSlots = selectedPredicateCandidateSlots(state, filters, {
+    allowScalarIndexBuild: expectation.allowScalarIndexBuild,
+    exactRangeCandidates: expectation.exactRangeCandidates,
+    excludedField: expectation.excludedField,
+    maxSlotCount: state.slots.length,
+  });
+  expect(candidateSlots?.slots).toStrictEqual(expectation.expectedSlots);
+};
+
 const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
   return [
     {
       name: "full scan callback baseline: selective customer + fallback sort",
       counter: fullScanSelectiveCounter,
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: false,
+        excludedField: noExcludedField,
+        expectedSlots: undefined,
+      },
       expectedCallbackCount: rowCount,
       expectedKeys: [`order-${targetCustomerIndex}`],
       expectedTotalRows: 1,
@@ -260,6 +297,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "exact scalar candidate: selective customer + fallback sort",
       counter: selectiveScalarCounter,
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: false,
+        excludedField: noExcludedField,
+        expectedSlots: [targetCustomerIndex],
+      },
       expectedCallbackCount: 1,
       expectedKeys: [`order-${targetCustomerIndex}`],
       expectedTotalRows: 1,
@@ -280,6 +323,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "exact scalar candidate: selective customer without callback",
       counter: { count: 0 },
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: false,
+        excludedField: noExcludedField,
+        expectedSlots: [targetCustomerIndex],
+      },
       expectedCallbackCount: 0,
       expectedKeys: [`order-${targetCustomerIndex}`],
       expectedTotalRows: 1,
@@ -299,6 +348,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "exact multi-key in candidate: three customers + fallback sort",
       counter: multiKeyCounter,
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: false,
+        excludedField: noExcludedField,
+        expectedSlots: [10, targetCustomerIndex, targetLastCustomerIndex],
+      },
       expectedCallbackCount: targetCustomerIds.length,
       expectedKeys: [
         `order-10`,
@@ -330,6 +385,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "exact range candidate: upper price tail + fallback sort",
       counter: { count: 0 },
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: true,
+        excludedField: noExcludedField,
+        expectedSlots: slotIndexesFromRange(rowCount - 100, rowCount),
+      },
       expectedCallbackCount: 0,
       expectedKeys: orderKeysFromRange(rowCount - 100, rowCount - 50),
       expectedTotalRows: 100,
@@ -349,6 +410,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "full scan callback baseline: upper price tail + fallback sort",
       counter: fullScanUpperTailCounter,
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: false,
+        excludedField: noExcludedField,
+        expectedSlots: undefined,
+      },
       expectedCallbackCount: rowCount,
       expectedKeys: orderKeysFromRange(rowCount - 100, rowCount - 50),
       expectedTotalRows: 100,
@@ -367,6 +434,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "ordered equality seek: customer storage order",
       counter: { count: 0 },
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: true,
+        excludedField: "customerId",
+        expectedSlots: undefined,
+      },
       expectedCallbackCount: 0,
       expectedKeys: [`order-${targetCustomerIndex}`],
       expectedTotalRows: 1,
@@ -387,6 +460,12 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
     {
       name: "failed broad scalar candidate build + full scan",
       counter: broadRejectedCounter,
+      candidateExpectation: {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: false,
+        excludedField: noExcludedField,
+        expectedSlots: undefined,
+      },
       expectedCallbackCount: rowCount,
       expectedKeys: orderKeysFromRange(0, 50),
       expectedTotalRows: rowCount,
@@ -414,6 +493,11 @@ const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
 const runBenchmarkCase = (benchmarkCase: BenchmarkCase): void => {
   const current = profileState();
   resetCounter(benchmarkCase.counter);
+  assertCandidateExpectation(
+    current.state,
+    benchmarkCase.plan.predicate.filters,
+    benchmarkCase.candidateExpectation,
+  );
   const result = scanTopicRawWindow(current.state, benchmarkCase.plan);
   expect(result.keys).toStrictEqual(benchmarkCase.expectedKeys);
   expect(result.totalRows).toBe(benchmarkCase.expectedTotalRows);
@@ -455,8 +539,36 @@ beforeAll(() => {
     matches: unexpectedCallback("range index warmup should not call row callbacks"),
     compare: compareByUpdatedAtDesc,
     offset: 0,
-    limit: rowCount,
+    limit: 1,
   });
+
+  assertCandidateExpectation(
+    state,
+    [{ field: "customerId", operator: "eq", value: targetCustomerId }],
+    {
+      allowScalarIndexBuild: true,
+      exactRangeCandidates: false,
+      excludedField: noExcludedField,
+      expectedSlots: [targetCustomerIndex],
+    },
+  );
+  assertCandidateExpectation(
+    state,
+    [
+      {
+        field: "customerId",
+        operator: "in",
+        values: targetCustomerIds,
+        valueKeys: new Set(targetCustomerIds.map(scalarKey)),
+      },
+    ],
+    {
+      allowScalarIndexBuild: true,
+      exactRangeCandidates: false,
+      excludedField: noExcludedField,
+      expectedSlots: [10, targetCustomerIndex, targetLastCustomerIndex],
+    },
+  );
 
   for (const benchmarkCase of benchmarkCases()) {
     runBenchmarkCase(benchmarkCase);

--- a/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
@@ -1,0 +1,476 @@
+// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+import { beforeAll, bench, describe, expect } from "vitest";
+import { Schema } from "effect";
+import { compareQueryValue } from "./query-value";
+import { rawQueryCompilerMetadata } from "./raw-query-compiler";
+import { fieldValue, scalarEqualityKey } from "./row-values";
+import type { TopicRowEntry } from "./row-scan";
+import type { TopicRawWindowScanPlan } from "./raw-window-scan";
+import { createScalarPredicateIndexes } from "./topic-predicate-candidate-index";
+import { scanTopicRawWindow, type TopicRawWindowScanState } from "./topic-raw-window-scanner";
+
+declare const process: {
+  readonly env: Record<string, string | undefined>;
+};
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Finite,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+type OrderRow = typeof Order.Type;
+type OrderStatus = OrderRow["status"];
+type PredicateBenchState = {
+  readonly state: TopicRawWindowScanState;
+};
+type RowCallbackCounter = {
+  count: number;
+};
+type BenchmarkCase = {
+  readonly name: string;
+  readonly counter: RowCallbackCounter;
+  readonly expectedCallbackCount: number;
+  readonly expectedKeys: ReadonlyArray<string>;
+  readonly expectedTotalRows: number;
+  readonly plan: TopicRawWindowScanPlan<object>;
+};
+
+const defaultRowCount = 100_000;
+const minimumRowCount = 100;
+const defaultBenchmarkTimeMs = 250;
+const defaultIterations = 5;
+const defaultWarmupIterations = 0;
+const defaultWarmupTimeMs = 0;
+
+const positiveIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/u.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a positive integer.`);
+};
+
+const nonNegativeIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^(0|[1-9]\d*)$/u.test(trimmed)) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a non-negative integer.`);
+};
+
+const rowCountFromEnv = (): number => {
+  const raw = process.env["VIEW_SERVER_ENGINE_BENCH_ROWS"];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultRowCount;
+  }
+  if (raw.includes(",")) {
+    throw new Error("VIEW_SERVER_ENGINE_BENCH_ROWS accepts one row count per benchmark run.");
+  }
+  const parsed = positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ROWS", defaultRowCount);
+  if (parsed < minimumRowCount) {
+    throw new Error(`VIEW_SERVER_ENGINE_BENCH_ROWS must be at least ${minimumRowCount}.`);
+  }
+  return parsed;
+};
+
+const rowCount = rowCountFromEnv();
+const benchOptions = {
+  iterations: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ITERATIONS", defaultIterations),
+  time: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_TIME_MS", defaultBenchmarkTimeMs),
+  warmupIterations: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS",
+    defaultWarmupIterations,
+  ),
+  warmupTime: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS",
+    defaultWarmupTimeMs,
+  ),
+};
+
+let profile: PredicateBenchState | undefined;
+const targetCustomerIndex = Math.floor(rowCount / 2);
+const targetCustomerId = `customer-${targetCustomerIndex}`;
+const targetLastCustomerIndex = rowCount - 10;
+const targetCustomerIds = ["customer-10", targetCustomerId, `customer-${targetLastCustomerIndex}`];
+
+const orderStatus = (index: number): OrderStatus => {
+  if (index % 11 === 0) {
+    return "cancelled";
+  }
+  if (index % 3 === 0) {
+    return "closed";
+  }
+  return "open";
+};
+
+const region = (index: number): string => {
+  if (index % 7 === 0) {
+    return "apac";
+  }
+  if (index % 5 === 0) {
+    return "amer";
+  }
+  return "emea";
+};
+
+const order = (index: number): OrderRow => ({
+  id: `order-${index}`,
+  customerId: `customer-${index}`,
+  status: orderStatus(index),
+  price: index,
+  region: region(index),
+  updatedAt: rowCount - index,
+});
+
+const profileState = (): PredicateBenchState => {
+  if (profile === undefined) {
+    throw new Error("Raw predicate index benchmark profile is not initialized.");
+  }
+  return profile;
+};
+
+const compareByUpdatedAtDesc = (
+  left: TopicRowEntry<object>,
+  right: TopicRowEntry<object>,
+): number => {
+  const updatedAtComparison = compareQueryValue(
+    fieldValue(left.row, "updatedAt"),
+    fieldValue(right.row, "updatedAt"),
+  );
+  if (updatedAtComparison !== 0) {
+    return -updatedAtComparison;
+  }
+  return left.key.localeCompare(right.key);
+};
+
+const compareByCustomerIdAsc = (
+  left: TopicRowEntry<object>,
+  right: TopicRowEntry<object>,
+): number => {
+  const customerComparison = compareQueryValue(
+    fieldValue(left.row, "customerId"),
+    fieldValue(right.row, "customerId"),
+  );
+  if (customerComparison !== 0) {
+    return customerComparison;
+  }
+  return left.key.localeCompare(right.key);
+};
+
+const rowHasCustomerId = (row: object, customerId: string): boolean =>
+  fieldValue(row, "customerId") === customerId;
+
+const rowHasAnyCustomerId = (row: object, customerIds: ReadonlyArray<string>): boolean => {
+  const customerId = fieldValue(row, "customerId");
+  for (const candidate of customerIds) {
+    if (customerId === candidate) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const rowPriceInUpperTail = (row: object): boolean => {
+  const price = fieldValue(row, "price");
+  return typeof price === "number" && price >= rowCount - 100;
+};
+
+const resetCounter = (counter: RowCallbackCounter): void => {
+  counter.count = 0;
+};
+
+const orderKeysFromRange = (startInclusive: number, endExclusive: number): ReadonlyArray<string> =>
+  Array.from(
+    { length: endExclusive - startInclusive },
+    (_value, index) => `order-${startInclusive + index}`,
+  );
+
+const scalarKey = (value: string): string => {
+  const key = scalarEqualityKey(value);
+  if (key === undefined) {
+    throw new Error(`Expected scalar equality key for ${value}.`);
+  }
+  return key;
+};
+
+const countedMatch = (
+  counter: RowCallbackCounter,
+  predicate: (row: object) => boolean,
+): ((row: object) => boolean) => {
+  return (row) => {
+    counter.count += 1;
+    return predicate(row);
+  };
+};
+
+const unexpectedCallback = (message: string): ((row: object) => boolean) => {
+  return () => {
+    throw new Error(message);
+  };
+};
+
+const fullScanSelectiveCounter: RowCallbackCounter = { count: 0 };
+const fullScanUpperTailCounter: RowCallbackCounter = { count: 0 };
+const selectiveScalarCounter: RowCallbackCounter = { count: 0 };
+const multiKeyCounter: RowCallbackCounter = { count: 0 };
+const broadRejectedCounter: RowCallbackCounter = { count: 0 };
+
+const benchmarkCases = (): ReadonlyArray<BenchmarkCase> => {
+  return [
+    {
+      name: "full scan callback baseline: selective customer + fallback sort",
+      counter: fullScanSelectiveCounter,
+      expectedCallbackCount: rowCount,
+      expectedKeys: [`order-${targetCustomerIndex}`],
+      expectedTotalRows: 1,
+      plan: {
+        predicate: {
+          filters: [],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: countedMatch(fullScanSelectiveCounter, (row) =>
+          rowHasCustomerId(row, targetCustomerId),
+        ),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "exact scalar candidate: selective customer + fallback sort",
+      counter: selectiveScalarCounter,
+      expectedCallbackCount: 1,
+      expectedKeys: [`order-${targetCustomerIndex}`],
+      expectedTotalRows: 1,
+      plan: {
+        predicate: {
+          filters: [{ field: "customerId", operator: "eq", value: targetCustomerId }],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: countedMatch(selectiveScalarCounter, (row) =>
+          rowHasCustomerId(row, targetCustomerId),
+        ),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "exact scalar candidate: selective customer without callback",
+      counter: { count: 0 },
+      expectedCallbackCount: 0,
+      expectedKeys: [`order-${targetCustomerIndex}`],
+      expectedTotalRows: 1,
+      plan: {
+        predicate: {
+          filters: [{ field: "customerId", operator: "eq", value: targetCustomerId }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: unexpectedCallback("exact scalar candidate should not call row callbacks"),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "exact multi-key in candidate: three customers + fallback sort",
+      counter: multiKeyCounter,
+      expectedCallbackCount: targetCustomerIds.length,
+      expectedKeys: [
+        `order-10`,
+        `order-${targetCustomerIndex}`,
+        `order-${targetLastCustomerIndex}`,
+      ],
+      expectedTotalRows: targetCustomerIds.length,
+      plan: {
+        predicate: {
+          filters: [
+            {
+              field: "customerId",
+              operator: "in",
+              values: targetCustomerIds,
+              valueKeys: new Set(targetCustomerIds.map(scalarKey)),
+            },
+          ],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: countedMatch(multiKeyCounter, (row) =>
+          rowHasAnyCustomerId(row, targetCustomerIds),
+        ),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "exact range candidate: upper price tail + fallback sort",
+      counter: { count: 0 },
+      expectedCallbackCount: 0,
+      expectedKeys: orderKeysFromRange(rowCount - 100, rowCount - 50),
+      expectedTotalRows: 100,
+      plan: {
+        predicate: {
+          filters: [{ field: "price", operator: "gte", value: rowCount - 100 }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: unexpectedCallback("exact range candidate should not call row callbacks"),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "full scan callback baseline: upper price tail + fallback sort",
+      counter: fullScanUpperTailCounter,
+      expectedCallbackCount: rowCount,
+      expectedKeys: orderKeysFromRange(rowCount - 100, rowCount - 50),
+      expectedTotalRows: 100,
+      plan: {
+        predicate: {
+          filters: [],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: countedMatch(fullScanUpperTailCounter, rowPriceInUpperTail),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "ordered equality seek: customer storage order",
+      counter: { count: 0 },
+      expectedCallbackCount: 0,
+      expectedKeys: [`order-${targetCustomerIndex}`],
+      expectedTotalRows: 1,
+      plan: {
+        predicate: {
+          filters: [{ field: "customerId", operator: "eq", value: targetCustomerId }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [{ field: "customerId", direction: "asc" }],
+        storageOrderBy: [{ field: "customerId", direction: "asc" }],
+        matches: unexpectedCallback("ordered equality seek should not call row callbacks"),
+        compare: compareByCustomerIdAsc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+    {
+      name: "failed broad scalar candidate build + full scan",
+      counter: broadRejectedCounter,
+      expectedCallbackCount: rowCount,
+      expectedKeys: orderKeysFromRange(0, 50),
+      expectedTotalRows: rowCount,
+      plan: {
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["open", "closed", "cancelled"],
+            },
+          ],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        matches: countedMatch(broadRejectedCounter, () => true),
+        compare: compareByUpdatedAtDesc,
+        offset: 0,
+        limit: 50,
+      },
+    },
+  ];
+};
+
+const runBenchmarkCase = (benchmarkCase: BenchmarkCase): void => {
+  const current = profileState();
+  resetCounter(benchmarkCase.counter);
+  const result = scanTopicRawWindow(current.state, benchmarkCase.plan);
+  expect(result.keys).toStrictEqual(benchmarkCase.expectedKeys);
+  expect(result.totalRows).toBe(benchmarkCase.expectedTotalRows);
+  expect(benchmarkCase.counter.count).toBe(benchmarkCase.expectedCallbackCount);
+};
+
+beforeAll(() => {
+  const rows = Array.from({ length: rowCount }, (_value, index) => order(index));
+  const slots = rows.map((row) => ({
+    key: row.id,
+    row,
+  }));
+  const state: TopicRawWindowScanState = {
+    columns: new Map<string, ReadonlyArray<unknown>>([
+      ["id", rows.map((row) => row.id)],
+      ["customerId", rows.map((row) => row.customerId)],
+      ["status", rows.map((row) => row.status)],
+      ["price", rows.map((row) => row.price)],
+      ["region", rows.map((row) => row.region)],
+      ["updatedAt", rows.map((row) => row.updatedAt)],
+    ]),
+    orderedSlotIndexes: new Map(),
+    rawQueryMetadata: rawQueryCompilerMetadata(Order),
+    scalarPredicateIndexes: createScalarPredicateIndexes(),
+    slots,
+  };
+  profile = {
+    state,
+  };
+
+  scanTopicRawWindow(state, {
+    predicate: {
+      filters: [{ field: "price", operator: "gte", value: 0 }],
+      callbackRequired: false,
+      callbackSkippable: true,
+    },
+    orderBy: [{ field: "price", direction: "asc" }],
+    storageOrderBy: [{ field: "price", direction: "asc" }],
+    matches: unexpectedCallback("range index warmup should not call row callbacks"),
+    compare: compareByUpdatedAtDesc,
+    offset: 0,
+    limit: rowCount,
+  });
+
+  for (const benchmarkCase of benchmarkCases()) {
+    runBenchmarkCase(benchmarkCase);
+  }
+}, 0);
+
+describe(`raw predicate candidate index benchmark: ${rowCount} rows`, () => {
+  for (const benchmarkCase of benchmarkCases()) {
+    bench(
+      benchmarkCase.name,
+      () => {
+        runBenchmarkCase(benchmarkCase);
+      },
+      benchOptions,
+    );
+  }
+});

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1290,8 +1290,8 @@ benchmark. It compares:
 - failed broad scalar candidate build plus full scan
 
 It writes `packages/column-live-view-engine/.artifacts/raw-predicate-index.json`. Run each row count
-in a separate process. The benchmark rejects row counts below 100 because several cases assert exact
-50/100-row windows.
+in a separate process. The benchmark rejects row counts below 101 because several cases assert exact
+50/100-row windows and the range-candidate case must stay narrower than the whole table.
 
 ```bash
 VIEW_SERVER_ENGINE_BENCH_ROWS=100000 vp run --no-cache column-live-view-engine#bench:raw-predicate-index

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1261,7 +1261,7 @@ VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 vp run --no-cache column-live-view-engine#
 VIEW_SERVER_ENGINE_BENCH_ROWS=10000000 vp run --no-cache column-live-view-engine#bench:raw-snapshot
 ```
 
-Supported knobs:
+Raw snapshot knobs:
 
 - `VIEW_SERVER_ENGINE_BENCH_ROWS`: row count for this benchmark process.
 - `VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE`: publish batch size while seeding.
@@ -1270,10 +1270,47 @@ Supported knobs:
 - `VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS`: warmup iterations per case.
 - `VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS`: warmup time budget per case.
 
+Current raw predicate candidate index benchmark harness:
+
+```bash
+vp run --no-cache column-live-view-engine#bench:raw-predicate-index
+```
+
+This harness uses Vitest `bench()`, scanner-level callback counters, and returned-key assertions to
+prove exact predicate candidate indexes reduce steady-state row callback work without breaking window
+ordering. It pre-warms the ordered range index before timed samples; it is not a cold index-build
+benchmark. It compares:
+
+- full-scan callback baseline for selective customer filters
+- exact scalar candidate for selective `eq`
+- exact scalar candidate with no row callback when the predicate is callback-skippable
+- exact multi-key `in` candidate using authoritative value keys
+- exact range candidate over an existing ordered index
+- ordered equality seek over storage order
+- failed broad scalar candidate build plus full scan
+
+It writes `packages/column-live-view-engine/.artifacts/raw-predicate-index.json`. Run each row count
+in a separate process. The benchmark rejects row counts below 100 because several cases assert exact
+50/100-row windows.
+
+```bash
+VIEW_SERVER_ENGINE_BENCH_ROWS=100000 vp run --no-cache column-live-view-engine#bench:raw-predicate-index
+VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 vp run --no-cache column-live-view-engine#bench:raw-predicate-index
+VIEW_SERVER_ENGINE_BENCH_ROWS=10000000 vp run --no-cache column-live-view-engine#bench:raw-predicate-index
+```
+
+Raw predicate index knobs:
+
+- `VIEW_SERVER_ENGINE_BENCH_ROWS`: row count for this benchmark process.
+- `VIEW_SERVER_ENGINE_BENCH_ITERATIONS`: benchmark iterations per case.
+- `VIEW_SERVER_ENGINE_BENCH_TIME_MS`: benchmark time budget per case.
+- `VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS`: warmup iterations per case.
+- `VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS`: warmup time budget per case.
+
 For decision-quality large-row runs, keep `--no-cache` and use multiple iterations. One-sample runs
 are useful only to verify feasibility and approximate scale.
 
-Each benchmark artifact must include:
+Each production/runtime benchmark artifact must include:
 
 - row count
 - mutation count


### PR DESCRIPTION
## Summary

- Add a Vitest `bench()` harness for raw predicate candidate indexes.
- Compare full-scan baselines against exact scalar, multi-key `in`, range, ordered equality seek, and failed broad-candidate fallback cases.
- Assert returned keys, total rows, and row callback counts inside every benchmark sample so timing does not hide correctness regressions.
- Document the new benchmark command, row-count guard, steady-state scope, and supported knobs in the v2 plan.

## Validation

- `VIEW_SERVER_ENGINE_BENCH_ROWS=20 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=1 VIEW_SERVER_ENGINE_BENCH_TIME_MS=1 pnpm --filter @view-server/column-live-view-engine run bench:raw-predicate-index` fails intentionally with `VIEW_SERVER_ENGINE_BENCH_ROWS must be at least 100`.
- `VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=3 VIEW_SERVER_ENGINE_BENCH_TIME_MS=100 pnpm --filter @view-server/column-live-view-engine run bench:raw-predicate-index`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run ready`
- Forbidden-pattern scan clean for casts, Testing Library, act, flushSync, toEqual, assert, and coverage ignores.
