### PR TITLE
Patch order-neutral grouped evaluations

### DIFF
--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -1,6 +1,7 @@
 import {
   type MaterializedIncrementalGroupState,
   type RetainedMinMaxAggregateState,
+  finalizeGroup,
   newIncrementalGroupState,
   recomputeRetainedMinMaxAggregateState,
   removeAggregateState,
@@ -32,6 +33,16 @@ type CountOnlyIncrementalGroupState = {
 export type IncrementalGroupedQueryExecution<ResultRow extends RowObject> = {
   readonly incremental: boolean;
   readonly latest: () => QueryEvaluation<ResultRow>;
+};
+
+export type GroupedIncrementalExecutionDiagnostics = {
+  readonly onFullEvaluation: () => void;
+  readonly onPatchedEvaluation: () => void;
+};
+
+const noopGroupedIncrementalExecutionDiagnostics: GroupedIncrementalExecutionDiagnostics = {
+  onFullEvaluation: () => undefined,
+  onPatchedEvaluation: () => undefined,
 };
 
 const retainedValueAggregateCount = <Row extends RowObject>(
@@ -278,6 +289,40 @@ type UpsertIncrementalGroupedMemberResult = {
 
 type DirtyAggregateRecomputes = Set<RetainedMinMaxAggregateState>;
 
+type MaterializedEvaluationPatch = {
+  readonly dirtyGroups: Map<string, MaterializedIncrementalGroupState>;
+  requiresFullEvaluation: boolean;
+};
+
+const newMaterializedEvaluationPatch = (): MaterializedEvaluationPatch => ({
+  dirtyGroups: new Map<string, MaterializedIncrementalGroupState>(),
+  requiresFullEvaluation: false,
+});
+
+const orderByUsesAggregate = <Row extends RowObject>(
+  plan: GroupedQueryPlan<Row>,
+  alias: string,
+): boolean => {
+  for (const order of plan.orderBy) {
+    if ("aggregate" in order && order.aggregate === alias) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const markMaterializedAggregateChange = <Row extends RowObject>(
+  patch: MaterializedEvaluationPatch,
+  plan: GroupedQueryPlan<Row>,
+  group: MaterializedIncrementalGroupState,
+  alias: string,
+): void => {
+  patch.dirtyGroups.set(group.key, group);
+  if (orderByUsesAggregate(plan, alias)) {
+    patch.requiresFullEvaluation = true;
+  }
+};
+
 const markDirtyAggregateRecompute = (
   dirtyAggregateRecomputes: DirtyAggregateRecomputes,
   state: RetainedMinMaxAggregateState | undefined,
@@ -351,6 +396,7 @@ const upsertMatchingMaterializedIncrementalGroupedMember = <Row extends RowObjec
 
 const replaceMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   dirtyAggregateRecomputes: DirtyAggregateRecomputes,
+  patch: MaterializedEvaluationPatch,
   group: MaterializedIncrementalGroupState,
   plan: GroupedQueryPlan<Row>,
   key: string,
@@ -361,6 +407,7 @@ const replaceMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
     if (aggregateValueChanged(aggregate, previous, next)) {
       const state = group.aggregates[alias]!;
+      markMaterializedAggregateChange(patch, plan, group, alias);
       markDirtyAggregateRecompute(
         dirtyAggregateRecomputes,
         removeAggregateState(state, aggregate, previous),
@@ -415,6 +462,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
   matches: (row: Row) => boolean,
   batch: TopicRowChangeBatch<Row>,
   limits: GroupedIncrementalAdmissionLimits,
+  patch: MaterializedEvaluationPatch,
 ): boolean => {
   const retainedAggregateCount = retainedValueAggregateCount(plan);
   const dirtyAggregateRecomputes: DirtyAggregateRecomputes = new Set();
@@ -433,6 +481,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
       ) {
         replaceMaterializedIncrementalGroupedMember(
           dirtyAggregateRecomputes,
+          patch,
           group,
           plan,
           change.key,
@@ -453,6 +502,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
       );
       if (removed) {
         state.memberCount -= 1;
+        patch.requiresFullEvaluation = true;
       }
     }
     if (change.next !== undefined) {
@@ -467,6 +517,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
       if (upserted === undefined) {
         continue;
       }
+      patch.requiresFullEvaluation = true;
       if (upserted.groupSize > limits.maxMembersPerGroup) {
         return false;
       }
@@ -487,6 +538,57 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
   }
   recomputeDirtyAggregateStates(dirtyAggregateRecomputes);
   return true;
+};
+
+const patchOrderNeutralMaterializedEvaluation = (
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
+  patch: MaterializedEvaluationPatch,
+): QueryEvaluation<RowObject> => {
+  if (patch.dirtyGroups.size === 0) {
+    return {
+      ...state.evaluation,
+      version: state.version,
+    };
+  }
+
+  let visibleWindowChanged = false;
+  const window = state.evaluation.window.map((entry) => {
+    const group = patch.dirtyGroups.get(entry.key);
+    if (group !== undefined) {
+      visibleWindowChanged = true;
+      return finalizeGroup(group);
+    }
+    return entry;
+  });
+
+  if (!visibleWindowChanged) {
+    return {
+      ...state.evaluation,
+      version: state.version,
+    };
+  }
+
+  return {
+    keys: window.map((entry) => entry.key),
+    rows: window.map((entry) => entry.row),
+    totalRows: state.evaluation.totalRows,
+    version: state.version,
+    window,
+  };
+};
+
+const evaluateMaterializedGroupedQueryAfterPatches = <Row extends RowObject>(
+  state: Extract<IncrementalGroupedQueryState, { readonly mode: "materialized" }>,
+  plan: GroupedQueryPlan<Row>,
+  patch: MaterializedEvaluationPatch,
+  diagnostics: GroupedIncrementalExecutionDiagnostics,
+): QueryEvaluation<RowObject> => {
+  if (patch.requiresFullEvaluation) {
+    diagnostics.onFullEvaluation();
+    return evaluateIncrementalGroupedQuery(state, plan, state.version);
+  }
+  diagnostics.onPatchedEvaluation();
+  return patchOrderNeutralMaterializedEvaluation(state, patch);
 };
 
 const applyCountOnlyIncrementalGroupedQueryBatch = <Row extends RowObject>(
@@ -524,16 +626,20 @@ const applyMaterializedIncrementalGroupedQueryBatches = <Row extends RowObject>(
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
   limits: GroupedIncrementalAdmissionLimits,
+  diagnostics: GroupedIncrementalExecutionDiagnostics,
 ): boolean => {
+  const patch = newMaterializedEvaluationPatch();
   for (const batch of batches) {
-    if (!applyMaterializedIncrementalGroupedQueryBatch(state, plan, matches, batch, limits)) {
+    if (
+      !applyMaterializedIncrementalGroupedQueryBatch(state, plan, matches, batch, limits, patch)
+    ) {
       state.groups.clear();
       state.memberCount = 0;
       return false;
     }
     state.version = batch.version;
   }
-  state.evaluation = evaluateIncrementalGroupedQuery(state, plan, state.version);
+  state.evaluation = evaluateMaterializedGroupedQueryAfterPatches(state, plan, patch, diagnostics);
   return true;
 };
 
@@ -561,11 +667,19 @@ const applyIncrementalGroupedQueryBatches = <Row extends RowObject>(
   matches: (row: Row) => boolean,
   batches: ReadonlyArray<TopicRowChangeBatch<Row>>,
   limits: GroupedIncrementalAdmissionLimits,
+  diagnostics: GroupedIncrementalExecutionDiagnostics,
 ): boolean => {
   if (state.mode === "countOnly") {
     return applyCountOnlyIncrementalGroupedQueryBatches(state, plan, matches, batches, limits);
   }
-  return applyMaterializedIncrementalGroupedQueryBatches(state, plan, matches, batches, limits);
+  return applyMaterializedIncrementalGroupedQueryBatches(
+    state,
+    plan,
+    matches,
+    batches,
+    limits,
+    diagnostics,
+  );
 };
 
 const makeFallbackGroupedQueryExecution = <Row extends RowObject, ResultRow extends RowObject>(
@@ -599,6 +713,7 @@ export const makeIncrementalGroupedQueryExecution = <
   compiled: CompiledGroupedQuery<Row, ResultRow>,
   releaseRetainedChanges: () => void,
   limits: GroupedIncrementalAdmissionLimits = defaultGroupedIncrementalAdmissionLimits,
+  diagnostics: GroupedIncrementalExecutionDiagnostics = noopGroupedIncrementalExecutionDiagnostics,
 ): IncrementalGroupedQueryExecution<ResultRow> => {
   let build = buildIncrementalGroupedQueryState(store, compiled.plan, compiled.matches, limits);
   if (!build.admitted) {
@@ -641,6 +756,7 @@ export const makeIncrementalGroupedQueryExecution = <
           compiled.matches,
           batches,
           limits,
+          diagnostics,
         )
       ) {
         return activateFallback().latest();

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -2265,6 +2265,378 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
+  it.effect("patches order-neutral grouped aggregate rows without changing window order", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const rows = new Map<string, object>([
+        ["cancelled", order("cancelled", "cancelled", 5, 1, "emea")],
+        ["open-a", order("open-a", "open", 10, 2, "emea")],
+        ["open-b", order("open-b", "open", 20, 3, "emea")],
+        ["closed", order("closed", "closed", 7, 4, "emea")],
+      ]);
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      let fullEvaluationCount = 0;
+      let patchedEvaluationCount = 0;
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            maxPrice: { aggFunc: "max", field: "price" },
+            rowCount: { aggFunc: "count" },
+            totalPrice: { aggFunc: "sum", field: "price" },
+          },
+          orderBy: [{ field: "status", direction: "asc" }],
+          limit: 3,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(
+        store,
+        compiled,
+        () => {},
+        defaultGroupedIncrementalAdmissionLimits,
+        {
+          onFullEvaluation: () => {
+            fullEvaluationCount += 1;
+          },
+          onPatchedEvaluation: () => {
+            patchedEvaluationCount += 1;
+          },
+        },
+      );
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: "1",
+          totalPrice: "5",
+        },
+        {
+          status: "closed",
+          maxPrice: 7,
+          rowCount: "1",
+          totalPrice: "7",
+        },
+        {
+          status: "open",
+          maxPrice: 20,
+          rowCount: "2",
+          totalPrice: "30",
+        },
+      ]);
+
+      const previous = order("open-a", "open", 10, 2, "emea");
+      const next = order("open-a", "open", 15, 5, "emea");
+      rows.set("open-a", next);
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [{ key: "open-a", previous, next }],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: "1",
+          totalPrice: "5",
+        },
+        {
+          status: "closed",
+          maxPrice: 7,
+          rowCount: "1",
+          totalPrice: "7",
+        },
+        {
+          status: "open",
+          maxPrice: 20,
+          rowCount: "2",
+          totalPrice: "35",
+        },
+      ]);
+      expect(execution.latest().version).toBe(1);
+      expect(scanCount).toBe(1);
+      expect(fullEvaluationCount).toBe(0);
+      expect(patchedEvaluationCount).toBe(1);
+
+      const recomputedExtremumPrevious = order("open-b", "open", 20, 3, "emea");
+      const recomputedExtremumNext = order("open-b", "open", 12, 6, "emea");
+      rows.set("open-b", recomputedExtremumNext);
+      version = 2;
+      batches = [
+        {
+          version,
+          changes: [
+            {
+              key: "open-b",
+              previous: recomputedExtremumPrevious,
+              next: recomputedExtremumNext,
+            },
+          ],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: "1",
+          totalPrice: "5",
+        },
+        {
+          status: "closed",
+          maxPrice: 7,
+          rowCount: "1",
+          totalPrice: "7",
+        },
+        {
+          status: "open",
+          maxPrice: 15,
+          rowCount: "2",
+          totalPrice: "27",
+        },
+      ]);
+      expect(execution.latest().version).toBe(2);
+      expect(scanCount).toBe(1);
+      expect(fullEvaluationCount).toBe(0);
+      expect(patchedEvaluationCount).toBe(2);
+
+      const unchangedAggregatePrevious = order("open-b", "open", 12, 6, "emea");
+      const unchangedAggregateNext = order("open-b", "open", 12, 7, "emea");
+      rows.set("open-b", unchangedAggregateNext);
+      version = 3;
+      batches = [
+        {
+          version,
+          changes: [
+            {
+              key: "open-b",
+              previous: unchangedAggregatePrevious,
+              next: unchangedAggregateNext,
+            },
+          ],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: "1",
+          totalPrice: "5",
+        },
+        {
+          status: "closed",
+          maxPrice: 7,
+          rowCount: "1",
+          totalPrice: "7",
+        },
+        {
+          status: "open",
+          maxPrice: 15,
+          rowCount: "2",
+          totalPrice: "27",
+        },
+      ]);
+      expect(execution.latest().version).toBe(3);
+      expect(scanCount).toBe(1);
+      expect(fullEvaluationCount).toBe(0);
+      expect(patchedEvaluationCount).toBe(3);
+    }),
+  );
+
+  it.effect("keeps order-neutral grouped patches outside the visible window invisible", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const rows = new Map<string, object>([
+        ["cancelled", order("cancelled", "cancelled", 5, 1, "emea")],
+        ["open-a", order("open-a", "open", 10, 2, "emea")],
+        ["open-b", order("open-b", "open", 20, 3, "emea")],
+      ]);
+      let fullEvaluationCount = 0;
+      let patchedEvaluationCount = 0;
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            maxPrice: { aggFunc: "max", field: "price" },
+            rowCount: { aggFunc: "count" },
+            totalPrice: { aggFunc: "sum", field: "price" },
+          },
+          orderBy: [{ field: "status", direction: "asc" }],
+          limit: 1,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(
+        store,
+        compiled,
+        () => {},
+        defaultGroupedIncrementalAdmissionLimits,
+        {
+          onFullEvaluation: () => {
+            fullEvaluationCount += 1;
+          },
+          onPatchedEvaluation: () => {
+            patchedEvaluationCount += 1;
+          },
+        },
+      );
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: "1",
+          totalPrice: "5",
+        },
+      ]);
+
+      const previous = order("open-a", "open", 10, 2, "emea");
+      const next = order("open-a", "open", 15, 5, "emea");
+      rows.set("open-a", next);
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [{ key: "open-a", previous, next }],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: "1",
+          totalPrice: "5",
+        },
+      ]);
+      expect(execution.latest().version).toBe(1);
+      expect(scanCount).toBe(1);
+      expect(fullEvaluationCount).toBe(0);
+      expect(patchedEvaluationCount).toBe(1);
+    }),
+  );
+
+  it.effect("fully re-evaluates grouped windows when patched aggregates drive ordering", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let scanCount = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const rows = new Map<string, object>([
+        ["open", order("open", "open", 10, 1, "emea")],
+        ["closed", order("closed", "closed", 20, 2, "emea")],
+      ]);
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          scanCount += 1;
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      let fullEvaluationCount = 0;
+      let patchedEvaluationCount = 0;
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+            totalPrice: { aggFunc: "sum", field: "price" },
+          },
+          orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(
+        store,
+        compiled,
+        () => {},
+        defaultGroupedIncrementalAdmissionLimits,
+        {
+          onFullEvaluation: () => {
+            fullEvaluationCount += 1;
+          },
+          onPatchedEvaluation: () => {
+            patchedEvaluationCount += 1;
+          },
+        },
+      );
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "closed",
+          rowCount: "1",
+          totalPrice: "20",
+        },
+        {
+          status: "open",
+          rowCount: "1",
+          totalPrice: "10",
+        },
+      ]);
+
+      const previous = order("open", "open", 10, 1, "emea");
+      const next = order("open", "open", 30, 3, "emea");
+      rows.set("open", next);
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [{ key: "open", previous, next }],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "open",
+          rowCount: "1",
+          totalPrice: "30",
+        },
+        {
+          status: "closed",
+          rowCount: "1",
+          totalPrice: "20",
+        },
+      ]);
+      expect(scanCount).toBe(1);
+      expect(fullEvaluationCount).toBe(1);
+      expect(patchedEvaluationCount).toBe(0);
+    }),
+  );
+
   it.effect("tracks incremental zero-limit grouped counts without aggregate windows", () =>
     Effect.gen(function* () {
       let version = 0;
@@ -3936,6 +4308,122 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       health = yield* engine.health();
       expect(health.topics.orders.activeViews).toBe(0);
       expect(health.topics.orders.activeSubscriptions).toBe(0);
+    }),
+  );
+
+  it.effect("emits grouped deltas for order-neutral aggregate patches", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("cancelled", "cancelled", 5, 1, "emea"),
+        order("closed", "closed", 7, 2, "emea"),
+        order("open-a", "open", 10, 3, "emea"),
+        order("open-b", "open", 20, 4, "emea"),
+      ]);
+      const query = {
+        groupBy: ["status"],
+        aggregates: {
+          maxPrice: { aggFunc: "max", field: "price" },
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+        limit: 3,
+      } satisfies {
+        readonly groupBy: readonly ["status"];
+        readonly aggregates: {
+          readonly maxPrice: { readonly aggFunc: "max"; readonly field: "price" };
+          readonly rowCount: { readonly aggFunc: "count" };
+          readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+        };
+        readonly orderBy: readonly [{ readonly field: "status"; readonly direction: "asc" }];
+        readonly limit: 3;
+      };
+
+      const subscription = yield* engine.subscribe("orders", query);
+      const read = yield* makeEventReader(subscription);
+      const snapshot = firstEvent(yield* read(1));
+      expectSnapshotEvent(snapshot);
+      expect(snapshot.rows).toStrictEqual([
+        {
+          status: "cancelled",
+          maxPrice: 5,
+          rowCount: 1n,
+          totalPrice: fromStringUnsafe("5"),
+        },
+        {
+          status: "closed",
+          maxPrice: 7,
+          rowCount: 1n,
+          totalPrice: fromStringUnsafe("7"),
+        },
+        {
+          status: "open",
+          maxPrice: 20,
+          rowCount: 2n,
+          totalPrice: fromStringUnsafe("30"),
+        },
+      ]);
+      const openGroupKey = expectDefined(snapshot.keys[2]);
+      const queryId = snapshot.queryId;
+
+      yield* engine.patch("orders", "open-a", {
+        price: 15,
+        updatedAt: 5,
+      });
+      const visibleDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(visibleDelta);
+      expect(visibleDelta).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId,
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          {
+            type: "update",
+            key: openGroupKey,
+            row: {
+              status: "open",
+              maxPrice: 20,
+              rowCount: 2n,
+              totalPrice: fromStringUnsafe("35"),
+            },
+            index: 2,
+          },
+        ],
+        totalRows: 3,
+      });
+
+      yield* engine.patch("orders", "open-b", {
+        price: 12,
+        updatedAt: 6,
+      });
+      const extremumDelta = firstEvent(yield* read(1));
+      expectDeltaEvent(extremumDelta);
+      expect(extremumDelta).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId,
+        fromVersion: 2,
+        toVersion: 3,
+        operations: [
+          {
+            type: "update",
+            key: openGroupKey,
+            row: {
+              status: "open",
+              maxPrice: 15,
+              rowCount: 2n,
+              totalPrice: fromStringUnsafe("27"),
+            },
+            index: 2,
+          },
+        ],
+        totalRows: 3,
+      });
+
+      yield* subscription.close();
     }),
   );
 

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1597,6 +1597,17 @@ Interpretation notes:
 - Current incremental grouped write maintenance updates aggregate states reversibly for inserts,
   removals, same-group patches, and group moves. Count, count-distinct, sum, avg, min, and max are
   adjusted from the changed row instead of recomputing every dirty group from its member map.
