### PR TITLE
Deepen topic store state seams

### DIFF
--- a/packages/column-live-view-engine/src/topic-store-health.ts
+++ b/packages/column-live-view-engine/src/topic-store-health.ts
@@ -1,9 +1,12 @@
 import { Clock, Effect } from "effect";
 import type { TopicRuntimeHealth } from "@view-server/config";
-import { activeStoreQueryExecutionCounts, type ActiveQueryExecutionCounts } from "./active-query";
-import type { createTopicHealthLedger } from "./topic-health-ledger";
-import { TopicStore, topicStoreReadModel, topicStoreState } from "./topic-store-state";
-import type { LiveTopicSubscriber } from "./topic-subscriber";
+import type { ActiveQueryExecutionCounts } from "./active-query";
+import {
+  collectTopicStoreActiveQueryCounts,
+  TopicStore,
+  topicStoreHealthSource,
+  type TopicStoreHealthSource,
+} from "./topic-store-state";
 
 export type TopicStoreHealthView = {
   readonly topic: string;
@@ -30,23 +33,7 @@ export type TopicStoreHealthView = {
 
 export type TopicStoreHealthState = {
   readonly activeQueries: ActiveQueryExecutionCounts;
-  readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
-  readonly subscribers: ReadonlySet<LiveTopicSubscriber>;
-  readonly topic: string;
-};
-
-const topicStoreHealthState = (
-  store: TopicStore,
-  activeQueries: ActiveQueryExecutionCounts,
-): TopicStoreHealthState => {
-  const state = topicStoreState(store);
-  return {
-    activeQueries,
-    healthLedger: state.healthLedger,
-    subscribers: state.subscribers,
-    topic: store.topic,
-  };
-};
+} & TopicStoreHealthSource;
 
 export const collectTopicStoreHealthView = Effect.fn(
   "ColumnLiveViewEngine.topicStore.healthView.collect",
@@ -90,7 +77,13 @@ export const collectTopicStoreHealthView = Effect.fn(
 
 export const collectTopicStoreHealth = Effect.fn("ColumnLiveViewEngine.topicStore.health")(
   function* (store: TopicStore, closed: boolean) {
-    const activeQueries = yield* activeStoreQueryExecutionCounts(topicStoreReadModel(store));
-    return yield* collectTopicStoreHealthView(topicStoreHealthState(store, activeQueries), closed);
+    const activeQueries = yield* collectTopicStoreActiveQueryCounts(store);
+    return yield* collectTopicStoreHealthView(
+      {
+        ...topicStoreHealthSource(store),
+        activeQueries,
+      },
+      closed,
+    );
   },
 );

--- a/packages/column-live-view-engine/src/topic-store-lifecycle.ts
+++ b/packages/column-live-view-engine/src/topic-store-lifecycle.ts
@@ -1,13 +1,10 @@
 import type { StatusEvent } from "@view-server/config";
 import { Effect } from "effect";
-import { clearStoreRawQueryExecutions } from "./active-query";
-import { withTopicStoreNotification, withTopicStoreTransaction } from "./topic-store-mutation";
 import {
-  topicStoreReadModel,
-  topicStoreState,
-  type TopicStore,
-  type TopicStoreState,
-} from "./topic-store-state";
+  withTopicStoreStateTransition,
+  type TopicStoreMutationState,
+} from "./topic-store-mutation";
+import { clearTopicStoreQueryExecutions, type TopicStore } from "./topic-store-state";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 
 const resetStatusEvent = (store: TopicStore, subscriber: LiveTopicSubscriber): StatusEvent => ({
@@ -32,7 +29,7 @@ const engineClosedStatusEvent = (
 });
 
 const drainTopicStoreSubscribersForReset = (
-  state: TopicStoreState,
+  state: TopicStoreMutationState,
 ): ReadonlyArray<LiveTopicSubscriber> => {
   state.storage.clear();
   const closingSubscribers = [...state.subscribers];
@@ -45,7 +42,7 @@ const drainTopicStoreSubscribersForReset = (
 };
 
 const drainTopicStoreSubscribersForClose = (
-  state: TopicStoreState,
+  state: TopicStoreMutationState,
 ): ReadonlyArray<LiveTopicSubscriber> => {
   const closingSubscribers = [...state.subscribers];
   for (const subscriber of closingSubscribers) {
@@ -59,41 +56,31 @@ const drainTopicStoreSubscribersForClose = (
 export const resetTopicStore = Effect.fn("ColumnLiveViewEngine.topicStore.reset")(function* (
   store: TopicStore,
 ) {
-  const state = topicStoreState(store);
-  yield* withTopicStoreNotification(
-    state,
-    withTopicStoreTransaction(
-      state,
-      Effect.gen(function* () {
-        const subscribers = yield* Effect.sync(() => {
-          return drainTopicStoreSubscribersForReset(state);
-        });
-        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
-        for (const subscriber of subscribers) {
-          yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
-        }
-      }),
-    ),
+  yield* withTopicStoreStateTransition(store, (state) =>
+    Effect.gen(function* () {
+      const subscribers = yield* Effect.sync(() => {
+        return drainTopicStoreSubscribersForReset(state);
+      });
+      yield* clearTopicStoreQueryExecutions(store);
+      for (const subscriber of subscribers) {
+        yield* subscriber.closeWithStatus(resetStatusEvent(store, subscriber));
+      }
+    }),
   );
 });
 
 export const closeTopicStoreSubscriptions = Effect.fn(
   "ColumnLiveViewEngine.topicStore.closeSubscriptions",
 )(function* (store: TopicStore) {
-  const state = topicStoreState(store);
-  yield* withTopicStoreNotification(
-    state,
-    withTopicStoreTransaction(
-      state,
-      Effect.gen(function* () {
-        const subscribers = yield* Effect.sync(() => {
-          return drainTopicStoreSubscribersForClose(state);
-        });
-        yield* clearStoreRawQueryExecutions(topicStoreReadModel(store));
-        for (const subscriber of subscribers) {
-          yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
-        }
-      }),
-    ),
+  yield* withTopicStoreStateTransition(store, (state) =>
+    Effect.gen(function* () {
+      const subscribers = yield* Effect.sync(() => {
+        return drainTopicStoreSubscribersForClose(state);
+      });
+      yield* clearTopicStoreQueryExecutions(store);
+      for (const subscriber of subscribers) {
+        yield* subscriber.closeWithStatus(engineClosedStatusEvent(store, subscriber));
+      }
+    }),
   );
 });

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -27,23 +27,48 @@ export type TopicStoreMutationContext = {
   readonly delete: (key: string) => number;
 };
 
+const withTopicStoreStateTransaction = <Success, Error, Requirements>(
+  state: TopicStoreMutationState,
+  effect: Effect.Effect<Success, Error, Requirements>,
+): Effect.Effect<Success, Error, Requirements> =>
+  state.mutationSemaphore.withPermits(1)(Effect.uninterruptible(effect));
+
+const withTopicStoreStateNotification = <Success, Error, Requirements>(
+  state: TopicStoreMutationState,
+  effect: Effect.Effect<Success, Error, Requirements>,
+): Effect.Effect<Success, Error, Requirements> =>
+  state.notificationSemaphore.withPermits(1)(Effect.uninterruptible(effect));
+
 export const withTopicStoreTransaction = Effect.fn("ColumnLiveViewEngine.topicStore.transaction")(
   function* <Success, Error, Requirements>(
-    state: TopicStoreMutationState,
+    store: TopicStore,
     effect: Effect.Effect<Success, Error, Requirements>,
   ) {
-    return yield* state.mutationSemaphore.withPermits(1)(Effect.uninterruptible(effect));
+    return yield* withTopicStoreStateTransaction(topicStoreState(store), effect);
   },
 );
 
 export const withTopicStoreNotification = Effect.fn("ColumnLiveViewEngine.topicStore.notification")(
   function* <Success, Error, Requirements>(
-    state: TopicStoreMutationState,
+    store: TopicStore,
     effect: Effect.Effect<Success, Error, Requirements>,
   ) {
-    return yield* state.notificationSemaphore.withPermits(1)(Effect.uninterruptible(effect));
+    return yield* withTopicStoreStateNotification(topicStoreState(store), effect);
   },
 );
+
+export const withTopicStoreStateTransition = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.stateTransition",
+)(function* <Success, Error, Requirements>(
+  store: TopicStore,
+  transition: (state: TopicStoreMutationState) => Effect.Effect<Success, Error, Requirements>,
+) {
+  const state = topicStoreState(store);
+  return yield* withTopicStoreStateNotification(
+    state,
+    withTopicStoreStateTransaction(state, transition(state)),
+  );
+});
 
 const commitTopicStoreState = (
   state: TopicStoreMutationState,
@@ -113,7 +138,7 @@ const notifyTopicStoreSubscribers = Effect.fn("ColumnLiveViewEngine.topicStore.n
   store: TopicStore,
   subscribers: ReadonlyArray<LiveTopicSubscriber>,
 ) {
-  yield* withTopicStoreNotification(
+  yield* withTopicStoreStateNotification(
     state,
     Effect.gen(function* () {
       for (const subscriber of subscribers) {
@@ -135,7 +160,7 @@ export const runTopicStoreMutationTransaction = Effect.fn(
   yield* withTopicStoreMutationBatch(
     state,
     Effect.gen(function* () {
-      const subscribers = yield* withTopicStoreTransaction(
+      const subscribers = yield* withTopicStoreStateTransaction(
         state,
         Effect.gen(function* () {
           const rowsChanged = yield* mutate(topicStoreMutationContext(state));

--- a/packages/column-live-view-engine/src/topic-store-state.ts
+++ b/packages/column-live-view-engine/src/topic-store-state.ts
@@ -1,5 +1,10 @@
-import { Schema, Semaphore } from "effect";
-import type { ActiveQueryStoreState } from "./active-query";
+import { Effect, Schema, Semaphore } from "effect";
+import {
+  activeStoreQueryExecutionCounts,
+  clearStoreRawQueryExecutions,
+  type ActiveQueryExecutionCounts,
+  type ActiveQueryStoreState,
+} from "./active-query";
 import { ColumnarTopicStore } from "./columnar-topic-store";
 import { createTopicHealthLedger } from "./topic-health-ledger";
 import type { TopicStoreMutationState } from "./topic-store-mutation";
@@ -16,6 +21,12 @@ export type TopicStoreSubscriptionPermit = {
 export type TopicStoreState = TopicStoreMutationState;
 
 const topicStoreStates = new WeakMap<TopicStore, TopicStoreState>();
+
+export type TopicStoreHealthSource = {
+  readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
+  readonly subscribers: ReadonlySet<LiveTopicSubscriber>;
+  readonly topic: string;
+};
 
 export class TopicStore {
   declare private readonly topicStoreBrand: void;
@@ -51,8 +62,63 @@ export const makeTopicStoreSubscriptionPermit = (
   store,
 });
 
+export const openTopicStoreSubscriber = (
+  permit: TopicStoreSubscriptionPermit,
+  subscriber: LiveTopicSubscriber,
+): void => {
+  const state = topicStoreState(permit.store);
+  state.healthLedger.openSubscription(subscriber);
+  state.subscribers.add(subscriber);
+};
+
+export const closeTopicStoreSubscriber = (
+  store: TopicStore,
+  subscriber: LiveTopicSubscriber,
+): void => {
+  const state = topicStoreState(store);
+  state.healthLedger.closeSubscription(subscriber);
+  state.subscribers.delete(subscriber);
+};
+
+export const updateTopicStoreSubscriberQueueDepth = (
+  store: TopicStore,
+  subscriber: LiveTopicSubscriber,
+  queueDepth: number,
+): void => {
+  topicStoreState(store).healthLedger.updateQueueDepth(subscriber, queueDepth);
+  subscriber.maxQueueDepth = Math.max(subscriber.maxQueueDepth, queueDepth);
+};
+
+export const markTopicStoreSubscriberBackpressure = (
+  store: TopicStore,
+  subscriber: LiveTopicSubscriber,
+): void => {
+  topicStoreState(store).healthLedger.markBackpressure(subscriber);
+  subscriber.backpressureEvents += 1;
+};
+
+export const topicStoreHealthSource = (store: TopicStore): TopicStoreHealthSource => {
+  const state = topicStoreState(store);
+  return {
+    healthLedger: state.healthLedger,
+    subscribers: state.subscribers,
+    topic: store.topic,
+  };
+};
+
 export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerMetadata =>
   topicStoreState(store).storage.rawQueryMetadata;
 
 export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
   topicStoreState(store).storage.readModel;
+
+export const clearTopicStoreQueryExecutions = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.queryExecutions.clear",
+)((store: TopicStore) => clearStoreRawQueryExecutions(topicStoreReadModel(store)));
+
+export const collectTopicStoreActiveQueryCounts = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.queryExecutions.count",
+)(
+  (store: TopicStore): Effect.Effect<ActiveQueryExecutionCounts> =>
+    activeStoreQueryExecutionCounts(topicStoreReadModel(store)),
+);

--- a/packages/column-live-view-engine/src/topic-store-subscription.ts
+++ b/packages/column-live-view-engine/src/topic-store-subscription.ts
@@ -7,10 +7,13 @@ import {
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 import { withTopicStoreNotification, withTopicStoreTransaction } from "./topic-store-mutation";
 import {
+  closeTopicStoreSubscriber,
+  markTopicStoreSubscriberBackpressure,
   makeTopicStoreSubscriptionPermit,
-  topicStoreState,
+  openTopicStoreSubscriber,
   type TopicStore,
   type TopicStoreSubscriptionPermit,
+  updateTopicStoreSubscriberQueueDepth,
 } from "./topic-store-state";
 
 export function acquireTopicStoreSubscription<
@@ -28,7 +31,7 @@ export function acquireTopicStoreSubscription<
   return acquireSubscriptionHandoff(
     (markAcquired: (subscription: Subscription) => Effect.Effect<void>) =>
       withTopicStoreTransaction(
-        topicStoreState(store),
+        store,
         acquire(makeTopicStoreSubscriptionPermit(store), markAcquired),
       ),
     options,
@@ -39,9 +42,7 @@ export const registerTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.add",
 )(function (permit: TopicStoreSubscriptionPermit, subscriber: LiveTopicSubscriber) {
   return Effect.sync(() => {
-    const state = topicStoreState(permit.store);
-    state.healthLedger.openSubscription(subscriber);
-    state.subscribers.add(subscriber);
+    openTopicStoreSubscriber(permit, subscriber);
   });
 });
 
@@ -49,9 +50,7 @@ const unregisterTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.remove",
 )(function (store: TopicStore, subscriber: LiveTopicSubscriber) {
   return Effect.sync(() => {
-    const state = topicStoreState(store);
-    state.healthLedger.closeSubscription(subscriber);
-    state.subscribers.delete(subscriber);
+    closeTopicStoreSubscriber(store, subscriber);
   });
 });
 
@@ -59,8 +58,7 @@ export const trackTopicStoreSubscriptionQueueDepth = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.queueDepth",
 )((store: TopicStore, subscriber: LiveTopicSubscriber, queueDepth: number) =>
   Effect.sync(() => {
-    topicStoreState(store).healthLedger.updateQueueDepth(subscriber, queueDepth);
-    subscriber.maxQueueDepth = Math.max(subscriber.maxQueueDepth, queueDepth);
+    updateTopicStoreSubscriberQueueDepth(store, subscriber, queueDepth);
   }),
 );
 
@@ -68,19 +66,17 @@ const reportTopicStoreSubscriptionBackpressure = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.backpressure",
 )((store: TopicStore, subscriber: LiveTopicSubscriber) =>
   Effect.sync(() => {
-    topicStoreState(store).healthLedger.markBackpressure(subscriber);
-    subscriber.backpressureEvents += 1;
+    markTopicStoreSubscriberBackpressure(store, subscriber);
   }),
 );
 
 export const closeTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.close",
 )(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
-  const state = topicStoreState(store);
   yield* withTopicStoreNotification(
-    state,
+    store,
     withTopicStoreTransaction(
-      state,
+      store,
       Effect.gen(function* () {
         if (subscriber.closed) {
           return;
@@ -96,9 +92,8 @@ export const closeTopicStoreSubscription = Effect.fn(
 export const closeBackpressuredTopicStoreSubscription = Effect.fn(
   "ColumnLiveViewEngine.topicStore.subscribe.closeBackpressured",
 )(function* (store: TopicStore, subscriber: LiveTopicSubscriber, finalize: Effect.Effect<void>) {
-  const state = topicStoreState(store);
   yield* withTopicStoreTransaction(
-    state,
+    store,
     Effect.gen(function* () {
       if (subscriber.closed) {
         return;


### PR DESCRIPTION
## Summary
- Move subscriber, lifecycle, and health state access behind TopicStore helper operations.
- Add store-level transaction/notification wrappers plus a locked state-transition helper for reset/close paths.
- Route lifecycle and health query-execution access through TopicStore helpers instead of reaching into the read model directly.

## Validation
- 3 reviewer agents clean after one fix loop.
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- forbidden-pattern scans for casts, toEqual, coverage ignores, Testing Library, act, flushSync: clean
- pnpm run ready
