### PR TITLE
Fix Kafka ingress cleanup lifecycle

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,13 +13,14 @@
     }
   },
   "scripts": {
-    "build": "vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp pack",
+    "build": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp pack",
     "test": "node ../../scripts/test-runtime.mjs"
   },
   "dependencies": {
     "@platformatic/kafka": "catalog:",
     "@view-server/client": "workspace:*",
     "@view-server/config": "workspace:*",
+    "@view-server/effect-utils": "workspace:*",
     "@view-server/runtime-core": "workspace:*",
     "@view-server/server": "workspace:*",
     "effect": "catalog:"

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -9,8 +9,9 @@ import {
 } from "@view-server/config";
 import { makeViewServerRuntimeCore } from "@view-server/runtime-core";
 import { Buffer } from "node:buffer";
-import { Effect, Exit, Fiber, Schema, Scope } from "effect";
+import { Cause, Effect, Exit, Fiber, Logger, References, Schema, Scope } from "effect";
 import { makeViewServerKafkaHealthLedger } from "./kafka-health";
+import type { ViewServerKafkaHealthLedger } from "./kafka-health";
 import {
   assignedPartitionsForSourceTopic,
   bootstrapBrokers,
@@ -18,6 +19,8 @@ import {
   closeKafkaConsumerAfterStartFailure,
   closeKafkaConsumerOnPostConsumeStartupFailure,
   closeKafkaConsumerOnStartFailure,
+  closeKafkaMessageStreamFiber,
+  closeStartedKafkaRegionConsumers,
   closeStartedKafkaConsumerResources,
   kafkaHeadersFromMessage,
   kafkaConsumerCloseError,
@@ -28,6 +31,7 @@ import {
   kafkaStreamCloseError,
   kafkaStreamError,
   makeViewServerKafkaIngress,
+  makeStartedKafkaConsumerResourcesFinalizer,
   mapKafkaConsumerStartError,
   mapKafkaStreamError,
   messageFromUnknown,
@@ -70,6 +74,21 @@ const viewServer = defineViewServerConfig({
 type Topics = typeof viewServer.topics;
 type KafkaMessageBytes = Buffer | null | undefined;
 type KafkaMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
+type CapturedLog = {
+  readonly cause: Cause.Cause<unknown>;
+  readonly message: unknown;
+};
+
+const makeCapturedLogs = () => {
+  const logs: Array<CapturedLog> = [];
+  const logger = Logger.make<unknown, void>((options) => {
+    logs.push({
+      cause: options.cause,
+      message: options.message,
+    });
+  });
+  return { logger, logs };
+};
 
 const regions = {
   cold: "localhost:9093",
@@ -452,6 +471,39 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("closes Kafka consumers even when stream close fails", () =>
+    Effect.gen(function* () {
+      let closeForce: boolean | undefined = undefined;
+      let streamCloseCount = 0;
+
+      const closeExit = yield* Effect.exit(
+        closeKafkaConsumer({
+          consumer: {
+            close: (force) => {
+              closeForce = force;
+            },
+          },
+          stream: {
+            close: () => {
+              streamCloseCount += 1;
+              throw new Error("stream close failed");
+            },
+          },
+        }),
+      );
+
+      expect({
+        closeForce,
+        closeFailurePreserved: Exit.isFailure(closeExit),
+        streamCloseCount,
+      }).toStrictEqual({
+        closeForce: true,
+        closeFailurePreserved: true,
+        streamCloseCount: 1,
+      });
+    }),
+  );
+
   it.effect("closes started Kafka resources with and without health listeners", () =>
     Effect.gen(function* () {
       let closeForce: boolean | undefined = undefined;
@@ -521,14 +573,201 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         }),
       };
 
-      yield* closeStartedKafkaConsumerResources(resources);
+      const exit = yield* Effect.exit(closeStartedKafkaConsumerResources(resources));
 
       expect({
         closeForce,
+        defectPreserved: Exit.hasDies(exit),
+        failed: Exit.isFailure(exit),
+        interrupted: Exit.hasInterrupts(exit),
         streamCloseCount,
       }).toStrictEqual({
         closeForce: true,
+        defectPreserved: true,
+        failed: true,
+        interrupted: false,
         streamCloseCount: 1,
+      });
+    }),
+  );
+
+  it.effect("retries started Kafka resource cleanup after a defecting close attempt", () =>
+    Effect.gen(function* () {
+      let closeForce: boolean | undefined = undefined;
+      let listenerCloseCount = 0;
+      let streamCloseCount = 0;
+      let listenerClose: Effect.Effect<void> = Effect.die(new Error("listener close failed"));
+      const resources: StartedKafkaConsumerResources = {
+        consumer: {
+          close: (force) => {
+            closeForce = force;
+          },
+        },
+        stream: {
+          close: () => {
+            streamCloseCount += 1;
+          },
+        },
+        healthListeners: () => ({
+          close: Effect.suspend(() => {
+            listenerCloseCount += 1;
+            const close = listenerClose;
+            listenerClose = Effect.void;
+            return close;
+          }),
+          processed: Effect.succeed(0),
+          waitForProcessed: () => Effect.void,
+        }),
+      };
+      const finalizer = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
+      const firstExit = yield* Effect.exit(finalizer);
+      yield* finalizer;
+      yield* finalizer;
+
+      expect({
+        closeForce,
+        firstAttemptDefected: Exit.hasDies(firstExit),
+        listenerCloseCount,
+        streamCloseCount,
+      }).toStrictEqual({
+        closeForce: true,
+        firstAttemptDefected: true,
+        listenerCloseCount: 2,
+        streamCloseCount: 2,
+      });
+    }),
+  );
+
+  it.effect("waits for Kafka stream fiber finalizers before close completes", () =>
+    Effect.gen(function* () {
+      let closeResourcesCount = 0;
+      let streamFinalizerCount = 0;
+      const streamFiber = yield* Effect.never.pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            streamFinalizerCount += 1;
+          }),
+        ),
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      yield* closeKafkaMessageStreamFiber(
+        streamFiber,
+        Effect.sync(() => {
+          closeResourcesCount += 1;
+        }),
+      );
+
+      expect({
+        closeResourcesCount,
+        streamFinalizerCount,
+      }).toStrictEqual({
+        closeResourcesCount: 1,
+        streamFinalizerCount: 1,
+      });
+    }),
+  );
+
+  it.effect("waits for Kafka stream fiber finalizers when resource cleanup defects", () =>
+    Effect.gen(function* () {
+      let closeResourcesCount = 0;
+      let streamFinalizerCount = 0;
+      const streamFiber = yield* Effect.never.pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            streamFinalizerCount += 1;
+          }),
+        ),
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      const exit = yield* Effect.exit(
+        closeKafkaMessageStreamFiber(
+          streamFiber,
+          Effect.gen(function* () {
+            closeResourcesCount += 1;
+            return yield* Effect.die(new Error("resource close failed"));
+          }),
+        ),
+      );
+
+      expect({
+        closeResourcesCount,
+        defectPreserved: Exit.hasDies(exit),
+        streamFinalizerCount,
+      }).toStrictEqual({
+        closeResourcesCount: 1,
+        defectPreserved: true,
+        streamFinalizerCount: 1,
+      });
+    }),
+  );
+
+  it.effect("preserves Kafka stream fiber finalizer defects during close", () =>
+    Effect.gen(function* () {
+      let closeResourcesCount = 0;
+      let streamFinalizerCount = 0;
+      const streamFiber = yield* Effect.never.pipe(
+        Effect.ensuring(
+          Effect.gen(function* () {
+            streamFinalizerCount += 1;
+            return yield* Effect.die(new Error("stream finalizer failed"));
+          }),
+        ),
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      const exit = yield* Effect.exit(
+        closeKafkaMessageStreamFiber(
+          streamFiber,
+          Effect.sync(() => {
+            closeResourcesCount += 1;
+          }),
+        ),
+      );
+
+      expect({
+        closeResourcesCount,
+        defectPreserved: Exit.hasDies(exit),
+        streamFinalizerCount,
+      }).toStrictEqual({
+        closeResourcesCount: 1,
+        defectPreserved: true,
+        streamFinalizerCount: 1,
+      });
+    }),
+  );
+
+  it.effect("closes all started region consumers before returning close defects", () =>
+    Effect.gen(function* () {
+      const closed: Array<string> = [];
+      const closeExit = yield* Effect.exit(
+        closeStartedKafkaRegionConsumers([
+          {
+            close: Effect.gen(function* () {
+              closed.push("first");
+              return yield* Effect.die(new Error("first close failed"));
+            }),
+          },
+          {
+            close: Effect.sync(() => {
+              closed.push("second");
+            }),
+          },
+          {
+            close: Effect.sync(() => {
+              closed.push("third");
+            }),
+          },
+        ]),
+      );
+
+      expect({
+        closed,
+        defectPreserved: Exit.hasDies(closeExit),
+      }).toStrictEqual({
+        closed: ["first", "second", "third"],
+        defectPreserved: true,
       });
     }),
   );
@@ -1004,10 +1243,167 @@ describe("@view-server/runtime Kafka ingress internals", () => {
 
       yield* listenerRegistration.close;
       yield* Scope.close(scope, Exit.void);
-      yield* Effect.promise(() => Promise.resolve(consumer.close(true))).pipe(Effect.ignore);
+      yield* Effect.promise(() => Promise.resolve(consumer.close(true)));
       yield* runtimeCore.close;
     }),
   );
