### PR TITLE
Add insert-only active raw query deltas

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -10,7 +10,12 @@ import {
   releaseRawQueryExecution,
 } from "./active-query";
 import { prepareRawQuery } from "./raw-query-compiler";
-import { publishTopicStoreRow, TopicStore } from "./topic-store";
+import {
+  publishTopicStoreRow,
+  publishTopicStoreRows,
+  resetTopicStore,
+  TopicStore,
+} from "./topic-store";
 import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 
 const invalidRow = (_topic: string, message: string): Error => new Error(message);
@@ -389,6 +394,462 @@ describe("column-live-view-engine active query execution", () => {
 
       yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
     }),
+  );
+
+  it.effect("updates raw active windows from retained insert-only changes without rescanning", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-insert-incremental",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-insert-incremental",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-insert-incremental",
+        queryId: "query",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: "b",
+          },
+          {
+            type: "insert",
+            key: "d",
+            row: {
+              id: "d",
+              score: 4,
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 4,
+      });
+      expect(scanLimits).toStrictEqual([2]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      expect(readModel.changesSince(3)).toBeUndefined();
+    }),
+  );
+
+  it.effect("updates total rows for lower-ranked insert-only raw changes without rescanning", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-insert-incremental-count-only",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-insert-incremental-count-only",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 0 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-insert-incremental-count-only",
+        queryId: "query",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [],
+        totalRows: 4,
+      });
+      expect(scanLimits).toStrictEqual([2]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect("releases retained raw changes when a topic reset clears active queries", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-insert-reset-release",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const readModel = topicStoreReadModel(store);
+      const compiled = yield* prepareRawQuery(
+        "raw-insert-reset-release",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      yield* acquireRawQueryExecution(readModel, compiled);
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+      expect(readModel.changesSince(3)).toBeDefined();
+
+      yield* resetTopicStore(store);
+      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
+
+      yield* publishTopicStoreRow(store, { id: "e", status: "open", score: 5 }, invalidRow);
+      expect(readModel.changesSince(0)).toBeUndefined();
+    }),
+  );
+
+  it.effect("falls back to a raw window scan when retained changes replace rows", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-replacement-fallback",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-replacement-fallback",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 5 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-replacement-fallback",
+        queryId: "query",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "move",
+            key: "b",
+            fromIndex: 1,
+            toIndex: 0,
+          },
+          {
+            type: "update",
+            key: "b",
+            row: {
+              id: "b",
+              score: 5,
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 3,
+      });
+      expect(scanLimits).toStrictEqual([2, 2]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect("falls back to a raw window scan when retained raw changes are unavailable", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-unavailable-changes-fallback",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        changesSince: () => undefined,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-unavailable-changes-fallback",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta).operations).toStrictEqual([
+        {
+          type: "remove",
+          key: "a",
+        },
+        {
+          type: "insert",
+          key: "c",
+          row: {
+            id: "c",
+            score: 3,
+          },
+          index: 0,
+        },
+      ]);
+      expect(scanLimits).toStrictEqual([2, 2]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect("ignores non-matching insert-only raw changes without rescanning", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-mixed-insert-incremental",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-mixed-insert-incremental",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRows(
+        store,
+        [
+          { id: "closed", status: "closed", score: 10 },
+          { id: "c", status: "open", score: 3 },
+        ],
+        invalidRow,
+      );
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta).operations).toStrictEqual([
+        {
+          type: "remove",
+          key: "a",
+        },
+        {
+          type: "insert",
+          key: "c",
+          row: {
+            id: "c",
+            score: 3,
+          },
+          index: 0,
+        },
+      ]);
+      expect(scanLimits).toStrictEqual([2]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect(
+    "updates zero-limit raw active queries from insert-only changes without rescanning",
+    () =>
+      Effect.gen(function* () {
+        const store = new TopicStore(
+          "raw-zero-limit-incremental",
+          Schema.Struct({
+            id: Schema.String,
+            status: Schema.String,
+            score: Schema.Number,
+          }),
+          "id",
+          () => {},
+        );
+        yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+
+        const scanLimits: Array<number | undefined> = [];
+        const readModel = topicStoreReadModel(store);
+        const observedReadModel = {
+          ...readModel,
+          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+            scanLimits.push(plan.limit);
+            return readModel.scanRawWindow(plan);
+          },
+        };
+
+        const compiled = yield* prepareRawQuery(
+          "raw-zero-limit-incremental",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id"],
+            where: {
+              status: "open",
+            },
+            limit: 0,
+          },
+        );
+
+        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        expect(execution.initial("query").totalRows).toBe(1);
+        const cursor = execution.createCursor();
+
+        yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+        const delta = yield* execution.next("query", cursor);
+        expect(Option.getOrThrow(delta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-zero-limit-incremental",
+          queryId: "query",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [],
+          totalRows: 2,
+        });
+        expect(scanLimits).toStrictEqual([0]);
+
+        yield* releaseRawQueryExecution(observedReadModel, compiled);
+      }),
   );
 
   it.effect("shrinks shared base windows immediately when larger windows release", () =>

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -19,6 +19,7 @@ type ActiveQueryBaseExecution = {
 
 export type RawQueryExecutionSlot = {
   readonly execution: ActiveQueryBaseExecution;
+  readonly releaseRetainedChanges: () => void;
   readonly windows: Map<string, RawQueryExecutionWindowSlot>;
   refs: number;
 };
@@ -58,6 +59,58 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   return {
     ...scanResult,
     version,
+  };
+};
+
+const updateBaseEvaluationFromInsertOnlyChanges = (
+  store: ActiveQueryStoreState,
+  compiled: CompiledRawQuery<object, object>,
+  evaluation: ActiveQueryBaseEvaluation<object>,
+  queryWindow: RawQueryPlanWindow,
+): ActiveQueryBaseEvaluation<object> | undefined => {
+  const currentVersion = store.version();
+  const batches = store.changesSince(evaluation.version);
+  if (batches === undefined) {
+    return undefined;
+  }
+
+  let totalRows = evaluation.totalRows;
+  const insertedWindowEntries: Array<{ readonly key: string; readonly row: object }> = [];
+  for (const batch of batches) {
+    for (const change of batch.changes) {
+      if (change.previous !== undefined || change.next === undefined) {
+        return undefined;
+      }
+      if (!compiled.plan.predicate.matches(change.next)) {
+        continue;
+      }
+      totalRows += 1;
+      if (queryWindow.limit !== 0) {
+        insertedWindowEntries.push({
+          key: change.key,
+          row: change.next,
+        });
+      }
+    }
+  }
+
+  if (queryWindow.limit === 0) {
+    return {
+      keys: [],
+      totalRows,
+      version: currentVersion,
+      window: [],
+    };
+  }
+
+  const window = [...evaluation.window, ...insertedWindowEntries].sort(compiled.plan.compare);
+  const limitedWindow =
+    queryWindow.limit === undefined ? window : window.slice(0, queryWindow.limit);
+  return {
+    keys: limitedWindow.map((entry) => entry.key),
+    totalRows,
+    version: currentVersion,
+    window: limitedWindow,
   };
 };
 
@@ -197,14 +250,26 @@ const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.ma
       const latest = () => {
         const storeVersion = store.version();
         const nextBaseWindow = baseWindowForActiveWindows(windows);
-        if (
-          snapshot.version !== storeVersion ||
-          nextBaseWindow.offset !== baseWindow.offset ||
-          nextBaseWindow.limit !== baseWindow.limit
-        ) {
+        const windowChanged =
+          nextBaseWindow.offset !== baseWindow.offset || nextBaseWindow.limit !== baseWindow.limit;
+        if (windowChanged) {
           baseWindow = nextBaseWindow;
           snapshot = {
             evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
+            version: storeVersion,
+          };
+          return snapshot.evaluation;
+        }
+        if (snapshot.version !== storeVersion) {
+          const incrementalEvaluation = updateBaseEvaluationFromInsertOnlyChanges(
+            store,
+            canonicalCompiled,
+            snapshot.evaluation,
+            baseWindow,
+          );
+          snapshot = {
+            evaluation:
+              incrementalEvaluation ?? evaluateBaseQuery(store, canonicalCompiled, baseWindow),
             version: storeVersion,
           };
         }
@@ -234,12 +299,16 @@ export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
     const windows = new Map<string, RawQueryExecutionWindowSlot>();
     acquireRawQueryWindow(windows, compiled.plan.window);
     const execution = yield* makeRawQueryExecution(store, compiled, windows);
-    map.set(key, {
-      execution,
-      windows,
-      refs: 1,
+    return yield* Effect.sync(() => {
+      store.retainChanges();
+      map.set(key, {
+        execution,
+        releaseRetainedChanges: () => store.releaseChanges(),
+        windows,
+        refs: 1,
+      });
+      return leaseRawQueryExecution(store, execution, compiled);
     });
-    return leaseRawQueryExecution(store, execution, compiled);
   },
 );
 
@@ -263,6 +332,7 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
         entry.execution.latest();
         return undefined;
       }
+      entry.releaseRetainedChanges();
       map.delete(key);
       return undefined;
     }),
