### PR TITLE
Project raw rows from column vectors

### DIFF
--- a/benchmarks/baselines/smoke.json
+++ b/benchmarks/baselines/smoke.json
@@ -8,101 +8,110 @@
       "benchmarks": [
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.3961669999999913,
-          "meanMs": 0.23964999999999465,
-          "minMs": 0.17925000000002456,
+          "maxMs": 0.4444159999999897,
+          "meanMs": 0.26313300000000484,
+          "minMs": 0.19675000000000864,
           "name": "equality filter + top-k sort",
-          "p99Ms": 0.3961669999999913,
+          "p99Ms": 0.4444159999999897,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.517832999999996,
-          "meanMs": 0.2173749999999927,
-          "minMs": 0.13262500000001864,
+          "maxMs": 0.4933330000000069,
+          "meanMs": 0.20554160000000365,
+          "minMs": 0.11725000000001273,
           "name": "selective equality filter + fallback top-k sort",
-          "p99Ms": 0.517832999999996,
+          "p99Ms": 0.4933330000000069,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.3973750000000109,
-          "meanMs": 0.13284900000001443,
-          "minMs": 0.0742089999999962,
+          "maxMs": 0.5567500000000223,
+          "meanMs": 0.30624160000000983,
+          "minMs": 0.11079200000000355,
           "name": "ordered equality filter + indexed seek",
-          "p99Ms": 0.3973750000000109,
-          "sampleCount": 8
+          "p99Ms": 0.5567500000000223,
+          "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.20979099999999562,
-          "meanMs": 0.10799999999998704,
-          "minMs": 0.08283299999999372,
+          "maxMs": 0.6742500000000291,
+          "meanMs": 0.2535582000000204,
+          "minMs": 0.11883300000005192,
           "name": "ordered in filter + indexed seek",
-          "p99Ms": 0.20979099999999562,
-          "sampleCount": 10
+          "p99Ms": 0.6742500000000291,
+          "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.17441700000000537,
-          "meanMs": 0.08000653846153664,
-          "minMs": 0.0631249999999568,
+          "maxMs": 0.22525000000001683,
+          "meanMs": 0.09200754545455228,
+          "minMs": 0.0654580000000351,
           "name": "range filter + top-k sort",
-          "p99Ms": 0.17441700000000537,
-          "sampleCount": 13
-        },
-        {
-          "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.28204099999999244,
-          "meanMs": 0.09100754545455526,
-          "minMs": 0.06304199999999582,
-          "name": "bigint range filter + indexed seek",
-          "p99Ms": 0.28204099999999244,
+          "p99Ms": 0.22525000000001683,
           "sampleCount": 11
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.45208399999995663,
-          "meanMs": 0.12596375000000393,
-          "minMs": 0.06779199999999719,
-          "name": "BigDecimal range filter + indexed seek",
-          "p99Ms": 0.45208399999995663,
-          "sampleCount": 8
+          "maxMs": 0.3477919999999699,
+          "meanMs": 0.10209590000000617,
+          "minMs": 0.06662499999998772,
+          "name": "bigint range filter + indexed seek",
+          "p99Ms": 0.3477919999999699,
+          "sampleCount": 10
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.3045829999999796,
-          "meanMs": 0.18424983333332534,
-          "minMs": 0.12341599999996333,
-          "name": "selective range filter + fallback top-k sort",
-          "p99Ms": 0.3045829999999796,
+          "maxMs": 0.5576249999999732,
+          "meanMs": 0.16916666666666438,
+          "minMs": 0.07624999999995907,
+          "name": "BigDecimal range filter + indexed seek",
+          "p99Ms": 0.5576249999999732,
           "sampleCount": 6
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.5092920000000163,
-          "meanMs": 0.14614899999999612,
-          "minMs": 0.0687499999999659,
+          "maxMs": 0.365291999999954,
+          "meanMs": 0.21760839999998324,
+          "minMs": 0.14945799999998144,
+          "name": "selective range filter + fallback top-k sort",
+          "p99Ms": 0.365291999999954,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
+          "maxMs": 0.5461249999999609,
+          "meanMs": 0.222099999999989,
+          "minMs": 0.10716700000000401,
           "name": "compound filter + top-k sort",
-          "p99Ms": 0.5092920000000163,
-          "sampleCount": 7
+          "p99Ms": 0.5461249999999609,
+          "sampleCount": 5
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.13562500000000455,
-          "meanMs": 0.06378118749999473,
-          "minMs": 0.05608300000000099,
+          "maxMs": 1.427082999999982,
+          "meanMs": 0.8097249999999917,
+          "minMs": 0.5375839999999812,
+          "name": "wide scalar projection + top-k sort",
+          "p99Ms": 1.427082999999982,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
+          "maxMs": 0.2453750000000241,
+          "meanMs": 0.07800961538462686,
+          "minMs": 0.05900000000002592,
           "name": "filtered totalRows via zero-row window",
-          "p99Ms": 0.13562500000000455,
-          "sampleCount": 16
+          "p99Ms": 0.2453750000000241,
+          "sampleCount": 13
         },
         {
           "groupName": "src/raw-snapshot.bench.ts > raw snapshot and delta engine benchmark: 1000 rows",
-          "maxMs": 0.8114579999999592,
-          "meanMs": 0.33984139999998886,
-          "minMs": 0.20037500000000819,
+          "maxMs": 1.0241250000000264,
+          "meanMs": 0.3870418000000086,
+          "minMs": 0.2103749999999991,
           "name": "live subscription delta after publish",
-          "p99Ms": 0.8114579999999592,
+          "p99Ms": 1.0241250000000264,
           "sampleCount": 5
         }
       ],
