### PR TITLE
Reserve column capacity for append batches

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -269,6 +269,7 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
 
   const price = createTopicColumnValues("price", metadata);
   const finitePrice = createTopicColumnValues("finitePrice", metadata);
+  price.reserve(32);
   price.set(20, 42);
   price.set(21, undefined);
   price.copySlot(0, 20);
@@ -295,6 +296,7 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   expect(price.length).toBe(0);
 
   const status = createTopicColumnValues("status", metadata);
+  status.reserve(4);
   status.set(0, "open");
   status.set(1, { structured: true });
   status.copySlot(0, 1);
@@ -310,21 +312,28 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   expect(status.length).toBe(0);
 
   const optionalPrice = createTopicColumnValuesFromArray("optionalPrice", metadata, [1, undefined]);
-  const quantity = createTopicColumnValuesFromArray("quantity", metadata, [1n, 2n]);
-  const decimalPrice = createTopicColumnValuesFromArray("decimalPrice", metadata, [
-    fromStringUnsafe("1.25"),
-    "not-a-decimal",
-  ]);
+  const quantity = createTopicColumnValues("quantity", metadata);
+  const decimalPrice = createTopicColumnValues("decimalPrice", metadata);
+  const generic = createTopicColumnValues("unknown", metadata);
+  quantity.reserve(8);
+  quantity.set(0, 1n);
+  quantity.set(1, 2n);
+  decimalPrice.reserve(8);
+  decimalPrice.set(0, fromStringUnsafe("1.25"));
+  decimalPrice.set(1, "not-a-decimal");
+  generic.reserve(8);
 
   expect(optionalPrice.kind).toBe("number");
   expect(quantity.kind).toBe("bigint");
   expect(decimalPrice.kind).toBe("bigDecimal");
+  expect(generic.kind).toBe("generic");
   expect(columnValue(optionalPrice, 0)).toBe(1);
   expect(columnValue(optionalPrice, 1)).toBeUndefined();
   expect(columnValue(quantity, 0)).toBe(1n);
   expect(columnValue(quantity, -1)).toBeUndefined();
   expect(columnValue(decimalPrice, 0)).toStrictEqual(fromStringUnsafe("1.25"));
   expect(columnValue(decimalPrice, 1)).toBeUndefined();
+  expect(generic.length).toBe(0);
 });
 
 it("keeps scalar range helpers exact for numeric runtime domains", () => {
@@ -4782,6 +4791,8 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         order("same", "closed", 2, 2, "emea"),
         order("same", "open", 3, 3, "emea"),
         order("same", "closed", 4, 4, "emea"),
+        order("fresh", "open", 5, 5, "amer"),
+        order("fresh", "closed", 6, 6, "amer"),
         order("other", "open", 10, 10, "amer"),
       ]);
 
@@ -4789,7 +4800,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expectDeltaEvent(delta);
       state = applyDelta(state, delta);
       expect(normalizeDecimalFields(state.rows)).toStrictEqual([
-        { status: "closed", rowCount: 1n, totalPrice: "4" },
+        { status: "closed", rowCount: 2n, totalPrice: "10" },
         { status: "open", rowCount: 1n, totalPrice: "10" },
       ]);
 

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -44,6 +44,7 @@ type MutableColumnOperations = {
   clear(): void;
   copySlot(targetSlot: number, sourceSlot: number): void;
   pop(): void;
+  reserve(minimumCapacity: number): void;
   set(slot: number, value: unknown): void;
 };
 
@@ -84,6 +85,8 @@ class GenericTopicColumn implements MutableGenericTopicColumnValues {
     this.values.pop();
   }
 
+  reserve(_minimumCapacity: number): void {}
+
   clear(): void {
     this.values.length = 0;
   }