@@ -271,7 +341,11 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
 export const clearRawQueryExecutions = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.clearStore")(
   (store: ActiveQueryStoreState) =>
     Effect.sync(() => {
-      getActiveRawQueryMap(store).clear();
+      const map = getActiveRawQueryMap(store);
+      for (const entry of map.values()) {
+        entry.releaseRetainedChanges();
+      }
+      map.clear();
     }),
 );
 

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1434,6 +1434,20 @@ VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp 
 VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout:ten-window
 ```
 
+Active raw queries retain the row-change journal while the active query is leased. Insert-only
+change batches can update the shared base window incrementally by merging the previous base window
+with matching inserted rows, sorting that retained candidate window, and preserving `totalRows`.
+For active top-k/windowed queries this keeps the sorted candidate set bounded by the shared base
+window size plus matching inserts. Updates, deletes, unavailable retained changes, and base-window
+shape changes fall back to a full raw window scan. This keeps correctness local while making
+append-heavy live top-k deltas avoid full 10M-row re-evaluation.
+
+Current directional result after the insert-only path:
+
+- 10M raw snapshot `live subscription delta after publish`: ~564ms mean -> ~5.3ms mean.
+- 1M rows / 250 subscribers / same-window fanout: ~49.5ms mean -> ~9.7ms mean.
+- 1M rows / 250 subscribers / ten-window fanout: ~50.7ms mean -> ~10.0ms mean.
+
 Raw live fanout knobs:
 
 - `VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE`: `same-window` or `ten-window`.


### PR DESCRIPTION
## Summary
- retain the topic row-change journal while a shared active raw query is leased
- update active raw base windows incrementally for insert-only batches instead of rescanning the full topic
- fall back to full raw window scans for updates, deletes, unavailable retained changes, and base-window shape changes
- add regressions for top-k inserts, lower-ranked count-only inserts, reset cleanup, replacement fallback, unavailable journal fallback, non-matching inserts, and zero-limit queries

## Benchmark signal
Serial local runs after this slice:
- 10M raw snapshot `live subscription delta after publish`: ~5.3ms mean, p99/max ~59.4ms
- 1M / 250 subscriber fanout same-window: ~9.7ms mean, p99/max ~15.6ms
- 1M / 250 subscriber fanout ten-window: ~10.0ms mean, p99/max ~14.8ms

Previous directional baseline before the insert-only fast path:
- 10M raw snapshot live delta: ~564ms mean
- 1M / 250 subscriber fanout same-window: ~49.5ms mean
- 1M / 250 subscriber fanout ten-window: ~50.7ms mean

## Validation
- `pnpm --filter @view-server/column-live-view-engine run test`
- `vp check --fix`
- `pnpm run check:effect`
- `pnpm run ready`
- 3-agent review pass: no blockers; review nits addressed before PR
