### PR TITLE
Fix runtime value domains and lifecycle edges

### DIFF
--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -1145,7 +1145,7 @@ describe("remote ViewServer client", () => {
 
       const badStartsWith = yield* Effect.flip(
         client.subscribe("badjson", {
-          // @ts-expect-error invalid query collapse keeps selected fields from being accepted.
+          // @ts-expect-error hostile callers can still send invalid selected fields.
           select: ["id"],
           where: {
             id: {
@@ -1156,7 +1156,7 @@ describe("remote ViewServer client", () => {
         }),
       );
       expect(badStartsWith.code).toBe("InvalidQuery");
-      expect(badStartsWith.message).toMatch(/Invalid startsWith filter for id/);
+      expect(badStartsWith.message).toBe("Invalid filter for id: expected string");
 
       yield* client.close;
       yield* server.close;

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit, Logger, References, Scope, Stream } from "effect";
+import { Cause, Effect, Exit, Fiber, Logger, References, Scope, Stream } from "effect";
 import type { StatusEvent } from "@view-server/config";
 import type { ViewServerLiveEvent } from "./live-client";
 import { makeRemoteSubscription } from "./remote-subscription";
@@ -124,6 +124,55 @@ describe("remote subscription", () => {
 
       expect(Exit.isFailure(closeExit)).toBe(true);
       expect(closeCount).toBe(1);
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("ends events without a transport error when the client scope closes", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      let failureStatusCount = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus: (topic, error) => {
+          failureStatusCount += 1;
+          return failureStatus(topic, error);
+        },
+        source: Stream.never,
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+      const eventsFiber = yield* subscription.events.pipe(Stream.runCollect, Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* Scope.close(clientScope, Exit.void);
+      const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+
+      expect(failureStatusCount).toBe(0);
+      expect(Array.from(events)).toStrictEqual([]);
+    }),
+  );
+
+  it.effect("does not turn source defects into clean event completion", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        source: Stream.die("source defect"),
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+
+      const defectSeen = yield* subscription.events.pipe(
+        Stream.runCollect,
+        Effect.matchCause({
+          onFailure: Cause.hasDies,
+          onSuccess: () => false,
+        }),
+      );
+
+      expect(defectSeen).toBe(true);
       yield* Scope.close(clientScope, Exit.void);
     }),
   );

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -13,6 +13,23 @@ const ignoreRemoteSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNo
 const ignoreRemoteSubscriptionStreamStartFailure =
   ignoreLoggedTypedFailuresPreserveNonTypedFailures("Remote subscription stream start failed.");
 
+const completeQueueFromProducerExit = <Row, Topic extends string, Key extends string>(
+  queue: Queue.Enqueue<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>,
+  exit: Exit.Exit<void>,
+) => {
+  if (Exit.isSuccess(exit)) {
+    return Queue.end(queue);
+  }
+  if (
+    Cause.hasInterrupts(exit.cause) &&
+    !Cause.hasDies(exit.cause) &&
+    !Cause.hasFails(exit.cause)
+  ) {
+    return Queue.end(queue);
+  }
+  return Queue.failCause(queue, exit.cause);
+};
+
 export type RemoteSubscriptionLifecycle = {
   readonly onOpen: Effect.Effect<void>;
   readonly onClose: Effect.Effect<void, unknown>;
@@ -62,7 +79,8 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
               scope,
               lifecycle.onClose.pipe(ignoreRemoteSubscriptionCloseFailure),
             );
-            yield* Stream.runIntoQueue(stream, queue).pipe(
+            yield* Stream.runForEach(stream, (event) => Queue.offer(queue, event)).pipe(
+              Effect.onExit((exit) => completeQueueFromProducerExit(queue, exit)),
               Effect.forkIn(scope, { startImmediately: true }),
               ignoreRemoteSubscriptionStreamStartFailure,
             );

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -43,7 +43,14 @@ import {
 } from "./raw-query-compiler";
 import { evaluateCompiledGroupedQuery, prepareGroupedQuery } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
-import { cloneRecord, cloneRow, fieldValue, rowsEqual, scalarEqualityKey } from "./row-values";
+import {
+  cloneRecord,
+  cloneRow,
+  fieldValue,
+  rowsEqual,
+  scalarEqualityKey,
+  valuesEqual,
+} from "./row-values";
 import type { TopicRowChangeBatch } from "./row-scan";
 import { scanTopicRawWindow } from "./topic-raw-window-scanner";
 import {
@@ -4054,44 +4061,19 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         id: Schema.String,
         amount: Schema.Union([Schema.Number, Schema.BigInt, Schema.BigDecimal]),
       });
-      const mixedNumericCompiled = yield* prepareRawQuery<object, object>(
-        "mixedNumeric",
-        rawQueryCompilerMetadata(MixedNumeric),
-        {
+      const mixedNumericRangeError = yield* Effect.flip(
+        prepareRawQuery<object, object>("mixedNumeric", rawQueryCompilerMetadata(MixedNumeric), {
           select: ["id"],
           where: {
             amount: {
               gt: 1,
             },
           },
-        },
+        }),
       );
-      const mixedNumericEvaluation = evaluateRawQuery(
-        {
-          scanRawWindow: (plan) => {
-            expect(plan.predicate).toStrictEqual({
-              filters: [],
-              callbackRequired: true,
-              callbackSkippable: false,
-            });
-            expect(plan.matches({ id: "number", amount: 2 })).toBe(true);
-            expect(plan.matches({ id: "bigint", amount: 2n })).toBe(false);
-            expect(plan.matches({ id: "decimal", amount: fromStringUnsafe("2") })).toBe(false);
-            return {
-              keys: [],
-              window: [],
-              totalRows: 0,
-            };
-          },
-          version: () => 20,
-        },
-        mixedNumericCompiled,
+      expect(mixedNumericRangeError.message).toBe(
+        "Raw query where field amount does not support range operators.",
       );
-
-      expect(mixedNumericEvaluation.keys).toStrictEqual([]);
-      expect(mixedNumericEvaluation.rows).toStrictEqual([]);
-      expect(mixedNumericEvaluation.totalRows).toBe(0);
-      expect(mixedNumericEvaluation.version).toBe(20);
     }),
   );
 
@@ -4152,12 +4134,12 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
-  it.effect("evaluates grouped mixed numeric aggregate states", () =>
+  it.effect("evaluates grouped BigDecimal aggregate states", () =>
     Effect.gen(function* () {
       const Mixed = Schema.Struct({
         id: Schema.String,
         group: Schema.String,
-        amount: Schema.Union([Schema.Number, Schema.BigInt, Schema.BigDecimal]),
+        amount: Schema.BigDecimal,
         optionalQuantity: Schema.Union([Schema.BigInt, Schema.Undefined]),
       });
       const mixedViewServer = defineViewServerConfig({
@@ -4172,13 +4154,12 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         topics: mixedViewServer.topics,
       });
       yield* mixedEngine.publishMany("mixed", [
-        { id: "1", group: "x", amount: 1n, optionalQuantity: 5n },
-        { id: "2", group: "x", amount: 2, optionalQuantity: undefined },
+        { id: "1", group: "x", amount: fromStringUnsafe("1"), optionalQuantity: 5n },
+        { id: "2", group: "x", amount: fromStringUnsafe("2"), optionalQuantity: undefined },
         { id: "3", group: "x", amount: fromStringUnsafe("3.5"), optionalQuantity: 7n },
-        { id: "4", group: "x", amount: Number.NaN, optionalQuantity: undefined },
-        { id: "5", group: "y", amount: Number.NaN, optionalQuantity: undefined },
-        { id: "6", group: "z", amount: 1n, optionalQuantity: 1n },
-        { id: "7", group: "z", amount: 2n, optionalQuantity: 2n },
+        { id: "4", group: "y", amount: fromStringUnsafe("0"), optionalQuantity: undefined },
+        { id: "5", group: "z", amount: fromStringUnsafe("1"), optionalQuantity: 1n },
+        { id: "6", group: "z", amount: fromStringUnsafe("2"), optionalQuantity: 2n },
       ]);
       const mixedQuery = {
         groupBy: ["group"],
@@ -10566,6 +10547,17 @@ describe("ColumnLiveViewEngine validation and health", () => {
 
   it("treats rows with different selected column counts as different", () => {
     expect(rowsEqual({ id: "1" }, { id: "1", note: "new" })).toBe(false);
+  });
+
+  it("does not structurally compare map and set values on row hot paths", () => {
+    expect(valuesEqual(new Map([["venue", "xnys"]]), new Map([["venue", "xnys"]]))).toBe(false);
+    expect(valuesEqual(new Set(["xnys"]), new Set(["xnys"]))).toBe(false);
+    expect(
+      rowsEqual(
+        { id: "1", payload: new Map([["venue", "xnys"]]) },
+        { id: "1", payload: new Map([["venue", "xnys"]]) },
+      ),
+    ).toBe(false);
   });
 
   it("ignores inherited row properties", () => {

--- a/packages/column-live-view-engine/src/raw-query-decoder.ts
+++ b/packages/column-live-view-engine/src/raw-query-decoder.ts
@@ -295,7 +295,7 @@ export const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.val
       }
       if (
         keys.some((key) => rangeFilterOperatorKeys.has(key)) &&
-        !metadata.numericFieldNames.has(field)
+        (!metadata.numericFieldNames.has(field) || metadata.rangeValueKinds.get(field)?.size !== 1)
       ) {
         return yield* InvalidQueryError.make({
           topic,

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -21,6 +21,7 @@ import {
   VIEW_SERVER_HEALTH_TOPIC,
   viewServerReservedTopicNames,
   viewServerSchemaFieldMetadata,
+  viewServerUnsupportedRuntimeFieldDomain,
   viewServerTopicNameIsReserved,
   viewServerHealthSummaryFromHealth,
   viewServerHealthSummaryRowFromHealth,
@@ -2019,6 +2020,361 @@ describe("defineViewServerConfig", () => {
       isStructured: true,
       isStructuredObject: false,
     });
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Date)).toBe("Date");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeUtc)).toBe("DateTimeUtc");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeUtcFromString)).toBe(
+      "DateTimeUtc",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeZoned)).toBe("DateTimeZoned");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeZonedFromString)).toBe(
+      "DateTimeZoned",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Duration)).toBe("Duration");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Symbol)).toBe("Symbol");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZone)).toBe("TimeZone");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneFromString)).toBe("TimeZone");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneNamed)).toBe("TimeZoneNamed");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneNamedFromString)).toBe(
+      "TimeZoneNamed",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneOffset)).toBe("TimeZoneOffset");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Trim)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8Array)).toBe("Uint8Array");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromBase64)).toBe("Uint8Array");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromBase64Url)).toBe(
+      "Uint8Array",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromHex)).toBe("Uint8Array");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.suspend(() => Schema.Date))).toBe("Date");
+    const recursiveSuspend: Schema.Schema<string> = Schema.suspend(() => recursiveSuspend);
+    expect(viewServerUnsupportedRuntimeFieldDomain(recursiveSuspend)).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.decodeTo(Schema.Duration, {
+            decode: SchemaGetter.transform(() => Duration.millis(1)),
+            encode: SchemaGetter.transform(() => "1"),
+          }),
+        ),
+      ),
+    ).toBe("Duration");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.encodeTo(Schema.Duration, {
+            decode: SchemaGetter.transform(() => "1"),
+            encode: SchemaGetter.transform(() => Duration.millis(1)),
+          }),
+        ),
+      ),
+    ).toBe("Duration");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Array(Schema.RegExp))).toBe("RegExp");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Tuple([Schema.RegExp]))).toBe("RegExp");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Date]),
+      ),
+    ).toBe("Date");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.Symbol, Schema.String)),
+    ).toBe("Symbol");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.String, Schema.String)),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.String, Schema.URL))).toBe(
+      "URL",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.BigInt, Schema.Number])),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.BigDecimal, Schema.Number])),
+    ).toBe("mixed numeric domain: bigDecimal, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Literal(1), Schema.Literal(2n)]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.String, Schema.File])),
+    ).toBe("File");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.decodeTo(Schema.Union([Schema.Number, Schema.BigInt]), {
+            decode: SchemaGetter.transform(() => 1n),
+            encode: SchemaGetter.transform(() => "1"),
+          }),
+        ),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.encodeTo(Schema.Union([Schema.Number, Schema.BigInt]), {
+            decode: SchemaGetter.transform(() => "1"),
+            encode: SchemaGetter.transform(() => 1n),
+          }),
+        ),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          nested: Schema.Struct({
+            href: Schema.URL,
+          }),
+        }),
+      ),
+    ).toBe("URL");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Option(Schema.Date))).toBe("Date");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Option(Schema.Union([Schema.Number, Schema.BigInt])),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Option(Schema.String))).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Redacted(Schema.Duration))).toBe(
+      "Duration",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          nested: Schema.Struct({
+            amount: Schema.Union([Schema.Number, Schema.BigInt]),
+          }),
+        }),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Record(Schema.String, Schema.Union([Schema.Number, Schema.BigInt])),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Tuple([Schema.Union([Schema.Number, Schema.BigInt])]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [
+          Schema.Union([Schema.Number, Schema.BigInt]),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.String,
+          Schema.Struct({
+            amount: Schema.Union([Schema.Number, Schema.BigInt]),
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Array(Schema.Number), Schema.Array(Schema.BigInt)]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Tuple([Schema.BigInt])]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Array(Schema.Number), Schema.Tuple([Schema.BigInt])]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Struct({
+            amount: Schema.BigInt,
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            payload: Schema.Array(Schema.Number),
+          }),
+          Schema.Struct({
+            payload: Schema.Tuple([Schema.BigInt]),
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Record(Schema.String, Schema.Number),
+          Schema.Struct({
+            amount: Schema.BigInt,
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Record(Schema.String, Schema.BigInt),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Array(Schema.BigInt)]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]),
+          Schema.Tuple([Schema.BigInt]),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]),
+          Schema.Tuple([Schema.String, Schema.BigInt]),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Number, Schema.Array(Schema.BigInt)]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Record(Schema.String, Schema.BigInt)]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Tuple([Schema.BigInt]),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Array(Schema.BigInt),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            price: Schema.Number,
+          }),
+          Schema.Struct({
+            quantity: Schema.BigInt,
+          }),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          quantity: Schema.BigInt,
+          price: Schema.Number,
+        }),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.String]),
+      ),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Struct({ id: Schema.String }))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain({})).toBe(undefined);
+  });
+
+  it("rejects topic fields with unsupported runtime value domains", () => {
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          dated: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              createdAt: Schema.Date,
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic dated field createdAt uses unsupported runtime domain: Date");
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          nested: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              metadata: Schema.Struct({
+                latency: Schema.Duration,
+              }),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic nested field metadata uses unsupported runtime domain: Duration");
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          mixedNumeric: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              amount: Schema.Union([Schema.BigInt, Schema.Number]),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic mixedNumeric field amount uses unsupported runtime domain: mixed numeric domain: bigint, number",
+    );
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          nestedMixedNumeric: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              payload: Schema.Struct({
+                amount: Schema.Union([Schema.BigInt, Schema.Number]),
+              }),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic nestedMixedNumeric field payload uses unsupported runtime domain: mixed numeric domain: bigint, number",
+    );
   });
 
   it("defines topics and pure runtime option contracts without starting a runtime", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeOptionsDefinition,
 } from "./kafka-contract";
 import type { RowFromSchema, RowSchema, StringFieldKey, TopicDefinition } from "./topic-contract";
