### PR TITLE
Add typed Kafka source codecs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -162,6 +162,10 @@ _Avoid_: Seed provider, mock provider
 An external Kafka topic or future server-side source that provides messages to be mapped into a View Server Topic.
 _Avoid_: View Server Topic
 
+**Kafka Source Codec**:
+A typed decoder contract for Kafka message keys and values before Mapping, such as protobuf, JSON, string, bytes, or a custom Effectful decoder. It is the source-format Seam; the View Server Topic schema remains the target truth.
+_Avoid_: Topic schema, row schema, serializer
+
 **Region**:
 A named Kafka/source deployment location configured for ingestion.
 _Avoid_: Location string, environment, cluster unless discussing infrastructure
@@ -204,6 +208,7 @@ _Avoid_: Browser write, send, emit
 - A **View Server Provider** supplies a **Live Client** to React hooks.
 - A **View Server In-Memory Provider** supplies the same hook behavior through an **In-Memory View Server**.
 - A **Real View Server** and **In-Memory View Server** differ only by transport and ingress **Adapters**, not by query, storage, health, or subscription logic.
+- A **Source Topic** uses one **Kafka Source Codec** for its value and optionally one **Kafka Source Codec** for its key.
 - A **Source Topic** is mapped into a **View Server Topic** through a **Mapping**.
 - **Health Ledger** state feeds engine health, runtime health, transport health, and React health.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,33 @@
+services:
+  kafka:
+    image: apache/kafka:4.3.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: "1"
+      KAFKA_PROCESS_ROLES: "broker,controller"
+      KAFKA_LISTENERS: "PLAINTEXT://:9092,INTERNAL://:29092,CONTROLLER://:9093"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://localhost:9092,INTERNAL://kafka:29092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@localhost:9093"
+      KAFKA_LOG_DIRS: "/tmp/view-server-kafka-logs"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+      KAFKA_NUM_PARTITIONS: "3"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    tmpfs:
+      - /tmp/view-server-kafka-logs:size=1g
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, expectTypeOf, it } from "@effect/vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv2";
 import type { GenMessage } from "@bufbuild/protobuf/codegenv2";
 import type { Message } from "@bufbuild/protobuf";