@@ -116,6 +125,7 @@
         "BigDecimal range filter + indexed seek",
         "selective range filter + fallback top-k sort",
         "compound filter + top-k sort",
+        "wide scalar projection + top-k sort",
         "filtered totalRows via zero-row window",
         "live subscription delta after publish"
       ],
@@ -123,7 +133,7 @@
       "benchmarkScope": "engine-raw-snapshot",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 43253760,
+      "memoryRssTotalDeltaBytes": 43302912,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-snapshot-1000rows.json",
@@ -140,74 +150,74 @@
       "benchmarks": [
         {
           "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.07533300000000054,
-          "meanMs": 0.06436706250000235,
-          "minMs": 0.059332999999980984,
+          "maxMs": 0.09145899999998619,
+          "meanMs": 0.07622321428572068,
+          "minMs": 0.0677079999999819,
           "name": "full scan callback baseline: selective customer + fallback sort",
-          "p99Ms": 0.07533300000000054,
-          "sampleCount": 16
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.03608300000001918,
-          "meanMs": 0.028394638888886763,
-          "minMs": 0.024042000000008557,
-          "name": "exact scalar candidate: selective customer + fallback sort",
-          "p99Ms": 0.03608300000001918,
-          "sampleCount": 36
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.04095799999998917,
-          "meanMs": 0.02675768421052507,
-          "minMs": 0.02312499999999318,
-          "name": "exact scalar candidate: selective customer without callback",
-          "p99Ms": 0.04095799999998917,
-          "sampleCount": 38
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.04179199999998673,
-          "meanMs": 0.029707147058824247,
-          "minMs": 0.026041999999989685,
-          "name": "exact multi-key in candidate: three customers + fallback sort",
-          "p99Ms": 0.04179199999998673,
-          "sampleCount": 34
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.1251670000000047,
-          "meanMs": 0.10037920000000326,
-          "minMs": 0.0887079999999969,
-          "name": "exact range candidate: upper price tail + fallback sort",
-          "p99Ms": 0.1251670000000047,
-          "sampleCount": 10
-        },
-        {
-          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.08012500000000955,
-          "meanMs": 0.07447328571428662,
-          "minMs": 0.07237500000002228,
-          "name": "full scan callback baseline: upper price tail + fallback sort",
-          "p99Ms": 0.08012500000000955,
+          "p99Ms": 0.09145899999998619,
           "sampleCount": 14
         },
         {
           "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.036167000000006055,
-          "meanMs": 0.028041777777777572,
-          "minMs": 0.022458999999997786,
-          "name": "ordered equality seek: customer storage order",
-          "p99Ms": 0.036167000000006055,
-          "sampleCount": 36
+          "maxMs": 0.05400000000003047,
+          "meanMs": 0.03126171875000061,
+          "minMs": 0.026041999999961263,
+          "name": "exact scalar candidate: selective customer + fallback sort",
+          "p99Ms": 0.05400000000003047,
+          "sampleCount": 32
         },
         {
           "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
-          "maxMs": 0.3994160000000022,
-          "meanMs": 0.37909139999999864,
-          "minMs": 0.35166699999999196,
+          "maxMs": 0.03937500000000682,
+          "meanMs": 0.0268245526315809,
+          "minMs": 0.022749999999973625,
+          "name": "exact scalar candidate: selective customer without callback",
+          "p99Ms": 0.03937500000000682,
+          "sampleCount": 38
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.04958299999998417,
+          "meanMs": 0.030799333333332568,
+          "minMs": 0.026041999999961263,
+          "name": "exact multi-key in candidate: three customers + fallback sort",
+          "p99Ms": 0.04958299999998417,
+          "sampleCount": 33
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.4632080000000087,
+          "meanMs": 0.2057706666666661,
+          "minMs": 0.09908300000000736,
+          "name": "exact range candidate: upper price tail + fallback sort",
+          "p99Ms": 0.4632080000000087,
+          "sampleCount": 6
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.14508299999999963,
+          "meanMs": 0.10094559999999433,
+          "minMs": 0.07420799999999872,
+          "name": "full scan callback baseline: upper price tail + fallback sort",
+          "p99Ms": 0.14508299999999963,
+          "sampleCount": 10
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.07712500000002365,
+          "meanMs": 0.03461489655172374,
+          "minMs": 0.02341599999999744,
+          "name": "ordered equality seek: customer storage order",
+          "p99Ms": 0.07712500000002365,
+          "sampleCount": 29
+        },
+        {
+          "groupName": "src/raw-predicate-index.bench.ts > raw predicate candidate index benchmark: 1000 rows",
+          "maxMs": 0.423041000000012,
+          "meanMs": 0.3826999999999998,
+          "minMs": 0.33491700000001856,
           "name": "failed broad scalar candidate build + full scan",
-          "p99Ms": 0.3994160000000022,
+          "p99Ms": 0.423041000000012,
           "sampleCount": 5
         }
       ],
