### PR TITLE
Coalesce runtime health reads

### DIFF
--- a/packages/runtime-core/src/health.ts
+++ b/packages/runtime-core/src/health.ts
@@ -1,10 +1,9 @@
 import type {
-  ColumnLiveViewEngine,
   ColumnLiveViewEngineHealth,
   DecodableTopicDefinitions,
 } from "@view-server/column-live-view-engine";
 import type { TransportHealth, ViewServerHealth } from "@view-server/config";
-import { Clock, Effect, Fiber, Semaphore } from "effect";
+import { Clock, Deferred, Effect, Fiber, Semaphore, type Exit } from "effect";
 import type * as Duration from "effect/Duration";
 import type { AtomRef } from "effect/unstable/reactivity";
 
@@ -77,25 +76,88 @@ export const readHealth = Effect.fn("ViewServerRuntimeCore.health.read")(functio
   health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
   transportHealth: RuntimeCoreTransportHealth<Topics> = defaultRuntimeCoreTransportHealth,
   healthOverlay: RuntimeCoreHealthOverlay<Topics> = defaultRuntimeCoreHealthOverlay,
+  shouldInstall: () => boolean = () => true,
+  onInstall: () => void = () => undefined,
 ) {
   const nowMillis = yield* Clock.currentTimeMillis;
   const value = healthFromEngine(yield* engine.health(), transportHealth, healthOverlay, nowMillis);
   yield* Effect.sync(() => {
-    health.update((current) => nextHealthValue(current, value));
+    if (shouldInstall()) {
+      health.update((current) => nextHealthValue(current, value));
+      onInstall();
+    }
   });
   return health.value;
 });
 
