### PR TITLE
Tighten topic store seam checks

### DIFF
--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -27,23 +27,12 @@ const restrictedTopicStoreHelpers = [
   {
     name: "topicStoreReadModel",
     pattern: /\btopicStoreReadModel\b/,
-    allowedPaths: new Set([
-      topicStoreHealthFile,
-      topicStoreLifecycleFile,
-      topicStoreQueryFile,
-      topicStoreStateFile,
-    ]),
+    allowedPaths: new Set([topicStoreQueryFile, topicStoreStateFile]),
   },
   {
     name: "topicStoreState",
     pattern: /\btopicStoreState\b/,
-    allowedPaths: new Set([
-      topicStoreHealthFile,
-      topicStoreLifecycleFile,
-      topicStoreMutationFile,
-      topicStoreStateFile,
-      topicStoreSubscriptionFile,
-    ]),
+    allowedPaths: new Set([topicStoreMutationFile, topicStoreStateFile]),
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Tighten internal seam checks so production modules can no longer import topicStoreReadModel outside topic-store-query/state.
- Tighten topicStoreState access to mutation/state only after the state seam refactor.

## Validation
- 3 reviewer agents clean.
- pnpm run check:internal-seams
- vp check --fix scripts/check-internal-seams.ts
- forbidden-pattern scans for casts, toEqual, coverage ignores, Testing Library, act, flushSync: clean
- pnpm run ready