@@ -225,7 +235,7 @@
       "benchmarkScope": "engine-raw-predicate-index",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 14696448,
+      "memoryRssTotalDeltaBytes": 15613952,
       "minimumSampleCount": 5,
       "mutationCount": 0,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-predicate-index-1000rows.json",
@@ -242,47 +252,47 @@
       "benchmarks": [
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 0.23304200000001174,
-          "meanMs": 0.11289822222221978,
-          "minMs": 0.08887500000003001,
+          "maxMs": 0.3320420000000013,
+          "meanMs": 0.13348449999999445,
+          "minMs": 0.09204199999999219,
           "name": "publish append single row",
-          "p99Ms": 0.23304200000001174,
-          "sampleCount": 9
+          "p99Ms": 0.3320420000000013,
+          "sampleCount": 8
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.7803749999999923,
-          "meanMs": 2.1845749999999837,
-          "minMs": 1.8826669999999694,
+          "maxMs": 2.8749579999999924,
+          "meanMs": 2.3158583999999904,
+          "minMs": 1.9763750000000186,
           "name": "publishMany append batch",
-          "p99Ms": 2.7803749999999923,
+          "p99Ms": 2.8749579999999924,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.2151660000000106,
-          "meanMs": 1.9996329999999944,
-          "minMs": 1.919290999999987,
+          "maxMs": 2.6432079999999587,
+          "meanMs": 2.304683199999988,
+          "minMs": 2.0306249999999864,
           "name": "publishMany replace existing batch",
-          "p99Ms": 2.2151660000000106,
+          "p99Ms": 2.6432079999999587,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.389667000000031,
-          "meanMs": 6.169766600000014,
-          "minMs": 5.87741699999998,
+          "maxMs": 6.767917000000011,
+          "meanMs": 6.341491600000007,
+          "minMs": 6.1526250000000005,
           "name": "patch existing rows one by one",
-          "p99Ms": 6.389667000000031,
+          "p99Ms": 6.767917000000011,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 5.6590419999999995,
-          "meanMs": 5.069625400000007,
-          "minMs": 4.507292000000007,
+          "maxMs": 5.828542000000027,
+          "meanMs": 5.163975200000015,
+          "minMs": 4.602666999999997,
           "name": "append then delete batch",
-          "p99Ms": 5.6590419999999995,
+          "p99Ms": 5.828542000000027,
           "sampleCount": 5
         }
       ],
@@ -297,9 +307,9 @@
       "benchmarkScope": "engine-raw-write",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 55001088,
+      "memoryRssTotalDeltaBytes": 56197120,
       "minimumSampleCount": 5,
-      "mutationCount": 3509,
+      "mutationCount": 3508,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-write-base-1000rows.json",
       "queuedEventCount": 0,
       "rowCount": 1000,
@@ -314,47 +324,47 @@
       "benchmarks": [
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 0.27495800000002646,
-          "meanMs": 0.13654675000000793,
-          "minMs": 0.1004169999999931,
+          "maxMs": 0.6513330000000224,
+          "meanMs": 0.23816640000001144,
+          "minMs": 0.11916600000000699,
           "name": "publish append single row",
-          "p99Ms": 0.27495800000002646,
-          "sampleCount": 8
+          "p99Ms": 0.6513330000000224,
+          "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.891125000000045,
-          "meanMs": 2.306141400000024,
-          "minMs": 2.007333000000017,
+          "maxMs": 16.298042000000066,
+          "meanMs": 6.18643360000001,
+          "minMs": 2.872332999999969,
           "name": "publishMany append batch",
-          "p99Ms": 2.891125000000045,
+          "p99Ms": 16.298042000000066,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 2.311333999999988,
-          "meanMs": 2.09000860000001,
-          "minMs": 1.9910409999999956,
+          "maxMs": 3.4320419999999103,
+          "meanMs": 2.6939001999999848,
+          "minMs": 2.13900000000001,
           "name": "publishMany replace existing batch",
-          "p99Ms": 2.311333999999988,
+          "p99Ms": 3.4320419999999103,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.842707999999959,
-          "meanMs": 6.3811000000000035,
-          "minMs": 5.85733300000004,
+          "maxMs": 10.95195799999999,
+          "meanMs": 7.965250000000014,
+          "minMs": 6.809792000000016,
           "name": "patch existing rows one by one",
-          "p99Ms": 6.842707999999959,
+          "p99Ms": 10.95195799999999,
           "sampleCount": 5
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 5.625124999999969,
-          "meanMs": 5.164241400000003,
-          "minMs": 4.705874999999992,
+          "maxMs": 7.773874999999975,
+          "meanMs": 6.463091800000006,
+          "minMs": 5.049000000000092,
           "name": "append then delete batch",
-          "p99Ms": 5.625124999999969,
+          "p99Ms": 7.773874999999975,
           "sampleCount": 5
         }
       ],
