### PR TITLE
Use column scalar keys for predicate indexes

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -61,6 +61,7 @@ import {
   selectedPredicateCandidateSlots,
 } from "./topic-predicate-candidate-index";
 import {
+  columnScalarEqualityKey,
   columnValue,
   createTopicColumnValues,
   createTopicColumnValuesFromArray,
@@ -334,6 +335,18 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   expect(columnValue(decimalPrice, 0)).toStrictEqual(fromStringUnsafe("1.25"));
   expect(columnValue(decimalPrice, 1)).toBeUndefined();
   expect(generic.length).toBe(0);
+
+  expect(columnScalarEqualityKey(optionalPrice, 0)).toBe("number:1");
+  expect(columnScalarEqualityKey(optionalPrice, 1)).toBeUndefined();
+  expect(columnScalarEqualityKey(quantity, 0)).toBe("bigint:1");
+  expect(columnScalarEqualityKey(quantity, -1)).toBeUndefined();
+  expect(columnScalarEqualityKey(decimalPrice, 0)).toBe("bigDecimal:1.25");
+  expect(columnScalarEqualityKey(decimalPrice, 1)).toBeUndefined();
+
+  generic.set(0, "generic");
+  generic.set(1, { unsupported: true });
+  expect(columnScalarEqualityKey(generic, 0)).toBe("string:7:generic");
+  expect(columnScalarEqualityKey(generic, 1)).toBeUndefined();
 });
 
 it("keeps scalar range helpers exact for numeric runtime domains", () => {

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -1,4 +1,5 @@
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+import { scalarEqualityKey } from "./row-values";
 import { isBigDecimal, type BigDecimal } from "effect/BigDecimal";
 
 export type TopicColumnKind = "generic" | "string" | "number" | "bigint" | "bigDecimal";
@@ -287,6 +288,29 @@ class BigDecimalTopicColumn implements MutableBigDecimalTopicColumnValues {
 }
 
 export const columnValue = (column: TopicColumnValues, slot: number): unknown => column.get(slot);
+
+export const columnScalarEqualityKey = (
+  column: TopicColumnValues,
+  slot: number,
+): string | undefined => {
+  if (column.kind === "string") {
+    const value = column.stringAt(slot);
+    return value === undefined ? undefined : scalarEqualityKey(value);
+  }
+  if (column.kind === "number") {
+    const value = column.numberAt(slot);
+    return value === undefined ? undefined : scalarEqualityKey(value);
+  }
+  if (column.kind === "bigint") {
+    const value = column.bigintAt(slot);
+    return value === undefined ? undefined : scalarEqualityKey(value);
+  }
+  if (column.kind === "bigDecimal") {
+    const value = column.bigDecimalAt(slot);
+    return value === undefined ? undefined : scalarEqualityKey(value);
+  }
+  return scalarEqualityKey(column.get(slot));
+};
 
 export const createTopicColumnValues = (
   field: string,

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-index.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-index.ts
@@ -10,7 +10,7 @@ import {
   rangeBoundsAreEmpty,
 } from "./topic-ordered-window";
 import { scalarEqualityKey } from "./row-values";
-import { columnValue, type TopicColumnValues } from "./topic-column-vector";
+import { columnScalarEqualityKey, type TopicColumnValues } from "./topic-column-vector";
 
 type RangePredicateFilter = TopicRawPredicateFilterPlan & {
   readonly operator: "gt" | "gte" | "lt" | "lte";
@@ -247,7 +247,7 @@ const unionScalarPredicateSlots = (
     missingBuckets.set(key, new Set());
   }
   for (let slot = 0; slot < column.length; slot += 1) {
-    const key = scalarEqualityKey(columnValue(column, slot));
+    const key = columnScalarEqualityKey(column, slot);
     if (key === undefined) {
       continue;
     }
@@ -295,7 +295,7 @@ const ensureScalarPredicateBucket = (
 
   const bucket = new Set<number>();
   for (let slot = 0; slot < column.length; slot += 1) {
-    if (scalarEqualityKey(columnValue(column, slot)) !== valueKey) {
+    if (columnScalarEqualityKey(column, slot) !== valueKey) {
       continue;
     }
     bucket.add(slot);
@@ -370,7 +370,7 @@ const addSlotToScalarPredicateIndex = (
   if (column === undefined) {
     return;
   }
-  const key = scalarEqualityKey(columnValue(column, slot));
+  const key = columnScalarEqualityKey(column, slot);
   if (key === undefined || !index.indexedKeys.has(key)) {
     return;
   }
@@ -389,7 +389,7 @@ const removeSlotFromScalarPredicateIndex = (
   if (column === undefined) {
     return;
   }
-  const key = scalarEqualityKey(columnValue(column, slot));
+  const key = columnScalarEqualityKey(column, slot);
   if (key === undefined || !index.indexedKeys.has(key)) {
     return;
   }

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -1,14 +1,18 @@
 import type { TopicRawPredicateFilterPlan } from "./raw-predicate-plan";
 import type { TopicRawWindowScanPlan } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
-import { scalarEqualityKey, valuesEqual } from "./row-values";
+import { valuesEqual } from "./row-values";
 import {
   columnValueDoesNotEqual,
   compareExactRangeColumnValue,
   compareRangeColumnValue,
   isComparableRangeValue,
 } from "./topic-range-value";
-import { columnValue, type TopicColumnValues } from "./topic-column-vector";
+import {
+  columnScalarEqualityKey,
+  columnValue,
+  type TopicColumnValues,
+} from "./topic-column-vector";
 import { equals as bigDecimalEquals, isBigDecimal } from "effect/BigDecimal";
 
 type RowObject = object;
@@ -134,7 +138,7 @@ const slotFilterMatcher = (
       if (filter.valueKeys !== undefined) {
         const valueKeys = filter.valueKeys;
         return (slot) => {
-          const key = scalarEqualityKey(columnValue(column, slot));
+          const key = columnScalarEqualityKey(column, slot);
           return key !== undefined && valueKeys.has(key);
         };
       }


### PR DESCRIPTION
## Summary
- Add columnScalarEqualityKey for typed scalar column vectors.
- Route raw in predicate matching through column-backed scalar keys.
- Route scalar predicate candidate index build/update/remove through the same helper.
- Add coverage for number, bigint, BigDecimal, generic scalar, unsupported generic, and missing-slot behavior.

## Validation
- vp check --fix on changed files
- pnpm --filter @view-server/column-live-view-engine run test
- VIEW_SERVER_ENGINE_BENCH_ROWS=1000 vp test bench packages/column-live-view-engine/src/raw-predicate-index.bench.ts --run --testTimeout 0
- pnpm run check:effect
- 3 reviewer agents: no findings
- pnpm run ready: passed build, package export checks, internal seam checks, benchmark baseline tests, vp check, strict Effect LSP, package tests, and browser React tests; final @view-server/runtime Kafka e2e could not run locally because Docker/OrbStack is not running: /Users/bruno/.orbstack/run/docker.sock missing.