### PR TITLE
Document Kafka ingest recovery contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -174,6 +174,14 @@ _Avoid_: Location string, environment, cluster unless discussing infrastructure
 The typed function that transforms a source message, key, region, schema, and metadata into a Topic Row for a View Server Topic.
 _Avoid_: Serializer, mapper when it obscures the target Topic Row contract
 
+**Kafka Delivery Contract**:
+The operational guarantee for Kafka ingestion. During a live process, a message is committed only after the mapped Topic Row is published into the Runtime Core; success health is recorded after commit. Across process restarts, the in-memory Runtime Core has no durable row checkpoint yet, so committed consumer-group resume is not a full rebuild strategy by itself.
+_Avoid_: Exactly-once claim, durable recovery, database replication
+
+**Kafka Consumer Group Assumption**:
+The current runtime starts one consumer per configured Region using the configured consumer group. It records assignments and lag for the current process, but does not yet implement a full rebalance/revoke recovery story or durable checkpoint handoff between consumers.
+_Avoid_: Clustered recovery, multi-consumer partition handoff
+
 **Publish**:
 A server-side mutation that inserts or replaces a Topic Row in a View Server Topic.
 _Avoid_: Browser write, send, emit
@@ -210,6 +218,8 @@ _Avoid_: Browser write, send, emit
 - A **Real View Server** and **In-Memory View Server** differ only by transport and ingress **Adapters**, not by query, storage, health, or subscription logic.
 - A **Source Topic** uses one **Kafka Source Codec** for its value and optionally one **Kafka Source Codec** for its key.
 - A **Source Topic** is mapped into a **View Server Topic** through a **Mapping**.
+- The current **Kafka Delivery Contract** is live-process at-least-once after successful publish-then-commit sequencing, but not durable restart recovery unless Kafka is replayed from an authoritative position.
+- A **Kafka Consumer Group Assumption** must be documented anywhere runtime options expose consumer-group resume behavior.
 - **Health Ledger** state feeds engine health, runtime health, transport health, and React health.
 
 ## Example Dialogue
@@ -231,3 +241,4 @@ _Avoid_: Browser write, send, emit
 - "subscription" is not a WebSocket connection; a single connection can carry multiple **Subscriptions**.
 - "health" should specify **Health Ledger**, engine health, runtime health, transport health, or React health when the owner matters.
 - "view" is overloaded in database/UI language; prefer **Live Query**, **Snapshot**, or **Grouped Query** depending on the intended concept.
+- "Kafka consumer group resume" is not equivalent to **View Server** recovery until durable checkpoints/WAL exist. If the runtime must rebuild rows after restart, replay Kafka from an authoritative position such as the beginning of the relevant Source Topics.

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -454,7 +454,6 @@ type ViewServerHealth = {
       string,
       {
         status: "ready" | "degraded" | "starting";
-        topic: string;
         rowCount: number;
         liveRowCount: number;
         deletedRowCount: number;
@@ -463,10 +462,13 @@ type ViewServerHealth = {
         mutationsPerSecond: number;
         rowsPerSecond: number;
         pendingMutationBatches: number;
+        activeFallbackGroupedViews: number;
+        activeIncrementalGroupedViews: number;
         activeViews: number;
         activeSubscriptions: number;
         queuedEvents: number;
         maxQueueDepth: number;
+        backpressureEvents: number;
         memoryBytes: number;
         tombstoneCount: number;
         compactionPending: boolean;
@@ -500,12 +502,12 @@ type ViewServerHealth = {
             bytesPerSecond: number;
             decodedMessagesPerSecond: number;
             decodeFailuresPerSecond: number;
+            mappingFailuresPerSecond: number;
+            processingFailuresPerSecond: number;
             lastMessageAt: number | null;
             lastCommitAt: number | null;
-            consumerLagMessages: number | null;
-            consumerLagMs: number | null;
+            consumerLagMessages: bigint | null;
             lagSampledAt: number | null;
-            highWatermarkOffset: string | null;
             committedOffset: string | null;
             lastError: string | null;
           }
@@ -552,7 +554,7 @@ Kafka lag policy:
 - Sample lag on the same cached health cadence, around once per second.
 - Do not add per-message or per-batch broker round trips just to compute lag.
 - If precise lag is expensive, expose the best cheap approximation and mark the sample time with `lagSampledAt`.
-- If lag cannot be obtained cheaply, return `consumerLagMessages: null` / `consumerLagMs: null` rather than harming ingest throughput.
+- If lag cannot be obtained cheaply, return `consumerLagMessages: null` rather than harming ingest throughput.
 - Lag should never be computed in the row ingestion hot loop.
 
 Health snapshot cadence:
@@ -1103,16 +1105,21 @@ The runtime is in-memory first, but production needs an explicit recovery story.
 Initial policy:
 
 - Kafka is the source of truth.
-- On startup, runtime rebuilds in-memory state by consuming configured topics from the configured start position.
-- The default production start policy should be explicit, not magic:
+- Current implementation status: the runtime exposes a configured Kafka consumer group, consumes committed offsets with an earliest fallback for a new group, and commits only after successful publish; success health records the committed offset after commit.
+- Current restart contract: because Runtime Core rows are in memory and no durable WAL/checkpoint exists yet, committed consumer-group resume can skip rows that were committed before process death. It is a live-process ingestion mode, not a lossless full rebuild strategy.
+- Until WAL/checkpoints exist, production deployments that need rebuild-after-restart semantics must replay Kafka from an authoritative position, such as earliest offsets for the Source Topics or a dedicated rebuild group.
+- Future startup policy: runtime rebuilds in-memory state by consuming configured topics from a configured start position.
+- The future production start policy should be explicit, not magic:
 
 ```ts
 startFrom: "earliest" | "latest" | { committedConsumerGroup: string };
 ```
 
 - If `startFrom: "latest"`, health should clearly show topics are not backfilled.
+- If `startFrom: { committedConsumerGroup }`, health and docs must clearly state that this assumes durable View Server state already exists or that skipped committed rows are acceptable.
 - WAL/checkpoints are allowed later, but should not be required for the first production milestone.
 - The engine must expose hooks that would allow future checkpoints without changing `useLiveQuery`.
+- Current consumer-group assumption: one runtime process owns the configured Region consumers for the group. Full rebalance/revoke handoff, multiple active consumers in one group, and checkpoint handoff are roadmap items, not current guarantees.
 
 Recovery tests:
 


### PR DESCRIPTION
## Summary
- document the current Kafka delivery contract: publish succeeds before commit, success health records after commit
- document that committed consumer-group resume is not durable View Server recovery until WAL/checkpoints exist
- align the plan health shape with the current health contract fields

## Validation
- vp check --fix CONTEXT.md plans/v2-column-live-view-engine-plan.md
- vp check
- git diff --check
- stale health-field scan for consumerLagMs/highWatermarkOffset
- pnpm run ready
- 3-agent review loop clean after fixes