### PR TITLE
Harden live subscription terminal status delivery

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -5802,6 +5802,37 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect(
+    "delivers engine closed status when the subscription queue already contains a snapshot",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({
+          topics: viewServer.topics,
+          subscriptionQueueCapacity: 1,
+        });
+        yield* engine.publish("orders", order("a", "open", 10, 1));
+        const subscription = yield* engine.subscribe("orders", { select: ["id"] });
+
+        yield* engine.close();
+
+        const events = yield* collectEvents(subscription);
+        expect(events).toStrictEqual([
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "query-0",
+            status: "closed",
+            code: "SubscriptionClosed",
+            message: "Subscription closed because the engine closed.",
+          },
+        ]);
+        const health = yield* engine.health();
+        expect(health.topics["orders"].activeSubscriptions).toBe(0);
+        expect(health.topics["orders"].activeViews).toBe(0);
+        expect(health.activeSubscriptions).toBe(0);
+      }),
+  );
+
   it.effect("does not register subscriptions after a concurrent engine close", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();
@@ -10357,6 +10388,37 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(health.activeSubscriptions).toBe(0);
       expect(health.topics["orders"].activeViews).toBe(0);
     }),
+  );
+
+  it.effect(
+    "delivers reset closed status when the subscription queue already contains a snapshot",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({
+          topics: viewServer.topics,
+          subscriptionQueueCapacity: 1,
+        });
+        yield* engine.publish("orders", order("1", "open", 10, 1));
+        const subscription = yield* engine.subscribe("orders", { select: ["id"] });
+
+        yield* engine.reset();
+
+        const events = yield* collectEvents(subscription);
+        expect(events).toStrictEqual([
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "query-0",
+            status: "closed",
+            code: "SubscriptionClosed",
+            message: "Subscription closed because the engine reset.",
+          },
+        ]);
+        const health = yield* engine.health();
+        expect(health.version).toBe(0);
+        expect(health.activeSubscriptions).toBe(0);
+        expect(health.topics["orders"].activeViews).toBe(0);
+      }),
   );
 
   it.effect("rejects reset after the engine is closed", () =>

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -42,6 +42,23 @@ const backpressureStatusEvent = (
   message: "Subscription closed because its event queue exceeded capacity.",
 });
 
+const clearBufferedEvents = Effect.fn("ColumnLiveViewEngine.liveSubscription.clearBufferedEvents")(
+  function* <ResultRow extends RowObject>(
+    queue: Queue.Queue<LiveSubscriptionEvent<ResultRow>, Cause.Done>,
+  ) {
+    yield* Queue.clear(queue);
+  },
+);
+
+const offerTerminalStatusEvent = Effect.fn(
+  "ColumnLiveViewEngine.liveSubscription.offerTerminalStatus",
+)(function* <ResultRow extends RowObject>(
+  queue: Queue.Queue<LiveSubscriptionEvent<ResultRow>, Cause.Done>,
+  event: StatusEvent,
+) {
+  yield* Queue.offer(queue, event).pipe(Effect.asVoid);
+});
+
 const closeForBackpressure = Effect.fn(
   "ColumnLiveViewEngine.liveSubscription.closeForBackpressure",
 )(function* <ResultRow extends RowObject>(
@@ -53,8 +70,8 @@ const closeForBackpressure = Effect.fn(
   yield* Effect.uninterruptible(
     Effect.gen(function* () {
       yield* closeBackpressuredTopicStoreSubscription(store, subscriber, release);
-      yield* Queue.takeAll(queue).pipe(Effect.ignore);
-      yield* Queue.offer(queue, backpressureStatusEvent(store, subscriber)).pipe(Effect.ignore);
+      yield* clearBufferedEvents(queue);
+      yield* offerTerminalStatusEvent(queue, backpressureStatusEvent(store, subscriber));
       yield* Queue.end(queue);
     }),
   );
@@ -95,12 +112,9 @@ export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscrip
       closeWithStatus: (event) =>
         Effect.gen(function* () {
           subscriber.closed = true;
-          let drained = yield* Queue.poll(queue);
-          while (Option.isSome(drained)) {
-            drained = yield* Queue.poll(queue);
-          }
+          yield* clearBufferedEvents(queue);
           yield* releaseExecution;
-          yield* Queue.offer(queue, event).pipe(Effect.ignore);
+          yield* offerTerminalStatusEvent(queue, event);
           yield* Queue.end(queue);
         }),
       maxQueueDepth: 0,


### PR DESCRIPTION
## Summary
- replace ignored live-subscription queue drains with explicit `Queue.clear`
- make terminal status delivery explicit before ending close/reset/backpressure queues
- add e2e engine regressions for close/reset status delivery when the initial snapshot is still buffered

## Validation
- `pnpm --filter @view-server/column-live-view-engine run test -- src/index.test.ts`
- `vp check --fix`
- `pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity warning`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run ready`

## Review
- 3 reviewer agents: no findings
