### PR TITLE
Optimize broad raw snapshot scans

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -7409,6 +7409,307 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     expect(state.scalarPredicateIndexes.get("status")?.buckets.has(openKey)).toBe(false);
   });
 
+  it("counts exact broad zero-row scans without reading row objects", () => {
+    const openKey = scalarEqualityKey("open");
+    const rows = [
+      ...Array.from({ length: 100_001 }, (_value, index) =>
+        order(`open-${index}`, "open", index, index),
+      ),
+      order("closed-row", "closed", 0, 0),
+    ];
+    const metadata = rawQueryCompilerMetadata(Order);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+        ["status", rows.map((row) => row.status)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => {
+        const entry = {
+          key: row.id,
+          row,
+        };
+        Object.defineProperty(entry, "row", {
+          get: () => {
+            throw new Error("exact zero-row count scan should not read row objects");
+          },
+        });
+        return entry;
+      }),
+    };
+
+    const result = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [
+          {
+            field: "status",
+            operator: "in",
+            values: ["open"],
+            valueKeys: new Set([openKey]),
+          },
+        ],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("exact zero-row count scan should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: 0,
+    });
+
+    expect(result.keys).toStrictEqual([]);
+    expect(result.totalRows).toBe(rows.length - 1);
+  });
+
+  it("keeps generic numeric range predicate fallbacks conservative", () => {
+    const GenericMetric = Schema.Struct({
+      id: Schema.String,
+      price: Schema.Unknown,
+    });
+    const rows = [
+      { id: "nan", price: Number.NaN },
+      { id: "low", price: 1 },
+      { id: "high", price: 3 },
+    ];
+    const metadata = rawQueryCompilerMetadata(GenericMetric);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+
+    const exactRange = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [{ field: "price", operator: "gt", value: 2 }],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("exact generic numeric range should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(exactRange.keys).toStrictEqual(["high"]);
+    expect(exactRange.totalRows).toBe(1);
+
+    const exactRangeBoundary = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [{ field: "price", operator: "gte", value: 1 }],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("exact generic numeric boundary range should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(exactRangeBoundary.keys).toStrictEqual(["high", "low"]);
+    expect(exactRangeBoundary.totalRows).toBe(2);
+
+    const exactNonFiniteRange = scanTopicRawWindow(
+      {
+        ...state,
+        columns: makeColumns(metadata, [
+          ["id", rows.map((row) => row.id)],
+          ["price", [Number.POSITIVE_INFINITY, 1, 3]],
+        ]),
+      },
+      {
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: 2 }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("exact non-finite numeric range should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      },
+    );
+    expect(exactNonFiniteRange.keys).toStrictEqual(["high"]);
+    expect(exactNonFiniteRange.totalRows).toBe(1);
+
+    const nonExactRange = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [{ field: "price", operator: "gt", value: 2 }],
+        callbackRequired: true,
+      },
+      orderBy: [],
+      matches: (row) => fieldValue(row, "id") !== "nan",
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(nonExactRange.keys).toStrictEqual(["high"]);
+    expect(nonExactRange.totalRows).toBe(1);
+
+    const nonExactNonFiniteRange = scanTopicRawWindow(
+      {
+        ...state,
+        columns: makeColumns(metadata, [
+          ["id", rows.map((row) => row.id)],
+          ["price", [Number.POSITIVE_INFINITY, 1, 3]],
+        ]),
+      },
+      {
+        predicate: {
+          filters: [{ field: "price", operator: "gt", value: 2 }],
+          callbackRequired: true,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      },
+    );
+    expect(nonExactNonFiniteRange.keys).toStrictEqual(["high", "nan"]);
+    expect(nonExactNonFiniteRange.totalRows).toBe(2);
+
+    const exactNotEqual = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [{ field: "price", operator: "neq", value: 1 }],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("exact generic numeric neq should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(exactNotEqual.keys).toStrictEqual(["high", "nan"]);
+    expect(exactNotEqual.totalRows).toBe(2);
+  });
+
+  it("keeps number-column non-finite range predicates aligned with query semantics", () => {
+    const NumericMetric = Schema.Struct({
+      id: Schema.String,
+      price: Schema.Number,
+    });
+    const rows = [
+      { id: "infinite", price: Number.POSITIVE_INFINITY },
+      { id: "low", price: 1 },
+      { id: "high", price: 3 },
+    ];
+    const metadata = rawQueryCompilerMetadata(NumericMetric);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+
+    const exactRange = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [{ field: "price", operator: "gt", value: 2 }],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("exact number-column non-finite range should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(exactRange.keys).toStrictEqual(["high"]);
+    expect(exactRange.totalRows).toBe(1);
+
+    const nonExactRange = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [{ field: "price", operator: "gt", value: 2 }],
+        callbackRequired: true,
+      },
+      orderBy: [],
+      matches: () => true,
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(nonExactRange.keys).toStrictEqual(["high", "infinite"]);
+    expect(nonExactRange.totalRows).toBe(2);
+  });
+
+  it("falls back to query-value ordering for invalid number-column slots", () => {
+    const NumericMetric = Schema.Struct({
+      id: Schema.String,
+      price: Schema.Number,
+    });
+    const rows = [
+      { id: "valid", price: 1 },
+      { id: "invalid", price: "not-a-number" },
+      { id: "infinite", price: Number.POSITIVE_INFINITY },
+      { id: "nan", price: Number.NaN },
+    ];
+    const metadata = rawQueryCompilerMetadata(NumericMetric);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+
+    const result = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [{ field: "price", direction: "asc" }],
+      storageOrderBy: [{ field: "price", direction: "asc" }],
+      matches: () => {
+        throw new Error("exact ordered numeric scan should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+
+    expect(result.keys).toStrictEqual(["invalid", "valid", "infinite", "nan"]);
+    expect(result.totalRows).toBe(4);
+  });
+
   it.effect("uses bigint range hints conservatively for manual plans", () =>
     Effect.gen(function* () {
       const store = new TopicStore("positions", Position, "id", () => {});

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -2,20 +2,38 @@ import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 
 export type TopicColumnKind = "generic" | "number";
 
-export type TopicColumnValues = {
+type BaseTopicColumnValues = {
   readonly kind: TopicColumnKind;
   readonly length: number;
   get(slot: number): unknown;
 };
 
-export type MutableTopicColumnValues = TopicColumnValues & {
+export type GenericTopicColumnValues = BaseTopicColumnValues & {
+  readonly kind: "generic";
+};
+
+export type NumberTopicColumnValues = BaseTopicColumnValues & {
+  readonly kind: "number";
+  numberAt(slot: number): number | undefined;
+};
+
+export type TopicColumnValues = GenericTopicColumnValues | NumberTopicColumnValues;
+
+type MutableColumnOperations = {
   clear(): void;
   copySlot(targetSlot: number, sourceSlot: number): void;
   pop(): void;
   set(slot: number, value: unknown): void;
 };
 
-class GenericTopicColumn implements MutableTopicColumnValues {
+type MutableGenericTopicColumnValues = GenericTopicColumnValues & MutableColumnOperations;
+type MutableNumberTopicColumnValues = NumberTopicColumnValues & MutableColumnOperations;
+
+export type MutableTopicColumnValues =
+  | MutableGenericTopicColumnValues
+  | MutableNumberTopicColumnValues;
+
+class GenericTopicColumn implements MutableGenericTopicColumnValues {
   readonly kind = "generic";
   private readonly values: Array<unknown> = [];
 
@@ -44,7 +62,7 @@ class GenericTopicColumn implements MutableTopicColumnValues {
   }
 }
 
-class NumberTopicColumn implements MutableTopicColumnValues {
+class NumberTopicColumn implements MutableNumberTopicColumnValues {
   readonly kind = "number";
   private values = new Float64Array(0);
   private validity = new Uint8Array(0);
@@ -55,6 +73,10 @@ class NumberTopicColumn implements MutableTopicColumnValues {
   }
 
   get(slot: number): unknown {
+    return this.numberAt(slot);
+  }
+
+  numberAt(slot: number): number | undefined {
     if (slot < 0 || slot >= this.lengthValue || this.validity[slot] !== 1) {
       return undefined;
     }

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -154,7 +154,7 @@ const compareSlotsByStorageOrder = (
 ): number => {
   for (const order of storageOrderBy) {
     const column = state.columns.get(order.field)!;
-    const comparison = compareQueryValue(columnValue(column, left), columnValue(column, right));
+    const comparison = compareSlotColumnValues(column, left, right);
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
@@ -162,6 +162,26 @@ const compareSlotsByStorageOrder = (
   const leftKey = state.slots[left]!.key;
   const rightKey = state.slots[right]!.key;
   return Number(leftKey > rightKey) - Number(leftKey < rightKey);
+};
+
+const compareSlotColumnValues = (
+  column: TopicColumnValues,
+  left: number,
+  right: number,
+): number => {
+  if (column.kind === "number") {
+    const leftValue = column.numberAt(left);
+    const rightValue = column.numberAt(right);
+    if (
+      leftValue !== undefined &&
+      rightValue !== undefined &&
+      Number.isFinite(leftValue) &&
+      Number.isFinite(rightValue)
+    ) {
+      return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+    }
+  }
+  return compareQueryValue(columnValue(column, left), columnValue(column, right));
 };
 
 const storageOrderByFieldsExist = (

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -18,7 +18,7 @@ import {
   type OrderedRawWindow,
   type OrderedSlotIndex,
 } from "./topic-ordered-window";
-import { slotMatchesRawPredicatePlan } from "./topic-slot-predicate";
+import { rawPredicateSlotMatcher } from "./topic-slot-predicate";
 
 type RowObject = object;
 
@@ -38,6 +38,7 @@ export const scanTopicRawWindow = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
 ): TopicRawWindowScanResult<object> => {
+  const matchesSlot = rawPredicateMatchesSlot(state, plan);
   const orderedWindow = rawWindowOrderedWindow(state, plan);
   if (orderedWindow !== undefined) {
     const orderedSlotCount = orderedRawWindowSlotCount(orderedWindow);
@@ -49,9 +50,9 @@ export const scanTopicRawWindow = (
     });
     if (candidateSlots !== undefined && candidateSlots.slots.length < orderedSlotCount) {
       const compareSlots = rawWindowSlotComparator(state, plan)!;
-      return scanRawWindowCandidateSlots(state, plan, compareSlots, candidateSlots);
+      return scanRawWindowCandidateSlots(state, plan, compareSlots, matchesSlot, candidateSlots);
     }
-    return scanRawWindowOrderedSlots(state, plan, orderedWindow);
+    return scanRawWindowOrderedSlots(state, plan, matchesSlot, orderedWindow);
   }
 
   const compareSlots =
@@ -63,9 +64,9 @@ export const scanTopicRawWindow = (
     maxSlotCount: Math.min(state.slots.length, materializedPredicateCandidateSlotBudget),
   });
   if (candidateSlots !== undefined) {
-    return scanRawWindowCandidateSlots(state, plan, compareSlots, candidateSlots);
+    return scanRawWindowCandidateSlots(state, plan, compareSlots, matchesSlot, candidateSlots);
   }
-  return scanRawWindowSlots(state, plan, compareSlots);
+  return scanRawWindowSlots(state, plan, compareSlots, matchesSlot);
 };
 
 export { insertSlotIntoRawWindowIndexes };
@@ -73,6 +74,7 @@ export { insertSlotIntoRawWindowIndexes };
 const scanRawWindowOrderedSlots = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
+  matchesSlot: (slot: number) => boolean,
   orderedWindow: OrderedRawWindow,
 ): TopicRawWindowScanResult<object> => {
   let totalRows = 0;
@@ -81,8 +83,7 @@ const scanRawWindowOrderedSlots = (
   for (const span of orderedWindow.spans) {
     for (let slotIndex = span.startIndex; slotIndex < span.endIndex; slotIndex += 1) {
       const slot = orderedWindow.slots[slotIndex]!;
-      const entry = state.slots[slot]!;
-      if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, state.columns)) {
+      if (!matchesSlot(slot)) {
         continue;
       }
       const matchIndex = totalRows;
@@ -99,6 +100,7 @@ const scanRawWindowCandidateSlots = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
   compareSlots: (left: number, right: number) => number,
+  matchesSlot: (slot: number) => boolean,
   candidateSlots: PredicateCandidateSlots,
 ): TopicRawWindowScanResult<object> => {
   const boundedWindowEnd = boundedRawWindowEnd(plan);
@@ -107,6 +109,7 @@ const scanRawWindowCandidateSlots = (
       state,
       plan,
       compareSlots,
+      matchesSlot,
       boundedWindowEnd,
       candidateSlots,
     );
@@ -115,8 +118,7 @@ const scanRawWindowCandidateSlots = (
   let totalRows = 0;
   const filteredSlots: Array<number> = [];
   for (const slot of candidateSlots.slots) {
-    const entry = state.slots[slot]!;
-    if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, state.columns)) {
+    if (!matchesSlot(slot)) {
       continue;
     }
     totalRows += 1;
@@ -136,17 +138,17 @@ const scanRawWindowSlots = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
   compareSlots: (left: number, right: number) => number,
+  matchesSlot: (slot: number) => boolean,
 ): TopicRawWindowScanResult<object> => {
   const boundedWindowEnd = boundedRawWindowEnd(plan);
   if (boundedWindowEnd !== undefined) {
-    return scanRawWindowBoundedSlots(state, plan, compareSlots, boundedWindowEnd);
+    return scanRawWindowBoundedSlots(state, plan, compareSlots, matchesSlot, boundedWindowEnd);
   }
 
   let totalRows = 0;
   const filteredSlots: Array<number> = [];
   for (let slot = 0; slot < state.slots.length; slot += 1) {
-    const entry = state.slots[slot]!;
-    if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, state.columns)) {
+    if (!matchesSlot(slot)) {
       continue;
     }
     totalRows += 1;
@@ -166,13 +168,13 @@ const scanRawWindowBoundedSlots = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
   compareSlots: (left: number, right: number) => number,
+  matchesSlot: (slot: number) => boolean,
   windowEnd: number,
 ): TopicRawWindowScanResult<object> => {
   let totalRows = 0;
   const windowSlots: Array<number> = [];
   for (let slot = 0; slot < state.slots.length; slot += 1) {
-    const entry = state.slots[slot]!;
-    if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, state.columns)) {
+    if (!matchesSlot(slot)) {
       continue;
     }
     totalRows += 1;
@@ -195,14 +197,14 @@ const scanRawWindowBoundedSlotCandidates = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
   compareSlots: (left: number, right: number) => number,
+  matchesSlot: (slot: number) => boolean,
   windowEnd: number,
   candidateSlots: PredicateCandidateSlots,
 ): TopicRawWindowScanResult<object> => {
   let totalRows = 0;
   const windowSlots: Array<number> = [];
   for (const slot of candidateSlots.slots) {
-    const entry = state.slots[slot]!;
-    if (!slotMatchesRawPredicatePlan(slot, plan, entry.row, state.columns)) {
+    if (!matchesSlot(slot)) {
       continue;
     }
     totalRows += 1;
@@ -219,6 +221,17 @@ const scanRawWindowBoundedSlotCandidates = (
     }
   }
   return rawWindowScanResult(state, windowSlots.slice(plan.offset), totalRows);
+};
+
+const rawPredicateMatchesSlot = (
+  state: TopicRawWindowScanState,
+  plan: TopicRawWindowScanPlan<object>,
+): ((slot: number) => boolean) => {
+  const matcher = rawPredicateSlotMatcher(plan, state.columns);
+  if (matcher.kind === "slot") {
+    return matcher.matchesSlot;
+  }
+  return (slot) => matcher.matchesEntry(slot, state.slots[slot]!);
 };
 
 const rawWindowScanResult = (

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -1,5 +1,6 @@
 import type { TopicRawPredicateFilterPlan } from "./raw-predicate-plan";
 import type { TopicRawWindowScanPlan } from "./raw-window-scan";
+import type { TopicRowEntry } from "./row-scan";
 import { scalarEqualityKey, valuesEqual } from "./row-values";
 import {
   columnValueDoesNotEqual,
@@ -11,99 +12,225 @@ import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 
 type RowObject = object;
 
-export const slotMatchesRawPredicatePlan = <Row extends RowObject>(
-  slot: number,
-  plan: TopicRawWindowScanPlan<Row>,
-  row: Row,
-  columns: ReadonlyMap<string, TopicColumnValues>,
-): boolean => {
-  const exact = plan.predicate.callbackSkippable === true;
-  if (!slotMayMatchFilters(slot, plan.predicate.filters, columns, exact)) {
-    return false;
-  }
-  return exact || plan.matches(row);
+type SlotFilterMatcher = (slot: number) => boolean;
+type RangePredicateFilter = TopicRawPredicateFilterPlan & {
+  readonly operator: "gt" | "gte" | "lt" | "lte";
+  readonly value: unknown;
 };
 
-const slotMayMatchFilters = (
-  slot: number,
+export type RawPredicateSlotMatcher<Row extends RowObject> =
+  | {
+      readonly kind: "slot";
+      readonly matchesSlot: (slot: number) => boolean;
+    }
+  | {
+      readonly kind: "entry";
+      readonly matchesEntry: (slot: number, entry: TopicRowEntry<Row>) => boolean;
+    };
+
+export const rawPredicateSlotMatcher = <Row extends RowObject>(
+  plan: TopicRawWindowScanPlan<Row>,
+  columns: ReadonlyMap<string, TopicColumnValues>,
+): RawPredicateSlotMatcher<Row> => {
+  const exact = plan.predicate.callbackSkippable === true;
+  const filterMatchers = slotFilterMatchers(plan.predicate.filters, columns, exact);
+  const matchesFilters = (slot: number): boolean => {
+    for (const matcher of filterMatchers) {
+      if (!matcher(slot)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  if (exact) {
+    return {
+      kind: "slot",
+      matchesSlot: matchesFilters,
+    };
+  }
+
+  return {
+    kind: "entry",
+    matchesEntry: (slot, entry) => matchesFilters(slot) && plan.matches(entry.row),
+  };
+};
+
+const slotFilterMatchers = (
   filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
   columns: ReadonlyMap<string, TopicColumnValues>,
   exact: boolean,
-): boolean => {
+): ReadonlyArray<SlotFilterMatcher> => {
+  const matchers: Array<SlotFilterMatcher> = [];
   for (const filter of filters) {
-    if (!slotMayMatchFilter(slot, filter, columns, exact)) {
-      return false;
-    }
+    matchers.push(slotFilterMatcher(filter, columns, exact));
   }
-  return true;
+  return matchers;
 };
 
-const slotMayMatchFilter = (
-  slot: number,
+const slotFilterMatcher = (
   filter: TopicRawPredicateFilterPlan,
   columns: ReadonlyMap<string, TopicColumnValues>,
   exact: boolean,
-): boolean => {
+): SlotFilterMatcher => {
   const column = columns.get(filter.field);
   if (column === undefined) {
-    return true;
-  }
-  const value = columnValue(column, slot);
-
-  if (filter.operator === "eq") {
-    return valuesEqual(value, filter.value);
-  }
-  if (filter.operator === "neq") {
-    if (exact) {
-      return columnValueDoesNotEqual(value, filter.value);
-    }
-    return !valuesEqual(value, filter.value);
-  }
-  if (filter.operator === "in") {
-    if (filter.valueKeys !== undefined) {
-      const key = scalarEqualityKey(value);
-      return key !== undefined && filter.valueKeys.has(key);
-    }
-    return filter.values.some((candidate) => valuesEqual(value, candidate));
-  }
-  if (filter.operator === "startsWith") {
-    if (typeof filter.value !== "string") {
-      return true;
-    }
-    return typeof value === "string" && value.startsWith(filter.value);
+    return () => true;
   }
 
+  switch (filter.operator) {
+    case "eq": {
+      if (column.kind === "number" && typeof filter.value === "number") {
+        return (slot) => Object.is(column.numberAt(slot), filter.value);
+      }
+      return (slot) => valuesEqual(columnValue(column, slot), filter.value);
+    }
+    case "neq": {
+      if (exact) {
+        if (column.kind === "number" && typeof filter.value === "number") {
+          return (slot) => {
+            const value = column.numberAt(slot);
+            return value !== undefined && !Object.is(value, filter.value);
+          };
+        }
+        return (slot) => columnValueDoesNotEqual(columnValue(column, slot), filter.value);
+      }
+      return (slot) => !valuesEqual(columnValue(column, slot), filter.value);
+    }
+    case "in": {
+      if (filter.valueKeys !== undefined) {
+        const valueKeys = filter.valueKeys;
+        return (slot) => {
+          const key = scalarEqualityKey(columnValue(column, slot));
+          return key !== undefined && valueKeys.has(key);
+        };
+      }
+      return (slot) => {
+        const value = columnValue(column, slot);
+        return filter.values.some((candidate) => valuesEqual(value, candidate));
+      };
+    }
+    case "startsWith": {
+      if (typeof filter.value !== "string") {
+        return () => true;
+      }
+      const prefix = filter.value;
+      return (slot) => {
+        const value = columnValue(column, slot);
+        return typeof value === "string" && value.startsWith(prefix);
+      };
+    }
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte": {
+      const rangeFilter: RangePredicateFilter = {
+        field: filter.field,
+        operator: filter.operator,
+        value: filter.value,
+      };
+      return rangeSlotFilterMatcher(column, rangeFilter, exact);
+    }
+  }
+};
+
+const rangeSlotFilterMatcher = (
+  column: TopicColumnValues,
+  filter: RangePredicateFilter,
+  exact: boolean,
+): SlotFilterMatcher => {
   if (exact && !isComparableRangeValue(filter.value)) {
-    return true;
+    return () => true;
   }
-  if (exact) {
-    const exactComparison = compareExactRangeColumnValue(value, filter.value);
-    if (exactComparison === undefined) {
-      return false;
-    }
-    if (filter.operator === "gt") {
-      return exactComparison > 0;
-    }
-    if (filter.operator === "gte") {
-      return exactComparison >= 0;
-    }
-    if (filter.operator === "lt") {
-      return exactComparison < 0;
-    }
-    return exactComparison <= 0;
+  const numberRangeMatcher = numberColumnRangeMatcher(column, filter, exact);
+  if (numberRangeMatcher !== undefined) {
+    return numberRangeMatcher;
   }
 
-  const comparison = compareRangeColumnValue(value, filter.value);
-  if (comparison === undefined) {
-    return true;
+  if (exact) {
+    return (slot) => {
+      const exactComparison = compareExactRangeColumnValue(columnValue(column, slot), filter.value);
+      if (exactComparison === undefined) {
+        return false;
+      }
+      return rangeComparisonMatches(filter.operator, exactComparison);
+    };
   }
+
+  return (slot) => {
+    const comparison = compareRangeColumnValue(columnValue(column, slot), filter.value);
+    return comparison === undefined || rangeComparisonMatches(filter.operator, comparison);
+  };
+};
+
+const numberColumnRangeMatcher = (
+  column: TopicColumnValues,
+  filter: RangePredicateFilter,
+  exact: boolean,
+): SlotFilterMatcher | undefined => {
+  if (
+    column.kind !== "number" ||
+    typeof filter.value !== "number" ||
+    !Number.isFinite(filter.value)
+  ) {
+    return undefined;
+  }
+  const expected = filter.value;
   if (filter.operator === "gt") {
-    return comparison > 0;
+    return exact
+      ? (slot) => {
+          const value = column.numberAt(slot);
+          return value !== undefined && Number.isFinite(value) && value > expected;
+        }
+      : (slot) => {
+          const value = column.numberAt(slot);
+          return value === undefined || !Number.isFinite(value) || value > expected;
+        };
   }
   if (filter.operator === "gte") {
-    return comparison >= 0;
+    return exact
+      ? (slot) => {
+          const value = column.numberAt(slot);
+          return value !== undefined && Number.isFinite(value) && value >= expected;
+        }
+      : (slot) => {
+          const value = column.numberAt(slot);
+          return value === undefined || !Number.isFinite(value) || value >= expected;
+        };
   }
   if (filter.operator === "lt") {
+    return exact
+      ? (slot) => {
+          const value = column.numberAt(slot);
+          return value !== undefined && Number.isFinite(value) && value < expected;
+        }
+      : (slot) => {
+          const value = column.numberAt(slot);
+          return value === undefined || !Number.isFinite(value) || value < expected;
+        };
+  }
+  return exact
+    ? (slot) => {
+        const value = column.numberAt(slot);
+        return value !== undefined && Number.isFinite(value) && value <= expected;
+      }
+    : (slot) => {
+        const value = column.numberAt(slot);
+        return value === undefined || !Number.isFinite(value) || value <= expected;
+      };
+};
+
+const rangeComparisonMatches = (
+  operator: TopicRawPredicateFilterPlan["operator"],
+  comparison: number,
+): boolean => {
+  if (operator === "gt") {
+    return comparison > 0;
+  }
+  if (operator === "gte") {
+    return comparison >= 0;
+  }
+  if (operator === "lt") {
     return comparison < 0;
   }
   return comparison <= 0;

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1301,6 +1301,25 @@ Raw snapshot knobs:
 - `VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS`: warmup iterations per case.
 - `VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS`: warmup time budget per case.
 
+Current broad-scan optimization signal:
+
+- Exact raw scans precompile slot predicates per scan, resolve columns once, use direct numeric
+  column comparisons for finite number ranges/orderings, and avoid row-object reads when
+  `callbackSkippable` proves column predicates are authoritative.
+- These are warm/shared-engine benchmark signals: the raw snapshot harness has an existing live
+  subscription and shared same-process indexes. They are not cold index-build numbers.
+- 10M raw snapshot `compound filter + top-k sort`: ~1983ms mean -> ~959ms mean.
+- 10M raw snapshot `filtered totalRows via zero-row window`: ~727ms mean -> ~635ms mean. This case
+  was noisy in the current run: median/p75 stayed near ~356ms while one outlier lifted mean/max.
+- 10M raw snapshot `equality filter + top-k sort`: ~442ms mean -> ~280ms mean.
+- 10M raw snapshot `range filter + top-k sort`: ~224ms mean -> ~52ms mean.
+- 1M raw write sanity, base mode: single append ~0.049ms mean, batch append ~14.7ms mean.
+- 1M raw write sanity, indexed mode: single append ~0.423ms mean, batch append ~15.5ms mean.
+- 10M raw write sanity, base mode: single append ~0.054ms mean, batch append ~16.7ms mean.
+- 10M raw write sanity, indexed mode: single append ~2.14ms mean, batch append ~161ms mean and
+  very noisy. Treat the batch result as benchmark-state/GC pressure after warmed indexed writes, not
+  a direct per-row ordered-index splice cost measurement.
+
 Current raw predicate candidate index benchmark harness:
 
 ```bash


### PR DESCRIPTION
## Summary
- Precompile raw slot predicates once per scan and avoid row-object reads for exact callback-skippable raw predicates.
- Add number-column fast paths for finite numeric filters/orderings while preserving non-finite and manual-callback semantics.
- Document 10M raw snapshot/write benchmark results and caveats.

## Validation
- pnpm run ready
- 3-agent review cycle: no blockers

## Benchmark Signals
- 10M compound filter + top-k sort: ~1983ms mean -> ~959ms mean.
- 10M filtered totalRows zero-row window: ~727ms mean -> ~635ms mean, noisy.
- 10M equality filter + top-k sort: ~442ms mean -> ~280ms mean.
- 10M range filter + top-k sort: ~224ms mean -> ~52ms mean.
