### PR TITLE
Guard package subexport seams

### DIFF
--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -90,7 +90,14 @@ const publicPackageExports = [
   "@view-server/server",
 ];
 
+const forbiddenDeepImportSuffixes = ["dist/index.js", "internal", "src/index"];
+
+const forbiddenPackageSubpathDeepImports = publicPackageExports.flatMap((specifier) =>
+  forbiddenDeepImportSuffixes.map((suffix) => `${specifier}/${suffix}`),
+);
+
 const forbiddenPackageDeepImports = [
+  ...forbiddenPackageSubpathDeepImports,
   "@view-server/client/src/index",
   "@view-server/client/dist/index.js",
   "@view-server/client/src/live-client",


### PR DESCRIPTION
## Summary
- derive forbidden deep-import smoke checks for every public package export and subexport
- cover subpath seams such as @view-server/config/health/internal and @view-server/react/testing/internal generically
- keep existing explicit forbidden deep-import examples

## Validation
- pnpm run check:package-exports
- vp check --fix scripts/check-package-exports.ts
- forbidden-pattern scans on touched script
- 3-agent review loop: no findings
- pnpm run ready