@@ -119,6 +122,8 @@ class StringTopicColumn implements MutableStringTopicColumnValues {
   pop(): void {
     this.values.pop();
   }
+
+  reserve(_minimumCapacity: number): void {}
 
   clear(): void {
     this.values.length = 0;
@@ -178,6 +183,10 @@ class NumberTopicColumn implements MutableNumberTopicColumnValues {
     this.validity[this.lengthValue] = 0;
   }
 
+  reserve(minimumCapacity: number): void {
+    this.ensureCapacity(minimumCapacity);
+  }
+
   clear(): void {
     this.values = new Float64Array(0);
     this.validity = new Uint8Array(0);
@@ -232,6 +241,8 @@ class BigIntTopicColumn implements MutableBigIntTopicColumnValues {
     this.values.pop();
   }
 
+  reserve(_minimumCapacity: number): void {}
+
   clear(): void {
     this.values.length = 0;
   }
@@ -267,6 +278,8 @@ class BigDecimalTopicColumn implements MutableBigDecimalTopicColumnValues {
   pop(): void {
     this.values.pop();
   }
+
+  reserve(_minimumCapacity: number): void {}
 
   clear(): void {
     this.values.length = 0;

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -32,6 +32,14 @@ import {
 
 type RowObject = object;
 
+type AppendBatchReservation = {
+  reserveFrom(startIndex: number): void;
+};
+
+const noopAppendBatchReservation: AppendBatchReservation = {
+  reserveFrom: () => {},
+};
+
 export class TopicRowStorage {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly readModel: ActiveQueryStoreState;
@@ -39,6 +47,7 @@ export class TopicRowStorage {
   private readonly slots: Array<TopicRowEntry<object>> = [];
   private readonly keyToSlot = new Map<string, number>();
   private readonly columns = new Map<string, MutableTopicColumnValues>();
+  private readonly reservableColumns: Array<MutableTopicColumnValues> = [];
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
   private readonly scalarPredicateIndexes = createScalarPredicateIndexes();
   private readonly rowChangeJournal = new TopicRowChangeJournal<object>();
@@ -66,7 +75,11 @@ export class TopicRowStorage {
       topic,
     };
     for (const field of this.rawQueryMetadata.fieldNames) {
-      this.columns.set(field, createTopicColumnValues(field, this.rawQueryMetadata));
+      const column = createTopicColumnValues(field, this.rawQueryMetadata);
+      this.columns.set(field, column);
+      if (column.kind === "number") {
+        this.reservableColumns.push(column);
+      }
     }
     this.readModel = {
       activeQueries: createActiveQueryRegistry(),
@@ -135,16 +148,17 @@ export class TopicRowStorage {
   }
 
   setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
+    const appendReservation = this.createAppendBatchReservation(preparedRows);
     if (preparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
       this.orderedSlotIndexes.clear();
-      for (const prepared of preparedRows) {
-        this.setPreparedWithoutIndexMaintenance(prepared);
+      for (let index = 0; index < preparedRows.length; index += 1) {
+        this.setPreparedWithoutIndexMaintenance(preparedRows[index]!, appendReservation, index);
       }
       return;
     }
 
-    for (const prepared of preparedRows) {
-      this.setPrepared(prepared);
+    for (let index = 0; index < preparedRows.length; index += 1) {
+      this.setPreparedInBatch(preparedRows[index]!, appendReservation, index);
     }
   }
 
@@ -235,11 +249,78 @@ export class TopicRowStorage {
     }
   }
 
+  private createAppendBatchReservation(
+    preparedRows: ReadonlyArray<PreparedTopicRow>,
+  ): AppendBatchReservation {
+    if (this.reservableColumns.length === 0) {
+      return noopAppendBatchReservation;
+    }
+    let reserved = false;
+    return {
+      reserveFrom: (startIndex) => {
+        if (reserved) {
+          return;
+        }
+        reserved = true;
+        let appendCount = 0;
+        const appendKeys = new Set<string>();
+        for (let index = startIndex; index < preparedRows.length; index += 1) {
+          const key = preparedRows[index]!.key;
+          if (!this.keyToSlot.has(key) && !appendKeys.has(key)) {
+            appendKeys.add(key);
+            appendCount += 1;
+          }
+        }
+        const minimumCapacity = this.slots.length + appendCount;
+        for (const column of this.reservableColumns) {
+          column.reserve(minimumCapacity);
+        }
+      },
+    };
+  }
+
+  private setPreparedInBatch(
+    prepared: PreparedTopicRow,
+    appendReservation: AppendBatchReservation,
+    batchIndex: number,
+  ): void {
+    const existingSlot = this.keyToSlot.get(prepared.key);
+    if (existingSlot !== undefined) {
+      const previous = this.slots[existingSlot]!.row;
+      this.removeSlotFromScalarIndexes(existingSlot);
+      this.writeSlot(existingSlot, prepared);
+      this.addSlotToScalarIndexes(existingSlot);
+      this.recordRowChange({
+        key: prepared.key,
+        previous,
+        next: prepared.row,
+      });
+      this.orderedSlotIndexes.clear();
+      return;
+    }
+
+    appendReservation.reserveFrom(batchIndex);
+    const slot = this.slots.length;
+    this.keyToSlot.set(prepared.key, slot);
+    this.writeSlot(slot, prepared);
+    this.addSlotToScalarIndexes(slot);
+    this.recordRowChange({
+      key: prepared.key,
+      previous: undefined,
+      next: prepared.row,
+    });
+    this.insertSlotIntoOrderedIndexes(slot);
+  }
+
   private insertSlotIntoOrderedIndexes(slot: number): void {
     insertSlotIntoRawWindowIndexes(this.rawWindowScanState, slot);
   }
 
-  private setPreparedWithoutIndexMaintenance(prepared: PreparedTopicRow): void {
+  private setPreparedWithoutIndexMaintenance(
+    prepared: PreparedTopicRow,
+    appendReservation: AppendBatchReservation,
+    batchIndex: number,
+  ): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
       const previous = this.slots[existingSlot]!.row;
@@ -254,6 +335,7 @@ export class TopicRowStorage {
       return;
     }
 
+    appendReservation.reserveFrom(batchIndex);
     const slot = this.slots.length;
     this.keyToSlot.set(prepared.key, slot);
     this.writeSlot(slot, prepared);


### PR DESCRIPTION
## Summary
- add an internal reserve operation to mutable topic column vectors
- reserve number-column typed-array capacity once before publishMany append batches
- dedupe absent keys during reserve accounting so duplicate-key batches do not over-reserve
- keep row store as source of truth and preserve duplicate-key batch convergence

## Validation
- vp check --fix packages/column-live-view-engine/src/topic-column-vector.ts packages/column-live-view-engine/src/topic-row-storage.ts packages/column-live-view-engine/src/index.test.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run ready
- pnpm run bench:baseline:smoke
- 3 reviewer agents, second pass clean: no blockers/P1/P2 found

## Notes
- Array-backed string/bigint/BigDecimal/generic columns keep reserve as a no-op because changing JS array length would make capacity visible as row length. Numeric typed-array columns get the capacity win safely.