### PR TITLE
Cap broad predicate candidate materialization

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -7357,6 +7357,58 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     expect(rangeNotSmallerThanBudget).toBeUndefined();
   });
 
+  it("does not materialize broad scalar candidate buckets during raw scans", () => {
+    const openKey = scalarEqualityKey("open");
+    const rows = [
+      ...Array.from({ length: 100_001 }, (_value, index) =>
+        order(`open-${index}`, "open", index, index),
+      ),
+      order("closed-row", "closed", 0, 0),
+    ];
+    const metadata = rawQueryCompilerMetadata(Order);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+        ["status", rows.map((row) => row.status)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+
+    const result = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [
+          {
+            field: "status",
+            operator: "in",
+            values: ["open"],
+            valueKeys: new Set([openKey]),
+          },
+        ],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("broad exact scalar fallback should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: 1,
+    });
+
+    expect(result.keys).toStrictEqual(["open-0"]);
+    expect(result.totalRows).toBe(rows.length - 1);
+    expect(state.scalarPredicateIndexes.get("status")?.indexedKeys.has(openKey)).toBe(false);
+    expect(state.scalarPredicateIndexes.get("status")?.buckets.has(openKey)).toBe(false);
+  });
+
   it.effect("uses bigint range hints conservatively for manual plans", () =>
     Effect.gen(function* () {
       const store = new TopicStore("positions", Position, "id", () => {});

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -31,6 +31,8 @@ export type TopicRawWindowScanState = {
 };
 
 const maxBoundedRawWindowEnd = 1_024;
+const maxMaterializedPredicateCandidateSlots = 100_000;
+const materializedPredicateCandidateSlotBudget = maxMaterializedPredicateCandidateSlots + 1;
 
 export const scanTopicRawWindow = (
   state: TopicRawWindowScanState,
@@ -43,7 +45,7 @@ export const scanTopicRawWindow = (
       allowScalarIndexBuild: false,
       exactRangeCandidates: plan.predicate.callbackSkippable === true,
       excludedField: orderedWindow.candidateExcludedField,
-      maxSlotCount: orderedSlotCount,
+      maxSlotCount: Math.min(orderedSlotCount, materializedPredicateCandidateSlotBudget),
     });
     if (candidateSlots !== undefined && candidateSlots.slots.length < orderedSlotCount) {
       const compareSlots = rawWindowSlotComparator(state, plan)!;
@@ -58,7 +60,7 @@ export const scanTopicRawWindow = (
   const candidateSlots = selectedPredicateCandidateSlots(state, plan.predicate.filters, {
     allowScalarIndexBuild: true,
     exactRangeCandidates: plan.predicate.callbackSkippable === true,
-    maxSlotCount: state.slots.length,
+    maxSlotCount: Math.min(state.slots.length, materializedPredicateCandidateSlotBudget),
   });
   if (candidateSlots !== undefined) {
     return scanRawWindowCandidateSlots(state, plan, compareSlots, candidateSlots);

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1320,6 +1320,13 @@ benchmark. It compares:
 - ordered equality seek over storage order
 - failed broad scalar candidate build plus full scan
 
+Scanner-level predicate candidate selection uses a materialization safety budget, not a semantic
+filter. New candidate builds up to 100k slots may be materialized; broader scalar/range candidates
+fall back to the normal scan path so 10M-row topics do not allocate and sort multi-million-slot
+candidate arrays. Already-warmed scalar buckets that later grow beyond the budget are also rejected
+for scan selection; bucket eviction/adaptive budgets are separate performance work. This fallback
+must preserve `totalRows`, deterministic ordering, and exact predicate semantics.
+
 It writes profile-specific Vitest timing JSON plus a View Server summary sidecar, for example
 `raw-predicate-index-100000rows.json` and `raw-predicate-index-100000rows.summary.json`. Run each row
 count in a separate process. The benchmark rejects row counts below 101 because several cases assert


### PR DESCRIPTION
## Summary
- cap scanner-level raw predicate candidate materialization to avoid broad scalar/range candidate OOMs on large topics
- keep candidates up to 100k materialized, then fall back to the normal scan path without changing query semantics
- add a non-full-topic regression proving 100,001 matching scalar rows do not materialize/cache an oversized bucket
- document the materialization safety budget and follow-up bucket eviction/adaptive budget work

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- pnpm run ready
- VIEW_SERVER_ENGINE_BENCH_ROWS=10000000 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=1 VIEW_SERVER_ENGINE_BENCH_TIME_MS=1 vp run --no-cache column-live-view-engine#bench:raw-snapshot

## Review
- 3-agent review pass found one test blocker; fixed by adding a non-matching row so the regression proves broad-but-not-full-topic rejection
- second 3-agent review pass found no blockers
