### PR TITLE
Log typed subscription close failures

### DIFF
--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -169,7 +169,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     source: Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>, ViewServerRemoteClientError>,
     lifecycle: {
       readonly onOpen: Effect.Effect<void>;
-      readonly onClose: Effect.Effect<void>;
+      readonly onClose: Effect.Effect<void, unknown>;
     } = {
       onOpen: Effect.void,
       onClose: Effect.void,

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, Scope, Stream } from "effect";
+import { Cause, Effect, Exit, Logger, References, Scope, Stream } from "effect";
 import type { StatusEvent } from "@view-server/config";
 import type { ViewServerLiveEvent } from "./live-client";
 import { makeRemoteSubscription } from "./remote-subscription";
 
 type Row = {
   readonly id: string;
+};
+
+type CapturedLog = {
+  readonly cause: Cause.Cause<unknown>;
+  readonly logLevel: unknown;
+  readonly message: unknown;
+};
+
+const makeCapturedLogs = () => {
+  const logs: Array<CapturedLog> = [];
+  const logger = Logger.make<unknown, void>((options) => {
+    logs.push({
+      cause: options.cause,
+      logLevel: options.logLevel,
+      message: options.message,
+    });
+  });
+  return { logger, logs };
 };
 
 const snapshot: ViewServerLiveEvent<Row> = {
@@ -109,4 +127,42 @@ describe("remote subscription", () => {
       yield* Scope.close(clientScope, Exit.void);
     }),
   );
+
+  it.effect("logs and ignores typed lifecycle close failures", () => {
+    const { logger, logs } = makeCapturedLogs();
+
+    return Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      let closeCount = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        lifecycle: {
+          onOpen: Effect.void,
+          onClose: Effect.gen(function* () {
+            closeCount += 1;
+            return yield* Effect.fail("typed close failure");
+          }),
+        },
+        source: Stream.make(snapshot),
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+
+      const closeExit = yield* Effect.exit(subscription.close());
+
+      expect(Exit.isSuccess(closeExit)).toBe(true);
+      expect(closeCount).toBe(1);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.message).toStrictEqual(["Remote subscription close failed."]);
+      expect(logs[0]?.logLevel).toBe("Warn");
+      expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
+      expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
+      expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
+      yield* Scope.close(clientScope, Exit.void);
+    }).pipe(
+      Effect.provide(Logger.layer([logger])),
+      Effect.provideService(References.MinimumLogLevel, "Trace"),
+    );
+  });
 });

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -8,16 +8,14 @@ import type {
 } from "./live-client";
 
 const ignoreRemoteSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
-  "Ignoring remote subscription close failure.",
+  "Remote subscription close failed.",
 );
 const ignoreRemoteSubscriptionStreamStartFailure =
-  ignoreLoggedTypedFailuresPreserveNonTypedFailures(
-    "Ignoring remote subscription stream start failure.",
-  );
+  ignoreLoggedTypedFailuresPreserveNonTypedFailures("Remote subscription stream start failed.");
 
 export type RemoteSubscriptionLifecycle = {
   readonly onOpen: Effect.Effect<void>;
-  readonly onClose: Effect.Effect<void>;
+  readonly onClose: Effect.Effect<void, unknown>;
 };
 
 export type RemoteSubscriptionOptions<

--- a/packages/effect-utils/src/index.test.ts
+++ b/packages/effect-utils/src/index.test.ts
@@ -7,6 +7,7 @@ const ignoreCloseFailure =
 
 type CapturedLog = {
   readonly cause: Cause.Cause<unknown>;
+  readonly logLevel: unknown;
   readonly message: unknown;
 };
 
