### PR TITLE
Optimize incremental grouped writes

### DIFF
--- a/packages/column-live-view-engine/src/grouped-aggregate-state.ts
+++ b/packages/column-live-view-engine/src/grouped-aggregate-state.ts
@@ -3,6 +3,7 @@ import {
   fromBigInt,
   fromNumberUnsafe,
   isBigDecimal,
+  subtract as subtractBigDecimal,
   sum as sumBigDecimal,
   type BigDecimal,
 } from "effect/BigDecimal";
@@ -26,36 +27,63 @@ export type RuntimeGroupedAggregate =
       readonly resultKind: "bigint" | "bigDecimal";
     };
 
+type CountAggregateState = {
+  readonly aggFunc: "count";
+  count: bigint;
+};
+
+type CountDistinctAggregateState = {
+  readonly aggFunc: "countDistinct";
+  readonly values: Map<string, number>;
+  count: bigint;
+};
+
+type BigIntSumAggregateState = {
+  readonly aggFunc: "sum";
+  readonly resultKind: "bigint";
+  bigintTotal: bigint;
+};
+
+type BigDecimalSumAggregateState = {
+  readonly aggFunc: "sum";
+  readonly resultKind: "bigDecimal";
+  decimalTotal: BigDecimal;
+};
+
+type AverageAggregateState = {
+  readonly aggFunc: "avg";
+  count: bigint;
+  total: BigDecimal;
+};
+
+type MinMaxAggregateValueState = {
+  count: number;
+  value: unknown;
+};
+
+type BaseMinMaxAggregateState = {
+  readonly aggFunc: "min" | "max";
+  value: unknown;
+  hasValue: boolean;
+};
+
+export type RetainedMinMaxAggregateState = BaseMinMaxAggregateState & {
+  readonly values: Map<string, MinMaxAggregateValueState>;
+};
+
+type NonMinMaxAggregateState =
+  | CountAggregateState
+  | CountDistinctAggregateState
+  | BigIntSumAggregateState
+  | BigDecimalSumAggregateState
+  | AverageAggregateState;
+
 type AggregateState =
-  | {
-      readonly aggFunc: "count";
-      count: bigint;
-    }
-  | {
-      readonly aggFunc: "countDistinct";
-      readonly values: Set<string>;
-      count: bigint;
-    }
-  | {
-      readonly aggFunc: "sum";
-      readonly resultKind: "bigint";
-      bigintTotal: bigint;
-    }
-  | {
-      readonly aggFunc: "sum";
-      readonly resultKind: "bigDecimal";
-      decimalTotal: BigDecimal;
-    }
-  | {
-      readonly aggFunc: "avg";
-      count: bigint;
-      total: BigDecimal;
-    }
-  | {
-      readonly aggFunc: "min" | "max";
-      value: unknown;
-      hasValue: boolean;
-    };
+  | NonMinMaxAggregateState
+  | BaseMinMaxAggregateState
+  | RetainedMinMaxAggregateState;
+
+export type ReversibleAggregateState = NonMinMaxAggregateState | RetainedMinMaxAggregateState;
 
 export type GroupState = {
   readonly key: string;
@@ -63,7 +91,8 @@ export type GroupState = {
   readonly aggregates: Record<string, AggregateState>;
 };
 
-export type MaterializedIncrementalGroupState = GroupState & {
+export type MaterializedIncrementalGroupState = Omit<GroupState, "aggregates"> & {
+  readonly aggregates: Record<string, ReversibleAggregateState>;
   readonly members: Map<string, RowObject>;
 };
 
@@ -94,7 +123,7 @@ const emptyAggregateState = (aggregate: RuntimeGroupedAggregate): AggregateState
   if (aggregate.aggFunc === "countDistinct") {
     return {
       aggFunc: "countDistinct",
-      values: new Set<string>(),
+      values: new Map<string, number>(),
       count: 0n,
     };
   }
@@ -125,6 +154,50 @@ const emptyAggregateState = (aggregate: RuntimeGroupedAggregate): AggregateState
   };
 };
 
+const emptyReversibleAggregateState = (
+  aggregate: RuntimeGroupedAggregate,
+): ReversibleAggregateState => {
+  if (aggregate.aggFunc === "count") {
+    return {
+      aggFunc: "count",
+      count: 0n,
+    };
+  }
+  if (aggregate.aggFunc === "countDistinct") {
+    return {
+      aggFunc: "countDistinct",
+      values: new Map<string, number>(),
+      count: 0n,
+    };
+  }
+  if (aggregate.aggFunc === "sum") {
+    return aggregate.resultKind === "bigint"
+      ? {
+          aggFunc: "sum",
+          resultKind: "bigint",
+          bigintTotal: 0n,
+        }
+      : {
+          aggFunc: "sum",
+          resultKind: "bigDecimal",
+          decimalTotal: fromBigInt(0n),
+        };
+  }
+  if (aggregate.aggFunc === "avg") {
+    return {
+      aggFunc: "avg",
+      count: 0n,
+      total: fromBigInt(0n),
+    };
+  }
+  return {
+    aggFunc: aggregate.aggFunc,
+    values: new Map<string, MinMaxAggregateValueState>(),
+    value: undefined,
+    hasValue: false,
+  };
+};
+
 const aggregateFieldValue = (row: RowObject, aggregate: RuntimeGroupedAggregate): unknown =>
   "field" in aggregate ? fieldValue(row, aggregate.field) : undefined;
 