@@ -369,9 +379,9 @@
       "benchmarkScope": "engine-raw-write",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 57065472,
+      "memoryRssTotalDeltaBytes": 59146240,
       "minimumSampleCount": 5,
-      "mutationCount": 3508,
+      "mutationCount": 3505,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-write-indexed-1000rows.json",
       "queuedEventCount": 0,
       "rowCount": 1000,
@@ -386,11 +396,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 1000 rows, 5 subscribers, same-window",
-          "maxMs": 2.080291000000045,
-          "meanMs": 0.9105414000000224,
-          "minMs": 0.5465829999999983,
+          "maxMs": 2.2818750000000136,
+          "meanMs": 0.9898333999999978,
+          "minMs": 0.5832079999999564,
           "name": "same-window subscribers publish + delta fanout",
-          "p99Ms": 2.080291000000045,
+          "p99Ms": 2.2818750000000136,
           "sampleCount": 5
         }
       ],
@@ -399,7 +409,7 @@
       "benchmarkScope": "engine-raw-live-fanout",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 38993920,
+      "memoryRssTotalDeltaBytes": 38486016,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-same-window-1000rows-5subs.json",
@@ -416,11 +426,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 1000 rows, 5 subscribers, ten-window",
-          "maxMs": 2.0637080000000196,
-          "meanMs": 0.9142913999999905,
-          "minMs": 0.5452909999999633,
+          "maxMs": 3.605959000000041,
+          "meanMs": 1.268792000000019,
+          "minMs": 0.5810839999999757,
           "name": "ten-window subscribers publish + delta fanout",
-          "p99Ms": 2.0637080000000196,
+          "p99Ms": 3.605959000000041,
           "sampleCount": 5
         }
       ],
@@ -429,7 +439,7 @@
       "benchmarkScope": "engine-raw-live-fanout",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 40452096,
+      "memoryRssTotalDeltaBytes": 39337984,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-ten-window-1000rows-5subs.json",
@@ -446,56 +456,56 @@
       "benchmarks": [
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 2.9722909999999843,
-          "meanMs": 2.535474799999986,
-          "minMs": 2.1734579999999823,
+          "maxMs": 5.83095800000001,
+          "meanMs": 3.8125582000000007,
+          "minMs": 2.6067500000000337,
           "name": "status grouped count/sum/min/max/avg",
-          "p99Ms": 2.9722909999999843,
+          "p99Ms": 5.83095800000001,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 1.7837499999999977,
-          "meanMs": 1.57025000000001,
-          "minMs": 1.488125000000025,
+          "maxMs": 2.5117500000000064,
+          "meanMs": 1.9132166000000097,
+          "minMs": 1.5785830000000374,
           "name": "region+status grouped count/sum/min/max/avg",
-          "p99Ms": 1.7837499999999977,
+          "p99Ms": 2.5117500000000064,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 1.5,
-          "meanMs": 1.387008400000002,
-          "minMs": 1.3017080000000192,
+          "maxMs": 2.0748330000000124,
+          "meanMs": 1.579766600000005,
+          "minMs": 1.359583999999984,
           "name": "high-cardinality desk grouped aggregates",
-          "p99Ms": 1.5,
+          "p99Ms": 2.0748330000000124,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 0.47662500000001273,
-          "meanMs": 0.4410665999999878,
-          "minMs": 0.425707999999986,
+          "maxMs": 0.522625000000005,
+          "meanMs": 0.4820085999999947,
+          "minMs": 0.450917000000004,
           "name": "high-cardinality desk group count via zero-row window",
-          "p99Ms": 0.47662500000001273,
+          "p99Ms": 0.522625000000005,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 0.8487499999999955,
-          "meanMs": 0.7719665999999961,
-          "minMs": 0.7222909999999843,
+          "maxMs": 1.5189589999999953,
+          "meanMs": 0.9672419999999988,
+          "minMs": 0.7860840000000167,
           "name": "filtered status grouped aggregates",
-          "p99Ms": 0.8487499999999955,
+          "p99Ms": 1.5189589999999953,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-aggregate.bench.ts > grouped aggregate engine benchmark: 1000 rows",
-          "maxMs": 0.7304159999999911,
-          "meanMs": 0.29850820000001477,
-          "minMs": 0.17995799999999917,
+          "maxMs": 0.9061660000000415,
+          "meanMs": 0.3356916000000069,
+          "minMs": 0.17549999999999955,
           "name": "live grouped aggregate delta after publish",
-          "p99Ms": 0.7304159999999911,
+          "p99Ms": 0.9061660000000415,
           "sampleCount": 5
         }
       ],
@@ -511,7 +521,7 @@
       "benchmarkScope": "engine-grouped-aggregate",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 58802176,
+      "memoryRssTotalDeltaBytes": 57819136,
       "minimumSampleCount": 5,
       "mutationCount": 1005,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-aggregate-1000rows.json",
