### PR TITLE
Evict broad scalar predicate buckets

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -49,6 +49,7 @@ import { scanTopicRawWindow } from "./topic-raw-window-scanner";
 import {
   addSlotToScalarPredicateIndexes,
   createScalarPredicateIndexes,
+  maxRetainedScalarPredicateBucketSlots,
   removeSlotFromScalarPredicateIndexes,
   selectedPredicateCandidateSlots,
 } from "./topic-predicate-candidate-index";
@@ -8310,8 +8311,219 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
     expect(result.keys).toStrictEqual(["open-0"]);
     expect(result.totalRows).toBe(rows.length - 1);
-    expect(state.scalarPredicateIndexes.get("status")?.indexedKeys.has(openKey)).toBe(false);
-    expect(state.scalarPredicateIndexes.get("status")?.buckets.has(openKey)).toBe(false);
+    expect(state.scalarPredicateIndexes.has("status")).toBe(false);
+  });
+
+  it("evicts scalar predicate buckets that grow past the retained budget", () => {
+    const openKey = scalarEqualityKey("open");
+    const rows = Array.from(
+      { length: maxRetainedScalarPredicateBucketSlots + 1 },
+      (_value, index) => order(`open-${index}`, "open", index, index),
+    );
+    const metadata = rawQueryCompilerMetadata(Order);
+    const scalarPredicateIndexes = createScalarPredicateIndexes();
+    scalarPredicateIndexes.set("status", {
+      buckets: new Map([
+        [
+          openKey,
+          new Set(
+            Array.from({ length: maxRetainedScalarPredicateBucketSlots }, (_value, index) => index),
+          ),
+        ],
+      ]),
+      indexedKeys: new Set([openKey]),
+    });
+
+    addSlotToScalarPredicateIndexes(
+      scalarPredicateIndexes,
+      makeColumns(metadata, [["status", rows.map((row) => row.status)]]),
+      maxRetainedScalarPredicateBucketSlots,
+    );
+
+    expect(scalarPredicateIndexes.has("status")).toBe(false);
+  });
+
+  it("does not retain newly built single-key scalar predicate buckets beyond the retained budget", () => {
+    const rows = Array.from(
+      { length: maxRetainedScalarPredicateBucketSlots + 1 },
+      (_value, index) => order(`open-${index}`, "open", index, index),
+    );
+    const metadata = rawQueryCompilerMetadata(Order);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+        ["status", rows.map((row) => row.status)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+
+    const candidate = selectedPredicateCandidateSlots(
+      state,
+      [{ field: "status", operator: "eq", value: "open" }],
+      {
+        allowScalarIndexBuild: true,
+        exactRangeCandidates: true,
+        maxSlotCount: maxRetainedScalarPredicateBucketSlots + 2,
+      },
+    );
+
+    expect(candidate).toBeUndefined();
+    expect(state.scalarPredicateIndexes.has("status")).toBe(false);
+  });
+
+  it("does not retain newly built multi-key scalar predicate buckets beyond the retained budget", () => {
+    const rows = Array.from(
+      { length: maxRetainedScalarPredicateBucketSlots + 1 },
+      (_value, index) => order(`open-${index}`, "open", index, index),
+    );
+    rows.push(order("closed-row", "closed", 0, 0));
+    const metadata = rawQueryCompilerMetadata(Order);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+        ["status", rows.map((row) => row.status)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+
+    const candidate = selectedPredicateCandidateSlots(
+      state,
+      [{ field: "status", operator: "in", values: ["open", "closed"] }],
+      {
+        allowScalarIndexBuild: true,
+        exactRangeCandidates: true,
+        maxSlotCount: maxRetainedScalarPredicateBucketSlots + 3,
+      },
+    );
+
+    expect(candidate).toBeUndefined();
+    expect(state.scalarPredicateIndexes.has("status")).toBe(false);
+  });
+
+  it("evicts already broad single-key scalar predicate buckets during candidate selection", () => {
+    const openKey = scalarEqualityKey("open");
+    const rows = Array.from(
+      { length: maxRetainedScalarPredicateBucketSlots + 1 },
+      (_value, index) => order(`open-${index}`, "open", index, index),
+    );
+    const metadata = rawQueryCompilerMetadata(Order);
+    const state = {
+      columns: makeColumns(metadata, [
+        ["id", rows.map((row) => row.id)],
+        ["price", rows.map((row) => row.price)],
+        ["status", rows.map((row) => row.status)],
+      ]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+    state.scalarPredicateIndexes.set("status", {
+      buckets: new Map([
+        [
+          openKey,
+          new Set(
+            Array.from(
+              { length: maxRetainedScalarPredicateBucketSlots + 1 },
+              (_value, index) => index,
+            ),
+          ),
+        ],
+      ]),
+      indexedKeys: new Set([openKey]),
+    });
+
+    const candidate = selectedPredicateCandidateSlots(
+      state,
+      [{ field: "status", operator: "eq", value: "open" }],
+      {
+        allowScalarIndexBuild: false,
+        exactRangeCandidates: true,
+        maxSlotCount: maxRetainedScalarPredicateBucketSlots + 1,
+      },
+    );
+
+    expect(candidate).toBeUndefined();
+    expect(state.scalarPredicateIndexes.has("status")).toBe(false);
+  });
+
+  it("evicts already broad scalar predicate buckets during candidate selection", () => {
+    const openKey = scalarEqualityKey("open");
+    const closedKey = scalarEqualityKey("closed");
+    const rows = Array.from(
+      { length: maxRetainedScalarPredicateBucketSlots + 1 },
+      (_value, index) => order(`open-${index}`, "open", index, index),
+    );
+    rows.push(order("closed-row", "closed", 0, 0));
+    const metadata = rawQueryCompilerMetadata(Order);
+    const statusColumn: TopicColumnValues = {
+      get: () => {
+        throw new Error("over-budget cached scalar buckets should not be rebuilt");
+      },
+      kind: "generic",
+      length: rows.length,
+    };
+    const state = {
+      columns: new Map([["status", statusColumn]]),
+      orderedSlotIndexes: new Map(),
+      rawQueryMetadata: metadata,
+      scalarPredicateIndexes: createScalarPredicateIndexes(),
+      slots: rows.map((row) => ({
+        key: row.id,
+        row,
+      })),
+    };
+    state.scalarPredicateIndexes.set("status", {
+      buckets: new Map([
+        [
+          openKey,
+          new Set(
+            Array.from(
+              { length: maxRetainedScalarPredicateBucketSlots + 1 },
+              (_value, index) => index,
+            ),
+          ),
+        ],
+        [closedKey, new Set([maxRetainedScalarPredicateBucketSlots + 1])],
+      ]),
+      indexedKeys: new Set([openKey, closedKey]),
+    });
+
+    const candidate = selectedPredicateCandidateSlots(
+      state,
+      [{ field: "status", operator: "in", values: ["open", "closed"] }],
+      {
+        allowScalarIndexBuild: true,
+        exactRangeCandidates: true,
+        maxSlotCount: maxRetainedScalarPredicateBucketSlots + 1,
+      },
+    );
+
+    const statusIndex = state.scalarPredicateIndexes.get("status")!;
+    expect(candidate).toBeUndefined();
+    expect(statusIndex.indexedKeys.has(openKey)).toBe(false);
+    expect(statusIndex.buckets.has(openKey)).toBe(false);
+    expect(statusIndex.indexedKeys.has(closedKey)).toBe(true);
+    expect(statusIndex.buckets.get(closedKey)).toStrictEqual(
+      new Set([maxRetainedScalarPredicateBucketSlots + 1]),
+    );
   });
 
   it("counts exact broad zero-row scans without reading row objects", () => {

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-index.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-index.ts
@@ -21,6 +21,8 @@ type ScalarPredicateFieldIndex = {
   readonly indexedKeys: Set<string>;
 };
 
+export const maxRetainedScalarPredicateBucketSlots = 100_000;
+
 export type ScalarPredicateIndexes = Map<string, ScalarPredicateFieldIndex>;
 
 export type PredicateCandidateSlotIndexState = RawOrderedWindowIndexState & {
@@ -47,6 +49,7 @@ export const addSlotToScalarPredicateIndexes = (
 ): void => {
   for (const [field, index] of indexes) {
     addSlotToScalarPredicateIndex(index, columns.get(field), slot);
+    pruneEmptyScalarPredicateIndex(indexes, field, index);
   }
 };
 
@@ -57,6 +60,7 @@ export const removeSlotFromScalarPredicateIndexes = (
 ): void => {
   for (const [field, index] of indexes) {
     removeSlotFromScalarPredicateIndex(index, columns.get(field), slot);
+    pruneEmptyScalarPredicateIndex(indexes, field, index);
   }
 };
 
@@ -143,6 +147,7 @@ const scalarEqualityCandidateSlots = (
   }
   const column = state.columns.get(field)!;
   const slots = unionScalarPredicateSlots(index, column, valueKeys, allowIndexBuild, maxSlotCount);
+  pruneEmptyScalarPredicateIndex(state.scalarPredicateIndexes, field, index);
   if (slots === undefined) {
     return undefined;
   }
@@ -220,6 +225,10 @@ const unionScalarPredicateSlots = (
       continue;
     }
     const bucket = index.buckets.get(key)!;
+    if (scalarPredicateBucketIsOverRetainedBudget(bucket)) {
+      evictScalarPredicateBucket(index, key);
+      return undefined;
+    }
     for (const slot of bucket) {
       slots.add(slot);
       if (maxSlotCount !== undefined && slots.size >= maxSlotCount) {
@@ -247,6 +256,9 @@ const unionScalarPredicateSlots = (
       continue;
     }
     bucket.add(slot);
+    if (scalarPredicateBucketIsOverRetainedBudget(bucket)) {
+      return undefined;
+    }
     slots.add(slot);
     if (maxSlotCount !== undefined && slots.size >= maxSlotCount) {
       return undefined;
@@ -270,7 +282,12 @@ const ensureScalarPredicateBucket = (
   maxSlotCount: number | undefined,
 ): Set<number> | undefined => {
   if (index.indexedKeys.has(valueKey)) {
-    return index.buckets.get(valueKey)!;
+    const bucket = index.buckets.get(valueKey)!;
+    if (scalarPredicateBucketIsOverRetainedBudget(bucket)) {
+      evictScalarPredicateBucket(index, valueKey);
+      return undefined;
+    }
+    return bucket;
   }
   if (!allowBucketBuild) {
     return undefined;
@@ -282,6 +299,9 @@ const ensureScalarPredicateBucket = (
       continue;
     }
     bucket.add(slot);
+    if (scalarPredicateBucketIsOverRetainedBudget(bucket)) {
+      return undefined;
+    }
     if (maxSlotCount !== undefined && bucket.size >= maxSlotCount) {
       return undefined;
     }
@@ -356,6 +376,9 @@ const addSlotToScalarPredicateIndex = (
   }
   const bucket = index.buckets.get(key)!;
   bucket.add(slot);
+  if (scalarPredicateBucketIsOverRetainedBudget(bucket)) {
+    evictScalarPredicateBucket(index, key);
+  }
 };
 
 const removeSlotFromScalarPredicateIndex = (
@@ -371,6 +394,24 @@ const removeSlotFromScalarPredicateIndex = (
     return;
   }
   index.buckets.get(key)!.delete(slot);
+};
+
+const scalarPredicateBucketIsOverRetainedBudget = (bucket: Set<number>): boolean =>
+  bucket.size > maxRetainedScalarPredicateBucketSlots;
+
+const evictScalarPredicateBucket = (index: ScalarPredicateFieldIndex, key: string): void => {
+  index.indexedKeys.delete(key);
+  index.buckets.delete(key);
+};
+
+const pruneEmptyScalarPredicateIndex = (
+  indexes: ScalarPredicateIndexes,
+  field: string,
+  index: ScalarPredicateFieldIndex,
+): void => {
+  if (index.indexedKeys.size === 0) {
+    indexes.delete(field);
+  }
 };
 
 const isRangePredicateFilter = (

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -3,6 +3,7 @@ import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-win
 import type { TopicRowEntry } from "./row-scan";
 import type { TopicColumnValues } from "./topic-column-vector";
 import {
+  maxRetainedScalarPredicateBucketSlots,
   selectedPredicateCandidateSlots,
   type PredicateCandidateSlotIndexState,
   type PredicateCandidateSlots,
@@ -32,7 +33,7 @@ export type TopicRawWindowScanState = {
 
 const maxSortedBoundedRawWindowEnd = 1_024;
 const maxHeapBoundedRawWindowEnd = 100_000;
-const maxMaterializedPredicateCandidateSlots = 100_000;
+const maxMaterializedPredicateCandidateSlots = maxRetainedScalarPredicateBucketSlots;
 const materializedPredicateCandidateSlotBudget = maxMaterializedPredicateCandidateSlots + 1;
 
 type BoundedRawWindowStrategy = {

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1374,9 +1374,10 @@ benchmark. It compares:
 Scanner-level predicate candidate selection uses a materialization safety budget, not a semantic
 filter. New candidate builds up to 100k slots may be materialized; broader scalar/range candidates
 fall back to the normal scan path so 10M-row topics do not allocate and sort multi-million-slot
-candidate arrays. Already-warmed scalar buckets that later grow beyond the budget are also rejected
-for scan selection; bucket eviction/adaptive budgets are separate performance work. This fallback
-must preserve `totalRows`, deterministic ordering, and exact predicate semantics.
+candidate arrays. Already-warmed scalar buckets that later grow beyond the retained bucket budget
+are evicted and rejected for scan selection, so broad buckets do not keep adding write-path
+maintenance and memory pressure after they stop being selective. This fallback must preserve
+`totalRows`, deterministic ordering, and exact predicate semantics.
 
 It writes profile-specific Vitest timing JSON plus a View Server summary sidecar, for example
 `raw-predicate-index-100000rows.json` and `raw-predicate-index-100000rows.summary.json`. Run each row


### PR DESCRIPTION
## Summary
- enforce scalar predicate retained-bucket budget inside the predicate index module, not only through scanner caller budgets
- evict and prune broad cached scalar buckets/empty field indexes so writes stop maintaining unusable buckets
- reuse the retained bucket cap for raw window candidate materialization and document the updated behavior

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- source/test forbidden-pattern scan on touched files
- pnpm run ready
- 3-agent review loop: final pass returned No findings from all reviewers