### PR TITLE
Add explicit Kafka start policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -179,7 +179,7 @@ The typed function that transforms a source message, key, region, schema, and me
 _Avoid_: Serializer, mapper when it obscures the target Topic Row contract
 
 **Kafka Delivery Contract**:
-The operational guarantee for Kafka ingestion. During a live process, a message is committed only after the mapped Topic Row is published into the Runtime Core; success health is recorded after commit. Across process restarts, the in-memory Runtime Core has no durable row checkpoint yet, so committed consumer-group resume is not a full rebuild strategy by itself.
+The operational guarantee for Kafka ingestion. During a live process, a message is committed only after the mapped Topic Row is published into the Runtime Core; success health is recorded after commit. Kafka startup uses an explicit `startFrom` policy: `earliest`, `latest`, or a committed consumer group with fallback; health exposes the normalized consumer group, mode, and fallback mode actually used. Across process restarts, the in-memory Runtime Core has no durable row checkpoint yet, so committed consumer-group resume is not a full rebuild strategy by itself.
 _Avoid_: Exactly-once claim, durable recovery, database replication
 
 **Kafka Consumer Group Assumption**:

--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -688,6 +688,11 @@ describe("remote ViewServer client", () => {
       expect(server.healthRequests()).toBe(1);
       const refreshedHealth = health(0, 0);
       const ignoredKafka = {
+        startFrom: {
+          consumerGroupId: "view-server-test",
+          fallbackMode: "earliest",
+          mode: "committed",
+        },
         regions: {
           usa: {
             status: "connected",

--- a/packages/config/src/health-contract.ts
+++ b/packages/config/src/health-contract.ts
@@ -77,6 +77,23 @@ export type KafkaTopicHealth = {
   readonly regions: Record<string, KafkaTopicRegionHealth>;
 };
 
+export type KafkaStartFromHealth =
+  | {
+      readonly consumerGroupId: string;
+      readonly mode: "earliest";
+      readonly fallbackMode: "earliest";
+    }
+  | {
+      readonly consumerGroupId: string;
+      readonly mode: "latest";
+      readonly fallbackMode: "latest";
+    }
+  | {
+      readonly consumerGroupId: string;
+      readonly mode: "committed";
+      readonly fallbackMode: "earliest" | "latest" | "fail";
+    };
+
 export type TransportHealth = {
   readonly activeClients: number;
   readonly activeStreams: number;
@@ -101,6 +118,7 @@ export type ViewServerHealth<Topics extends object = Record<string, object>> = {
     };
   };
   readonly kafka?: {
+    readonly startFrom: KafkaStartFromHealth;
     readonly regions: Record<string, KafkaRegionHealth>;
     readonly topics: Record<string, KafkaTopicHealth>;
   };

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -28,6 +28,7 @@ import {
   type KafkaCodec,
   type KafkaMappingInput,
   type KafkaMessageMetadata,
+  type KafkaStartFromHealth,
   type KafkaCodecError,
   type KafkaCodecType,
   type KafkaDecodeError,
@@ -1771,6 +1772,55 @@ const runtimeTopicHealth = (
   memoryBytes: 0,
   tombstoneCount: 0,
   compactionPending: false,
+});
+
+const kafkaStartFromHealth = {
+  consumerGroupId: "view-server-test",
+  fallbackMode: "earliest",
+  mode: "committed",
+} as const;
+
+const kafkaLatestStartFromHealth = {
+  consumerGroupId: "view-server-latest",
+  fallbackMode: "latest",
+  mode: "latest",
+} satisfies KafkaStartFromHealth;
+
+const kafkaEarliestStartFromHealth = {
+  consumerGroupId: "view-server-earliest",
+  fallbackMode: "earliest",
+  mode: "earliest",
+} satisfies KafkaStartFromHealth;
+
+const kafkaCommittedFailStartFromHealth = {
+  consumerGroupId: "view-server-committed",
+  fallbackMode: "fail",
+  mode: "committed",
+} satisfies KafkaStartFromHealth;
+
+describe("Kafka health start policy", () => {
+  it("types only normalized start policy combinations", () => {
+    expectTypeOf<{
+      readonly consumerGroupId: "view-server-invalid-latest-fail";
+      readonly fallbackMode: "fail";
+      readonly mode: "latest";
+    }>().not.toMatchTypeOf<KafkaStartFromHealth>();
+    expect(kafkaLatestStartFromHealth).toStrictEqual({
+      consumerGroupId: "view-server-latest",
+      fallbackMode: "latest",
+      mode: "latest",
+    });
+    expect(kafkaEarliestStartFromHealth).toStrictEqual({
+      consumerGroupId: "view-server-earliest",
+      fallbackMode: "earliest",
+      mode: "earliest",
+    });
+    expect(kafkaCommittedFailStartFromHealth).toStrictEqual({
+      consumerGroupId: "view-server-committed",
+      fallbackMode: "fail",
+      mode: "committed",
+    });
+  });
 });
 
 type LiveQueryCall<Topics extends object> = {
@@ -4216,6 +4266,7 @@ describe("public type surface", () => {
         },
       },
       kafka: {
+        startFrom: kafkaStartFromHealth,
         regions: {
           usa: {
             status: "connected",
@@ -4326,6 +4377,7 @@ describe("public type surface", () => {
         },
       },
       kafka: {
+        startFrom: kafkaStartFromHealth,
         regions: {
           usa: {
             status: "connected",
@@ -5475,6 +5527,7 @@ const assertCompileTimeContracts = () => {
     websocketPort: 8080,
     kafka: {
       consumerGroupId: "view-server-type-test",
+      startFrom: "latest",
       regions: {
         usa: "broker-a:9092",
       },
@@ -5686,6 +5739,70 @@ const assertCompileTimeContracts = () => {
     websocketPort: 8080,
     kafka: {
       consumerGroupId: "view-server-type-test",
+      startFrom: {
+        committedConsumerGroup: "view-server-existing-group",
+        fallback: "fail",
+      },
+      regions: {
+        usa: "broker-a:9092",
+      },
+      topics: {},
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    kafka: {
+      consumerGroupId: "view-server-type-test",
+      // @ts-expect-error committed Kafka start config requires committedConsumerGroup.
+      startFrom: {
+        fallback: "earliest",
+      },
+      regions: {
+        usa: "broker-a:9092",
+      },
+      topics: {},
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    kafka: {
+      consumerGroupId: "view-server-type-test",
+      // @ts-expect-error runtime Kafka startFrom only accepts earliest, latest, or committed group config.
+      startFrom: "middle",
+      regions: {
+        usa: "broker-a:9092",
+      },
+      topics: {},
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    kafka: {
+      consumerGroupId: "view-server-type-test",
+      startFrom: {
+        committedConsumerGroup: "view-server-existing-group",
+        // @ts-expect-error committed Kafka start fallback must be earliest, latest, or fail.
+        fallback: "middle",
+      },
+      regions: {
+        usa: "broker-a:9092",
+      },
+      topics: {},
+    },
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    kafka: {
+      consumerGroupId: "view-server-type-test",
+      startFrom: {
+        committedConsumerGroup: "view-server-existing-group",
+        // @ts-expect-error committed Kafka start config rejects unknown keys.
+        committedConsumerGroupId: "view-server-typo",
+      },
       regions: {
         usa: "broker-a:9092",
       },

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -55,6 +55,7 @@ export type {
 export type {
   KafkaRegionHealth,
   KafkaRegionStatus,
+  KafkaStartFromHealth,
   KafkaTopicHealth,
   KafkaTopicRegionHealth,
   KafkaTopicStatus,
@@ -135,6 +136,8 @@ export type {
   RuntimeRegions,
   RuntimeValue,
   ValidateRuntimeOptions,
+  ViewServerKafkaCommittedStartFrom,
+  ViewServerKafkaStartFrom,
 } from "./kafka-contract";
 
 type ViewServerConfigTopicShape = Record<

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -1314,6 +1314,13 @@ type ValidateKafkaTopics<
   >;
 };
 
+export type ViewServerKafkaCommittedStartFrom = {
+  readonly committedConsumerGroup: string;
+  readonly fallback?: "earliest" | "latest" | "fail";
+};
+
+export type ViewServerKafkaStartFrom = "earliest" | "latest" | ViewServerKafkaCommittedStartFrom;
+
 export type RuntimeOptions<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
@@ -1322,6 +1329,7 @@ export type RuntimeOptions<
   readonly websocketPort: RuntimeValue<number>;
   readonly kafka: {
     readonly consumerGroupId: string;
+    readonly startFrom?: ViewServerKafkaStartFrom;
     readonly regions: Regions;
     readonly topics: ValidateKafkaTopics<Topics, Regions, KafkaTopics>;
   };
@@ -1331,6 +1339,7 @@ export type RuntimeOptionsCandidate = {
   readonly websocketPort: RuntimeValue<number>;
   readonly kafka: {
     readonly consumerGroupId: string;
+    readonly startFrom?: ViewServerKafkaStartFrom;
     readonly regions: RuntimeRegions;
     readonly topics: Record<string, object>;
   };
@@ -1360,10 +1369,26 @@ type RejectExtraRuntimeKafkaKeys<Options, Shape> = Options extends {
     : unknown
   : unknown;
 
+type RejectExtraRuntimeKafkaStartFromKeys<Options> = Options extends {
+  readonly kafka: {
+    readonly startFrom: infer CandidateStartFrom;
+  };
+}
+  ? CandidateStartFrom extends object
+    ? {
+        readonly kafka: {
+          readonly startFrom: CandidateStartFrom &
+            RejectExtraKeys<CandidateStartFrom, ViewServerKafkaCommittedStartFrom>;
+        };
+      }
+    : unknown
+  : unknown;
+
 export type ExactRuntimeOptions<Topics extends KafkaTopicSchemaRegistry, Options> = Options &
   ValidateRuntimeOptions<Topics, Options> &
   RejectExtraKeys<Options, ValidateRuntimeOptions<Topics, Options>> &
-  RejectExtraRuntimeKafkaKeys<Options, ValidateRuntimeOptions<Topics, Options>>;
+  RejectExtraRuntimeKafkaKeys<Options, ValidateRuntimeOptions<Topics, Options>> &
+  RejectExtraRuntimeKafkaStartFromKeys<Options>;
 
 export type KafkaTopicHelper<Topics extends KafkaTopicSchemaRegistry> = <
   const Regions extends RuntimeRegions,

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -103,6 +103,12 @@ const topicHealth = {
   compactionPending: false,
 } as const;
 
+const kafkaStartFromHealth = {
+  consumerGroupId: "view-server-test",
+  fallbackMode: "latest",
+  mode: "latest",
+} as const;
+
 const wireHealth = {
   status: "ready",
   version: 1,
@@ -262,6 +268,7 @@ describe("@view-server/protocol", () => {
           },
         },
         kafka: {
+          startFrom: kafkaStartFromHealth,
           regions: {},
           topics: {
             orders: {
@@ -308,9 +315,26 @@ describe("@view-server/protocol", () => {
         2,
       );
       const encodedLagHealth = yield* Schema.encodeUnknownEffect(ViewServerHealthSchema)(lagHealth);
+      expect(lagHealth.kafka?.startFrom).toStrictEqual(kafkaStartFromHealth);
       expect(encodedLagHealth.kafka?.topics["orders"]?.regions["usa"]?.consumerLagMessages).toBe(
         largeLag.toString(),
       );
+      expect(encodedLagHealth.kafka?.startFrom).toStrictEqual(kafkaStartFromHealth);
+      const impossibleKafkaStartFromHealth = yield* Effect.flip(
+        Schema.decodeUnknownEffect(ViewServerHealthSchema)({
+          ...wireHealth,
+          kafka: {
+            startFrom: {
+              consumerGroupId: "view-server-invalid-latest-fail",
+              fallbackMode: "fail",
+              mode: "latest",
+            },
+            regions: {},
+            topics: {},
+          },
+        }),
+      );
+      expect(String(impossibleKafkaStartFromHealth)).toContain("fallbackMode");
 
       const snapshot = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)({
         type: "snapshot",
@@ -2514,6 +2538,7 @@ describe("@view-server/protocol", () => {
       const validKafkaViewServerTopic = yield* viewServerDecodeHealth(viewServer, {
         ...wireHealth,
         kafka: {
+          startFrom: kafkaStartFromHealth,
           regions: {},
           topics: {
             ordersSource: {
@@ -2533,6 +2558,7 @@ describe("@view-server/protocol", () => {
         viewServerDecodeHealth(viewServer, {
           ...wireHealth,
           kafka: {
+            startFrom: kafkaStartFromHealth,
             regions: {},
             topics: {
               ordersSource: {

--- a/packages/protocol/src/protocol-health-schema.ts
+++ b/packages/protocol/src/protocol-health-schema.ts
@@ -1,4 +1,5 @@
 import type {
+  KafkaStartFromHealth,
   TopicRuntimeHealth,
   TransportHealth,
   ViewServerHealthSummaryRow,
@@ -46,6 +47,24 @@ const TransportHealthSchema: Schema.Codec<TransportHealth> = Schema.Struct({
   lastError: StringOrNull,
 });
 
+const KafkaStartFromHealthSchema: Schema.Codec<KafkaStartFromHealth> = Schema.Union([
+  Schema.Struct({
+    consumerGroupId: Schema.String,
+    mode: Schema.Literal("earliest"),
+    fallbackMode: Schema.Literal("earliest"),
+  }),
+  Schema.Struct({
+    consumerGroupId: Schema.String,
+    mode: Schema.Literal("latest"),
+    fallbackMode: Schema.Literal("latest"),
+  }),
+  Schema.Struct({
+    consumerGroupId: Schema.String,
+    mode: Schema.Literal("committed"),
+    fallbackMode: Schema.Literals(["earliest", "latest", "fail"]),
+  }),
+]);
+
 export const ViewServerHealthSchema = Schema.Struct({
   status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
   version: Schema.Number,
@@ -55,6 +74,7 @@ export const ViewServerHealthSchema = Schema.Struct({
   }),
   kafka: Schema.optionalKey(
     Schema.Struct({
+      startFrom: KafkaStartFromHealthSchema,
       regions: Schema.Record(
         Schema.String,
         Schema.Struct({

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -463,6 +463,11 @@ describe("@view-server/runtime-core", () => {
           ...health,
           status: "degraded",
           kafka: {
+            startFrom: {
+              consumerGroupId: "view-server-test",
+              fallbackMode: "earliest",
+              mode: "committed",
+            },
             regions: {
               local: {
                 status: "connected",

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -153,6 +153,117 @@ describe("runtime type contracts", () => {
       kafka: {
         consumerGroupId: "view-server-type-test",
         regions: usaKafkaRegions,
+        startFrom: "latest",
+        topics: {
+          orders: usaKafkaTopic({
+            regions: ["usa"],
+            value: kafka.json(Order),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              price: value.price,
+            }),
+          }),
+        },
+      },
+    });
+    const runtimeWithCommittedKafkaStart = makeViewServerRuntime(viewServer, {
+      kafka: {
+        consumerGroupId: "view-server-type-test",
+        regions: usaKafkaRegions,
+        startFrom: {
+          committedConsumerGroup: "view-server-existing-group",
+          fallback: "fail",
+        },
+        topics: {
+          orders: usaKafkaTopic({
+            regions: ["usa"],
+            value: kafka.json(Order),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              price: value.price,
+            }),
+          }),
+        },
+      },
+    });
+    const invalidKafkaStartFrom = makeViewServerRuntime(viewServer, {
+      kafka: {
+        consumerGroupId: "view-server-type-test",
+        regions: usaKafkaRegions,
+        // @ts-expect-error runtime Kafka startFrom only accepts earliest, latest, or committed group config.
+        startFrom: "middle",
+        topics: {
+          orders: usaKafkaTopic({
+            regions: ["usa"],
+            value: kafka.json(Order),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              price: value.price,
+            }),
+          }),
+        },
+      },
+    });
+    const invalidCommittedKafkaStartFallback = makeViewServerRuntime(viewServer, {
+      kafka: {
+        consumerGroupId: "view-server-type-test",
+        regions: usaKafkaRegions,
+        startFrom: {
+          committedConsumerGroup: "view-server-existing-group",
+          // @ts-expect-error committed Kafka start fallback must be earliest, latest, or fail.
+          fallback: "middle",
+        },
+        topics: {
+          orders: usaKafkaTopic({
+            regions: ["usa"],
+            value: kafka.json(Order),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              price: value.price,
+            }),
+          }),
+        },
+      },
+    });
+    const invalidCommittedKafkaStartMissingGroup = makeViewServerRuntime(viewServer, {
+      kafka: {
+        consumerGroupId: "view-server-type-test",
+        regions: usaKafkaRegions,
+        // @ts-expect-error committed Kafka start config requires committedConsumerGroup.
+        startFrom: {
+          fallback: "earliest",
+        },
+        topics: {
+          orders: usaKafkaTopic({
+            regions: ["usa"],
+            value: kafka.json(Order),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              price: value.price,
+            }),
+          }),
+        },
+      },
+    });
+    const invalidCommittedKafkaStartKey = makeViewServerRuntime(viewServer, {
+      kafka: {
+        consumerGroupId: "view-server-type-test",
+        regions: usaKafkaRegions,
+        startFrom: {
+          committedConsumerGroup: "view-server-existing-group",
+          // @ts-expect-error committed Kafka start config rejects unknown keys.
+          committedConsumerGroupId: "view-server-typo",
+        },
         topics: {
           orders: usaKafkaTopic({
             regions: ["usa"],
@@ -230,6 +341,13 @@ describe("runtime type contracts", () => {
     expectTypeOf<Effect.Success<typeof runtimeWithKafka>>().toMatchTypeOf<
       ViewServerRuntime<typeof viewServer.topics>
     >();
+    expectTypeOf<Effect.Success<typeof runtimeWithCommittedKafkaStart>>().toMatchTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>
+    >();
+    expectTypeOf(invalidKafkaStartFrom).not.toBeAny();
+    expectTypeOf(invalidCommittedKafkaStartFallback).not.toBeAny();
+    expectTypeOf(invalidCommittedKafkaStartMissingGroup).not.toBeAny();
+    expectTypeOf(invalidCommittedKafkaStartKey).not.toBeAny();
     expectTypeOf(invalidKafkaOptionKey).not.toBeAny();
     expectTypeOf(invalidMissingKafkaConsumerGroup).not.toBeAny();
     expectTypeOf(invalidKafkaRegionRuntime).not.toBeAny();

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -12,7 +12,10 @@ import {
 } from "./internal";
 import { makeViewServerRuntime, runViewServerRuntime } from "./index";
 import { ViewServerKafkaIngressError } from "./kafka-ingress";
-import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
+import {
+  resolveViewServerRuntimeOptions,
+  type ResolvedViewServerKafkaRuntimeOptions,
+} from "./runtime-options";
 import { makeViewServerRuntimeTransportHealth } from "./transport-health";
 
 const Order = Schema.Struct({
@@ -380,8 +383,10 @@ describe("@view-server/runtime", () => {
       });
 
       expect({
+        consume: kafkaOptions?.consume,
         consumerGroupId: kafkaOptions?.consumerGroupId,
         regions: kafkaOptions?.regions,
+        startFrom: kafkaOptions?.startFrom,
         topics: Object.fromEntries(
           Object.entries(kafkaOptions?.topics ?? {}).map(([sourceTopic, topic]) => [
             sourceTopic,
@@ -392,8 +397,16 @@ describe("@view-server/runtime", () => {
           ]),
         ),
       }).toStrictEqual({
+        consume: {
+          consumerGroupId: "view-server-test-runtime",
+          fallbackMode: "earliest",
+          mode: "committed",
+        },
         consumerGroupId: "view-server-test-runtime",
         regions: nullRecord([["local", "localhost:9092"]]),
+        startFrom: {
+          committedConsumerGroup: "view-server-test-runtime",
+        },
         topics: {
           "orders-source": {
             regions: ["local"],
@@ -403,6 +416,93 @@ describe("@view-server/runtime", () => {
       });
 
       yield* runtime.close;
+    }),
+  );
+
+  it.effect("resolves explicit Kafka start policies", () =>
+    Effect.gen(function* () {
+      const regions = {
+        local: "localhost:9092",
+      };
+      const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
+      const topics = {
+        "orders-source": localKafkaTopic({
+          regions: ["local"],
+          value: kafka.json(Order),
+          key: kafka.stringKey(),
+          viewServerTopic: "orders",
+          mapping: ({ key, value }) => ({
+            id: key,
+            price: value.price,
+          }),
+        }),
+      };
+
+      const earliest = yield* resolveViewServerRuntimeOptions({
+        kafka: {
+          consumerGroupId: "view-server-earliest",
+          regions,
+          startFrom: "earliest",
+          topics,
+        },
+      });
+      const latest = yield* resolveViewServerRuntimeOptions({
+        kafka: {
+          consumerGroupId: "view-server-latest",
+          regions,
+          startFrom: "latest",
+          topics,
+        },
+      });
+      const committed = yield* resolveViewServerRuntimeOptions({
+        kafka: {
+          consumerGroupId: "view-server-default",
+          regions,
+          startFrom: {
+            committedConsumerGroup: "view-server-existing-group",
+            fallback: "fail",
+          },
+          topics,
+        },
+      });
+      const committedWithDefaultFallback = yield* resolveViewServerRuntimeOptions({
+        kafka: {
+          consumerGroupId: "view-server-default-fallback",
+          regions,
+          startFrom: {
+            committedConsumerGroup: "view-server-existing-default-fallback-group",
+          },
+          topics,
+        },
+      });
+
+      expect({
+        committed: committed.kafkaOptions?.consume,
+        committedWithDefaultFallback: committedWithDefaultFallback.kafkaOptions?.consume,
+        earliest: earliest.kafkaOptions?.consume,
+        latest: latest.kafkaOptions?.consume,
+      }).toStrictEqual({
+        committed: {
+          consumerGroupId: "view-server-existing-group",
+          fallbackMode: "fail",
+          mode: "committed",
+        },
+        committedWithDefaultFallback: {
+          consumerGroupId: "view-server-existing-default-fallback-group",
+          fallbackMode: "earliest",
+          mode: "committed",
+        },
+        earliest: {
+          consumerGroupId: "view-server-earliest",
+          fallbackMode: "earliest",
+          mode: "earliest",
+        },
+        latest: {
+          consumerGroupId: "view-server-latest",
+          fallbackMode: "latest",
+          mode: "latest",
+        },
+      });
     }),
   );
 

--- a/packages/runtime/src/kafka-health.ts
+++ b/packages/runtime/src/kafka-health.ts
@@ -1,5 +1,6 @@
 import type {
   KafkaRegionHealth,
+  KafkaStartFromHealth,
   KafkaTopicHealth,
   KafkaTopicRegionHealth,
   ViewServerHealth,
@@ -256,6 +257,7 @@ const mergeRuntimeStatus = <Topics extends ViewServerRuntimeTopicDefinitions>(
 export const makeViewServerKafkaHealthLedger = <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(input: {
+  readonly startFrom: KafkaStartFromHealth;
   readonly regions: Readonly<Record<string, string>>;
   readonly topics: Readonly<
     Record<
@@ -324,6 +326,7 @@ export const makeViewServerKafkaHealthLedger = <
     }
 
     return {
+      startFrom: input.startFrom,
       regions: regionHealth,
       topics: topicHealth,
     };

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -10,7 +10,7 @@ import {
 import { makeViewServerRuntimeCore } from "@view-server/runtime-core";
 import { Buffer } from "node:buffer";
 import { Cause, Deferred, Effect, Exit, Fiber, Logger, References, Schema, Scope } from "effect";
-import { makeViewServerKafkaHealthLedger } from "./kafka-health";
+import { makeViewServerKafkaHealthLedger as makeViewServerKafkaHealthLedgerBase } from "./kafka-health";
 import type { ViewServerKafkaHealthLedger } from "./kafka-health";
 import {
   assignedPartitionsForSourceTopic,
@@ -50,6 +50,7 @@ import type {
   ViewServerKafkaIngressError,
 } from "./kafka-ingress";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -113,8 +114,22 @@ const forgedMappingTagCodecError: {
   message: "forged mapping tag",
 };
 
+const committedKafkaStart = (
+  consumerGroupId: string,
+): Pick<ResolvedViewServerKafkaRuntimeOptions<Topics>, "consume" | "startFrom"> => ({
+  consume: {
+    consumerGroupId,
+    fallbackMode: "earliest",
+    mode: "committed",
+  },
+  startFrom: {
+    committedConsumerGroup: consumerGroupId,
+  },
+});
+
 const kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
   consumerGroupId: "view-server-test",
+  ...committedKafkaStart("view-server-test"),
   regions,
   topics: {
     [ordersSourceTopic]: localKafkaTopic({
@@ -130,6 +145,21 @@ const kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
     }),
   },
 };
+
+type KafkaHealthLedgerInput<LedgerTopics extends ViewServerRuntimeTopicDefinitions> = Parameters<
+  typeof makeViewServerKafkaHealthLedgerBase<LedgerTopics>
+>[0];
+
+const makeViewServerKafkaHealthLedger = <
+  const LedgerTopics extends ViewServerRuntimeTopicDefinitions,
+>(
+  input: Omit<KafkaHealthLedgerInput<LedgerTopics>, "startFrom"> &
+    Partial<Pick<KafkaHealthLedgerInput<LedgerTopics>, "startFrom">>,
+): ViewServerKafkaHealthLedger<LedgerTopics> =>
+  makeViewServerKafkaHealthLedgerBase<LedgerTopics>({
+    startFrom: kafkaOptions.consume,
+    ...input,
+  });
 
 const nullRecord = <Value>(entries: Record<string, Value>): Record<string, Value> => {
   const record: Record<string, Value> = Object.create(null);
@@ -993,6 +1023,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       }).toStrictEqual({
         status: "degraded",
         kafka: {
+          startFrom: kafkaOptions.consume,
           regions: nullRecord({
             local: {
               status: "disconnected",
@@ -1048,6 +1079,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         3_000,
       );
       expect(splitRegionHealth.kafka).toStrictEqual({
+        startFrom: kafkaOptions.consume,
         regions: nullRecord({
           cold: {
             status: "starting",
@@ -1536,6 +1568,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         ready: {
           status: "ready",
           kafka: {
+            startFrom: kafkaOptions.consume,
             regions: nullRecord({
               local: {
                 status: "connected",
@@ -1574,6 +1607,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         starting: {
           status: "starting",
           kafka: {
+            startFrom: kafkaOptions.consume,
             regions: nullRecord({
               cold: {
                 status: "starting",
@@ -2049,6 +2083,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       }).toStrictEqual({
         status: "degraded",
         kafka: {
+          startFrom: kafkaOptions.consume,
           regions: nullRecord({
             local: {
               status: "disconnected",
@@ -2302,12 +2337,14 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
       const emptyKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
         consumerGroupId: "view-server-empty-test",
+        ...committedKafkaStart("view-server-empty-test"),
         regions: {
           cold: "localhost:9093",
         },
         topics: {},
       };
       const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        startFrom: emptyKafkaOptions.consume,
         regions: emptyKafkaOptions.regions,
         topics: {},
       });
@@ -2324,6 +2361,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
 
       expect(health.status).toBe("ready");
       expect(health.kafka).toStrictEqual({
+        startFrom: emptyKafkaOptions.consume,
         regions: nullRecord({}),
         topics: nullRecord({}),
       });
@@ -2400,6 +2438,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         true,
       );
       expect(health.kafka).toStrictEqual({
+        startFrom: kafkaOptions.consume,
         regions: expectedRegions,
         topics: expectedTopics,
       });
@@ -2496,6 +2535,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
       const invalidKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
         consumerGroupId: "view-server-invalid-broker-test",
+        ...committedKafkaStart("view-server-invalid-broker-test"),
         regions: {
           local: "",
         },
@@ -2514,6 +2554,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         },
       };
       const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        startFrom: invalidKafkaOptions.consume,
         regions: invalidKafkaOptions.regions,
         topics: {
           [ordersSourceTopic]: {
@@ -2692,17 +2733,9 @@ describe("@view-server/runtime Kafka ingress internals", () => {
   it.effect("records mapping failures separately from decode failures", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
-      const ledger = makeViewServerKafkaHealthLedger<Topics>({
-        regions: kafkaOptions.regions,
-        topics: {
-          [ordersSourceTopic]: {
-            regions: ["local"],
-            viewServerTopic: "orders",
-          },
-        },
-      });
       const throwingKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
         consumerGroupId: "view-server-mapping-failure-test",
+        ...committedKafkaStart("view-server-mapping-failure-test"),
         regions,
         topics: {
           [ordersSourceTopic]: localKafkaTopic({
@@ -2716,6 +2749,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           }),
         },
       };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        startFrom: throwingKafkaOptions.consume,
+        regions: throwingKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
       let healthRefreshRequestCount = 0;
@@ -2793,17 +2836,9 @@ describe("@view-server/runtime Kafka ingress internals", () => {
   it.effect("records untagged codec failures as decode failures", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
-      const ledger = makeViewServerKafkaHealthLedger<Topics>({
-        regions: kafkaOptions.regions,
-        topics: {
-          [ordersSourceTopic]: {
-            regions: ["local"],
-            viewServerTopic: "orders",
-          },
-        },
-      });
       const untaggedDecodeKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
         consumerGroupId: "view-server-untagged-decode-failure-test",
+        ...committedKafkaStart("view-server-untagged-decode-failure-test"),
         regions,
         topics: {
           [ordersSourceTopic]: localKafkaTopic({
@@ -2822,6 +2857,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           }),
         },
       };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        startFrom: untaggedDecodeKafkaOptions.consume,
+        regions: untaggedDecodeKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
 
@@ -2883,17 +2928,9 @@ describe("@view-server/runtime Kafka ingress internals", () => {
   it.effect("does not classify custom codec errors as mapping failures by public tag alone", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
-      const ledger = makeViewServerKafkaHealthLedger<Topics>({
-        regions: kafkaOptions.regions,
-        topics: {
-          [ordersSourceTopic]: {
-            regions: ["local"],
-            viewServerTopic: "orders",
-          },
-        },
-      });
       const forgedMappingTagKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
         consumerGroupId: "view-server-forged-mapping-tag-test",
+        ...committedKafkaStart("view-server-forged-mapping-tag-test"),
         regions,
         topics: {
           [ordersSourceTopic]: localKafkaTopic({
@@ -2912,6 +2949,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           }),
         },
       };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        startFrom: forgedMappingTagKafkaOptions.consume,
+        regions: forgedMappingTagKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
 
@@ -2979,17 +3026,9 @@ describe("@view-server/runtime Kafka ingress internals", () => {
   it.effect("records primitive codec failures as decode failures", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
-      const ledger = makeViewServerKafkaHealthLedger<Topics>({
-        regions: kafkaOptions.regions,
-        topics: {
-          [ordersSourceTopic]: {
-            regions: ["local"],
-            viewServerTopic: "orders",
-          },
-        },
-      });
       const primitiveDecodeKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
         consumerGroupId: "view-server-primitive-decode-failure-test",
+        ...committedKafkaStart("view-server-primitive-decode-failure-test"),
         regions,
         topics: {
           [ordersSourceTopic]: localKafkaTopic({
@@ -3008,6 +3047,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
           }),
         },
       };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        startFrom: primitiveDecodeKafkaOptions.consume,
+        regions: primitiveDecodeKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
 

--- a/packages/runtime/src/kafka-ingress.test.ts
+++ b/packages/runtime/src/kafka-ingress.test.ts
@@ -289,6 +289,11 @@ describe("@view-server/runtime Kafka ingress", () => {
                   trades: 1,
                 },
                 kafka: {
+                  startFrom: {
+                    consumerGroupId,
+                    fallbackMode: "earliest",
+                    mode: "committed",
+                  },
                   regions: nullRecord({
                     local: {
                       status: "connected",

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -347,13 +347,13 @@ const makeKafkaConsumer = Effect.fn("ViewServerRuntime.kafka.consumer.make")(fun
   region: string,
   brokers: string,
   topics: ReadonlyArray<string>,
-  consumerGroupId: string,
+  consume: ResolvedViewServerKafkaRuntimeOptions<ViewServerRuntimeTopicDefinitions>["consume"],
 ) {
   const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
     autocreateTopics: false,
     bootstrapBrokers: [...bootstrapBrokers(brokers)],
     clientId: `view-server-${region}`,
-    groupId: consumerGroupId,
+    groupId: consume.consumerGroupId,
     retries: true,
   });
   const stream = yield* closeKafkaConsumerOnStartFailure(
@@ -362,8 +362,8 @@ const makeKafkaConsumer = Effect.fn("ViewServerRuntime.kafka.consumer.make")(fun
       try: () =>
         consumer.consume({
           autocommit: false,
-          fallbackMode: "earliest",
-          mode: "committed",
+          fallbackMode: consume.fallbackMode,
+          mode: consume.mode,
           topics: [...topics],
         }),
       catch: mapKafkaConsumerStartError(region),
@@ -767,12 +767,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
   topics: ReadonlyArray<string>,
   scope: Scope.Scope,
 ) {
-  const { consumer, stream } = yield* makeKafkaConsumer(
-    region,
-    brokers,
-    topics,
-    options.consumerGroupId,
-  );
+  const { consumer, stream } = yield* makeKafkaConsumer(region, brokers, topics, options.consume);
   let healthListeners: KafkaConsumerHealthListenerRegistration | null = null;
   const resources: StartedKafkaConsumerResources = {
     consumer,

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -51,6 +51,7 @@ export const makeDefaultRuntimeDependencies = <
   makeServer: makeViewServerWebSocketServer,
   makeKafkaHealthLedger: (_config, options) =>
     makeViewServerKafkaHealthLedger({
+      startFrom: options.consume,
       regions: options.regions,
       topics: Object.fromEntries(
         Object.entries(options.topics).map(([sourceTopic, topic]) => [

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -1,6 +1,11 @@
 import type { ViewServerRuntimeCoreOptionsFor } from "@view-server/runtime-core";
 import type { ViewServerWebSocketServerOptions } from "@view-server/server";
-import type { RuntimeRegions, RuntimeValue } from "@view-server/config";
+import type {
+  KafkaStartFromHealth,
+  RuntimeRegions,
+  RuntimeValue,
+  ViewServerKafkaStartFrom,
+} from "@view-server/config";
 import { Config, Effect } from "effect";
 import type {
   ViewServerKafkaRuntimeOptions,
@@ -22,12 +27,43 @@ export type ResolvedViewServerKafkaRuntimeOptions<
   Regions extends RuntimeRegions = RuntimeRegions,
 > = {
   readonly consumerGroupId: string;
+  readonly startFrom: ViewServerKafkaStartFrom;
+  readonly consume: KafkaStartFromHealth;
   readonly regions: Record<string, string>;
   readonly topics: ViewServerKafkaRuntimeOptions<Topics, Regions>["topics"];
 };
 
 const resolveRuntimeValue = <A>(value: RuntimeValue<A>): Effect.Effect<A, Config.ConfigError> =>
   Config.isConfig(value) ? value : Effect.succeed(value);
+
+const defaultKafkaStartFrom = (consumerGroupId: string): ViewServerKafkaStartFrom => ({
+  committedConsumerGroup: consumerGroupId,
+});
+
+const normalizeKafkaConsumePolicy = (
+  consumerGroupId: string,
+  startFrom: ViewServerKafkaStartFrom,
+): ResolvedViewServerKafkaRuntimeOptions<ViewServerRuntimeTopicDefinitions>["consume"] => {
+  if (startFrom === "earliest") {
+    return {
+      consumerGroupId,
+      fallbackMode: "earliest",
+      mode: "earliest",
+    };
+  }
+  if (startFrom === "latest") {
+    return {
+      consumerGroupId,
+      fallbackMode: "latest",
+      mode: "latest",
+    };
+  }
+  return {
+    consumerGroupId: startFrom.committedConsumerGroup,
+    fallbackMode: startFrom.fallback ?? "earliest",
+    mode: "committed",
+  };
+};
 
 const resolveKafkaOptions: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
@@ -46,9 +82,12 @@ const resolveKafkaOptions: <
     for (const [region, bootstrap] of entries) {
       regions[region] = bootstrap;
     }
+    const startFrom = options.startFrom ?? defaultKafkaStartFrom(options.consumerGroupId);
     return {
       consumerGroupId: options.consumerGroupId,
+      consume: normalizeKafkaConsumePolicy(options.consumerGroupId, startFrom),
       regions,
+      startFrom,
       topics: options.topics,
     };
   });

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -6,6 +6,7 @@ import type {
   RowSchema,
   TopicDefinitions,
   ViewServerHealth,
+  ViewServerKafkaStartFrom,
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@view-server/config";
@@ -27,6 +28,7 @@ export type ViewServerKafkaRuntimeOptions<
   Regions extends RuntimeRegions = RuntimeRegions,
 > = {
   readonly consumerGroupId: string;
+  readonly startFrom?: ViewServerKafkaStartFrom;
   readonly regions: Regions;
   readonly topics: Record<string, KafkaRuntimeTopicDefinition<Topics, Regions>>;
 };
@@ -83,13 +85,29 @@ type RuntimeKafkaRegionConstraint<
     }
   : unknown;
 
+type RuntimeKafkaStartFromExactKeysConstraint<Options> = Options extends {
+  readonly kafka: {
+    readonly startFrom: infer CandidateStartFrom;
+  };
+}
+  ? CandidateStartFrom extends object
+    ? {
+        readonly kafka: {
+          readonly startFrom: CandidateStartFrom &
+            RejectExtraKeys<CandidateStartFrom, Extract<ViewServerKafkaStartFrom, object>>;
+        };
+      }
+    : unknown
+  : unknown;
+
 export type ViewServerRuntimeOptionsInput<
   Topics extends ViewServerRuntimeTopicDefinitions,
   Options extends ViewServerRuntimeOptions<Topics> = ViewServerRuntimeOptions<Topics>,
 > = Options &
   RejectExtraKeys<Options, ViewServerRuntimeOptions<Topics>> &
   RuntimeKafkaExactKeysConstraint<Options> &
-  RuntimeKafkaRegionConstraint<Topics, Options>;
+  RuntimeKafkaRegionConstraint<Topics, Options> &
+  RuntimeKafkaStartFromExactKeysConstraint<Options>;
 
 export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> = {
   readonly url: string;

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -123,6 +123,12 @@ const edgeViewServer = defineViewServerConfig({
 
 const createServerTestRuntime = createViewServerRuntimeCore;
 
+const kafkaStartFromHealth = {
+  consumerGroupId: "view-server-test",
+  fallbackMode: "latest",
+  mode: "latest",
+} as const;
+
 type OrderRow = typeof Order.Type;
 type TradeRow = typeof Trade.Type;
 type QuoteRow = typeof Quote.Type;
@@ -561,6 +567,7 @@ describe("@view-server/server", () => {
             Effect.succeed({
               ...baseHealth,
               kafka: {
+                startFrom: kafkaStartFromHealth,
                 regions: {},
                 topics: {
                   source_orders: {
@@ -598,6 +605,7 @@ describe("@view-server/server", () => {
         ...baseHealth,
         status: "degraded",
         kafka: {
+          startFrom: kafkaStartFromHealth,
           regions: {},
           topics: {
             source_orders: {
@@ -653,6 +661,7 @@ describe("@view-server/server", () => {
         ...baseHealth,
         status: "degraded",
         kafka: {
+          startFrom: kafkaStartFromHealth,
           regions: {},
           topics: {
             source_orders: {
@@ -1519,6 +1528,7 @@ describe("@view-server/server", () => {
             Effect.succeed({
               ...baseHealth,
               kafka: {
+                startFrom: kafkaStartFromHealth,
                 regions: {},
                 topics: {
                   source_orders: {

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1112,14 +1112,19 @@ The runtime is in-memory first, but production needs an explicit recovery story.
 Initial policy:
 
 - Kafka is the source of truth.
-- Current implementation status: the runtime exposes a configured Kafka consumer group, consumes committed offsets with an earliest fallback for a new group, and commits only after successful publish; success health records the committed offset after commit.
+- Current implementation status: the runtime exposes a configured Kafka consumer group and an explicit Kafka `startFrom` policy. The default preserves the current live-process behavior: consume committed offsets for the configured group with an earliest fallback for a new group. Runtime config can also request `startFrom: "earliest"`, `startFrom: "latest"`, or a committed consumer group with `earliest`, `latest`, or `fail` fallback. The runtime commits only after successful publish; success health records the committed offset after commit.
 - Current restart contract: because Runtime Core rows are in memory and no durable WAL/checkpoint exists yet, committed consumer-group resume can skip rows that were committed before process death. It is a live-process ingestion mode, not a lossless full rebuild strategy.
 - Until WAL/checkpoints exist, production deployments that need rebuild-after-restart semantics must replay Kafka from an authoritative position, such as earliest offsets for the Source Topics or a dedicated rebuild group.
-- Future startup policy: runtime rebuilds in-memory state by consuming configured topics from a configured start position.
-- The future production start policy should be explicit, not magic:
+- Production startup policy is explicit, not magic:
 
 ```ts
-startFrom: "earliest" | "latest" | { committedConsumerGroup: string };
+startFrom:
+  | "earliest"
+  | "latest"
+  | {
+      committedConsumerGroup: string;
+      fallback?: "earliest" | "latest" | "fail";
+    };
 ```
 
 - If `startFrom: "latest"`, health should clearly show topics are not backfilled.


### PR DESCRIPTION
## Summary

- Add explicit Kafka `startFrom` runtime policy: `"earliest"`, `"latest"`, or committed consumer-group resume with `fallback`.
- Normalize Kafka consume policy once and pass it to both `@platformatic/kafka` and runtime health.
- Expose normalized Kafka start policy in health and enforce valid mode/fallback combinations in the public type and protocol schema.
- Update docs, public type tests, protocol tests, runtime option tests, and Kafka ingress health assertions.

## Validation

- `vp check --fix`
- `pnpm --filter @view-server/config run test`
- `pnpm --filter @view-server/protocol run test`
- `pnpm --filter @view-server/runtime run test`
- `pnpm exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --severity warning`
- `pnpm run ready`

## Review

- 3 internal reviewer agents: no blockers / no P1/P2 findings after final pass.