@@ -528,47 +538,47 @@
       "benchmarks": [
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 1.0173340000000053,
-          "meanMs": 0.4884583999999904,
-          "minMs": 0.3124159999999847,
+          "maxMs": 1.257583000000011,
+          "meanMs": 0.602224799999999,
+          "minMs": 0.3456249999999841,
           "name": "grouped publishMany append batch",
-          "p99Ms": 1.0173340000000053,
+          "p99Ms": 1.257583000000011,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.5509999999999877,
-          "meanMs": 0.3535663999999997,
-          "minMs": 0.24425000000002228,
+          "maxMs": 1.0845420000000559,
+          "meanMs": 0.49499160000000303,
+          "minMs": 0.2732499999999618,
           "name": "grouped publishMany replace extrema batch",
-          "p99Ms": 0.5509999999999877,
+          "p99Ms": 1.0845420000000559,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.39733300000000327,
-          "meanMs": 0.25227479999999786,
-          "minMs": 0.18720799999999826,
+          "maxMs": 0.7199579999999628,
+          "meanMs": 0.33982500000000754,
+          "minMs": 0.21687500000001592,
           "name": "grouped patch aggregate values",
-          "p99Ms": 0.39733300000000327,
+          "p99Ms": 0.7199579999999628,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.336749999999995,
-          "meanMs": 0.25430840000001353,
-          "minMs": 0.22570799999999736,
+          "maxMs": 0.4103330000000369,
+          "meanMs": 0.28203320000001214,
+          "minMs": 0.2385420000000522,
           "name": "grouped patch group moves",
-          "p99Ms": 0.336749999999995,
+          "p99Ms": 0.4103330000000369,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.3057499999999891,
-          "meanMs": 0.2039916000000062,
-          "minMs": 0.1656669999999849,
+          "maxMs": 0.4263750000000073,
+          "meanMs": 0.23643319999999904,
+          "minMs": 0.18433299999998098,
           "name": "grouped delete existing rows",
-          "p99Ms": 0.3057499999999891,
+          "p99Ms": 0.4263750000000073,
           "sampleCount": 5
         }
       ],
@@ -603,7 +613,7 @@
         "writeBatchSize": 1
       },
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 47841280,
+      "memoryRssTotalDeltaBytes": 47448064,
       "minimumSampleCount": 5,
       "mutationCount": 1025,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000rows-1mutations.json",
@@ -620,11 +630,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: noop, 101 rows",
-          "maxMs": 1.3674159999999915,
-          "meanMs": 0.7291498000000047,
-          "minMs": 0.5129999999999768,
+          "maxMs": 1.5514160000000174,
+          "meanMs": 0.7546080000000188,
+          "minMs": 0.4922910000000229,
           "name": "retained nonmatching update delete no-op",
-          "p99Ms": 1.3674159999999915,
+          "p99Ms": 1.5514160000000174,
           "sampleCount": 5
         }
       ],
@@ -633,7 +643,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 10321920,
+      "memoryRssTotalDeltaBytes": 11993088,
       "minimumSampleCount": 5,
       "mutationCount": 116,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-noop-101rows.json",
@@ -650,11 +660,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: match-update, 101 rows",
-          "maxMs": 1.006750000000011,
-          "meanMs": 0.4442500000000109,
-          "minMs": 0.2863750000000209,
+          "maxMs": 0.9892909999999802,
+          "meanMs": 0.4435579999999959,
+          "minMs": 0.2915830000000028,
           "name": "retained match-to-match update delta",
-          "p99Ms": 1.006750000000011,
+          "p99Ms": 0.9892909999999802,
           "sampleCount": 5
         }
       ],
@@ -663,7 +673,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 5816320,
+      "memoryRssTotalDeltaBytes": 6782976,
       "minimumSampleCount": 5,
       "mutationCount": 106,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-match-update-101rows.json",
@@ -680,11 +690,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: predicate-enter, 101 rows",
-          "maxMs": 1.2977920000000154,
-          "meanMs": 0.6371833999999922,
-          "minMs": 0.42183299999999235,
+          "maxMs": 1.561458000000016,
+          "meanMs": 0.725341400000002,
+          "minMs": 0.47066599999999426,
           "name": "retained predicate-enter update delta",
-          "p99Ms": 1.2977920000000154,
+          "p99Ms": 1.561458000000016,
           "sampleCount": 5
         }
       ],
@@ -693,7 +703,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 9928704,
+      "memoryRssTotalDeltaBytes": 9699328,
       "minimumSampleCount": 5,
       "mutationCount": 111,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-predicate-enter-101rows.json",
@@ -710,11 +720,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: visible-delete, 101 rows",
-          "maxMs": 0.7300000000000182,
-          "meanMs": 0.35604160000002594,
-          "minMs": 0.2190830000000119,
+          "maxMs": 0.7938340000000039,
+          "meanMs": 0.38794999999998936,
+          "minMs": 0.24741599999998698,
           "name": "retained visible delete refill/fallback sequence",
-          "p99Ms": 0.7300000000000182,
+          "p99Ms": 0.7938340000000039,
           "sampleCount": 5
         }
       ],
@@ -723,7 +733,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 4866048,
+      "memoryRssTotalDeltaBytes": 6160384,
       "minimumSampleCount": 5,
       "mutationCount": 106,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-visible-delete-101rows.json",
