### PR TITLE
Add serial benchmark baseline runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "bench:baseline": "node scripts/run-benchmark-baseline.mjs --profile=smoke",
+    "bench:baseline:release": "node scripts/run-benchmark-baseline.mjs --profile=release",
+    "bench:baseline:smoke": "node scripts/run-benchmark-baseline.mjs --profile=smoke",
     "check:effect": "effect-language-service diagnostics --project packages/config/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/client/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/runtime-core/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/in-memory/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/server/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict && effect-language-service diagnostics --project packages/react/tsconfig.json --format text --strict",
     "check:internal-seams": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/node-ambient.d.ts scripts/check-internal-seams.ts && node --experimental-strip-types scripts/check-internal-seams.ts",
     "check:package-exports": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/check-package-exports.ts && node --experimental-strip-types scripts/check-package-exports.ts",

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1246,6 +1246,28 @@ Minimum benchmark profiles:
 - reconnect/route-change churn
 - slow-client/backpressure
 
+Preferred serial benchmark runner:
+
+```bash
+pnpm run bench:baseline:smoke
+pnpm run bench:baseline
+pnpm run bench:baseline:release
+```
+
+`bench:baseline` and `bench:baseline:smoke` run one small Chromium/browser profile plus small
+engine profiles with one-iteration / 1ms Vitest benchmark smoke settings. Use them as the PR
+sanity check for benchmark wiring. `bench:baseline:release` is the release-quality serial profile
+and runs the documented row counts/browser profiles in separate processes. It intentionally
+executes one benchmark process at a time so GC, RSS, browser state, and artifact files are not
+polluted by competing benchmark suites.
+
+The serial runner is `scripts/run-benchmark-baseline.mjs`. It supports
+`VIEW_SERVER_BENCH_BASELINE_PROFILE=smoke|release` or `--profile=smoke|release`; an explicit
+`--profile` argument wins over the environment variable, so the root package scripts always run the
+profile they name. Use the environment variable only when invoking the Node script directly. The
+runner scrubs benchmark-specific environment variables before each child process so stale local
+tuning cannot pollute baseline runs.
+
 Current engine raw benchmark harness:
 
 ```bash

--- a/scripts/run-benchmark-baseline.mjs
+++ b/scripts/run-benchmark-baseline.mjs
@@ -1,0 +1,202 @@
+import { spawn } from "node:child_process";
+import { constants as osConstants } from "node:os";
+
+const commonEngineSmokeEnv = {
+  VIEW_SERVER_ENGINE_BENCH_ITERATIONS: "1",
+  VIEW_SERVER_ENGINE_BENCH_TIME_MS: "1",
+  VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS: "0",
+  VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS: "0",
+};
+
+const commonReactSmokeEnv = {
+  VIEW_SERVER_REACT_BENCH_ITERATIONS: "1",
+  VIEW_SERVER_REACT_BENCH_TIME_MS: "1",
+  VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS: "0",
+  VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS: "0",
+};
+
+const task = (label, vpTask, env) => ({
+  args: ["run", "--no-cache", vpTask],
+  command: "vp",
+  env,
+  label,
+});
+
+const rawSnapshotTask = (rowCount, env = {}) =>
+  task(`raw snapshot ${rowCount} rows`, "column-live-view-engine#bench:raw-snapshot", {
+    VIEW_SERVER_ENGINE_BENCH_ROWS: String(rowCount),
+    ...env,
+  });
+
+const rawPredicateIndexTask = (rowCount, env = {}) =>
+  task(
+    `raw predicate index ${rowCount} rows`,
+    "column-live-view-engine#bench:raw-predicate-index",
+    {
+      VIEW_SERVER_ENGINE_BENCH_ROWS: String(rowCount),
+      ...env,
+    },
+  );
+
+const rawLiveFanoutTask = (fanoutCase, rowCount, subscriberCount, env = {}) =>
+  task(
+    `raw live fanout ${fanoutCase} ${rowCount} rows ${subscriberCount} subscribers`,
+    "column-live-view-engine#bench:raw-live-fanout",
+    {
+      VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE: fanoutCase,
+      VIEW_SERVER_ENGINE_BENCH_ROWS: String(rowCount),
+      VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS: String(subscriberCount),
+      ...env,
+    },
+  );
+
+const reactInMemoryTask = (browser, rowCount, env = {}) =>
+  task(`React in-memory ${browser} ${rowCount} rows`, "react#bench:in-memory-live-query", {
+    VIEW_SERVER_REACT_BENCH_BROWSER: browser,
+    VIEW_SERVER_REACT_BENCH_ROWS: String(rowCount),
+    ...env,
+  });
+
+const profiles = new Map([
+  [
+    "smoke",
+    [
+      rawSnapshotTask(1_000, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "500",
+        ...commonEngineSmokeEnv,
+      }),
+      rawPredicateIndexTask(1_000, commonEngineSmokeEnv),
+      rawLiveFanoutTask("same-window", 1_000, 5, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "500",
+        ...commonEngineSmokeEnv,
+      }),
+      rawLiveFanoutTask("ten-window", 1_000, 5, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "500",
+        ...commonEngineSmokeEnv,
+      }),
+      reactInMemoryTask("chromium", 20, {
+        VIEW_SERVER_REACT_BENCH_BATCH_SIZE: "10",
+        ...commonReactSmokeEnv,
+      }),
+    ],
+  ],
+  [
+    "release",
+    [
+      rawSnapshotTask(100_000),
+      rawSnapshotTask(1_000_000),
+      rawSnapshotTask(10_000_000),
+      rawPredicateIndexTask(100_000),
+      rawPredicateIndexTask(1_000_000),
+      rawPredicateIndexTask(10_000_000),
+      rawLiveFanoutTask("same-window", 100_000, 50),
+      rawLiveFanoutTask("ten-window", 100_000, 50),
+      rawLiveFanoutTask("same-window", 1_000_000, 250),
+      rawLiveFanoutTask("ten-window", 1_000_000, 250),
+      reactInMemoryTask("chromium", 10_000),
+      reactInMemoryTask("firefox", 10_000),
+      reactInMemoryTask("webkit", 10_000),
+    ],
+  ],
+]);
+
+const isBenchmarkEnvironmentKey = (key) =>
+  key === "VIEW_SERVER_BENCH_BASELINE_PROFILE" ||
+  key.startsWith("VIEW_SERVER_ENGINE_BENCH_") ||
+  key.startsWith("VIEW_SERVER_REACT_BENCH_") ||
+  key.startsWith("VITE_VIEW_SERVER_REACT_BENCH_");
+
+const cleanParentEnvironment = () =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !isBenchmarkEnvironmentKey(key)),
+  );
+
+const exitCodeForSignal = (signal) => {
+  const signalNumber = osConstants.signals[signal];
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+};
+
+let activeChild;
+let terminatingExitCode;
+
+const childIsRunning = (child) => child.exitCode === null && child.signalCode === null;
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    terminatingExitCode ??= exitCodeForSignal(signal);
+    if (activeChild !== undefined && childIsRunning(activeChild)) {
+      activeChild.kill(signal);
+      return;
+    }
+    process.exit(terminatingExitCode);
+  });
+}
+
+const runTask = (currentTask) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(currentTask.command, currentTask.args, {
+      env: {
+        ...parentEnvironment,
+        ...currentTask.env,
+      },
+      stdio: "inherit",
+    });
+    activeChild = child;
+
+    const clearActiveChild = () => {
+      if (activeChild === child) {
+        activeChild = undefined;
+      }
+    };
+
+    child.once("error", (error) => {
+      clearActiveChild();
+      reject(error);
+    });
+    child.once("close", (status, signal) => {
+      clearActiveChild();
+      if (terminatingExitCode !== undefined) {
+        resolve(terminatingExitCode);
+        return;
+      }
+      if (signal !== null) {
+        resolve(exitCodeForSignal(signal));
+        return;
+      }
+      resolve(status ?? 1);
+    });
+  });
+
+const profileArgument = process.argv.find((argument) => argument.startsWith("--profile="));
+const requestedProfile =
+  profileArgument?.slice("--profile=".length) ??
+  process.env["VIEW_SERVER_BENCH_BASELINE_PROFILE"] ??
+  "smoke";
+const tasks = profiles.get(requestedProfile);
+const parentEnvironment = cleanParentEnvironment();
+
+if (tasks === undefined) {
+  console.error(
+    [
+      `Unknown benchmark baseline profile: ${requestedProfile}`,
+      `Available profiles: ${[...profiles.keys()].join(", ")}`,
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+console.log(`Running ${requestedProfile} benchmark baseline serially (${tasks.length} tasks).`);
+
+for (const [index, currentTask] of tasks.entries()) {
+  const taskNumber = index + 1;
+  const startedAt = process.hrtime.bigint();
+  console.log(`\n[${taskNumber}/${tasks.length}] ${currentTask.label}`);
+  const exitCode = await runTask(currentTask);
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+  const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+  console.log(`[${taskNumber}/${tasks.length}] completed in ${elapsedMs.toFixed(0)}ms`);
+}
+
+console.log(`\n${requestedProfile} benchmark baseline completed.`);


### PR DESCRIPTION
## Summary
- add a root serial benchmark baseline runner with smoke and release profiles
- run each Vitest benchmark in a separate process with benchmark env scrubbing
- document the preferred smoke/release baseline workflow

## Validation
- node --check scripts/run-benchmark-baseline.mjs
- node scripts/run-benchmark-baseline.mjs --profile=unknown
- signal-forwarding trap test: parent exits 143 when child traps SIGTERM and exits 0
- pnpm run bench:baseline
- sidecar benchmark summaries checked for zero cleanup/backpressure leaks
- git diff --check
- pnpm run ready

## Review
- 3 local review agents checked the runner; blocker findings were fixed before this PR
