### PR TITLE
Seal TopicStore seam and add raw fanout benchmark

### DIFF
--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -14,6 +14,9 @@
   },
   "scripts": {
     "build": "vp pack",
+    "bench:raw-live-fanout": "vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-live-fanout-${VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE:-manual}-${VIEW_SERVER_ENGINE_BENCH_ROWS:-default}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-default}subs.json",
+    "bench:raw-live-fanout:same-window": "VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=same-window vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-live-fanout-same-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-default}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-default}subs.json",
+    "bench:raw-live-fanout:ten-window": "VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=ten-window vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-live-fanout-ten-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-default}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-default}subs.json",
     "bench:raw-predicate-index": "vp test bench src/raw-predicate-index.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-predicate-index.json",
     "bench:raw-snapshot": "vp test bench src/raw-snapshot.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-snapshot.json",
     "test": "vp test run --coverage --typecheck"

--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -10,12 +10,8 @@ import {
   releaseRawQueryExecution,
 } from "./active-query";
 import { prepareRawQuery } from "./raw-query-compiler";
-import {
-  publishTopicStoreRow,
-  TopicStore,
-  topicStoreRawQueryMetadata,
-  topicStoreReadModel,
-} from "./topic-store";
+import { publishTopicStoreRow, TopicStore } from "./topic-store";
+import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 
 const invalidRow = (_topic: string, message: string): Error => new Error(message);
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -59,9 +59,8 @@ import {
   registerTopicStoreSubscription,
   resetTopicStore,
   TopicStore,
-  topicStoreRawQueryMetadata,
-  topicStoreReadModel,
 } from "./topic-store";
+import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 
 const Order = Schema.Struct({
   id: Schema.String,

--- a/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
+++ b/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
@@ -1,0 +1,395 @@
+// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+import { afterAll, beforeAll, bench, describe, expect } from "vitest";
+import { defineViewServerConfig } from "@view-server/config";
+import { Cause, Effect, Exit, Schema, Scope, Stream } from "effect";
+import {
+  createColumnLiveViewEngine,
+  type ColumnLiveViewEngine,
+  type ColumnLiveViewEngineEvent,
+  type ColumnLiveViewSubscription,
+} from "./index";
+
+declare const process: {
+  readonly env: Record<string, string | undefined>;
+};
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Finite,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+type Engine = ColumnLiveViewEngine<Topics>;
+type OrderRow = typeof Order.Type;
+type OrderStatus = OrderRow["status"];
+type SelectedOrderRow = Pick<OrderRow, "id" | "customerId" | "price" | "status" | "updatedAt">;
+type OrderSubscription = ColumnLiveViewSubscription<SelectedOrderRow>;
+type OrderEvent = ColumnLiveViewEngineEvent<SelectedOrderRow>;
+type OrderEventReader = () => Effect.Effect<ReadonlyArray<OrderEvent>, Cause.Done>;
+type FanoutCaseName = "same-window" | "ten-window";
+type CaseSpecificDeltaExpectation = (
+  eventChunks: ReadonlyArray<ReadonlyArray<OrderEvent>>,
+  rowId: string,
+  readerCount: number,
+) => void;
+
+type FanoutCaseProfile = {
+  engine: Engine | undefined;
+  nextDeltaVersion: number;
+  readers: ReadonlyArray<OrderEventReader>;
+  scope: Scope.Closeable | undefined;
+  subscriptions: ReadonlyArray<OrderSubscription>;
+  nextDeltaIndex: number;
+};
+
+type BenchmarkProfile = {
+  readonly rowCount: number;
+  readonly subscriberCount: number;
+  readonly fanoutCaseName: FanoutCaseName;
+  fanoutCase: FanoutCaseProfile;
+};
+
+const defaultRowCount = 100_000;
+const defaultBatchSize = 10_000;
+const defaultSubscriberCount = 50;
+const defaultIterations = 5;
+const defaultBenchmarkTimeMs = 250;
+const defaultWarmupIterations = 0;
+const defaultWarmupTimeMs = 0;
+const defaultFanoutCaseName: FanoutCaseName = "same-window";
+
+const positiveIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/u.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a positive integer.`);
+};
+
+const nonNegativeIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^(0|[1-9]\d*)$/u.test(trimmed)) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a non-negative integer.`);
+};
+
+const rowCountFromEnv = (): number => {
+  const raw = process.env["VIEW_SERVER_ENGINE_BENCH_ROWS"];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultRowCount;
+  }
+  if (raw.includes(",")) {
+    throw new Error("VIEW_SERVER_ENGINE_BENCH_ROWS accepts one row count per benchmark run.");
+  }
+  return positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ROWS", defaultRowCount);
+};
+
+const fanoutCaseNameFromEnv = (): FanoutCaseName => {
+  const raw = process.env["VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE"];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultFanoutCaseName;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "same-window" || trimmed === "ten-window") {
+    return trimmed;
+  }
+  throw new Error("VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE must be same-window or ten-window.");
+};
+
+const benchmarkRowCount = rowCountFromEnv();
+const fanoutCaseName = fanoutCaseNameFromEnv();
+const batchSize = positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE", defaultBatchSize);
+const subscriberCount = positiveIntegerFromEnv(
+  "VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS",
+  defaultSubscriberCount,
+);
+const benchOptions = {
+  iterations: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ITERATIONS", defaultIterations),
+  time: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_TIME_MS", defaultBenchmarkTimeMs),
+  warmupIterations: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS",
+    defaultWarmupIterations,
+  ),
+  warmupTime: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS",
+    defaultWarmupTimeMs,
+  ),
+};
+
+const emptyFanoutCaseProfile = (): FanoutCaseProfile => ({
+  engine: undefined,
+  nextDeltaVersion: Math.ceil(benchmarkRowCount / batchSize),
+  readers: [],
+  scope: undefined,
+  subscriptions: [],
+  nextDeltaIndex: benchmarkRowCount,
+});
+
+const profile: BenchmarkProfile = {
+  rowCount: benchmarkRowCount,
+  subscriberCount,
+  fanoutCaseName,
+  fanoutCase: emptyFanoutCaseProfile(),
+};
+
+const orderStatus = (index: number): OrderStatus => {
+  if (index % 5 === 0) {
+    return "cancelled";
+  }
+  if (index % 3 === 0) {
+    return "closed";
+  }
+  return "open";
+};
+
+const region = (index: number): string => {
+  if (index % 7 === 0) {
+    return "apac";
+  }
+  if (index % 5 === 0) {
+    return "amer";
+  }
+  return "emea";
+};
+
+const seedOrder = (index: number): OrderRow => ({
+  id: `order-${index}`,
+  customerId: `customer-${index % 100_000}`,
+  status: orderStatus(index),
+  price: index % 1_000_000,
+  region: region(index),
+  updatedAt: index,
+});
+
+const deltaOrder = (index: number): OrderRow => ({
+  id: `delta-${index}`,
+  customerId: `customer-delta-${index % 100_000}`,
+  status: "open",
+  price: 1_000_000 + (index % 10_000),
+  region: "emea",
+  updatedAt: 1_000_000_000 + index,
+});
+
+const fanoutCaseWindowOffset = (caseName: FanoutCaseName): ((index: number) => number) => {
+  if (caseName === "same-window") {
+    return () => 0;
+  }
+  return (index) => index % 10;
+};
+
+const seedEngine = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.seed")(function* (
+  engine: Engine,
+  rowCount: number,
+) {
+  let next = 0;
+  while (next < rowCount) {
+    const count = Math.min(batchSize, rowCount - next);
+    const rows = Array.from({ length: count }, (_value, offset) => seedOrder(next + offset));
+    yield* engine.publishMany("orders", rows);
+    next += count;
+  }
+});
+
+const fanoutCaseEngine = (
+  benchmarkProfile: BenchmarkProfile,
+  fanoutCase: FanoutCaseProfile,
+): Engine => {
+  if (fanoutCase.engine === undefined) {
+    throw new Error(`Benchmark profile ${benchmarkProfile.rowCount} rows is not initialized.`);
+  }
+  return fanoutCase.engine;
+};
+
+const makeEventReader = (
+  subscription: OrderSubscription,
+  scope: Scope.Closeable,
+): Effect.Effect<OrderEventReader> =>
+  Stream.toPull(subscription.events).pipe(
+    Effect.map(
+      (pull): OrderEventReader =>
+        () =>
+          Effect.map(pull, (chunk) => [...chunk]),
+    ),
+    Effect.provideService(Scope.Scope, scope),
+  );
+
+const makeSubscriptions = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.subscribe")(
+  function* (engine: Engine, count: number, windowOffset: (index: number) => number) {
+    const subscriptions = yield* Effect.forEach(
+      Array.from({ length: count }, (_value, index) => index),
+      (index) =>
+        engine.subscribe("orders", {
+          select: ["id", "customerId", "price", "status", "updatedAt"],
+          where: {
+            status: { eq: "open" },
+          },
+          orderBy: [{ field: "updatedAt", direction: "desc" }],
+          offset: windowOffset(index),
+          limit: 50,
+        }),
+      { concurrency: "unbounded" },
+    );
+    const scope = yield* Scope.make("parallel");
+    const readers = yield* Effect.forEach(subscriptions, (subscription) =>
+      makeEventReader(subscription, scope),
+    );
+    yield* Effect.forEach(readers, (reader) => reader(), { concurrency: "unbounded" });
+    return {
+      readers,
+      scope,
+      subscriptions,
+    };
+  },
+);
+
+const makeFanoutCase = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.case.make")(function* (
+  benchmarkProfile: BenchmarkProfile,
+  fanoutCase: FanoutCaseProfile,
+  windowOffset: (index: number) => number,
+) {
+  const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+  fanoutCase.engine = engine;
+  yield* seedEngine(engine, benchmarkProfile.rowCount);
+  const subscriptions = yield* makeSubscriptions(
+    engine,
+    benchmarkProfile.subscriberCount,
+    windowOffset,
+  );
+  fanoutCase.engine = engine;
+  fanoutCase.readers = subscriptions.readers;
+  fanoutCase.scope = subscriptions.scope;
+  fanoutCase.subscriptions = subscriptions.subscriptions;
+});
+
+const closeSubscriptions = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.closeSubscriptions")(
+  function* (subscriptions: ReadonlyArray<OrderSubscription>, scope: Scope.Closeable | undefined) {
+    yield* Effect.forEach(subscriptions, (subscription) => subscription.close(), {
+      concurrency: "unbounded",
+    });
+    if (scope !== undefined) {
+      yield* Scope.close(scope, Exit.void);
+    }
+  },
+);
+
+const closeFanoutCase = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.case.close")(function* (
+  fanoutCase: FanoutCaseProfile,
+) {
+  yield* closeSubscriptions(fanoutCase.subscriptions, fanoutCase.scope);
+  if (fanoutCase.engine !== undefined) {
+    yield* fanoutCase.engine.close();
+  }
+});
+
+const publishAndRead = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.publishAndRead")(
+  function* (benchmarkProfile: BenchmarkProfile, fanoutCase: FanoutCaseProfile) {
+    const engine = fanoutCaseEngine(benchmarkProfile, fanoutCase);
+    const row = deltaOrder(fanoutCase.nextDeltaIndex);
+    fanoutCase.nextDeltaIndex += 1;
+    fanoutCase.nextDeltaVersion += 1;
+    const expectedDeltaVersion = fanoutCase.nextDeltaVersion;
+    yield* engine.publish("orders", row);
+    const eventChunks = yield* Effect.forEach(fanoutCase.readers, (reader) => reader(), {
+      concurrency: "unbounded",
+    });
+    expect(eventChunks).toHaveLength(fanoutCase.readers.length);
+    expect(
+      eventChunks.map((events) =>
+        events.some((event) => eventIsDeltaVersion(event, expectedDeltaVersion)),
+      ),
+    ).toStrictEqual(Array.from({ length: fanoutCase.readers.length }, () => true));
+    expectCaseSpecificDelta[benchmarkProfile.fanoutCaseName](
+      eventChunks,
+      row.id,
+      fanoutCase.readers.length,
+    );
+  },
+);
+
+const eventIsDeltaVersion = (event: OrderEvent, expectedDeltaVersion: number): boolean =>
+  event.type === "delta" && event.toVersion === expectedDeltaVersion;
+
+const eventIncludesDeltaRow = (event: OrderEvent, rowId: string): boolean => {
+  if (event.type !== "delta") {
+    return false;
+  }
+  return event.operations.some((operation) => {
+    if (operation.type === "insert" || operation.type === "update") {
+      return operation.key === rowId && operation.row.id === rowId;
+    }
+    return false;
+  });
+};
+
+const expectSameWindowDeltaRows: CaseSpecificDeltaExpectation = (
+  eventChunks,
+  rowId,
+  readerCount,
+) => {
+  expect(
+    eventChunks.map((events) => events.some((event) => eventIncludesDeltaRow(event, rowId))),
+  ).toStrictEqual(Array.from({ length: readerCount }, () => true));
+};
+
+const expectTenWindowDeltaRows: CaseSpecificDeltaExpectation = (
+  eventChunks,
+  _rowId,
+  readerCount,
+) => {
+  expect(eventChunks).toHaveLength(readerCount);
+};
+
+const expectCaseSpecificDelta: Record<FanoutCaseName, CaseSpecificDeltaExpectation> = {
+  "same-window": expectSameWindowDeltaRows,
+  "ten-window": expectTenWindowDeltaRows,
+};
+
+beforeAll(async () => {
+  await Effect.runPromise(
+    makeFanoutCase(profile, profile.fanoutCase, fanoutCaseWindowOffset(profile.fanoutCaseName)),
+  );
+}, 0);
+
+afterAll(async () => {
+  await Effect.runPromise(closeFanoutCase(profile.fanoutCase));
+}, 0);
+
+describe(`raw live fanout benchmark: ${profile.rowCount} rows, ${profile.subscriberCount} subscribers, ${profile.fanoutCaseName}`, () => {
+  bench(
+    `${profile.fanoutCaseName} subscribers publish + delta fanout`,
+    async () => {
+      await Effect.runPromise(publishAndRead(profile, profile.fanoutCase));
+    },
+    benchOptions,
+  );
+});

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -1,6 +1,6 @@
-import { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
+import { TopicStore } from "./topic-store-state";
 
-export { TopicStore, topicStoreRawQueryMetadata, topicStoreReadModel };
+export { TopicStore };
 export {
   deleteTopicStoreRow,
   patchTopicStoreRow,

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1313,6 +1313,53 @@ Raw predicate index knobs:
 For decision-quality large-row runs, keep `--no-cache` and use multiple iterations. One-sample runs
 are useful only to verify feasibility and approximate scale.
 
+Current raw live fanout benchmark harness:
+
+```bash
+vp run --no-cache column-live-view-engine#bench:raw-live-fanout
+```
+
+This harness uses Vitest `bench()` against the public `ColumnLiveViewEngine` subscribe/publish path,
+not scanner internals. It seeds one topic, opens many raw live subscriptions, drains initial
+snapshots, publishes a matching row, and waits for every subscriber to receive a delta for the
+publish version. The same-window case also verifies the inserted row appears in every subscriber
+delta. It runs one fanout case per process so large profiles do not hold multiple full engines in
+memory:
+
+- same-query/same-window subscribers
+- same-query/ten-window subscribers
+
+It writes case-specific artifacts under `packages/column-live-view-engine/.artifacts/`, such as
+`raw-live-fanout-same-window-100000rows-50subs.json` and
+`raw-live-fanout-ten-window-1000000rows-250subs.json`. Run each row count in a separate process,
+and run each fanout case separately, so previous profiles do not contaminate GC/RSS/latency or
+overwrite each other:
+
+```bash
+VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=same-window VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout
+VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=ten-window VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout
+VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=same-window VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=250 vp run --no-cache column-live-view-engine#bench:raw-live-fanout
+VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=ten-window VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=250 vp run --no-cache column-live-view-engine#bench:raw-live-fanout
+```
+
+For the default case-specific scripts:
+
+```bash
+VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout:same-window
+VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout:ten-window
+```
+
+Raw live fanout knobs:
+
+- `VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE`: `same-window` or `ten-window`.
+- `VIEW_SERVER_ENGINE_BENCH_ROWS`: row count for this benchmark process.
+- `VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE`: publish batch size while seeding.
+- `VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS`: live subscriber count.
+- `VIEW_SERVER_ENGINE_BENCH_ITERATIONS`: benchmark iterations per case.
+- `VIEW_SERVER_ENGINE_BENCH_TIME_MS`: benchmark time budget per case.
+- `VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS`: warmup iterations per case.
+- `VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS`: warmup time budget per case.
+
 Each production/runtime benchmark artifact must include:
 
 - row count

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -17,18 +17,17 @@ const restrictedTopicStoreHelpers = [
   {
     name: "makeTopicStoreSubscriptionPermit",
     pattern: /\bmakeTopicStoreSubscriptionPermit\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreStateFile, topicStoreSubscriptionFile]),
+    allowedPaths: new Set([topicStoreStateFile, topicStoreSubscriptionFile]),
   },
   {
     name: "topicStoreRawQueryMetadata",
     pattern: /\btopicStoreRawQueryMetadata\b/,
-    allowedPaths: new Set([topicStoreFile, topicStoreQueryFile, topicStoreStateFile]),
+    allowedPaths: new Set([topicStoreQueryFile, topicStoreStateFile]),
   },
   {
     name: "topicStoreReadModel",
     pattern: /\btopicStoreReadModel\b/,
     allowedPaths: new Set([
-      topicStoreFile,
       topicStoreHealthFile,
       topicStoreLifecycleFile,
       topicStoreQueryFile,
@@ -39,7 +38,6 @@ const restrictedTopicStoreHelpers = [
     name: "topicStoreState",
     pattern: /\btopicStoreState\b/,
     allowedPaths: new Set([
-      topicStoreFile,
       topicStoreHealthFile,
       topicStoreLifecycleFile,
       topicStoreMutationFile,
@@ -71,6 +69,58 @@ const isTestFile = (path: string): boolean =>
   path.endsWith(".test.ts") || path.endsWith(".test-d.ts");
 
 const violations: Array<string> = [];
+const topicStoreStateExportViolations: Array<string> = [];
+
+const restrictedTopicStoreStateExports = [
+  {
+    label: "namespace import",
+    pattern: /import\s+\*\s+as\s+\w+\s+from\s+["']\.\/topic-store-state["']/,
+  },
+  {
+    label: "wildcard re-export",
+    pattern: /export\s+\*\s+from\s+["']\.\/topic-store-state["']/,
+  },
+  {
+    label: "namespace re-export",
+    pattern: /export\s+\*\s+as\s+\w+\s+from\s+["']\.\/topic-store-state["']/,
+  },
+  {
+    label: "subscription permit factory re-export",
+    pattern:
+      /export\s+\{[^}]*\bmakeTopicStoreSubscriptionPermit\b[^}]*\}\s+from\s+["']\.\/topic-store-state["']/s,
+  },
+  {
+    label: "local subscription permit factory re-export",
+    pattern: /export\s+\{[^}]*\bmakeTopicStoreSubscriptionPermit\b[^}]*\}/s,
+  },
+  {
+    label: "raw query metadata helper re-export",
+    pattern:
+      /export\s+\{[^}]*\btopicStoreRawQueryMetadata\b[^}]*\}\s+from\s+["']\.\/topic-store-state["']/s,
+  },
+  {
+    label: "local raw query metadata helper re-export",
+    pattern: /export\s+\{[^}]*\btopicStoreRawQueryMetadata\b[^}]*\}/s,
+  },
+  {
+    label: "read model helper re-export",
+    pattern:
+      /export\s+\{[^}]*\btopicStoreReadModel\b[^}]*\}\s+from\s+["']\.\/topic-store-state["']/s,
+  },
+  {
+    label: "local read model helper re-export",
+    pattern: /export\s+\{[^}]*\btopicStoreReadModel\b[^}]*\}/s,
+  },
+  {
+    label: "state helper re-export",
+    pattern:
+      /export\s+\{[^}]*\btopicStoreState\b[^}]*\}\s+from\s+["']\.\/topic-store-state["']/s,
+  },
+  {
+    label: "local state helper re-export",
+    pattern: /export\s+\{[^}]*\btopicStoreState\b[^}]*\}/s,
+  },
+] as const;
 
 for (const path of sourceFiles(engineSourceRoot)) {
   if (isTestFile(path)) {
@@ -78,6 +128,17 @@ for (const path of sourceFiles(engineSourceRoot)) {
   }
 
   const contents = readFileSync(path, "utf8");
+  if (path !== topicStoreStateFile) {
+    for (const restriction of restrictedTopicStoreStateExports) {
+      if (!restriction.pattern.test(contents)) {
+        continue;
+      }
+      topicStoreStateExportViolations.push(
+        `${relative(repoRoot, path)} has a restricted ${restriction.label}`,
+      );
+    }
+  }
+
   for (const helper of restrictedTopicStoreHelpers) {
     if (helper.allowedPaths.has(path) || !helper.pattern.test(contents)) {
       continue;
@@ -92,6 +153,15 @@ if (violations.length > 0) {
       "Production engine modules must not use restricted TopicStore state helpers.",
       "Route query/read-model behavior through TopicStore helper operations instead.",
       ...violations.map((path) => `- ${path}`),
+    ].join("\n"),
+  );
+}
+
+if (topicStoreStateExportViolations.length > 0) {
+  throw new Error(
+    [
+      "Production engine modules must not re-export restricted TopicStore state internals.",
+      ...topicStoreStateExportViolations.map((path) => `- ${path}`),
     ].join("\n"),
   );
 }


### PR DESCRIPTION
## Summary
- seal the TopicStore facade so production modules cannot re-export restricted topic-store-state internals
- strengthen check:internal-seams against wildcard, namespace, and local restricted helper re-exports
- add a Vitest raw live fanout benchmark for same-window and ten-window subscription fanout through the public engine API
- document process-isolated fanout benchmark usage and profile-specific artifacts

## Validation
- pnpm run ready
- pnpm --filter @view-server/column-live-view-engine run test
- strict Effect LSP for @view-server/column-live-view-engine
- raw fanout smoke: same-window 1000 rows / 5 subscribers
- raw fanout smoke: ten-window 1000 rows / 5 subscribers
- check:internal-seams negative checks for wildcard and namespace topic-store-state leaks
- 3 review agents: no findings