+- Same-group patches whose changed aggregates are not used by grouped `orderBy` patch the current
+  materialized grouped evaluation in place. Visible dirty groups get fresh finalized aggregate rows;
+  dirty groups outside the visible window only advance the evaluation version. Group add/delete/move,
+  predicate enter/leave, and aggregate changes that affect grouped ordering still rebuild the grouped
+  window.
+- The default grouped-write benchmark keeps both a field-ordered grouped subscription and an
+  aggregate-ordered grouped subscription open. `grouped patch aggregate values` is therefore a mixed
+  signal: the field-ordered subscription can use the order-neutral evaluation patch, while the
+  aggregate-ordered subscription still rebuilds its grouped window. The diagnostics-backed grouped
+  correctness tests are the isolated regression guard for the order-neutral patch path until a
+  dedicated benchmark profile is added.
 - Retained `min`/`max` removals can invalidate the current extremum. The incremental executor batches
   those invalidations and recomputes each dirty `{group, aggregate}` once after the mutation batch,
   avoiding repeated retained-map scans when a single `publishMany` replaces or deletes many extrema.


### PR DESCRIPTION
## Summary
- Patch materialized grouped evaluations in place for same-group aggregate changes that do not drive grouped orderBy.
- Keep full grouped window re-evaluation for membership changes, group moves, predicate enter/leave, and aggregate changes used by grouped orderBy.
- Add diagnostics-backed regression tests for patched vs full evaluation, retained min/max recompute, invisible dirty groups, aggregate-order fallback, and live grouped delta emission.
- Document that the grouped-write benchmark remains a mixed signal until an isolated order-neutral profile exists.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run bench:baseline:smoke
- pnpm run ready
- 3 reviewer agents: No findings / No findings / No findings

## Notes
- The live subscription test intentionally covers visible grouped deltas only; invisible dirty groups are covered by direct diagnostics tests to avoid negative stream waits.