### PR TITLE
Optimize retained raw active changes

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -11,6 +11,8 @@ import {
 } from "./active-query";
 import { prepareRawQuery } from "./raw-query-compiler";
 import {
+  deleteTopicStoreRow,
+  patchTopicStoreRow,
   publishTopicStoreRow,
   publishTopicStoreRows,
   resetTopicStore,
@@ -850,6 +852,323 @@ describe("column-live-view-engine active query execution", () => {
 
         yield* releaseRawQueryExecution(observedReadModel, compiled);
       }),
+  );
+
+  it.effect("ignores non-matching retained raw updates and deletes without rescanning", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-non-matching-change-incremental",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(
+        store,
+        { id: "closed-update", status: "closed", score: 3 },
+        invalidRow,
+      );
+      yield* publishTopicStoreRow(
+        store,
+        { id: "closed-delete", status: "closed", score: 4 },
+        invalidRow,
+      );
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-non-matching-change-incremental",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      let compareCount = 0;
+      const observedCompiled = {
+        ...compiled,
+        plan: {
+          ...compiled.plan,
+          compare: (
+            left: Parameters<typeof compiled.plan.compare>[0],
+            right: Parameters<typeof compiled.plan.compare>[1],
+          ) => {
+            compareCount += 1;
+            return compiled.plan.compare(left, right);
+          },
+        },
+      };
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, observedCompiled);
+      expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+      const cursor = execution.createCursor();
+      compareCount = 0;
+
+      yield* patchTopicStoreRow(
+        store,
+        "closed-update",
+        {
+          score: 30,
+        },
+        invalidRow,
+      );
+      yield* deleteTopicStoreRow(store, "closed-delete");
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.isNone(delta)).toBe(true);
+      expect(scanLimits).toStrictEqual([2]);
+      expect(compareCount).toBe(0);
+
+      yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
+    }),
+  );
+
+  it.effect(
+    "emits the next visible raw delta from the last delivered version after no-op changes",
+    () =>
+      Effect.gen(function* () {
+        const store = new TopicStore(
+          "raw-noop-then-visible-version",
+          Schema.Struct({
+            id: Schema.String,
+            status: Schema.String,
+            score: Schema.Number,
+          }),
+          "id",
+          () => {},
+        );
+        yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+        yield* publishTopicStoreRow(
+          store,
+          { id: "closed", status: "closed", score: 3 },
+          invalidRow,
+        );
+
+        const readModel = topicStoreReadModel(store);
+        const compiled = yield* prepareRawQuery(
+          "raw-noop-then-visible-version",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id", "score"],
+            where: {
+              status: "open",
+            },
+            orderBy: [{ field: "score", direction: "desc" }],
+            limit: 2,
+          },
+        );
+
+        const execution = yield* acquireRawQueryExecution(readModel, compiled);
+        expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+        const cursor = execution.createCursor();
+
+        yield* patchTopicStoreRow(
+          store,
+          "closed",
+          {
+            score: 30,
+          },
+          invalidRow,
+        );
+
+        const noOpDelta = yield* execution.next("query", cursor);
+        expect(Option.isNone(noOpDelta)).toBe(true);
+
+        yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 4 }, invalidRow);
+
+        const visibleDelta = yield* execution.next("query", cursor);
+        expect(Option.getOrThrow(visibleDelta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-noop-then-visible-version",
+          queryId: "query",
+          fromVersion: 3,
+          toVersion: 5,
+          operations: [
+            {
+              type: "remove",
+              key: "a",
+            },
+            {
+              type: "insert",
+              key: "c",
+              row: {
+                id: "c",
+                score: 4,
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 3,
+        });
+
+        yield* releaseRawQueryExecution(readModel, compiled);
+      }),
+  );
+
+  it.effect(
+    "updates zero-limit raw active counts from retained updates and deletes without rescanning",
+    () =>
+      Effect.gen(function* () {
+        const store = new TopicStore(
+          "raw-zero-limit-mixed-incremental",
+          Schema.Struct({
+            id: Schema.String,
+            status: Schema.String,
+            score: Schema.Number,
+          }),
+          "id",
+          () => {},
+        );
+        yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "b", status: "closed", score: 2 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "d", status: "closed", score: 4 }, invalidRow);
+
+        const scanLimits: Array<number | undefined> = [];
+        const readModel = topicStoreReadModel(store);
+        const observedReadModel = {
+          ...readModel,
+          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+            scanLimits.push(plan.limit);
+            return readModel.scanRawWindow(plan);
+          },
+        };
+
+        const compiled = yield* prepareRawQuery(
+          "raw-zero-limit-mixed-incremental",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id"],
+            where: {
+              status: "open",
+            },
+            limit: 0,
+          },
+        );
+
+        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        expect(execution.initial("query").totalRows).toBe(2);
+        const cursor = execution.createCursor();
+
+        yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "c", status: "closed", score: 3 }, invalidRow);
+        yield* patchTopicStoreRow(
+          store,
+          "d",
+          {
+            score: 40,
+          },
+          invalidRow,
+        );
+        yield* deleteTopicStoreRow(store, "a");
+
+        const delta = yield* execution.next("query", cursor);
+        expect(Option.getOrThrow(delta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-zero-limit-mixed-incremental",
+          queryId: "query",
+          fromVersion: 4,
+          toVersion: 8,
+          operations: [],
+          totalRows: 1,
+        });
+        expect(scanLimits).toStrictEqual([0]);
+
+        yield* releaseRawQueryExecution(observedReadModel, compiled);
+      }),
+  );
+
+  it.effect("falls back to a raw window scan when retained deletes remove matching rows", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-visible-delete-fallback",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-visible-delete-fallback",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* deleteTopicStoreRow(store, "c");
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-visible-delete-fallback",
+        queryId: "query",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: "c",
+          },
+          {
+            type: "insert",
+            key: "a",
+            row: {
+              id: "a",
+              score: 1,
+            },
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+      });
+      expect(scanLimits).toStrictEqual([2, 2]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
   );
 
   it.effect("shrinks shared base windows immediately when larger windows release", () =>

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -62,7 +62,7 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
   };
 };
 