@@ -15,6 +16,7 @@ const makeCapturedLogs = () => {
   const logger = Logger.make<unknown, void>((options) => {
     logs.push({
       cause: options.cause,
+      logLevel: options.logLevel,
       message: options.message,
     });
   });
@@ -28,7 +30,9 @@ describe("close policy", () => {
     return Effect.gen(function* () {
       yield* Effect.fail("typed close failure").pipe(ignoreCloseFailure);
 
+      expect(logs).toHaveLength(1);
       expect(logs[0]?.message).toStrictEqual(["Ignoring close failure."]);
+      expect(logs[0]?.logLevel).toBe("Warn");
       expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
       expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
       expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
@@ -84,7 +88,9 @@ describe("close policy", () => {
       expect(Cause.hasDies(cause)).toBe(true);
       expect(Cause.hasFails(cause)).toBe(false);
       expect(Cause.hasInterrupts(cause)).toBe(false);
+      expect(logs).toHaveLength(1);
       expect(logs[0]?.message).toStrictEqual(["Ignoring close failure."]);
+      expect(logs[0]?.logLevel).toBe("Warn");
       expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
       expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
       expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
@@ -111,7 +117,9 @@ describe("close policy", () => {
       expect(Cause.hasDies(cause)).toBe(false);
       expect(Cause.hasFails(cause)).toBe(false);
       expect(Cause.hasInterrupts(cause)).toBe(true);
+      expect(logs).toHaveLength(1);
       expect(logs[0]?.message).toStrictEqual(["Ignoring close failure."]);
+      expect(logs[0]?.logLevel).toBe("Warn");
       expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
       expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
       expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);

--- a/packages/effect-utils/src/index.ts
+++ b/packages/effect-utils/src/index.ts
@@ -17,7 +17,7 @@ export const ignoreLoggedTypedFailuresPreserveNonTypedFailures =
         const logTypedFailures =
           typedFailures.length === 0
             ? Effect.void
-            : Effect.logInfo(message, Cause.fromReasons(typedFailures));
+            : Effect.logWarning(message, Cause.fromReasons(typedFailures));
 
         return nonTypedFailures.length === 0
           ? logTypedFailures

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -990,9 +990,17 @@ describe("@view-server/server", () => {
   );
 
   it.live("logs typed RPC handler stream finalization close failures", () => {
-    const logMessages: Array<unknown> = [];
+    const logs: Array<{
+      readonly cause: Cause.Cause<unknown>;
+      readonly logLevel: unknown;
+      readonly message: unknown;
+    }> = [];
     const logger = Logger.make<unknown, void>((options) => {
-      logMessages.push(options.message);
+      logs.push({
+        cause: options.cause,
+        logLevel: options.logLevel,
+        message: options.message,
+      });
     });
     let closeAttempts = 0;
     const closeFailure: ViewServerTransportError = {
@@ -1049,7 +1057,12 @@ describe("@view-server/server", () => {
 
       yield* Deferred.await(closeStarted);
       expect(closeAttempts).toBe(1);
-      expect(logMessages).toStrictEqual([["Ignoring RPC subscription close failure."]]);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.message).toStrictEqual(["RPC subscription close failed."]);
+      expect(logs[0]?.logLevel).toBe("Warn");
+      expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
+      expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
+      expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
       yield* inMemory.close;
     }).pipe(
       Effect.provide(Logger.layer([logger])),
@@ -1060,9 +1073,17 @@ describe("@view-server/server", () => {
   it.live(
     "preserves RPC handler stream finalization close defects mixed with typed failures",
     () => {
-      const logMessages: Array<unknown> = [];
+      const logs: Array<{
+        readonly cause: Cause.Cause<unknown>;
+        readonly logLevel: unknown;
+        readonly message: unknown;
+      }> = [];
       const logger = Logger.make<unknown, void>((options) => {
-        logMessages.push(options.message);
+        logs.push({
+          cause: options.cause,
+          logLevel: options.logLevel,
+          message: options.message,
+        });
       });
       let closeAttempts = 0;
       const closeFailure: ViewServerTransportError = {
@@ -1121,7 +1142,12 @@ describe("@view-server/server", () => {
         expect(Cause.hasDies(cause)).toBe(true);
         expect(Cause.hasFails(cause)).toBe(false);
         expect(closeAttempts).toBe(1);
-        expect(logMessages).toStrictEqual([["Ignoring RPC subscription close failure."]]);
+        expect(logs).toHaveLength(1);
+        expect(logs[0]?.message).toStrictEqual(["RPC subscription close failed."]);
+        expect(logs[0]?.logLevel).toBe("Warn");
+        expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
+        expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
+        expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
         yield* inMemory.close;
       }).pipe(
         Effect.provide(Logger.layer([logger])),

--- a/packages/server/src/rpc-handlers.ts
+++ b/packages/server/src/rpc-handlers.ts
@@ -15,7 +15,7 @@ import { Effect, Exit, Stream } from "effect";
 import type { ViewServerWebSocketServerInput } from "./server-types";
 
 const ignoreSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
-  "Ignoring RPC subscription close failure.",
+  "RPC subscription close failed.",
 );
 
 export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>(


### PR DESCRIPTION
## Summary
- log typed close/finalizer failures at warning level instead of info
- clarify server/client subscription close failure log messages
- add remote subscription coverage for typed lifecycle close failures
- strengthen server and shared close-policy tests to assert one warning log and preserved Cause shape

## Validation
- vp check --fix packages/effect-utils/src/index.ts packages/effect-utils/src/index.test.ts packages/client/src/remote-client.ts packages/client/src/remote-subscription.ts packages/client/src/remote-subscription.test.ts packages/server/src/rpc-handlers.ts packages/server/src/index.test.ts
- pnpm --filter @view-server/effect-utils run test
- pnpm --filter @view-server/client run test
- pnpm --filter @view-server/server run test
- pnpm exec effect-language-service diagnostics --project packages/effect-utils/tsconfig.json --format text --severity error
- pnpm exec effect-language-service diagnostics --project packages/client/tsconfig.json --format text --severity error
- pnpm exec effect-language-service diagnostics --project packages/server/tsconfig.json --format text --severity error
- pnpm run ready
- 3-agent review loop: no blockers; non-blocking log-level/exact-count suggestions addressed before PR