@@ -740,11 +750,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: exhausted-lookahead, 101 rows",
-          "maxMs": 1.0537500000000364,
-          "meanMs": 0.5825916000000007,
-          "minMs": 0.4372500000000059,
+          "maxMs": 1.1250830000000178,
+          "meanMs": 0.7473662000000104,
+          "minMs": 0.4524160000000279,
           "name": "retained visible delete pair lookahead plus fallback",
-          "p99Ms": 1.0537500000000364,
+          "p99Ms": 1.1250830000000178,
           "sampleCount": 5
         }
       ],
@@ -753,7 +763,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 8028160,
+      "memoryRssTotalDeltaBytes": 9027584,
       "minimumSampleCount": 5,
       "mutationCount": 111,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-exhausted-lookahead-101rows.json",
@@ -770,11 +780,11 @@
       "benchmarks": [
         {
           "groupName": "src/raw-active-retained-delta.bench.ts > raw active retained delta benchmark: count-only, 101 rows",
-          "maxMs": 0.5631250000000136,
-          "meanMs": 0.26405839999999897,
-          "minMs": 0.176667000000009,
+          "maxMs": 0.5858339999999771,
+          "meanMs": 0.27139199999999164,
+          "minMs": 0.1802500000000009,
           "name": "count-only retained insert delta",
-          "p99Ms": 0.5631250000000136,
+          "p99Ms": 0.5858339999999771,
           "sampleCount": 5
         }
       ],
@@ -783,7 +793,7 @@
       "benchmarkScope": "engine-raw-active-retained-delta",
       "cleanupLeakCount": 0,
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 6225920,
+      "memoryRssTotalDeltaBytes": 5079040,
       "minimumSampleCount": 5,
       "mutationCount": 106,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-active-retained-delta-count-only-101rows.json",
@@ -800,11 +810,11 @@
       "benchmarks": [
         {
           "groupName": "src/in-memory-live-query.bench.tsx > React in-memory useLiveQuery browser benchmark: 20 rows",
-          "maxMs": 1.8000000715255737,
+          "maxMs": 1.9000000953674316,
           "meanMs": 0.7400000095367432,
           "minMs": 0.3999999761581421,
           "name": "publish matching row -> rendered top row",
-          "p99Ms": 1.8000000715255737,
+          "p99Ms": 1.9000000953674316,
           "sampleCount": 5
         }
       ],

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -9,7 +9,8 @@ import {
 } from "./raw-query-plan";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
-import type { TopicRawWindowScan, TopicRawWindowScanResult } from "./raw-window-scan";
+import type { TopicRawWindowScan } from "./raw-window-scan";
+import type { TopicRowEntry } from "./row-scan";
 
 type RowObject = object;
 
@@ -29,18 +30,21 @@ type RawQueryExecutionWindowSlot = {
   refs: number;
 };
 