+
+  it.effect("logs Kafka listener callback failures after applying ledger updates", () => {
+    const { logger, logs } = makeCapturedLogs();
+
+    return Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      const failingLedger: ViewServerKafkaHealthLedger<Topics> = {
+        ...ledger,
+        topicConnected: (sourceTopic, region, assignedPartitions, nowMillis) =>
+          ledger
+            .topicConnected(sourceTopic, region, assignedPartitions, nowMillis)
+            .pipe(Effect.andThen(Effect.die(new Error("listener ledger defect")))),
+      };
+      const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
+        bootstrapBrokers: ["127.0.0.1:1"],
+        clientId: "view-server-listener-failure-test",
+        groupId: "view-server-listener-failure-test",
+      });
+      const scope = yield* Scope.make("parallel");
+      const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
+        consumer,
+        failingLedger,
+        runtimeCore.client,
+        "local",
+        [ordersSourceTopic],
+        scope,
+      );
+      const processedWait = yield* listenerRegistration
+        .waitForProcessed(1)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      consumer.emit("consumer:group:join", {
+        groupId: "view-server-listener-failure-test",
+        memberId: "member-1",
+        assignments: [{ topic: ordersSourceTopic, partitions: [0] }],
+      });
+      yield* Fiber.join(processedWait);
+      const processed = yield* listenerRegistration.processed;
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+      const log = logs[0];
+
+      expect({
+        logCauseHasDefect: Cause.hasDies(log?.cause ?? Cause.empty),
+        logMessage: log?.message,
+        logCount: logs.length,
+        processed,
+        region: health.kafka?.regions["local"],
+        topicRegion: health.kafka?.topics[ordersSourceTopic]?.regions["local"],
+      }).toStrictEqual({
+        logCauseHasDefect: true,
+        logMessage: ["Kafka health listener dispatch failed."],
+        logCount: 1,
+        processed: 1,
+        region: {
+          status: "connected",
+          brokers: regions.local,
+          lastConnectedAt: expect.any(Number),
+          lastError: null,
+        },
+        topicRegion: {
+          connected: true,
+          assignedPartitions: 1,
+          messagesPerSecond: 0,
+          bytesPerSecond: 0,
+          decodedMessagesPerSecond: 0,
+          decodeFailuresPerSecond: 0,
+          mappingFailuresPerSecond: 0,
+          processingFailuresPerSecond: 0,
+          lastMessageAt: null,
+          lastCommitAt: null,
+          consumerLagMessages: null,
+          lagSampledAt: null,
+          committedOffset: null,
+          lastError: null,
+        },
+      });
+
+      yield* listenerRegistration.close;
+      yield* Scope.close(scope, Exit.void);
+      yield* Effect.promise(() => Promise.resolve(consumer.close(true)));
+      yield* runtimeCore.close;
+    }).pipe(
+      Effect.provide(Logger.layer([logger])),
+      Effect.provideService(References.MinimumLogLevel, "Trace"),
+    );
+  });
+
+  it.effect("does not log pure Kafka listener interruptions", () => {
+    const { logger, logs } = makeCapturedLogs();
+
+    return Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      const interruptingLedger: ViewServerKafkaHealthLedger<Topics> = {
+        ...ledger,
+        topicConnected: () => Effect.interrupt,
+      };
+      const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
+        bootstrapBrokers: ["127.0.0.1:1"],
+        clientId: "view-server-listener-interrupt-test",
+        groupId: "view-server-listener-interrupt-test",
+      });
+      const scope = yield* Scope.make("parallel");
+      const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
+        consumer,
+        interruptingLedger,
+        runtimeCore.client,
+        "local",
+        [ordersSourceTopic],
+        scope,
+      );
+      const processedWait = yield* listenerRegistration
+        .waitForProcessed(1)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      consumer.emit("consumer:group:join", {
+        groupId: "view-server-listener-interrupt-test",
+        memberId: "member-1",
+        assignments: [{ topic: ordersSourceTopic, partitions: [0] }],
+      });
+      yield* Fiber.join(processedWait);
+      const processed = yield* listenerRegistration.processed;
+
+      expect({
+        logCount: logs.length,
+        processed,
+      }).toStrictEqual({
+        logCount: 0,
+        processed: 1,
+      });
+
+      yield* listenerRegistration.close;
+      yield* Scope.close(scope, Exit.void);
+      yield* Effect.promise(() => Promise.resolve(consumer.close(true)));
+      yield* runtimeCore.close;
+    }).pipe(
+      Effect.provide(Logger.layer([logger])),
+      Effect.provideService(References.MinimumLogLevel, "Trace"),
+    );
+  });
 
   it.effect("reports Kafka overlay ready and starting runtime statuses", () =>
     Effect.gen(function* () {
@@ -1810,7 +2206,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       });
 
       yield* listenerRegistration.close;
-      yield* Effect.promise(() => Promise.resolve(consumer.close(true))).pipe(Effect.ignore);
+      yield* Effect.promise(() => Promise.resolve(consumer.close(true)));
       yield* runtimeCore.close;
     }),
   );

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -14,6 +14,10 @@ import {
   type ViewServerRuntimeClient,
 } from "@view-server/config";
 import {
+  ignoreLoggedTypedFailuresPreserveNonTypedFailures,
+  runAllFinalizers,
+} from "@view-server/effect-utils";
+import {
   Cause,
   Clock,
   Deferred,
@@ -24,6 +28,7 @@ import {
   Option,
   Ref,
   Schema,
+  Semaphore,
   Scope,
   Stream,
 } from "effect";
@@ -46,7 +51,7 @@ export type ViewServerKafkaIngress = {
 };
 
 export type StartedKafkaRegionConsumer = {
-  readonly close: Effect.Effect<void>;
+  readonly close: Effect.Effect<void, ViewServerKafkaIngressError>;
 };
 
 type KafkaConsumer = Consumer<Buffer, Buffer, Buffer, Buffer>;
@@ -78,6 +83,26 @@ type KafkaConsumerHealthListenerProcessedState = {
 };
 
 const emptyMessageBytes = Buffer.alloc(0);
+const ignoreKafkaConsumerCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring Kafka consumer close failure.",
+);
+const ignoreKafkaStartedResourceCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring Kafka started resource close failure.",
+);
+const ignoreKafkaHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring Kafka health refresh failure.",
+);
+const logKafkaHealthListenerDispatchFailure = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<void, E, R> =>
+  effect.pipe(
+    Effect.asVoid,
+    Effect.catchCause((cause) =>
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.failCause(cause)
+        : Effect.logError("Kafka health listener dispatch failed.", cause),
+    ),
+  );
 
 const kafkaHeaderIsRepeated = (
   value: string | Uint8Array | ReadonlyArray<string | Uint8Array>,
@@ -247,7 +272,7 @@ export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTop
 
 const refreshKafkaHealth = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   client: ViewServerRuntimeClient<Topics>,
-) => client.health().pipe(Effect.ignore);
+) => client.health().pipe(ignoreKafkaHealthRefreshFailure);
 
 export const recordKafkaAssignments = Effect.fn(
   "ViewServerRuntime.kafka.consumer.recordAssignments",
@@ -302,7 +327,7 @@ export const closeKafkaConsumerAfterStartFailure = Effect.fn(
   yield* Effect.tryPromise({
     try: () => Promise.resolve(consumer.close(true)),
     catch: kafkaConsumerCloseError,
-  }).pipe(Effect.ignore);
+  }).pipe(ignoreKafkaConsumerCloseFailure);
 });
 
 export const closeKafkaConsumerOnStartFailure = Effect.fn(
@@ -352,14 +377,16 @@ export const closeKafkaConsumer = Effect.fn("ViewServerRuntime.kafka.consumer.cl
     readonly consumer: CloseableKafkaConsumer;
     readonly stream: CloseableKafkaStream;
   }) {
-    yield* Effect.tryPromise({
-      try: () => Promise.resolve(input.stream.close()),
-      catch: kafkaStreamCloseError,
-    }).pipe(Effect.ignore);
-    yield* Effect.tryPromise({
-      try: () => Promise.resolve(input.consumer.close(true)),
-      catch: kafkaConsumerCloseError,
-    }).pipe(Effect.ignore);
+    yield* runAllFinalizers([
+      Effect.tryPromise({
+        try: () => Promise.resolve(input.stream.close()),
+        catch: kafkaStreamCloseError,
+      }),
+      Effect.tryPromise({
+        try: () => Promise.resolve(input.consumer.close(true)),
+        catch: kafkaConsumerCloseError,
+      }),
+    ]);
   },
 );
 