+import { viewServerUnsupportedRuntimeFieldDomain } from "./schema-field-metadata";
 
 export type {
   Aggregate,
@@ -90,6 +91,7 @@ export type {
 } from "./runtime-contract";
 export {
   viewServerSchemaFieldMetadata,
+  viewServerUnsupportedRuntimeFieldDomain,
   type ViewServerSchemaFieldMetadata,
 } from "./schema-field-metadata";
 export type {
@@ -190,6 +192,14 @@ export const defineViewServerConfig = <
     for (const field of Object.keys(schema.fields)) {
       if (field === "__proto__" || field === "prototype" || field === "constructor") {
         throw new Error(`View Server topic ${topic} uses a reserved row field name: ${field}`);
+      }
+      const unsupportedRuntimeDomain = viewServerUnsupportedRuntimeFieldDomain(
+        schema.fields[field],
+      );
+      if (unsupportedRuntimeDomain !== undefined) {
+        throw new Error(
+          `View Server topic ${topic} field ${field} uses unsupported runtime domain: ${unsupportedRuntimeDomain}`,
+        );
       }
     }
   }

--- a/packages/config/src/schema-field-metadata.ts
+++ b/packages/config/src/schema-field-metadata.ts
@@ -1,4 +1,4 @@
-import { SchemaAST } from "effect";
+import { Schema, SchemaAST } from "effect";
 
 export type ViewServerSchemaFieldMetadata = {
   readonly isNumeric: boolean;
@@ -10,6 +10,22 @@ export type ViewServerSchemaFieldMetadata = {
 };
 
 type NumericKind = "none" | "bigint" | "bigDecimal";
+type NumericRuntimeDomain = "number" | "bigint" | "bigDecimal";
+type NumericRuntimeDomainPathSegment =
+  | readonly ["index", number]
+  | readonly ["indexWildcard", number]
+  | readonly ["property", string]
+  | readonly ["propertyWildcard"];
+type NumericRuntimeDomainPath = ReadonlyArray<NumericRuntimeDomainPathSegment>;
+type NumericRuntimeDomainEntry = {
+  readonly domain: NumericRuntimeDomain;
+  readonly path: NumericRuntimeDomainPath;
+};
+type UnsupportedRuntimeDomainDescriptor = {
+  readonly name: string;
+  readonly run: unknown;
+  readonly link: unknown;
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -26,6 +42,52 @@ const isBigDecimalAst = (ast: SchemaAST.AST): boolean =>
   SchemaAST.isDeclaration(ast) &&
   isRecord(ast.annotations?.["typeConstructor"]) &&
   ast.annotations["typeConstructor"]["_tag"] === "effect/BigDecimal";
+
+const declarationLink = (ast: SchemaAST.AST): unknown =>
+  Reflect.get(Object(Reflect.get(ast, "annotations")), "toCodecJson") ??
+  Reflect.get(Object(Reflect.get(ast, "annotations")), "toCodec");
+
+const unsupportedRuntimeDomainDescriptor = (
+  name: string,
+  schema: { readonly ast: SchemaAST.AST },
+): UnsupportedRuntimeDomainDescriptor => ({
+  link: declarationLink(schema.ast),
+  name,
+  run: Reflect.get(schema.ast, "run"),
+});
+
+const unsupportedRuntimeDomainDescriptors = [
+  unsupportedRuntimeDomainDescriptor("Date", Schema.Date),
+  unsupportedRuntimeDomainDescriptor("DateTimeUtc", Schema.DateTimeUtc),
+  unsupportedRuntimeDomainDescriptor("DateTimeZoned", Schema.DateTimeZoned),
+  unsupportedRuntimeDomainDescriptor("Duration", Schema.Duration),
+  unsupportedRuntimeDomainDescriptor("Error", Schema.Error),
+  unsupportedRuntimeDomainDescriptor("ErrorWithStack", Schema.ErrorWithStack),
+  unsupportedRuntimeDomainDescriptor("File", Schema.File),
+  unsupportedRuntimeDomainDescriptor("FormData", Schema.FormData),
+  unsupportedRuntimeDomainDescriptor("RegExp", Schema.RegExp),
+  unsupportedRuntimeDomainDescriptor("Symbol", Schema.Symbol),
+  unsupportedRuntimeDomainDescriptor("TimeZone", Schema.TimeZone),
+  unsupportedRuntimeDomainDescriptor("TimeZoneNamed", Schema.TimeZoneNamed),
+  unsupportedRuntimeDomainDescriptor("TimeZoneOffset", Schema.TimeZoneOffset),
+  unsupportedRuntimeDomainDescriptor("Uint8Array", Schema.Uint8Array),
+  unsupportedRuntimeDomainDescriptor("URL", Schema.URL),
+  unsupportedRuntimeDomainDescriptor("URLSearchParams", Schema.URLSearchParams),
+];
+
+const unsupportedRuntimeDeclarationName = (ast: SchemaAST.AST): string | undefined => {
+  if (SchemaAST.isUniqueSymbol(ast) || ast._tag === "Symbol") {
+    return "Symbol";
+  }
+  if (!SchemaAST.isDeclaration(ast)) {
+    return undefined;
+  }
+  const run = Reflect.get(ast, "run");
+  const link = declarationLink(ast);
+  return unsupportedRuntimeDomainDescriptors.find(
+    (descriptor) => descriptor.run === run && descriptor.link === link,
+  )?.name;
+};
 
 const isStringLiteralAst = (ast: SchemaAST.AST): boolean =>
   SchemaAST.isLiteral(ast) && typeof ast.literal === "string";
@@ -55,6 +117,152 @@ const numericKindAst = (ast: SchemaAST.AST): NumericKind => {
     sawBigDecimal ||= kind === "bigDecimal";
   }
   return sawBigDecimal ? "bigDecimal" : "bigint";
+};
+
+const addNumericRuntimeDomainAtPath = (
+  entries: Array<NumericRuntimeDomainEntry>,
+  path: NumericRuntimeDomainPath,
+  domain: NumericRuntimeDomain,
+) => entries.push({ domain, path });
+
+const numericRuntimePathSegmentsOverlap = (
+  left: NumericRuntimeDomainPathSegment,
+  right: NumericRuntimeDomainPathSegment,
+): boolean => {
+  if (
+    left[0] === "propertyWildcard" &&
+    (right[0] === "property" || right[0] === "propertyWildcard")
+  ) {
+    return true;
+  }
+  if (right[0] === "propertyWildcard" && left[0] === "property") {
+    return true;
+  }
+  if (left[0] === "indexWildcard" && (right[0] === "index" || right[0] === "indexWildcard")) {
+    return right[0] === "index" ? right[1] >= left[1] : true;
+  }
+  if (right[0] === "indexWildcard" && left[0] === "index") {
+    return left[1] >= right[1];
+  }
+  if (left[0] === "property" && right[0] === "property") {
+    return left[1] === right[1];
+  }
+  if (left[0] === "index" && right[0] === "index") {
+    return left[1] === right[1];
+  }
+  return false;
+};
+
+const numericRuntimePathsOverlap = (
+  left: NumericRuntimeDomainPath,
+  right: NumericRuntimeDomainPath,
+): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((segment, index) => numericRuntimePathSegmentsOverlap(segment, right[index]!));
+};
+
+const collectNumericRuntimeDomainsByPath = (
+  ast: SchemaAST.AST,
+  path: NumericRuntimeDomainPath,
+  entries: Array<NumericRuntimeDomainEntry>,
+  active: Set<SchemaAST.AST>,
+): void => {
+  if (SchemaAST.isNumber(ast)) {
+    addNumericRuntimeDomainAtPath(entries, path, "number");
+    return;
+  }
+  if (SchemaAST.isBigInt(ast)) {
+    addNumericRuntimeDomainAtPath(entries, path, "bigint");
+    return;
+  }
+  if (isBigDecimalAst(ast)) {
+    addNumericRuntimeDomainAtPath(entries, path, "bigDecimal");
+    return;
+  }
+  if (SchemaAST.isLiteral(ast)) {
+    if (typeof ast.literal === "number") {
+      addNumericRuntimeDomainAtPath(entries, path, "number");
+    }
+    if (typeof ast.literal === "bigint") {
+      addNumericRuntimeDomainAtPath(entries, path, "bigint");
+    }
+    return;
+  }
+  if (active.has(ast)) {
+    return;
+  }
+  active.add(ast);
+  if (SchemaAST.isSuspend(ast)) {
+    collectNumericRuntimeDomainsByPath(ast.thunk(), path, entries, active);
+    active.delete(ast);
+    return;
+  }
+  if (ast.encoding !== undefined) {
+    for (const link of ast.encoding) {
+      collectNumericRuntimeDomainsByPath(link.to, path, entries, active);
+    }
+  }
+  if (SchemaAST.isDeclaration(ast)) {
+    for (const typeParameter of ast.typeParameters) {
+      collectNumericRuntimeDomainsByPath(typeParameter, path, entries, active);
+    }
+  }
+  if (SchemaAST.isObjects(ast)) {
+    for (const property of ast.propertySignatures) {
+      collectNumericRuntimeDomainsByPath(
+        property.type,
+        [...path, ["property", String(property.name)]],
+        entries,
+        active,
+      );
+    }
+    for (const index of ast.indexSignatures) {
+      collectNumericRuntimeDomainsByPath(
+        index.type,
+        [...path, ["propertyWildcard"]],
+        entries,
+        active,
+      );
+    }
+  }
+  if (SchemaAST.isArrays(ast)) {
+    for (const [index, element] of ast.elements.entries()) {
+      collectNumericRuntimeDomainsByPath(element, [...path, ["index", index]], entries, active);
+    }
+    for (const rest of ast.rest) {
+      collectNumericRuntimeDomainsByPath(
+        rest,
+        [...path, ["indexWildcard", ast.elements.length]],
+        entries,
+        active,
+      );
+    }
+  }
+  if (SchemaAST.isUnion(ast)) {
+    for (const member of ast.types) {
+      collectNumericRuntimeDomainsByPath(member, path, entries, active);
+    }
+  }
+  active.delete(ast);
+};
+
+const nestedMixedNumericRuntimeDomainAst = (ast: SchemaAST.AST): string | undefined => {
+  const entries: Array<NumericRuntimeDomainEntry> = [];
+  collectNumericRuntimeDomainsByPath(ast, [], entries, new Set());
+  for (const left of entries) {
+    const domains = new Set<NumericRuntimeDomain>([left.domain]);
+    for (const right of entries) {
+      if (numericRuntimePathsOverlap(left.path, right.path)) {
+        domains.add(right.domain);
+      }
+    }
+    if (domains.size > 1) {
+      return `mixed numeric domain: ${Array.from(domains).toSorted().join(", ")}`;
+    }
+  }
+  return undefined;
 };
 
 const isStringAst = (ast: SchemaAST.AST): boolean => {
@@ -100,4 +308,86 @@ export const viewServerSchemaFieldMetadata = (schema: unknown): ViewServerSchema
     isStructuredObject: isStructuredObjectAst(ast),
     ...(isNumeric ? { sumResultKind: numericKind } : {}),
   };
+};
+
+const unsupportedRuntimeDomainAst = (
+  ast: SchemaAST.AST,
+  seen: Set<SchemaAST.AST>,
+): string | undefined => {
+  if (seen.has(ast)) {
+    return undefined;
+  }
+  seen.add(ast);
+  const unsupportedDeclaration = unsupportedRuntimeDeclarationName(ast);
+  if (unsupportedDeclaration !== undefined) {
+    return unsupportedDeclaration;
+  }
+  if (SchemaAST.isSuspend(ast)) {
+    return unsupportedRuntimeDomainAst(ast.thunk(), seen);
+  }
+  if (ast.encoding !== undefined) {
+    for (const link of ast.encoding) {
+      const unsupported = unsupportedRuntimeDomainAst(link.to, seen);
+      if (unsupported !== undefined) {
+        return unsupported;
+      }
+    }
+  }
+  if (SchemaAST.isDeclaration(ast)) {
+    for (const typeParameter of ast.typeParameters) {
+      const unsupported = unsupportedRuntimeDomainAst(typeParameter, seen);
+      if (unsupported !== undefined) {
+        return unsupported;
+      }
+    }
+  }
+  if (SchemaAST.isObjects(ast)) {
+    for (const property of ast.propertySignatures) {
+      const unsupported = unsupportedRuntimeDomainAst(property.type, seen);
+      if (unsupported !== undefined) {
+        return unsupported;
+      }
+    }
+    for (const index of ast.indexSignatures) {
+      const unsupportedParameter = unsupportedRuntimeDomainAst(index.parameter, seen);
+      if (unsupportedParameter !== undefined) {
+        return unsupportedParameter;
+      }
+      const unsupportedValue = unsupportedRuntimeDomainAst(index.type, seen);
+      if (unsupportedValue !== undefined) {
+        return unsupportedValue;
+      }
+    }
+  }
+  if (SchemaAST.isArrays(ast)) {
+    for (const element of ast.elements) {
+      const unsupported = unsupportedRuntimeDomainAst(element, seen);
+      if (unsupported !== undefined) {
+        return unsupported;
+      }
+    }
+    for (const rest of ast.rest) {
+      const unsupported = unsupportedRuntimeDomainAst(rest, seen);
+      if (unsupported !== undefined) {
+        return unsupported;
+      }
+    }
+  }
+  if (SchemaAST.isUnion(ast)) {
+    for (const member of ast.types) {
+      const unsupported = unsupportedRuntimeDomainAst(member, seen);
+      if (unsupported !== undefined) {
+        return unsupported;
+      }
+    }
+  }
+  return undefined;
+};
+
+export const viewServerUnsupportedRuntimeFieldDomain = (schema: unknown): string | undefined => {
+  const ast = schemaAst(schema);
+  if (ast === undefined) {
+    return undefined;
+  }
+  return unsupportedRuntimeDomainAst(ast, new Set()) ?? nestedMixedNumericRuntimeDomainAst(ast);
 };

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -42,6 +42,7 @@ import { SchemaGetter } from "effect";
 
 const Order = Schema.Struct({
   id: Schema.String,
+  status: Schema.Literals(["open", "closed"]),
   price: Schema.Number,
   quantity: Schema.BigInt,
   decimalPrice: Schema.BigDecimal,
@@ -1635,6 +1636,95 @@ describe("@view-server/protocol", () => {
       );
       expect(invalidDecodedStringStartsWith.message).toMatch(/Invalid filter for id/);
 
+      const trimmedViewServer = defineViewServerConfig({
+        topics: {
+          trimmed: {
+            schema: Schema.Struct({
+              id: Schema.Trim,
+            }),
+            key: "id",
+          },
+        },
+      });
+      const encodedTrimmedStartsWith = yield* viewServerEncodeRawQuery(
+        trimmedViewServer,
+        "trimmed",
+        {
+          select: ["id"],
+          where: { id: { startsWith: "  abc  " } },
+        },
+      );
+      expect(encodedTrimmedStartsWith).toStrictEqual({
+        select: ["id"],
+        where: { id: { startsWith: "  abc  " } },
+      });
+
+      const decodedTrimmedStartsWith = yield* viewServerDecodeRawQuery(
+        trimmedViewServer,
+        "trimmed",
+        {
+          select: ["id"],
+          where: { id: { startsWith: "  abc  " } },
+        },
+      );
+      expect(decodedTrimmedStartsWith).toStrictEqual({
+        select: ["id"],
+        where: { id: { startsWith: "  abc  " } },
+      });
+
+      const badJsonStartsWith = yield* Effect.flip(
+        viewServerEncodeRawQuery(viewServer, "badjson", {
+          select: ["id"],
+          where: { id: { startsWith: 1 } },
+        }),
+      );
+      expect(badJsonStartsWith.message).toBe("Invalid filter for id: expected string");
+
+      const refinedStringViewServer = defineViewServerConfig({
+        topics: {
+          refined: {
+            schema: Schema.Struct({
+              id: Schema.String.check(Schema.isMinLength(2)),
+            }),
+            key: "id",
+          },
+        },
+      });
+      const encodedRefinedStartsWith = yield* viewServerEncodeRawQuery(
+        refinedStringViewServer,
+        "refined",
+        {
+          select: ["id"],
+          where: { id: { startsWith: "x" } },
+        },
+      );
+      expect(encodedRefinedStartsWith).toStrictEqual({
+        select: ["id"],
+        where: { id: { startsWith: "x" } },
+      });
+
+      const decodedRefinedStartsWith = yield* viewServerDecodeRawQuery(
+        refinedStringViewServer,
+        "refined",
+        {
+          select: ["id"],
+          where: { id: { startsWith: "x" } },
+        },
+      );
+      expect(decodedRefinedStartsWith).toStrictEqual({
+        select: ["id"],
+        where: { id: { startsWith: "x" } },
+      });
+
+      const encodedLiteralStartsWith = yield* viewServerEncodeRawQuery(viewServer, "orders", {
+        select: ["status"],
+        where: { status: { startsWith: "op" } },
+      });
+      expect(encodedLiteralStartsWith).toStrictEqual({
+        select: ["status"],
+        where: { status: { startsWith: "op" } },
+      });
+
       const structuredEncodeStartsWith = yield* Effect.flip(
         viewServerEncodeRawQuery(viewServer, "orders", {
           select: ["id"],
@@ -1669,6 +1759,40 @@ describe("@view-server/protocol", () => {
         "Filter metadata does not support startsWith",
       );
 
+      const structuredEncodeRange = yield* Effect.flip(
+        viewServerEncodeRawQuery(viewServer, "orders", {
+          select: ["id"],
+          where: {
+            metadata: {
+              gt: {
+                _viewServerScalar: "kind",
+                value: "x",
+              },
+            },
+          },
+        }),
+      );
+      expect(structuredEncodeRange.message).toBe(
+        "Filter metadata does not support range operators",
+      );
+
+      const structuredDecodeRange = yield* Effect.flip(
+        viewServerDecodeRawQuery(viewServer, "orders", {
+          select: ["id"],
+          where: {
+            metadata: {
+              gt: {
+                _viewServerScalar: "kind",
+                value: "x",
+              },
+            },
+          },
+        }),
+      );
+      expect(structuredDecodeRange.message).toBe(
+        "Filter metadata does not support range operators",
+      );
+
       const invalidRangeOperator = yield* Effect.flip(
         viewServerEncodeRawQuery(viewServer, "orders", {
           select: ["id"],
@@ -1684,14 +1808,6 @@ describe("@view-server/protocol", () => {
         }),
       );
       expect(nonJsonFilter.message).toMatch(/Filter id is not JSON-safe/);
-
-      const badStartsWith = yield* Effect.flip(
-        viewServerEncodeRawQuery(viewServer, "badjson", {
-          select: ["id"],
-          where: { id: { startsWith: 1 } },
-        }),
-      );
-      expect(badStartsWith.message).toMatch(/Invalid startsWith filter for id/);
 
       const badDecodedField = yield* Effect.flip(
         viewServerDecodeRawQuery(viewServer, "orders", {

--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -60,39 +60,25 @@ const decodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(
 const encodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.encode")(function* (
   topic: string,
   field: string,
-  schema: JsonFieldSchema,
+  _schema: JsonFieldSchema,
   value: unknown,
 ) {
-  const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-  if (typeof decoded !== "string") {
-    return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
+  if (typeof value !== "string") {
+    return yield* Effect.fail(invalidQuery(topic, `Invalid filter for ${field}: expected string`));
   }
-  return yield* Schema.decodeUnknownEffect(Schema.String)(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid startsWith filter for ${field}: ${error.message}`),
-    ),
-  );
+  return value;
 });
 
 const decodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.decode")(function* (
   topic: string,
   field: string,
-  schema: JsonFieldSchema,
+  _schema: JsonFieldSchema,
   value: unknown,
 ) {
-  const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) =>
-      invalidQuery(topic, `Invalid filter for ${field}: ${error.message}`),
-    ),
-  );
-  if (typeof decoded !== "string") {
-    return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
+  if (typeof value !== "string") {
+    return yield* Effect.fail(invalidQuery(topic, `Invalid filter for ${field}: expected string`));
   }
-  return decoded;
+  return value;
 });
 
 const validateOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.validate")(
@@ -103,9 +89,6 @@ const validateOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operato
     value: Record<string, unknown>,
   ) {
     const metadata = viewServerSchemaFieldMetadata(schema);
-    if (metadata.isStructured) {
-      return;
-    }
     const keys = Object.keys(value);
     if (keys.includes("startsWith") && !metadata.isString) {
       return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));

--- a/packages/runtime-core/src/health.ts
+++ b/packages/runtime-core/src/health.ts
@@ -3,7 +3,7 @@ import type {
   DecodableTopicDefinitions,
 } from "@view-server/column-live-view-engine";
 import type { TransportHealth, ViewServerHealth } from "@view-server/config";
-import { Clock, Deferred, Effect, Fiber, Semaphore, type Exit } from "effect";
+import { Clock, Deferred, Effect, Exit, Fiber, Scope, Semaphore } from "effect";
 import type * as Duration from "effect/Duration";
 import type { AtomRef } from "effect/unstable/reactivity";
 
@@ -159,10 +159,10 @@ export const makeCoalescedHealthReader = <const Topics extends DecodableTopicDef
   });
 };
 
-export const makeHealthRefreshScheduler = (
-  refresh: Effect.Effect<void>,
-  cadence: Duration.Input = "1 second",
-) => {
+export const makeHealthRefreshScheduler = Effect.fn(
+  "ViewServerRuntimeCore.healthRefreshScheduler.make",
+)(function* (refresh: Effect.Effect<void>, cadence: Duration.Input = "1 second") {
+  const schedulerScope = yield* Scope.make("parallel");
   let scheduled = false;
   let pending = false;
   let closed = false;
@@ -242,7 +242,7 @@ export const makeHealthRefreshScheduler = (
             const { token } = decision;
             const fiber = yield* drainRefreshes().pipe(
               Effect.ensuring(clearActiveRun(token)),
-              Effect.forkDetach({ startImmediately: true }),
+              Effect.forkIn(schedulerScope, { startImmediately: true }),
             );
             yield* Effect.sync(() => {
               activeFiber = fiber;
@@ -270,6 +270,7 @@ export const makeHealthRefreshScheduler = (
         if (fiber !== undefined) {
           yield* Fiber.interrupt(fiber).pipe(Effect.asVoid);
         }
+        yield* Scope.close(schedulerScope, Exit.void);
       }),
     );
   });
@@ -278,4 +279,4 @@ export const makeHealthRefreshScheduler = (
     close: close(),
     request: requestRefresh(),
   };
-};
+});

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -935,7 +935,7 @@ describe("@view-server/runtime-core", () => {
           );
         },
       };
-      const scheduler = makeHealthRefreshScheduler(
+      const scheduler = yield* makeHealthRefreshScheduler(
         Effect.gen(function* () {
           const readInstallEpoch = installEpoch;
           yield* readHealth(
@@ -999,7 +999,7 @@ describe("@view-server/runtime-core", () => {
           );
         },
       };
-      const scheduler = makeHealthRefreshScheduler(
+      const scheduler = yield* makeHealthRefreshScheduler(
         Effect.gen(function* () {
           const readInstallEpoch = installEpoch;
           yield* readHealth(
@@ -1091,7 +1091,7 @@ describe("@view-server/runtime-core", () => {
           { started: secondStarted, finished: secondFinished },
         ] as const;
 
-        const scheduler = makeHealthRefreshScheduler(
+        const scheduler = yield* makeHealthRefreshScheduler(
           Effect.gen(function* () {
             const refreshStep = refreshSteps[refreshCount] ?? refreshSteps[1];
             yield* Effect.sync(() => {
@@ -1119,7 +1119,7 @@ describe("@view-server/runtime-core", () => {
   it.effect("closes a sleeping health scheduler refresh fiber", () =>
     Effect.gen(function* () {
       let refreshCount = 0;
-      const scheduler = makeHealthRefreshScheduler(
+      const scheduler = yield* makeHealthRefreshScheduler(
         Effect.sync(() => {
           refreshCount += 1;
         }),
@@ -1140,7 +1140,7 @@ describe("@view-server/runtime-core", () => {
       const secondStarted = yield* Deferred.make<void>();
       const startedSignals = [firstStarted, secondStarted] as const;
       let refreshCount = 0;
-      const scheduler = makeHealthRefreshScheduler(
+      const scheduler = yield* makeHealthRefreshScheduler(
         Effect.gen(function* () {
           const started = startedSignals[refreshCount] ?? secondStarted;
           yield* Effect.sync(() => {
@@ -1166,7 +1166,7 @@ describe("@view-server/runtime-core", () => {
   it.effect("ignores health scheduler refresh requests after close", () =>
     Effect.gen(function* () {
       let refreshCount = 0;
-      const scheduler = makeHealthRefreshScheduler(
+      const scheduler = yield* makeHealthRefreshScheduler(
         Effect.sync(() => {
           refreshCount += 1;
         }),

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -29,7 +29,7 @@ import {
   viewServerHealthSummaryRowFromHealth,
   viewServerHealthTopicRowsFromHealth,
 } from "@view-server/config";
-import { Cause, Clock, Effect, Fiber, Queue, Semaphore, Stream } from "effect";
+import { Cause, Clock, Effect, Exit, Queue, Scope, Semaphore, Stream } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
 import { engineErrorToRuntimeError } from "./runtime-error";
 
@@ -155,6 +155,8 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
               64,
             );
             const updates = yield* Queue.sliding<ViewServerHealth<Topics>, Cause.Done>(1);
+            const subscriptionScope = yield* Scope.make("parallel");
+            const closeSubscriptionScope = Scope.close(subscriptionScope, Exit.void);
             const subscription = { close: Effect.void };
             let subscriptionClosed = false;
             const offerSnapshot = Effect.fn("ViewServerRuntimeCore.health.snapshot.offer")(
@@ -163,9 +165,9 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
                 yield* Queue.offer(queue, snapshotFromHealth(nextHealth, updatedAtNanos));
               },
             );
-            const pumpFiber = yield* Stream.fromQueue(updates).pipe(
+            yield* Stream.fromQueue(updates).pipe(
               Stream.runForEach(offerSnapshot),
-              Effect.forkDetach({ startImmediately: true }),
+              Effect.forkIn(subscriptionScope, { startImmediately: true }),
             );
             const unsubscribe = health.subscribe((nextHealth) => {
               Queue.offerUnsafe(updates, nextHealth);
@@ -184,7 +186,7 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
               );
               if (shouldClose) {
                 yield* Queue.end(updates);
-                yield* Fiber.interrupt(pumpFiber).pipe(Effect.asVoid);
+                yield* closeSubscriptionScope;
                 yield* Queue.end(queue);
               }
             });

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -32,103 +32,109 @@ export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> 
   readonly refreshHealth: Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;
 };
 
-export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.make")(<
-  const Topics extends DecodableTopicDefinitions,
->(
-  engine: ColumnLiveViewEngine<Topics>,
-  health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
-  transportHealth: RuntimeCoreTransportHealth<Topics>,
-  healthOverlay?: RuntimeCoreHealthOverlay<Topics>,
-  healthRefreshCadence?: Duration.Input,
-): Effect.Effect<RuntimeCoreClientInstance<Topics>> => {
-  let healthReadEpoch = 0;
-  let healthInstallEpoch = 0;
-  const bumpHealthReadEpoch = Effect.sync(() => {
-    healthReadEpoch += 1;
-  });
-  const readRuntimeHealth = (epoch: number, installMode: "strict" | "scheduled") => {
-    const installEpoch = healthInstallEpoch;
-    return readHealth(
-      engine,
-      health,
-      transportHealth,
-      healthOverlay,
-      () =>
-        healthInstallEpoch === installEpoch &&
-        (installMode === "scheduled" || healthReadEpoch === epoch),
-      () => {
-        healthInstallEpoch += 1;
-      },
-    );
-  };
-  const healthReader = makeCoalescedHealthReader(
-    (epoch) => readRuntimeHealth(epoch, "strict"),
-    () => healthReadEpoch,
-  );
-  const scheduledHealthReader = makeCoalescedHealthReader(
-    (epoch) => readRuntimeHealth(epoch, "scheduled"),
-    () => healthReadEpoch,
-  );
-  const scheduledHealthRefresh = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.scheduled")(
-    function* () {
-      yield* scheduledHealthReader();
-    },
-  );
-  const healthRefreshScheduler = makeHealthRefreshScheduler(
-    scheduledHealthRefresh(),
-    healthRefreshCadence,
-  );
-  const requestHealthRefresh = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.request")(
-    function* () {
-      yield* Effect.uninterruptible(
-        bumpHealthReadEpoch.pipe(Effect.andThen(healthRefreshScheduler.request)),
+export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.make")(
+  <const Topics extends DecodableTopicDefinitions>(
+    engine: ColumnLiveViewEngine<Topics>,
+    health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
+    transportHealth: RuntimeCoreTransportHealth<Topics>,
+    healthOverlay?: RuntimeCoreHealthOverlay<Topics>,
+    healthRefreshCadence?: Duration.Input,
+  ): Effect.Effect<RuntimeCoreClientInstance<Topics>> =>
+    Effect.gen(function* () {
+      let healthReadEpoch = 0;
+      let healthInstallEpoch = 0;
+      const bumpHealthReadEpoch = Effect.sync(() => {
+        healthReadEpoch += 1;
+      });
+      const readRuntimeHealth = (epoch: number, installMode: "strict" | "scheduled") => {
+        const installEpoch = healthInstallEpoch;
+        return readHealth(
+          engine,
+          health,
+          transportHealth,
+          healthOverlay,
+          () =>
+            healthInstallEpoch === installEpoch &&
+            (installMode === "scheduled" || healthReadEpoch === epoch),
+          () => {
+            healthInstallEpoch += 1;
+          },
+        );
+      };
+      const healthReader = makeCoalescedHealthReader(
+        (epoch) => readRuntimeHealth(epoch, "strict"),
+        () => healthReadEpoch,
       );
-    },
-  );
-  const refreshHealthNow = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.now")(
-    function* () {
-      return yield* Effect.uninterruptible(
-        bumpHealthReadEpoch.pipe(Effect.andThen(healthReader())),
+      const scheduledHealthReader = makeCoalescedHealthReader(
+        (epoch) => readRuntimeHealth(epoch, "scheduled"),
+        () => healthReadEpoch,
       );
-    },
-  );
-  const snapshot = <
-    Topic extends Extract<keyof Topics, string>,
-    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
-  >(
-    topic: Topic,
-    query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
-  ): Effect.Effect<
-    LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
-    ViewServerRuntimeError
-  > => engine.snapshot<Topic, Query>(topic, query).pipe(Effect.mapError(engineErrorToRuntimeError));
-  return Effect.succeed<RuntimeCoreClientInstance<Topics>>({
-    client: {
-      publish: (topic, row) =>
-        Effect.uninterruptible(
-          engine.publish(topic, row).pipe(Effect.tap(() => requestHealthRefresh())),
-        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-      publishMany: (topic, rows) =>
-        Effect.uninterruptible(
-          engine.publishMany(topic, rows).pipe(Effect.tap(() => requestHealthRefresh())),
-        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-      patch: (topic, key, patch) =>
-        Effect.uninterruptible(
-          engine.patch(topic, key, patch).pipe(Effect.tap(() => requestHealthRefresh())),
-        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-      delete: (topic, key) =>
-        Effect.uninterruptible(
-          engine.delete(topic, key).pipe(Effect.tap(() => requestHealthRefresh())),
-        ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-      snapshot,
-      health: () => healthReader(),
-      reset: () =>
-        Effect.uninterruptible(engine.reset().pipe(Effect.tap(() => requestHealthRefresh()))).pipe(
-          Effect.mapError(engineErrorToRuntimeError),
-        ),
-    },
-    close: healthRefreshScheduler.close,
-    requestHealthRefresh: requestHealthRefresh(),
-    refreshHealth: refreshHealthNow(),
-  });
-});
+      const scheduledHealthRefresh = Effect.fn(
+        "ViewServerRuntimeCore.client.healthRefresh.scheduled",
+      )(function* () {
+        yield* scheduledHealthReader();
+      });
+      const healthRefreshScheduler = yield* makeHealthRefreshScheduler(
+        scheduledHealthRefresh(),
+        healthRefreshCadence,
+      );
+      const requestHealthRefresh = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.request")(
+        function* () {
+          yield* Effect.uninterruptible(
+            bumpHealthReadEpoch.pipe(Effect.andThen(healthRefreshScheduler.request)),
+          );
+        },
+      );
+      const refreshHealthNow = Effect.fn("ViewServerRuntimeCore.client.healthRefresh.now")(
+        function* () {
+          return yield* Effect.uninterruptible(
+            bumpHealthReadEpoch.pipe(Effect.andThen(healthReader())),
+          );
+        },
+      );
+      const snapshot = <
+        Topic extends Extract<keyof Topics, string>,
+        const Query extends
+          | RawQuery<TopicRow<Topics, Topic>>
+          | GroupedQuery<TopicRow<Topics, Topic>>,
+      >(
+        topic: Topic,
+        query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+      ): Effect.Effect<
+        LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+        ViewServerRuntimeError
+      > =>
+        engine
+          .snapshot<Topic, Query>(topic, query)
+          .pipe(Effect.mapError(engineErrorToRuntimeError));
+      return {
+        client: {
+          publish: (topic, row) =>
+            Effect.uninterruptible(
+              engine.publish(topic, row).pipe(Effect.tap(() => requestHealthRefresh())),
+            ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+          publishMany: (topic, rows) =>
+            Effect.uninterruptible(
+              engine.publishMany(topic, rows).pipe(Effect.tap(() => requestHealthRefresh())),
+            ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+          patch: (topic, key, patch) =>
+            Effect.uninterruptible(
+              engine.patch(topic, key, patch).pipe(Effect.tap(() => requestHealthRefresh())),
+            ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+          delete: (topic, key) =>
+            Effect.uninterruptible(
+              engine.delete(topic, key).pipe(Effect.tap(() => requestHealthRefresh())),
+            ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+          snapshot,
+          health: () => healthReader(),
+          reset: () =>
+            Effect.uninterruptible(
+              engine.reset().pipe(Effect.tap(() => requestHealthRefresh())),
+            ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+        },
+        close: healthRefreshScheduler.close,
+        requestHealthRefresh: requestHealthRefresh(),
+        refreshHealth: refreshHealthNow(),
+      } satisfies RuntimeCoreClientInstance<Topics>;
+    }),
+);

--- a/packages/runtime/src/kafka-health.ts
+++ b/packages/runtime/src/kafka-health.ts
@@ -35,8 +35,21 @@ type KafkaTopicRegionLedger = {
   committedOffset: string | null;
   lastError: string | null;
   regionLastError: string | null;
-  windowSecond: number | null;
+  rateBuckets: Array<KafkaRateBucket | undefined>;
 };
+
+type KafkaRateBucket = {
+  occurredAt: number;
+  messages: number;
+  bytes: number;
+  decoded: number;
+  failed: number;
+  mappingFailed: number;
+  processingFailed: number;
+};
+
+const kafkaRateWindowMillis = 1_000;
+const maxKafkaRateBuckets = kafkaRateWindowMillis + 1;
 
 type KafkaTopicLedger = {
   status: KafkaTopicHealth["status"];
@@ -128,7 +141,7 @@ const initialTopicRegionLedger = (): KafkaTopicRegionLedger => ({
   committedOffset: null,
   lastError: null,
   regionLastError: null,
-  windowSecond: null,
+  rateBuckets: Array.from({ length: maxKafkaRateBuckets }, () => undefined),
 });
 
 const copyTopicRegionHealth = (region: KafkaTopicRegionLedger): KafkaTopicRegionHealth => ({
@@ -160,35 +173,59 @@ const incrementWindow = (
     readonly processingFailed: number;
   },
 ) => {
-  const nextSecond = Math.floor(nowMillis / 1000);
-  if (region.windowSecond !== nextSecond) {
-    region.windowSecond = nextSecond;
-    region.messagesPerSecond = 0;
-    region.bytesPerSecond = 0;
-    region.decodedMessagesPerSecond = 0;
-    region.decodeFailuresPerSecond = 0;
-    region.mappingFailuresPerSecond = 0;
-    region.processingFailuresPerSecond = 0;
+  const occurredAt = Math.trunc(nowMillis);
+  const bucketIndex = Math.abs(occurredAt % maxKafkaRateBuckets);
+  const existingBucket = region.rateBuckets[bucketIndex];
+  if (existingBucket !== undefined && existingBucket.occurredAt === occurredAt) {
+    existingBucket.messages += counters.messages;
+    existingBucket.bytes += counters.bytes;
+    existingBucket.decoded += counters.decoded;
+    existingBucket.failed += counters.failed;
+    existingBucket.mappingFailed += counters.mappingFailed;
+    existingBucket.processingFailed += counters.processingFailed;
+    return;
   }
-  region.messagesPerSecond += counters.messages;
-  region.bytesPerSecond += counters.bytes;
-  region.decodedMessagesPerSecond += counters.decoded;
-  region.decodeFailuresPerSecond += counters.failed;
-  region.mappingFailuresPerSecond += counters.mappingFailed;
-  region.processingFailuresPerSecond += counters.processingFailed;
+  region.rateBuckets[bucketIndex] = {
+    occurredAt,
+    messages: counters.messages,
+    bytes: counters.bytes,
+    decoded: counters.decoded,
+    failed: counters.failed,
+    mappingFailed: counters.mappingFailed,
+    processingFailed: counters.processingFailed,
+  };
 };
 
 const resetIdleWindow = (region: KafkaTopicRegionLedger, nowMillis: number) => {
-  const nextSecond = Math.floor(nowMillis / 1000);
-  if (region.windowSecond !== null && region.windowSecond !== nextSecond) {
-    region.windowSecond = nextSecond;
-    region.messagesPerSecond = 0;
-    region.bytesPerSecond = 0;
-    region.decodedMessagesPerSecond = 0;
-    region.decodeFailuresPerSecond = 0;
-    region.mappingFailuresPerSecond = 0;
-    region.processingFailuresPerSecond = 0;
+  const occurredBefore = Math.trunc(nowMillis) - kafkaRateWindowMillis;
+  const occurredAfter = Math.trunc(nowMillis);
+  let messagesPerSecond = 0;
+  let bytesPerSecond = 0;
+  let decodedMessagesPerSecond = 0;
+  let decodeFailuresPerSecond = 0;
+  let mappingFailuresPerSecond = 0;
+  let processingFailuresPerSecond = 0;
+  for (const bucket of region.rateBuckets) {
+    if (
+      bucket === undefined ||
+      bucket.occurredAt < occurredBefore ||
+      bucket.occurredAt > occurredAfter
+    ) {
+      continue;
+    }
+    messagesPerSecond += bucket.messages;
+    bytesPerSecond += bucket.bytes;
+    decodedMessagesPerSecond += bucket.decoded;
+    decodeFailuresPerSecond += bucket.failed;
+    mappingFailuresPerSecond += bucket.mappingFailed;
+    processingFailuresPerSecond += bucket.processingFailed;
   }
+  region.messagesPerSecond = messagesPerSecond;
+  region.bytesPerSecond = bytesPerSecond;
+  region.decodedMessagesPerSecond = decodedMessagesPerSecond;
+  region.decodeFailuresPerSecond = decodeFailuresPerSecond;
+  region.mappingFailuresPerSecond = mappingFailuresPerSecond;
+  region.processingFailuresPerSecond = processingFailuresPerSecond;
 };
 
 const copyRegionHealth = (region: KafkaRegionLedger): KafkaRegionHealth => ({

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -1052,9 +1052,9 @@ describe("@view-server/runtime Kafka ingress internals", () => {
                 local: {
                   connected: false,
                   assignedPartitions: 2,
-                  messagesPerSecond: 2,
-                  bytesPerSecond: 25,
-                  decodedMessagesPerSecond: 1,
+                  messagesPerSecond: 3,
+                  bytesPerSecond: 35,
+                  decodedMessagesPerSecond: 2,
                   decodeFailuresPerSecond: 1,
                   mappingFailuresPerSecond: 0,
                   processingFailuresPerSecond: 0,
@@ -1683,7 +1683,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
-  it.effect("resets idle Kafka per-second counters on health reads", () =>
+  it.effect("reports Kafka per-second counters over a rolling one-second window", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
       const ledger = makeViewServerKafkaHealthLedger<Topics>({
@@ -1704,9 +1704,26 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       });
 
       const activeHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 1_000);
-      const idleHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      const boundaryHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      const idleHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_001);
 
       expect(activeHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]).toStrictEqual({
+        connected: true,
+        assignedPartitions: 1,
+        messagesPerSecond: 1,
+        bytesPerSecond: 10,
+        decodedMessagesPerSecond: 1,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        processingFailuresPerSecond: 0,
+        lastMessageAt: 1_000,
+        lastCommitAt: 1_000,
+        consumerLagMessages: null,
+        lagSampledAt: null,
+        committedOffset: "1",
+        lastError: null,
+      });
+      expect(boundaryHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]).toStrictEqual({
         connected: true,
         assignedPartitions: 1,
         messagesPerSecond: 1,


### PR DESCRIPTION
## Summary

- reject unsupported runtime value domains and overlapping mixed numeric domains in View Server topic schemas
- keep startsWith as a string-prefix protocol operator without full field decoding
- make health scheduling/subscription lifecycle scoped instead of detached, and keep remote subscription defects visible
- switch Kafka health rate counters to rolling one-second buckets
- preserve hot-path row equality semantics for Map/Set by identity

## Validation

- 3 reviewer agents clean: no blockers/P1/P2
- git diff --check
- pnpm run ready
