### PR TITLE
Extract protocol JSON field codec

### DIFF
--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -1,7 +1,10 @@
 import { viewServerSchemaFieldMetadata, type ViewServerRuntimeError } from "@view-server/config";
 import { Effect, Schema } from "effect";
-
-export type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
+import {
+  decodeJsonFieldValue,
+  encodeJsonFieldValue,
+  type JsonFieldSchema,
+} from "./protocol-json-field-codec";
 
 export const filterOperatorKeys = new Set([
   "eq",
@@ -31,35 +34,27 @@ const invalidQuery = (topic: string, message: string): ViewServerRuntimeError =>
   topic,
 });
 
-const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(function* (
+const encodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(function* (
   topic: string,
   field: string,
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Filter ${field} is not JSON-safe: ${error.message}`),
-    ),
-  );
+  return yield* encodeJsonFieldValue(schema, value, {
+    invalid: (message) => invalidQuery(topic, `Invalid filter for ${field}: ${message}`),
+    notJsonSafe: (message) => invalidQuery(topic, `Filter ${field} is not JSON-safe: ${message}`),
+  });
 });
 
-const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(function* (
+const decodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(function* (
   topic: string,
   field: string,
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
+  return yield* decodeJsonFieldValue(schema, value, {
+    invalid: (message) => invalidQuery(topic, `Invalid filter for ${field}: ${message}`),
+  });
 });
 
 const encodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.encode")(function* (
@@ -134,12 +129,12 @@ const encodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.
   for (const [operator, operatorValue] of Object.entries(value)) {
     if (operator === "in" && Array.isArray(operatorValue)) {
       output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
-        encodeJsonFieldValue(topic, field, schema, entry),
+        encodeFilterJsonFieldValue(topic, field, schema, entry),
       );
     } else if (operator === "startsWith") {
       output[operator] = yield* encodeStringFilterValue(topic, field, schema, operatorValue);
     } else {
-      output[operator] = yield* encodeJsonFieldValue(topic, field, schema, operatorValue);
+      output[operator] = yield* encodeFilterJsonFieldValue(topic, field, schema, operatorValue);
     }
   }
   return output;
@@ -156,12 +151,12 @@ const decodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.
   for (const [operator, operatorValue] of Object.entries(value)) {
     if (operator === "in" && Array.isArray(operatorValue)) {
       output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
-        decodeJsonFieldValue(topic, field, schema, entry),
+        decodeFilterJsonFieldValue(topic, field, schema, entry),
       );
     } else if (operator === "startsWith") {
       output[operator] = yield* decodeStringFilterValue(topic, field, schema, operatorValue);
     } else {
-      output[operator] = yield* decodeJsonFieldValue(topic, field, schema, operatorValue);
+      output[operator] = yield* decodeFilterJsonFieldValue(topic, field, schema, operatorValue);
     }
   }
   return output;
@@ -174,11 +169,11 @@ export const encodeFilterValue = Effect.fn("ViewServerProtocol.filter.encode")(f
   value: unknown,
 ) {
   if (!isFilterObject(value)) {
-    return yield* encodeJsonFieldValue(topic, field, schema, value);
+    return yield* encodeFilterJsonFieldValue(topic, field, schema, value);
   }
   return yield* Effect.matchEffect(encodeOperatorFilterValue(topic, field, schema, value), {
     onFailure: (operatorError) =>
-      Effect.matchEffect(encodeJsonFieldValue(topic, field, schema, value), {
+      Effect.matchEffect(encodeFilterJsonFieldValue(topic, field, schema, value), {
         onFailure: () => Effect.fail(operatorError),
         onSuccess: Effect.succeed,
       }),
@@ -193,11 +188,11 @@ export const decodeFilterValue = Effect.fn("ViewServerProtocol.filter.decode")(f
   value: unknown,
 ) {
   if (!isFilterObject(value)) {
-    return yield* decodeJsonFieldValue(topic, field, schema, value);
+    return yield* decodeFilterJsonFieldValue(topic, field, schema, value);
   }
   return yield* Effect.matchEffect(decodeOperatorFilterValue(topic, field, schema, value), {
     onFailure: (operatorError) =>
-      Effect.matchEffect(decodeJsonFieldValue(topic, field, schema, value), {
+      Effect.matchEffect(decodeFilterJsonFieldValue(topic, field, schema, value), {
         onFailure: () => Effect.fail(operatorError),
         onSuccess: Effect.succeed,
       }),

--- a/packages/protocol/src/protocol-grouped-query-codec.ts
+++ b/packages/protocol/src/protocol-grouped-query-codec.ts
@@ -10,7 +10,7 @@ import type {
 } from "@view-server/config";
 import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
-import type { JsonFieldSchema } from "./protocol-field-filter-codec";
+import type { JsonFieldSchema } from "./protocol-json-field-codec";
 import {
   decodeWhere,
   encodeWhere,

--- a/packages/protocol/src/protocol-json-field-codec.ts
+++ b/packages/protocol/src/protocol-json-field-codec.ts
@@ -1,0 +1,31 @@
+import { Effect, Schema } from "effect";
+
+export type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
+
+type JsonFieldCodecErrors<E> = {
+  readonly invalid: (message: string) => E;
+  readonly notJsonSafe: (message: string) => E;
+};
+
+export const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.encode")(function* <E>(
+  schema: JsonFieldSchema,
+  value: unknown,
+  errors: JsonFieldCodecErrors<E>,
+) {
+  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) => errors.invalid(error.message)),
+  );
+  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
+    Effect.mapError((error) => errors.notJsonSafe(error.message)),
+  );
+});
+
+export const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.decode")(function* <E>(
+  schema: JsonFieldSchema,
+  value: unknown,
+  errors: Pick<JsonFieldCodecErrors<E>, "invalid">,
+) {
+  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
+    Effect.mapError((error) => errors.invalid(error.message)),
+  );
+});

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -2,6 +2,11 @@ import type { TopicDefinitions, ViewServerRuntimeError } from "@view-server/conf
 import { Effect, Schema } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
+import {
+  decodeJsonFieldValue,
+  encodeJsonFieldValue,
+  type JsonFieldSchema,
+} from "./protocol-json-field-codec";
 import type { ViewServerEventGroupedQuery, ViewServerEventQuery } from "./protocol-query-schema";
 
 const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
@@ -18,17 +23,13 @@ export const isViewServerEventGroupedQuery = (
 const encodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.encode")(function* (
   topic: string,
   field: string,
-  schema: Schema.Codec<unknown>,
+  schema: JsonFieldSchema,
   value: unknown,
 ) {
-  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
-  );
-  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
-    Effect.mapError((error) =>
-      invalidRow(topic, `Field ${field} is not JSON-safe: ${error.message}`),
-    ),
-  );
+  return yield* encodeJsonFieldValue(schema, value, {
+    invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+    notJsonSafe: (message) => invalidRow(topic, `Field ${field} is not JSON-safe: ${message}`),
+  });
 });
 
 export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.encode")(function* <
@@ -84,9 +85,9 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
       );
     }
     const fieldSchema = config.topics[topic]!.schema.fields[field]!;
-    output[field] = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(fieldSchema))(value).pipe(
-      Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
-    );
+    output[field] = yield* decodeJsonFieldValue(fieldSchema, value, {
+      invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+    });
   }
   return output;
 });
@@ -168,11 +169,9 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   for (const [field, value] of Object.entries(row)) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
-      output[field] = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(fieldSchema))(
-        value,
-      ).pipe(
-        Effect.mapError((error) => invalidRow(topic, `Invalid field ${field}: ${error.message}`)),
-      );
+      output[field] = yield* decodeJsonFieldValue(fieldSchema, value, {
+        invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+      });
     } else if (aggregateAliases.has(field)) {
       const aggregate = query.aggregates[field];
       if (aggregate === undefined) {

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -113,6 +113,8 @@ const forbiddenPackageDeepImports = [
   "@view-server/in-memory/dist/index.js",
   "@view-server/protocol/src/index",
   "@view-server/protocol/dist/index.js",
+  "@view-server/protocol/src/protocol-json-field-codec",
+  "@view-server/protocol/protocol-json-field-codec",
   "@view-server/protocol/src/protocol-row-codec",
   "@view-server/protocol/protocol-row-codec",
   "@view-server/react/src/index",


### PR DESCRIPTION
## Summary
- extract shared schema-aware JSON field encode/decode helper for protocol row and filter codecs
- keep InvalidQuery/InvalidRow message ownership at the caller sites so wire error behavior stays unchanged
- update grouped query codec to import the internal schema type from the new helper
- add explicit package-export rejects for the new internal protocol helper

## Validation
- vp check --fix touched files
- pnpm --filter @view-server/protocol run test
- pnpm run check:package-exports
- pnpm exec effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict
- pnpm run ready
- forbidden-pattern and cast scans clean on touched files
- 3-agent review loop: no findings