### PR TITLE
Rename current topic storage implementation

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -22,7 +22,7 @@ import {
   type ColumnLiveViewEngineEvent,
   type ColumnLiveViewSubscription,
 } from "./index";
-import { ColumnarTopicStore } from "./columnar-topic-store";
+import { TopicRowStorage } from "./topic-row-storage";
 import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
@@ -6206,7 +6206,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
   it.effect("clears retained row-change journals on active execution clear and overflow", () =>
     Effect.gen(function* () {
-      const storage = new ColumnarTopicStore("orders", Order, "id");
+      const storage = new TopicRowStorage("orders", Order, "id");
       const compiled = yield* prepareGroupedQuery<object, object>(
         "orders",
         rawQueryCompilerMetadata(Order),
@@ -6278,7 +6278,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       storage.advanceVersion();
       expect(storage.readModel.changesSince(afterClearVersion)).toBeUndefined();
 
-      const fallbackStorage = new ColumnarTopicStore("orders", Order, "id");
+      const fallbackStorage = new TopicRowStorage("orders", Order, "id");
       fallbackStorage.setPreparedMany(
         Array.from({ length: 65_537 }, (_value, index) => ({
           key: `fallback-${index}`,
@@ -6296,7 +6296,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
   it.effect("releases retained row-change journals after grouped fallback demotion", () =>
     Effect.gen(function* () {
-      const storage = new ColumnarTopicStore("orders", Order, "id");
+      const storage = new TopicRowStorage("orders", Order, "id");
       const compiled = yield* prepareGroupedQuery<object, object>(
         "orders",
         rawQueryCompilerMetadata(Order),

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -32,7 +32,7 @@ import {
 
 type RowObject = object;
 
-export class ColumnarTopicStore {
+export class TopicRowStorage {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly readModel: ActiveQueryStoreState;
 
@@ -198,29 +198,24 @@ export class ColumnarTopicStore {
     return scanTopicRawWindow(this.rawWindowScanState, plan);
   }
 
-  prepareRow = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.row.prepare")(function* <
+  prepareRow = Effect.fn("ColumnLiveViewEngine.topicRowStorage.row.prepare")(function* <
     Error,
     Row extends RowObject,
-  >(this: ColumnarTopicStore, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
+  >(this: TopicRowStorage, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
     return yield* prepareTopicRow(this.rowPreparation, row, invalidRow);
   });
 
-  prepareRows = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.rows.prepare")(function* <
+  prepareRows = Effect.fn("ColumnLiveViewEngine.topicRowStorage.rows.prepare")(function* <
     Error,
     Row extends RowObject,
-  >(this: ColumnarTopicStore, rows: ReadonlyArray<Row>, invalidRow: InvalidRowErrorFactory<Error>) {
+  >(this: TopicRowStorage, rows: ReadonlyArray<Row>, invalidRow: InvalidRowErrorFactory<Error>) {
     return yield* Effect.forEach(rows, (row) => this.prepareRow(row, invalidRow));
   });
 
-  preparePatch = Effect.fn("ColumnLiveViewEngine.columnarTopicStore.patch.prepare")(function* <
+  preparePatch = Effect.fn("ColumnLiveViewEngine.topicRowStorage.patch.prepare")(function* <
     Patch extends Partial<RowObject>,
     Error,
-  >(
-    this: ColumnarTopicStore,
-    key: string,
-    patch: Patch,
-    invalidRow: InvalidRowErrorFactory<Error>,
-  ) {
+  >(this: TopicRowStorage, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
     return yield* prepareTopicPatch(
       this.rowPreparation,
       key,

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -1,5 +1,5 @@
 import { Clock, Effect, Semaphore } from "effect";
-import type { ColumnarTopicStore } from "./columnar-topic-store";
+import type { TopicRowStorage } from "./topic-row-storage";
 import type { InvalidRowErrorFactory, PreparedTopicRow } from "./topic-row-preparation";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
@@ -8,7 +8,7 @@ import { topicStoreState, type TopicStore } from "./topic-store-state";
 type RowObject = object;
 
 export type TopicStoreMutationState = {
-  readonly storage: ColumnarTopicStore;
+  readonly storage: TopicRowStorage;
   readonly subscribers: Set<LiveTopicSubscriber>;
   readonly mutationSemaphore: Semaphore.Semaphore;
   readonly notificationSemaphore: Semaphore.Semaphore;

--- a/packages/column-live-view-engine/src/topic-store-state.ts
+++ b/packages/column-live-view-engine/src/topic-store-state.ts
@@ -5,7 +5,7 @@ import {
   type ActiveQueryExecutionCounts,
   type ActiveQueryStoreState,
 } from "./active-query";
-import { ColumnarTopicStore } from "./columnar-topic-store";
+import { TopicRowStorage } from "./topic-row-storage";
 import { createTopicHealthLedger } from "./topic-health-ledger";
 import type { TopicStoreMutationState } from "./topic-store-mutation";
 import type { RawQueryCompilerMetadata } from "./raw-query-compiler";
@@ -37,7 +37,7 @@ export class TopicStore {
     keyField: string,
     onCommit: () => void,
   ) {
-    const storage = new ColumnarTopicStore(topic, schema, keyField);
+    const storage = new TopicRowStorage(topic, schema, keyField);
     const subscribers = new Set<LiveTopicSubscriber>();
     const state: TopicStoreState = {
       storage,

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -12,13 +12,18 @@ The main internal abstraction is:
 ColumnLiveViewEngine;
 ```
 
-The core per-topic store is:
+The core per-topic seam is the Topic Store Module:
 
 ```ts
-ColumnarTopicStore;
+TopicStore;
 ```
 
-One View Server topic is one logical table. The same authoritative in-memory columnar store serves:
+The current implementation behind that seam is `TopicRowStorage`: a row-oriented authoritative store
+with private column vectors and query indexes where they are already useful. A future
+`ColumnarTopicStore` implementation may replace that storage behind the same `TopicStore` seam when
+benchmarks prove the write/read tradeoff is better.
+
+One View Server topic is one logical table. The same authoritative in-memory Topic Store serves:
 
 - initial snapshots
 - live deltas
@@ -237,7 +242,7 @@ The hook must be fully type-safe from `defineViewServerConfig` without requiring
 - The real provider supplies that client through the WebSocket/Effect RPC transport adapter.
 - Both providers must exercise the same runtime core, query compiler, store, snapshot/delta, health, and lifecycle implementation. Only transport/ingress adapters differ.
 
-No mock query engine should exist. Browser tests should exercise the same query compiler, columnar store, snapshot logic, delta logic, and grouped accumulator as production.
+No mock query engine should exist. Browser tests should exercise the same query compiler, TopicStore, TopicRowStorage, snapshot logic, delta logic, and grouped accumulator as production.
 
 Because there is no external snapshot backend, browser-mode Vitest can run full View Server behavior in memory. Each in-memory provider instance owns fresh state by default.
 
@@ -753,7 +758,9 @@ Initial modules:
 
 ```txt
 ColumnLiveViewEngine
-  ColumnarTopicStore
+  TopicStore
+    TopicRowStorage
+    future ColumnarTopicStore implementation
   QueryCompiler
   RawSnapshotExecutor
   CountExecutor
@@ -762,7 +769,7 @@ ColumnLiveViewEngine
   ChangeStream
 ```
 
-`ColumnarTopicStore` should be schema-driven:
+The future `ColumnarTopicStore` implementation should be schema-driven:
 
 - numbers: `Float64Array`, `Int32Array`, or narrower typed arrays where safe
 - booleans: `Uint8Array`
@@ -1005,7 +1012,7 @@ Takeaway:
 
 - TypeScript typed arrays are credible for raw live views.
 - Rust/native is probably useful later for count/group/projection-heavy workloads.
-- The live engine should start with our own authoritative columnar store, not Mongo/Perspective/Polars as the primary runtime engine.
+- The live engine should start with our own authoritative TopicStore and TopicRowStorage implementation, not Mongo/Perspective/Polars as the primary runtime engine.
 
 ## Acceptance Criteria For The First Production Slice
 
@@ -1045,7 +1052,7 @@ apps/examples
 Responsibilities:
 
 - `packages/config`: `defineViewServerConfig`, query DSL types, schema/topic typing, shared public types.
-- `packages/column-live-view-engine`: in-memory columnar store, snapshot, subscribe, deltas, grouped aggregates, health core.
+- `packages/column-live-view-engine`: in-memory TopicStore/TopicRowStorage, snapshot, subscribe, deltas, grouped aggregates, health core.
 - `packages/runtime-core`: shared engine-backed runtime Module; owns the `ColumnLiveViewEngine`, runtime client, live client, pushed health streams, and lifecycle.
 - `packages/client`: transport-neutral live client contracts, query state, and remote client entrypoints.
 - `packages/protocol`: Effect RPC WebSocket wire schema and encode/decode boundary.


### PR DESCRIPTION
## Summary

- Renames the current internal storage implementation from `ColumnarTopicStore` to `TopicRowStorage`.
- Updates storage span labels from `columnarTopicStore` to `topicRowStorage`.
- Updates the v2 plan so current-state docs say `TopicStore` / `TopicRowStorage`, while reserving `ColumnarTopicStore` for a future implementation behind the same seam.

## Validation

- `vp check --fix`
- `pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity warning`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm run ready`
- Three-agent review pass: no blocking findings after the plan terminology cleanup.

## Notes

This is intentionally a naming/locality cleanup only. The storage remains internal and is not exported from the package root.