-const updateBaseEvaluationFromInsertOnlyChanges = (
+const updateBaseEvaluationFromRetainedChanges = (
   store: ActiveQueryStoreState,
   compiled: CompiledRawQuery<object, object>,
   evaluation: ActiveQueryBaseEvaluation<object>,
@@ -78,14 +78,27 @@ const updateBaseEvaluationFromInsertOnlyChanges = (
   const insertedWindowEntries: Array<{ readonly key: string; readonly row: object }> = [];
   for (const batch of batches) {
     for (const change of batch.changes) {
-      if (change.previous !== undefined || change.next === undefined) {
-        return undefined;
-      }
-      if (!compiled.plan.predicate.matches(change.next)) {
+      const previousMatches =
+        change.previous !== undefined && compiled.plan.predicate.matches(change.previous);
+      const nextMatches = change.next !== undefined && compiled.plan.predicate.matches(change.next);
+
+      if (queryWindow.limit === 0) {
+        if (previousMatches && !nextMatches) {
+          totalRows -= 1;
+        } else if (!previousMatches && nextMatches) {
+          totalRows += 1;
+        }
         continue;
       }
-      totalRows += 1;
-      if (queryWindow.limit !== 0) {
+
+      if (change.previous !== undefined) {
+        if (previousMatches || nextMatches) {
+          return undefined;
+        }
+        continue;
+      }
+      if (change.next !== undefined && nextMatches) {
+        totalRows += 1;
         insertedWindowEntries.push({
           key: change.key,
           row: change.next,
@@ -100,6 +113,13 @@ const updateBaseEvaluationFromInsertOnlyChanges = (
       totalRows,
       version: currentVersion,
       window: [],
+    };
+  }
+
+  if (insertedWindowEntries.length === 0) {
+    return {
+      ...evaluation,
+      version: currentVersion,
     };
   }
 
@@ -261,7 +281,7 @@ const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.ma
           return snapshot.evaluation;
         }
         if (snapshot.version !== storeVersion) {
-          const incrementalEvaluation = updateBaseEvaluationFromInsertOnlyChanges(
+          const incrementalEvaluation = updateBaseEvaluationFromRetainedChanges(
             store,
             canonicalCompiled,
             snapshot.evaluation,

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1457,13 +1457,15 @@ VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp 
 VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout:ten-window
 ```
 
-Active raw queries retain the row-change journal while the active query is leased. Insert-only
-change batches can update the shared base window incrementally by merging the previous base window
-with matching inserted rows, sorting that retained candidate window, and preserving `totalRows`.
-For active top-k/windowed queries this keeps the sorted candidate set bounded by the shared base
-window size plus matching inserts. Updates, deletes, unavailable retained changes, and base-window
-shape changes fall back to a full raw window scan. This keeps correctness local while making
-append-heavy live top-k deltas avoid full 10M-row re-evaluation.
+Active raw queries retain the row-change journal while the active query is leased. Retained insert
+batches can update the shared base window incrementally by merging the previous base window with
+matching inserted rows, sorting that retained candidate window, and preserving `totalRows`. Retained
+updates/deletes that provably do not match the predicate are ignored without rescanning. For
+`limit: 0` count-only subscriptions, retained inserts, updates, and deletes adjust `totalRows`
+directly because there is no visible window to refill. Visible updates/deletes, unavailable retained
+changes, and base-window shape changes still fall back to a full raw window scan. This keeps
+correctness local while making append-heavy live top-k deltas and count-only retained changes avoid
+full 10M-row re-evaluation.
 
 Current directional result after the insert-only path:
 


### PR DESCRIPTION
## Summary
- Extend active raw retained-change handling beyond insert-only batches.
- Skip full rescans for non-matching retained updates/deletes and avoid copy/sort work when no inserted rows affect the active window.
- Update zero-limit raw active queries from retained insert/update/delete count deltas.
- Add regression coverage for scan avoidance, comparator avoidance, visible-delete fallback, and cursor version semantics after no-op retained changes.
- Update the column live view engine plan with the retained-change behavior.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test -- active-query.test.ts
- vp check --fix
- pnpm run check:effect
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run ready

## Review
- 3 subagent review cycle completed.
- Initial performance finding fixed: no-op retained update/delete no longer copies/sorts the retained base window.
- Final reviewers reported no blockers.