### PR TITLE
Harden package subexport seam checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
   - in-memory: in-process Adapter over runtime-core for tests, demos, Storybook, and browser benchmarks.
   - runtime: production composition of runtime-core plus server and future Kafka/TCP/gRPC ingress Adapters.
 - Do not make production packages depend on testing packages or in-memory implementations.
+- Package export checks must cover approved root exports, approved subexports, and rejected deep/internal subpaths. A package seam is not enforced if `@view-server/package/src/...`, `@view-server/package/dist/...`, or unapproved nested subexports can resolve.
 
 ## Common Blockers
 
@@ -158,6 +159,7 @@ These issues block merge until fixed or explicitly accepted by the user:
 - Production runtime imports the in-memory Adapter instead of runtime-core.
 - Browser/remote client exposes publish, publishMany, reset, or other admin mutation RPCs.
 - A package imports through a root export that also pulls in the wrong runtime/platform adapter.
+- An unapproved deep import or nested subexport resolves across a package seam.
 - Public API type tests are missing for new generic inference or rejection behavior.
 - Runtime fields that are always present are modeled as optional.
 - A benchmark comparison runs multiple candidates concurrently or omits process/child failure checks.

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -50,6 +50,95 @@ const requireModule = (moduleName: string, moduleValue: unknown) => {
   }
 };
 
+const requireResolvablePackageExport = (specifier: string) => {
+  try {
+    return import.meta.resolve(specifier);
+  } catch (error) {
+    throw new Error(`${specifier} should resolve as a public package export`, { cause: error });
+  }
+};
+
+const rejectResolvablePackageExport = (specifier: string) => {
+  const unexpectedMessage = `${specifier} unexpectedly resolves as a public package export`;
+  try {
+    const resolved = import.meta.resolve(specifier);
+    throw new Error(`${unexpectedMessage}: ${resolved}`);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(unexpectedMessage)) {
+      throw error;
+    }
+  }
+};
+
+const publicPackageExports = [
+  "@view-server/client",
+  "@view-server/client/remote",
+  "@view-server/column-live-view-engine",
+  "@view-server/config",
+  "@view-server/config/health",
+  "@view-server/config/kafka",
+  "@view-server/config/live-protocol",
+  "@view-server/config/query",
+  "@view-server/config/runtime",
+  "@view-server/effect-utils",
+  "@view-server/in-memory",
+  "@view-server/protocol",
+  "@view-server/react",
+  "@view-server/react/testing",
+  "@view-server/runtime",
+  "@view-server/runtime-core",
+  "@view-server/server",
+];
+
+const forbiddenPackageDeepImports = [
+  "@view-server/client/src/index",
+  "@view-server/client/dist/index.js",
+  "@view-server/client/src/live-client",
+  "@view-server/client/src/remote-client",
+  "@view-server/client/remote/client",
+  "@view-server/client/remote/internal",
+  "@view-server/column-live-view-engine/src/index",
+  "@view-server/column-live-view-engine/dist/index.js",
+  "@view-server/column-live-view-engine/src/topic-store-state",
+  "@view-server/column-live-view-engine/topic-store-state",
+  "@view-server/config/src/index",
+  "@view-server/config/dist/index.js",
+  "@view-server/config/dist/topic-contract.js",
+  "@view-server/config/src/topic-contract",
+  "@view-server/config/query/raw-query-contract",
+  "@view-server/config/query/src/topic-contract",
+  "@view-server/effect-utils/src/index",
+  "@view-server/effect-utils/dist/index.js",
+  "@view-server/in-memory/src/index",
+  "@view-server/in-memory/dist/index.js",
+  "@view-server/protocol/src/index",
+  "@view-server/protocol/dist/index.js",
+  "@view-server/protocol/src/protocol-row-codec",
+  "@view-server/protocol/protocol-row-codec",
+  "@view-server/react/src/index",
+  "@view-server/react/dist/index.js",
+  "@view-server/react/dist/testing.js",
+  "@view-server/react/src/testing",
+  "@view-server/react/testing/internal",
+  "@view-server/runtime/src/internal",
+  "@view-server/runtime/dist/index.js",
+  "@view-server/runtime/internal",
+  "@view-server/runtime-core/src/health",
+  "@view-server/runtime-core/dist/index.js",
+  "@view-server/runtime-core/health",
+  "@view-server/server/src/rpc-handlers",
+  "@view-server/server/dist/index.js",
+  "@view-server/server/rpc-handlers",
+];
+
+for (const specifier of publicPackageExports) {
+  requireResolvablePackageExport(specifier);
+}
+
+for (const specifier of forbiddenPackageDeepImports) {
+  rejectResolvablePackageExport(specifier);
+}
+
 requireExport("@view-server/config", configPackage, "defineViewServerConfig");
 requireExport("@view-server/config", configPackage, "defineKafkaTopic");
 requireExport("@view-server/config", configPackage, "kafka");


### PR DESCRIPTION
## Summary
- Add positive resolution checks for every approved @view-server package root export and subexport.
- Add negative resolution checks for representative unapproved src/dist/internal/nested subexports across packages.
- Document that subexport/deep-import seam enforcement is a merge blocker in AGENTS.md.

## Validation
- pnpm run check:package-exports
- pnpm run ready
- targeted forbidden-pattern scan clean on changed TS code
- 3 reviewer agents clean

## Note
A broad repo forbidden-pattern scan still reports pre-existing runtime Kafka ignoreCause usage and the literal forbidden-pattern examples in AGENTS.md. This slice does not add or modify those runtime paths.