-import type { Effect } from "effect";
+import { FieldDescriptorProto_Type, FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";
 import type * as BigDecimal from "effect/BigDecimal";
-import { Config, Schema } from "effect";
+import { Config, Effect, Schema } from "effect";
 import {
-  defineProto,
   defineViewServerConfig,
+  kafka,
   VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
   VIEW_SERVER_HEALTH_TOPIC,
   viewServerReservedTopicNames,
@@ -15,8 +17,12 @@ import {
   viewServerHealthSummaryFromHealth,
   viewServerHealthSummaryRowFromHealth,
   viewServerHealthTopicRowsFromHealth,
+  type KafkaCodec,
   type KafkaMappingInput,
   type KafkaMessageMetadata,
+  type KafkaCodecError,
+  type KafkaCodecType,
+  type KafkaDecodeError,
   type KafkaTopicDefinition,
   type ExactGroupedQuery,
   type ExactRawQuery,
@@ -25,7 +31,6 @@ import {
   type LiveQueryRow,
   type LiveSubscription,
   type LiveTransportAdapter,
-  type ProtobufEsGeneratedMessageDescriptor,
   type RawQuery,
   type SnapshotEvent,
   type StatusEvent,
@@ -73,41 +78,82 @@ const Position = Schema.Struct({
   optionalNotional: Schema.Union([Schema.Number, Schema.Undefined]),
 });
 
+const OrderWithExtraSourceField = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Number,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+  ze: Schema.Boolean,
+});
+
 declare const decimal: (value: string) => BigDecimal.BigDecimal;
 
-const ordersValueProto = defineProto<{
+type OrdersValueMessage = Message<"viewserver.test.OrderValue"> & {
   readonly customerId: string;
   readonly status: "open" | "closed" | "cancelled";
   readonly price: number;
   readonly updatedAt: number;
-}>();
-const ordersKeyProto = defineProto<{
+};
+
+type OrdersKeyMessage = Message<"viewserver.test.OrderKey"> & {
   readonly orderId: string;
-}>();
-const tradesValueProto = defineProto<{
+};
+
+type TradesValueMessage = Message<"viewserver.test.TradeValue"> & {
   readonly symbol: string;
   readonly quantity: number;
   readonly price: number;
-}>();
-
-const ordersValueSchema: ProtobufEsGeneratedMessageDescriptor<{
-  readonly customerId: string;
-  readonly status: "open" | "closed" | "cancelled";
-  readonly price: number;
-  readonly updatedAt: number;
-}> = {
-  typeName: "viewserver.test.OrderValue",
-  fields: {},
-  _viewServerProtoType: (value) => value,
 };
 
-const ordersKeySchema: ProtobufEsGeneratedMessageDescriptor<{
-  readonly orderId: string;
-}> = {
-  typeName: "viewserver.test.OrderKey",
-  fields: {},
-  _viewServerProtoType: (value) => value,
+type CustomKafkaCodecError = {
+  readonly _tag: "CustomKafkaCodecError";
+  readonly message: string;
 };
+
+const base64FromBytes = (bytes: Uint8Array) =>
+  globalThis.btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+
+const testProtoFile = fileDesc(
+  base64FromBytes(
+    toBinary(
+      FileDescriptorProtoSchema,
+      create(FileDescriptorProtoSchema, {
+        name: "viewserver/test.proto",
+        package: "viewserver.test",
+        syntax: "proto3",
+        messageType: [
+          {
+            name: "OrderValue",
+            field: [
+              { name: "customer_id", number: 1, type: FieldDescriptorProto_Type.STRING },
+              { name: "status", number: 2, type: FieldDescriptorProto_Type.STRING },
+              { name: "price", number: 3, type: FieldDescriptorProto_Type.DOUBLE },
+              { name: "updated_at", number: 4, type: FieldDescriptorProto_Type.DOUBLE },
+            ],
+          },
+          {
+            name: "OrderKey",
+            field: [{ name: "order_id", number: 1, type: FieldDescriptorProto_Type.STRING }],
+          },
+          {
+            name: "TradeValue",
+            field: [
+              { name: "symbol", number: 1, type: FieldDescriptorProto_Type.STRING },
+              { name: "quantity", number: 2, type: FieldDescriptorProto_Type.DOUBLE },
+              { name: "price", number: 3, type: FieldDescriptorProto_Type.DOUBLE },
+            ],
+          },
+        ],
+      }),
+    ),
+  ),
+);
+
+const ordersValueSchema = messageDesc<OrdersValueMessage>(testProtoFile, 0);
+const ordersKeySchema = messageDesc<OrdersKeyMessage>(testProtoFile, 1);
+const tradesValueSchema = messageDesc<TradesValueMessage>(testProtoFile, 2);
 
 declare const generatedOrdersValueSchema: GenMessage<
   Message<"viewserver.test.OrderValue"> & {
@@ -192,6 +238,9 @@ const kafkaRegions = {
 };
 
 const kafkaTopic = viewServer.kafkaTopic<typeof kafkaRegions>();
+const ordersValueKafkaCodec = kafka.protobuf(ordersValueSchema);
+const ordersKeyKafkaCodec = kafka.protobuf(ordersKeySchema);
+const tradesValueKafkaCodec = kafka.protobuf(tradesValueSchema);
 
 describe("defineViewServerConfig", () => {
   it("derives schema field metadata for query validation", () => {
@@ -369,17 +418,12 @@ describe("defineViewServerConfig", () => {
         topics: {
           orders: kafkaTopic({
             regions: ["usa", "london"],
-            protoValue: ordersValueProto,
-            protoKey: ordersKeyProto,
+            value: kafka.protobuf(ordersValueSchema),
+            key: kafka.protobuf(ordersKeySchema),
             viewServerTopic: "orders",
             mapping: ({ key, value, region }) => {
-              expectTypeOf(key).toEqualTypeOf<{ readonly orderId: string }>();
-              expectTypeOf(value).toEqualTypeOf<{
-                readonly customerId: string;
-                readonly status: "open" | "closed" | "cancelled";
-                readonly price: number;
-                readonly updatedAt: number;
-              }>();
+              expectTypeOf(key).toEqualTypeOf<OrdersKeyMessage>();
+              expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
               expectTypeOf(region).toEqualTypeOf<"usa" | "london">();
               return {
                 id: key.orderId,
@@ -393,15 +437,11 @@ describe("defineViewServerConfig", () => {
           }),
           trades: kafkaTopic({
             regions: ["usa"],
-            protoValue: tradesValueProto,
+            value: kafka.protobuf(tradesValueSchema),
             viewServerTopic: "trades",
             mapping: ({ key, value, region }) => {
               expectTypeOf(key).toEqualTypeOf<string>();
-              expectTypeOf(value).toEqualTypeOf<{
-                readonly symbol: string;
-                readonly quantity: number;
-                readonly price: number;
-              }>();
+              expectTypeOf(value).toEqualTypeOf<TradesValueMessage>();
               expectTypeOf(region).toEqualTypeOf<"usa">();
               return {
                 id: key,
@@ -421,6 +461,66 @@ describe("defineViewServerConfig", () => {
     expect(runtimeOptions.websocketPort).toBe(runtimeEnvironmentConfig.websocketPort);
     expect(Config.isConfig(runtimeEnvironmentConfig.tcpPublishPort)).toBe(true);
     expect(Config.isConfig(runtimeConfig.port("VIEW_SERVER_TCP_PUBLISH_PORT"))).toBe(true);
+  });
+
+  it("defines typed Kafka source codecs", () => {
+    const bytesCodec = kafka.bytes();
+    const stringCodec = kafka.string();
+    const stringKeyCodec = kafka.stringKey();
+    const jsonCodec = kafka.json(Order);
+    const protobufCodec = kafka.protobuf(ordersValueSchema);
+    const customCodec = kafka.codec({
+      name: "custom-order-value",
+      decode: ({ bytes }): Effect.Effect<{ readonly byteLength: number }, never> =>
+        Effect.succeed({
+          byteLength: bytes.byteLength,
+        }),
+    });
+    const customErrorCodec = kafka.codec({
+      name: "custom-order-value-with-error",
+      decode: (): Effect.Effect<{ readonly id: string }, CustomKafkaCodecError> =>
+        Effect.fail({
+          _tag: "CustomKafkaCodecError",
+          message: "decode failed",
+        }),
+    });
+
+    expect(bytesCodec.format).toBe("bytes");
+    expect(stringCodec.format).toBe("string");
+    expect(stringKeyCodec.format).toBe("string");
+    expect(jsonCodec.schema).toBe(Order);
+    expect(protobufCodec.descriptor).toBe(ordersValueSchema);
+    expect(customCodec.name).toBe("custom-order-value");
+    expect(
+      Effect.runSync(
+        customCodec.decode({
+          bytes: new Uint8Array([1, 2, 3]),
+          metadata: {
+            sourceTopic: "orders-source",
+            sourceRegion: "usa",
+            partition: 0,
+            offset: "1",
+            timestamp: null,
+            headers: {},
+          },
+        }),
+      ),
+    ).toStrictEqual({
+      byteLength: 3,
+    });
+
+    expectTypeOf<KafkaCodecType<typeof bytesCodec>>().toEqualTypeOf<Uint8Array>();
+    expectTypeOf<KafkaCodecType<typeof stringCodec>>().toEqualTypeOf<string>();
+    expectTypeOf<KafkaCodecType<typeof stringKeyCodec>>().toEqualTypeOf<string>();
+    expectTypeOf<KafkaCodecType<typeof jsonCodec>>().toEqualTypeOf<typeof Order.Type>();
+    expectTypeOf<KafkaCodecType<typeof protobufCodec>>().toEqualTypeOf<OrdersValueMessage>();
+    expectTypeOf<KafkaCodecType<typeof customCodec>>().toEqualTypeOf<{
+      readonly byteLength: number;
+    }>();
+    expectTypeOf<KafkaCodecError<typeof jsonCodec>>().toEqualTypeOf<KafkaDecodeError>();
+    expectTypeOf<KafkaCodecError<typeof protobufCodec>>().toEqualTypeOf<KafkaDecodeError>();
+    expectTypeOf<KafkaCodecError<typeof customCodec>>().toEqualTypeOf<never>();
+    expectTypeOf<KafkaCodecError<typeof customErrorCodec>>().toEqualTypeOf<CustomKafkaCodecError>();
   });
 
   it("does not expose executable React or runtime placeholders from config", () => {
@@ -941,16 +1041,11 @@ describe("public type surface", () => {
   it("infers unannotated Kafka mapping callback parameters through the topic helper", () => {
     const topic = kafkaTopic({
       regions: ["usa", "london"],
-      protoValue: ordersValueSchema,
+      value: kafka.protobuf(ordersValueSchema),
       viewServerTopic: "orders",
       mapping: ({ key, value, region }) => {
         expectTypeOf(key).toEqualTypeOf<string>();
-        expectTypeOf(value).toEqualTypeOf<{
-          readonly customerId: string;
-          readonly status: "open" | "closed" | "cancelled";
-          readonly price: number;
-          readonly updatedAt: number;
-        }>();
+        expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
         expectTypeOf(region).toEqualTypeOf<"usa" | "london">();
         return {
           id: key,
@@ -967,17 +1062,12 @@ describe("public type surface", () => {
 
     const keyedTopic = kafkaTopic({
       regions: ["usa"],
-      protoValue: ordersValueSchema,
-      protoKey: ordersKeySchema,
+      value: kafka.protobuf(ordersValueSchema),
+      key: kafka.protobuf(ordersKeySchema),
       viewServerTopic: "orders",
       mapping: ({ key, value, region }) => {
-        expectTypeOf(key).toEqualTypeOf<{ readonly orderId: string }>();
-        expectTypeOf(value).toEqualTypeOf<{
-          readonly customerId: string;
-          readonly status: "open" | "closed" | "cancelled";
-          readonly price: number;
-          readonly updatedAt: number;
-        }>();
+        expectTypeOf(key).toEqualTypeOf<OrdersKeyMessage>();
+        expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
         expectTypeOf(region).toEqualTypeOf<"usa">();
         return {
           id: key.orderId,
@@ -990,7 +1080,64 @@ describe("public type surface", () => {
       },
     });
 
-    expect(keyedTopic.protoKey).toBe(ordersKeySchema);
+    expect(keyedTopic.key.descriptor).toBe(ordersKeySchema);
+  });
+
+  it("supports json and custom Kafka source codecs without weakening mapping exactness", () => {
+    const jsonTopic = kafkaTopic({
+      regions: ["usa"],
+      value: kafka.json(Order),
+      viewServerTopic: "orders",
+      mapping: ({ key, value, region }) => {
+        expectTypeOf(key).toEqualTypeOf<string>();
+        expectTypeOf(value).toEqualTypeOf<typeof Order.Type>();
+        expectTypeOf(region).toEqualTypeOf<"usa">();
+        return value;
+      },
+    });
+
+    const customTopic = kafkaTopic({
+      regions: ["london"],
+      value: kafka.codec({
+        name: "trade-json-lines",
+        decode: (): Effect.Effect<
+          {
+            readonly tradeId: string;
+            readonly symbol: string;
+            readonly quantity: number;
+            readonly price: number;
+          },
+          never
+        > =>
+          Effect.succeed({
+            tradeId: "trade-1",
+            symbol: "AAPL",
+            quantity: 10,
+            price: 42,
+          }),
+      }),
+      viewServerTopic: "trades",
+      mapping: ({ key, value, region }) => {
+        expectTypeOf(key).toEqualTypeOf<string>();
+        expectTypeOf(value).toEqualTypeOf<{
+          readonly tradeId: string;
+          readonly symbol: string;
+          readonly quantity: number;
+          readonly price: number;
+        }>();
+        expectTypeOf(region).toEqualTypeOf<"london">();
+        return {
+          id: value.tradeId,
+          symbol: value.symbol,
+          quantity: value.quantity,
+          price: value.price,
+          region,
+        };
+      },
+    });
+
+    expect(jsonTopic.value.format).toBe("json");
+    expect(customTopic.value.format).toBe("custom");
   });
 
   it("keeps real Protobuf-ES v2 generated schema inference typechecked", () => {
@@ -1001,8 +1148,8 @@ describe("public type surface", () => {
 const assertGeneratedSchemaContracts = () => {
   const keyedTopic = kafkaTopic({
     regions: ["usa", "london"],
-    protoValue: generatedOrdersValueSchema,
-    protoKey: generatedOrdersKeySchema,
+    value: kafka.protobuf(generatedOrdersValueSchema),
+    key: kafka.protobuf(generatedOrdersKeySchema),
     viewServerTopic: "orders",
     mapping: ({ key, value, region }) => {
       expectTypeOf(key).toEqualTypeOf<
@@ -1028,17 +1175,15 @@ const assertGeneratedSchemaContracts = () => {
     },
   });
 
-  expectTypeOf(keyedTopic.protoKey).toEqualTypeOf<
-    GenMessage<
-      Message<"viewserver.test.OrderKey"> & {
-        readonly orderId: string;
-      }
-    >
+  expectTypeOf<KafkaCodecType<typeof keyedTopic.key>>().toEqualTypeOf<
+    Message<"viewserver.test.OrderKey"> & {
+      readonly orderId: string;
+    }
   >();
 
   kafkaTopic({
     regions: ["usa", "london"],
-    protoValue: generatedOrdersValueSchema,
+    value: kafka.protobuf(generatedOrdersValueSchema),
     viewServerTopic: "orders",
     mapping: ({ key, value, region }) => {
       expectTypeOf(key).toEqualTypeOf<string>();
@@ -1068,37 +1213,146 @@ const assertCompileTimeContracts = () => {
     usa: "broker-a:9092",
   };
   const localKafkaTopic = viewServer.kafkaTopic<typeof localKafkaRegions>();
+  const londonKafkaRegions = {
+    london: "broker-b:9092",
+  };
+  const londonKafkaTopic = viewServer.kafkaTopic<typeof londonKafkaRegions>()({
+    regions: ["london"],
+    value: kafka.protobuf(ordersValueSchema),
+    viewServerTopic: "orders",
+    mapping: ({ key, value, region }) => ({
+      id: key,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region,
+      updatedAt: value.updatedAt,
+    }),
+  });
+  type UnsafeJsonParseResult = ReturnType<typeof JSON.parse>;
+  const unsafeValueCodec: KafkaCodec<UnsafeJsonParseResult> = kafka.bytes();
+  const unsafeErrorCodec: KafkaCodec<string, UnsafeJsonParseResult> = kafka.string();
+  const unknownErrorCodec: KafkaCodec<string, unknown> = kafka.string();
+
+  // @ts-expect-error protobuf descriptors cannot be inferred from any
+  kafka.protobuf(JSON.parse("{}"));
+
+  // @ts-expect-error json schemas cannot be inferred from any
+  kafka.json(JSON.parse("{}"));
+
+  // @ts-expect-error custom Kafka codec values cannot infer any
+  kafka.codec({
+    name: "unsafe-effect-json-parse",
+    decode: () => Effect.succeed(JSON.parse("{}")),
+  });
+
+  // @ts-expect-error custom Kafka codec errors cannot infer any
+  kafka.codec({
+    name: "unsafe-effect-json-parse-error",
+    decode: () => Effect.fail(JSON.parse("{}")),
+  });
+
+  localKafkaTopic({
+    regions: ["usa"],
+    // @ts-expect-error Kafka value codecs cannot be inferred from any
+    value: JSON.parse("{}"),
+    viewServerTopic: "orders",
+    mapping: (): typeof Order.Type => ({
+      id: "order-1",
+      customerId: "customer-1",
+      status: "open",
+      price: 42,
+      region: "usa",
+      updatedAt: 1,
+    }),
+  });
+
+  localKafkaTopic({
+    regions: ["usa"],
+    value: kafka.protobuf(ordersValueSchema),
+    // @ts-expect-error Kafka key codecs cannot be inferred from any
+    key: JSON.parse("{}"),
+    viewServerTopic: "orders",
+    mapping: (): typeof Order.Type => ({
+      id: "order-1",
+      customerId: "customer-1",
+      status: "open",
+      price: 42,
+      region: "usa",
+      updatedAt: 1,
+    }),
+  });
+
+  localKafkaTopic({
+    regions: ["usa"],
+    // @ts-expect-error Kafka value codecs cannot be widened to KafkaCodec<any>
+    value: unsafeValueCodec,
+    viewServerTopic: "orders",
+    mapping: (): typeof Order.Type => ({
+      id: "order-1",
+      customerId: "customer-1",
+      status: "open",
+      price: 42,
+      region: "usa",
+      updatedAt: 1,
+    }),
+  });
+
+  localKafkaTopic({
+    regions: ["usa"],
+    // @ts-expect-error Kafka codec error channels cannot be widened to any
+    value: unsafeErrorCodec,
+    viewServerTopic: "orders",
+    mapping: (): typeof Order.Type => ({
+      id: "order-1",
+      customerId: "customer-1",
+      status: "open",
+      price: 42,
+      region: "usa",
+      updatedAt: 1,
+    }),
+  });
+
+  localKafkaTopic({
+    regions: ["usa"],
+    // @ts-expect-error Kafka codec error channels cannot be widened to unknown
+    value: unknownErrorCodec,
+    viewServerTopic: "orders",
+    mapping: (): typeof Order.Type => ({
+      id: "order-1",
+      customerId: "customer-1",
+      status: "open",
+      price: 42,
+      region: "usa",
+      updatedAt: 1,
+    }),
+  });
 
   expectTypeOf<
     KafkaMappingInput<
       typeof viewServer.topics,
       "orders",
       "usa" | "london",
-      typeof ordersValueProto,
-      typeof ordersKeyProto
+      typeof ordersValueKafkaCodec,
+      typeof ordersKeyKafkaCodec
     >["key"]
-  >().toEqualTypeOf<{ readonly orderId: string }>();
+  >().toEqualTypeOf<OrdersKeyMessage>();
   expectTypeOf<
     KafkaMappingInput<
       typeof viewServer.topics,
       "orders",
       "usa" | "london",
-      typeof ordersValueProto,
-      typeof ordersKeyProto
+      typeof ordersValueKafkaCodec,
+      typeof ordersKeyKafkaCodec
     >["value"]
-  >().toEqualTypeOf<{
-    readonly customerId: string;
-    readonly status: "open" | "closed" | "cancelled";
-    readonly price: number;
-    readonly updatedAt: number;
-  }>();
+  >().toEqualTypeOf<OrdersValueMessage>();
   expectTypeOf<
     KafkaMappingInput<
       typeof viewServer.topics,
       "orders",
       "usa" | "london",
-      typeof ordersValueProto,
-      typeof ordersKeyProto
+      typeof ordersValueKafkaCodec,
+      typeof ordersKeyKafkaCodec
     >["region"]
   >().toEqualTypeOf<"usa" | "london">();
   expectTypeOf<
@@ -1106,8 +1360,8 @@ const assertCompileTimeContracts = () => {
       typeof viewServer.topics,
       "orders",
       "usa" | "london",
-      typeof ordersValueProto,
-      typeof ordersKeyProto
+      typeof ordersValueKafkaCodec,
+      typeof ordersKeyKafkaCodec
     >["schema"]
   >().toEqualTypeOf<typeof Order>();
   expectTypeOf<
@@ -1115,8 +1369,8 @@ const assertCompileTimeContracts = () => {
       typeof viewServer.topics,
       "orders",
       "usa" | "london",
-      typeof ordersValueProto,
-      typeof ordersKeyProto
+      typeof ordersValueKafkaCodec,
+      typeof ordersKeyKafkaCodec
     >["metadata"]["sourceRegion"]
   >().toEqualTypeOf<"usa" | "london">();
   expectTypeOf<
@@ -1124,7 +1378,7 @@ const assertCompileTimeContracts = () => {
       typeof viewServer.topics,
       "trades",
       "usa",
-      typeof tradesValueProto,
+      typeof tradesValueKafkaCodec,
       undefined
     >["key"]
   >().toEqualTypeOf<string>();
@@ -1133,20 +1387,16 @@ const assertCompileTimeContracts = () => {
       typeof viewServer.topics,
       "trades",
       "usa",
-      typeof tradesValueProto,
+      typeof tradesValueKafkaCodec,
       undefined
     >["value"]
-  >().toEqualTypeOf<{
-    readonly symbol: string;
-    readonly quantity: number;
-    readonly price: number;
-  }>();
+  >().toEqualTypeOf<TradesValueMessage>();
   expectTypeOf<
     KafkaMappingInput<
       typeof viewServer.topics,
       "trades",
       "usa",
-      typeof tradesValueProto,
+      typeof tradesValueKafkaCodec,
       undefined
     >["region"]
   >().toEqualTypeOf<"usa">();
@@ -1155,7 +1405,7 @@ const assertCompileTimeContracts = () => {
       typeof viewServer.topics,
       "trades",
       "usa",
-      typeof tradesValueProto,
+      typeof tradesValueKafkaCodec,
       undefined
     >["schema"]
   >().toEqualTypeOf<typeof Trade>();
@@ -1325,10 +1575,46 @@ const assertCompileTimeContracts = () => {
     },
   });
 
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+    kafka: {
+      regions: localKafkaRegions,
+      topics: {
+        // @ts-expect-error Kafka source topics must be created with viewServer.kafkaTopic
+        orders: {
+          regions: ["usa"],
+          value: kafka.protobuf(ordersValueSchema),
+          viewServerTopic: "orders",
+          mapping: () => ({
+            id: "order-1",
+            customerId: "customer-1",
+            status: "open",
+            price: 42,
+            region: "usa",
+            updatedAt: 1,
+          }),
+        },
+      },
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+    kafka: {
+      regions: localKafkaRegions,
+      topics: {
+        // @ts-expect-error Kafka topic helper regions must match runtime kafka.regions
+        orders: londonKafkaTopic,
+      },
+    },
+  });
+
   localKafkaTopic({
     // @ts-expect-error Kafka topic regions are constrained to kafka.regions keys
     regions: ["USA"],
-    protoValue: ordersValueProto,
+    value: kafka.protobuf(ordersValueSchema),
     viewServerTopic: "orders",
     mapping: ({ key, value }) => ({
       id: key,
@@ -1343,7 +1629,7 @@ const assertCompileTimeContracts = () => {
   localKafkaTopic({
     // @ts-expect-error Kafka topic regions must be non-empty
     regions: [],
-    protoValue: ordersValueProto,
+    value: kafka.protobuf(ordersValueSchema),
     viewServerTopic: "orders",
     mapping: ({ key, value }) => ({
       id: key,
@@ -1357,7 +1643,7 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    protoValue: ordersValueProto,
+    value: kafka.protobuf(ordersValueSchema),
     // @ts-expect-error Kafka mappings must target a configured View Server topic
     viewServerTopic: "customers",
     mapping: ({ key, value, region }) => ({
@@ -1374,12 +1660,12 @@ const assertCompileTimeContracts = () => {
     typeof viewServer.topics,
     typeof localKafkaRegions,
     "orders",
-    typeof ordersValueProto,
+    typeof ordersValueKafkaCodec,
     undefined,
     readonly ["usa"]
   > = {
     regions: ["usa"],
-    protoValue: ordersValueProto,
+    value: kafka.protobuf(ordersValueSchema),
     viewServerTopic: "orders",
     // @ts-expect-error Kafka topic definitions reject unknown topic contract fields
     extraTopicField: true,
@@ -1397,9 +1683,9 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    protoValue: ordersValueProto,
-    // @ts-expect-error unsupported proto key descriptors must fail instead of inferring unknown
-    protoKey: {},
+    value: kafka.protobuf(ordersValueSchema),
+    // @ts-expect-error unsupported Kafka key codecs must fail instead of inferring unknown
+    key: {},
     viewServerTopic: "orders",
     mapping: ({ key, value, region }) => ({
       id: key,
@@ -1413,8 +1699,16 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    protoValue: ordersValueProto,
-    protoKey: ordersKeyProto,
+    value: kafka.json(OrderWithExtraSourceField),
+    viewServerTopic: "orders",
+    // @ts-expect-error returning source JSON value directly rejects fields outside the target row
+    mapping: ({ value }) => value,
+  });
+
+  localKafkaTopic({
+    regions: ["usa"],
+    value: kafka.protobuf(ordersValueSchema),
+    key: kafka.protobuf(ordersKeySchema),
     viewServerTopic: "orders",
     // @ts-expect-error unannotated mapping returns must match the target View Server topic row
     mapping: ({ key, value, region }) => ({
@@ -1428,8 +1722,8 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    protoValue: ordersValueProto,
-    protoKey: ordersKeyProto,
+    value: kafka.protobuf(ordersValueSchema),
+    key: kafka.protobuf(ordersKeySchema),
     viewServerTopic: "orders",
     // @ts-expect-error unannotated mapping returns reject extra fields outside the target row
     mapping: ({ key, value, region }) => ({
@@ -1445,17 +1739,12 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    protoValue: ordersValueProto,
-    protoKey: ordersKeyProto,
+    value: kafka.protobuf(ordersValueSchema),
+    key: kafka.protobuf(ordersKeySchema),
     viewServerTopic: "orders",
     mapping: ({ key, value, schema, metadata }) => {
-      expectTypeOf(key).toEqualTypeOf<{ readonly orderId: string }>();
-      expectTypeOf(value).toEqualTypeOf<{
-        readonly customerId: string;
-        readonly status: "open" | "closed" | "cancelled";
-        readonly price: number;
-        readonly updatedAt: number;
-      }>();
+      expectTypeOf(key).toEqualTypeOf<OrdersKeyMessage>();
+      expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
       expectTypeOf(schema).toEqualTypeOf<typeof Order>();
       expectTypeOf(metadata.sourceRegion).toEqualTypeOf<"usa">();
       expectTypeOf(metadata.headers).toEqualTypeOf<
@@ -1482,8 +1771,8 @@ const assertCompileTimeContracts = () => {
       topics: {
         orders: localKafkaTopic({
           regions: ["usa"],
-          protoValue: ordersValueProto,
-          protoKey: ordersKeyProto,
+          value: kafka.protobuf(ordersValueSchema),
+          key: kafka.protobuf(ordersKeySchema),
           viewServerTopic: "orders",
           // @ts-expect-error mapping return must match the target View Server topic row type
           mapping: ({ key, value, region }) => ({
@@ -1508,8 +1797,8 @@ const assertCompileTimeContracts = () => {
       topics: {
         orders: localKafkaTopic({
           regions: ["usa"],
-          protoValue: ordersValueProto,
-          protoKey: ordersKeyProto,
+          value: kafka.protobuf(ordersValueSchema),
+          key: kafka.protobuf(ordersKeySchema),
           viewServerTopic: "orders",
           // @ts-expect-error raw runtime topic mappings must return the target topic row
           mapping: ({ key, value, region }) => ({
@@ -2177,17 +2466,12 @@ const assertCompileTimeContracts = () => {
       topics: {
         orders: localKafkaTopic({
           regions: ["usa"],
-          protoValue: ordersValueProto,
-          protoKey: ordersKeyProto,
+          value: kafka.protobuf(ordersValueSchema),
+          key: kafka.protobuf(ordersKeySchema),
           viewServerTopic: "orders",
           mapping: ({ key, value, region }) => {
-            expectTypeOf(key).toEqualTypeOf<{ readonly orderId: string }>();
-            expectTypeOf(value).toEqualTypeOf<{
-              readonly customerId: string;
-              readonly status: "open" | "closed" | "cancelled";
-              readonly price: number;
-              readonly updatedAt: number;
-            }>();
+            expectTypeOf(key).toEqualTypeOf<OrdersKeyMessage>();
+            expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
             expectTypeOf(region).toEqualTypeOf<"usa">();
             return {
               id: key.orderId,
@@ -2201,15 +2485,11 @@ const assertCompileTimeContracts = () => {
         }),
         trades: localKafkaTopic({
           regions: ["usa"],
-          protoValue: tradesValueProto,
+          value: kafka.protobuf(tradesValueSchema),
           viewServerTopic: "trades",
           mapping: ({ key, value, region }) => {
             expectTypeOf(key).toEqualTypeOf<string>();
-            expectTypeOf(value).toEqualTypeOf<{
-              readonly symbol: string;
-              readonly quantity: number;
-              readonly price: number;
-            }>();
+            expectTypeOf(value).toEqualTypeOf<TradesValueMessage>();
             expectTypeOf(region).toEqualTypeOf<"usa">();
             return {
               id: key,
@@ -2226,8 +2506,8 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    // @ts-expect-error unsupported proto descriptors must fail instead of inferring unknown
-    protoValue: {},
+    // @ts-expect-error unsupported Kafka value codecs must fail instead of inferring unknown
+    value: {},
     viewServerTopic: "orders",
     mapping: ({ key }) => ({
       id: key,
@@ -2241,8 +2521,8 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    // @ts-expect-error $typeName-only objects are message instances, not generated schemas
-    protoValue: { $typeName: "viewserver.test.OrderValue" },
+    // @ts-expect-error $typeName-only objects are message instances, not generated schemas/codecs
+    value: { $typeName: "viewserver.test.OrderValue" },
     viewServerTopic: "orders",
     mapping: ({ key }) => ({
       id: key,
@@ -2256,8 +2536,8 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    // @ts-expect-error arbitrary decoder shapes are not accepted as generated proto schemas
-    protoValue: {
+    // @ts-expect-error arbitrary decoder shapes are not accepted as Kafka codecs
+    value: {
       fromBinary: (_bytes: Uint8Array) => ({
         customerId: "customer-1",
         status: "open",
@@ -2278,8 +2558,8 @@ const assertCompileTimeContracts = () => {
 
   localKafkaTopic({
     regions: ["usa"],
-    // @ts-expect-error row Effect schemas are not Kafka proto descriptors
-    protoValue: Order,
+    // @ts-expect-error row Effect schemas are not Kafka codecs unless wrapped with kafka.json
+    value: Order,
     viewServerTopic: "orders",
     mapping: ({ key }) => ({
       id: key,

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1229,6 +1229,55 @@ const assertCompileTimeContracts = () => {
       updatedAt: value.updatedAt,
     }),
   });
+  const validLocalOrdersTopic = localKafkaTopic({
+    regions: ["usa"],
+    value: kafka.protobuf(ordersValueSchema),
+    viewServerTopic: "orders",
+    mapping: ({ key, value, region }) => ({
+      id: key,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region,
+      updatedAt: value.updatedAt,
+    }),
+  });
+  const validKeyedLocalOrdersTopic = localKafkaTopic({
+    regions: ["usa"],
+    value: kafka.protobuf(ordersValueSchema),
+    key: kafka.protobuf(ordersKeySchema),
+    viewServerTopic: "orders",
+    mapping: ({ key, value, region }) => ({
+      id: key.orderId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region,
+      updatedAt: value.updatedAt,
+    }),
+  });
+  const spreadValueMismatchTopic = {
+    ...validLocalOrdersTopic,
+    value: kafka.string(),
+  };
+  const spreadKeyMismatchTopic = {
+    ...validKeyedLocalOrdersTopic,
+    key: kafka.stringKey(),
+  };
+  const spreadMappingMismatchTopic = {
+    ...validLocalOrdersTopic,
+    mapping: (): typeof Trade.Type => ({
+      id: "trade-1",
+      symbol: "AAPL",
+      quantity: 1,
+      price: 42,
+      region: "usa",
+    }),
+  };
+  const spreadTargetMismatchTopic = {
+    ...validLocalOrdersTopic,
+    viewServerTopic: "trades",
+  };
   type UnsafeJsonParseResult = ReturnType<typeof JSON.parse>;
   const unsafeValueCodec: KafkaCodec<UnsafeJsonParseResult> = kafka.bytes();
   const unsafeErrorCodec: KafkaCodec<string, UnsafeJsonParseResult> = kafka.string();
@@ -1595,6 +1644,54 @@ const assertCompileTimeContracts = () => {
             updatedAt: 1,
           }),
         },
+      },
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+    kafka: {
+      regions: localKafkaRegions,
+      topics: {
+        // @ts-expect-error spread-mutated Kafka topic values must still match mapping input types
+        orders: spreadValueMismatchTopic,
+      },
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+    kafka: {
+      regions: localKafkaRegions,
+      topics: {
+        // @ts-expect-error spread-mutated Kafka topic keys must still match mapping input types
+        orders: spreadKeyMismatchTopic,
+      },
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+    kafka: {
+      regions: localKafkaRegions,
+      topics: {
+        // @ts-expect-error spread-mutated Kafka mappings must still return the target topic row
+        orders: spreadMappingMismatchTopic,
+      },
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+    kafka: {
+      regions: localKafkaRegions,
+      topics: {
+        // @ts-expect-error spread-mutated Kafka target topics must still match the mapping row
+        orders: spreadTargetMismatchTopic,
       },
     },
   });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -100,17 +100,20 @@ export type {
   StatusEvent,
   StatusEventCode,
 } from "./live-protocol";
-export { defineKafkaTopic, defineProto } from "./kafka-contract";
+export { defineKafkaTopic, kafka } from "./kafka-contract";
 export type {
   ExactRuntimeOptions,
+  KafkaCodec,
+  KafkaCodecDecodeInput,
+  KafkaCodecError,
+  KafkaCodecType,
+  KafkaDecodeError,
   KafkaMappingInput,
   KafkaMessageMetadata,
+  KafkaProtobufType,
   KafkaTopicDefinition,
   KafkaTopicHelper,
   NonEmptyReadonlyArray,
-  ProtoCodec,
-  ProtoType,
-  ProtobufEsGeneratedMessageDescriptor,
   RuntimeOptions,
   RuntimeOptionsCandidate,
   RuntimeOptionsDefinition,

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -1,6 +1,6 @@
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
-import type { Config } from "effect";
-import type { TopicRow, TopicSchema } from "./topic-contract";
+import type { Config, Effect } from "effect";
+import type { RowFromSchema, RowSchema, TopicRow, TopicSchema } from "./topic-contract";
 
 export type RuntimeValue<A> = A | Config.Config<A>;
 export type RuntimeRegions = Record<string, RuntimeValue<string>>;
@@ -10,38 +10,128 @@ type RejectExtraKeys<Candidate, Shape> = {
   readonly [Key in Exclude<keyof Candidate, keyof Shape>]: never;
 };
 
+type IsAny<A> = 0 extends 1 & A ? true : false;
+
+type IsUnknown<A> =
+  IsAny<A> extends true
+    ? false
+    : unknown extends A
+      ? [A] extends [unknown]
+        ? true
+        : false
+      : false;
+
+type RejectAnyCodecValue<A> =
+  IsAny<A> extends true ? { readonly __viewServerKafkaCodecValueCannotBeAny: never } : unknown;
+
+type RejectAnyCodecError<E> =
+  IsAny<E> extends true ? { readonly __viewServerKafkaCodecErrorCannotBeAny: never } : unknown;
+
 type ExactObject<Candidate, Shape> = Candidate & RejectExtraKeys<Candidate, Shape>;
 
 type ExactMappingReturn<Input, Row, Mapping extends (input: Input) => Row> = Mapping &
   ((input: Input) => ExactObject<ReturnType<Mapping>, Row>);
 
-const ProtoCodecTypeId = Symbol("@view-server/config/ProtoCodec");
+const KafkaCodecValueTypeId = Symbol("@view-server/config/KafkaCodecValue");
+const KafkaCodecErrorTypeId = Symbol("@view-server/config/KafkaCodecError");
+const KafkaTopicDefinitionTypeId = Symbol("@view-server/config/KafkaTopicDefinition");
 
-export type ProtoCodec<T> = {
-  readonly [ProtoCodecTypeId]: ReadonlyArray<T>;
+export type KafkaDecodeError = {
+  readonly _tag: "KafkaDecodeError";
+  readonly message: string;
+  readonly cause?: unknown;
 };
 
-export const defineProto = <T>(): ProtoCodec<T> => ({
-  [ProtoCodecTypeId]: [],
+export type KafkaCodec<A, E = never> = {
+  readonly [KafkaCodecValueTypeId]: ReadonlyArray<A>;
+  readonly [KafkaCodecErrorTypeId]: ReadonlyArray<E>;
+  readonly format: string;
+};
+
+export type KafkaCodecType<Codec> = Codec extends KafkaCodec<infer A, infer _E> ? A : never;
+export type KafkaCodecError<Codec> = Codec extends KafkaCodec<infer _A, infer E> ? E : never;
+
+export type KafkaCodecDecodeInput = {
+  readonly bytes: Uint8Array;
+  readonly metadata: KafkaMessageMetadata;
+};
+
+export type KafkaProtobufType<Proto> = Proto extends DescMessage ? MessageShape<Proto> : never;
+
+type SupportedKafkaProtobufInput<Proto> =
+  IsAny<Proto> extends true ? never : [KafkaProtobufType<Proto>] extends [never] ? never : Proto;
+
+type SupportedKafkaCodec<Codec> =
+  IsAny<Codec> extends true
+    ? never
+    : IsAny<KafkaCodecType<Codec>> extends true
+      ? never
+      : IsAny<KafkaCodecError<Codec>> extends true
+        ? never
+        : IsUnknown<KafkaCodecError<Codec>> extends true
+          ? never
+          : [KafkaCodecType<Codec>] extends [never]
+            ? never
+            : Codec;
+
+type SupportedKafkaJsonSchema<SourceSchema extends RowSchema> =
+  IsAny<SourceSchema> extends true ? never : SourceSchema;
+
+type KafkaTopicDefinitionMarker = {
+  readonly [KafkaTopicDefinitionTypeId]: true;
+};
+
+const makeKafkaCodec = <A, E, Format extends string>(
+  format: Format,
+): KafkaCodec<A, E> & {
+  readonly format: Format;
+} => ({
+  [KafkaCodecValueTypeId]: [],
+  [KafkaCodecErrorTypeId]: [],
+  format,
 });
 
-export type ProtobufEsGeneratedMessageDescriptor<T extends object> = {
-  readonly typeName: string;
-  readonly fields?: unknown;
-  readonly field?: Record<string, unknown>;
-  readonly _viewServerProtoType: (value: T) => T;
+export const kafka = {
+  bytes: (): KafkaCodec<Uint8Array> & { readonly format: "bytes" } =>
+    makeKafkaCodec<Uint8Array, never, "bytes">("bytes"),
+  string: (): KafkaCodec<string> & { readonly format: "string" } =>
+    makeKafkaCodec<string, never, "string">("string"),
+  stringKey: (): KafkaCodec<string> & { readonly format: "string" } =>
+    makeKafkaCodec<string, never, "string">("string"),
+  json: <const SourceSchema extends RowSchema>(
+    schema: SupportedKafkaJsonSchema<SourceSchema>,
+  ): KafkaCodec<RowFromSchema<SourceSchema>, KafkaDecodeError> & {
+    readonly format: "json";
+    readonly schema: SourceSchema;
+  } => ({
+    ...makeKafkaCodec<RowFromSchema<SourceSchema>, KafkaDecodeError, "json">("json"),
+    schema,
+  }),
+  protobuf: <const Proto>(
+    descriptor: SupportedKafkaProtobufInput<Proto>,
+  ): KafkaCodec<KafkaProtobufType<Proto>, KafkaDecodeError> & {
+    readonly format: "protobuf";
+    readonly descriptor: SupportedKafkaProtobufInput<Proto>;
+  } => ({
+    ...makeKafkaCodec<KafkaProtobufType<Proto>, KafkaDecodeError, "protobuf">("protobuf"),
+    descriptor,
+  }),
+  codec: <A, E>(
+    definition: {
+      readonly name: string;
+      readonly decode: (input: KafkaCodecDecodeInput) => Effect.Effect<A, E, never>;
+    } & RejectAnyCodecValue<NoInfer<A>> &
+      RejectAnyCodecError<NoInfer<E>>,
+  ): KafkaCodec<A, E> & {
+    readonly format: "custom";
+    readonly name: string;
+    readonly decode: (input: KafkaCodecDecodeInput) => Effect.Effect<A, E, never>;
+  } => ({
+    ...makeKafkaCodec<A, E, "custom">("custom"),
+    name: definition.name,
+    decode: definition.decode,
+  }),
 };
-
-export type ProtoType<Proto> =
-  Proto extends ProtoCodec<infer T>
-    ? T
-    : Proto extends DescMessage
-      ? MessageShape<Proto>
-      : Proto extends ProtobufEsGeneratedMessageDescriptor<infer T>
-        ? T
-        : never;
-
-type SupportedProto<Proto> = [ProtoType<Proto>] extends [never] ? never : Proto;
 
 export type KafkaMessageMetadata<Region extends string = string> = {
   readonly sourceTopic: string;
@@ -58,139 +148,178 @@ export type KafkaMappingInput<
   Topics extends object,
   ViewTopic extends Extract<keyof Topics, string>,
   Region extends string,
-  ProtoValue,
-  ProtoKey,
+  ValueCodec,
+  KeyCodec,
 > = {
-  readonly key: [ProtoKey] extends [undefined] ? string : ProtoType<ProtoKey>;
-  readonly value: ProtoType<ProtoValue>;
+  readonly key: [KeyCodec] extends [undefined] ? string : KafkaCodecType<KeyCodec>;
+  readonly value: KafkaCodecType<ValueCodec>;
   readonly region: Region;
   readonly schema: TopicSchema<Topics, ViewTopic>;
   readonly metadata: KafkaMessageMetadata<Region>;
 };
 
-type KafkaTopicWithoutProtoKey<
+type KafkaTopicWithoutKeyInput<
   Topics extends object,
   Regions extends RuntimeRegions,
   ViewTopic extends Extract<keyof Topics, string>,
-  ProtoValue,
+  ValueCodec,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
   Mapping extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
   ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
   ) => TopicRow<Topics, ViewTopic>,
 > = {
   readonly regions: TopicRegions;
-  readonly protoValue: SupportedProto<ProtoValue>;
+  readonly value: SupportedKafkaCodec<ValueCodec>;
   readonly viewServerTopic: ViewTopic;
   readonly mapping: ExactMappingReturn<
-    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
     TopicRow<Topics, ViewTopic>,
     Mapping
   >;
 };
 
-type KafkaTopicWithProtoKey<
+type KafkaTopicWithoutKey<
   Topics extends object,
   Regions extends RuntimeRegions,
   ViewTopic extends Extract<keyof Topics, string>,
-  ProtoValue,
-  ProtoKey,
+  ValueCodec,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
   Mapping extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
   ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
+  ) => TopicRow<Topics, ViewTopic>,
+> = KafkaTopicWithoutKeyInput<Topics, Regions, ViewTopic, ValueCodec, TopicRegions, Mapping> &
+  KafkaTopicDefinitionMarker;
+
+type KafkaTopicWithKeyInput<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  ViewTopic extends Extract<keyof Topics, string>,
+  ValueCodec,
+  KeyCodec,
+  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+  Mapping extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
   ) => TopicRow<Topics, ViewTopic>,
 > = {
   readonly regions: TopicRegions;
-  readonly protoValue: SupportedProto<ProtoValue>;
-  readonly protoKey: SupportedProto<ProtoKey>;
+  readonly value: SupportedKafkaCodec<ValueCodec>;
+  readonly key: SupportedKafkaCodec<KeyCodec>;
   readonly viewServerTopic: ViewTopic;
   readonly mapping: ExactMappingReturn<
-    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
     TopicRow<Topics, ViewTopic>,
     Mapping
   >;
 };
+
+type KafkaTopicWithKey<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  ViewTopic extends Extract<keyof Topics, string>,
+  ValueCodec,
+  KeyCodec,
+  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+  Mapping extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
+  ) => TopicRow<Topics, ViewTopic>,
+> = KafkaTopicWithKeyInput<
+  Topics,
+  Regions,
+  ViewTopic,
+  ValueCodec,
+  KeyCodec,
+  TopicRegions,
+  Mapping
+> &
+  KafkaTopicDefinitionMarker;
 
 export type KafkaTopicDefinition<
   Topics extends object,
   Regions extends RuntimeRegions,
   ViewTopic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
-  ProtoValue = unknown,
-  ProtoKey = unknown,
+  ValueCodec = unknown,
+  KeyCodec = unknown,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
     NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-  MappingWithoutProtoKey extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+  MappingWithoutKey extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
   ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
   ) => TopicRow<Topics, ViewTopic>,
-  MappingWithProtoKey extends (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+  MappingWithKey extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
   ) => TopicRow<Topics, ViewTopic> = (
-    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
   ) => TopicRow<Topics, ViewTopic>,
 > =
-  | KafkaTopicWithoutProtoKey<
+  | KafkaTopicWithoutKey<Topics, Regions, ViewTopic, ValueCodec, TopicRegions, MappingWithoutKey>
+  | KafkaTopicWithKey<
       Topics,
       Regions,
       ViewTopic,
-      ProtoValue,
+      ValueCodec,
+      KeyCodec,
       TopicRegions,
-      MappingWithoutProtoKey
+      MappingWithKey
+    >;
+
+type KafkaTopicDefinitionInput<
+  Topics extends object,
+  Regions extends RuntimeRegions,
+  ViewTopic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
+  ValueCodec = unknown,
+  KeyCodec = unknown,
+  TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
+    NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
+  MappingWithoutKey extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
+  ) => TopicRow<Topics, ViewTopic>,
+  MappingWithKey extends (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
+  ) => TopicRow<Topics, ViewTopic> = (
+    input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
+  ) => TopicRow<Topics, ViewTopic>,
+> =
+  | KafkaTopicWithoutKeyInput<
+      Topics,
+      Regions,
+      ViewTopic,
+      ValueCodec,
+      TopicRegions,
+      MappingWithoutKey
     >
-  | KafkaTopicWithProtoKey<
+  | KafkaTopicWithKeyInput<
       Topics,
       Regions,
       ViewTopic,
-      ProtoValue,
-      ProtoKey,
+      ValueCodec,
+      KeyCodec,
       TopicRegions,
-      MappingWithProtoKey
+      MappingWithKey
     >;
 
 type ValidateKafkaTopic<
   Topics extends object,
   Regions extends RuntimeRegions,
   Candidate,
-> = Candidate extends {
-  readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
-    Extract<keyof Regions, string>
-  >;
-  readonly protoValue: infer ProtoValue;
-  readonly protoKey: infer ProtoKey;
-  readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
-  readonly mapping: infer Mapping;
+> = Candidate extends KafkaTopicDefinitionMarker & {
+  readonly regions: NonEmptyReadonlyArray<Extract<keyof Regions, string>>;
+  readonly value: KafkaCodec<unknown, unknown>;
+  readonly viewServerTopic: Extract<keyof Topics, string>;
+  readonly mapping: (input: never) => TopicRow<Topics, Extract<keyof Topics, string>>;
 }
-  ? Mapping extends (
-      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
-    ) => TopicRow<Topics, ViewTopic>
-    ? KafkaTopicWithProtoKey<
-        Topics,
-        Regions,
-        ViewTopic,
-        ProtoValue,
-        ProtoKey,
-        TopicRegions,
-        Mapping
-      >
-    : never
-  : Candidate extends {
-        readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
-          Extract<keyof Regions, string>
-        >;
-        readonly protoValue: infer ProtoValue;
-        readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
-        readonly mapping: infer Mapping;
-      }
-    ? Mapping extends (
-        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
-      ) => TopicRow<Topics, ViewTopic>
-      ? KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>
-      : never
-    : never;
+  ? Candidate
+  : never;
 
 type ValidateKafkaTopics<
   Topics extends object,
@@ -258,96 +387,92 @@ export type ExactRuntimeOptions<Topics extends object, Options> = Options &
 export type KafkaTopicHelper<Topics extends object> = <const Regions extends RuntimeRegions>() => {
   <
     const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-    ProtoValue,
-    ProtoKey,
+    ValueCodec,
+    KeyCodec,
     const ViewTopic extends Extract<keyof Topics, string>,
     Mapping extends (
-      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
     ) => TopicRow<Topics, ViewTopic>,
   >(
-    topic: KafkaTopicWithProtoKey<
+    topic: KafkaTopicWithKeyInput<
       Topics,
       Regions,
       ViewTopic,
-      ProtoValue,
-      ProtoKey,
+      ValueCodec,
+      KeyCodec,
       TopicRegions,
       Mapping
     >,
-  ): KafkaTopicWithProtoKey<
-    Topics,
-    Regions,
-    ViewTopic,
-    ProtoValue,
-    ProtoKey,
-    TopicRegions,
-    Mapping
-  >;
+  ): KafkaTopicWithKey<Topics, Regions, ViewTopic, ValueCodec, KeyCodec, TopicRegions, Mapping>;
   <
     const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-    ProtoValue,
+    ValueCodec,
     const ViewTopic extends Extract<keyof Topics, string>,
     Mapping extends (
-      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+      input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
     ) => TopicRow<Topics, ViewTopic>,
   >(
-    topic: KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>,
-  ): KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>;
+    topic: KafkaTopicWithoutKeyInput<Topics, Regions, ViewTopic, ValueCodec, TopicRegions, Mapping>,
+  ): KafkaTopicWithoutKey<Topics, Regions, ViewTopic, ValueCodec, TopicRegions, Mapping>;
 };
 
 export const defineKafkaTopic = <Topics extends object>(): KafkaTopicHelper<Topics> => {
   function forRegions<const Regions extends RuntimeRegions>() {
     function topicHelper<
       const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-      ProtoValue,
-      ProtoKey,
+      ValueCodec,
+      KeyCodec,
       const ViewTopic extends Extract<keyof Topics, string>,
       Mapping extends (
-        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, ProtoKey>,
+        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
       ) => TopicRow<Topics, ViewTopic>,
     >(
-      topic: KafkaTopicWithProtoKey<
+      topic: KafkaTopicWithKeyInput<
         Topics,
         Regions,
         ViewTopic,
-        ProtoValue,
-        ProtoKey,
+        ValueCodec,
+        KeyCodec,
         TopicRegions,
         Mapping
       >,
-    ): KafkaTopicWithProtoKey<
-      Topics,
-      Regions,
-      ViewTopic,
-      ProtoValue,
-      ProtoKey,
-      TopicRegions,
-      Mapping
-    >;
+    ): KafkaTopicWithKey<Topics, Regions, ViewTopic, ValueCodec, KeyCodec, TopicRegions, Mapping>;
     function topicHelper<
       const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-      ProtoValue,
+      ValueCodec,
       const ViewTopic extends Extract<keyof Topics, string>,
       Mapping extends (
-        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ProtoValue, undefined>,
+        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
       ) => TopicRow<Topics, ViewTopic>,
     >(
-      topic: KafkaTopicWithoutProtoKey<
+      topic: KafkaTopicWithoutKeyInput<
         Topics,
         Regions,
         ViewTopic,
-        ProtoValue,
+        ValueCodec,
         TopicRegions,
         Mapping
       >,
-    ): KafkaTopicWithoutProtoKey<Topics, Regions, ViewTopic, ProtoValue, TopicRegions, Mapping>;
+    ): KafkaTopicWithoutKey<Topics, Regions, ViewTopic, ValueCodec, TopicRegions, Mapping>;
     function topicHelper<
       const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
-      ProtoValue,
-      ProtoKey,
+      ValueCodec,
+      KeyCodec,
       const ViewTopic extends Extract<keyof Topics, string>,
-    >(topic: KafkaTopicDefinition<Topics, Regions, ViewTopic, ProtoValue, ProtoKey, TopicRegions>) {
-      return topic;
+    >(
+      topic: KafkaTopicDefinitionInput<
+        Topics,
+        Regions,
+        ViewTopic,
+        ValueCodec,
+        KeyCodec,
+        TopicRegions
+      >,
+    ) {
+      return {
+        ...topic,
+        [KafkaTopicDefinitionTypeId]: true,
+      };
     }
 
     return topicHelper;

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -313,13 +313,54 @@ type ValidateKafkaTopic<
   Regions extends RuntimeRegions,
   Candidate,
 > = Candidate extends KafkaTopicDefinitionMarker & {
-  readonly regions: NonEmptyReadonlyArray<Extract<keyof Regions, string>>;
-  readonly value: KafkaCodec<unknown, unknown>;
-  readonly viewServerTopic: Extract<keyof Topics, string>;
-  readonly mapping: (input: never) => TopicRow<Topics, Extract<keyof Topics, string>>;
+  readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
+    Extract<keyof Regions, string>
+  >;
+  readonly value: infer ValueCodec;
+  readonly key: infer KeyCodec;
+  readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
 }
-  ? Candidate
-  : never;
+  ? Candidate extends {
+      readonly mapping: infer Mapping extends (
+        input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, KeyCodec>,
+      ) => TopicRow<Topics, ViewTopic>;
+    }
+    ? Candidate extends KafkaTopicWithKey<
+        Topics,
+        Regions,
+        ViewTopic,
+        ValueCodec,
+        KeyCodec,
+        TopicRegions,
+        Mapping
+      >
+      ? Candidate
+      : never
+    : never
+  : Candidate extends KafkaTopicDefinitionMarker & {
+        readonly regions: infer TopicRegions extends NonEmptyReadonlyArray<
+          Extract<keyof Regions, string>
+        >;
+        readonly value: infer ValueCodec;
+        readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
+      }
+    ? Candidate extends {
+        readonly mapping: infer Mapping extends (
+          input: KafkaMappingInput<Topics, ViewTopic, TopicRegions[number], ValueCodec, undefined>,
+        ) => TopicRow<Topics, ViewTopic>;
+      }
+      ? Candidate extends KafkaTopicWithoutKey<
+          Topics,
+          Regions,
+          ViewTopic,
+          ValueCodec,
+          TopicRegions,
+          Mapping
+        >
+        ? Candidate
+        : never
+      : never
+    : never;
 
 type ValidateKafkaTopics<
   Topics extends object,

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -264,24 +264,29 @@ import {
   ordersBufProtoValue,
   tradesBufProtoValue,
 } from "@buf/generated_code/orders_buf_proto";
+import { kafka } from "@view-server/config";
 import { viewServer } from "./view-server.config";
+
+const kafkaRegions = {
+  usa: "broker-a:9092,broker-b:9092",
+  london: "broker-c:9092,broker-d:9092",
+};
+
+const kafkaTopic = viewServer.kafkaTopic<typeof kafkaRegions>();
 
 export const runtime = viewServer.createRuntime({
   websocketPort: 8080,
   tcpPublishPort: 8081,
 
   kafka: {
-    regions: {
-      usa: "broker-a:9092,broker-b:9092",
-      london: "broker-c:9092,broker-d:9092",
-    },
+    regions: kafkaRegions,
 
     topics: {
-      orders: {
+      orders: kafkaTopic({
         regions: ["usa", "london"],
 
-        protoValue: ordersBufProtoValue,
-        protoKey: ordersBufProtoKey,
+        value: kafka.protobuf(ordersBufProtoValue),
+        key: kafka.protobuf(ordersBufProtoKey),
 
         viewServerTopic: "orders",
 
@@ -295,12 +300,12 @@ export const runtime = viewServer.createRuntime({
             updatedAt: value.updatedAt,
           };
         },
-      },
+      }),
 
-      trades: {
+      trades: kafkaTopic({
         regions: ["usa"],
 
-        protoValue: tradesBufProtoValue,
+        value: kafka.protobuf(tradesBufProtoValue),
 
         viewServerTopic: "trades",
 
@@ -313,7 +318,7 @@ export const runtime = viewServer.createRuntime({
             region,
           };
         },
-      },
+      }),
     },
   },
 });
@@ -665,8 +670,8 @@ Use:
 websocketPort;
 tcpPublishPort;
 viewServerTopic;
-protoValue;
-protoKey;
+value;
+key;
 ```
 
 Avoid:
@@ -686,17 +691,22 @@ protoSchemaKey;
 The runtime API should enforce these at compile time:
 
 - `kafka.regions` values are bootstrap strings, not arrays.
+- Kafka source topic definitions must be created with `viewServer.kafkaTopic<typeof kafkaRegions>()(...)`; direct unwrapped objects are rejected so nested topic contracts cannot widen.
 - `topics[...].regions` only accepts keys from `kafka.regions`.
 - `regions: ["usa", "london"]` passes.
 - `regions: ["USA"]` fails.
 - `viewServerTopic` only accepts topic keys from `defineViewServerConfig`.
-- If `protoKey` is provided, `mapping({ key })` is inferred from that protobuf key type.
-- If `protoKey` is omitted, `mapping({ key })` is a string.
-- `mapping({ value })` is inferred from `protoValue`.
+- `value` must be an explicit Kafka source codec such as `kafka.protobuf(...)`, `kafka.json(...)`, `kafka.string()`, `kafka.bytes()`, or `kafka.codec(...)`.
+- If `key` is provided, `mapping({ key })` is inferred from that Kafka key codec.
+- If `key` is omitted, `mapping({ key })` is a UTF-8 string.
+- `mapping({ value })` is inferred from the Kafka value codec.
 - `mapping({ region })` is narrowed to the configured region literals for that Kafka topic.
 - `mapping` return value must match the target `viewServerTopic` row schema.
 - `schema` in `mapping` should be the Effect Schema from the target View Server topic.
 - `metadata` should leave room for Kafka headers, partition, offset, timestamp, source topic, and source region.
+- Protobuf source codecs should accept the direct generated Buf descriptor/code.
+- JSON source codecs should validate decoded JSON through the provided Effect Schema.
+- Custom source codecs should keep arbitrary formats behind one typed decoder seam.
 
 The mapping function should receive one object argument, not positional arguments. Positional arguments will age badly once metadata, tracing, validation, or decode context is added.
 

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -50,13 +50,13 @@ const requireModule = (moduleName: string, moduleValue: unknown) => {
 };
 
 requireExport("@view-server/config", configPackage, "defineViewServerConfig");
-requireExport("@view-server/config", configPackage, "defineProto");
 requireExport("@view-server/config", configPackage, "defineKafkaTopic");
+requireExport("@view-server/config", configPackage, "kafka");
 requireModule("@view-server/config/query", queryPackage);
 requireModule("@view-server/config/health", healthPackage);
 requireModule("@view-server/config/live-protocol", liveProtocolPackage);
-requireExport("@view-server/config/kafka", kafkaPackage, "defineProto");
 requireExport("@view-server/config/kafka", kafkaPackage, "defineKafkaTopic");
+requireExport("@view-server/config/kafka", kafkaPackage, "kafka");
 requireExport("@view-server/config/runtime", runtimePackage, "runtimeConfig");
 requireExport("@view-server/config/runtime", runtimePackage, "runtimeEnvironmentConfig");
 requireExport("@view-server/client", clientPackage, "stableQueryKey");


### PR DESCRIPTION
## Summary
- add typed Kafka source codecs: protobuf, JSON, string, bytes, and custom Effect decoders
- require source topics to be declared through the typed kafkaTopic helper with mandatory exact mappings
- replace fake protobuf descriptor support with real Buf DescMessage / MessageShape typing
- add Apache Kafka compose config using apache/kafka:4.3.0 with tmpfs logs
- update context, plan, and package export checks

## Validation
- pnpm --filter @view-server/config exec tsc -p tsconfig.json --noEmit
- pnpm --filter @view-server/config run test
- docker compose -f compose.yaml config
- vp check --fix
- pnpm run ready

## Review
- 3 local reviewer agents: no blockers after recheck
