### PR TITLE
Add schema-derived scalar columns

### DIFF
--- a/benchmarks/baselines/smoke.json
+++ b/benchmarks/baselines/smoke.json
@@ -8,83 +8,101 @@
       "benchmarks": [
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.594791999999984,
-          "meanMs": 0.32870019999999156,
-          "minMs": 0.246249999999975,
+          "maxMs": 0.3961669999999913,
+          "meanMs": 0.23964999999999465,
+          "minMs": 0.17925000000002456,
           "name": "equality filter + top-k sort",
-          "p99Ms": 0.594791999999984,
+          "p99Ms": 0.3961669999999913,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.5255410000000325,
-          "meanMs": 0.21049960000000284,
-          "minMs": 0.12020899999998846,
+          "maxMs": 0.517832999999996,
+          "meanMs": 0.2173749999999927,
+          "minMs": 0.13262500000001864,
           "name": "selective equality filter + fallback top-k sort",
-          "p99Ms": 0.5255410000000325,
+          "p99Ms": 0.517832999999996,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.4064159999999788,
-          "meanMs": 0.1456547142857078,
-          "minMs": 0.07591600000000653,
+          "maxMs": 0.3973750000000109,
+          "meanMs": 0.13284900000001443,
+          "minMs": 0.0742089999999962,
           "name": "ordered equality filter + indexed seek",
-          "p99Ms": 0.4064159999999788,
-          "sampleCount": 7
+          "p99Ms": 0.3973750000000109,
+          "sampleCount": 8
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.23466600000000426,
-          "meanMs": 0.10982490000000097,
-          "minMs": 0.08383300000002691,
+          "maxMs": 0.20979099999999562,
+          "meanMs": 0.10799999999998704,
+          "minMs": 0.08283299999999372,
           "name": "ordered in filter + indexed seek",
-          "p99Ms": 0.23466600000000426,
+          "p99Ms": 0.20979099999999562,
           "sampleCount": 10
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.17204199999997627,
-          "meanMs": 0.07868899999999712,
-          "minMs": 0.06391600000000608,
+          "maxMs": 0.17441700000000537,
+          "meanMs": 0.08000653846153664,
+          "minMs": 0.0631249999999568,
           "name": "range filter + top-k sort",
-          "p99Ms": 0.17204199999997627,
+          "p99Ms": 0.17441700000000537,
           "sampleCount": 13
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.336749999999995,
-          "meanMs": 0.21922500000000583,
-          "minMs": 0.1634999999999991,
-          "name": "selective range filter + fallback top-k sort",
-          "p99Ms": 0.336749999999995,
-          "sampleCount": 5
+          "maxMs": 0.28204099999999244,
+          "meanMs": 0.09100754545455526,
+          "minMs": 0.06304199999999582,
+          "name": "bigint range filter + indexed seek",
+          "p99Ms": 0.28204099999999244,
+          "sampleCount": 11
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.5289999999999964,
-          "meanMs": 0.17702083333333007,
-          "minMs": 0.0963329999999587,
-          "name": "compound filter + top-k sort",
-          "p99Ms": 0.5289999999999964,
+          "maxMs": 0.45208399999995663,
+          "meanMs": 0.12596375000000393,
+          "minMs": 0.06779199999999719,
+          "name": "BigDecimal range filter + indexed seek",
+          "p99Ms": 0.45208399999995663,
+          "sampleCount": 8
+        },
+        {
+          "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
+          "maxMs": 0.3045829999999796,
+          "meanMs": 0.18424983333332534,
+          "minMs": 0.12341599999996333,
+          "name": "selective range filter + fallback top-k sort",
+          "p99Ms": 0.3045829999999796,
           "sampleCount": 6
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.2498329999999669,
-          "meanMs": 0.10858319999999252,
-          "minMs": 0.07641700000004903,
-          "name": "filtered totalRows via zero-row window",
-          "p99Ms": 0.2498329999999669,
-          "sampleCount": 10
+          "maxMs": 0.5092920000000163,
+          "meanMs": 0.14614899999999612,
+          "minMs": 0.0687499999999659,
+          "name": "compound filter + top-k sort",
+          "p99Ms": 0.5092920000000163,
+          "sampleCount": 7
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.9350000000000023,
-          "meanMs": 0.372849999999994,
-          "minMs": 0.21245799999996962,
+          "maxMs": 0.13562500000000455,
+          "meanMs": 0.06378118749999473,
+          "minMs": 0.05608300000000099,
+          "name": "filtered totalRows via zero-row window",
+          "p99Ms": 0.13562500000000455,
+          "sampleCount": 16
+        },
+        {
+          "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
+          "maxMs": 0.8114579999999592,
+          "meanMs": 0.33984139999998886,
+          "minMs": 0.20037500000000819,
           "name": "live subscription delta after publish",
-          "p99Ms": 0.9350000000000023,
+          "p99Ms": 0.8114579999999592,
           "sampleCount": 5
         }
       ],
@@ -94,6 +112,8 @@
         "ordered equality filter + indexed seek",
         "ordered in filter + indexed seek",
         "range filter + top-k sort",
+        "bigint range filter + indexed seek",
+        "BigDecimal range filter + indexed seek",
         "selective range filter + fallback top-k sort",
         "compound filter + top-k sort",
         "filtered totalRows via zero-row window",
@@ -103,7 +123,7 @@
       "benchmarkScope": "engine-raw-snapshot",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 44204032,
