### PR TITLE
Add engine benchmark summary artifacts

### DIFF
--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -14,11 +14,11 @@
   },
   "scripts": {
     "build": "vp pack",
-    "bench:raw-live-fanout": "vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-live-fanout-${VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE:-manual}-${VIEW_SERVER_ENGINE_BENCH_ROWS:-default}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-default}subs.json",
-    "bench:raw-live-fanout:same-window": "VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=same-window vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-live-fanout-same-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-default}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-default}subs.json",
-    "bench:raw-live-fanout:ten-window": "VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=ten-window vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-live-fanout-ten-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-default}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-default}subs.json",
-    "bench:raw-predicate-index": "vp test bench src/raw-predicate-index.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-predicate-index.json",
-    "bench:raw-snapshot": "vp test bench src/raw-snapshot.bench.ts --run --testTimeout 0 --outputJson .artifacts/raw-snapshot.json",
+    "bench:raw-live-fanout": "sh -c 'output=.artifacts/raw-live-fanout-${VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE:-same-window}-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-50}subs.json; VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson $output'",
+    "bench:raw-live-fanout:same-window": "sh -c 'output=.artifacts/raw-live-fanout-same-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-50}subs.json; VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=same-window VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson $output'",
+    "bench:raw-live-fanout:ten-window": "sh -c 'output=.artifacts/raw-live-fanout-ten-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-50}subs.json; VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=ten-window VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson $output'",
+    "bench:raw-predicate-index": "sh -c 'output=.artifacts/raw-predicate-index-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows.json; VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-predicate-index.bench.ts --run --testTimeout 0 --outputJson $output'",
+    "bench:raw-snapshot": "sh -c 'output=.artifacts/raw-snapshot-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows.json; VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-snapshot.bench.ts --run --testTimeout 0 --outputJson $output'",
     "test": "vp test run --coverage --typecheck"
   },
   "dependencies": {

--- a/packages/column-live-view-engine/src/benchmark-artifact.test.ts
+++ b/packages/column-live-view-engine/src/benchmark-artifact.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "@effect/vitest";
+import { readFileSync } from "node:fs";
+import {
+  activeViewCountFromEngineHealth,
+  backpressureCountFromEngineHealth,
+  benchmarkOutputJsonPath,
+  benchmarkSummaryPath,
+  cleanupLeakCountFromEngineHealth,
+  failOnBenchmarkCleanupLeaks,
+  isBenchmarkEngineHealth,
+  memoryDelta,
+  memorySnapshot,
+  queuedEventCountFromEngineHealth,
+  writeBenchmarkArtifact,
+  type BenchmarkMemorySnapshot,
+} from "./benchmark-artifact";
+
+const memory = (value: number): BenchmarkMemorySnapshot => ({
+  arrayBuffersBytes: value,
+  externalBytes: value + 1,
+  heapTotalBytes: value + 2,
+  heapUsedBytes: value + 3,
+  rssBytes: value + 4,
+});
+
+describe("benchmark artifact helpers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds benchmark artifact paths from env or fallback", () => {
+    vi.stubEnv("VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON", undefined);
+    expect(benchmarkOutputJsonPath("raw-snapshot-100rows.json")).toBe(
+      ".artifacts/raw-snapshot-100rows.json",
+    );
+    vi.stubEnv("VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON", " ");
+    expect(benchmarkOutputJsonPath("raw-snapshot-100rows.json")).toBe(
+      ".artifacts/raw-snapshot-100rows.json",
+    );
+
+    vi.stubEnv("VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON", " .artifacts/custom.json ");
+    expect(benchmarkOutputJsonPath("raw-snapshot-100rows.json")).toBe(".artifacts/custom.json");
+  });
+
+  it("builds summary paths for json and non-json outputs", () => {
+    expect(benchmarkSummaryPath(".artifacts/raw.json")).toBe(".artifacts/raw.summary.json");
+    expect(benchmarkSummaryPath(".artifacts/raw")).toBe(".artifacts/raw.summary.json");
+  });
+
+  it("computes memory and health counters", () => {
+    const currentMemory = memorySnapshot();
+    expect(typeof currentMemory.rssBytes).toBe("number");
+
+    expect(memoryDelta(memory(1), memory(3))).toStrictEqual({
+      arrayBuffersBytes: 2,
+      externalBytes: 2,
+      heapTotalBytes: 2,
+      heapUsedBytes: 2,
+      rssBytes: 2,
+    });
+
+    const health = {
+      activeSubscriptions: 2,
+      backpressureEvents: 5,
+      maxQueueDepth: 999,
+      queuedEvents: 3,
+      topics: {
+        orders: {
+          activeViews: 7,
+        },
+      },
+    };
+    expect(isBenchmarkEngineHealth(health)).toBe(true);
+    expect(cleanupLeakCountFromEngineHealth(health)).toBe(12);
+    expect(backpressureCountFromEngineHealth(health)).toBe(5);
+    expect(queuedEventCountFromEngineHealth(health)).toBe(3);
+    expect(activeViewCountFromEngineHealth(health)).toBe(7);
+
+    const healthWithoutTopics = {
+      activeSubscriptions: 2,
+      backpressureEvents: 5,
+      maxQueueDepth: 999,
+      queuedEvents: 3,
+    };
+    expect(isBenchmarkEngineHealth(healthWithoutTopics)).toBe(true);
+    expect(activeViewCountFromEngineHealth(healthWithoutTopics)).toBe(0);
+    expect(
+      isBenchmarkEngineHealth({
+        activeSubscriptions: 2,
+        backpressureEvents: 5,
+        maxQueueDepth: 999,
+        queuedEvents: 3,
+        topics: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      isBenchmarkEngineHealth({
+        activeSubscriptions: 2,
+        backpressureEvents: 5,
+        maxQueueDepth: 999,
+        queuedEvents: 3,
+        topics: null,
+      }),
+    ).toBe(false);
+
+    expect(isBenchmarkEngineHealth(null)).toBe(false);
+    expect(isBenchmarkEngineHealth({ activeSubscriptions: 1 })).toBe(false);
+    expect(
+      isBenchmarkEngineHealth({
+        activeSubscriptions: "2",
+        backpressureEvents: 5,
+        maxQueueDepth: 999,
+        queuedEvents: 3,
+      }),
+    ).toBe(false);
+    expect(
+      isBenchmarkEngineHealth({
+        activeSubscriptions: 2,
+        backpressureEvents: 5,
+        maxQueueDepth: 999,
+        queuedEvents: 3,
+        topics: {
+          orders: {
+            activeViews: "7",
+          },
+        },
+      }),
+    ).toBe(false);
+    expect(cleanupLeakCountFromEngineHealth({})).toBe(0);
+    expect(backpressureCountFromEngineHealth({})).toBe(0);
+    expect(queuedEventCountFromEngineHealth({})).toBe(0);
+    expect(failOnBenchmarkCleanupLeaks(0)).toBeUndefined();
+    expect(() => failOnBenchmarkCleanupLeaks(2)).toThrow(
+      "Benchmark cleanup leaked 2 active resource(s).",
+    );
+  });
+
+  it("writes benchmark summary artifacts", () => {
+    const outputJsonPath = ".artifacts/benchmark-artifact-test.json";
+    writeBenchmarkArtifact({
+      artifactKind: "engine-benchmark-summary",
+      backpressureCount: 0,
+      benchmarkCases: ["case-a"],
+      benchmarkName: "benchmark artifact test",
+      benchmarkScope: "engine-raw-snapshot",
+      cleanupLeakCount: 0,
+      health: {
+        status: "ready",
+      },
+      latency: {
+        outputJsonPath,
+        source: "vitest-output-json",
+      },
+      memoryAfterBenchmark: memory(5),
+      memoryAfterSetup: memory(3),
+      memoryBefore: memory(1),
+      mutationCount: 10,
+      notes: ["test artifact"],
+      outputJsonPath,
+      queuedEventCount: 0,
+      rowCount: 100,
+      subscriberCount: 1,
+      topics: ["orders"],
+    });
+
+    expect(readFileSync(".artifacts/benchmark-artifact-test.summary.json", "utf8")).toBe(
+      `${JSON.stringify(
+        {
+          artifactKind: "engine-benchmark-summary",
+          backpressureCount: 0,
+          benchmarkCases: ["case-a"],
+          benchmarkName: "benchmark artifact test",
+          benchmarkScope: "engine-raw-snapshot",
+          cleanupLeakCount: 0,
+          health: {
+            status: "ready",
+          },
+          latency: {
+            outputJsonPath,
+            source: "vitest-output-json",
+          },
+          memory: {
+            afterBenchmark: memory(5),
+            afterSetup: memory(3),
+            before: memory(1),
+            benchmarkDelta: memoryDelta(memory(3), memory(5)),
+            setupDelta: memoryDelta(memory(1), memory(3)),
+            totalDelta: memoryDelta(memory(1), memory(5)),
+          },
+          mutationCount: 10,
+          notes: ["test artifact"],
+          outputJsonPath,
+          queuedEventCount: 0,
+          rowCount: 100,
+          subscriberCount: 1,
+          topics: ["orders"],
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+  });
+});

--- a/packages/column-live-view-engine/src/benchmark-artifact.ts
+++ b/packages/column-live-view-engine/src/benchmark-artifact.ts
@@ -1,0 +1,229 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+declare const process: {
+  readonly cwd: () => string;
+  readonly env: Record<string, string | undefined>;
+  readonly memoryUsage: () => {
+    readonly arrayBuffers: number;
+    readonly external: number;
+    readonly heapTotal: number;
+    readonly heapUsed: number;
+    readonly rss: number;
+  };
+};
+
+export type BenchmarkMemorySnapshot = {
+  readonly arrayBuffersBytes: number;
+  readonly externalBytes: number;
+  readonly heapTotalBytes: number;
+  readonly heapUsedBytes: number;
+  readonly rssBytes: number;
+};
+
+export type BenchmarkMemoryDelta = {
+  readonly arrayBuffersBytes: number;
+  readonly externalBytes: number;
+  readonly heapTotalBytes: number;
+  readonly heapUsedBytes: number;
+  readonly rssBytes: number;
+};
+
+export type BenchmarkEngineHealth = {
+  readonly activeSubscriptions: number;
+  readonly backpressureEvents: number;
+  readonly maxQueueDepth: number;
+  readonly queuedEvents: number;
+  readonly topics?: Readonly<Record<string, BenchmarkTopicHealth>>;
+};
+
+export type BenchmarkTopicHealth = {
+  readonly activeViews: number;
+};
+
+export type BenchmarkArtifactInput = {
+  readonly artifactKind: "engine-benchmark-summary";
+  readonly benchmarkName: string;
+  readonly benchmarkScope:
+    | "engine-raw-snapshot"
+    | "engine-raw-predicate-index"
+    | "engine-raw-live-fanout";
+  readonly rowCount: number;
+  readonly mutationCount: number;
+  readonly subscriberCount: number;
+  readonly topics: ReadonlyArray<string>;
+  readonly benchmarkCases: ReadonlyArray<string>;
+  readonly outputJsonPath: string;
+  readonly memoryBefore: BenchmarkMemorySnapshot;
+  readonly memoryAfterSetup: BenchmarkMemorySnapshot;
+  readonly memoryAfterBenchmark: BenchmarkMemorySnapshot;
+  readonly latency: {
+    readonly source: "vitest-output-json";
+    readonly outputJsonPath: string;
+  };
+  readonly backpressureCount: number;
+  readonly cleanupLeakCount: number;
+  readonly queuedEventCount: number;
+  readonly health: unknown;
+  readonly notes: ReadonlyArray<string>;
+};
+
+export const memorySnapshot = (): BenchmarkMemorySnapshot => {
+  const memory = process.memoryUsage();
+  return {
+    arrayBuffersBytes: memory.arrayBuffers,
+    externalBytes: memory.external,
+    heapTotalBytes: memory.heapTotal,
+    heapUsedBytes: memory.heapUsed,
+    rssBytes: memory.rss,
+  };
+};
+
+export const memoryDelta = (
+  before: BenchmarkMemorySnapshot,
+  after: BenchmarkMemorySnapshot,
+): BenchmarkMemoryDelta => ({
+  arrayBuffersBytes: after.arrayBuffersBytes - before.arrayBuffersBytes,
+  externalBytes: after.externalBytes - before.externalBytes,
+  heapTotalBytes: after.heapTotalBytes - before.heapTotalBytes,
+  heapUsedBytes: after.heapUsedBytes - before.heapUsedBytes,
+  rssBytes: after.rssBytes - before.rssBytes,
+});
+
+export const benchmarkOutputJsonPath = (fallbackName: string): string => {
+  const configured = process.env["VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON"];
+  if (configured !== undefined && configured.trim() !== "") {
+    return configured.trim();
+  }
+  return join(".artifacts", fallbackName);
+};
+
+export const benchmarkSummaryPath = (outputJsonPath: string): string => {
+  if (outputJsonPath.endsWith(".json")) {
+    return `${outputJsonPath.slice(0, -".json".length)}.summary.json`;
+  }
+  return `${outputJsonPath}.summary.json`;
+};
+
+export const cleanupLeakCountFromEngineHealth = (health: unknown): number => {
+  if (!isBenchmarkEngineHealth(health)) {
+    return 0;
+  }
+  return health.activeSubscriptions + health.queuedEvents + activeViewCountFromEngineHealth(health);
+};
+
+export const backpressureCountFromEngineHealth = (health: unknown): number => {
+  if (!isBenchmarkEngineHealth(health)) {
+    return 0;
+  }
+  return health.backpressureEvents;
+};
+
+export const queuedEventCountFromEngineHealth = (health: unknown): number => {
+  if (!isBenchmarkEngineHealth(health)) {
+    return 0;
+  }
+  return health.queuedEvents;
+};
+
+export const failOnBenchmarkCleanupLeaks = (cleanupLeakCount: number): void => {
+  if (cleanupLeakCount > 0) {
+    throw new Error(`Benchmark cleanup leaked ${cleanupLeakCount} active resource(s).`);
+  }
+};
+
+export const isBenchmarkEngineHealth = (value: unknown): value is BenchmarkEngineHealth => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (
+    !("activeSubscriptions" in value) ||
+    !("backpressureEvents" in value) ||
+    !("maxQueueDepth" in value) ||
+    !("queuedEvents" in value)
+  ) {
+    return false;
+  }
+  const hasEngineCounters =
+    typeof value.activeSubscriptions === "number" &&
+    typeof value.backpressureEvents === "number" &&
+    typeof value.maxQueueDepth === "number" &&
+    typeof value.queuedEvents === "number";
+
+  if (!hasEngineCounters) {
+    return false;
+  }
+
+  if (!("topics" in value)) {
+    return true;
+  }
+
+  const topics = value.topics;
+  if (topics === undefined) {
+    return true;
+  }
+  if (typeof topics !== "object" || topics === null) {
+    return false;
+  }
+
+  for (const topic of Object.values(topics)) {
+    if (
+      typeof topic !== "object" ||
+      topic === null ||
+      !("activeViews" in topic) ||
+      typeof topic.activeViews !== "number"
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const activeViewCountFromEngineHealth = (health: BenchmarkEngineHealth): number => {
+  if (health.topics === undefined) {
+    return 0;
+  }
+  let activeViewCount = 0;
+  for (const topic of Object.values(health.topics)) {
+    activeViewCount += topic.activeViews;
+  }
+  return activeViewCount;
+};
+
+export const writeBenchmarkArtifact = (input: BenchmarkArtifactInput): void => {
+  const summaryPath = benchmarkSummaryPath(input.outputJsonPath);
+  mkdirSync(dirname(summaryPath), { recursive: true });
+  writeFileSync(
+    summaryPath,
+    `${JSON.stringify(
+      {
+        artifactKind: input.artifactKind,
+        backpressureCount: input.backpressureCount,
+        benchmarkCases: input.benchmarkCases,
+        benchmarkName: input.benchmarkName,
+        benchmarkScope: input.benchmarkScope,
+        cleanupLeakCount: input.cleanupLeakCount,
+        health: input.health,
+        latency: input.latency,
+        memory: {
+          afterBenchmark: input.memoryAfterBenchmark,
+          afterSetup: input.memoryAfterSetup,
+          before: input.memoryBefore,
+          benchmarkDelta: memoryDelta(input.memoryAfterSetup, input.memoryAfterBenchmark),
+          setupDelta: memoryDelta(input.memoryBefore, input.memoryAfterSetup),
+          totalDelta: memoryDelta(input.memoryBefore, input.memoryAfterBenchmark),
+        },
+        mutationCount: input.mutationCount,
+        notes: input.notes,
+        outputJsonPath: input.outputJsonPath,
+        queuedEventCount: input.queuedEventCount,
+        rowCount: input.rowCount,
+        subscriberCount: input.subscriberCount,
+        topics: input.topics,
+      },
+      undefined,
+      2,
+    )}\n`,
+  );
+};

--- a/packages/column-live-view-engine/src/benchmark-node-ambient.d.ts
+++ b/packages/column-live-view-engine/src/benchmark-node-ambient.d.ts
@@ -1,0 +1,10 @@
+declare module "node:fs" {
+  export const mkdirSync: (path: string, options: { readonly recursive: true }) => void;
+  export const readFileSync: (path: string, encoding: "utf8") => string;
+  export const writeFileSync: (path: string, data: string) => void;
+}
+
+declare module "node:path" {
+  export const dirname: (path: string) => string;
+  export const join: (...paths: ReadonlyArray<string>) => string;
+}

--- a/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
+++ b/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
@@ -8,6 +8,16 @@ import {
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
 } from "./index";
+import {
+  backpressureCountFromEngineHealth,
+  benchmarkOutputJsonPath,
+  cleanupLeakCountFromEngineHealth,
+  failOnBenchmarkCleanupLeaks,
+  memorySnapshot,
+  queuedEventCountFromEngineHealth,
+  writeBenchmarkArtifact,
+  type BenchmarkMemorySnapshot,
+} from "./benchmark-artifact";
 
 declare const process: {
   readonly env: Record<string, string | undefined>;
@@ -60,6 +70,7 @@ type BenchmarkProfile = {
   readonly subscriberCount: number;
   readonly fanoutCaseName: FanoutCaseName;
   fanoutCase: FanoutCaseProfile;
+  memoryAfterSetup: BenchmarkMemorySnapshot | undefined;
 };
 
 const defaultRowCount = 100_000;
@@ -133,6 +144,10 @@ const subscriberCount = positiveIntegerFromEnv(
   "VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS",
   defaultSubscriberCount,
 );
+const outputJsonPath = benchmarkOutputJsonPath(
+  `raw-live-fanout-${fanoutCaseName}-${benchmarkRowCount}rows-${subscriberCount}subs.json`,
+);
+const memoryBefore = memorySnapshot();
 const benchOptions = {
   iterations: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ITERATIONS", defaultIterations),
   time: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_TIME_MS", defaultBenchmarkTimeMs),
@@ -160,6 +175,7 @@ const profile: BenchmarkProfile = {
   subscriberCount,
   fanoutCaseName,
   fanoutCase: emptyFanoutCaseProfile(),
+  memoryAfterSetup: undefined,
 };
 
 const orderStatus = (index: number): OrderStatus => {
@@ -302,15 +318,6 @@ const closeSubscriptions = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.c
   },
 );
 
-const closeFanoutCase = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.case.close")(function* (
-  fanoutCase: FanoutCaseProfile,
-) {
-  yield* closeSubscriptions(fanoutCase.subscriptions, fanoutCase.scope);
-  if (fanoutCase.engine !== undefined) {
-    yield* fanoutCase.engine.close();
-  }
-});
-
 const publishAndRead = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.publishAndRead")(
   function* (benchmarkProfile: BenchmarkProfile, fanoutCase: FanoutCaseProfile) {
     const engine = fanoutCaseEngine(benchmarkProfile, fanoutCase);
@@ -378,10 +385,55 @@ beforeAll(async () => {
   await Effect.runPromise(
     makeFanoutCase(profile, profile.fanoutCase, fanoutCaseWindowOffset(profile.fanoutCaseName)),
   );
+  profile.memoryAfterSetup = memorySnapshot();
 }, 0);
 
 afterAll(async () => {
-  await Effect.runPromise(closeFanoutCase(profile.fanoutCase));
+  const memoryAfterSetup = profile.memoryAfterSetup ?? memoryBefore;
+  const mutationCount = profile.fanoutCase.nextDeltaIndex;
+  await Effect.runPromise(
+    closeSubscriptions(profile.fanoutCase.subscriptions, profile.fanoutCase.scope),
+  );
+  const health =
+    profile.fanoutCase.engine === undefined
+      ? {
+          status: "not-started",
+        }
+      : await Effect.runPromise(profile.fanoutCase.engine.health());
+  const cleanupLeakCount = cleanupLeakCountFromEngineHealth(health);
+  if (profile.fanoutCase.engine !== undefined) {
+    await Effect.runPromise(profile.fanoutCase.engine.close());
+  }
+  profile.fanoutCase = emptyFanoutCaseProfile();
+  profile.memoryAfterSetup = undefined;
+  const memoryAfterBenchmark = memorySnapshot();
+  writeBenchmarkArtifact({
+    artifactKind: "engine-benchmark-summary",
+    backpressureCount: backpressureCountFromEngineHealth(health),
+    benchmarkCases: [`${profile.fanoutCaseName} subscribers publish + delta fanout`],
+    benchmarkName: "raw live fanout benchmark",
+    benchmarkScope: "engine-raw-live-fanout",
+    cleanupLeakCount,
+    health,
+    latency: {
+      outputJsonPath,
+      source: "vitest-output-json",
+    },
+    memoryAfterBenchmark,
+    memoryAfterSetup,
+    memoryBefore,
+    mutationCount,
+    notes: [
+      "Latency percentiles are emitted by Vitest in outputJsonPath.",
+      "mutationCount includes setup seed rows plus live fanout publish benchmark iterations.",
+    ],
+    outputJsonPath,
+    queuedEventCount: queuedEventCountFromEngineHealth(health),
+    rowCount: profile.rowCount,
+    subscriberCount: profile.subscriberCount,
+    topics: ["orders"],
+  });
+  failOnBenchmarkCleanupLeaks(cleanupLeakCount);
 }, 0);
 
 describe(`raw live fanout benchmark: ${profile.rowCount} rows, ${profile.subscriberCount} subscribers, ${profile.fanoutCaseName}`, () => {

--- a/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
@@ -1,6 +1,12 @@
 // Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
-import { beforeAll, bench, describe, expect } from "vitest";
+import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { Schema } from "effect";
+import {
+  benchmarkOutputJsonPath,
+  memorySnapshot,
+  writeBenchmarkArtifact,
+  type BenchmarkMemorySnapshot,
+} from "./benchmark-artifact";
 import { compareQueryValue } from "./query-value";
 import { rawQueryCompilerMetadata } from "./raw-query-compiler";
 import { fieldValue, scalarEqualityKey } from "./row-values";
@@ -105,6 +111,9 @@ const rowCountFromEnv = (): number => {
 };
 
 const rowCount = rowCountFromEnv();
+const outputJsonPath = benchmarkOutputJsonPath(`raw-predicate-index-${rowCount}rows.json`);
+const memoryBefore = memorySnapshot();
+let memoryAfterSetup: BenchmarkMemorySnapshot = memoryBefore;
 const benchOptions = {
   iterations: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ITERATIONS", defaultIterations),
   time: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_TIME_MS", defaultBenchmarkTimeMs),
@@ -573,7 +582,43 @@ beforeAll(() => {
   for (const benchmarkCase of benchmarkCases()) {
     runBenchmarkCase(benchmarkCase);
   }
+  memoryAfterSetup = memorySnapshot();
 }, 0);
+
+afterAll(() => {
+  const benchmarkCaseNames = benchmarkCases().map((benchmarkCase) => benchmarkCase.name);
+  profile = undefined;
+  const memoryAfterBenchmark = memorySnapshot();
+  writeBenchmarkArtifact({
+    artifactKind: "engine-benchmark-summary",
+    backpressureCount: 0,
+    benchmarkCases: benchmarkCaseNames,
+    benchmarkName: "raw predicate candidate index benchmark",
+    benchmarkScope: "engine-raw-predicate-index",
+    cleanupLeakCount: 0,
+    health: {
+      rowCount,
+      status: "scanner-level",
+    },
+    latency: {
+      outputJsonPath,
+      source: "vitest-output-json",
+    },
+    memoryAfterBenchmark,
+    memoryAfterSetup,
+    memoryBefore,
+    mutationCount: 0,
+    notes: [
+      "Latency percentiles are emitted by Vitest in outputJsonPath.",
+      "This scanner-level benchmark has no subscriptions, backpressure, engine health, or engine cleanup leak assertion.",
+    ],
+    outputJsonPath,
+    queuedEventCount: 0,
+    rowCount,
+    subscriberCount: 0,
+    topics: ["orders"],
+  });
+});
 
 describe(`raw predicate candidate index benchmark: ${rowCount} rows`, () => {
   for (const benchmarkCase of benchmarkCases()) {

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -8,6 +8,16 @@ import {
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
 } from "./index";
+import {
+  backpressureCountFromEngineHealth,
+  benchmarkOutputJsonPath,
+  cleanupLeakCountFromEngineHealth,
+  failOnBenchmarkCleanupLeaks,
+  memorySnapshot,
+  queuedEventCountFromEngineHealth,
+  writeBenchmarkArtifact,
+  type BenchmarkMemorySnapshot,
+} from "./benchmark-artifact";
 
 declare const process: {
   readonly env: Record<string, string | undefined>;
@@ -45,6 +55,7 @@ type BenchmarkProfile = {
   readonly rowCount: number;
   engine: Engine | undefined;
   eventReader: OrderEventReader | undefined;
+  memoryAfterSetup: BenchmarkMemorySnapshot | undefined;
   scope: Scope.Closeable | undefined;
   subscription: OrderSubscription | undefined;
   nextDeltaIndex: number;
@@ -110,6 +121,8 @@ const rowCountFromEnv = (): number => {
 
 const benchmarkRowCount = rowCountFromEnv();
 const batchSize = positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE", defaultBatchSize);
+const outputJsonPath = benchmarkOutputJsonPath(`raw-snapshot-${benchmarkRowCount}rows.json`);
+const memoryBefore = memorySnapshot();
 const benchOptions = {
   iterations: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ITERATIONS", defaultIterations),
   time: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_TIME_MS", defaultBenchmarkTimeMs),
@@ -127,6 +140,7 @@ const profile: BenchmarkProfile = {
   rowCount: benchmarkRowCount,
   engine: undefined,
   eventReader: undefined,
+  memoryAfterSetup: undefined,
   scope: undefined,
   subscription: undefined,
   nextDeltaIndex: benchmarkRowCount,
@@ -235,23 +249,71 @@ beforeAll(async () => {
   await Effect.runPromise(eventReader(1));
   profile.engine = engine;
   profile.eventReader = eventReader;
+  profile.memoryAfterSetup = memorySnapshot();
   profile.scope = scope;
   profile.subscription = subscription;
 }, 0);
 
 afterAll(async () => {
-  const scope = profile.scope;
-  if (scope !== undefined) {
-    await Effect.runPromise(Scope.close(scope, Exit.void));
+  const memoryAfterSetup = profile.memoryAfterSetup ?? memoryBefore;
+  const mutationCount = profile.nextDeltaIndex;
+  if (profile.subscription !== undefined) {
+    await Effect.runPromise(profile.subscription.close());
+    profile.subscription = undefined;
   }
-  const subscription = profile.subscription;
-  if (subscription !== undefined) {
-    await Effect.runPromise(subscription.close());
+  if (profile.scope !== undefined) {
+    await Effect.runPromise(Scope.close(profile.scope, Exit.void));
+    profile.scope = undefined;
   }
-  const engine = profile.engine;
-  if (engine !== undefined) {
-    await Effect.runPromise(engine.close());
+  let health: unknown = {
+    status: "not-started",
+  };
+  if (profile.engine !== undefined) {
+    health = await Effect.runPromise(profile.engine.health());
+    await Effect.runPromise(profile.engine.close());
+    profile.engine = undefined;
   }
+  profile.eventReader = undefined;
+  profile.memoryAfterSetup = undefined;
+  const memoryAfterBenchmark = memorySnapshot();
+  const cleanupLeakCount = cleanupLeakCountFromEngineHealth(health);
+  writeBenchmarkArtifact({
+    artifactKind: "engine-benchmark-summary",
+    backpressureCount: backpressureCountFromEngineHealth(health),
+    benchmarkCases: [
+      "equality filter + top-k sort",
+      "selective equality filter + fallback top-k sort",
+      "ordered equality filter + indexed seek",
+      "ordered in filter + indexed seek",
+      "range filter + top-k sort",
+      "selective range filter + fallback top-k sort",
+      "compound filter + top-k sort",
+      "filtered totalRows via zero-row window",
+      "live subscription delta after publish",
+    ],
+    benchmarkName: "raw snapshot and delta engine benchmark",
+    benchmarkScope: "engine-raw-snapshot",
+    cleanupLeakCount,
+    health,
+    latency: {
+      outputJsonPath,
+      source: "vitest-output-json",
+    },
+    memoryAfterBenchmark,
+    memoryAfterSetup,
+    memoryBefore,
+    mutationCount,
+    notes: [
+      "Latency percentiles are emitted by Vitest in outputJsonPath.",
+      "mutationCount includes setup seed rows plus live delta publish benchmark iterations.",
+    ],
+    outputJsonPath,
+    queuedEventCount: queuedEventCountFromEngineHealth(health),
+    rowCount: profile.rowCount,
+    subscriberCount: 1,
+    topics: ["orders"],
+  });
+  failOnBenchmarkCleanupLeaks(cleanupLeakCount);
 }, 0);
 
 describe(`raw snapshot and delta engine benchmark: ${profile.rowCount} rows`, () => {

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1252,11 +1252,12 @@ Current engine raw benchmark harness:
 vp run --no-cache column-live-view-engine#bench:raw-snapshot
 ```
 
-Use `--no-cache` because benchmark row counts and timing are environment-driven. This harness is
-currently a timing-focused raw engine benchmark; the full production benchmark artifact fields below
-still need to be added to the broader benchmark suite. It defaults to a 100k-row smoke profile and
-writes `packages/column-live-view-engine/.artifacts/raw-snapshot.json`. Run each row count in a
-separate process so previous profiles do not contaminate GC/RSS/latency. For example:
+Use `--no-cache` because benchmark row counts and timing are environment-driven. It defaults to a
+100k-row smoke profile and writes both Vitest timing JSON and a View Server summary sidecar under
+`packages/column-live-view-engine/.artifacts/`, for example
+`raw-snapshot-100000rows.json` and `raw-snapshot-100000rows.summary.json`. Run each row count in a
+separate process so previous profiles do not contaminate GC/RSS/latency or overwrite artifacts. For
+example:
 
 ```bash
 VIEW_SERVER_ENGINE_BENCH_ROWS=100000 vp run --no-cache column-live-view-engine#bench:raw-snapshot
@@ -1292,9 +1293,10 @@ benchmark. It compares:
 - ordered equality seek over storage order
 - failed broad scalar candidate build plus full scan
 
-It writes `packages/column-live-view-engine/.artifacts/raw-predicate-index.json`. Run each row count
-in a separate process. The benchmark rejects row counts below 101 because several cases assert exact
-50/100-row windows and the range-candidate case must stay narrower than the whole table.
+It writes profile-specific Vitest timing JSON plus a View Server summary sidecar, for example
+`raw-predicate-index-100000rows.json` and `raw-predicate-index-100000rows.summary.json`. Run each row
+count in a separate process. The benchmark rejects row counts below 101 because several cases assert
+exact 50/100-row windows and the range-candidate case must stay narrower than the whole table.
 
 ```bash
 VIEW_SERVER_ENGINE_BENCH_ROWS=100000 vp run --no-cache column-live-view-engine#bench:raw-predicate-index
@@ -1331,9 +1333,9 @@ memory:
 
 It writes case-specific artifacts under `packages/column-live-view-engine/.artifacts/`, such as
 `raw-live-fanout-same-window-100000rows-50subs.json` and
-`raw-live-fanout-ten-window-1000000rows-250subs.json`. Run each row count in a separate process,
-and run each fanout case separately, so previous profiles do not contaminate GC/RSS/latency or
-overwrite each other:
+`raw-live-fanout-ten-window-1000000rows-250subs.json`, plus matching `.summary.json` sidecars. Run
+each row count in a separate process, and run each fanout case separately, so previous profiles do
+not contaminate GC/RSS/latency or overwrite each other:
 
 ```bash
 VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=same-window VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout
@@ -1360,18 +1362,18 @@ Raw live fanout knobs:
 - `VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS`: warmup iterations per case.
 - `VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS`: warmup time budget per case.
 
-Each production/runtime benchmark artifact must include:
+Each production/runtime benchmark sidecar must include:
 
 - row count
 - mutation count
 - subscribers
 - topics
-- p50/p95/p99/max latency
-- memory/RSS/heap
-- queued events/bytes
+- latency source pointing at the Vitest timing JSON containing p50/p95/p99/max samples
+- memory/RSS/heap before setup, after setup, and after clearing retained benchmark fixture references
+- top-level queued event count
 - backpressure count
-- cleanup leak count
-- health snapshot after cleanup
+- cleanup leak count, with non-zero engine cleanup leaks failing the benchmark after the sidecar is written
+- health snapshot after explicit subscription cleanup and before force-closing the engine
 
 ### Documentation
 


### PR DESCRIPTION
## Summary
- add View Server summary sidecars for raw snapshot, raw predicate index, and raw live fanout Vitest benchmarks
- include stable profile-specific artifact paths, row/mutation/subscriber/topic metadata, queued/backpressure/cleanup counters, health snapshots, and memory snapshots
- capture cleanup health before engine force-close, include active views in cleanup leak counts, and fail engine benchmarks after writing sidecars when cleanup leaks remain
- document the benchmark sidecar contract in the plan

## Validation
- vp check --fix on changed files
- pnpm --filter @view-server/column-live-view-engine exec tsc -p tsconfig.json --noEmit
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error --severity warning --severity message
- smoke: bench:raw-snapshot with 1000 rows
- smoke: bench:raw-predicate-index with 200 rows
- smoke: bench:raw-live-fanout:same-window with 1000 rows / 5 subscribers
- pnpm run ready
- 3-agent review loop: no findings after fixes
