### PR TITLE
Add active raw lookahead delete deltas

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -467,7 +467,7 @@ describe("column-live-view-engine active query execution", () => {
         ],
         totalRows: 4,
       });
-      expect(scanLimits).toStrictEqual([2]);
+      expect(scanLimits).toStrictEqual([3]);
 
       yield* releaseRawQueryExecution(observedReadModel, compiled);
       expect(readModel.changesSince(3)).toBeUndefined();
@@ -529,7 +529,7 @@ describe("column-live-view-engine active query execution", () => {
         operations: [],
         totalRows: 4,
       });
-      expect(scanLimits).toStrictEqual([2]);
+      expect(scanLimits).toStrictEqual([3]);
 
       yield* releaseRawQueryExecution(observedReadModel, compiled);
     }),
@@ -648,7 +648,7 @@ describe("column-live-view-engine active query execution", () => {
         ],
         totalRows: 3,
       });
-      expect(scanLimits).toStrictEqual([2, 2]);
+      expect(scanLimits).toStrictEqual([3, 3]);
 
       yield* releaseRawQueryExecution(observedReadModel, compiled);
     }),
@@ -715,7 +715,7 @@ describe("column-live-view-engine active query execution", () => {
           index: 0,
         },
       ]);
-      expect(scanLimits).toStrictEqual([2, 2]);
+      expect(scanLimits).toStrictEqual([3, 3]);
 
       yield* releaseRawQueryExecution(observedReadModel, compiled);
     }),
@@ -788,7 +788,7 @@ describe("column-live-view-engine active query execution", () => {
           index: 0,
         },
       ]);
-      expect(scanLimits).toStrictEqual([2]);
+      expect(scanLimits).toStrictEqual([3]);
 
       yield* releaseRawQueryExecution(observedReadModel, compiled);
     }),