+      "memoryRssTotalDeltaBytes": 43253760,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-snapshot-1000rows.json",
@@ -120,74 +140,74 @@
       "benchmarks": [
         {
           "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.07050000000000978,
-          "meanMs": 0.06419275000000013,
-          "minMs": 0.05979199999998741,
+          "maxMs": 0.07533300000000054,
+          "meanMs": 0.06436706250000235,
+          "minMs": 0.059332999999980984,
           "name": "full scan callback baseline: selective customer + fallback sort",
-          "p99Ms": 0.07050000000000978,
+          "p99Ms": 0.07533300000000054,
           "sampleCount": 16
         },
         {
           "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.04833399999998278,
-          "meanMs": 0.0298346176470562,
-          "minMs": 0.023792000000014468,
+          "maxMs": 0.03608300000001918,
+          "meanMs": 0.028394638888886763,
+          "minMs": 0.024042000000008557,
           "name": "exact scalar candidate: selective customer + fallback sort",
-          "p99Ms": 0.04833399999998278,
-          "sampleCount": 34
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.04733299999998053,
-          "meanMs": 0.027065432432432257,
-          "minMs": 0.02337500000004411,
-          "name": "exact scalar candidate: selective customer without callback",
-          "p99Ms": 0.04733299999998053,
-          "sampleCount": 37
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.14304200000003675,
-          "meanMs": 0.03646728571428274,
-          "minMs": 0.027124999999955435,
-          "name": "exact multi-key in candidate: three customers + fallback sort",
-          "p99Ms": 0.14304200000003675,
-          "sampleCount": 28
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.12287499999996498,
-          "meanMs": 0.10367500000000404,
-          "minMs": 0.08683300000001282,
-          "name": "exact range candidate: upper price tail + fallback sort",
-          "p99Ms": 0.12287499999996498,
-          "sampleCount": 10
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.10687500000000227,
-          "meanMs": 0.07612499999999857,
-          "minMs": 0.07154199999996536,
-          "name": "full scan callback baseline: upper price tail + fallback sort",
-          "p99Ms": 0.10687500000000227,
-          "sampleCount": 14
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.03637500000002092,
-          "meanMs": 0.028087972222220654,
-          "minMs": 0.02287499999999909,
-          "name": "ordered equality seek: customer storage order",
-          "p99Ms": 0.03637500000002092,
+          "p99Ms": 0.03608300000001918,
           "sampleCount": 36
         },
         {
           "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.4047080000000278,
-          "meanMs": 0.3810663999999974,
-          "minMs": 0.3269999999999982,
+          "maxMs": 0.04095799999998917,
+          "meanMs": 0.02675768421052507,
+          "minMs": 0.02312499999999318,
+          "name": "exact scalar candidate: selective customer without callback",
+          "p99Ms": 0.04095799999998917,
+          "sampleCount": 38
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.04179199999998673,
+          "meanMs": 0.029707147058824247,
+          "minMs": 0.026041999999989685,
+          "name": "exact multi-key in candidate: three customers + fallback sort",
+          "p99Ms": 0.04179199999998673,
+          "sampleCount": 34
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.1251670000000047,
+          "meanMs": 0.10037920000000326,
+          "minMs": 0.0887079999999969,
+          "name": "exact range candidate: upper price tail + fallback sort",
+          "p99Ms": 0.1251670000000047,
+          "sampleCount": 10
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.08012500000000955,
+          "meanMs": 0.07447328571428662,
+          "minMs": 0.07237500000002228,
+          "name": "full scan callback baseline: upper price tail + fallback sort",
+          "p99Ms": 0.08012500000000955,
+          "sampleCount": 14
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.036167000000006055,
+          "meanMs": 0.028041777777777572,
+          "minMs": 0.022458999999997786,
+          "name": "ordered equality seek: customer storage order",
+          "p99Ms": 0.036167000000006055,
+          "sampleCount": 36
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.3994160000000022,
+          "meanMs": 0.37909139999999864,
+          "minMs": 0.35166699999999196,
           "name": "failed broad scalar candidate build + full scan",
-          "p99Ms": 0.4047080000000278,
+          "p99Ms": 0.3994160000000022,
           "sampleCount": 5
         }
       ],
@@ -205,7 +225,7 @@
       "benchmarkScope": "engine-raw-predicate-index",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 12288000,
+      "memoryRssTotalDeltaBytes": 14696448,
       "minimumSampleCount": 5,
       "mutationCount": 0,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-predicate-index-1000rows.json",
@@ -222,47 +242,47 @@
       "benchmarks": [
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 0.23362500000001774,
-          "meanMs": 0.11421288888889573,
+          "maxMs": 0.23304200000001174,
+          "meanMs": 0.11289822222221978,
           "minMs": 0.08887500000003001,
           "name": "publish append single row",
-          "p99Ms": 0.23362500000001774,
+          "p99Ms": 0.23304200000001174,
           "sampleCount": 9
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.963292000000024,
-          "meanMs": 2.2987750000000005,
-          "minMs": 1.9388329999999883,
+          "maxMs": 2.7803749999999923,
+          "meanMs": 2.1845749999999837,
+          "minMs": 1.8826669999999694,
           "name": "publishMany append batch",
-          "p99Ms": 2.963292000000024,
+          "p99Ms": 2.7803749999999923,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.5721249999999714,
-          "meanMs": 2.1267251999999757,
-          "minMs": 1.8765839999999798,
+          "maxMs": 2.2151660000000106,
+          "meanMs": 1.9996329999999944,
+          "minMs": 1.919290999999987,
           "name": "publishMany replace existing batch",
-          "p99Ms": 2.5721249999999714,
+          "p99Ms": 2.2151660000000106,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.601916999999958,
-          "meanMs": 6.289891599999987,
-          "minMs": 6.047124999999994,
+          "maxMs": 6.389667000000031,
+          "meanMs": 6.169766600000014,
+          "minMs": 5.87741699999998,
           "name": "patch existing rows one by one",
-          "p99Ms": 6.601916999999958,
+          "p99Ms": 6.389667000000031,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 5.819749999999999,
-          "meanMs": 5.177542000000005,
-          "minMs": 4.4014589999999885,
+          "maxMs": 5.6590419999999995,
+          "meanMs": 5.069625400000007,
+          "minMs": 4.507292000000007,
           "name": "append then delete batch",
-          "p99Ms": 5.819749999999999,
+          "p99Ms": 5.6590419999999995,
           "sampleCount": 5
         }
       ],
@@ -277,7 +297,7 @@
       "benchmarkScope": "engine-raw-write",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 51855360,
+      "memoryRssTotalDeltaBytes": 55001088,
       "minimumSampleCount": 5,
       "mutationCount": 3509,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-write-base-1000rows.json",
@@ -294,47 +314,47 @@
       "benchmarks": [
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 0.37237500000003365,
-          "meanMs": 0.1547438571428675,
-          "minMs": 0.10616599999997334,
+          "maxMs": 0.27495800000002646,
+          "meanMs": 0.13654675000000793,
+          "minMs": 0.1004169999999931,
           "name": "publish append single row",
-          "p99Ms": 0.37237500000003365,
-          "sampleCount": 7
+          "p99Ms": 0.27495800000002646,
+          "sampleCount": 8
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 3.042958999999996,
-          "meanMs": 2.55077500000001,
-          "minMs": 2.130958000000021,
+          "maxMs": 2.891125000000045,
+          "meanMs": 2.306141400000024,
+          "minMs": 2.007333000000017,
           "name": "publishMany append batch",
-          "p99Ms": 3.042958999999996,
+          "p99Ms": 2.891125000000045,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.7171659999999633,
-          "meanMs": 2.34985019999998,
-          "minMs": 2.079666999999972,
+          "maxMs": 2.311333999999988,
+          "meanMs": 2.09000860000001,
+          "minMs": 1.9910409999999956,
           "name": "publishMany replace existing batch",
-          "p99Ms": 2.7171659999999633,
+          "p99Ms": 2.311333999999988,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.918417000000034,
-          "meanMs": 6.208325400000012,
-          "minMs": 5.886209000000008,
+          "maxMs": 6.842707999999959,
+          "meanMs": 6.3811000000000035,
+          "minMs": 5.85733300000004,
           "name": "patch existing rows one by one",
-          "p99Ms": 6.918417000000034,
+          "p99Ms": 6.842707999999959,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.287124999999946,
-          "meanMs": 5.306233399999985,
-          "minMs": 4.556375000000003,
+          "maxMs": 5.625124999999969,
+          "meanMs": 5.164241400000003,
+          "minMs": 4.705874999999992,
           "name": "append then delete batch",
-          "p99Ms": 6.287124999999946,
+          "p99Ms": 5.625124999999969,
           "sampleCount": 5
         }
       ],
@@ -349,9 +369,9 @@
       "benchmarkScope": "engine-raw-write",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 52297728,
+      "memoryRssTotalDeltaBytes": 57065472,
       "minimumSampleCount": 5,
-      "mutationCount": 3507,
+      "mutationCount": 3508,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-write-indexed-1000rows.json",
       "queuedEventCount": 0,
       "rowCount": 1000,
