### PR TITLE
Optimize count-only raw scans

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -5710,6 +5710,31 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(zeroLimitPlan.keys).toStrictEqual([]);
       expect(zeroLimitPlan.totalRows).toBe(2);
 
+      let zeroLimitCompareCount = 0;
+      let zeroLimitMatchCount = 0;
+      const callbackRequiredZeroLimitPlan = readModel.scanRawWindow({
+        predicate: {
+          filters: [{ field: "price", operator: "gte", value: 20 }],
+          callbackRequired: true,
+        },
+        orderBy: [{ field: "price", direction: "desc" }],
+        storageOrderBy: [{ field: "price", direction: "desc" }],
+        matches: (row) => {
+          zeroLimitMatchCount += 1;
+          return fieldValue(row, "id") === "3";
+        },
+        compare: () => {
+          zeroLimitCompareCount += 1;
+          return 0;
+        },
+        offset: 1,
+        limit: 0,
+      });
+      expect(callbackRequiredZeroLimitPlan.keys).toStrictEqual([]);
+      expect(callbackRequiredZeroLimitPlan.totalRows).toBe(1);
+      expect(zeroLimitMatchCount).toBe(2);
+      expect(zeroLimitCompareCount).toBe(0);
+
       const unsafeWindowEndPlan = readModel.scanRawWindow({
         predicate: {
           filters: [],
@@ -5964,6 +5989,30 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(initialPriceMatch.keys).toStrictEqual(["matched"]);
 
+      const initialPriceMatchLargeLimit = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20],
+              valueKeys: new Set(["number:20"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("large-limit scalar candidate predicates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: 2_000,
+      });
+      expect(initialPriceMatchLargeLimit.keys).toStrictEqual(["matched"]);
+      expect(initialPriceMatchLargeLimit.totalRows).toBe(1);
+
       const initialPriceCountOnly = readModel.scanRawWindow({
         predicate: {
           filters: [
@@ -5987,6 +6036,29 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(initialPriceCountOnly.keys).toStrictEqual([]);
       expect(initialPriceCountOnly.totalRows).toBe(1);
+
+      const selectiveCountOnlyWithCallbackFilter = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "in",
+              values: [20, 40],
+              valueKeys: new Set(["number:20", "number:40"]),
+            },
+          ],
+          callbackRequired: true,
+        },
+        orderBy: [],
+        matches: (row) => fieldValue(row, "id") === "noted",
+        compare: () => {
+          throw new Error("selective count-only candidates should not compare rows");
+        },
+        offset: 0,
+        limit: 0,
+      });
+      expect(selectiveCountOnlyWithCallbackFilter.keys).toStrictEqual([]);
+      expect(selectiveCountOnlyWithCallbackFilter.totalRows).toBe(1);
 
       const initialRangeGreaterThan = readModel.scanRawWindow({
         predicate: {
@@ -6153,6 +6225,59 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         limit: undefined,
       });
       expect(rangeCandidateRejectedByIncompatibleSecondFilter.keys).toStrictEqual([]);
+
+      const warmedStatusBucket = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "status",
+              operator: "in",
+              values: ["closed"],
+              valueKeys: new Set(["string:6:closed"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("status bucket warmup should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: undefined,
+      });
+      expect(warmedStatusBucket.keys).toStrictEqual(["cold"]);
+
+      const orderedRangeCandidateRejectedBySecondFilter = readModel.scanRawWindow({
+        predicate: {
+          filters: [
+            {
+              field: "price",
+              operator: "gt",
+              value: 0,
+            },
+            {
+              field: "status",
+              operator: "in",
+              values: ["closed"],
+              valueKeys: new Set(["string:6:closed"]),
+            },
+          ],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => {
+          throw new Error("ordered compound range candidates should not call row callbacks");
+        },
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      });
+      expect(orderedRangeCandidateRejectedBySecondFilter.keys).toStrictEqual(["cold"]);
+      expect(orderedRangeCandidateRejectedBySecondFilter.totalRows).toBe(1);
 
       const partialPriceBuckets = readModel.scanRawWindow({
         predicate: {
@@ -6913,6 +7038,103 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
     expect(emptyRange.keys).toStrictEqual([]);
     expect(emptyRange.totalRows).toBe(0);
+  });
+
+  it("keeps count-only scans candidate-aware for selective scalar predicates", () => {
+    const rows = [
+      order("first", "open", 10, 1),
+      order("second", "closed", 20, 2),
+      order("third", "open", 30, 3),
+      order("fourth", "open", 40, 4),
+    ];
+    const slots = rows.map((row) => ({
+      key: row.id,
+      row,
+    }));
+    const metadata = rawQueryCompilerMetadata(Order);
+    const sourceStatusColumn = createTopicColumnValuesFromArray(
+      "status",
+      metadata,
+      rows.map((row) => row.status),
+    );
+    let statusReadCount = 0;
+    const observedStatusColumn: TopicColumnValues = {
+      kind: "generic",
+      get length() {
+        return sourceStatusColumn.length;
+      },
+      get(slot) {
+        statusReadCount += 1;
+        return columnValue(sourceStatusColumn, slot);
+      },
+    };
+    const state = {
+      columns: new Map<string, TopicColumnValues>([
+        [
+          "id",
+          createTopicColumnValuesFromArray(
+            "id",
+            metadata,
+            rows.map((row) => row.id),
+          ),
+        ],
+        ["status", observedStatusColumn],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots,
+    };
+
+    const warmClosedBucket = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [
+          {
+            field: "status",
+            operator: "in",
+            values: ["closed"],
+            valueKeys: new Set(["string:6:closed"]),
+          },
+        ],
+        callbackRequired: false,
+        callbackSkippable: true,
+      },
+      orderBy: [],
+      matches: () => {
+        throw new Error("scalar bucket warmup should not call row callbacks");
+      },
+      compare: (left, right) => left.key.localeCompare(right.key),
+      offset: 0,
+      limit: undefined,
+    });
+    expect(warmClosedBucket.keys).toStrictEqual(["second"]);
+    expect(statusReadCount).toBeGreaterThan(1);
+
+    statusReadCount = 0;
+    const countClosedRows = scanTopicRawWindow(state, {
+      predicate: {
+        filters: [
+          {
+            field: "status",
+            operator: "in",
+            values: ["closed"],
+            valueKeys: new Set(["string:6:closed"]),
+          },
+        ],
+        callbackRequired: true,
+      },
+      orderBy: [],
+      matches: (row) => fieldValue(row, "id") === "second",
+      compare: () => {
+        throw new Error("count-only scalar candidates should not compare rows");
+      },
+      offset: 0,
+      limit: 0,
+    });
+
+    expect(countClosedRows.keys).toStrictEqual([]);
+    expect(countClosedRows.totalRows).toBe(1);
+    expect(statusReadCount).toBe(1);
   });
 
   it("keeps exact candidate scans aligned with bounded and ordered raw windows", () => {

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -39,6 +39,10 @@ export const scanTopicRawWindow = (
   plan: TopicRawWindowScanPlan<object>,
 ): TopicRawWindowScanResult<object> => {
   const matchesSlot = rawPredicateMatchesSlot(state, plan);
+  if (plan.limit === 0) {
+    return countRawWindowSlots(state, plan, matchesSlot);
+  }
+
   const orderedWindow = rawWindowOrderedWindow(state, plan);
   if (orderedWindow !== undefined) {
     const orderedSlotCount = orderedRawWindowSlotCount(orderedWindow);
@@ -70,6 +74,43 @@ export const scanTopicRawWindow = (
 };
 
 export { insertSlotIntoRawWindowIndexes };
+
+const countRawWindowSlots = (
+  state: TopicRawWindowScanState,
+  plan: TopicRawWindowScanPlan<object>,
+  matchesSlot: (slot: number) => boolean,
+): TopicRawWindowScanResult<object> => {
+  const candidateSlots = selectedPredicateCandidateSlots(state, plan.predicate.filters, {
+    allowScalarIndexBuild: true,
+    exactRangeCandidates: plan.predicate.callbackSkippable === true,
+    maxSlotCount: Math.min(state.slots.length, materializedPredicateCandidateSlotBudget),
+  });
+  if (candidateSlots !== undefined) {
+    return countRawWindowCandidateSlots(state, matchesSlot, candidateSlots);
+  }
+
+  let totalRows = 0;
+  for (let slot = 0; slot < state.slots.length; slot += 1) {
+    if (matchesSlot(slot)) {
+      totalRows += 1;
+    }
+  }
+  return rawWindowScanResult(state, [], totalRows);
+};
+
+const countRawWindowCandidateSlots = (
+  state: TopicRawWindowScanState,
+  matchesSlot: (slot: number) => boolean,
+  candidateSlots: PredicateCandidateSlots,
+): TopicRawWindowScanResult<object> => {
+  let totalRows = 0;
+  for (const slot of candidateSlots.slots) {
+    if (matchesSlot(slot)) {
+      totalRows += 1;
+    }
+  }
+  return rawWindowScanResult(state, [], totalRows);
+};
 
 const scanRawWindowOrderedSlots = (
   state: TopicRawWindowScanState,
@@ -122,9 +163,7 @@ const scanRawWindowCandidateSlots = (
       continue;
     }
     totalRows += 1;
-    if (plan.limit !== 0) {
-      filteredSlots.push(slot);
-    }
+    filteredSlots.push(slot);
   }
   filteredSlots.sort(compareSlots);
   const windowSlots = filteredSlots.slice(
@@ -152,9 +191,7 @@ const scanRawWindowSlots = (
       continue;
     }
     totalRows += 1;
-    if (plan.limit !== 0) {
-      filteredSlots.push(slot);
-    }
+    filteredSlots.push(slot);
   }
   filteredSlots.sort(compareSlots);
   const windowSlots = filteredSlots.slice(

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1306,11 +1306,15 @@ Current broad-scan optimization signal:
 - Exact raw scans precompile slot predicates per scan, resolve columns once, use direct numeric
   column comparisons for finite number ranges/orderings, and avoid row-object reads when
   `callbackSkippable` proves column predicates are authoritative.
+- Count-only raw scans (`limit: 0`) now count matching slots without ordering/window materialization.
+  Selective predicate candidates are still used when available; broad predicates fall back to an
+  O(rows) count-only scan without comparator/sort/window work.
 - These are warm/shared-engine benchmark signals: the raw snapshot harness has an existing live
   subscription and shared same-process indexes. They are not cold index-build numbers.
 - 10M raw snapshot `compound filter + top-k sort`: ~1983ms mean -> ~959ms mean.
-- 10M raw snapshot `filtered totalRows via zero-row window`: ~727ms mean -> ~635ms mean. This case
-  was noisy in the current run: median/p75 stayed near ~356ms while one outlier lifted mean/max.
+- 10M raw snapshot `filtered totalRows via zero-row window`: ~727ms mean -> ~635ms mean -> one
+  noisy ~470ms mean run after the count-only branch. This case remains a warm/shared-engine signal
+  and still scans broad predicates.
 - 10M raw snapshot `equality filter + top-k sort`: ~442ms mean -> ~280ms mean.
 - 10M raw snapshot `range filter + top-k sort`: ~224ms mean -> ~52ms mean.
 - 1M raw write sanity, base mode: single append ~0.049ms mean, batch append ~14.7ms mean.


### PR DESCRIPTION
## Summary
- Add a candidate-aware count-only raw scan path for `limit: 0` queries.
- Preserve selective scalar/range candidate use before falling back to broad full-slot counting.
- Avoid comparator/sort/window materialization for total-row-only raw scans.
- Add scanner-level tests proving candidate-aware counting and callback-required correctness.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm run check:effect
- pnpm run ready
- 3-agent review cycle, second pass clean on blockers

## Benchmark Signal
- 10M `filtered totalRows via zero-row window`: one noisy warm/shared-engine run moved from the previously documented ~635ms mean to ~470ms mean.
- Broad count-only scans still do O(rows) predicate checks; this PR only removes unnecessary ordering/window work and preserves selective candidates.
