### PR TITLE
Preserve dangerous Kafka health keys

### DIFF
--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -54,6 +54,16 @@ const order = (id: string, price: number): OrderRow => ({
   price,
 });
 
+const nullRecord = <Value>(
+  entries: ReadonlyArray<readonly [string, Value]>,
+): Record<string, Value> => {
+  const record: Record<string, Value> = Object.create(null);
+  for (const [key, value] of entries) {
+    record[key] = value;
+  }
+  return record;
+};
+
 const fetchHealth = Effect.fn("ViewServerRuntime.test.health.fetch")(function* (url: string) {
   const response = yield* Effect.promise(() => fetch(url));
   const text = yield* Effect.promise(() => response.text());
@@ -383,15 +393,72 @@ describe("@view-server/runtime", () => {
         ),
       }).toStrictEqual({
         consumerGroupId: "view-server-test-runtime",
-        regions: {
-          local: "localhost:9092",
-        },
+        regions: nullRecord([["local", "localhost:9092"]]),
         topics: {
           "orders-source": {
             regions: ["local"],
             viewServerTopic: "orders",
           },
         },
+      });
+
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("preserves dangerous Kafka runtime option keys", () =>
+    Effect.gen(function* () {
+      type RuntimeDependencies = ViewServerRuntimeDependencies<typeof viewServer.topics>;
+      let kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<typeof viewServer.topics> | undefined;
+      const regions = nullRecord([["__proto__", Config.succeed("localhost:9092")]]);
+      const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
+      const dangerousTopic = localKafkaTopic({
+        regions: ["__proto__"],
+        value: kafka.json(Order),
+        key: kafka.stringKey(),
+        viewServerTopic: "orders",
+        mapping: ({ key, value }) => ({
+          id: key,
+          price: value.price,
+        }),
+      });
+      const topics = nullRecord([["__proto__", dangerousTopic]]);
+      const dependencies: RuntimeDependencies = {
+        ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
+        makeServer: () =>
+          Effect.succeed({
+            url: "ws://127.0.0.1:0/rpc",
+            healthUrl: "http://127.0.0.1:0/health",
+            close: Effect.void,
+          }),
+        makeKafkaIngress: (_config, _client, options) => {
+          kafkaOptions = options;
+          return Effect.succeed({
+            close: Effect.void,
+          });
+        },
+      };
+
+      const runtime = yield* makeViewServerRuntimeWithDependencies(dependencies, viewServer, {
+        kafka: {
+          consumerGroupId: "view-server-dangerous-key-test-runtime",
+          regions,
+          topics,
+        },
+      });
+
+      expect(Object.hasOwn(kafkaOptions?.regions ?? {}, "__proto__")).toBe(true);
+      expect(Object.hasOwn(kafkaOptions?.topics ?? {}, "__proto__")).toBe(true);
+      expect({
+        consumerGroupId: kafkaOptions?.consumerGroupId,
+        region: kafkaOptions?.regions["__proto__"],
+        topicRegions: kafkaOptions?.topics["__proto__"]?.regions,
+        viewServerTopic: kafkaOptions?.topics["__proto__"]?.viewServerTopic,
+      }).toStrictEqual({
+        consumerGroupId: "view-server-dangerous-key-test-runtime",
+        region: "localhost:9092",
+        topicRegions: ["__proto__"],
+        viewServerTopic: "orders",
       });
 
       yield* runtime.close;

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -2124,6 +2124,82 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("preserves dangerous Kafka health source topic and region keys", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const dangerousRegions: Record<string, string> = Object.create(null);
+      dangerousRegions["__proto__"] = "localhost:9092";
+      const dangerousTopics: Record<
+        string,
+        {
+          readonly viewServerTopic: "orders";
+          readonly regions: ReadonlyArray<string>;
+        }
+      > = Object.create(null);
+      dangerousTopics["__proto__"] = {
+        regions: ["__proto__"],
+        viewServerTopic: "orders",
+      };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: dangerousRegions,
+        topics: dangerousTopics,
+      });
+
+      yield* ledger.regionConnected("__proto__", 1_000);
+      yield* ledger.topicConnected("__proto__", "__proto__", 2, 1_000);
+      yield* ledger.messageDecoded("__proto__", "__proto__", {
+        bytes: 12,
+        committedOffset: "4",
+        nowMillis: 2_000,
+      });
+
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      const expectedRegions: Record<string, unknown> = Object.create(null);
+      expectedRegions["__proto__"] = {
+        status: "connected",
+        brokers: "localhost:9092",
+        lastConnectedAt: 1_000,
+        lastError: null,
+      };
+      const expectedTopicRegions: Record<string, unknown> = Object.create(null);
+      expectedTopicRegions["__proto__"] = {
+        connected: true,
+        assignedPartitions: 2,
+        messagesPerSecond: 1,
+        bytesPerSecond: 12,
+        decodedMessagesPerSecond: 1,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        processingFailuresPerSecond: 0,
+        lastMessageAt: 2_000,
+        lastCommitAt: 2_000,
+        consumerLagMessages: null,
+        lagSampledAt: null,
+        committedOffset: "4",
+        lastError: null,
+      };
+      const expectedTopics: Record<string, unknown> = Object.create(null);
+      expectedTopics["__proto__"] = {
+        status: "ready",
+        sourceTopic: "__proto__",
+        viewServerTopic: "orders",
+        regions: expectedTopicRegions,
+      };
+
+      expect(Object.hasOwn(health.kafka?.regions ?? {}, "__proto__")).toBe(true);
+      expect(Object.hasOwn(health.kafka?.topics ?? {}, "__proto__")).toBe(true);
+      expect(Object.hasOwn(health.kafka?.topics["__proto__"]?.regions ?? {}, "__proto__")).toBe(
+        true,
+      );
+      expect(health.kafka).toStrictEqual({
+        regions: expectedRegions,
+        topics: expectedTopics,
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("does not run Kafka listener callbacks after their scope closes", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -42,7 +42,7 @@ const resolveKafkaOptions: <
     const entries = yield* Effect.forEach(Object.entries(options.regions), ([region, value]) =>
       resolveRuntimeValue(value).pipe(Effect.map((bootstrap) => [region, bootstrap] as const)),
     );
-    const regions: Record<string, string> = {};
+    const regions: Record<string, string> = Object.create(null);
     for (const [region, bootstrap] of entries) {
       regions[region] = bootstrap;
     }


### PR DESCRIPTION
## Summary
- preserve resolved Kafka runtime region maps as null-prototype records so dynamic keys like `__proto__` survive option resolution
- add runtime option regression coverage for `__proto__` Kafka region/source topic keys
- add Kafka health ledger regression coverage proving `__proto__` source topic/region keys survive in health snapshots

## Validation
- `pnpm --filter @view-server/runtime run test`
- `vp check --fix packages/runtime/src/index.test.ts packages/runtime/src/kafka-ingress.internal.test.ts packages/runtime/src/runtime-options.ts`
- `pnpm exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --severity error`
- `pnpm run ready`
- 3-agent review loop: clean after fixing the runtime options seam blocker