-type ActiveQueryBaseEvaluation<Row extends RowObject> = TopicRawWindowScanResult<Row> & {
+type ActiveQueryBaseEvaluation<Row extends RowObject> = {
+  readonly keys: ReadonlyArray<string>;
   readonly retainedWindowFilled: boolean;
+  readonly totalRows: number;
   readonly version: number;
+  readonly window: ReadonlyArray<RetainedWindowEntry<Row>>;
 };
 
-type RetainedWindowEntry = {
+type RetainedWindowEntry<Row extends RowObject = RowObject> = TopicRowEntry<Row> & {
   readonly key: string;
-  readonly row: RowObject;
+  readonly row: Row;
 };
 
-type RetainedReplacementResult = {
-  readonly window: ReadonlyArray<RetainedWindowEntry>;
+type RetainedReplacementResult<Row extends RowObject> = {
+  readonly window: ReadonlyArray<RetainedWindowEntry<Row>>;
 };
 
 const retainedWindowFilled = (
@@ -73,26 +77,27 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
 ): ActiveQueryBaseEvaluation<Row> => {
   const version = store.version();
   const scanResult = store.scanRawWindow(rawQueryWindowScanPlan(compiled.plan, queryWindow));
+  const window = scanResult.window.map((entry) => ({
+    key: entry.key,
+    row: entry.row,
+  }));
   return {
     ...scanResult,
-    retainedWindowFilled: retainedWindowFilled(
-      scanResult.window,
-      scanResult.totalRows,
-      queryWindow,
-    ),
+    retainedWindowFilled: retainedWindowFilled(window, scanResult.totalRows, queryWindow),
     version,
+    window,
   };
 };
 
-const replaceRetainedMatchingEntry = (
-  windowEntries: ReadonlyArray<RetainedWindowEntry>,
+const replaceRetainedMatchingEntry = <Row extends RowObject>(
+  windowEntries: ReadonlyArray<RetainedWindowEntry<Row>>,
   key: string,
-  row: RowObject,
-  compare: (left: RetainedWindowEntry, right: RetainedWindowEntry) => number,
+  row: Row,
+  compare: (left: RetainedWindowEntry<Row>, right: RetainedWindowEntry<Row>) => number,
   retainedLimit: number | undefined,
-): RetainedReplacementResult | undefined => {
+): RetainedReplacementResult<Row> | undefined => {
   let previousIndex = -1;
-  let previousEntry: RetainedWindowEntry | undefined;
+  let previousEntry: RetainedWindowEntry<Row> | undefined;
   for (const [index, entry] of windowEntries.entries()) {
     if (entry.key === key) {
       previousIndex = index;
@@ -103,7 +108,7 @@ const replaceRetainedMatchingEntry = (
   if (previousEntry === undefined) {
     return undefined;
   }
-  const nextEntry = { key, row };
+  const nextEntry: RetainedWindowEntry<Row> = { key, row };
   if (retainedLimit !== undefined && compare(nextEntry, previousEntry) > 0) {
     return undefined;
   }
@@ -131,7 +136,7 @@ const updateBaseEvaluationFromRetainedChanges = (
   let totalRows = evaluation.totalRows;
   let windowEntries = evaluation.window;
   let removedRetainedEntry = false;
-  const insertedWindowEntries = new Map<string, { readonly key: string; readonly row: object }>();
+  const insertedWindowEntries = new Map<string, RetainedWindowEntry>();
   for (const batch of batches) {
     for (const change of batch.changes) {
       const previousMatches =
@@ -173,7 +178,9 @@ const updateBaseEvaluationFromRetainedChanges = (
         if (previousMatches) {
           totalRows -= 1;
           insertedWindowEntries.delete(change.key);
-          const removedWindowEntries = windowEntries.filter((entry) => entry.key !== change.key);
+          const removedWindowEntries: ReadonlyArray<RetainedWindowEntry> = windowEntries.filter(
+            (entry) => entry.key !== change.key,
+          );
           if (removedWindowEntries.length !== windowEntries.length) {
             windowEntries = removedWindowEntries;
             removedRetainedEntry = true;
@@ -256,12 +263,13 @@ const updateBaseEvaluationFromRetainedChanges = (
 };
 
 const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRawWindowScan<Row>,
   compiled: CompiledRawQuery<Row, ResultRow>,
   evaluation: ActiveQueryBaseEvaluation<Row>,
 ): QueryEvaluation<ResultRow> => {
   const window = evaluation.window.map((entry) => ({
     key: entry.key,
-    row: compiled.plan.project(entry.row),
+    row: projectRetainedEntry(store, compiled, entry),
   }));
 
   return {
@@ -274,6 +282,7 @@ const projectBaseEvaluation = <Row extends RowObject, ResultRow extends RowObjec
 };
 
 const projectWindowEvaluation = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRawWindowScan<Row>,
   compiled: CompiledRawQuery<Row, ResultRow>,
   evaluation: ActiveQueryBaseEvaluation<Row>,
 ): QueryEvaluation<ResultRow> => {
@@ -284,7 +293,7 @@ const projectWindowEvaluation = <Row extends RowObject, ResultRow extends RowObj
   const sourceWindow = evaluation.window.slice(compiled.plan.window.offset, end);
   const window = sourceWindow.map((entry) => ({
     key: entry.key,
-    row: compiled.plan.project(entry.row),
+    row: projectRetainedEntry(store, compiled, entry),
   }));
 
   return {
@@ -300,14 +309,39 @@ export const evaluateRawQuery = <Row extends RowObject, ResultRow extends RowObj
   store: TopicRawWindowScan<Row> & { readonly version: () => number },
   compiled: CompiledRawQuery<Row, ResultRow>,
 ): QueryEvaluation<ResultRow> =>
-  projectBaseEvaluation(compiled, evaluateBaseQuery(store, compiled));
+  projectBaseEvaluation(store, compiled, evaluateBaseQuery(store, compiled));
+
+function projectStoreSlot<Row extends RowObject, ResultRow extends RowObject>(
+  projectRawRow: (slot: number, selectedFields: ReadonlyArray<string>) => RowObject,
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  slot: number,
+): ResultRow;
+function projectStoreSlot(
+  projectRawRow: (slot: number, selectedFields: ReadonlyArray<string>) => RowObject,
+  compiled: CompiledRawQuery<RowObject, RowObject>,
+  slot: number,
+): RowObject {
+  return projectRawRow(slot, compiled.plan.selectedFields);
+}
+
+const projectRetainedEntry = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRawWindowScan<Row>,
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  entry: RetainedWindowEntry<Row>,
+): ResultRow => {
+  const slot = store.slotForKey?.(entry.key);
+  const projectRawRow = store.projectRawRow;
+  return slot === undefined || projectRawRow === undefined
+    ? compiled.plan.project(entry.row)
+    : projectStoreSlot(projectRawRow, compiled, slot);
+};
 
 const leaseRawQueryExecution = <ResultRow extends RowObject>(
   store: ActiveQueryStoreState,
   execution: ActiveQueryBaseExecution,
   compiled: CompiledRawQuery<object, ResultRow>,
 ): RawQueryExecution<ResultRow> => {
-  const latestEvaluation = () => projectWindowEvaluation(compiled, execution.latest());
+  const latestEvaluation = () => projectWindowEvaluation(store, compiled, execution.latest());
 
   return {
     initial: (queryId) => snapshotEvent(store, queryId, latestEvaluation()),

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -605,6 +605,38 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
+  it.effect("projects selected scalar fields after slot compaction", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+
+      yield* engine.publishMany("positions", [
+        position("deleted", "AAPL", 1n, "1.25", true),
+        position("kept", "MSFT", 2n, "2.50", false),
+      ]);
+      yield* engine.delete("positions", "deleted");
+
+      const snapshot = yield* engine.snapshot("positions", {
+        select: ["id", "symbol", "active", "quantity", "price"],
+        where: {
+          symbol: "MSFT",
+        },
+        orderBy: [{ field: "quantity", direction: "desc" }],
+        limit: 1,
+      });
+
+      expect(snapshot.rows).toStrictEqual([
+        {
+          active: false,
+          id: "kept",
+          price: fromStringUnsafe("2.50"),
+          quantity: 2n,
+          symbol: "MSFT",
+        },
+      ]);
+      expect(snapshot.totalRows).toBe(1);
+    }),
+  );
+
   it.effect("returns exact totalRows while windowing a sorted raw snapshot", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -297,6 +297,7 @@ afterAll(async () => {
       "BigDecimal range filter + indexed seek",
       "selective range filter + fallback top-k sort",
       "compound filter + top-k sort",
+      "wide scalar projection + top-k sort",
       "filtered totalRows via zero-row window",
       "live subscription delta after publish",
     ],
@@ -484,6 +485,32 @@ describe(`raw snapshot and delta engine benchmark: ${profile.rowCount} rows`, ()
           },
           orderBy: [{ field: "updatedAt", direction: "desc" }],
           limit: 50,
+        }),
+      );
+    },
+    benchOptions,
+  );
+
+  bench(
+    "wide scalar projection + top-k sort",
+    async () => {
+      await Effect.runPromise(
+        profileEngine(profile).snapshot("orders", {
+          select: [
+            "id",
+            "customerId",
+            "status",
+            "price",
+            "quantity",
+            "decimalPrice",
+            "region",
+            "updatedAt",
+          ],
+          where: {
+            status: { eq: "open" },
+          },
+          orderBy: [{ field: "updatedAt", direction: "desc" }],
+          limit: 200,
         }),
       );
     },

--- a/packages/column-live-view-engine/src/raw-window-scan.ts
+++ b/packages/column-live-view-engine/src/raw-window-scan.ts
@@ -29,5 +29,7 @@ export type TopicRawWindowScanResult<Row extends RowObject> = {
 };
 
 export type TopicRawWindowScan<Row extends RowObject> = {
+  readonly projectRawRow?: (slot: number, selectedFields: ReadonlyArray<string>) => RowObject;
   readonly scanRawWindow: (plan: TopicRawWindowScanPlan<Row>) => TopicRawWindowScanResult<Row>;
+  readonly slotForKey?: (key: string) => number | undefined;
 };

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -9,8 +9,12 @@ import type {
 import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-window-scan";
 import type { OrderedSlotIndex } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
-import { fieldValue } from "./row-values";
-import { createTopicColumnValues, type MutableTopicColumnValues } from "./topic-column-vector";
+import { cloneUnknown, fieldValue } from "./row-values";
+import {
+  columnValue,
+  createTopicColumnValues,
+  type MutableTopicColumnValues,
+} from "./topic-column-vector";
 import {
   addSlotToScalarPredicateIndexes,
   createScalarPredicateIndexes,
@@ -85,10 +89,12 @@ export class TopicRowStorage {
       activeQueries: createActiveQueryRegistry(),
       topic,
       changesSince: (version) => this.changesSince(version),
+      projectRawRow: (slot, selectedFields) => this.projectRawRow(slot, selectedFields),
       releaseChanges: () => this.releaseChanges(),
       retainChanges: () => this.retainChanges(),
       scanRows: (visitor) => this.scanRows(visitor),
       scanRawWindow: (plan) => this.scanRawWindow(plan),
+      slotForKey: (key) => this.slotForKey(key),
       version: () => this.versionValue,
     };
   }
@@ -210,6 +216,18 @@ export class TopicRowStorage {
 
   scanRawWindow(plan: TopicRawWindowScanPlan<object>): TopicRawWindowScanResult<object> {
     return scanTopicRawWindow(this.rawWindowScanState, plan);
+  }
+
+  projectRawRow(slot: number, selectedFields: ReadonlyArray<string>): RowObject {
+    const projected: Record<string, unknown> = {};
+    for (const field of selectedFields) {
+      projected[field] = cloneUnknown(columnValue(this.columns.get(field)!, slot));
+    }
+    return projected;
+  }
+
+  slotForKey(key: string): number | undefined {
+    return this.keyToSlot.get(key);
   }
 
   prepareRow = Effect.fn("ColumnLiveViewEngine.topicRowStorage.row.prepare")(function* <


### PR DESCRIPTION
## Summary
- Add an optional column-vector projection seam to raw window scans.
- Project selected raw rows from schema-derived column vectors via key -> current slot lookup.
- Keep row-store projection fallback for custom scanners and unavailable slots.
- Add a slot-compaction regression test and a wide scalar projection Vitest bench case.
- Refresh the smoke benchmark baseline for the new benchmark case.

## Validation
- pnpm run ready
- pnpm run bench:baseline:smoke:update
- pnpm run bench:baseline:smoke
- 3 reviewer agents: clean