@@ -366,11 +386,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 1000 rows, 5 subscribers, same-window",
-          "maxMs": 2.1127500000000055,
-          "meanMs": 0.937758400000007,
-          "minMs": 0.5816669999999817,
+          "maxMs": 2.080291000000045,
+          "meanMs": 0.9105414000000224,
+          "minMs": 0.5465829999999983,
           "name": "same-window subscribers publish + delta fanout",
-          "p99Ms": 2.1127500000000055,
+          "p99Ms": 2.080291000000045,
           "sampleCount": 5
         }
       ],
@@ -379,7 +399,7 @@
       "benchmarkScope": "engine-raw-live-fanout",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 38567936,
+      "memoryRssTotalDeltaBytes": 38993920,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-same-window-1000rows-5subs.json",
@@ -396,11 +416,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 1000 rows, 5 subscribers, ten-window",
-          "maxMs": 2.9193750000000023,
-          "meanMs": 1.1286001999999826,
-          "minMs": 0.5892499999999927,
+          "maxMs": 2.0637080000000196,
+          "meanMs": 0.9142913999999905,
+          "minMs": 0.5452909999999633,
           "name": "ten-window subscribers publish + delta fanout",
-          "p99Ms": 2.9193750000000023,
+          "p99Ms": 2.0637080000000196,
           "sampleCount": 5
         }
       ],
@@ -409,7 +429,7 @@
       "benchmarkScope": "engine-raw-live-fanout",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 41336832,
+      "memoryRssTotalDeltaBytes": 40452096,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-ten-window-1000rows-5subs.json",
@@ -426,56 +446,56 @@
       "benchmarks": [
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 3.477458000000013,
-          "meanMs": 2.7440833999999996,
-          "minMs": 2.2406670000000304,
+          "maxMs": 2.9722909999999843,
+          "meanMs": 2.535474799999986,
+          "minMs": 2.1734579999999823,
           "name": "status grouped count/sum/min/max/avg",
-          "p99Ms": 3.477458000000013,
+          "p99Ms": 2.9722909999999843,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 1.8972500000000423,
-          "meanMs": 1.6737166000000117,
-          "minMs": 1.5255839999999807,
+          "maxMs": 1.7837499999999977,
+          "meanMs": 1.57025000000001,
+          "minMs": 1.488125000000025,
           "name": "region+status grouped count/sum/min/max/avg",
-          "p99Ms": 1.8972500000000423,
+          "p99Ms": 1.7837499999999977,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 1.5722499999999968,
-          "meanMs": 1.4244750000000068,
-          "minMs": 1.3417080000000396,
+          "maxMs": 1.5,
+          "meanMs": 1.387008400000002,
+          "minMs": 1.3017080000000192,
           "name": "high-cardinality desk grouped aggregates",
-          "p99Ms": 1.5722499999999968,
+          "p99Ms": 1.5,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 0.5887910000000147,
-          "meanMs": 0.4930832000000123,
-          "minMs": 0.4295420000000263,
+          "maxMs": 0.47662500000001273,
+          "meanMs": 0.4410665999999878,
+          "minMs": 0.425707999999986,
           "name": "high-cardinality desk group count via zero-row window",
-          "p99Ms": 0.5887910000000147,
+          "p99Ms": 0.47662500000001273,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 0.9018330000000105,
-          "meanMs": 0.7832247999999936,
-          "minMs": 0.7224579999999605,
+          "maxMs": 0.8487499999999955,
+          "meanMs": 0.7719665999999961,
+          "minMs": 0.7222909999999843,
           "name": "filtered status grouped aggregates",
-          "p99Ms": 0.9018330000000105,
+          "p99Ms": 0.8487499999999955,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 0.7932500000000005,
-          "meanMs": 0.3135997999999859,
-          "minMs": 0.18058300000001282,
+          "maxMs": 0.7304159999999911,
+          "meanMs": 0.29850820000001477,
+          "minMs": 0.17995799999999917,
           "name": "live grouped aggregate delta after publish",
-          "p99Ms": 0.7932500000000005,
+          "p99Ms": 0.7304159999999911,
           "sampleCount": 5
         }
       ],
@@ -491,7 +511,7 @@
       "benchmarkScope": "engine-grouped-aggregate",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 55590912,
+      "memoryRssTotalDeltaBytes": 58802176,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-aggregate-1000rows.json",
@@ -508,47 +528,47 @@
       "benchmarks": [
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 1.0474590000000035,
-          "meanMs": 0.4957916000000068,
-          "minMs": 0.3089580000000183,
+          "maxMs": 1.0173340000000053,
+          "meanMs": 0.4884583999999904,
+          "minMs": 0.3124159999999847,
           "name": "grouped publishMany append batch",
-          "p99Ms": 1.0474590000000035,
+          "p99Ms": 1.0173340000000053,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.5251250000000027,
-          "meanMs": 0.36029140000000554,
-          "minMs": 0.2536660000000097,
+          "maxMs": 0.5509999999999877,
+          "meanMs": 0.3535663999999997,
+          "minMs": 0.24425000000002228,
           "name": "grouped publishMany replace extrema batch",
-          "p99Ms": 0.5251250000000027,
+          "p99Ms": 0.5509999999999877,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.4262499999999818,
-          "meanMs": 0.27774180000000115,
-          "minMs": 0.21141700000003993,
+          "maxMs": 0.39733300000000327,
+          "meanMs": 0.25227479999999786,
+          "minMs": 0.18720799999999826,
           "name": "grouped patch aggregate values",
-          "p99Ms": 0.4262499999999818,
+          "p99Ms": 0.39733300000000327,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.5941670000000272,
-          "meanMs": 0.31622520000000803,
-          "minMs": 0.20775000000003274,
+          "maxMs": 0.336749999999995,
+          "meanMs": 0.25430840000001353,
+          "minMs": 0.22570799999999736,
           "name": "grouped patch group moves",
-          "p99Ms": 0.5941670000000272,
+          "p99Ms": 0.336749999999995,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.35049999999995407,
-          "meanMs": 0.21179159999999228,
-          "minMs": 0.16137499999996407,
+          "maxMs": 0.3057499999999891,
+          "meanMs": 0.2039916000000062,
+          "minMs": 0.1656669999999849,
           "name": "grouped delete existing rows",
-          "p99Ms": 0.35049999999995407,
+          "p99Ms": 0.3057499999999891,
           "sampleCount": 5
         }
       ],
@@ -583,7 +603,7 @@
         "writeBatchSize": 1
       },
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 48021504,
+      "memoryRssTotalDeltaBytes": 47841280,
       "minimumSampleCount": 5,
       "mutationCount": 1025,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000rows-1mutations.json",
@@ -600,11 +620,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: noop, 101 rows",
-          "maxMs": 1.57570800000002,
-          "meanMs": 0.8139250000000061,
-          "minMs": 0.5220840000000067,
+          "maxMs": 1.3674159999999915,
+          "meanMs": 0.7291498000000047,
+          "minMs": 0.5129999999999768,
           "name": "retained nonmatching update delete no-op",
-          "p99Ms": 1.57570800000002,
+          "p99Ms": 1.3674159999999915,
           "sampleCount": 5
         }
       ],
