### PR TITLE
Add heap bounded raw window scans

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -6326,6 +6326,181 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("uses heap bounded scans for larger finite windows with stable row-key ties", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Order, "id", () => {});
+      const rows = Array.from({ length: 5_000 }, (_value, index) => {
+        const id = `order-${String(index).padStart(4, "0")}`;
+        const region = index < 4_900 ? "emea" : "amer";
+        return order(id, "open", Math.floor(index / 2), 5_000 - index, region);
+      });
+      yield* publishTopicStoreRows(store, rows, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      );
+
+      const compareByPriceThenKey = (
+        left: { readonly key: string; readonly row: object },
+        right: { readonly key: string; readonly row: object },
+      ) =>
+        numericRowField(left.row, "price") - numericRowField(right.row, "price") ||
+        left.key.localeCompare(right.key);
+
+      const heapWindow = topicStoreReadModel(store).scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: (row) => rowField(row, "region") === "emea",
+        compare: compareByPriceThenKey,
+        offset: 1_200,
+        limit: 10,
+      });
+
+      expect(heapWindow.keys).toStrictEqual([
+        "order-1200",
+        "order-1201",
+        "order-1202",
+        "order-1203",
+        "order-1204",
+        "order-1205",
+        "order-1206",
+        "order-1207",
+        "order-1208",
+        "order-1209",
+      ]);
+      expect(heapWindow.window.map((entry) => entry.key)).toStrictEqual([
+        "order-1200",
+        "order-1201",
+        "order-1202",
+        "order-1203",
+        "order-1204",
+        "order-1205",
+        "order-1206",
+        "order-1207",
+        "order-1208",
+        "order-1209",
+      ]);
+      expect(rowIds(heapWindow.window.map((entry) => entry.row))).toStrictEqual([
+        "order-1200",
+        "order-1201",
+        "order-1202",
+        "order-1203",
+        "order-1204",
+        "order-1205",
+        "order-1206",
+        "order-1207",
+        "order-1208",
+        "order-1209",
+      ]);
+      expect(heapWindow.totalRows).toBe(4_900);
+
+      const compareByPriceOnly = (
+        left: { readonly row: object },
+        right: { readonly row: object },
+      ) => numericRowField(left.row, "price") - numericRowField(right.row, "price");
+
+      const priceOnlyTieWindow = topicStoreReadModel(store).scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: (row) => rowField(row, "region") === "emea",
+        compare: compareByPriceOnly,
+        offset: 1_200,
+        limit: 10,
+      });
+
+      expect(priceOnlyTieWindow.keys).toStrictEqual([
+        "order-1200",
+        "order-1201",
+        "order-1202",
+        "order-1203",
+        "order-1204",
+        "order-1205",
+        "order-1206",
+        "order-1207",
+        "order-1208",
+        "order-1209",
+      ]);
+      expect(priceOnlyTieWindow.totalRows).toBe(4_900);
+
+      const compareByUpdatedAtThenKey = (
+        left: { readonly key: string; readonly row: object },
+        right: { readonly key: string; readonly row: object },
+      ) =>
+        numericRowField(left.row, "updatedAt") - numericRowField(right.row, "updatedAt") ||
+        left.key.localeCompare(right.key);
+
+      const candidateHeapWindow = topicStoreReadModel(store).scanRawWindow({
+        predicate: {
+          filters: [{ field: "region", operator: "eq", value: "emea" }],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: (row) => rowField(row, "id") !== "order-0000",
+        compare: compareByUpdatedAtThenKey,
+        offset: 1_200,
+        limit: 10,
+      });
+
+      expect(candidateHeapWindow.keys).toStrictEqual([
+        "order-3699",
+        "order-3698",
+        "order-3697",
+        "order-3696",
+        "order-3695",
+        "order-3694",
+        "order-3693",
+        "order-3692",
+        "order-3691",
+        "order-3690",
+      ]);
+      expect(candidateHeapWindow.window.map((entry) => entry.key)).toStrictEqual([
+        "order-3699",
+        "order-3698",
+        "order-3697",
+        "order-3696",
+        "order-3695",
+        "order-3694",
+        "order-3693",
+        "order-3692",
+        "order-3691",
+        "order-3690",
+      ]);
+      expect(rowIds(candidateHeapWindow.window.map((entry) => entry.row))).toStrictEqual([
+        "order-3699",
+        "order-3698",
+        "order-3697",
+        "order-3696",
+        "order-3695",
+        "order-3694",
+        "order-3693",
+        "order-3692",
+        "order-3691",
+        "order-3690",
+      ]);
+      expect(candidateHeapWindow.totalRows).toBe(4_899);
+
+      const unboundedFallbackWindow = topicStoreReadModel(store).scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 5_000,
+        limit: 1,
+      });
+
+      expect(unboundedFallbackWindow.keys).toStrictEqual([]);
+      expect(unboundedFallbackWindow.window).toStrictEqual([]);
+      expect(unboundedFallbackWindow.totalRows).toBe(5_000);
+    }),
+  );
+
   it.effect("skips row callbacks for complete column predicate plans", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -30,9 +30,15 @@ export type TopicRawWindowScanState = {
   readonly slots: ReadonlyArray<TopicRowEntry<object>>;
 };
 
-const maxBoundedRawWindowEnd = 1_024;
+const maxSortedBoundedRawWindowEnd = 1_024;
+const maxHeapBoundedRawWindowEnd = 100_000;
 const maxMaterializedPredicateCandidateSlots = 100_000;
 const materializedPredicateCandidateSlotBudget = maxMaterializedPredicateCandidateSlots + 1;
+
+type BoundedRawWindowStrategy = {
+  readonly kind: "heap" | "sorted";
+  readonly windowEnd: number;
+};
 
 export const scanTopicRawWindow = (
   state: TopicRawWindowScanState,
@@ -144,14 +150,24 @@ const scanRawWindowCandidateSlots = (
   matchesSlot: (slot: number) => boolean,
   candidateSlots: PredicateCandidateSlots,
 ): TopicRawWindowScanResult<object> => {
-  const boundedWindowEnd = boundedRawWindowEnd(plan);
-  if (boundedWindowEnd !== undefined) {
-    return scanRawWindowBoundedSlotCandidates(
+  const boundedWindow = boundedRawWindowStrategy(plan, candidateSlots.slots.length);
+  if (boundedWindow?.kind === "sorted") {
+    return scanRawWindowBoundedSortedSlotCandidates(
       state,
       plan,
       compareSlots,
       matchesSlot,
-      boundedWindowEnd,
+      boundedWindow.windowEnd,
+      candidateSlots,
+    );
+  }
+  if (boundedWindow?.kind === "heap") {
+    return scanRawWindowBoundedHeapSlotCandidates(
+      state,
+      plan,
+      compareSlots,
+      matchesSlot,
+      boundedWindow.windowEnd,
       candidateSlots,
     );
   }
@@ -179,9 +195,24 @@ const scanRawWindowSlots = (
   compareSlots: (left: number, right: number) => number,
   matchesSlot: (slot: number) => boolean,
 ): TopicRawWindowScanResult<object> => {
-  const boundedWindowEnd = boundedRawWindowEnd(plan);
-  if (boundedWindowEnd !== undefined) {
-    return scanRawWindowBoundedSlots(state, plan, compareSlots, matchesSlot, boundedWindowEnd);
+  const boundedWindow = boundedRawWindowStrategy(plan, state.slots.length);
+  if (boundedWindow?.kind === "sorted") {
+    return scanRawWindowBoundedSortedSlots(
+      state,
+      plan,
+      compareSlots,
+      matchesSlot,
+      boundedWindow.windowEnd,
+    );
+  }
+  if (boundedWindow?.kind === "heap") {
+    return scanRawWindowBoundedHeapSlots(
+      state,
+      plan,
+      compareSlots,
+      matchesSlot,
+      boundedWindow.windowEnd,
+    );
   }
 
   let totalRows = 0;
@@ -201,7 +232,7 @@ const scanRawWindowSlots = (
   return rawWindowScanResult(state, windowSlots, totalRows);
 };
 
-const scanRawWindowBoundedSlots = (
+const scanRawWindowBoundedSortedSlots = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
   compareSlots: (left: number, right: number) => number,
@@ -230,7 +261,7 @@ const scanRawWindowBoundedSlots = (
   return rawWindowScanResult(state, windowSlots.slice(plan.offset), totalRows);
 };
 
-const scanRawWindowBoundedSlotCandidates = (
+const scanRawWindowBoundedSortedSlotCandidates = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
   compareSlots: (left: number, right: number) => number,
@@ -260,6 +291,120 @@ const scanRawWindowBoundedSlotCandidates = (
   return rawWindowScanResult(state, windowSlots.slice(plan.offset), totalRows);
 };
 
+const scanRawWindowBoundedHeapSlots = (
+  state: TopicRawWindowScanState,
+  plan: TopicRawWindowScanPlan<object>,
+  compareSlots: (left: number, right: number) => number,
+  matchesSlot: (slot: number) => boolean,
+  windowEnd: number,
+): TopicRawWindowScanResult<object> => {
+  let totalRows = 0;
+  const heap: Array<number> = [];
+  const compareStableSlots = stableRawWindowSlotComparator(compareSlots);
+  for (let slot = 0; slot < state.slots.length; slot += 1) {
+    if (!matchesSlot(slot)) {
+      continue;
+    }
+    totalRows += 1;
+    retainBoundedRawWindowSlot(heap, slot, windowEnd, compareStableSlots);
+  }
+  heap.sort(compareStableSlots);
+  return rawWindowScanResult(state, heap.slice(plan.offset), totalRows);
+};
+
+const scanRawWindowBoundedHeapSlotCandidates = (
+  state: TopicRawWindowScanState,
+  plan: TopicRawWindowScanPlan<object>,
+  compareSlots: (left: number, right: number) => number,
+  matchesSlot: (slot: number) => boolean,
+  windowEnd: number,
+  candidateSlots: PredicateCandidateSlots,
+): TopicRawWindowScanResult<object> => {
+  let totalRows = 0;
+  const heap: Array<number> = [];
+  const compareStableSlots = stableRawWindowSlotComparator(compareSlots);
+  for (const slot of candidateSlots.slots) {
+    if (!matchesSlot(slot)) {
+      continue;
+    }
+    totalRows += 1;
+    retainBoundedRawWindowSlot(heap, slot, windowEnd, compareStableSlots);
+  }
+  heap.sort(compareStableSlots);
+  return rawWindowScanResult(state, heap.slice(plan.offset), totalRows);
+};
+
+const stableRawWindowSlotComparator =
+  (compareSlots: (left: number, right: number) => number) =>
+  (left: number, right: number): number => {
+    const comparison = compareSlots(left, right);
+    return comparison === 0 ? left - right : comparison;
+  };
+
+const retainBoundedRawWindowSlot = (
+  heap: Array<number>,
+  slot: number,
+  windowEnd: number,
+  compareSlots: (left: number, right: number) => number,
+): void => {
+  if (heap.length < windowEnd) {
+    heap.push(slot);
+    siftRawWindowSlotUp(heap, heap.length - 1, compareSlots);
+    return;
+  }
+  if (compareSlots(slot, heap[0]!) >= 0) {
+    return;
+  }
+  heap[0] = slot;
+  siftRawWindowSlotDown(heap, 0, compareSlots);
+};
+
+const siftRawWindowSlotUp = (
+  heap: Array<number>,
+  index: number,
+  compareSlots: (left: number, right: number) => number,
+): void => {
+  let current = index;
+  while (current > 0) {
+    const parent = Math.floor((current - 1) / 2);
+    if (compareSlots(heap[parent]!, heap[current]!) >= 0) {
+      return;
+    }
+    swapRawWindowHeapSlots(heap, parent, current);
+    current = parent;
+  }
+};
+
+const siftRawWindowSlotDown = (
+  heap: Array<number>,
+  index: number,
+  compareSlots: (left: number, right: number) => number,
+): void => {
+  let current = index;
+  while (true) {
+    const left = current * 2 + 1;
+    const right = left + 1;
+    let largest = current;
+    if (left < heap.length && compareSlots(heap[left]!, heap[largest]!) > 0) {
+      largest = left;
+    }
+    if (right < heap.length && compareSlots(heap[right]!, heap[largest]!) > 0) {
+      largest = right;
+    }
+    if (largest === current) {
+      return;
+    }
+    swapRawWindowHeapSlots(heap, current, largest);
+    current = largest;
+  }
+};
+
+const swapRawWindowHeapSlots = (heap: Array<number>, left: number, right: number): void => {
+  const value = heap[left]!;
+  heap[left] = heap[right]!;
+  heap[right] = value;
+};
+
 const rawPredicateMatchesSlot = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
@@ -284,7 +429,10 @@ const rawWindowScanResult = (
   };
 };
 
-const boundedRawWindowEnd = (plan: TopicRawWindowScanPlan<object>): number | undefined => {
+const boundedRawWindowStrategy = (
+  plan: TopicRawWindowScanPlan<object>,
+  candidateCount: number,
+): BoundedRawWindowStrategy | undefined => {
   if (plan.limit === undefined || plan.limit <= 0) {
     return undefined;
   }
@@ -292,8 +440,20 @@ const boundedRawWindowEnd = (plan: TopicRawWindowScanPlan<object>): number | und
     return undefined;
   }
   const windowEnd = plan.offset + plan.limit;
-  if (!Number.isSafeInteger(windowEnd) || windowEnd > maxBoundedRawWindowEnd) {
+  if (!Number.isSafeInteger(windowEnd)) {
     return undefined;
   }
-  return windowEnd;
+  if (windowEnd <= maxSortedBoundedRawWindowEnd) {
+    return {
+      kind: "sorted",
+      windowEnd,
+    };
+  }
+  if (windowEnd <= maxHeapBoundedRawWindowEnd && windowEnd * 4 <= candidateCount) {
+    return {
+      kind: "heap",
+      windowEnd,
+    };
+  }
+  return undefined;
 };


### PR DESCRIPTION
## Summary
- keep the existing sorted bounded raw-window path for small finite windows
- add a heap-backed bounded raw-window strategy for larger selective finite windows
- preserve stable ordering by falling back to slot id when a comparator returns equality
- add engine coverage for full-scan heap, candidate-slot heap, stable tie ordering, skipped matches, and fallback full scans

## Validation
- pnpm run ready
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- vp check --fix packages/column-live-view-engine/src/topic-raw-window-scanner.ts packages/column-live-view-engine/src/index.test.ts
- forbidden-pattern scan on touched files: clean
- 3 local reviewer agents: No findings