@@ -367,13 +394,60 @@ export const closeStartedKafkaConsumerResources = Effect.fn(
   "ViewServerRuntime.kafka.consumer.closeStartedResources",
 )(function* (resources: StartedKafkaConsumerResources) {
   const healthListeners = resources.healthListeners();
-  if (healthListeners !== null) {
-    yield* healthListeners.close.pipe(Effect.ignoreCause);
-  }
-  yield* closeKafkaConsumer({
+  const closeConsumer = closeKafkaConsumer({
     consumer: resources.consumer,
     stream: resources.stream,
   });
+  yield* runAllFinalizers(
+    healthListeners === null ? [closeConsumer] : [healthListeners.close, closeConsumer],
+  );
+});
+
+export const closeKafkaMessageStreamFiber = Effect.fn("ViewServerRuntime.kafka.stream.closeFiber")(
+  function* (
+    fiber: Fiber.Fiber<void, ViewServerKafkaIngressError>,
+    closeResources: Effect.Effect<void, ViewServerKafkaIngressError>,
+  ) {
+    const interruptFiber = yield* Fiber.interrupt(fiber).pipe(
+      Effect.forkChild({ startImmediately: true }),
+    );
+    const awaitTargetExit = Fiber.await(fiber).pipe(
+      Effect.andThen((exit) =>
+        Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)
+          ? Effect.failCause(exit.cause)
+          : Effect.void,
+      ),
+    );
+    yield* runAllFinalizers([closeResources, Fiber.join(interruptFiber), awaitTargetExit]);
+  },
+);
+
+export const makeStartedKafkaConsumerResourcesFinalizer = Effect.fn(
+  "ViewServerRuntime.kafka.consumer.makeStartedResourcesFinalizer",
+)((resources: StartedKafkaConsumerResources) =>
+  Ref.make(false).pipe(
+    Effect.map((resourcesClosed) => {
+      const closeLock = Semaphore.makeUnsafe(1);
+      return Effect.uninterruptible(
+        closeLock.withPermits(1)(
+          Effect.gen(function* () {
+            const alreadyClosed = yield* Ref.get(resourcesClosed);
+            if (alreadyClosed) {
+              return;
+            }
+            yield* closeStartedKafkaConsumerResources(resources);
+            yield* Ref.set(resourcesClosed, true);
+          }),
+        ),
+      );
+    }),
+  ),
+);
+
+export const closeStartedKafkaRegionConsumers = Effect.fn(
+  "ViewServerRuntime.kafka.regions.closeStartedConsumers",
+)(function* (consumers: ReadonlyArray<StartedKafkaRegionConsumer>) {
+  yield* runAllFinalizers(consumers.map((consumer) => consumer.close));
 });
 
 export const closeKafkaConsumerOnPostConsumeStartupFailure = Effect.fn(
@@ -584,10 +658,10 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
     if (listenersOpen.current) {
       runFork(
         effect.pipe(
+          logKafkaHealthListenerDispatchFailure,
           Effect.ensuring(markProcessed()),
           Effect.forkIn(scope, { startImmediately: true }),
           Effect.asVoid,
-          Effect.ignoreCause,
         ),
       );
     }
@@ -641,7 +715,7 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
       consumer.off("consumer:lag", lagListener);
       consumer.off("consumer:lag:error", lagErrorListener);
       consumer.stopLagMonitoring();
-    }).pipe(Effect.ignoreCause),
+    }),
     processed: Ref.get(processed).pipe(Effect.map((state) => state.count)),
     waitForProcessed,
   };