@@ -613,7 +633,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 10878976,
+      "memoryRssTotalDeltaBytes": 10321920,
       "minimumSampleCount": 5,
       "mutationCount": 116,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-noop-101rows.json",
@@ -630,11 +650,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: match-update, 101 rows",
-          "maxMs": 0.9725830000000428,
-          "meanMs": 0.4375330000000076,
-          "minMs": 0.27924999999999045,
+          "maxMs": 1.006750000000011,
+          "meanMs": 0.4442500000000109,
+          "minMs": 0.2863750000000209,
           "name": "retained match-to-match update delta",
-          "p99Ms": 0.9725830000000428,
+          "p99Ms": 1.006750000000011,
           "sampleCount": 5
         }
       ],
@@ -643,7 +663,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 6766592,
+      "memoryRssTotalDeltaBytes": 5816320,
       "minimumSampleCount": 5,
       "mutationCount": 106,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-match-update-101rows.json",
@@ -660,11 +680,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: predicate-enter, 101 rows",
-          "maxMs": 1.327292,
-          "meanMs": 0.7725334000000089,
-          "minMs": 0.5069159999999897,
+          "maxMs": 1.2977920000000154,
+          "meanMs": 0.6371833999999922,
+          "minMs": 0.42183299999999235,
           "name": "retained predicate-enter update delta",
-          "p99Ms": 1.327292,
+          "p99Ms": 1.2977920000000154,
           "sampleCount": 5
         }
       ],
@@ -673,7 +693,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 7766016,
+      "memoryRssTotalDeltaBytes": 9928704,
       "minimumSampleCount": 5,
       "mutationCount": 111,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-predicate-enter-101rows.json",
@@ -690,11 +710,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: visible-delete, 101 rows",
-          "maxMs": 0.7548340000000167,
-          "meanMs": 0.45481680000000324,
-          "minMs": 0.23095899999998437,
+          "maxMs": 0.7300000000000182,
+          "meanMs": 0.35604160000002594,
+          "minMs": 0.2190830000000119,
           "name": "retained visible delete refill/fallback sequence",
-          "p99Ms": 0.7548340000000167,
+          "p99Ms": 0.7300000000000182,
           "sampleCount": 5
         }
       ],
@@ -703,7 +723,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 5226496,
+      "memoryRssTotalDeltaBytes": 4866048,
       "minimumSampleCount": 5,
       "mutationCount": 106,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-visible-delete-101rows.json",
@@ -720,11 +740,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: exhausted-lookahead, 101 rows",
-          "maxMs": 1.057875000000024,
-          "meanMs": 0.577491600000019,
-          "minMs": 0.42079200000000583,
+          "maxMs": 1.0537500000000364,
+          "meanMs": 0.5825916000000007,
+          "minMs": 0.4372500000000059,
           "name": "retained visible delete pair lookahead plus fallback",
-          "p99Ms": 1.057875000000024,
+          "p99Ms": 1.0537500000000364,
           "sampleCount": 5
         }
       ],
@@ -733,7 +753,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 9060352,
+      "memoryRssTotalDeltaBytes": 8028160,
       "minimumSampleCount": 5,
       "mutationCount": 111,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-exhausted-lookahead-101rows.json",
@@ -750,11 +770,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: count-only, 101 rows",
-          "maxMs": 0.609457999999961,
-          "meanMs": 0.2820663999999965,
-          "minMs": 0.18891600000000608,
+          "maxMs": 0.5631250000000136,
+          "meanMs": 0.26405839999999897,
+          "minMs": 0.176667000000009,
           "name": "count-only retained insert delta",
-          "p99Ms": 0.609457999999961,
+          "p99Ms": 0.5631250000000136,
           "sampleCount": 5
         }
       ],
@@ -763,7 +783,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 4980736,
+      "memoryRssTotalDeltaBytes": 6225920,
       "minimumSampleCount": 5,
       "mutationCount": 106,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-count-only-101rows.json",
@@ -780,11 +800,11 @@
       "benchmarks": [
         {
           "groupName": "src/in-memory-live-query.bench.tsx > React in-memory useLiveQuery browser benchmark: 20 rows",
-          "maxMs": 2,
-          "meanMs": 0.7600000143051148,
+          "maxMs": 1.8000000715255737,
+          "meanMs": 0.7400000095367432,
           "minMs": 0.3999999761581421,
           "name": "publish matching row -> rendered top row",
-          "p99Ms": 2,
+          "p99Ms": 1.8000000715255737,
           "sampleCount": 5
         }
       ],

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -79,6 +79,11 @@ import {
   TopicStore,
 } from "./topic-store";
 import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
