### PR TITLE
Add schema-specialized topic column vectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 
 - Avoid O(n^2) hot paths unless benchmarked and justified.
 - Prefer indexed lookup/maps over repeated scans when memory tradeoffs are acceptable.
+- Benchmark write paths when adding read-path indexes, vectors, caches, or materialized state. A faster read path that destroys publish/patch/delete throughput is not a win.
 - Do not clone or materialize per subscriber when work can be shared by topic/query/window/plan.
 - Hot paths should avoid unnecessary allocations, schema decoding, object spreading, and health snapshots.
 - Health counters should update cheaply and publish at a bounded cadence.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,6 +70,10 @@ _Avoid_: chDB replacement, database adapter, query helper
 The per-topic storage and mutation unit behind a View Server Topic; it is expected to become column-oriented as performance work deepens.
 _Avoid_: Map wrapper, row array, topic state bag
 
+**Topic Column Vector**:
+The schema-derived per-field storage inside a Columnar Topic Store. A Topic Column Vector may use a specialized representation such as a numeric typed array or a generic object array, but callers interact through the Columnar Topic Store.
+_Avoid_: Public column API, typed-array contract
+
 **Active Query**:
 The engine-side representation of a compiled Live Query that can evaluate snapshots and deltas and may be shared by equivalent subscriptions.
 _Avoid_: Query object, filter function
@@ -180,6 +184,7 @@ _Avoid_: Browser write, send, emit
 - A **Grouped Query** returns group fields plus aggregate aliases.
 - A **Subscription** belongs to one **Live Query** and emits one **Snapshot** followed by zero or more **Deltas** and **Status Events**.
 - A **Column Live View Engine** owns one **Columnar Topic Store** per **View Server Topic**.
+- A **Columnar Topic Store** owns one **Topic Column Vector** per configured Topic Row field.
 - A **Runtime Core** owns one **Column Live View Engine** instance and exposes both a **Runtime Client** and a **Live Client**.
 - A **Raw Query Plan** is compiled once from a **Raw Query** before the **Columnar Topic Store** scans rows.
 - A **Raw Predicate Plan** is part of a **Raw Query Plan** and lets storage narrow scans without replacing the correctness callback unless it is proven exact.

--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -19,6 +19,7 @@
     "bench:raw-live-fanout:ten-window": "sh -c 'output=.artifacts/raw-live-fanout-ten-window-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows-${VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS:-50}subs.json; VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE=ten-window VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-live-fanout.bench.ts --run --testTimeout 0 --outputJson $output'",
     "bench:raw-predicate-index": "sh -c 'output=.artifacts/raw-predicate-index-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows.json; VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-predicate-index.bench.ts --run --testTimeout 0 --outputJson $output'",
     "bench:raw-snapshot": "sh -c 'output=.artifacts/raw-snapshot-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows.json; VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-snapshot.bench.ts --run --testTimeout 0 --outputJson $output'",