@@ -680,14 +754,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
     healthListeners: () => healthListeners,
     stream,
   };
-  let resourcesClosed = false;
-  const closeResources = Effect.suspend(() => {
-    if (resourcesClosed) {
-      return Effect.void;
-    }
-    resourcesClosed = true;
-    return closeStartedKafkaConsumerResources(resources);
-  });
+  const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
   return yield* closeKafkaConsumerOnPostConsumeStartupFailure(
     resources,
     Effect.gen(function* () {
@@ -717,13 +784,10 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
         health,
         region,
         stream,
-      ).pipe(Effect.ensuring(closeResources));
+      ).pipe(Effect.ensuring(closeResources.pipe(ignoreKafkaStartedResourceCloseFailure)));
       const fiber = yield* processStream.pipe(Effect.forkIn(scope, { startImmediately: true }));
       return {
-        close: Effect.all([Fiber.interrupt(fiber), closeResources], {
-          concurrency: "unbounded",
-          discard: true,
-        }),
+        close: closeKafkaMessageStreamFiber(fiber, closeResources),
       };
     }),
   );
@@ -745,9 +809,7 @@ export const startKafkaRegionConsumers = Effect.fn("ViewServerRuntime.kafka.regi
       { discard: true },
     ).pipe(
       Effect.onExit((exit) =>
-        Exit.isFailure(exit)
-          ? Effect.forEach(consumers, (consumer) => consumer.close, { discard: true })
-          : Effect.void,
+        Exit.isFailure(exit) ? closeStartedKafkaRegionConsumers(consumers) : Effect.void,
       ),
     );
     return consumers;