+import {
+  columnValueDoesNotEqual,
+  compareExactRangeColumnValue,
+  compareRangeColumnValue,
+} from "./topic-range-value";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -254,6 +259,7 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   const Metric = Schema.Struct({
     finitePrice: Schema.Finite,
     id: Schema.String,
+    decimalPrice: Schema.BigDecimal,
     optionalPrice: Schema.optionalKey(Schema.Number),
     price: Schema.Number,
     quantity: Schema.BigInt,
@@ -294,21 +300,53 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   status.copySlot(0, 1);
   status.pop();
 
-  expect(status.kind).toBe("generic");
+  expect(status.kind).toBe("string");
   expect(status.length).toBe(1);
-  expect(columnValue(status, 0)).toStrictEqual({ structured: true });
+  expect(columnValue(status, 0)).toBeUndefined();
+  expect(columnValue(status, -1)).toBeUndefined();
+  expect(columnValue(status, 1)).toBeUndefined();
 
   status.clear();
   expect(status.length).toBe(0);
 
   const optionalPrice = createTopicColumnValuesFromArray("optionalPrice", metadata, [1, undefined]);
   const quantity = createTopicColumnValuesFromArray("quantity", metadata, [1n, 2n]);
+  const decimalPrice = createTopicColumnValuesFromArray("decimalPrice", metadata, [
+    fromStringUnsafe("1.25"),
+    "not-a-decimal",
+  ]);
 
   expect(optionalPrice.kind).toBe("number");
-  expect(quantity.kind).toBe("generic");
+  expect(quantity.kind).toBe("bigint");
+  expect(decimalPrice.kind).toBe("bigDecimal");
   expect(columnValue(optionalPrice, 0)).toBe(1);
   expect(columnValue(optionalPrice, 1)).toBeUndefined();
   expect(columnValue(quantity, 0)).toBe(1n);
+  expect(columnValue(quantity, -1)).toBeUndefined();
+  expect(columnValue(decimalPrice, 0)).toStrictEqual(fromStringUnsafe("1.25"));
+  expect(columnValue(decimalPrice, 1)).toBeUndefined();
+});
+
+it("keeps scalar range helpers exact for numeric runtime domains", () => {
+  expect(compareExactRangeColumnValue(1, Number.NaN)).toBeUndefined();
+  expect(compareExactRangeColumnValue(2n, 2n)).toBe(0);
+  expect(compareExactRangeColumnValue(1n, 2n)).toBe(-1);
+  expect(compareExactRangeColumnValue(3n, 2n)).toBe(1);
+  expect(compareExactRangeColumnValue(fromStringUnsafe("2"), fromStringUnsafe("1"))).toBe(1);
+  expect(compareExactRangeColumnValue("2", 2)).toBeUndefined();
+
+  expect(compareRangeColumnValue(Number.POSITIVE_INFINITY, 1)).toBeUndefined();
+  expect(compareRangeColumnValue(2n, 2n)).toBe(0);
+  expect(compareRangeColumnValue(1n, 2n)).toBe(-1);
+  expect(compareRangeColumnValue(3n, 2n)).toBe(1);
+  expect(compareRangeColumnValue(fromStringUnsafe("1"), fromStringUnsafe("2"))).toBe(-1);
+  expect(compareRangeColumnValue("2", 2)).toBeUndefined();
+
+  expect(columnValueDoesNotEqual(fromStringUnsafe("1"), fromStringUnsafe("2"))).toBe(true);
+  expect(columnValueDoesNotEqual(fromStringUnsafe("1"), 1)).toBe(false);
+  expect(columnValueDoesNotEqual(1, Number.NaN)).toBe(false);
+  expect(columnValueDoesNotEqual(true, false)).toBe(true);
+  expect(columnValueDoesNotEqual("1", 1)).toBe(false);
 });
 
 const numericRowField = (row: object, field: string): number => {
@@ -8142,7 +8180,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     const priceColumn = state.columns.get("price")!;
     const statusColumn = state.columns.get("status")!;
     expect(priceColumn.kind).toBe("number");
-    expect(statusColumn.kind).toBe("generic");
+    expect(statusColumn.kind).toBe("string");
 
     const warmRangeIndex = scanTopicRawWindow(state, {
       predicate: {
@@ -8340,6 +8378,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         ["id", rows.map((row) => row.id)],
         ["symbol", rows.map((row) => row.symbol)],
         ["quantity", rows.map((row) => row.quantity)],
+        ["price", rows.map((row) => row.price)],
       ]),
       orderedSlotIndexes: new Map(),
       rawQueryMetadata: metadata,
@@ -8348,7 +8387,9 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     };
 
     const quantityColumn = state.columns.get("quantity")!;
-    expect(quantityColumn.kind).toBe("generic");
+    const priceColumn = state.columns.get("price")!;
+    expect(quantityColumn.kind).toBe("bigint");
+    expect(priceColumn.kind).toBe("bigDecimal");
 
     const boundedReplacement = scanTopicRawWindow(state, {
       predicate: {
@@ -8383,6 +8424,65 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
     expect(exactBigIntRange.keys).toStrictEqual(["equal", "high"]);
     expect(exactBigIntRange.totalRows).toBe(2);
+
+    const exactBigDecimalRange = scanTopicRawWindow(
+      {
+        ...state,
+        columns: makeColumns(metadata, [
+          ["id", rows.map((row) => row.id)],
+          ["symbol", rows.map((row) => row.symbol)],
+          ["quantity", rows.map((row) => row.quantity)],
+          ["price", [fromStringUnsafe("5"), fromStringUnsafe("10"), fromStringUnsafe("20")]],
+        ]),
+      },
+      {
+        predicate: {
+          filters: [{ field: "price", operator: "gte", value: fromStringUnsafe("10") }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("exact BigDecimal range candidates should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      },
+    );
+
+    expect(exactBigDecimalRange.keys).toStrictEqual(["equal", "high"]);
+    expect(exactBigDecimalRange.totalRows).toBe(2);
+
+    const orderedBigDecimalRange = scanTopicRawWindow(
+      {
+        ...state,
+        columns: makeColumns(metadata, [
+          ["id", rows.map((row) => row.id)],
+          ["symbol", rows.map((row) => row.symbol)],
+          ["quantity", rows.map((row) => row.quantity)],
+          ["price", [fromStringUnsafe("20"), fromStringUnsafe("10"), fromStringUnsafe("5")]],
+        ]),
+      },
+      {
+        predicate: {
+          filters: [{ field: "price", operator: "gte", value: fromStringUnsafe("5") }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        storageOrderBy: [{ field: "price", direction: "asc" }],
+        matches: () => {
+          throw new Error("ordered exact BigDecimal range should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: 3,
+      },
+    );
+
+    expect(orderedBigDecimalRange.keys).toStrictEqual(["high", "equal", "low"]);
+    expect(orderedBigDecimalRange.totalRows).toBe(3);
 
     const nonExactBigIntRange = scanTopicRawWindow(state, {
       predicate: {
@@ -8428,6 +8528,48 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
     expect(nonExactBigIntLowerRange.keys).toStrictEqual(["high", "missing-quantity"]);
     expect(nonExactBigIntLowerRange.totalRows).toBe(2);
+
+    const GenericName = Schema.Struct({
+      id: Schema.String,
+      label: Schema.Unknown,
+    });
+    const genericMetadata = rawQueryCompilerMetadata(GenericName);
+    const genericRows = [
+      { id: "match", label: "customer-a" },
+      { id: "miss", label: "account-a" },
+    ];
+    const genericStartsWith = scanTopicRawWindow(
+      {
+        columns: makeColumns(genericMetadata, [
+          ["id", genericRows.map((row) => row.id)],
+          ["label", genericRows.map((row) => row.label)],
+        ]),
+        orderedSlotIndexes: new Map(),
+        rawQueryMetadata: genericMetadata,
+        scalarPredicateIndexes: createScalarPredicateIndexes(),
+        slots: genericRows.map((row) => ({
+          key: row.id,
+          row,
+        })),
+      },
+      {
+        predicate: {
+          filters: [{ field: "label", operator: "startsWith", value: "customer-" }],
+          callbackRequired: false,
+          callbackSkippable: true,
+        },
+        orderBy: [],
+        matches: () => {
+          throw new Error("exact generic startsWith should not call row callbacks");
+        },
+        compare: (left, right) => left.key.localeCompare(right.key),
+        offset: 0,
+        limit: undefined,
+      },
+    );
+
+    expect(genericStartsWith.keys).toStrictEqual(["match"]);
+    expect(genericStartsWith.totalRows).toBe(1);
 
     const orderedCandidate = scanTopicRawWindow(state, {
       predicate: {

--- a/packages/column-live-view-engine/src/raw-query-metadata.ts
+++ b/packages/column-live-view-engine/src/raw-query-metadata.ts
@@ -17,6 +17,7 @@ export type RawQueryCompilerMetadata = {
   readonly numericFieldNames: ReadonlySet<string>;
   readonly numberFieldNames: ReadonlySet<string>;
   readonly bigintFieldNames: ReadonlySet<string>;
+  readonly bigDecimalFieldNames: ReadonlySet<string>;
   readonly rangeValueKinds: ReadonlyMap<string, ReadonlySet<RangeValueKind>>;
 };
 
@@ -77,6 +78,13 @@ const isPureNumberAst = (ast: SchemaAST.AST): boolean => {
   return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isPureNumberAst);
 };
 
+const isPureBigDecimalAst = (ast: SchemaAST.AST): boolean => {
+  if (isBigDecimalAst(ast)) {
+    return true;
+  }
+  return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isPureBigDecimalAst);
+};
+
 const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
   isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
 
@@ -135,6 +143,22 @@ const schemaBigintFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<str
     if (viewServerSchemaFieldMetadata(fieldSchema).isPureBigInt) {
       fields.add(field);
     }
+  }
+  return fields;
+};
+
+const schemaBigDecimalFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    const ast = schemaAst(fieldSchema);
+    if (ast === undefined || !isPureBigDecimalAst(ast)) {
+      continue;
+    }
+    fields.add(field);
   }
   return fields;
 };
@@ -213,5 +237,6 @@ export const rawQueryCompilerMetadata = (
   numericFieldNames: schemaNumericFieldNames(schema),
   numberFieldNames: schemaNumberFieldNames(schema),
   bigintFieldNames: schemaBigintFieldNames(schema),
+  bigDecimalFieldNames: schemaBigDecimalFieldNames(schema),
   rangeValueKinds: schemaRangeValueKinds(schema),
 });

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -2,6 +2,7 @@
 import { afterAll, beforeAll, bench, describe } from "vitest";
 import { defineViewServerConfig } from "@view-server/config";
 import { Cause, Effect, Exit, Schema, Scope, Stream } from "effect";
+import { fromStringUnsafe } from "effect/BigDecimal";
 import {
   createColumnLiveViewEngine,
   type ColumnLiveViewEngine,
@@ -28,6 +29,8 @@ const Order = Schema.Struct({
   customerId: Schema.String,
   status: Schema.Literals(["open", "closed", "cancelled"]),
   price: Schema.Finite,
+  quantity: Schema.BigInt,
+  decimalPrice: Schema.BigDecimal,
   region: Schema.String,
   updatedAt: Schema.Number,
 });
@@ -171,6 +174,8 @@ const seedOrder = (index: number): OrderRow => ({
   customerId: `customer-${index % 100_000}`,
   status: orderStatus(index),
   price: index % 1_000_000,
+  quantity: BigInt(index % 1_000_000),
+  decimalPrice: fromStringUnsafe(String(index % 1_000_000)),
   region: region(index),
   updatedAt: index,
 });
@@ -180,6 +185,8 @@ const deltaOrder = (index: number): OrderRow => ({
   customerId: `customer-delta-${index % 100_000}`,
   status: "open",
   price: 1_000_000 + (index % 10_000),
+  quantity: BigInt(1_000_000 + (index % 10_000)),
+  decimalPrice: fromStringUnsafe(String(1_000_000 + (index % 10_000))),
   region: "emea",
   updatedAt: 1_000_000_000 + index,
 });
@@ -286,6 +293,8 @@ afterAll(async () => {
       "ordered equality filter + indexed seek",
       "ordered in filter + indexed seek",
       "range filter + top-k sort",
+      "bigint range filter + indexed seek",
+      "BigDecimal range filter + indexed seek",
       "selective range filter + fallback top-k sort",
       "compound filter + top-k sort",
       "filtered totalRows via zero-row window",
@@ -400,6 +409,40 @@ describe(`raw snapshot and delta engine benchmark: ${profile.rowCount} rows`, ()
             price: { gte: 500_000 },
           },
           orderBy: [{ field: "price", direction: "asc" }],
+          limit: 100,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
+    "bigint range filter + indexed seek",
+    async () => {
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: ["id", "quantity", "status", "updatedAt"],
+          where: {
+            quantity: { gte: 500_000n },
+          },
+          orderBy: [{ field: "quantity", direction: "asc" }],
+          limit: 100,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
+    "BigDecimal range filter + indexed seek",
+    async () => {
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: ["id", "decimalPrice", "status", "updatedAt"],
+          where: {
+            decimalPrice: { gte: fromStringUnsafe("500000") },
+          },
+          orderBy: [{ field: "decimalPrice", direction: "asc" }],
           limit: 100,
         }),
       );

--- a/packages/column-live-view-engine/src/raw-write.bench.ts
+++ b/packages/column-live-view-engine/src/raw-write.bench.ts
@@ -2,6 +2,7 @@
 import { afterAll, beforeAll, bench, describe } from "vitest";
 import { defineViewServerConfig } from "@view-server/config";
 import { Effect, Schema } from "effect";
+import { fromStringUnsafe } from "effect/BigDecimal";
 import { createColumnLiveViewEngine, type ColumnLiveViewEngine } from "./index";
 import {
   backpressureCountFromEngineHealth,
@@ -23,6 +24,8 @@ const Order = Schema.Struct({
   customerId: Schema.String,
   status: Schema.Literals(["open", "closed", "cancelled"]),
   price: Schema.Finite,
+  quantity: Schema.BigInt,
+  decimalPrice: Schema.BigDecimal,
   region: Schema.String,
   updatedAt: Schema.Number,
 });
@@ -185,6 +188,8 @@ const seedOrder = (index: number): OrderRow => ({
   customerId: `customer-${index % 100_000}`,
   status: orderStatus(index),
   price: index % 1_000_000,
+  quantity: BigInt(index % 1_000_000),
+  decimalPrice: fromStringUnsafe(String(index % 1_000_000)),
   region: region(index),
   updatedAt: index,
 });
@@ -194,6 +199,8 @@ const generatedOrder = (prefix: string, index: number, generation: number): Orde
   customerId: `customer-${index % 100_000}`,
   status: orderStatus(index + generation),
   price: (index + generation) % 1_000_000,
+  quantity: BigInt((index + generation) % 1_000_000),
+  decimalPrice: fromStringUnsafe(String((index + generation) % 1_000_000)),
   region: region(index + generation),
   updatedAt: 1_000_000_000 + generation + index,
 });
@@ -222,7 +229,15 @@ const seedEngine = Effect.fn("ColumnLiveViewEngine.bench.rawWrite.seed")(functio
 
 const warmReadPathState = Effect.fn("ColumnLiveViewEngine.bench.rawWrite.warmReadPathState")(
   function* (engine: Engine) {
-    const select = ["id", "customerId", "price", "status", "updatedAt"] as const;
+    const select = [
+      "id",
+      "customerId",
+      "price",
+      "quantity",
+      "decimalPrice",
+      "status",
+      "updatedAt",
+    ] as const;
     yield* engine.snapshot("orders", {
       select,
       where: {
@@ -244,6 +259,24 @@ const warmReadPathState = Effect.fn("ColumnLiveViewEngine.bench.rawWrite.warmRea
         status: { eq: "open" },
       },
       orderBy: [{ field: "price", direction: "asc" }],
+      limit: 50,
+    });
+    yield* engine.snapshot("orders", {
+      select,
+      where: {
+        quantity: { gte: 0n },
+        status: { eq: "open" },
+      },
+      orderBy: [{ field: "quantity", direction: "asc" }],
+      limit: 50,
+    });
+    yield* engine.snapshot("orders", {
+      select,
+      where: {
+        decimalPrice: { gte: fromStringUnsafe("0") },
+        status: { eq: "open" },
+      },
+      orderBy: [{ field: "decimalPrice", direction: "asc" }],
       limit: 50,
     });
   },
@@ -371,6 +404,8 @@ describe(`raw write engine benchmark: ${profile.rowCount} rows`, () => {
         await Effect.runPromise(
           engine.patch("orders", `order-${offset}`, {
             price: generation + offset,
+            quantity: BigInt(generation + offset),
+            decimalPrice: fromStringUnsafe(String(generation + offset)),
             updatedAt: 2_000_000_000 + generation + offset,
           }),
         );

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -1,6 +1,7 @@
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+import { isBigDecimal, type BigDecimal } from "effect/BigDecimal";
 
-export type TopicColumnKind = "generic" | "number";
+export type TopicColumnKind = "generic" | "string" | "number" | "bigint" | "bigDecimal";
 
 type BaseTopicColumnValues = {
   readonly kind: TopicColumnKind;
@@ -12,12 +13,32 @@ export type GenericTopicColumnValues = BaseTopicColumnValues & {
   readonly kind: "generic";
 };
 
+export type StringTopicColumnValues = BaseTopicColumnValues & {
+  readonly kind: "string";
+  stringAt(slot: number): string | undefined;
+};
+
 export type NumberTopicColumnValues = BaseTopicColumnValues & {
   readonly kind: "number";
   numberAt(slot: number): number | undefined;
 };
 
-export type TopicColumnValues = GenericTopicColumnValues | NumberTopicColumnValues;
+export type BigIntTopicColumnValues = BaseTopicColumnValues & {
+  readonly kind: "bigint";
+  bigintAt(slot: number): bigint | undefined;
+};
+
+export type BigDecimalTopicColumnValues = BaseTopicColumnValues & {
+  readonly kind: "bigDecimal";
+  bigDecimalAt(slot: number): BigDecimal | undefined;
+};
+
+export type TopicColumnValues =
+  | GenericTopicColumnValues
+  | StringTopicColumnValues
+  | NumberTopicColumnValues
+  | BigIntTopicColumnValues
+  | BigDecimalTopicColumnValues;
 
 type MutableColumnOperations = {
   clear(): void;
@@ -27,11 +48,17 @@ type MutableColumnOperations = {
 };
 
 type MutableGenericTopicColumnValues = GenericTopicColumnValues & MutableColumnOperations;
+type MutableStringTopicColumnValues = StringTopicColumnValues & MutableColumnOperations;
 type MutableNumberTopicColumnValues = NumberTopicColumnValues & MutableColumnOperations;
+type MutableBigIntTopicColumnValues = BigIntTopicColumnValues & MutableColumnOperations;
+type MutableBigDecimalTopicColumnValues = BigDecimalTopicColumnValues & MutableColumnOperations;
 
 export type MutableTopicColumnValues =
   | MutableGenericTopicColumnValues
-  | MutableNumberTopicColumnValues;
+  | MutableStringTopicColumnValues
+  | MutableNumberTopicColumnValues
+  | MutableBigIntTopicColumnValues
+  | MutableBigDecimalTopicColumnValues;
 
 class GenericTopicColumn implements MutableGenericTopicColumnValues {
   readonly kind = "generic";
@@ -47,6 +74,42 @@ class GenericTopicColumn implements MutableGenericTopicColumnValues {
 
   set(slot: number, value: unknown): void {
     this.values[slot] = value;
+  }
+
+  copySlot(targetSlot: number, sourceSlot: number): void {
+    this.values[targetSlot] = this.values[sourceSlot];
+  }
+
+  pop(): void {
+    this.values.pop();
+  }
+
+  clear(): void {
+    this.values.length = 0;
+  }
+}
+
+class StringTopicColumn implements MutableStringTopicColumnValues {
+  readonly kind = "string";
+  private readonly values: Array<string | undefined> = [];
+
+  get length(): number {
+    return this.values.length;
+  }
+
+  get(slot: number): unknown {
+    return this.stringAt(slot);
+  }
+
+  stringAt(slot: number): string | undefined {
+    if (slot < 0 || slot >= this.values.length) {
+      return undefined;
+    }
+    return this.values[slot];
+  }
+
+  set(slot: number, value: unknown): void {
+    this.values[slot] = typeof value === "string" ? value : undefined;
   }
 
   copySlot(targetSlot: number, sourceSlot: number): void {
@@ -138,14 +201,95 @@ class NumberTopicColumn implements MutableNumberTopicColumnValues {
   }
 }
 
+class BigIntTopicColumn implements MutableBigIntTopicColumnValues {
+  readonly kind = "bigint";
+  private readonly values: Array<bigint | undefined> = [];
+
+  get length(): number {
+    return this.values.length;
+  }
+
+  get(slot: number): unknown {
+    return this.bigintAt(slot);
+  }
+
+  bigintAt(slot: number): bigint | undefined {
+    if (slot < 0 || slot >= this.values.length) {
+      return undefined;
+    }
+    return this.values[slot];
+  }
+
+  set(slot: number, value: unknown): void {
+    this.values[slot] = typeof value === "bigint" ? value : undefined;
+  }
+
+  copySlot(targetSlot: number, sourceSlot: number): void {
+    this.values[targetSlot] = this.values[sourceSlot];
+  }
+
+  pop(): void {
+    this.values.pop();
+  }
+
+  clear(): void {
+    this.values.length = 0;
+  }
+}
+
+class BigDecimalTopicColumn implements MutableBigDecimalTopicColumnValues {
+  readonly kind = "bigDecimal";
+  private readonly values: Array<BigDecimal | undefined> = [];
+
+  get length(): number {
+    return this.values.length;
+  }
+
+  get(slot: number): unknown {
+    return this.bigDecimalAt(slot);
+  }
+
+  bigDecimalAt(slot: number): BigDecimal | undefined {
+    if (slot < 0 || slot >= this.values.length) {
+      return undefined;
+    }
+    return this.values[slot];
+  }
+
+  set(slot: number, value: unknown): void {
+    this.values[slot] = isBigDecimal(value) ? value : undefined;
+  }
+
+  copySlot(targetSlot: number, sourceSlot: number): void {
+    this.values[targetSlot] = this.values[sourceSlot];
+  }
+
+  pop(): void {
+    this.values.pop();
+  }
+
+  clear(): void {
+    this.values.length = 0;
+  }
+}
+
 export const columnValue = (column: TopicColumnValues, slot: number): unknown => column.get(slot);
 
 export const createTopicColumnValues = (
   field: string,
   metadata: RawQueryCompilerMetadata,
 ): MutableTopicColumnValues => {
+  if (metadata.stringFieldNames.has(field)) {
+    return new StringTopicColumn();
+  }
   if (metadata.numberFieldNames.has(field)) {
     return new NumberTopicColumn();
+  }
+  if (metadata.bigintFieldNames.has(field)) {
+    return new BigIntTopicColumn();
+  }
+  if (metadata.bigDecimalFieldNames.has(field)) {
+    return new BigDecimalTopicColumn();
   }
   return new GenericTopicColumn();
 };

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -3,6 +3,7 @@ import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 import type { TopicRawOrderByPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
 import { columnValue, type TopicColumnValues } from "./topic-column-vector";
+import { Order as orderBigDecimal } from "effect/BigDecimal";
 import {
   distinctOrderedEqualityValues,
   equalityValueSatisfiesRangeBounds,
@@ -169,6 +170,13 @@ const compareSlotColumnValues = (
   left: number,
   right: number,
 ): number => {
+  if (column.kind === "string") {
+    const leftValue = column.stringAt(left);
+    const rightValue = column.stringAt(right);
+    if (leftValue !== undefined && rightValue !== undefined) {
+      return Number(leftValue > rightValue) - Number(leftValue < rightValue);
+    }
+  }
   if (column.kind === "number") {
     const leftValue = column.numberAt(left);
     const rightValue = column.numberAt(right);
@@ -179,6 +187,20 @@ const compareSlotColumnValues = (
       Number.isFinite(rightValue)
     ) {
       return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+    }
+  }
+  if (column.kind === "bigint") {
+    const leftValue = column.bigintAt(left);
+    const rightValue = column.bigintAt(right);
+    if (leftValue !== undefined && rightValue !== undefined) {
+      return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+    }
+  }
+  if (column.kind === "bigDecimal") {
+    const leftValue = column.bigDecimalAt(left);
+    const rightValue = column.bigDecimalAt(right);
+    if (leftValue !== undefined && rightValue !== undefined) {
+      return orderBigDecimal(leftValue, rightValue);
     }
   }
   return compareQueryValue(columnValue(column, left), columnValue(column, right));

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -9,6 +9,7 @@ import {
   isComparableRangeValue,
 } from "./topic-range-value";
 import { columnValue, type TopicColumnValues } from "./topic-column-vector";
+import { equals as bigDecimalEquals, isBigDecimal } from "effect/BigDecimal";
 
 type RowObject = object;
 
@@ -80,17 +81,49 @@ const slotFilterMatcher = (
 
   switch (filter.operator) {
     case "eq": {
+      if (column.kind === "string" && typeof filter.value === "string") {
+        return (slot) => column.stringAt(slot) === filter.value;
+      }
       if (column.kind === "number" && typeof filter.value === "number") {
         return (slot) => Object.is(column.numberAt(slot), filter.value);
+      }
+      if (column.kind === "bigint" && typeof filter.value === "bigint") {
+        return (slot) => column.bigintAt(slot) === filter.value;
+      }
+      if (column.kind === "bigDecimal" && isBigDecimal(filter.value)) {
+        const expected = filter.value;
+        return (slot) => {
+          const value = column.bigDecimalAt(slot);
+          return value !== undefined && bigDecimalEquals(value, expected);
+        };
       }
       return (slot) => valuesEqual(columnValue(column, slot), filter.value);
     }
     case "neq": {
       if (exact) {
+        if (column.kind === "string" && typeof filter.value === "string") {
+          return (slot) => {
+            const value = column.stringAt(slot);
+            return value !== undefined && value !== filter.value;
+          };
+        }
         if (column.kind === "number" && typeof filter.value === "number") {
           return (slot) => {
             const value = column.numberAt(slot);
             return value !== undefined && !Object.is(value, filter.value);
+          };
+        }
+        if (column.kind === "bigint" && typeof filter.value === "bigint") {
+          return (slot) => {
+            const value = column.bigintAt(slot);
+            return value !== undefined && value !== filter.value;
+          };
+        }
+        if (column.kind === "bigDecimal" && isBigDecimal(filter.value)) {
+          const expected = filter.value;
+          return (slot) => {
+            const value = column.bigDecimalAt(slot);
+            return value !== undefined && !bigDecimalEquals(value, expected);
           };
         }
         return (slot) => columnValueDoesNotEqual(columnValue(column, slot), filter.value);
@@ -115,6 +148,9 @@ const slotFilterMatcher = (
         return () => true;
       }
       const prefix = filter.value;
+      if (column.kind === "string") {
+        return (slot) => column.stringAt(slot)?.startsWith(prefix) === true;
+      }
       return (slot) => {
         const value = columnValue(column, slot);
         return typeof value === "string" && value.startsWith(prefix);
@@ -146,6 +182,14 @@ const rangeSlotFilterMatcher = (
   if (numberRangeMatcher !== undefined) {
     return numberRangeMatcher;
   }
+  const bigintRangeMatcher = bigintColumnRangeMatcher(column, filter, exact);
+  if (bigintRangeMatcher !== undefined) {
+    return bigintRangeMatcher;
+  }
+  const bigDecimalRangeMatcher = bigDecimalColumnRangeMatcher(column, filter, exact);
+  if (bigDecimalRangeMatcher !== undefined) {
+    return bigDecimalRangeMatcher;
+  }
 
   if (exact) {
     return (slot) => {
@@ -161,6 +205,50 @@ const rangeSlotFilterMatcher = (
     const comparison = compareRangeColumnValue(columnValue(column, slot), filter.value);
     return comparison === undefined || rangeComparisonMatches(filter.operator, comparison);
   };
+};
+
+const bigintColumnRangeMatcher = (
+  column: TopicColumnValues,
+  filter: RangePredicateFilter,
+  exact: boolean,
+): SlotFilterMatcher | undefined => {
+  if (column.kind !== "bigint" || typeof filter.value !== "bigint") {
+    return undefined;
+  }
+  const expected = filter.value;
+  return rangeColumnMatcher(
+    exact,
+    (slot) => {
+      const value = column.bigintAt(slot);
+      if (value === undefined) {
+        return undefined;
+      }
+      return value === expected ? 0 : value < expected ? -1 : 1;
+    },
+    filter.operator,
+  );
+};
+
+const bigDecimalColumnRangeMatcher = (
+  column: TopicColumnValues,
+  filter: RangePredicateFilter,
+  exact: boolean,
+): SlotFilterMatcher | undefined => {
+  if (column.kind !== "bigDecimal" || !isBigDecimal(filter.value)) {
+    return undefined;
+  }
+  const expected = filter.value;
+  return rangeColumnMatcher(
+    exact,
+    (slot) => {
+      const value = column.bigDecimalAt(slot);
+      if (value === undefined) {
+        return undefined;
+      }
+      return compareExactRangeColumnValue(value, expected);
+    },
+    filter.operator,
+  );
 };
 
 const numberColumnRangeMatcher = (
@@ -219,6 +307,21 @@ const numberColumnRangeMatcher = (
         return value === undefined || !Number.isFinite(value) || value <= expected;
       };
 };
+
+const rangeColumnMatcher = (
+  exact: boolean,
+  compareSlot: (slot: number) => number | undefined,
+  operator: TopicRawPredicateFilterPlan["operator"],
+): SlotFilterMatcher =>
+  exact
+    ? (slot) => {
+        const comparison = compareSlot(slot);
+        return comparison !== undefined && rangeComparisonMatches(operator, comparison);
+      }
+    : (slot) => {
+        const comparison = compareSlot(slot);
+        return comparison === undefined || rangeComparisonMatches(operator, comparison);
+      };
 
 const rangeComparisonMatches = (
   operator: TopicRawPredicateFilterPlan["operator"],


### PR DESCRIPTION
## Summary
- Add schema-derived column vectors for string, number, bigint, and BigDecimal scalar fields while keeping the row store as the source of truth/fallback.
- Push raw predicate and ordered-window execution through typed column paths where the compiler proves the filter/order is safe.
- Extend Vitest raw snapshot/write benchmarks to cover scalar read paths and write maintenance cost, then refresh the smoke benchmark baseline.

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run test:benchmark-baseline
- pnpm run bench:baseline:smoke:update
- pnpm run bench:baseline:smoke
- pnpm run ready
- 3 local reviewer agents: no blockers/P1/P2 found

## Notes
- Row storage remains authoritative; scalar columns are derived execution accelerators.
- Benchmarks remain Vitest bench only.