-export const refreshHealth = Effect.fn("ViewServerRuntimeCore.health.refresh")(function* <
-  const Topics extends DecodableTopicDefinitions,
->(
-  engine: ColumnLiveViewEngine<Topics>,
-  health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
-  transportHealth: RuntimeCoreTransportHealth<Topics>,
-  healthOverlay: RuntimeCoreHealthOverlay<Topics> = defaultRuntimeCoreHealthOverlay,
-) {
-  yield* readHealth(engine, health, transportHealth, healthOverlay);
-});
+export const makeCoalescedHealthReader = <const Topics extends DecodableTopicDefinitions, E>(
+  read: (epoch: number) => Effect.Effect<ViewServerHealth<Topics>, E>,
+  currentEpoch: () => number = () => 0,
+) => {
+  type ActiveRead = {
+    readonly deferred: Deferred.Deferred<ViewServerHealth<Topics>, E>;
+    readonly epoch: number;
+  };
+  let activeRead: ActiveRead | undefined = undefined;
+  const stateLock = Semaphore.makeUnsafe(1);
+  type ReadDecision =
+    | {
+        readonly _tag: "leader";
+        readonly active: ActiveRead;
+      }
+    | {
+        readonly _tag: "follower";
+        readonly deferred: Deferred.Deferred<ViewServerHealth<Topics>, E>;
+      };
+
+  const completeActiveRead = (active: ActiveRead, exit: Exit.Exit<ViewServerHealth<Topics>, E>) =>
+    Effect.uninterruptible(
+      stateLock.withPermit(
+        Effect.gen(function* () {
+          yield* Deferred.done(active.deferred, exit);
+          yield* Effect.sync(() => {
+            if (activeRead === active) {
+              activeRead = undefined;
+            }
+          });
+        }),
+      ),
+    );
+
+  return Effect.fn("ViewServerRuntimeCore.health.readCoalesced")(function* () {
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const decision = yield* stateLock.withPermit(
+          Effect.gen(function* () {
+            const epoch = currentEpoch();
+            if (activeRead !== undefined && activeRead.epoch === epoch) {
+              return {
+                _tag: "follower",
+                deferred: activeRead.deferred,
+              } satisfies ReadDecision;
+            }
+            const nextRead = yield* Deferred.make<ViewServerHealth<Topics>, E>();
+            const active = {
+              deferred: nextRead,
+              epoch,
+            };
+            activeRead = active;
+            return {
+              _tag: "leader",
+              active,
+            } satisfies ReadDecision;
+          }),
+        );
+        if (decision._tag === "follower") {
+          return yield* restore(Deferred.await(decision.deferred));
+        }
+        return yield* read(decision.active.epoch).pipe(
+          Effect.onExit((exit) => completeActiveRead(decision.active, exit)),
+        );
+      }),
+    );
+  });
+};
 
 export const makeHealthRefreshScheduler = (
   refresh: Effect.Effect<void>,

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "@effect/vitest";
-import type { ColumnLiveViewEngineHealth } from "@view-server/column-live-view-engine";
-import { defineViewServerConfig } from "@view-server/config";
-import { Deferred, Effect, Fiber, Schema, Stream } from "effect";
+import {
+  createColumnLiveViewEngine,
+  type ColumnLiveViewEngineHealth,
+} from "@view-server/column-live-view-engine";
+import { defineViewServerConfig, type ViewServerRuntimeError } from "@view-server/config";
+import { Deferred, Effect, Fiber, Queue, Schema, Stream } from "effect";
 import { AtomRef } from "effect/unstable/reactivity";
-import { healthFromEngine, makeHealthRefreshScheduler, readHealth } from "./health";
+import {
+  healthFromEngine,
+  makeCoalescedHealthReader,
+  makeHealthRefreshScheduler,
+  readHealth,
+} from "./health";
 import { createViewServerRuntimeCore, makeViewServerRuntimeCore } from "./index";
+import { makeRuntimeCoreLiveClient } from "./live-client";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -35,6 +44,12 @@ const order = (id: string, price: number): OrderRow => ({
   region: "usa",
   updatedAt: price,
 });
+
+const refreshFailed: ViewServerRuntimeError = {
+  _tag: "ViewServerRuntimeError",
+  code: "RuntimeUnavailable",
+  message: "Health refresh failed.",
+};
 
 const engineHealth = (
   status: "ready" | "stopping",
@@ -109,6 +124,8 @@ describe("@view-server/runtime-core", () => {
 
       const health = yield* runtimeCore.client.health();
       expect(health.engine.topics.orders.rowCount).toBe(2);
+      const refreshedHealth = yield* runtimeCore.refreshHealth;
+      expect(refreshedHealth.engine.topics.orders.rowCount).toBe(2);
 
       yield* subscription.close();
       yield* runtimeCore.client.reset();
@@ -207,6 +224,59 @@ describe("@view-server/runtime-core", () => {
       const health = yield* runtimeCore.client.health();
       expect(health.engine.topics.orders.activeSubscriptions).toBe(0);
       yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("releases acquired live subscriptions when initial health refresh fails", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+      const liveClient = yield* makeRuntimeCoreLiveClient(
+        engine,
+        health,
+        Effect.fail(refreshFailed),
+      );
+
+      const failedRaw = yield* Effect.flip(
+        liveClient.subscribe("orders", {
+          select: ["id"],
+          limit: 1,
+        }),
+      );
+      const afterRawFailure = yield* engine.health();
+      expect(failedRaw).toStrictEqual(refreshFailed);
+      expect(afterRawFailure.activeSubscriptions).toBe(0);
+
+      const failedRuntime = yield* Effect.flip(
+        liveClient.subscribeRuntime("orders", {
+          select: ["id"],
+          limit: 1,
+        }),
+      );
+      const afterRuntimeFailure = yield* engine.health();
+      expect(failedRuntime).toStrictEqual(refreshFailed);
+      expect(afterRuntimeFailure.activeSubscriptions).toBe(0);
+
+      yield* liveClient.close;
+    }),
+  );
+
+  it.effect("releases pushed health subscriptions when initial health refresh fails", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+      const liveClient = yield* makeRuntimeCoreLiveClient(
+        engine,
+        health,
+        Effect.fail(refreshFailed),
+      );
+
+      const failedSummary = yield* Effect.flip(liveClient.subscribeHealthSummary());
+      const failedDetail = yield* Effect.flip(liveClient.subscribeHealth());
+
+      expect(failedSummary).toStrictEqual(refreshFailed);
+      expect(failedDetail).toStrictEqual(refreshFailed);
+      yield* liveClient.close.pipe(Effect.timeout("1 second"));
     }),
   );
 
@@ -556,7 +626,7 @@ describe("@view-server/runtime-core", () => {
       yield* runtimeCore.client.health();
       const events = yield* Fiber.join(eventsFiber).pipe(
         Effect.timeout("1 second"),
-        Effect.ensuring(summary.close().pipe(Effect.andThen(runtimeCore.close), Effect.ignore)),
+        Effect.ensuring(summary.close().pipe(Effect.orDie, Effect.andThen(runtimeCore.close))),
       );
 
       expect(Array.from(events)).toStrictEqual([
@@ -638,6 +708,323 @@ describe("@view-server/runtime-core", () => {
       yield* Deferred.succeed(releaseFirstRead, undefined);
       yield* Fiber.join(staleRefresh);
       expect(health.value.status).toBe("stopping");
+    }),
+  );
+
+  it.effect("coalesces concurrent health reads while an active same-epoch read is running", () =>
+    Effect.gen(function* () {
+      const readStarted = yield* Deferred.make<void>();
+      const releaseRead = yield* Deferred.make<void>();
+      let readCount = 0;
+      const coalescedHealth = makeCoalescedHealthReader(
+        () =>
+          Effect.gen(function* () {
+            readCount += 1;
+            yield* Deferred.succeed(readStarted, undefined);
+            yield* Deferred.await(releaseRead);
+            return healthFromEngine(engineHealth("ready", readCount));
+          }),
+        () => 0,
+      );
+
+      const first = yield* coalescedHealth().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(readStarted);
+      const second = yield* coalescedHealth().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.succeed(releaseRead, undefined);
+      const [firstHealth, secondHealth] = yield* Effect.all(
+        [Fiber.join(first), Fiber.join(second)],
+        {
+          concurrency: 2,
+        },
+      ).pipe(Effect.timeout("1 second"));
+
+      expect(readCount).toBe(1);
+      expect(firstHealth.engine.topics.orders.rowCount).toBe(1);
+      expect(secondHealth.engine.topics.orders.rowCount).toBe(1);
+      const thirdHealth = yield* coalescedHealth();
+      expect(readCount).toBe(2);
+      expect(thirdHealth.engine.topics.orders.rowCount).toBe(2);
+    }),
+  );
+
+  it.effect("clears the active health read after a failed read so the next read retries", () =>
+    Effect.gen(function* () {
+      let readCount = 0;
+      const healthReads = [
+        Effect.fail("boom"),
+        Effect.succeed(healthFromEngine(engineHealth("ready", 2))),
+      ];
+      const coalescedHealth = makeCoalescedHealthReader(() =>
+        Effect.gen(function* () {
+          const nextRead =
+            healthReads[readCount] ?? Effect.succeed(healthFromEngine(engineHealth("ready", 3)));
+          readCount += 1;
+          return yield* nextRead;
+        }),
+      );
+
+      const failedHealth = yield* Effect.flip(coalescedHealth());
+      expect(failedHealth).toBe("boom");
+      const recoveredHealth = yield* coalescedHealth();
+      expect(readCount).toBe(2);
+      expect(recoveredHealth.engine.topics.orders.rowCount).toBe(2);
+    }),
+  );
+
+  it.effect("does not strand followers when the active health reader is interrupted", () =>
+    Effect.gen(function* () {
+      const firstReadStarted = yield* Deferred.make<void>();
+      const releaseFirstRead = yield* Deferred.make<void>();
+      const followerJoinedActiveRead = yield* Deferred.make<void>();
+      let epochCheckCount = 0;
+      let readCount = 0;
+      const coalescedHealth = makeCoalescedHealthReader(
+        () =>
+          Effect.gen(function* () {
+            readCount += 1;
+            yield* Deferred.succeed(firstReadStarted, undefined);
+            yield* Deferred.await(releaseFirstRead);
+            return healthFromEngine(engineHealth("ready", readCount));
+          }),
+        () => {
+          epochCheckCount += 1;
+          if (epochCheckCount === 2) {
+            Deferred.doneUnsafe(followerJoinedActiveRead, Effect.void);
+          }
+          return 0;
+        },
+      );
+
+      const leader = yield* coalescedHealth().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(firstReadStarted);
+      const follower = yield* coalescedHealth().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(followerJoinedActiveRead).pipe(
+        Effect.timeout("1 second"),
+        Effect.onError(() => Deferred.succeed(releaseFirstRead, undefined).pipe(Effect.asVoid)),
+      );
+
+      const interruptStarted = yield* Deferred.make<void>();
+      const interruptLeader = yield* Effect.gen(function* () {
+        yield* Deferred.succeed(interruptStarted, undefined);
+        yield* Fiber.interrupt(leader);
+      }).pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(interruptStarted);
+      yield* Deferred.succeed(releaseFirstRead, undefined);
+      yield* Fiber.join(interruptLeader);
+      const followerHealth = yield* Fiber.join(follower);
+      const nextHealth = yield* coalescedHealth();
+      expect(readCount).toBe(2);
+      expect(followerHealth.engine.topics.orders.rowCount).toBe(1);
+      expect(nextHealth.engine.topics.orders.rowCount).toBe(2);
+    }),
+  );
+
+  it.effect("starts a fresh health read after the caller epoch changes", () =>
+    Effect.gen(function* () {
+      const firstReadStarted = yield* Deferred.make<void>();
+      const releaseFirstRead = yield* Deferred.make<void>();
+      let epoch = 0;
+      let readCount = 0;
+      const healthReads = [
+        Effect.gen(function* () {
+          yield* Deferred.succeed(firstReadStarted, undefined);
+          yield* Deferred.await(releaseFirstRead);
+          return healthFromEngine(engineHealth("ready", 1));
+        }),
+        Effect.succeed(healthFromEngine(engineHealth("ready", 2))),
+      ];
+      const coalescedHealth = makeCoalescedHealthReader(
+        () =>
+          Effect.gen(function* () {
+            const nextRead =
+              healthReads[readCount] ?? Effect.succeed(healthFromEngine(engineHealth("ready", 3)));
+            readCount += 1;
+            return yield* nextRead;
+          }),
+        () => epoch,
+      );
+
+      const staleHealthRead = yield* coalescedHealth().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(firstReadStarted);
+      epoch += 1;
+      const freshHealth = yield* coalescedHealth();
+      yield* Deferred.succeed(releaseFirstRead, undefined);
+      const staleHealth = yield* Fiber.join(staleHealthRead);
+
+      expect(readCount).toBe(2);
+      expect(freshHealth.engine.topics.orders.rowCount).toBe(2);
+      expect(staleHealth.engine.topics.orders.rowCount).toBe(1);
+    }),
+  );
+
+  it.effect("does not let obsolete epoch health reads overwrite fresher cached health", () =>
+    Effect.gen(function* () {
+      const firstReadStarted = yield* Deferred.make<void>();
+      const releaseFirstRead = yield* Deferred.make<void>();
+      const health = AtomRef.make(healthFromEngine(engineHealth("ready", 0)));
+      let epoch = 0;
+      let readCount = 0;
+      const engineHealthReads = [
+        Effect.gen(function* () {
+          yield* Deferred.succeed(firstReadStarted, undefined);
+          yield* Deferred.await(releaseFirstRead);
+          return engineHealth("ready", 1);
+        }),
+        Effect.succeed(engineHealth("ready", 2)),
+      ];
+      const engine = {
+        health: () => {
+          const nextRead = engineHealthReads[readCount] ?? Effect.succeed(engineHealth("ready", 3));
+          return Effect.suspend(() =>
+            Effect.sync(() => {
+              readCount += 1;
+            }).pipe(Effect.andThen(nextRead)),
+          );
+        },
+      };
+      const coalescedHealth = makeCoalescedHealthReader(
+        (readEpoch) => readHealth(engine, health, undefined, undefined, () => epoch === readEpoch),
+        () => epoch,
+      );
+
+      const obsoleteHealthRead = yield* coalescedHealth().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(firstReadStarted);
+      epoch += 1;
+      const freshHealth = yield* coalescedHealth();
+      yield* Deferred.succeed(releaseFirstRead, undefined);
+      const obsoleteHealth = yield* Fiber.join(obsoleteHealthRead);
+
+      expect(freshHealth.engine.topics.orders.rowCount).toBe(2);
+      expect(obsoleteHealth.engine.topics.orders.rowCount).toBe(2);
+      expect(health.value.engine.topics.orders.rowCount).toBe(2);
+    }),
+  );
+
+  it.effect("does not let older scheduled health reads overwrite newer installed health", () =>
+    Effect.gen(function* () {
+      const scheduledReadStarted = yield* Deferred.make<void>();
+      const releaseScheduledRead = yield* Deferred.make<void>();
+      const scheduledReadFinished = yield* Deferred.make<void>();
+      const health = AtomRef.make(healthFromEngine(engineHealth("ready", 0)));
+      let installEpoch = 0;
+      let readCount = 0;
+      const engineHealthReads = [
+        Effect.gen(function* () {
+          yield* Deferred.succeed(scheduledReadStarted, undefined);
+          yield* Deferred.await(releaseScheduledRead);
+          return engineHealth("ready", 1);
+        }),
+        Effect.succeed(engineHealth("ready", 2)),
+      ];
+      const engine = {
+        health: () => {
+          const nextRead = engineHealthReads[readCount] ?? Effect.succeed(engineHealth("ready", 3));
+          return Effect.suspend(() =>
+            Effect.sync(() => {
+              readCount += 1;
+            }).pipe(Effect.andThen(nextRead)),
+          );
+        },
+      };
+      const scheduler = makeHealthRefreshScheduler(
+        Effect.gen(function* () {
+          const readInstallEpoch = installEpoch;
+          yield* readHealth(
+            engine,
+            health,
+            undefined,
+            undefined,
+            () => installEpoch === readInstallEpoch,
+            () => {
+              installEpoch += 1;
+            },
+          );
+          yield* Deferred.succeed(scheduledReadFinished, undefined);
+        }),
+        "0 millis",
+      );
+
+      yield* scheduler.request;
+      yield* Deferred.await(scheduledReadStarted).pipe(Effect.timeout("1 second"));
+      const freshHealth = yield* readHealth(engine, health, undefined, undefined, undefined, () => {
+        installEpoch += 1;
+      });
+      yield* Deferred.succeed(releaseScheduledRead, undefined);
+      yield* Deferred.await(scheduledReadFinished).pipe(Effect.timeout("1 second"));
+
+      expect(freshHealth.engine.topics.orders.rowCount).toBe(2);
+      expect(health.value.engine.topics.orders.rowCount).toBe(2);
+      yield* scheduler.close;
+    }),
+  );
+
+  it.effect("lets scheduled health refreshes install and follow up while requests continue", () =>
+    Effect.gen(function* () {
+      const firstReadStarted = yield* Deferred.make<void>();
+      const releaseFirstRead = yield* Deferred.make<void>();
+      const secondReadStarted = yield* Deferred.make<void>();
+      const releaseSecondRead = yield* Deferred.make<void>();
+      const refreshCompleted = yield* Queue.unbounded<void>();
+      const health = AtomRef.make(healthFromEngine(engineHealth("ready", 0)));
+      let installEpoch = 0;
+      let readCount = 0;
+      const engineHealthReads = [
+        Effect.gen(function* () {
+          yield* Deferred.succeed(firstReadStarted, undefined);
+          yield* Deferred.await(releaseFirstRead);
+          return engineHealth("ready", 1);
+        }),
+        Effect.gen(function* () {
+          yield* Deferred.succeed(secondReadStarted, undefined);
+          yield* Deferred.await(releaseSecondRead);
+          return engineHealth("ready", 2);
+        }),
+      ];
+      const engine = {
+        health: () => {
+          const nextRead = engineHealthReads[readCount] ?? Effect.succeed(engineHealth("ready", 3));
+          return Effect.suspend(() =>
+            Effect.sync(() => {
+              readCount += 1;
+            }).pipe(Effect.andThen(nextRead)),
+          );
+        },
+      };
+      const scheduler = makeHealthRefreshScheduler(
+        Effect.gen(function* () {
+          const readInstallEpoch = installEpoch;
+          yield* readHealth(
+            engine,
+            health,
+            undefined,
+            undefined,
+            () => installEpoch === readInstallEpoch,
+            () => {
+              installEpoch += 1;
+            },
+          );
+          yield* Queue.offer(refreshCompleted, undefined);
+        }),
+        "0 millis",
+      );
+
+      yield* scheduler.request;
+      yield* Deferred.await(firstReadStarted).pipe(Effect.timeout("1 second"));
+      yield* scheduler.request;
+      yield* Deferred.succeed(releaseFirstRead, undefined);
+      yield* Queue.take(refreshCompleted).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(secondReadStarted).pipe(Effect.timeout("1 second"));
+      expect(health.value.engine.topics.orders.rowCount).toBe(1);
+      yield* Deferred.succeed(releaseSecondRead, undefined);
+      yield* Queue.take(refreshCompleted).pipe(Effect.timeout("1 second"));
+
+      expect(readCount).toBe(2);
+      expect(health.value.engine.topics.orders.rowCount).toBe(2);
+      yield* scheduler.close;
     }),
   );
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -8,6 +8,7 @@ import type {
   ViewServerConfig,
   ViewServerHealth,
   ViewServerRuntimeClient,
+  ViewServerRuntimeError,
 } from "@view-server/config";
 import { runAllFinalizers } from "@view-server/effect-utils";
 import { Clock, Effect } from "effect";
@@ -31,6 +32,8 @@ export type ViewServerRuntimeCoreInstance<Topics extends DecodableTopicDefinitio
   readonly client: ViewServerRuntimeClient<Topics>;
   readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
   readonly close: Effect.Effect<void>;
+  readonly requestHealthRefresh: Effect.Effect<void>;
+  readonly refreshHealth: Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
 };
 
 export type ViewServerRuntimeCoreOptions = {
@@ -84,8 +87,7 @@ export const makeViewServerRuntimeCore: <const Topics extends DecodableTopicDefi
     const liveClient = yield* makeRuntimeCoreLiveClient<Topics>(
       engine,
       health,
-      transportHealth,
-      healthOverlay,
+      runtimeClient.refreshHealth,
     );
     const close = Effect.uninterruptible(runAllFinalizers([runtimeClient.close, liveClient.close]));
     return {
@@ -95,6 +97,8 @@ export const makeViewServerRuntimeCore: <const Topics extends DecodableTopicDefi
         close,
       },
       close,
+      requestHealthRefresh: runtimeClient.requestHealthRefresh,
+      refreshHealth: runtimeClient.refreshHealth,
     };
   },
 );

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -31,12 +31,6 @@ import {
 } from "@view-server/config";
 import { Cause, Clock, Effect, Fiber, Queue, Semaphore, Stream } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
-import {
-  readHealth,
-  refreshHealth,
-  type RuntimeCoreHealthOverlay,
-  type RuntimeCoreTransportHealth,
-} from "./health";
 import { engineErrorToRuntimeError } from "./runtime-error";
 
 const runtimeClosedError: ViewServerRuntimeError = {
@@ -49,12 +43,19 @@ const ignoreHealthSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNo
   "Ignoring runtime health subscription close failure.",
 );
 
+const ignoreLiveSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring runtime live subscription close failure.",
+);
+
+const ignoreRuntimeHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring runtime health refresh failure.",
+);
+
 export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveClient.make")(
   <const Topics extends DecodableTopicDefinitions>(
     engine: ColumnLiveViewEngine<Topics>,
     health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
-    transportHealth: RuntimeCoreTransportHealth<Topics>,
-    healthOverlay?: RuntimeCoreHealthOverlay<Topics>,
+    refreshHealth: Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>,
   ): Effect.Effect<ViewServerRuntimeLiveClient<Topics>> =>
     Effect.sync<ViewServerRuntimeLiveClient<Topics>>(() => {
       function subscribe<
@@ -81,37 +82,38 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError | ViewServerTransportError
       > {
+        const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
         return engine.subscribe<Topic, Query>(topic, query).pipe(
-          Effect.map((subscription) => ({
-            events: subscription.events,
-            close: () =>
-              subscription
-                .close()
-                .pipe(
-                  Effect.andThen(refreshHealth(engine, health, transportHealth, healthOverlay)),
-                ),
-          })),
-          Effect.tap(() => refreshHealth(engine, health, transportHealth, healthOverlay)),
           Effect.mapError(engineErrorToRuntimeError),
+          Effect.flatMap((subscription) =>
+            refreshHealth.pipe(
+              Effect.as({
+                events: subscription.events,
+                close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
+              }),
+              Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+            ),
+          ),
         );
       }
       const subscribeRuntime: ViewServerRuntimeLiveClient<Topics>["subscribeRuntime"] = (
         topic,
         query,
-      ) =>
-        engine.subscribeRuntime(topic, query).pipe(
-          Effect.map((subscription) => ({
-            events: subscription.events,
-            close: () =>
-              subscription
-                .close()
-                .pipe(
-                  Effect.andThen(refreshHealth(engine, health, transportHealth, healthOverlay)),
-                ),
-          })),
-          Effect.tap(() => refreshHealth(engine, health, transportHealth, healthOverlay)),
+      ) => {
+        const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
+        return engine.subscribeRuntime(topic, query).pipe(
           Effect.mapError(engineErrorToRuntimeError),
+          Effect.flatMap((subscription) =>
+            refreshHealth.pipe(
+              Effect.as({
+                events: subscription.events,
+                close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
+              }),
+              Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+            ),
+          ),
         );
+      };
       const activeHealthSubscriptions = new Set<{ close: Effect.Effect<void> }>();
       const healthSubscriptionLock = Semaphore.makeUnsafe(1);
       let healthSubscriptionsClosed = false;
@@ -134,7 +136,7 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
       const close = runAllFinalizers([
         closeActiveHealthSubscriptions,
         engine.close(),
-        refreshHealth(engine, health, transportHealth, healthOverlay),
+        ignoreRuntimeHealthRefreshFailure(refreshHealth),
       ]);
       const readonlyHealth = health.map((value) => value);
       const makeHealthSubscription = Effect.fn("ViewServerRuntimeCore.health.subscribe")(function* <
@@ -200,12 +202,9 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
               yield* releaseSubscription;
               return yield* Effect.fail(runtimeClosedError);
             }
-            const latestHealth = yield* readHealth(
-              engine,
-              health,
-              transportHealth,
-              healthOverlay,
-            ).pipe(Effect.mapError(engineErrorToRuntimeError));
+            const latestHealth = yield* refreshHealth.pipe(
+              Effect.onError(() => releaseSubscription),
+            );
             yield* offerSnapshot(latestHealth);
             return {
               events: Stream.fromQueue(queue).pipe(Stream.ensuring(subscription.close)),

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -17,8 +17,8 @@ import { Effect } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
 import {
   makeHealthRefreshScheduler,
+  makeCoalescedHealthReader,
   readHealth,
-  refreshHealth,
   type RuntimeCoreHealthOverlay,
   type RuntimeCoreTransportHealth,
 } from "./health";
@@ -28,6 +28,8 @@ import { engineErrorToRuntimeError } from "./runtime-error";
 export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> = {
   readonly client: ViewServerRuntimeClient<Topics>;
   readonly close: Effect.Effect<void>;
+  readonly requestHealthRefresh: Effect.Effect<void>;
+  readonly refreshHealth: Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
 };
 
 export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.make")(<
@@ -39,9 +41,56 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
   healthOverlay?: RuntimeCoreHealthOverlay<Topics>,
   healthRefreshCadence?: Duration.Input,
 ): Effect.Effect<RuntimeCoreClientInstance<Topics>> => {
+  let healthReadEpoch = 0;
+  let healthInstallEpoch = 0;
+  const bumpHealthReadEpoch = Effect.sync(() => {
+    healthReadEpoch += 1;
+  });
+  const readRuntimeHealth = (epoch: number, installMode: "strict" | "scheduled") => {
+    const installEpoch = healthInstallEpoch;
+    return readHealth(
+      engine,
+      health,
+      transportHealth,
+      healthOverlay,
+      () =>
+        healthInstallEpoch === installEpoch &&
+        (installMode === "scheduled" || healthReadEpoch === epoch),
+      () => {
+        healthInstallEpoch += 1;
+      },
+    );
+  };
+  const healthReader = makeCoalescedHealthReader(
+    (epoch) => readRuntimeHealth(epoch, "strict"),
+    () => healthReadEpoch,
+  );
+  const scheduledHealthReader = makeCoalescedHealthReader(
+    (epoch) => readRuntimeHealth(epoch, "scheduled"),
+    () => healthReadEpoch,
+  );
+  const scheduledHealthRefresh = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.scheduled")(
+    function* () {
+      yield* scheduledHealthReader();
+    },
+  );
   const healthRefreshScheduler = makeHealthRefreshScheduler(
-    refreshHealth(engine, health, transportHealth, healthOverlay),
+    scheduledHealthRefresh(),
     healthRefreshCadence,
+  );
+  const requestHealthRefresh = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.request")(
+    function* () {
+      yield* Effect.uninterruptible(
+        bumpHealthReadEpoch.pipe(Effect.andThen(healthRefreshScheduler.request)),
+      );
+    },
+  );
+  const refreshHealthNow = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.now")(
+    function* () {
+      return yield* Effect.uninterruptible(
+        bumpHealthReadEpoch.pipe(Effect.andThen(healthReader())),
+      );
+    },
   );
   const snapshot = <
     Topic extends Extract<keyof Topics, string>,