+    "bench:raw-write": "sh -c 'output=.artifacts/raw-write-${VIEW_SERVER_ENGINE_BENCH_WRITE_MODE:-indexed}-${VIEW_SERVER_ENGINE_BENCH_ROWS:-100000}rows.json; VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON=$output vp test bench src/raw-write.bench.ts --run --testTimeout 0 --outputJson $output'",
     "test": "vp test run --coverage --typecheck"
   },
   "dependencies": {

--- a/packages/column-live-view-engine/src/benchmark-artifact.ts
+++ b/packages/column-live-view-engine/src/benchmark-artifact.ts
@@ -47,7 +47,8 @@ export type BenchmarkArtifactInput = {
   readonly benchmarkScope:
     | "engine-raw-snapshot"
     | "engine-raw-predicate-index"
-    | "engine-raw-live-fanout";
+    | "engine-raw-live-fanout"
+    | "engine-raw-write";
   readonly rowCount: number;
   readonly mutationCount: number;
   readonly subscriberCount: number;

--- a/packages/column-live-view-engine/src/columnar-topic-store.ts
+++ b/packages/column-live-view-engine/src/columnar-topic-store.ts
@@ -10,6 +10,7 @@ import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-win
 import type { OrderedSlotIndex } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { fieldValue } from "./row-values";
+import { createTopicColumnValues, type MutableTopicColumnValues } from "./topic-column-vector";
 import {
   addSlotToScalarPredicateIndexes,
   createScalarPredicateIndexes,
@@ -31,15 +32,13 @@ import {
 
 type RowObject = object;
 
-type ColumnValues = Array<unknown>;
-
 export class ColumnarTopicStore {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly readModel: ActiveQueryStoreState;
 
   private readonly slots: Array<TopicRowEntry<object>> = [];
   private readonly keyToSlot = new Map<string, number>();
-  private readonly columns = new Map<string, ColumnValues>();
+  private readonly columns = new Map<string, MutableTopicColumnValues>();
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
   private readonly scalarPredicateIndexes = createScalarPredicateIndexes();
   private readonly rowChangeJournal = new TopicRowChangeJournal<object>();
@@ -67,7 +66,7 @@ export class ColumnarTopicStore {
       topic,
     };
     for (const field of this.rawQueryMetadata.fieldNames) {
-      this.columns.set(field, []);
+      this.columns.set(field, createTopicColumnValues(field, this.rawQueryMetadata));
     }
     this.readModel = {
       activeQueries: createActiveQueryRegistry(),
@@ -102,7 +101,7 @@ export class ColumnarTopicStore {
     this.scalarPredicateIndexes.clear();
     this.rowChangeJournal.clear(this.versionValue);
     for (const column of this.columns.values()) {
-      column.length = 0;
+      column.clear();
     }
     this.versionValue = 0;
   }
@@ -166,7 +165,7 @@ export class ColumnarTopicStore {
       this.slots[slot] = lastEntry;
       this.keyToSlot.set(lastEntry.key, slot);
       for (const column of this.columns.values()) {
-        column[slot] = column[lastSlot];
+        column.copySlot(slot, lastSlot);
       }
       this.addSlotToScalarIndexes(slot);
     }
@@ -237,7 +236,7 @@ export class ColumnarTopicStore {
       row: prepared.row,
     };
     for (const [field, column] of this.columns) {
-      column[slot] = fieldValue(prepared.row, field);
+      column.set(slot, fieldValue(prepared.row, field));
     }
   }
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -45,9 +45,17 @@ import { cloneRecord, cloneRow, fieldValue, rowsEqual, scalarEqualityKey } from 
 import type { TopicRowChangeBatch } from "./row-scan";
 import { scanTopicRawWindow } from "./topic-raw-window-scanner";
 import {
+  addSlotToScalarPredicateIndexes,
   createScalarPredicateIndexes,
+  removeSlotFromScalarPredicateIndexes,
   selectedPredicateCandidateSlots,
 } from "./topic-predicate-candidate-index";
+import {
+  columnValue,
+  createTopicColumnValues,
+  createTopicColumnValuesFromArray,
+  type TopicColumnValues,
+} from "./topic-column-vector";
 import {
   acquireTopicStoreSubscription,
   closeBackpressuredTopicStoreSubscription,
@@ -220,6 +228,78 @@ const rowField = (row: object, field: string): unknown => {
 
 const rowIds = (rows: ReadonlyArray<object>): ReadonlyArray<unknown> =>
   rows.map((row) => rowField(row, "id"));
+
+const makeColumns = (
+  metadata: ReturnType<typeof rawQueryCompilerMetadata>,
+  entries: ReadonlyArray<readonly [string, ReadonlyArray<unknown>]>,
+): Map<string, TopicColumnValues> => {
+  const columns = new Map<string, TopicColumnValues>();
+  for (const [field, values] of entries) {
+    columns.set(field, createTopicColumnValuesFromArray(field, metadata, values));
+  }
+  return columns;
+};
+
+it("derives topic column vectors from schema metadata and preserves slot mutation semantics", () => {
+  const Metric = Schema.Struct({
+    finitePrice: Schema.Finite,
+    id: Schema.String,
+    optionalPrice: Schema.optionalKey(Schema.Number),
+    price: Schema.Number,
+    quantity: Schema.BigInt,
+    status: Schema.String,
+  });
+  const metadata = rawQueryCompilerMetadata(Metric);
+
+  const price = createTopicColumnValues("price", metadata);
+  const finitePrice = createTopicColumnValues("finitePrice", metadata);
+  price.set(20, 42);
+  price.set(21, undefined);
+  price.copySlot(0, 20);
+  price.copySlot(1, 21);
+  price.copySlot(24, 20);
+  price.pop();
+
+  expect(price.kind).toBe("number");
+  expect(finitePrice.kind).toBe("number");
+  expect(price.length).toBe(24);
+  expect(columnValue(price, 0)).toBe(42);
+  expect(columnValue(price, 1)).toBeUndefined();
+  expect(columnValue(price, 23)).toBeUndefined();
+  expect(columnValue(price, 24)).toBeUndefined();
+  expect(columnValue(price, -1)).toBeUndefined();
+
+  price.clear();
+  price.copySlot(2, 99);
+  expect(price.length).toBe(3);
+  expect(columnValue(price, 2)).toBeUndefined();
+
+  price.clear();
+  price.pop();
+  expect(price.length).toBe(0);
+
+  const status = createTopicColumnValues("status", metadata);
+  status.set(0, "open");
+  status.set(1, { structured: true });
+  status.copySlot(0, 1);
+  status.pop();
+
+  expect(status.kind).toBe("generic");
+  expect(status.length).toBe(1);
+  expect(columnValue(status, 0)).toStrictEqual({ structured: true });
+
+  status.clear();
+  expect(status.length).toBe(0);
+
+  const optionalPrice = createTopicColumnValuesFromArray("optionalPrice", metadata, [1, undefined]);
+  const quantity = createTopicColumnValuesFromArray("quantity", metadata, [1n, 2n]);
+
+  expect(optionalPrice.kind).toBe("number");
+  expect(quantity.kind).toBe("generic");
+  expect(columnValue(optionalPrice, 0)).toBe(1);
+  expect(columnValue(optionalPrice, 1)).toBeUndefined();
+  expect(columnValue(quantity, 0)).toBe(1n);
+});
 
 const numericRowField = (row: object, field: string): number => {
   const value = fieldValue(row, field);
@@ -6737,17 +6817,23 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         row: second,
       },
     ];
+    const metadata = rawQueryCompilerMetadata(Order);
     const state = {
-      columns: new Map<string, ReadonlyArray<unknown>>([
+      columns: makeColumns(metadata, [
         ["id", [first.id, second.id]],
         ["price", [first.price, second.price]],
         ["status", [first.status, second.status]],
       ]),
       orderedSlotIndexes: new Map(),
-      rawQueryMetadata: rawQueryCompilerMetadata(Order),
+      rawQueryMetadata: metadata,
       scalarPredicateIndexes: createScalarPredicateIndexes(),
       slots,
     };
+
+    const priceColumn = state.columns.get("price")!;
+    const statusColumn = state.columns.get("status")!;
+    expect(priceColumn.kind).toBe("number");
+    expect(statusColumn.kind).toBe("generic");
 
     const warmRangeIndex = scanTopicRawWindow(state, {
       predicate: {
@@ -6842,17 +6928,21 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       key: row.id,
       row,
     }));
+    const metadata = rawQueryCompilerMetadata(Position);
     const state = {
-      columns: new Map<string, ReadonlyArray<unknown>>([
+      columns: makeColumns(metadata, [
         ["id", rows.map((row) => row.id)],
         ["symbol", rows.map((row) => row.symbol)],
         ["quantity", rows.map((row) => row.quantity)],
       ]),
       orderedSlotIndexes: new Map(),
-      rawQueryMetadata: rawQueryCompilerMetadata(Position),
+      rawQueryMetadata: metadata,
       scalarPredicateIndexes: createScalarPredicateIndexes(),
       slots,
     };
+
+    const quantityColumn = state.columns.get("quantity")!;
+    expect(quantityColumn.kind).toBe("generic");
 
     const boundedReplacement = scanTopicRawWindow(state, {
       predicate: {
@@ -7023,16 +7113,32 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     expect(symbolIndex.buckets.has("string:4:NVDA")).toBe(false);
   });
 
+  it("skips scalar index maintenance when an indexed field is absent from stored columns", () => {
+    const scalarPredicateIndexes = createScalarPredicateIndexes();
+    scalarPredicateIndexes.set("missing", {
+      buckets: new Map([["string:4:open", new Set([0])]]),
+      indexedKeys: new Set(["string:4:open"]),
+    });
+
+    addSlotToScalarPredicateIndexes(scalarPredicateIndexes, new Map(), 0);
+    removeSlotFromScalarPredicateIndexes(scalarPredicateIndexes, new Map(), 0);
+
+    const missingIndex = scalarPredicateIndexes.get("missing")!;
+    const openBucket = missingIndex.buckets.get("string:4:open")!;
+    expect(openBucket.has(0)).toBe(true);
+  });
+
   it("rejects exact candidates that are not smaller than their scan budget", () => {
     const rows = [order("a", "open", 1, 1), order("b", "closed", 2, 2), order("c", "open", 3, 3)];
+    const metadata = rawQueryCompilerMetadata(Order);
     const state = {
-      columns: new Map<string, ReadonlyArray<unknown>>([
+      columns: makeColumns(metadata, [
         ["id", rows.map((row) => row.id)],
         ["price", rows.map((row) => row.price)],
         ["status", [rows[0]!.status, rows[1]!.status, { nonScalar: true }]],
       ]),
       orderedSlotIndexes: new Map(),
-      rawQueryMetadata: rawQueryCompilerMetadata(Order),
+      rawQueryMetadata: metadata,
       scalarPredicateIndexes: createScalarPredicateIndexes(),
       slots: rows.map((row) => ({
         key: row.id,

--- a/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
@@ -17,6 +17,7 @@ import {
   selectedPredicateCandidateSlots,
 } from "./topic-predicate-candidate-index";
 import { scanTopicRawWindow, type TopicRawWindowScanState } from "./topic-raw-window-scanner";
+import { createTopicColumnValuesFromArray, type TopicColumnValues } from "./topic-column-vector";
 
 declare const process: {
   readonly env: Record<string, string | undefined>;
@@ -217,6 +218,17 @@ const rowPriceInUpperTail = (row: object): boolean => {
 
 const resetCounter = (counter: RowCallbackCounter): void => {
   counter.count = 0;
+};
+
+const makeColumns = (
+  metadata: ReturnType<typeof rawQueryCompilerMetadata>,
+  entries: ReadonlyArray<readonly [string, ReadonlyArray<unknown>]>,
+): Map<string, TopicColumnValues> => {
+  const columns = new Map<string, TopicColumnValues>();
+  for (const [field, values] of entries) {
+    columns.set(field, createTopicColumnValuesFromArray(field, metadata, values));
+  }
+  return columns;
 };
 
 const orderKeysFromRange = (startInclusive: number, endExclusive: number): ReadonlyArray<string> =>
@@ -519,8 +531,9 @@ beforeAll(() => {
     key: row.id,
     row,
   }));
+  const metadata = rawQueryCompilerMetadata(Order);
   const state: TopicRawWindowScanState = {
-    columns: new Map<string, ReadonlyArray<unknown>>([
+    columns: makeColumns(metadata, [
       ["id", rows.map((row) => row.id)],
       ["customerId", rows.map((row) => row.customerId)],
       ["status", rows.map((row) => row.status)],
@@ -529,7 +542,7 @@ beforeAll(() => {
       ["updatedAt", rows.map((row) => row.updatedAt)],
     ]),
     orderedSlotIndexes: new Map(),
-    rawQueryMetadata: rawQueryCompilerMetadata(Order),
+    rawQueryMetadata: metadata,
     scalarPredicateIndexes: createScalarPredicateIndexes(),
     slots,
   };

--- a/packages/column-live-view-engine/src/raw-query-metadata.ts
+++ b/packages/column-live-view-engine/src/raw-query-metadata.ts
@@ -15,6 +15,7 @@ export type RawQueryCompilerMetadata = {
   readonly structuredObjectFieldNames: ReadonlySet<string>;
   readonly stringFieldNames: ReadonlySet<string>;
   readonly numericFieldNames: ReadonlySet<string>;
+  readonly numberFieldNames: ReadonlySet<string>;
   readonly bigintFieldNames: ReadonlySet<string>;
   readonly rangeValueKinds: ReadonlyMap<string, ReadonlySet<RangeValueKind>>;
 };
@@ -66,6 +67,16 @@ const rangeValueKindsAst = (ast: SchemaAST.AST): ReadonlySet<RangeValueKind> => 
   return kinds;
 };
 
+const isPureNumberAst = (ast: SchemaAST.AST): boolean => {
+  if (SchemaAST.isNumber(ast)) {
+    return true;
+  }
+  if (SchemaAST.isLiteral(ast)) {
+    return typeof ast.literal === "number";
+  }
+  return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isPureNumberAst);
+};
+
 const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
   isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
 
@@ -91,6 +102,22 @@ const schemaNumericFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<st
   const fields = new Set<string>();
   for (const [field, fieldSchema] of Object.entries(schema.fields)) {
     if (!viewServerSchemaFieldMetadata(fieldSchema).isNumeric) {
+      continue;
+    }
+    fields.add(field);
+  }
+  return fields;
+};
+
+const schemaNumberFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    const ast = schemaAst(fieldSchema);
+    if (ast === undefined || !isPureNumberAst(ast)) {
       continue;
     }
     fields.add(field);
@@ -184,6 +211,7 @@ export const rawQueryCompilerMetadata = (
   structuredObjectFieldNames: schemaStructuredObjectFieldNames(schema),
   stringFieldNames: schemaStringFieldNames(schema),
   numericFieldNames: schemaNumericFieldNames(schema),
+  numberFieldNames: schemaNumberFieldNames(schema),
   bigintFieldNames: schemaBigintFieldNames(schema),
   rangeValueKinds: schemaRangeValueKinds(schema),
 });

--- a/packages/column-live-view-engine/src/raw-write.bench.ts
+++ b/packages/column-live-view-engine/src/raw-write.bench.ts
@@ -1,0 +1,396 @@
+// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+import { afterAll, beforeAll, bench, describe } from "vitest";
+import { defineViewServerConfig } from "@view-server/config";
+import { Effect, Schema } from "effect";
+import { createColumnLiveViewEngine, type ColumnLiveViewEngine } from "./index";
+import {
+  backpressureCountFromEngineHealth,
+  benchmarkOutputJsonPath,
+  cleanupLeakCountFromEngineHealth,
+  failOnBenchmarkCleanupLeaks,
+  memorySnapshot,
+  queuedEventCountFromEngineHealth,
+  writeBenchmarkArtifact,
+  type BenchmarkMemorySnapshot,
+} from "./benchmark-artifact";
+
+declare const process: {
+  readonly env: Record<string, string | undefined>;
+};
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Finite,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+type Engine = ColumnLiveViewEngine<Topics>;
+type OrderRow = typeof Order.Type;
+type OrderStatus = OrderRow["status"];
+type WriteMode = "base" | "indexed";
+
+type BenchmarkProfile = {
+  currentRowCount: number;
+  engine: Engine | undefined;
+  memoryAfterSetup: BenchmarkMemorySnapshot | undefined;
+  nextAppendIndex: number;
+  nextDeleteIndex: number;
+  nextPatchGeneration: number;
+  nextReplaceGeneration: number;
+  rowCount: number;
+};
+
+const defaultBatchSize = 1_000;
+const defaultBenchmarkTimeMs = 250;
+const defaultIterations = 5;
+const defaultRowCount = 100_000;
+const defaultWarmupIterations = 0;
+const defaultWarmupTimeMs = 0;
+const defaultWriteMode: WriteMode = "indexed";
+
+const positiveIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/u.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a positive integer.`);
+};
+
+const nonNegativeIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^(0|[1-9]\d*)$/u.test(trimmed)) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a non-negative integer.`);
+};
+
+const rowCountFromEnv = (): number => {
+  const raw = process.env["VIEW_SERVER_ENGINE_BENCH_ROWS"];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultRowCount;
+  }
+  if (raw.includes(",")) {
+    throw new Error("VIEW_SERVER_ENGINE_BENCH_ROWS accepts one row count per benchmark run.");
+  }
+  return positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ROWS", defaultRowCount);
+};
+
+const writeModeFromEnv = (): WriteMode => {
+  const raw = process.env["VIEW_SERVER_ENGINE_BENCH_WRITE_MODE"];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultWriteMode;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "base" || trimmed === "indexed") {
+    return trimmed;
+  }
+  throw new Error("VIEW_SERVER_ENGINE_BENCH_WRITE_MODE must be base or indexed.");
+};
+
+const benchmarkRowCount = rowCountFromEnv();
+const writeMode = writeModeFromEnv();
+const batchSize = positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE", defaultBatchSize);
+if (batchSize > benchmarkRowCount) {
+  throw new Error("VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE must be less than or equal to row count.");
+}
+const outputJsonPath = benchmarkOutputJsonPath(
+  `raw-write-${writeMode}-${benchmarkRowCount}rows.json`,
+);
+const memoryBefore = memorySnapshot();
+const benchOptions = {
+  iterations: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_ITERATIONS", defaultIterations),
+  time: positiveIntegerFromEnv("VIEW_SERVER_ENGINE_BENCH_TIME_MS", defaultBenchmarkTimeMs),
+  warmupIterations: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS",
+    defaultWarmupIterations,
+  ),
+  warmupTime: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS",
+    defaultWarmupTimeMs,
+  ),
+};
+if (benchOptions.warmupIterations > 0 || benchOptions.warmupTime > 0) {
+  throw new Error("Raw write benchmark mutates shared engine state; warmup must stay disabled.");
+}
+
+const profile: BenchmarkProfile = {
+  currentRowCount: benchmarkRowCount,
+  engine: undefined,
+  memoryAfterSetup: undefined,
+  nextAppendIndex: benchmarkRowCount,
+  nextDeleteIndex: 0,
+  nextPatchGeneration: 0,
+  nextReplaceGeneration: 0,
+  rowCount: benchmarkRowCount,
+};
+
+const orderStatus = (index: number): OrderStatus => {
+  if (index % 5 === 0) {
+    return "cancelled";
+  }
+  if (index % 3 === 0) {
+    return "closed";
+  }
+  return "open";
+};
+
+const region = (index: number): string => {
+  if (index % 7 === 0) {
+    return "apac";
+  }
+  if (index % 5 === 0) {
+    return "amer";
+  }
+  return "emea";
+};
+
+const benchmarkMutationCount = (): number =>
+  profile.rowCount +
+  (profile.nextAppendIndex - benchmarkRowCount) +
+  profile.nextReplaceGeneration * batchSize +
+  profile.nextPatchGeneration * batchSize +
+  profile.nextDeleteIndex * 2;
+
+const seedOrder = (index: number): OrderRow => ({
+  id: `order-${index}`,
+  customerId: `customer-${index % 100_000}`,
+  status: orderStatus(index),
+  price: index % 1_000_000,
+  region: region(index),
+  updatedAt: index,
+});
+
+const generatedOrder = (prefix: string, index: number, generation: number): OrderRow => ({
+  id: `${prefix}-${index}`,
+  customerId: `customer-${index % 100_000}`,
+  status: orderStatus(index + generation),
+  price: (index + generation) % 1_000_000,
+  region: region(index + generation),
+  updatedAt: 1_000_000_000 + generation + index,
+});
+
+const writeBatch = (
+  prefix: string,
+  startIndex: number,
+  generation: number,
+): ReadonlyArray<OrderRow> =>
+  Array.from({ length: batchSize }, (_value, offset) =>
+    generatedOrder(prefix, startIndex + offset, generation),
+  );
+
+const seedEngine = Effect.fn("ColumnLiveViewEngine.bench.rawWrite.seed")(function* (
+  engine: Engine,
+  rowCount: number,
+) {
+  let next = 0;
+  while (next < rowCount) {
+    const count = Math.min(batchSize, rowCount - next);
+    const rows = Array.from({ length: count }, (_value, offset) => seedOrder(next + offset));
+    yield* engine.publishMany("orders", rows);
+    next += count;
+  }
+});
+
+const warmReadPathState = Effect.fn("ColumnLiveViewEngine.bench.rawWrite.warmReadPathState")(
+  function* (engine: Engine) {
+    const select = ["id", "customerId", "price", "status", "updatedAt"] as const;
+    yield* engine.snapshot("orders", {
+      select,
+      where: {
+        customerId: { eq: "customer-1" },
+      },
+      limit: 50,
+    });
+    yield* engine.snapshot("orders", {
+      select,
+      where: {
+        status: { eq: "open" },
+      },
+      limit: 50,
+    });
+    yield* engine.snapshot("orders", {
+      select,
+      where: {
+        price: { gte: 0 },
+        status: { eq: "open" },
+      },
+      orderBy: [{ field: "price", direction: "asc" }],
+      limit: 50,
+    });
+  },
+);
+
+const prepareWriteMode = Effect.fn("ColumnLiveViewEngine.bench.rawWrite.prepareWriteMode")(
+  function* (engine: Engine, mode: WriteMode) {
+    if (mode === "indexed") {
+      yield* warmReadPathState(engine);
+    }
+  },
+);
+
+const profileEngine = (profile: BenchmarkProfile): Engine => {
+  if (profile.engine === undefined) {
+    throw new Error(`Raw write benchmark profile ${profile.rowCount} rows is not initialized.`);
+  }
+  return profile.engine;
+};
+
+beforeAll(async () => {
+  const engine = Effect.runSync(createColumnLiveViewEngine({ topics: viewServer.topics }));
+  await Effect.runPromise(seedEngine(engine, profile.rowCount));
+  await Effect.runPromise(prepareWriteMode(engine, writeMode));
+  profile.engine = engine;
+  profile.memoryAfterSetup = memorySnapshot();
+}, 0);
+
+afterAll(async () => {
+  const memoryAfterSetup = profile.memoryAfterSetup ?? memoryBefore;
+  let health: unknown = {
+    status: "not-started",
+  };
+  if (profile.engine !== undefined) {
+    health = await Effect.runPromise(profile.engine.health());
+    await Effect.runPromise(profile.engine.close());
+    profile.engine = undefined;
+  }
+  profile.memoryAfterSetup = undefined;
+  const memoryAfterBenchmark = memorySnapshot();
+  const cleanupLeakCount = cleanupLeakCountFromEngineHealth(health);
+  writeBenchmarkArtifact({
+    artifactKind: "engine-benchmark-summary",
+    backpressureCount: backpressureCountFromEngineHealth(health),
+    benchmarkCases: [
+      "publish append single row",
+      "publishMany append batch",
+      "publishMany replace existing batch",
+      "patch existing rows one by one",
+      "append then delete batch",
+    ],
+    benchmarkName: `raw write engine benchmark (${writeMode})`,
+    benchmarkScope: "engine-raw-write",
+    cleanupLeakCount,
+    health,
+    latency: {
+      outputJsonPath,
+      source: "vitest-output-json",
+    },
+    memoryAfterBenchmark,
+    memoryAfterSetup,
+    memoryBefore,
+    mutationCount: benchmarkMutationCount(),
+    notes: [
+      "Latency percentiles are emitted by Vitest in outputJsonPath.",
+      writeMode === "indexed"
+        ? "Indexed write mode pre-warms scalar predicate buckets and one ordered raw window index before timed writes. Single-row appends pay ordered-index insertion cost; batch writes measure scalar maintenance plus the current ordered-index invalidation/clear behavior."
+        : "Base write mode measures decoded engine writes without pre-warmed read-path indexes.",
+      `Seed row count: ${profile.rowCount}. Final tracked row count: ${profile.currentRowCount}.`,
+    ],
+    outputJsonPath,
+    queuedEventCount: queuedEventCountFromEngineHealth(health),
+    rowCount: profile.rowCount,
+    subscriberCount: 0,
+    topics: ["orders"],
+  });
+  failOnBenchmarkCleanupLeaks(cleanupLeakCount);
+}, 0);
+
+describe(`raw write engine benchmark: ${profile.rowCount} rows`, () => {
+  bench(
+    "publish append single row",
+    async () => {
+      const engine = profileEngine(profile);
+      const index = profile.nextAppendIndex;
+      profile.nextAppendIndex += 1;
+      profile.currentRowCount += 1;
+      await Effect.runPromise(
+        engine.publish("orders", generatedOrder("single-append", index, index)),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
+    "publishMany append batch",
+    async () => {
+      const engine = profileEngine(profile);
+      const rows = writeBatch("append", profile.nextAppendIndex, profile.nextAppendIndex);
+      profile.nextAppendIndex += batchSize;
+      profile.currentRowCount += batchSize;
+      await Effect.runPromise(engine.publishMany("orders", rows));
+    },
+    benchOptions,
+  );
+
+  bench(
+    "publishMany replace existing batch",
+    async () => {
+      const engine = profileEngine(profile);
+      const rows = writeBatch("order", 0, profile.nextReplaceGeneration);
+      profile.nextReplaceGeneration += 1;
+      await Effect.runPromise(engine.publishMany("orders", rows));
+    },
+    benchOptions,
+  );
+
+  bench(
+    "patch existing rows one by one",
+    async () => {
+      const engine = profileEngine(profile);
+      const generation = profile.nextPatchGeneration;
+      profile.nextPatchGeneration += 1;
+      for (let offset = 0; offset < batchSize; offset += 1) {
+        await Effect.runPromise(
+          engine.patch("orders", `order-${offset}`, {
+            price: generation + offset,
+            updatedAt: 2_000_000_000 + generation + offset,
+          }),
+        );
+      }
+    },
+    benchOptions,
+  );
+
+  bench(
+    "append then delete batch",
+    async () => {
+      const engine = profileEngine(profile);
+      const startIndex = profile.nextDeleteIndex;
+      const rows = writeBatch("delete", startIndex, startIndex);
+      profile.nextDeleteIndex += batchSize;
+      await Effect.runPromise(engine.publishMany("orders", rows));
+      for (const row of rows) {
+        await Effect.runPromise(engine.delete("orders", row.id));
+      }
+    },
+    benchOptions,
+  );
+});

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -1,0 +1,141 @@
+import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+
+export type TopicColumnKind = "generic" | "number";
+
+export type TopicColumnValues = {
+  readonly kind: TopicColumnKind;
+  readonly length: number;
+  get(slot: number): unknown;
+};
+
+export type MutableTopicColumnValues = TopicColumnValues & {
+  clear(): void;
+  copySlot(targetSlot: number, sourceSlot: number): void;
+  pop(): void;
+  set(slot: number, value: unknown): void;
+};
+
+class GenericTopicColumn implements MutableTopicColumnValues {
+  readonly kind = "generic";
+  private readonly values: Array<unknown> = [];
+
+  get length(): number {
+    return this.values.length;
+  }
+
+  get(slot: number): unknown {
+    return this.values[slot];
+  }
+
+  set(slot: number, value: unknown): void {
+    this.values[slot] = value;
+  }
+
+  copySlot(targetSlot: number, sourceSlot: number): void {
+    this.values[targetSlot] = this.values[sourceSlot];
+  }
+
+  pop(): void {
+    this.values.pop();
+  }
+
+  clear(): void {
+    this.values.length = 0;
+  }
+}
+
+class NumberTopicColumn implements MutableTopicColumnValues {
+  readonly kind = "number";
+  private values = new Float64Array(0);
+  private validity = new Uint8Array(0);
+  private lengthValue = 0;
+
+  get length(): number {
+    return this.lengthValue;
+  }
+
+  get(slot: number): unknown {
+    if (slot < 0 || slot >= this.lengthValue || this.validity[slot] !== 1) {
+      return undefined;
+    }
+    return this.values[slot];
+  }
+
+  set(slot: number, value: unknown): void {
+    this.ensureCapacity(slot + 1);
+    if (slot >= this.lengthValue) {
+      this.lengthValue = slot + 1;
+    }
+    if (typeof value === "number") {
+      this.values[slot] = value;
+      this.validity[slot] = 1;
+      return;
+    }
+    this.values[slot] = 0;
+    this.validity[slot] = 0;
+  }
+
+  copySlot(targetSlot: number, sourceSlot: number): void {
+    this.ensureCapacity(targetSlot + 1);
+    if (targetSlot >= this.lengthValue) {
+      this.lengthValue = targetSlot + 1;
+    }
+    this.values[targetSlot] = this.values[sourceSlot] ?? 0;
+    this.validity[targetSlot] = this.validity[sourceSlot] ?? 0;
+  }
+
+  pop(): void {
+    if (this.lengthValue === 0) {
+      return;
+    }
+    this.lengthValue -= 1;
+    this.values[this.lengthValue] = 0;
+    this.validity[this.lengthValue] = 0;
+  }
+
+  clear(): void {
+    this.values = new Float64Array(0);
+    this.validity = new Uint8Array(0);
+    this.lengthValue = 0;
+  }
+
+  private ensureCapacity(minimumCapacity: number): void {
+    if (minimumCapacity <= this.values.length) {
+      return;
+    }
+    let nextCapacity = Math.max(16, this.values.length * 2);
+    while (nextCapacity < minimumCapacity) {
+      nextCapacity *= 2;
+    }
+    const nextValues = new Float64Array(nextCapacity);
+    nextValues.set(this.values);
+    const nextValidity = new Uint8Array(nextCapacity);
+    nextValidity.set(this.validity);
+    this.values = nextValues;
+    this.validity = nextValidity;
+  }
+}
+
+export const columnValue = (column: TopicColumnValues, slot: number): unknown => column.get(slot);
+
+export const createTopicColumnValues = (
+  field: string,
+  metadata: RawQueryCompilerMetadata,
+): MutableTopicColumnValues => {
+  if (metadata.numberFieldNames.has(field)) {
+    return new NumberTopicColumn();
+  }
+  return new GenericTopicColumn();
+};
+
+export const createTopicColumnValuesFromArray = (
+  field: string,
+  metadata: RawQueryCompilerMetadata,
+  values: ReadonlyArray<unknown>,
+): TopicColumnValues => {
+  const column = createTopicColumnValues(field, metadata);
+  for (let slot = 0; slot < values.length; slot += 1) {
+    column.set(slot, values[slot]);
+  }
+  return column;
+};

--- a/packages/column-live-view-engine/src/topic-ordered-window.ts
+++ b/packages/column-live-view-engine/src/topic-ordered-window.ts
@@ -6,8 +6,7 @@ import {
   type RawQueryCompilerMetadata,
 } from "./raw-query-compiler";
 import { scalarEqualityKey } from "./row-values";
-
-type ColumnValues = ReadonlyArray<unknown>;
+import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 
 export type OrderedSlotIndex = {
   readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
@@ -223,7 +222,7 @@ export const rangeBoundsAreEmpty = (bounds: OrderedRangeBounds): boolean => {
 
 export const orderedSlotBoundIndex = (
   slots: ReadonlyArray<number>,
-  column: ColumnValues,
+  column: TopicColumnValues,
   value: unknown,
   predicate: (comparison: number) => boolean,
 ): number => {
@@ -231,7 +230,7 @@ export const orderedSlotBoundIndex = (
   let high = slots.length;
   while (low < high) {
     const middle = Math.floor((low + high) / 2);
-    const comparison = compareOrderedRangeValue(column[slots[middle]!], value);
+    const comparison = compareOrderedRangeValue(columnValue(column, slots[middle]!), value);
     if (predicate(comparison)) {
       high = middle;
     } else {

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-index.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-index.ts
@@ -10,8 +10,7 @@ import {
   rangeBoundsAreEmpty,
 } from "./topic-ordered-window";
 import { scalarEqualityKey } from "./row-values";
-
-type ColumnValues = ReadonlyArray<unknown>;
+import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 
 type RangePredicateFilter = TopicRawPredicateFilterPlan & {
   readonly operator: "gt" | "gte" | "lt" | "lte";
@@ -43,7 +42,7 @@ export const createScalarPredicateIndexes = (): ScalarPredicateIndexes => new Ma
 
 export const addSlotToScalarPredicateIndexes = (
   indexes: ScalarPredicateIndexes,
-  columns: ReadonlyMap<string, ColumnValues>,
+  columns: ReadonlyMap<string, TopicColumnValues>,
   slot: number,
 ): void => {
   for (const [field, index] of indexes) {
@@ -53,7 +52,7 @@ export const addSlotToScalarPredicateIndexes = (
 
 export const removeSlotFromScalarPredicateIndexes = (
   indexes: ScalarPredicateIndexes,
-  columns: ReadonlyMap<string, ColumnValues>,
+  columns: ReadonlyMap<string, TopicColumnValues>,
   slot: number,
 ): void => {
   for (const [field, index] of indexes) {
@@ -189,7 +188,7 @@ const scalarPredicateIndexForField = (
 
 const unionScalarPredicateSlots = (
   index: ScalarPredicateFieldIndex,
-  column: ColumnValues,
+  column: TopicColumnValues,
   valueKeys: ReadonlyArray<string>,
   allowBucketBuild: boolean,
   maxSlotCount: number | undefined,
@@ -239,7 +238,7 @@ const unionScalarPredicateSlots = (
     missingBuckets.set(key, new Set());
   }
   for (let slot = 0; slot < column.length; slot += 1) {
-    const key = scalarEqualityKey(column[slot]);
+    const key = scalarEqualityKey(columnValue(column, slot));
     if (key === undefined) {
       continue;
     }
@@ -265,7 +264,7 @@ const unionScalarPredicateSlots = (
 
 const ensureScalarPredicateBucket = (
   index: ScalarPredicateFieldIndex,
-  column: ColumnValues,
+  column: TopicColumnValues,
   valueKey: string,
   allowBucketBuild: boolean,
   maxSlotCount: number | undefined,
@@ -279,7 +278,7 @@ const ensureScalarPredicateBucket = (
 
   const bucket = new Set<number>();
   for (let slot = 0; slot < column.length; slot += 1) {
-    if (scalarEqualityKey(column[slot]) !== valueKey) {
+    if (scalarEqualityKey(columnValue(column, slot)) !== valueKey) {
       continue;
     }
     bucket.add(slot);
@@ -345,10 +344,13 @@ const slotsFromOrderedSpans = (
 
 const addSlotToScalarPredicateIndex = (
   index: ScalarPredicateFieldIndex,
-  column: ColumnValues | undefined,
+  column: TopicColumnValues | undefined,
   slot: number,
 ): void => {
-  const key = scalarEqualityKey(column?.[slot]);
+  if (column === undefined) {
+    return;
+  }
+  const key = scalarEqualityKey(columnValue(column, slot));
   if (key === undefined || !index.indexedKeys.has(key)) {
     return;
   }
@@ -358,10 +360,13 @@ const addSlotToScalarPredicateIndex = (
 
 const removeSlotFromScalarPredicateIndex = (
   index: ScalarPredicateFieldIndex,
-  column: ColumnValues | undefined,
+  column: TopicColumnValues | undefined,
   slot: number,
 ): void => {
-  const key = scalarEqualityKey(column?.[slot]);
+  if (column === undefined) {
+    return;
+  }
+  const key = scalarEqualityKey(columnValue(column, slot));
   if (key === undefined || !index.indexedKeys.has(key)) {
     return;
   }

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -2,6 +2,7 @@ import { compareQueryValue } from "./query-value";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 import type { TopicRawOrderByPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
+import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 import {
   distinctOrderedEqualityValues,
   equalityValueSatisfiesRangeBounds,
@@ -20,9 +21,8 @@ import {
   type OrderedSlotIndex,
 } from "./topic-ordered-window";
 
-type ColumnValues = ReadonlyArray<unknown>;
 export type RawOrderedWindowIndexState = {
-  readonly columns: ReadonlyMap<string, ColumnValues>;
+  readonly columns: ReadonlyMap<string, TopicColumnValues>;
   readonly orderedSlotIndexes: Map<string, OrderedSlotIndex>;
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly slots: ReadonlyArray<TopicRowEntry<object>>;
@@ -154,7 +154,7 @@ const compareSlotsByStorageOrder = (
 ): number => {
   for (const order of storageOrderBy) {
     const column = state.columns.get(order.field)!;
-    const comparison = compareQueryValue(column[left], column[right]);
+    const comparison = compareQueryValue(columnValue(column, left), columnValue(column, right));
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -1,6 +1,7 @@
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
+import type { TopicColumnValues } from "./topic-column-vector";
 import {
   selectedPredicateCandidateSlots,
   type PredicateCandidateSlotIndexState,
@@ -19,11 +20,10 @@ import {
 } from "./topic-ordered-window";
 import { slotMatchesRawPredicatePlan } from "./topic-slot-predicate";
 
-type ColumnValues = ReadonlyArray<unknown>;
 type RowObject = object;
 
 export type TopicRawWindowScanState = {
-  readonly columns: ReadonlyMap<string, ColumnValues>;
+  readonly columns: ReadonlyMap<string, TopicColumnValues>;
   readonly orderedSlotIndexes: Map<string, OrderedSlotIndex>;
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly scalarPredicateIndexes: PredicateCandidateSlotIndexState["scalarPredicateIndexes"];

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -7,15 +7,15 @@ import {
   compareRangeColumnValue,
   isComparableRangeValue,
 } from "./topic-range-value";
+import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 
 type RowObject = object;
-type ColumnValues = ReadonlyArray<unknown>;
 
 export const slotMatchesRawPredicatePlan = <Row extends RowObject>(
   slot: number,
   plan: TopicRawWindowScanPlan<Row>,
   row: Row,
-  columns: ReadonlyMap<string, ColumnValues>,
+  columns: ReadonlyMap<string, TopicColumnValues>,
 ): boolean => {
   const exact = plan.predicate.callbackSkippable === true;
   if (!slotMayMatchFilters(slot, plan.predicate.filters, columns, exact)) {
@@ -27,7 +27,7 @@ export const slotMatchesRawPredicatePlan = <Row extends RowObject>(
 const slotMayMatchFilters = (
   slot: number,
   filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
-  columns: ReadonlyMap<string, ColumnValues>,
+  columns: ReadonlyMap<string, TopicColumnValues>,
   exact: boolean,
 ): boolean => {
   for (const filter of filters) {
@@ -41,14 +41,14 @@ const slotMayMatchFilters = (
 const slotMayMatchFilter = (
   slot: number,
   filter: TopicRawPredicateFilterPlan,
-  columns: ReadonlyMap<string, ColumnValues>,
+  columns: ReadonlyMap<string, TopicColumnValues>,
   exact: boolean,
 ): boolean => {
   const column = columns.get(filter.field);
   if (column === undefined) {
     return true;
   }
-  const value = column[slot];
+  const value = columnValue(column, slot);
 
   if (filter.operator === "eq") {
     return valuesEqual(value, filter.value);

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -763,6 +763,11 @@ ColumnLiveViewEngine
 
 The first implementation can be TypeScript/Node typed arrays. Prior prototypes showed typed arrays are credible for simplified raw filter/sort/top-k cases without indexes. Rust/native can remain a later acceleration path for projection/count/group-heavy paths if numbers require it.
 
+Schema specialization must measure both sides of the tradeoff. A Topic Column Vector or index can
+make Raw Query reads faster while adding publish/patch/delete maintenance cost. Every storage
+optimization that adds per-field state should have a matching write-path benchmark so read wins do
+not hide write regressions.
+
 ## Engine Subscribe Contract
 
 The engine should expose a direct subscription API independent of WebSockets:
@@ -1336,6 +1341,55 @@ Raw predicate index knobs:
 
 For decision-quality large-row runs, keep `--no-cache` and use multiple iterations. One-sample runs
 are useful only to verify feasibility and approximate scale.
+
+Current raw write benchmark harness:
+
+```bash
+vp run --no-cache column-live-view-engine#bench:raw-write
+```
+
+This harness uses Vitest `bench()` against the public `ColumnLiveViewEngine` mutation path. It seeds a
+single topic, optionally warms read-path indexes, then measures:
+
+- `publishMany` appends
+- single-row `publish` appends
+- `publishMany` replacements of existing rows
+- per-row `patch`
+- append followed by `delete`
+
+The benchmark exists to catch the other side of read optimization work: schema-specialized Topic
+Column Vectors, predicate indexes, ordered window indexes, and materialized state can improve reads
+while adding write maintenance cost. Treat raw-write results as part of the same decision as raw
+snapshot/predicate/fanout results.
+
+Run both modes when evaluating a storage change:
+
+- `base`: decoded engine writes without pre-warmed read-path indexes.
+- `indexed`: pre-warms scalar predicate buckets and one ordered Raw Window Index before timed writes.
+  Single-row appends pay ordered-index insertion cost; batch writes measure scalar predicate index
+  maintenance plus the current ordered-index invalidation/clear behavior.
+
+It writes `raw-write-<mode>-<rows>rows.json` plus a matching `.summary.json` sidecar. Run each mode
+and row count in a separate process:
+
+```bash
+VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=base VIEW_SERVER_ENGINE_BENCH_ROWS=100000 vp run --no-cache column-live-view-engine#bench:raw-write
+VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=indexed VIEW_SERVER_ENGINE_BENCH_ROWS=100000 vp run --no-cache column-live-view-engine#bench:raw-write
+VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=base VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 vp run --no-cache column-live-view-engine#bench:raw-write
+VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=indexed VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 vp run --no-cache column-live-view-engine#bench:raw-write
+VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=base VIEW_SERVER_ENGINE_BENCH_ROWS=10000000 vp run --no-cache column-live-view-engine#bench:raw-write
+VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=indexed VIEW_SERVER_ENGINE_BENCH_ROWS=10000000 vp run --no-cache column-live-view-engine#bench:raw-write
+```
+
+Raw write knobs:
+
+- `VIEW_SERVER_ENGINE_BENCH_WRITE_MODE`: `base` or `indexed`; defaults to `indexed`.
+- `VIEW_SERVER_ENGINE_BENCH_ROWS`: seeded row count for this benchmark process.
+- `VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE`: publish batch size while seeding and timed write batch size.
+- `VIEW_SERVER_ENGINE_BENCH_ITERATIONS`: benchmark iterations per case.
+- `VIEW_SERVER_ENGINE_BENCH_TIME_MS`: benchmark time budget per case.
+- `VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS`: must remain `0`; raw-write mutates shared engine state.
+- `VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS`: must remain `0`; raw-write mutates shared engine state.
 
 Current raw live fanout benchmark harness:
 

--- a/scripts/run-benchmark-baseline.mjs
+++ b/scripts/run-benchmark-baseline.mjs
@@ -38,6 +38,13 @@ const rawPredicateIndexTask = (rowCount, env = {}) =>
     },
   );
 
+const rawWriteTask = (writeMode, rowCount, env = {}) =>
+  task(`raw write ${writeMode} ${rowCount} rows`, "column-live-view-engine#bench:raw-write", {
+    VIEW_SERVER_ENGINE_BENCH_ROWS: String(rowCount),
+    VIEW_SERVER_ENGINE_BENCH_WRITE_MODE: writeMode,
+    ...env,
+  });
+
 const rawLiveFanoutTask = (fanoutCase, rowCount, subscriberCount, env = {}) =>
   task(
     `raw live fanout ${fanoutCase} ${rowCount} rows ${subscriberCount} subscribers`,
@@ -66,6 +73,14 @@ const profiles = new Map([
         ...commonEngineSmokeEnv,
       }),
       rawPredicateIndexTask(1_000, commonEngineSmokeEnv),
+      rawWriteTask("base", 1_000, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "100",
+        ...commonEngineSmokeEnv,
+      }),
+      rawWriteTask("indexed", 1_000, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "100",
+        ...commonEngineSmokeEnv,
+      }),
       rawLiveFanoutTask("same-window", 1_000, 5, {
         VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "500",
         ...commonEngineSmokeEnv,
@@ -89,6 +104,12 @@ const profiles = new Map([
       rawPredicateIndexTask(100_000),
       rawPredicateIndexTask(1_000_000),
       rawPredicateIndexTask(10_000_000),
+      rawWriteTask("base", 100_000),
+      rawWriteTask("indexed", 100_000),
+      rawWriteTask("base", 1_000_000),
+      rawWriteTask("indexed", 1_000_000),
+      rawWriteTask("base", 10_000_000),
+      rawWriteTask("indexed", 10_000_000),
       rawLiveFanoutTask("same-window", 100_000, 50),
       rawLiveFanoutTask("ten-window", 100_000, 50),
       rawLiveFanoutTask("same-window", 1_000_000, 250),


### PR DESCRIPTION
## Summary

- Add schema-derived Topic Column Vectors for column storage, with `number` fields backed by typed arrays and non-number fields kept generic.
- Route raw predicate scans, ordered windows, and scalar candidate indexes through the column vector interface.
- Add raw write benchmarks with `base` and `indexed` modes so read-path optimizations are evaluated against publish/patch/delete cost.
- Extend the serial benchmark baseline with raw-write base/indexed smoke tasks.
- Document the read/write tradeoff in AGENTS, CONTEXT, and the v2 plan.

## Benchmark Scope

`raw-write` now measures:

- single-row `publish` append, including hot ordered-index insertion in indexed mode
- `publishMany` append batch
- `publishMany` replacement batch
- per-row patch batch
- append followed by delete batch

Indexed mode pre-warms scalar predicate buckets and one ordered raw window index. Batch cases intentionally measure scalar maintenance plus the current ordered-index invalidation/clear behavior, not sustained ordered-index batch maintenance.

## Validation

- `pnpm --filter @view-server/column-live-view-engine exec tsc -p tsconfig.json --noEmit`
- `vp check --fix`
- `pnpm --filter @view-server/column-live-view-engine run test` (100% coverage)
- `VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=base ... vp run --no-cache column-live-view-engine#bench:raw-write`
- `VIEW_SERVER_ENGINE_BENCH_WRITE_MODE=indexed ... vp run --no-cache column-live-view-engine#bench:raw-write`
- `pnpm run bench:baseline`
- `pnpm run ready`

## Review

Three review agents did two rounds. Initial concern was benchmark overclaim around ordered-index write overhead. Fixed with a single-row hot-index append case, narrower artifact/docs wording, warmup guard, and explicit `Schema.Finite` vector coverage. Final reviewer verdict: no blockers.