@@ -933,7 +933,7 @@ describe("column-live-view-engine active query execution", () => {
 
       const delta = yield* execution.next("query", cursor);
       expect(Option.isNone(delta)).toBe(true);
-      expect(scanLimits).toStrictEqual([2]);
+      expect(scanLimits).toStrictEqual([3]);
       expect(compareCount).toBe(0);
 
       yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
@@ -1023,6 +1023,305 @@ describe("column-live-view-engine active query execution", () => {
       }),
   );
 
+  it.effect("adds predicate-entering retained raw updates without rescanning", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-retained-update-enters-predicate",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "d", status: "closed", score: 4 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-retained-update-enters-predicate",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-retained-update-enters-predicate",
+        queryId: "query",
+        fromVersion: 4,
+        toVersion: 5,
+        operations: [
+          {
+            type: "remove",
+            key: "b",
+          },
+          {
+            type: "insert",
+            key: "d",
+            row: {
+              id: "d",
+              score: 4,
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 4,
+      });
+      expect(scanLimits).toStrictEqual([3]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect("removes same-key pending raw insert candidates before merging retained changes", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-same-key-pending-insert-removed",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-same-key-pending-insert-removed",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+      yield* deleteTopicStoreRow(store, "d");
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.isNone(delta)).toBe(true);
+      expect(scanLimits).toStrictEqual([3]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect("falls back after a retained removal consumes lookahead before a later delete", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-retained-removal-consumes-lookahead",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 100 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 90 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 80 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 70 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-retained-removal-consumes-lookahead",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["a", "b"]);
+      const cursor = execution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "a", status: "closed", score: 100 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "low", status: "open", score: 0 }, invalidRow);
+
+      const firstDelta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(firstDelta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-retained-removal-consumes-lookahead",
+        queryId: "query",
+        fromVersion: 4,
+        toVersion: 6,
+        operations: [
+          {
+            type: "remove",
+            key: "a",
+          },
+          {
+            type: "insert",
+            key: "c",
+            row: {
+              id: "c",
+              score: 80,
+            },
+            index: 1,
+          },
+        ],
+        totalRows: 4,
+      });
+      expect(scanLimits).toStrictEqual([3]);
+
+      yield* deleteTopicStoreRow(store, "b");
+
+      const secondDelta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(secondDelta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-retained-removal-consumes-lookahead",
+        queryId: "query",
+        fromVersion: 6,
+        toVersion: 7,
+        operations: [
+          {
+            type: "remove",
+            key: "b",
+          },
+          {
+            type: "insert",
+            key: "d",
+            row: {
+              id: "d",
+              score: 70,
+            },
+            index: 1,
+          },
+        ],
+        totalRows: 3,
+      });
+      expect(scanLimits).toStrictEqual([3, 3]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect(
+    "updates total rows for matching deletes outside retained raw windows without rescanning",
+    () =>
+      Effect.gen(function* () {
+        const store = new TopicStore(
+          "raw-delete-outside-retained-window",
+          Schema.Struct({
+            id: Schema.String,
+            status: Schema.String,
+            score: Schema.Number,
+          }),
+          "id",
+          () => {},
+        );
+        yield* publishTopicStoreRow(store, { id: "low", status: "open", score: 0 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+        const scanLimits: Array<number | undefined> = [];
+        const readModel = topicStoreReadModel(store);
+        const observedReadModel = {
+          ...readModel,
+          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+            scanLimits.push(plan.limit);
+            return readModel.scanRawWindow(plan);
+          },
+        };
+
+        const compiled = yield* prepareRawQuery(
+          "raw-delete-outside-retained-window",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id", "score"],
+            where: {
+              status: "open",
+            },
+            orderBy: [{ field: "score", direction: "desc" }],
+            limit: 2,
+          },
+        );
+
+        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
+        const cursor = execution.createCursor();
+
+        yield* deleteTopicStoreRow(store, "low");
+
+        const delta = yield* execution.next("query", cursor);
+        expect(Option.getOrThrow(delta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-delete-outside-retained-window",
+          queryId: "query",
+          fromVersion: 4,
+          toVersion: 5,
+          operations: [],
+          totalRows: 3,
+        });
+        expect(scanLimits).toStrictEqual([3]);
+
+        yield* releaseRawQueryExecution(observedReadModel, compiled);
+      }),
+  );
+
   it.effect(
     "updates zero-limit raw active counts from retained updates and deletes without rescanning",
     () =>
@@ -1096,7 +1395,7 @@ describe("column-live-view-engine active query execution", () => {
       }),
   );
 
-  it.effect("falls back to a raw window scan when retained deletes remove matching rows", () =>
+  it.effect("refills retained visible raw deletes from lookahead without rescanning", () =>
     Effect.gen(function* () {
       const store = new TopicStore(
         "raw-visible-delete-fallback",
@@ -1165,7 +1464,97 @@ describe("column-live-view-engine active query execution", () => {
         ],
         totalRows: 2,
       });
-      expect(scanLimits).toStrictEqual([2, 2]);
+      expect(scanLimits).toStrictEqual([3]);
+
+      yield* releaseRawQueryExecution(observedReadModel, compiled);
+    }),
+  );
+
+  it.effect("falls back to a raw window scan when retained deletes exhaust lookahead", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-visible-delete-exhausted-lookahead",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return readModel.scanRawWindow(plan);
+        },
+      };
+
+      const compiled = yield* prepareRawQuery(
+        "raw-visible-delete-exhausted-lookahead",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      expect(execution.initial("query").keys).toStrictEqual(["d", "c"]);
+      const cursor = execution.createCursor();
+
+      yield* deleteTopicStoreRow(store, "d");
+      yield* deleteTopicStoreRow(store, "c");
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.getOrThrow(delta)).toStrictEqual({
+        type: "delta",
+        topic: "raw-visible-delete-exhausted-lookahead",
+        queryId: "query",
+        fromVersion: 4,
+        toVersion: 6,
+        operations: [
+          {
+            type: "remove",
+            key: "d",
+          },
+          {
+            type: "remove",
+            key: "c",
+          },
+          {
+            type: "insert",
+            key: "b",
+            row: {
+              id: "b",
+              score: 2,
+            },
+            index: 0,
+          },
+          {
+            type: "insert",
+            key: "a",
+            row: {
+              id: "a",
+              score: 1,
+            },
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+      });
+      expect(scanLimits).toStrictEqual([3, 3]);
 
       yield* releaseRawQueryExecution(observedReadModel, compiled);
     }),
@@ -1232,7 +1621,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(narrowExecution.initial("narrow").keys).toStrictEqual(["c"]);
 
       yield* releaseRawQueryExecution(observedReadModel, wideWindow);
-      expect(scanLimits).toStrictEqual([3, 2]);
+      expect(scanLimits).toStrictEqual([4, 3]);
       expect(narrowExecution.initial("narrow-after-shrink").keys).toStrictEqual(["c"]);
 
       yield* releaseRawQueryExecution(observedReadModel, narrowWindow);
@@ -1300,7 +1689,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(unboundedExecution.initial("unbounded").keys).toStrictEqual(["c", "b", "a"]);
 
       yield* releaseRawQueryExecution(observedReadModel, unboundedWindow);
-      expect(scanLimits).toStrictEqual([2, undefined, 2]);
+      expect(scanLimits).toStrictEqual([3, undefined, 3]);
       expect(boundedExecution.initial("bounded-after-compact").keys).toStrictEqual(["b"]);
 
       yield* releaseRawQueryExecution(observedReadModel, boundedWindow);

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -75,7 +75,9 @@ const updateBaseEvaluationFromRetainedChanges = (
   }
 
   let totalRows = evaluation.totalRows;
-  const insertedWindowEntries: Array<{ readonly key: string; readonly row: object }> = [];
+  let windowEntries = evaluation.window;
+  let removedRetainedEntry = false;
+  const insertedWindowEntries = new Map<string, { readonly key: string; readonly row: object }>();
   for (const batch of batches) {
     for (const change of batch.changes) {
       const previousMatches =
@@ -92,14 +94,31 @@ const updateBaseEvaluationFromRetainedChanges = (
       }
 
       if (change.previous !== undefined) {
-        if (previousMatches || nextMatches) {
+        if (previousMatches && nextMatches) {
           return undefined;
+        }
+        if (previousMatches) {
+          totalRows -= 1;
+          insertedWindowEntries.delete(change.key);
+          const removedWindowEntries = windowEntries.filter((entry) => entry.key !== change.key);
+          if (removedWindowEntries.length !== windowEntries.length) {
+            windowEntries = removedWindowEntries;
+            removedRetainedEntry = true;
+          }
+          continue;
+        }
+        if (nextMatches) {
+          totalRows += 1;
+          insertedWindowEntries.set(change.key, {
+            key: change.key,
+            row: change.next,
+          });
         }
         continue;
       }
       if (change.next !== undefined && nextMatches) {
         totalRows += 1;
-        insertedWindowEntries.push({
+        insertedWindowEntries.set(change.key, {
           key: change.key,
           row: change.next,
         });
@@ -116,16 +135,37 @@ const updateBaseEvaluationFromRetainedChanges = (
     };
   }
 
-  if (insertedWindowEntries.length === 0) {
+  const requiredWindowEntries =
+    queryWindow.limit === undefined ? undefined : Math.max(0, queryWindow.limit - 1);
+  if (
+    requiredWindowEntries !== undefined &&
+    windowEntries.length < Math.min(totalRows, requiredWindowEntries)
+  ) {
+    return undefined;
+  }
+
+  if (insertedWindowEntries.size === 0) {
+    if (windowEntries === evaluation.window && totalRows === evaluation.totalRows) {
+      return {
+        ...evaluation,
+        version: currentVersion,
+      };
+    }
     return {
       ...evaluation,
+      keys: windowEntries.map((entry) => entry.key),
+      totalRows,
       version: currentVersion,
+      window: windowEntries,
     };
   }
 
-  const window = [...evaluation.window, ...insertedWindowEntries].sort(compiled.plan.compare);
-  const limitedWindow =
-    queryWindow.limit === undefined ? window : window.slice(0, queryWindow.limit);
+  const window = [...windowEntries, ...insertedWindowEntries.values()].sort(compiled.plan.compare);
+  const retainedLimit =
+    removedRetainedEntry && requiredWindowEntries !== undefined
+      ? requiredWindowEntries
+      : queryWindow.limit;
+  const limitedWindow = retainedLimit === undefined ? window : window.slice(0, retainedLimit);
   return {
     keys: limitedWindow.map((entry) => entry.key),
     totalRows,
@@ -221,6 +261,13 @@ const baseWindowForActiveWindows = (
   return rawQueryPlanWindow(0, limit);
 };
 
+const retainedWindowForBaseWindow = (window: RawQueryPlanWindow): RawQueryPlanWindow => {
+  if (window.limit === undefined || window.limit === 0) {
+    return window;
+  }
+  return rawQueryPlanWindow(window.offset, window.limit + 1);
+};
+
 const acquireRawQueryWindow = (
   windows: Map<string, RawQueryExecutionWindowSlot>,
   window: RawQueryPlanWindow,
@@ -262,8 +309,9 @@ const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.ma
   ) =>
     Effect.sync(() => {
       let baseWindow = baseWindowForActiveWindows(windows);
+      let retainedWindow = retainedWindowForBaseWindow(baseWindow);
       let snapshot = {
-        evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
+        evaluation: evaluateBaseQuery(store, canonicalCompiled, retainedWindow),
         version: store.version(),
       };
 
@@ -274,8 +322,9 @@ const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.ma
           nextBaseWindow.offset !== baseWindow.offset || nextBaseWindow.limit !== baseWindow.limit;
         if (windowChanged) {
           baseWindow = nextBaseWindow;
+          retainedWindow = retainedWindowForBaseWindow(baseWindow);
           snapshot = {
-            evaluation: evaluateBaseQuery(store, canonicalCompiled, baseWindow),
+            evaluation: evaluateBaseQuery(store, canonicalCompiled, retainedWindow),
             version: storeVersion,
           };
           return snapshot.evaluation;
@@ -285,11 +334,11 @@ const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.ma
             store,
             canonicalCompiled,
             snapshot.evaluation,
-            baseWindow,
+            retainedWindow,
           );
           snapshot = {
             evaluation:
-              incrementalEvaluation ?? evaluateBaseQuery(store, canonicalCompiled, baseWindow),
+              incrementalEvaluation ?? evaluateBaseQuery(store, canonicalCompiled, retainedWindow),
             version: storeVersion,
           };
         }

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1457,15 +1457,19 @@ VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp 
 VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS=50 vp run --no-cache column-live-view-engine#bench:raw-live-fanout:ten-window
 ```
 
-Active raw queries retain the row-change journal while the active query is leased. Retained insert
-batches can update the shared base window incrementally by merging the previous base window with
+Active raw queries retain the row-change journal while the active query is leased. Finite non-zero
+active windows retain one extra lookahead row beyond the shared visible base window. Retained insert
+batches can update the shared base window incrementally by merging the previous retained window with
 matching inserted rows, sorting that retained candidate window, and preserving `totalRows`. Retained
-updates/deletes that provably do not match the predicate are ignored without rescanning. For
-`limit: 0` count-only subscriptions, retained inserts, updates, and deletes adjust `totalRows`
-directly because there is no visible window to refill. Visible updates/deletes, unavailable retained
-changes, and base-window shape changes still fall back to a full raw window scan. This keeps
-correctness local while making append-heavy live top-k deltas and count-only retained changes avoid
-full 10M-row re-evaluation.
+updates/deletes that provably do not match the predicate are ignored without rescanning. Retained
+deletes or predicate-leaving updates can refill visible windows from the lookahead row when one
+changed row leaves the retained window. Matching deletes outside the retained window update
+`totalRows` without touching the visible window. For `limit: 0` count-only subscriptions, retained
+inserts, updates, and deletes adjust `totalRows` directly because there is no visible window to
+refill. Visible match-to-match updates, unavailable retained changes, exhausted lookahead, and
+base-window shape changes still fall back to a full raw window scan. This keeps correctness local
+while making append-heavy live top-k deltas, simple retained deletes/leaves, and count-only retained
+changes avoid full 10M-row re-evaluation.
 
 Current directional result after the insert-only path:
 


### PR DESCRIPTION
## Summary
- retain one extra active raw lookahead row for finite non-zero windows
- update retained delete/predicate-leave deltas without a full scan when lookahead covers the visible window
- fast-return no-op retained batches by only advancing snapshot version
- remove same-key pending insert candidates and avoid trusting unverified lookahead after retained removals

## Tests
- pnpm --filter @view-server/column-live-view-engine run test -- active-query.test.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Review
- 3-agent review loop completed with no blockers after fixes