@@ -56,36 +105,30 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
   return Effect.succeed<RuntimeCoreClientInstance<Topics>>({
     client: {
       publish: (topic, row) =>
-        engine.publish(topic, row).pipe(
-          Effect.tap(() => healthRefreshScheduler.request),
-          Effect.mapError(engineErrorToRuntimeError),
-        ),
+        Effect.uninterruptible(
+          engine.publish(topic, row).pipe(Effect.tap(() => requestHealthRefresh())),
+        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
       publishMany: (topic, rows) =>
-        engine.publishMany(topic, rows).pipe(
-          Effect.tap(() => healthRefreshScheduler.request),
-          Effect.mapError(engineErrorToRuntimeError),
-        ),
+        Effect.uninterruptible(
+          engine.publishMany(topic, rows).pipe(Effect.tap(() => requestHealthRefresh())),
+        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
       patch: (topic, key, patch) =>
-        engine.patch(topic, key, patch).pipe(
-          Effect.tap(() => healthRefreshScheduler.request),
-          Effect.mapError(engineErrorToRuntimeError),
-        ),
+        Effect.uninterruptible(
+          engine.patch(topic, key, patch).pipe(Effect.tap(() => requestHealthRefresh())),
+        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
       delete: (topic, key) =>
-        engine.delete(topic, key).pipe(
-          Effect.tap(() => healthRefreshScheduler.request),
-          Effect.mapError(engineErrorToRuntimeError),
-        ),
+        Effect.uninterruptible(
+          engine.delete(topic, key).pipe(Effect.tap(() => requestHealthRefresh())),
+        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
       snapshot,
-      health: () =>
-        readHealth(engine, health, transportHealth, healthOverlay).pipe(
-          Effect.mapError(engineErrorToRuntimeError),
-        ),
+      health: () => healthReader(),
       reset: () =>
-        engine.reset().pipe(
-          Effect.tap(() => healthRefreshScheduler.request),
+        Effect.uninterruptible(engine.reset().pipe(Effect.tap(() => requestHealthRefresh()))).pipe(
           Effect.mapError(engineErrorToRuntimeError),
         ),
     },
     close: healthRefreshScheduler.close,
+    requestHealthRefresh: requestHealthRefresh(),
+    refreshHealth: refreshHealthNow(),
   });
 });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -352,7 +352,7 @@ describe("@view-server/runtime", () => {
             healthUrl: "http://127.0.0.1:0/health",
             close: Effect.void,
           }),
-        makeKafkaIngress: (_config, _client, options) => {
+        makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
           kafkaOptions = options;
           return Effect.succeed({
             close: Effect.void,
@@ -431,7 +431,7 @@ describe("@view-server/runtime", () => {
             healthUrl: "http://127.0.0.1:0/health",
             close: Effect.void,
           }),
-        makeKafkaIngress: (_config, _client, options) => {
+        makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
           kafkaOptions = options;
           return Effect.succeed({
             close: Effect.void,
@@ -473,7 +473,7 @@ describe("@view-server/runtime", () => {
       const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
       const dependencies: ViewServerRuntimeDependencies<typeof viewServer.topics> = {
         ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
-        makeKafkaIngress: (_config, _client, _options, health) =>
+        makeKafkaIngress: (_config, _client, _requestHealthRefresh, _options, health) =>
           health.regionDisconnected("local", "lost").pipe(
             Effect.as({
               close: Effect.void,
@@ -508,7 +508,7 @@ describe("@view-server/runtime", () => {
             expect(health.health.status).toBe("degraded");
             expect(health.health.engine.topics.orders.rowCount).toBe(0);
           }),
-        (runtime) => runtime.close.pipe(Effect.ignore),
+        (runtime) => runtime.close,
       );
     }),
   );

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -1,5 +1,6 @@
 import type { ViewServerLiveClient, ViewServerRuntimeLiveClient } from "@view-server/client";
 import type { RuntimeRegions, ViewServerConfig, ViewServerHealth } from "@view-server/config";
+import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
 import type { ViewServerRuntimeCoreOptionsFor } from "@view-server/runtime-core";
 import { Config, Effect, Exit, Layer } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
@@ -36,6 +37,10 @@ const toPublicLiveClient = <const Topics extends ViewServerRuntimeTopicDefinitio
   subscribeHealth: liveClient.subscribeHealth,
   subscribeHealthSummary: liveClient.subscribeHealthSummary,
 });
+
+const ignoreRuntimeHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring runtime health refresh failure.",
+);
 
 type RuntimeCoreOptionsBuilder<Topics extends ViewServerRuntimeTopicDefinitions> = {
   groupedIncrementalAdmissionLimits?: NonNullable<
@@ -92,7 +97,7 @@ export const makeViewServerRuntimeWithDependencies: <
     ): ViewServerHealth<Topics> => kafkaHealth.healthOverlay(health, nowMillis);
   }
   const runtimeCore = yield* dependencies.makeRuntimeCore(config, runtimeCoreInput);
-  const refreshTransportHealth = runtimeCore.client.health().pipe(Effect.ignore);
+  const refreshTransportHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
   const server = yield* dependencies
     .makeServer(
       config,
@@ -113,7 +118,13 @@ export const makeViewServerRuntimeWithDependencies: <
     kafkaOptions === undefined || kafkaHealth === undefined
       ? undefined
       : yield* dependencies
-          .makeKafkaIngress(config, runtimeCore.client, kafkaOptions, kafkaHealth)
+          .makeKafkaIngress(
+            config,
+            runtimeCore.client,
+            runtimeCore.requestHealthRefresh,
+            kafkaOptions,
+            kafkaHealth,
+          )
           .pipe(
             Effect.onExit((exit) =>
               Exit.isFailure(exit)

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -1128,18 +1128,14 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           },
         },
       });
-      let healthReadCount = 0;
-      const refreshingClient: ViewServerRuntimeClient<Topics> = {
-        ...runtimeCore.client,
-        health: () =>
-          Effect.sync(() => {
-            healthReadCount += 1;
-          }).pipe(Effect.andThen(runtimeCore.client.health())),
-      };
+      let healthRefreshRequestCount = 0;
+      const requestHealthRefresh = Effect.sync(() => {
+        healthRefreshRequestCount += 1;
+      });
       yield* ledger.regionConnected("local", 1_000);
       yield* recordKafkaAssignments(
         ledger,
-        refreshingClient,
+        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         [{ topic: ordersSourceTopic, partitions: [0, 1] }],
@@ -1147,7 +1143,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       );
       yield* recordKafkaLag(
         ledger,
-        refreshingClient,
+        requestHealthRefresh,
         "local",
         new Map([
           [ordersSourceTopic, [3n, -1n, 2n]],
@@ -1157,7 +1153,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       );
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
 
-      expect(healthReadCount).toBe(2);
+      expect(healthRefreshRequestCount).toBe(2);
       expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
         status: "ready",
         sourceTopic: ordersSourceTopic,
@@ -1198,14 +1194,10 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           },
         },
       });
-      let healthReadCount = 0;
-      const refreshingClient: ViewServerRuntimeClient<Topics> = {
-        ...runtimeCore.client,
-        health: () =>
-          Effect.sync(() => {
-            healthReadCount += 1;
-          }).pipe(Effect.andThen(runtimeCore.client.health())),
-      };
+      let healthRefreshRequestCount = 0;
+      const requestHealthRefresh = Effect.sync(() => {
+        healthRefreshRequestCount += 1;
+      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-listener-test",
@@ -1216,7 +1208,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         ledger,
-        refreshingClient,
+        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1246,10 +1238,10 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const degradedHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect({
-        healthReadCount,
+        healthRefreshRequestCount,
         processed: degradedProcessed,
       }).toStrictEqual({
-        healthReadCount: 5,
+        healthRefreshRequestCount: 5,
         processed: 5,
       });
       expect({
@@ -1296,10 +1288,10 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const recoveredHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect({
-        healthReadCount,
+        healthRefreshRequestCount,
         processed: recoveredProcessed,
       }).toStrictEqual({
-        healthReadCount: 7,
+        healthRefreshRequestCount: 7,
         processed: 7,
       });
       expect({
@@ -1369,7 +1361,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         failingLedger,
-        runtimeCore.client,
+        runtimeCore.requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1461,7 +1453,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         interruptingLedger,
-        runtimeCore.client,
+        runtimeCore.requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1858,6 +1850,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         runKafkaMessageStream(
           viewServer,
           defectiveClient,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -1940,6 +1933,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         runKafkaMessageStream(
           viewServer,
           interruptingClient,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2016,6 +2010,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2114,6 +2109,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2199,6 +2195,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const ingress = yield* makeViewServerKafkaIngress(
         viewServer,
         runtimeCore.client,
+        runtimeCore.requestHealthRefresh,
         emptyKafkaOptions,
         ledger,
       );
@@ -2303,14 +2300,10 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           },
         },
       });
-      let healthReadCount = 0;
-      const refreshingClient: ViewServerRuntimeClient<Topics> = {
-        ...runtimeCore.client,
-        health: () =>
-          Effect.sync(() => {
-            healthReadCount += 1;
-          }).pipe(Effect.andThen(runtimeCore.client.health())),
-      };
+      let healthRefreshRequestCount = 0;
+      const requestHealthRefresh = Effect.sync(() => {
+        healthRefreshRequestCount += 1;
+      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-scoped-listener-test",
@@ -2320,7 +2313,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         ledger,
-        refreshingClient,
+        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -2336,11 +2329,11 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect({
-        healthReadCount,
+        healthRefreshRequestCount,
         region: health.kafka?.regions["local"],
         topic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
-        healthReadCount: 0,
+        healthRefreshRequestCount: 0,
         region: {
           status: "starting",
           brokers: regions.local,
@@ -2411,7 +2404,13 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       });
 
       const exit = yield* Effect.exit(
-        makeViewServerKafkaIngress(viewServer, runtimeCore.client, invalidKafkaOptions, ledger),
+        makeViewServerKafkaIngress(
+          viewServer,
+          runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
+          invalidKafkaOptions,
+          ledger,
+        ),
       );
 
       expect(Exit.isFailure(exit)).toBe(true);
@@ -2439,6 +2438,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.client,
+        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -2451,6 +2451,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.client,
+        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -2472,6 +2473,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2491,6 +2493,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         processKafkaMessage(
           viewServer,
           failingClient,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2595,19 +2598,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       };
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
-      let healthReadCount = 0;
-      const refreshingClient: ViewServerRuntimeClient<Topics> = {
-        ...runtimeCore.client,
-        health: () =>
-          Effect.sync(() => {
-            healthReadCount += 1;
-          }).pipe(Effect.andThen(runtimeCore.client.health())),
-      };
+      let healthRefreshRequestCount = 0;
+      const requestHealthRefresh = Effect.sync(() => {
+        healthRefreshRequestCount += 1;
+      });
 
       const error = yield* Effect.flip(
         processKafkaMessage(
           viewServer,
-          refreshingClient,
+          runtimeCore.client,
+          requestHealthRefresh,
           throwingKafkaOptions,
           ledger,
           "local",
@@ -2631,7 +2631,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           region: error.region,
           sourceTopic: error.sourceTopic,
         },
-        healthReadCount,
+        healthRefreshRequestCount,
         kafkaTopic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
         error: {
@@ -2640,7 +2640,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           region: "local",
           sourceTopic: ordersSourceTopic,
         },
-        healthReadCount: 1,
+        healthRefreshRequestCount: 1,
         kafkaTopic: {
           status: "degraded",
           sourceTopic: ordersSourceTopic,
@@ -2709,6 +2709,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           untaggedDecodeKafkaOptions,
           ledger,
           "local",
@@ -2798,6 +2799,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           forgedMappingTagKafkaOptions,
           ledger,
           "local",
@@ -2893,6 +2895,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           primitiveDecodeKafkaOptions,
           ledger,
           "local",
@@ -2957,19 +2960,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
-      let healthReadCount = 0;
-      const refreshingClient: ViewServerRuntimeClient<Topics> = {
-        ...runtimeCore.client,
-        health: () =>
-          Effect.sync(() => {
-            healthReadCount += 1;
-          }).pipe(Effect.andThen(runtimeCore.client.health())),
-      };
+      let healthRefreshRequestCount = 0;
+      const requestHealthRefresh = Effect.sync(() => {
+        healthRefreshRequestCount += 1;
+      });
 
       const exit = yield* Effect.exit(
         processKafkaMessage(
           viewServer,
-          refreshingClient,
+          runtimeCore.client,
+          requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2984,7 +2984,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect(Exit.isFailure(exit)).toBe(true);
-      expect(healthReadCount).toBe(1);
+      expect(healthRefreshRequestCount).toBe(1);
       expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
         status: "degraded",
         sourceTopic: ordersSourceTopic,
@@ -3032,6 +3032,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -81,6 +81,7 @@ type KafkaConsumerHealthListenerProcessedState = {
   readonly count: number;
   readonly waiters: ReadonlyArray<KafkaConsumerHealthListenerWaiter>;
 };
+type ViewServerKafkaHealthRefreshRequest = Effect.Effect<void>;
 
 const emptyMessageBytes = Buffer.alloc(0);
 const ignoreKafkaConsumerCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
@@ -270,15 +271,14 @@ export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTop
     .regionDisconnected(region, error.message, options)
     .pipe(Effect.andThen(Effect.fail(error)));
 
-const refreshKafkaHealth = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  client: ViewServerRuntimeClient<Topics>,
-) => client.health().pipe(ignoreKafkaHealthRefreshFailure);
+const requestKafkaHealthRefresh = (requestHealthRefresh: ViewServerKafkaHealthRefreshRequest) =>
+  requestHealthRefresh.pipe(ignoreKafkaHealthRefreshFailure);
 
 export const recordKafkaAssignments = Effect.fn(
   "ViewServerRuntime.kafka.consumer.recordAssignments",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   health: ViewServerKafkaHealthLedger<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   region: string,
   topics: ReadonlyArray<string>,
   assignments: ReadonlyArray<GroupAssignment> | null | undefined,
@@ -296,14 +296,14 @@ export const recordKafkaAssignments = Effect.fn(
       ),
     { discard: true },
   );
-  yield* refreshKafkaHealth(client);
+  yield* requestKafkaHealthRefresh(requestHealthRefresh);
 });
 
 export const recordKafkaLag = Effect.fn("ViewServerRuntime.kafka.consumer.recordLag")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(
   health: ViewServerKafkaHealthLedger<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   region: string,
   lag: Offsets,
   nowMillis: number,
@@ -318,7 +318,7 @@ export const recordKafkaLag = Effect.fn("ViewServerRuntime.kafka.consumer.record
       }),
     { discard: true },
   );
-  yield* refreshKafkaHealth(client);
+  yield* requestKafkaHealthRefresh(requestHealthRefresh);
 });
 
 export const closeKafkaConsumerAfterStartFailure = Effect.fn(
@@ -469,6 +469,7 @@ export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.pr
 >(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
@@ -491,7 +492,7 @@ export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.pr
     timestamp: Number(message.timestamp),
     headers: kafkaHeadersFromMessage(message.headers),
   };
-  const refreshHealth = refreshKafkaHealth(client);
+  const requestHealthRefreshAfterLedgerUpdate = requestKafkaHealthRefresh(requestHealthRefresh);
   const decoded = yield* decodeKafkaTopicMessage(topic, {
     keyBytes,
     valueBytes,
@@ -508,7 +509,7 @@ export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.pr
               nowMillis,
             })
             .pipe(
-              Effect.andThen(refreshHealth),
+              Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
               Effect.andThen(Effect.fail(kafkaMessageMappingError(region, sourceTopic, error))),
             );
         }
@@ -519,7 +520,7 @@ export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.pr
             nowMillis,
           })
           .pipe(
-            Effect.andThen(refreshHealth),
+            Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
             Effect.andThen(Effect.fail(kafkaMessageDecodeError(region, sourceTopic, error))),
           );
       },
@@ -536,21 +537,27 @@ export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.pr
             nowMillis,
           })
           .pipe(
-            Effect.andThen(refreshHealth),
+            Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
             Effect.andThen(Effect.fail(kafkaMessageProcessingError(region, sourceTopic, cause))),
           ),
       onSuccess: () => Effect.succeed(true),
     }),
   );
-  yield* Effect.tryPromise({
-    try: () => Promise.resolve(message.commit()),
-    catch: (cause) => kafkaMessageCommitError(region, sourceTopic, cause),
-  });
-  yield* health.messageDecoded(sourceTopic, region, {
-    bytes: messageBytes,
-    committedOffset: String(message.offset + 1n),
-    nowMillis,
-  });
+  yield* Effect.uninterruptible(
+    Effect.tryPromise({
+      try: () => Promise.resolve(message.commit()),
+      catch: (cause) => kafkaMessageCommitError(region, sourceTopic, cause),
+    }).pipe(
+      Effect.andThen(
+        health.messageDecoded(sourceTopic, region, {
+          bytes: messageBytes,
+          committedOffset: String(message.offset + 1n),
+          nowMillis,
+        }),
+      ),
+      Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
+    ),
+  );
 });
 
 export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.run")(function* <