@@ -781,8 +843,9 @@ export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntime
     },
   ).pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)));
   return {
-    close: Effect.forEach(consumers, (consumer) => consumer.close, {
-      discard: true,
-    }).pipe(Effect.ensuring(Scope.close(scope, Exit.void))),
+    close: closeStartedKafkaRegionConsumers(consumers).pipe(
+      ignoreKafkaStartedResourceCloseFailure,
+      Effect.ensuring(Scope.close(scope, Exit.void)),
+    ),
   };
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       '@view-server/config':
         specifier: workspace:*
         version: link:../config
+      '@view-server/effect-utils':
+        specifier: workspace:*
+        version: link:../effect-utils
       '@view-server/runtime-core':
         specifier: workspace:*
         version: link:../runtime-core

--- a/scripts/test-runtime.mjs
+++ b/scripts/test-runtime.mjs
@@ -24,7 +24,7 @@ if (exitCode === 0) {
     "sh",
     [
       "-c",
-      "vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp test run --coverage --typecheck",
+      "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp test run --coverage --typecheck",
     ],
     {
       cwd: runtimeDirectory,


### PR DESCRIPTION
## Summary
- make Kafka ingress cleanup run all finalizers without short-circuiting
- preserve internal typed close failures while keeping public ingress close infallible for typed Kafka close errors
- await stream fiber exits during close so finalizer defects are not lost
- add regression coverage for listener failure logging, cleanup retry, stream finalizer ordering, and defect preservation

## Validation
- pnpm run ready
- forbidden-pattern scans clean for Effect.ignore/ignoreCause, casts, toEqual, coverage ignores, Testing Library, act/flushSync, and assert
- 3-agent review pass: no findings