@@ -139,10 +212,13 @@ export const updateAggregateState = (
     return;
   }
   if (state.aggFunc === "countDistinct") {
-    const sizeBefore = state.values.size;
-    state.values.add(stableQueryValueString(value));
-    if (state.values.size !== sizeBefore) {
+    const key = stableQueryValueString(value);
+    const count = state.values.get(key);
+    if (count === undefined) {
+      state.values.set(key, 1);
       state.count += 1n;
+    } else {
+      state.values.set(key, count + 1);
     }
     return;
   }
@@ -167,6 +243,19 @@ export const updateAggregateState = (
     }
     return;
   }
+  if ("values" in state) {
+    const values = state.values;
+    const key = stableQueryValueString(value);
+    const entry = values.get(key);
+    if (entry === undefined) {
+      values.set(key, {
+        count: 1,
+        value: cloneUnknown(value),
+      });
+    } else {
+      entry.count += 1;
+    }
+  }
   if (!state.hasValue) {
     state.value = cloneUnknown(value);
     state.hasValue = true;
@@ -179,6 +268,87 @@ export const updateAggregateState = (
   if ((state.aggFunc === "min" && comparison < 0) || (state.aggFunc === "max" && comparison > 0)) {
     state.value = cloneUnknown(value);
   }
+};
+
+const recomputeMinMaxAggregateState = (state: RetainedMinMaxAggregateState): void => {
+  let nextValue: unknown;
+  let hasValue = false;
+  for (const entry of state.values.values()) {
+    if (!hasValue) {
+      nextValue = cloneUnknown(entry.value);
+      hasValue = true;
+      continue;
+    }
+    const comparison = compareQueryValue(entry.value, nextValue);
+    const isBetterValue = state.aggFunc === "min" ? comparison < 0 : comparison > 0;
+    if (isBetterValue) {
+      nextValue = cloneUnknown(entry.value);
+    }
+  }
+  state.value = nextValue;
+  state.hasValue = hasValue;
+};
+
+export const removeAggregateState = (
+  state: ReversibleAggregateState,
+  aggregate: RuntimeGroupedAggregate,
+  row: RowObject,
+): RetainedMinMaxAggregateState | undefined => {
+  const value = aggregateFieldValue(row, aggregate);
+  if (state.aggFunc === "count") {
+    state.count -= 1n;
+    return undefined;
+  }
+  if (state.aggFunc === "countDistinct") {
+    const key = stableQueryValueString(value);
+    const count = state.values.get(key)!;
+    if (count === 1) {
+      state.values.delete(key);
+      state.count -= 1n;
+    } else {
+      state.values.set(key, count - 1);
+    }
+    return undefined;
+  }
+  if (state.aggFunc === "sum") {
+    if (state.resultKind === "bigint") {
+      if (typeof value === "bigint") {
+        state.bigintTotal -= value;
+      }
+      return undefined;
+    }
+    const decimal = runtimeValueToDecimal(value);
+    if (decimal !== undefined) {
+      state.decimalTotal = subtractBigDecimal(state.decimalTotal, decimal);
+    }
+    return undefined;
+  }
+  if (state.aggFunc === "avg") {
+    const decimal = runtimeValueToDecimal(value);
+    if (decimal !== undefined) {
+      state.count -= 1n;
+      state.total = subtractBigDecimal(state.total, decimal);
+    }
+    return undefined;
+  }
+  const key = stableQueryValueString(value);
+  const values = state.values;
+  const entry = values.get(key)!;
+  if (entry.count > 1) {
+    entry.count -= 1;
+    return undefined;
+  }
+  values.delete(key);
+  if (state.hasValue && stableQueryValueString(state.value) === key) {
+    return state;
+  }
+  return undefined;
+};
+
+export const recomputeRetainedMinMaxAggregateState = (
+  state: RetainedMinMaxAggregateState,
+): void => {
+  recomputeMinMaxAggregateState(state);
 };
 
 const aggregateStateValue = (state: AggregateState): unknown => {
@@ -239,33 +409,21 @@ export const newIncrementalGroupState = (
   groupBy: ReadonlyArray<string>,
   aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
   row: RowObject,
-): MaterializedIncrementalGroupState => ({
-  ...newGroupState(key, groupBy, aggregates, row),
-  members: new Map(),
-});
-
-const resetAggregateStates = (
-  group: GroupState,
-  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
-): void => {
-  for (const key of Object.keys(group.aggregates)) {
-    delete group.aggregates[key];
+): MaterializedIncrementalGroupState => {
+  const resultRow: Record<string, unknown> = {};
+  for (const field of groupBy) {
+    resultRow[field] = cloneUnknown(fieldValue(row, field));
   }
+  const aggregateStates: Record<string, ReversibleAggregateState> = {};
   for (const [alias, aggregate] of Object.entries(aggregates)) {
-    group.aggregates[alias] = emptyAggregateState(aggregate);
+    aggregateStates[alias] = emptyReversibleAggregateState(aggregate);
   }
-};
-
-export const recomputeIncrementalGroupState = (
-  group: MaterializedIncrementalGroupState,
-  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
-): void => {
-  resetAggregateStates(group, aggregates);
-  for (const row of group.members.values()) {
-    for (const [alias, aggregate] of Object.entries(aggregates)) {
-      updateAggregateState(group.aggregates[alias]!, aggregate, row);
-    }
-  }
+  return {
+    key,
+    row: resultRow,
+    aggregates: aggregateStates,
+    members: new Map(),
+  };
 };
 
 export const finalizeGroup = (group: GroupState): StoredRowOf<RowObject> => {

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -1,7 +1,9 @@
 import {
   type MaterializedIncrementalGroupState,
+  type RetainedMinMaxAggregateState,
   newIncrementalGroupState,
-  recomputeIncrementalGroupState,
+  recomputeRetainedMinMaxAggregateState,
+  removeAggregateState,
   updateAggregateState,
 } from "./grouped-aggregate-state";
 import { typedGroupedEvaluation } from "./grouped-query-evaluation";
@@ -14,6 +16,7 @@ import {
 import type { CompiledGroupedQuery } from "./grouped-query-compiler";
 import type { QueryEvaluation } from "./query-result";
 import type { TopicRowChangeBatch, TopicRowScan } from "./row-scan";
+import { fieldValue, valuesEqual } from "./row-values";
 
 type RowObject = object;
 
@@ -30,6 +33,25 @@ export type IncrementalGroupedQueryExecution<ResultRow extends RowObject> = {
 const maxIncrementalGroupedMembers = 65_536;
 const maxIncrementalGroupedMembersPerGroup = 4_096;
 const maxIncrementalGroupedGroups = 8_192;
+
+const retainedValueAggregateCount = <Row extends RowObject>(
+  plan: GroupedQueryPlan<Row>,
+): number => {
+  let count = 0;
+  for (const aggregate of Object.values(plan.aggregates)) {
+    if (
+      aggregate.aggFunc === "countDistinct" ||
+      aggregate.aggFunc === "min" ||
+      aggregate.aggFunc === "max"
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+const retainedValueEntryEstimate = (memberCount: number, retainedAggregateCount: number): number =>
+  memberCount * retainedAggregateCount;
 
 const newZeroLimitIncrementalGroupState = (key: string): CountOnlyIncrementalGroupState => ({
   key,
@@ -133,6 +155,7 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
   matches: (row: Row) => boolean,
 ): IncrementalGroupedQueryBuildState => {
   const groups = new Map<string, MaterializedIncrementalGroupState>();
+  const retainedAggregateCount = retainedValueAggregateCount(plan);
   let memberCount = 0;
   let admitted = true;
   store.scanRows((key, row) => {
@@ -152,6 +175,8 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
     memberCount += 1;
     if (
       memberCount > maxIncrementalGroupedMembers ||
+      retainedValueEntryEstimate(memberCount, retainedAggregateCount) >
+        maxIncrementalGroupedMembers ||
       group.members.size > maxIncrementalGroupedMembersPerGroup ||
       groups.size > maxIncrementalGroupedGroups
     ) {
@@ -193,12 +218,12 @@ const buildIncrementalGroupedQueryState = <Row extends RowObject>(
     : buildMaterializedIncrementalGroupedQueryState(store, plan, matches);
 
 const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
   groups: Map<string, MaterializedIncrementalGroupState>,
   plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   key: string,
   row: Row,
-  dirtyGroups: Set<MaterializedIncrementalGroupState>,
 ): boolean => {
   if (!matches(row)) {
     return false;
@@ -214,10 +239,11 @@ const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   }
   if (group.members.size === 0) {
     groups.delete(groupedKey);
-    dirtyGroups.delete(group);
     return true;
   }
-  dirtyGroups.add(group);
+  for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+    removeMaterializedAggregateState(dirtyAggregateRecomputes, group, alias, aggregate, row);
+  }
   return true;
 };
 
@@ -247,17 +273,56 @@ type UpsertIncrementalGroupedMemberResult = {
   readonly inserted: boolean;
 };
 
-const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+type DirtyAggregateRecomputes = Set<RetainedMinMaxAggregateState>;
+
+const markDirtyAggregateRecompute = (
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
+  state: RetainedMinMaxAggregateState | undefined,
+): void => {
+  if (state !== undefined) {
+    dirtyAggregateRecomputes.add(state);
+  }
+};
+
+const removeMaterializedAggregateState = <Row extends RowObject>(
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
+  group: MaterializedIncrementalGroupState,
+  alias: string,
+  aggregate: GroupedQueryPlan<Row>["aggregates"][string],
+  row: Row,
+): void => {
+  markDirtyAggregateRecompute(
+    dirtyAggregateRecomputes,
+    removeAggregateState(group.aggregates[alias]!, aggregate, row),
+  );
+};
+
+const recomputeDirtyAggregateStates = (
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
+): void => {
+  for (const state of dirtyAggregateRecomputes) {
+    recomputeRetainedMinMaxAggregateState(state);
+  }
+};
+
+const aggregateValueChanged = <Row extends RowObject>(
+  aggregate: GroupedQueryPlan<Row>["aggregates"][string],
+  previous: Row,
+  next: Row,
+): boolean => {
+  if (!("field" in aggregate)) {
+    return false;
+  }
+  return !valuesEqual(fieldValue(previous, aggregate.field), fieldValue(next, aggregate.field));
+};
+
+const upsertMatchingMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
   groups: Map<string, MaterializedIncrementalGroupState>,
   plan: GroupedQueryPlan<Row>,
-  matches: (row: Row) => boolean,
   key: string,
   row: Row,
-  dirtyGroups: Set<MaterializedIncrementalGroupState>,
-): UpsertIncrementalGroupedMemberResult | undefined => {
-  if (!matches(row)) {
-    return undefined;
-  }
+): UpsertIncrementalGroupedMemberResult => {
   const groupedKey = plan.groupKey(row);
   let group = groups.get(groupedKey);
   if (group === undefined) {
@@ -265,12 +330,61 @@ const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
     groups.set(groupedKey, group);
   }
   const inserted = !group.members.has(key);
+  const previous = group.members.get(key);
+  if (previous !== undefined) {
+    for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+      removeMaterializedAggregateState(dirtyAggregateRecomputes, group, alias, aggregate, previous);
+    }
+  }
   group.members.set(key, row);
-  dirtyGroups.add(group);
+  for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+    updateAggregateState(group.aggregates[alias]!, aggregate, row);
+  }
   return {
     groupSize: group.members.size,
     inserted,
   };
+};
+
+const replaceMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
+  group: MaterializedIncrementalGroupState,
+  plan: GroupedQueryPlan<Row>,
+  key: string,
+  previous: Row,
+  next: Row,
+): void => {
+  group.members.set(key, next);
+  for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+    if (aggregateValueChanged(aggregate, previous, next)) {
+      const state = group.aggregates[alias]!;
+      markDirtyAggregateRecompute(
+        dirtyAggregateRecomputes,
+        removeAggregateState(state, aggregate, previous),
+      );
+      updateAggregateState(state, aggregate, next);
+    }
+  }
+};
+
+const upsertMaterializedIncrementalGroupedMember = <Row extends RowObject>(
+  dirtyAggregateRecomputes: DirtyAggregateRecomputes,
+  groups: Map<string, MaterializedIncrementalGroupState>,
+  plan: GroupedQueryPlan<Row>,
+  matches: (row: Row) => boolean,
+  key: string,
+  row: Row,
+): UpsertIncrementalGroupedMemberResult | undefined => {
+  if (!matches(row)) {
+    return undefined;
+  }
+  return upsertMatchingMaterializedIncrementalGroupedMember(
+    dirtyAggregateRecomputes,
+    groups,
+    plan,
+    key,
+    row,
+  );
 };
 
 const upsertCountOnlyIncrementalGroupedMember = <Row extends RowObject>(
@@ -297,17 +411,41 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
   plan: GroupedQueryPlan<Row>,
   matches: (row: Row) => boolean,
   batch: TopicRowChangeBatch<Row>,
-  dirtyGroups: Set<MaterializedIncrementalGroupState>,
 ): boolean => {
+  const retainedAggregateCount = retainedValueAggregateCount(plan);
+  const dirtyAggregateRecomputes: DirtyAggregateRecomputes = new Set();
   for (const change of batch.changes) {
+    if (change.previous !== undefined && change.next !== undefined) {
+      const previousMatches = matches(change.previous);
+      const nextMatches = matches(change.next);
+      const groupedKey = plan.groupKey(change.previous);
+      const group = state.groups.get(groupedKey);
+      if (
+        previousMatches &&
+        nextMatches &&
+        groupedKey === plan.groupKey(change.next) &&
+        group !== undefined &&
+        group.members.has(change.key)
+      ) {
+        replaceMaterializedIncrementalGroupedMember(
+          dirtyAggregateRecomputes,
+          group,
+          plan,
+          change.key,
+          change.previous,
+          change.next,
+        );
+        continue;
+      }
+    }
     if (change.previous !== undefined) {
       const removed = removeMaterializedIncrementalGroupedMember(
+        dirtyAggregateRecomputes,
         state.groups,
         plan,
         matches,
         change.key,
         change.previous,
-        dirtyGroups,
       );
       if (removed) {
         state.memberCount -= 1;
@@ -315,12 +453,12 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
     }
     if (change.next !== undefined) {
       const upserted = upsertMaterializedIncrementalGroupedMember(
+        dirtyAggregateRecomputes,
         state.groups,
         plan,
         matches,
         change.key,
         change.next,
-        dirtyGroups,
       );
       if (upserted === undefined) {
         continue;
@@ -333,12 +471,17 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
       }
       if (upserted.inserted) {
         state.memberCount += 1;
-        if (state.memberCount > maxIncrementalGroupedMembers) {
+        if (
+          state.memberCount > maxIncrementalGroupedMembers ||
+          retainedValueEntryEstimate(state.memberCount, retainedAggregateCount) >
+            maxIncrementalGroupedMembers
+        ) {
           return false;
         }
       }
     }
   }
+  recomputeDirtyAggregateStates(dirtyAggregateRecomputes);
   return true;
 };
 
@@ -376,17 +519,13 @@ const applyMaterializedIncrementalGroupedQueryBatches = <Row extends RowObject>(
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
 ): boolean => {
-  const dirtyGroups = new Set<MaterializedIncrementalGroupState>();
   for (const batch of batches) {
-    if (!applyMaterializedIncrementalGroupedQueryBatch(state, plan, matches, batch, dirtyGroups)) {
+    if (!applyMaterializedIncrementalGroupedQueryBatch(state, plan, matches, batch)) {
       state.groups.clear();
       state.memberCount = 0;
       return false;
     }
     state.version = batch.version;
-  }
-  for (const group of dirtyGroups) {
-    recomputeIncrementalGroupState(group, plan.aggregates);
   }
   state.evaluation = evaluateIncrementalGroupedQuery(state, plan, state.version);
   return true;

--- a/packages/column-live-view-engine/src/grouped-write.bench.ts
+++ b/packages/column-live-view-engine/src/grouped-write.bench.ts
@@ -66,10 +66,12 @@ type BenchmarkProfile = {
   deltaVersionCount: number;
   deleteKeys: ReadonlyArray<string>;
   engine: Engine | undefined;
+  extremeReplaceIndexes: ReadonlyArray<number>;
   groupMoveKeys: ReadonlyArray<string>;
   memoryAfterSetup: BenchmarkMemorySnapshot | undefined;
   nextAppendIndex: number;
   nextDeleteKeyIndex: number;
+  nextExtremeReplaceIndex: number;
   nextGroupMoveKeyIndex: number;
   nextSameGroupPatchKeyIndex: number;
   regionStatusReader: GroupedEventReader | undefined;
@@ -204,10 +206,12 @@ const profile: BenchmarkProfile = {
   deltaVersionCount: 0,
   deleteKeys: [],
   engine: undefined,
+  extremeReplaceIndexes: [],
   groupMoveKeys: [],
   memoryAfterSetup: undefined,
   nextAppendIndex: benchmarkRowCount,
   nextDeleteKeyIndex: 0,
+  nextExtremeReplaceIndex: 0,
   nextGroupMoveKeyIndex: 0,
   nextSameGroupPatchKeyIndex: 0,
   regionStatusReader: undefined,
@@ -283,6 +287,7 @@ const appendedRows = (startIndex: number, generation: number): ReadonlyArray<Ord
       ? {
           ...generatedOrder("grouped-append", startIndex + offset, generation),
           price: incrementalPriceThreshold(benchmarkRowCount) + offset,
+          region: "synthetic-append",
           status: "open",
         }
       : generatedOrder("grouped-append", startIndex + offset, generation),
@@ -309,11 +314,52 @@ const matchingSeedKeysForStatus = (
   return keys;
 };
 
+const matchingSeedIndexesForGroup = (
+  requiredCount: number,
+  status: OrderStatus,
+  requiredRegion: string,
+): ReadonlyArray<number> => {
+  const rows: Array<OrderRow> = [];
+  let index = 0;
+  while (index < benchmarkRowCount) {
+    const row = seedOrder(index);
+    if (
+      row.status === status &&
+      row.region === requiredRegion &&
+      rowMatchesGroupedWriteMode(index)
+    ) {
+      rows.push(row);
+    }
+    index += 1;
+  }
+  rows.sort((left, right) => left.price - right.price || left.updatedAt - right.updatedAt);
+  if (rows.length < requiredCount) {
+    throw new Error(
+      `Expected ${requiredCount} seeded ${requiredRegion}/${status} row(s) for grouped write benchmark, found ${rows.length}.`,
+    );
+  }
+  return rows
+    .slice(0, requiredCount)
+    .map((row) => Number.parseInt(row.id.slice("order-".length), 10));
+};
+
+const extremeReplacementRows = (
+  indexes: ReadonlyArray<number>,
+  generation: number,
+): ReadonlyArray<OrderRow> =>
+  indexes.map((index, offset) => ({
+    ...seedOrder(index),
+    price: 5_000_000 + generation + offset,
+    quantity: BigInt(20_000 + offset),
+    updatedAt: 5_000_000_000 + generation + offset,
+  }));
+
 const primaryGroupedAggregateQuery = () => {
   const base = {
     groupBy: ["region", "status"],
     aggregates: {
       averagePrice: { aggFunc: "avg", field: "price" },
+      distinctOrders: { aggFunc: "countDistinct", field: "id" },
       maxPrice: { aggFunc: "max", field: "price" },
       minPrice: { aggFunc: "min", field: "price" },
       rowCount: { aggFunc: "count" },
@@ -342,6 +388,7 @@ const secondaryGroupedAggregateQuery = () => {
     groupBy: ["status", "region"],
     aggregates: {
       averagePrice: { aggFunc: "avg", field: "price" },
+      distinctOrders: { aggFunc: "countDistinct", field: "id" },
       maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
       rowCount: { aggFunc: "count" },
       totalPrice: { aggFunc: "sum", field: "price" },
@@ -499,6 +546,7 @@ beforeAll(async () => {
     "open",
   );
   profile.engine = engine;
+  profile.extremeReplaceIndexes = matchingSeedIndexesForGroup(requiredMutationKeys, "open", "emea");
   profile.groupMoveKeys = matchingSeedKeysForStatus(
     Math.floor(benchmarkRowCount * 0.33),
     requiredMutationKeys,
@@ -574,6 +622,7 @@ afterAll(async () => {
   profile.memoryAfterSetup = undefined;
   profile.regionStatusReader = undefined;
   profile.deleteKeys = [];
+  profile.extremeReplaceIndexes = [];
   profile.groupMoveKeys = [];
   profile.sameGroupPatchKeys = [];
   profile.statusReader = undefined;
@@ -584,6 +633,7 @@ afterAll(async () => {
     backpressureCount: backpressureCountFromEngineHealth(health),
     benchmarkCases: [
       "grouped publishMany append batch",
+      "grouped publishMany replace extrema batch",
       "grouped patch aggregate values",
       "grouped patch group moves",
       "grouped delete existing rows",
@@ -635,6 +685,26 @@ describe(`grouped write engine benchmark: ${profile.rowCount} rows`, () => {
       profile.rowMutationCount += rows.length;
       await Effect.runPromise(engine.publishMany("orders", rows));
       await drainDeltas(profile, "grouped publishMany append batch");
+    },
+    benchOptions,
+  );
+
+  bench(
+    "grouped publishMany replace extrema batch",
+    async () => {
+      const engine = profileEngine(profile);
+      const start = profile.nextExtremeReplaceIndex;
+      const indexes = profile.extremeReplaceIndexes.slice(start, start + mutationBatchSize);
+      if (indexes.length !== mutationBatchSize) {
+        throw new Error("Grouped write benchmark exhausted extrema replacement indexes.");
+      }
+      profile.nextExtremeReplaceIndex += indexes.length;
+      profile.deltaVersionCount += 1;
+      profile.rowMutationCount += indexes.length;
+      await Effect.runPromise(
+        engine.publishMany("orders", extremeReplacementRows(indexes, profile.rowMutationCount)),
+      );
+      await drainDeltas(profile, "grouped publishMany replace extrema batch");
     },
     benchOptions,
   );

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -1569,6 +1569,8 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         aggregates: {
           totalQuantity: { aggFunc: "sum", field: "quantity" },
           averageQuantity: { aggFunc: "avg", field: "quantity" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+          averagePrice: { aggFunc: "avg", field: "price" },
           minQuantity: { aggFunc: "min", field: "quantity" },
           maxQuantity: { aggFunc: "max", field: "quantity" },
         },
@@ -1579,6 +1581,8 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           symbol: "AAPL",
           totalQuantity: "30",
           averageQuantity: "15",
+          totalPrice: "3",
+          averagePrice: "1.5",
           minQuantity: "10",
           maxQuantity: "20",
         },
@@ -1586,10 +1590,147 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           symbol: "MSFT",
           totalQuantity: "5",
           averageQuantity: "5",
+          totalPrice: "3",
+          averagePrice: "3",
           minQuantity: "5",
           maxQuantity: "5",
         },
       ]);
+    }),
+  );
+
+  it.effect("updates grouped bigint sums incrementally through live subscriptions", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("positions", [
+        position("1", "AAPL", 10n, "1.00"),
+        position("2", "AAPL", 20n, "2.00"),
+        position("3", "MSFT", 5n, "3.00"),
+      ]);
+      const query = {
+        groupBy: ["symbol"],
+        aggregates: {
+          totalQuantity: { aggFunc: "sum", field: "quantity" },
+          averageQuantity: { aggFunc: "avg", field: "quantity" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+          averagePrice: { aggFunc: "avg", field: "price" },
+          minQuantity: { aggFunc: "min", field: "quantity" },
+          maxQuantity: { aggFunc: "max", field: "quantity" },
+        },
+        orderBy: [{ field: "symbol", direction: "asc" }],
+      } satisfies {
+        readonly groupBy: readonly ["symbol"];
+        readonly aggregates: {
+          readonly totalQuantity: { readonly aggFunc: "sum"; readonly field: "quantity" };
+          readonly averageQuantity: { readonly aggFunc: "avg"; readonly field: "quantity" };
+          readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+          readonly averagePrice: { readonly aggFunc: "avg"; readonly field: "price" };
+          readonly minQuantity: { readonly aggFunc: "min"; readonly field: "quantity" };
+          readonly maxQuantity: { readonly aggFunc: "max"; readonly field: "quantity" };
+        };
+        readonly orderBy: readonly [{ readonly field: "symbol"; readonly direction: "asc" }];
+      };
+
+      const subscription = yield* engine.subscribe("positions", query);
+      const read = yield* makeEventReader(subscription);
+      const snapshot = firstEvent(yield* read(1));
+      expectSnapshotEvent(snapshot);
+      let state = stateFromSnapshot(snapshot);
+      expect(normalizeDecimalAndBigIntFields(state.rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          totalQuantity: "30",
+          averageQuantity: "15",
+          totalPrice: "3",
+          averagePrice: "1.5",
+          minQuantity: "10",
+          maxQuantity: "20",
+        },
+        {
+          symbol: "MSFT",
+          totalQuantity: "5",
+          averageQuantity: "5",
+          totalPrice: "3",
+          averagePrice: "3",
+          minQuantity: "5",
+          maxQuantity: "5",
+        },
+      ]);
+
+      yield* engine.patch("positions", "2", {
+        price: fromStringUnsafe("4.00"),
+        quantity: 30n,
+      });
+      const patchedDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(patchedDelta);
+      state = applyDelta(state, patchedDelta);
+      expect(normalizeDecimalAndBigIntFields(state.rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          totalQuantity: "40",
+          averageQuantity: "20",
+          totalPrice: "5",
+          averagePrice: "2.5",
+          minQuantity: "10",
+          maxQuantity: "30",
+        },
+        {
+          symbol: "MSFT",
+          totalQuantity: "5",
+          averageQuantity: "5",
+          totalPrice: "3",
+          averagePrice: "3",
+          minQuantity: "5",
+          maxQuantity: "5",
+        },
+      ]);
+
+      yield* engine.delete("positions", "1");
+      const deletedDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(deletedDelta);
+      state = applyDelta(state, deletedDelta);
+      expect(normalizeDecimalAndBigIntFields(state.rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          totalQuantity: "30",
+          averageQuantity: "30",
+          totalPrice: "4",
+          averagePrice: "4",
+          minQuantity: "30",
+          maxQuantity: "30",
+        },
+        {
+          symbol: "MSFT",
+          totalQuantity: "5",
+          averageQuantity: "5",
+          totalPrice: "3",
+          averagePrice: "3",
+          minQuantity: "5",
+          maxQuantity: "5",
+        },
+      ]);
+
+      yield* engine.patch("positions", "2", {
+        price: fromStringUnsafe("5.00"),
+        quantity: 25n,
+        symbol: "MSFT",
+      });
+      const movedDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(movedDelta);
+      state = applyDelta(state, movedDelta);
+      expect(normalizeDecimalAndBigIntFields(state.rows)).toStrictEqual([
+        {
+          symbol: "MSFT",
+          totalQuantity: "30",
+          averageQuantity: "15",
+          totalPrice: "8",
+          averagePrice: "4",
+          minQuantity: "5",
+          maxQuantity: "25",
+        },
+      ]);
+
+      yield* subscription.close();
     }),
   );
 
@@ -2092,6 +2233,16 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
               next: undefined,
             },
             {
+              key: "missing-replace-member",
+              previous: order("missing-replace-member", "open", 6, 6, "emea"),
+              next: order("missing-replace-member", "open", 7, 7, "emea"),
+            },
+            {
+              key: "missing-replace-group",
+              previous: order("missing-replace-group", "cancelled", 8, 8, "emea"),
+              next: order("missing-replace-group", "cancelled", 9, 9, "emea"),
+            },
+            {
               key: "1",
               previous: undefined,
               next: order("1", "open", 15, 6, "emea"),
@@ -2103,8 +2254,9 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       ];
 
       expect(execution.latest().rows).toStrictEqual([
+        { status: "cancelled", rowCount: 1n },
         { status: "closed", rowCount: 1n },
-        { status: "open", rowCount: 1n },
+        { status: "open", rowCount: 2n },
       ]);
       expect(scanCount).toBe(1);
     }),
@@ -2281,6 +2433,127 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expect(execution.latest().rows).toStrictEqual([]);
       expect(execution.latest().totalRows).toBe(8_195);
       expect(execution.incremental).toBe(false);
+      expect(scanCount).toBe(2);
+    }),
+  );
+
+  it.effect("ignores malformed runtime aggregate values while removing grouped members", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const malformedPosition = {
+        id: "bad",
+        accountId: "account-bad",
+        symbol: "AAPL",
+        active: true,
+        quantity: "bad",
+        price: "bad",
+      };
+      const validPosition = position("good", "AAPL", 10n, "2.00");
+      const rows = new Map<string, object>([
+        ["bad", malformedPosition],
+        ["good", validPosition],
+      ]);
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          groupBy: ["symbol"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+            totalQuantity: { aggFunc: "sum", field: "quantity" },
+            averageQuantity: { aggFunc: "avg", field: "quantity" },
+            totalPrice: { aggFunc: "sum", field: "price" },
+            averagePrice: { aggFunc: "avg", field: "price" },
+          },
+          orderBy: [{ field: "symbol", direction: "asc" }],
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          rowCount: "2",
+          totalQuantity: "10",
+          averageQuantity: "10",
+          totalPrice: "2",
+          averagePrice: "2",
+        },
+      ]);
+      expect(scanCount).toBe(1);
+
+      rows.delete("bad");
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [{ key: "bad", previous: malformedPosition, next: undefined }],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          symbol: "AAPL",
+          rowCount: "1",
+          totalQuantity: "10",
+          averageQuantity: "10",
+          totalPrice: "2",
+          averagePrice: "2",
+        },
+      ]);
+      expect(scanCount).toBe(1);
+    }),
+  );
+
+  it.effect("falls back when grouped retained aggregate state exceeds admission", () =>
+    Effect.gen(function* () {
+      let scanCount = 0;
+      const rows = new Map<string, object>(
+        Array.from({ length: 4_096 }, (_value, index) => [
+          `row-${index}`,
+          order(`row-${index}`, "open", index, index),
+        ]),
+      );
+      const store = {
+        changesSince: () => [],
+        scanRows: (visitor: (key: string, row: object) => false | void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => 0,
+      };
+      const retainedAggregates = Object.fromEntries(
+        Array.from({ length: 17 }, (_value, index) => [
+          `maxUpdatedAt${index}`,
+          { aggFunc: "max", field: "updatedAt" },
+        ]),
+      );
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: retainedAggregates,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(store, compiled, () => {});
+
+      expect(execution.incremental).toBe(false);
+      expect(execution.latest().totalRows).toBe(1);
       expect(scanCount).toBe(2);
     }),
   );
@@ -3767,6 +4040,203 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           averagePrice: "17.5",
           minUpdatedAt: 3,
           maxUpdatedAt: 4,
+        },
+      ]);
+
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("keeps grouped aggregate state exact across duplicate removals", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("1", "open", 10, 1, "emea"),
+        order("2", "open", 20, 6, "emea"),
+        order("3", "open", 30, 5, "amer"),
+      ]);
+      const query = {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          distinctRegions: { aggFunc: "countDistinct", field: "region" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+          averagePrice: { aggFunc: "avg", field: "price" },
+          minUpdatedAt: { aggFunc: "min", field: "updatedAt" },
+          maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      } satisfies {
+        readonly groupBy: readonly ["status"];
+        readonly aggregates: {
+          readonly rowCount: { readonly aggFunc: "count" };
+          readonly distinctRegions: {
+            readonly aggFunc: "countDistinct";
+            readonly field: "region";
+          };
+          readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+          readonly averagePrice: { readonly aggFunc: "avg"; readonly field: "price" };
+          readonly minUpdatedAt: { readonly aggFunc: "min"; readonly field: "updatedAt" };
+          readonly maxUpdatedAt: { readonly aggFunc: "max"; readonly field: "updatedAt" };
+        };
+        readonly orderBy: readonly [{ readonly field: "status"; readonly direction: "asc" }];
+      };
+
+      const subscription = yield* engine.subscribe("orders", query);
+      const read = yield* makeEventReader(subscription);
+      const snapshot = firstEvent(yield* read(1));
+      expectSnapshotEvent(snapshot);
+      let state = stateFromSnapshot(snapshot);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 3n,
+          distinctRegions: 2n,
+          totalPrice: "60",
+          averagePrice: "20",
+          minUpdatedAt: 1,
+          maxUpdatedAt: 6,
+        },
+      ]);
+
+      yield* engine.patch("orders", "2", {
+        price: 50,
+      });
+      const patchedDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(patchedDelta);
+      state = applyDelta(state, patchedDelta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 3n,
+          distinctRegions: 2n,
+          totalPrice: "90",
+          averagePrice: "30",
+          minUpdatedAt: 1,
+          maxUpdatedAt: 6,
+        },
+      ]);
+
+      yield* engine.delete("orders", "1");
+      const deletedDuplicateDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(deletedDuplicateDelta);
+      state = applyDelta(state, deletedDuplicateDelta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 2n,
+          distinctRegions: 2n,
+          totalPrice: "80",
+          averagePrice: "40",
+          minUpdatedAt: 5,
+          maxUpdatedAt: 6,
+        },
+      ]);
+
+      yield* engine.delete("orders", "3");
+      const deletedDistinctDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(deletedDistinctDelta);
+      state = applyDelta(state, deletedDistinctDelta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 1n,
+          distinctRegions: 1n,
+          totalPrice: "50",
+          averagePrice: "50",
+          minUpdatedAt: 6,
+          maxUpdatedAt: 6,
+        },
+      ]);
+
+      yield* engine.patch("orders", "2", {
+        status: "closed",
+        price: 25,
+        region: "amer",
+        updatedAt: 2,
+      });
+      const movedDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(movedDelta);
+      state = applyDelta(state, movedDelta);
+      expect(normalizeDecimalFields(state.rows)).toStrictEqual([
+        {
+          status: "closed",
+          rowCount: 1n,
+          distinctRegions: 1n,
+          totalPrice: "25",
+          averagePrice: "25",
+          minUpdatedAt: 2,
+          maxUpdatedAt: 2,
+        },
+      ]);
+
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("keeps duplicate grouped min max values after deleting one duplicate", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("1", "open", 10, 6, "emea"),
+        order("2", "open", 20, 6, "amer"),
+        order("3", "open", 30, 1, "amer"),
+        order("4", "open", 40, 3, "emea"),
+        order("5", "open", 50, 2, "emea"),
+      ]);
+      const query = {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          minUpdatedAt: { aggFunc: "min", field: "updatedAt" },
+          maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+      } satisfies {
+        readonly groupBy: readonly ["status"];
+        readonly aggregates: {
+          readonly rowCount: { readonly aggFunc: "count" };
+          readonly minUpdatedAt: { readonly aggFunc: "min"; readonly field: "updatedAt" };
+          readonly maxUpdatedAt: { readonly aggFunc: "max"; readonly field: "updatedAt" };
+        };
+        readonly orderBy: readonly [{ readonly field: "status"; readonly direction: "asc" }];
+      };
+
+      const subscription = yield* engine.subscribe("orders", query);
+      const read = yield* makeEventReader(subscription);
+      let state = stateFromSnapshot(firstEvent(yield* read(1)));
+      expect(state.rows).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 5n,
+          minUpdatedAt: 1,
+          maxUpdatedAt: 6,
+        },
+      ]);
+
+      yield* engine.delete("orders", "1");
+      const delta = firstEvent(yield* read(1));
+      expectDeltaEvent(delta);
+      state = applyDelta(state, delta);
+      expect(state.rows).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 4n,
+          minUpdatedAt: 1,
+          maxUpdatedAt: 6,
+        },
+      ]);
+
+      yield* engine.delete("orders", "2");
+      const maxDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(maxDelta);
+      state = applyDelta(state, maxDelta);
+      expect(state.rows).toStrictEqual([
+        {
+          status: "open",
+          rowCount: 3n,
+          minUpdatedAt: 1,
+          maxUpdatedAt: 3,
         },
       ]);
 

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1517,6 +1517,7 @@ patch/delete/group-move costs can become very expensive at high row counts.
 Grouped write benchmark cases:
 
 - `grouped publishMany append batch`