@@ -558,6 +565,7 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
 >(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
@@ -568,7 +576,7 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
     mapKafkaStreamError(region),
   ).pipe(
     Stream.runForEach((message) =>
-      processKafkaMessage(config, client, options, health, region, message),
+      processKafkaMessage(config, client, requestHealthRefresh, options, health, region, message),
     ),
     Effect.catchCause((cause) => {
       if (Cause.hasInterruptsOnly(cause)) {
@@ -578,13 +586,13 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
       if (Option.isSome(error)) {
         return recordKafkaStreamError(health, region, error.value, {
           preserveTopicErrors: true,
-        }).pipe(Effect.ensuring(refreshKafkaHealth(client)));
+        }).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
       }
       return recordKafkaStreamError(
         health,
         region,
         kafkaStreamError(region, Cause.squash(cause)),
-      ).pipe(Effect.ensuring(refreshKafkaHealth(client)));
+      ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
     }),
   );
 });
@@ -594,7 +602,7 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   consumer: KafkaConsumer,
   health: ViewServerKafkaHealthLedger<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   region: string,
   topics: ReadonlyArray<string>,
   scope: Scope.Scope,
@@ -676,7 +684,7 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
         const nowMillis = yield* Clock.currentTimeMillis;
         yield* recordKafkaAssignments(
           health,
-          client,
+          requestHealthRefresh,
           region,
           topics,
           payload.assignments ?? consumer.assignments,
@@ -689,7 +697,7 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
     runScoped(
       Effect.gen(function* () {
         const nowMillis = yield* Clock.currentTimeMillis;
-        yield* recordKafkaLag(health, client, region, lag, nowMillis);
+        yield* recordKafkaLag(health, requestHealthRefresh, region, lag, nowMillis);
       }),
     );
   };