+- `grouped publishMany replace extrema batch`
 - `grouped patch aggregate values`
 - `grouped patch group moves`
 - `grouped delete existing rows`
@@ -1542,6 +1543,15 @@ Interpretation notes:
   subscriptions.
 - Incremental mode covers admitted grouped insert/update/move/delete write pressure. Fallback mode
   covers broad grouped rebuild pressure and is intentionally a different signal.
+- Current incremental grouped write maintenance updates aggregate states reversibly for inserts,
+  removals, same-group patches, and group moves. Count, count-distinct, sum, avg, min, and max are
+  adjusted from the changed row instead of recomputing every dirty group from its member map.
+- Retained `min`/`max` removals can invalidate the current extremum. The incremental executor batches
+  those invalidations and recomputes each dirty `{group, aggregate}` once after the mutation batch,
+  avoiding repeated retained-map scans when a single `publishMany` replaces or deletes many extrema.
+- Incremental grouped admission also budgets retained value state for `countDistinct`, `min`, and
+  `max`. Queries that would retain too many alias/member reverse entries demote to fallback rather
+  than keeping high-cardinality reversible state alive between writes.
 - The benchmark does not prove a future grouped materialized index is worthwhile by itself; compare
   it with grouped read benchmarks before adopting storage that adds write maintenance.
 - Keep grouped write and grouped aggregate benchmarks together when evaluating grouped engine


### PR DESCRIPTION
## Summary
- add reversible grouped aggregate maintenance for countDistinct, sum, avg, min, and max
- coalesce retained min/max recomputes once per mutation batch
- add grouped write benchmark coverage for publishMany extrema replacement
- document retained aggregate admission and incremental grouped write behavior

## Validation
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- vp run --no-cache column-live-view-engine#test -- src/index.test.ts
- VIEW_SERVER_ENGINE_BENCH_GROUPED_WRITE_MODE=incremental VIEW_SERVER_ENGINE_BENCH_ROWS=1000000 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=3 VIEW_SERVER_ENGINE_BENCH_TIME_MS=0 VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS=0 VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS=0 VIEW_SERVER_ENGINE_BENCH_WRITE_BATCH_SIZE=32 vp run --no-cache column-live-view-engine#bench:grouped-write
- pnpm run bench:baseline:smoke
- pnpm run ready

## Review
- 3 agent review cycle completed
- prior blocker about per-extremum retained min/max recompute was fixed and re-reviewed cleanly