@@ -697,14 +705,14 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
     runScoped(
       health
         .regionDisconnected(region, "Kafka consumer left group")
-        .pipe(Effect.andThen(refreshKafkaHealth(client))),
+        .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh))),
     );
   };
   const lagErrorListener = (error: unknown) => {
     runScoped(
       health
         .regionDegraded(region, messageFromUnknown(error))
-        .pipe(Effect.andThen(refreshKafkaHealth(client))),
+        .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh))),
     );
   };
   consumer.on("consumer:group:join", groupJoinListener);
@@ -739,6 +747,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
 >(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
@@ -765,7 +774,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
       healthListeners = yield* registerKafkaConsumerHealthListeners(
         consumer,
         health,
-        client,
+        requestHealthRefresh,
         region,
         topics,
         scope,
@@ -775,7 +784,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
       yield* health.regionConnected(region, nowMillis);
       yield* recordKafkaAssignments(
         health,
-        client,
+        requestHealthRefresh,
         region,
         topics,
         consumer.assignments,
@@ -784,6 +793,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
       const processStream = runKafkaMessageStream(
         config,
         client,
+        requestHealthRefresh,
         options,
         health,
         region,
@@ -823,6 +833,7 @@ export const startKafkaRegionConsumers = Effect.fn("ViewServerRuntime.kafka.regi
 export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
   health: ViewServerKafkaHealthLedger<Topics>,
 ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError> = Effect.fn(
@@ -830,6 +841,7 @@ export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntime
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
   health: ViewServerKafkaHealthLedger<Topics>,
 ) {
@@ -843,7 +855,17 @@ export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntime
           close: Effect.void,
         });
       }
-      return startRegionConsumer(config, client, options, health, region, brokers, topics, scope);
+      return startRegionConsumer(
+        config,
+        client,
+        requestHealthRefresh,
+        options,
+        health,
+        region,
+        brokers,
+        topics,
+        scope,
+      );
     },
   ).pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)));
   return {

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -38,6 +38,7 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
   readonly makeKafkaIngress: (
     config: ViewServerConfig<Topics>,
     client: ViewServerRuntimeClient<Topics>,
+    requestHealthRefresh: Effect.Effect<void>,
     options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
     health: ViewServerKafkaHealthLedger<Topics>,
   ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError>;


### PR DESCRIPTION
## Summary
- add epoch/install-aware coalesced runtime health reads
- split exact immediate health refresh from cadenced scheduled health refresh requests
- route Kafka health updates through cadenced refresh requests, including success-path messageDecoded updates
- keep scheduled pushed/cached health cadence-first while preventing stale health from overwriting newer installed snapshots
- close acquired live subscriptions if initial health refresh fails before the handle is returned
- make health invalidation/scheduler handoff and Kafka commit-success accounting uninterruptible

## Validation
- vp check --fix touched files
- pnpm --filter @view-server/runtime-core run test
- pnpm --filter @view-server/runtime run test
- strict Effect LSP for runtime-core and runtime
- forbidden-pattern and broad-cast scans clean
- pnpm run ready
- 3-agent review loop clean