### PR TITLE
Specialize column scalar equality keys

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -312,10 +312,19 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   status.clear();
   expect(status.length).toBe(0);
 
+  const statusKeys = createTopicColumnValues("status", metadata);
   const optionalPrice = createTopicColumnValuesFromArray("optionalPrice", metadata, [1, undefined]);
+  const numberKeys = createTopicColumnValues("optionalPrice", metadata);
   const quantity = createTopicColumnValues("quantity", metadata);
   const decimalPrice = createTopicColumnValues("decimalPrice", metadata);
   const generic = createTopicColumnValues("unknown", metadata);
+  statusKeys.reserve(8);
+  statusKeys.set(0, "a:b");
+  numberKeys.reserve(8);
+  numberKeys.set(0, -0);
+  numberKeys.set(1, Number.NaN);
+  numberKeys.set(2, Number.POSITIVE_INFINITY);
+  numberKeys.set(3, Number.NEGATIVE_INFINITY);
   quantity.reserve(8);
   quantity.set(0, 1n);
   quantity.set(1, 2n);
@@ -328,6 +337,8 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
   expect(quantity.kind).toBe("bigint");
   expect(decimalPrice.kind).toBe("bigDecimal");
   expect(generic.kind).toBe("generic");
+  expect(columnScalarEqualityKey(statusKeys, 0)).toBe("string:3:a:b");
+  expect(columnScalarEqualityKey(statusKeys, 1)).toBeUndefined();
   expect(columnValue(optionalPrice, 0)).toBe(1);
   expect(columnValue(optionalPrice, 1)).toBeUndefined();
   expect(columnValue(quantity, 0)).toBe(1n);
@@ -338,6 +349,10 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
 
   expect(columnScalarEqualityKey(optionalPrice, 0)).toBe("number:1");
   expect(columnScalarEqualityKey(optionalPrice, 1)).toBeUndefined();
+  expect(columnScalarEqualityKey(numberKeys, 0)).toBe("number:-0");
+  expect(columnScalarEqualityKey(numberKeys, 1)).toBe("number:NaN");
+  expect(columnScalarEqualityKey(numberKeys, 2)).toBe("number:Infinity");
+  expect(columnScalarEqualityKey(numberKeys, 3)).toBe("number:-Infinity");
   expect(columnScalarEqualityKey(quantity, 0)).toBe("bigint:1");
   expect(columnScalarEqualityKey(quantity, -1)).toBeUndefined();
   expect(columnScalarEqualityKey(decimalPrice, 0)).toBe("bigDecimal:1.25");

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -295,15 +295,17 @@ export const columnScalarEqualityKey = (
 ): string | undefined => {
   if (column.kind === "string") {
     const value = column.stringAt(slot);
-    return value === undefined ? undefined : scalarEqualityKey(value);
+    return value === undefined ? undefined : `string:${value.length}:${value}`;
   }
   if (column.kind === "number") {
     const value = column.numberAt(slot);
-    return value === undefined ? undefined : scalarEqualityKey(value);
+    return value === undefined
+      ? undefined
+      : `number:${Object.is(value, -0) ? "-0" : value.toString()}`;
   }
   if (column.kind === "bigint") {
     const value = column.bigintAt(slot);
-    return value === undefined ? undefined : scalarEqualityKey(value);
+    return value === undefined ? undefined : `bigint:${value.toString()}`;
   }
   if (column.kind === "bigDecimal") {
     const value = column.bigDecimalAt(slot);


### PR DESCRIPTION
Summary
- Inline string, number, and bigint scalar equality key formatting for typed topic columns.
- Keep BigDecimal and generic fallback routed through scalarEqualityKey.
- Add edge coverage for string delimiter values, missing string slots, -0, NaN, Infinity, and -Infinity.

Validation
- vp check --fix packages/column-live-view-engine/src/topic-column-vector.ts packages/column-live-view-engine/src/index.test.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- VIEW_SERVER_ENGINE_BENCH_ROWS=1000 vp test bench packages/column-live-view-engine/src/raw-predicate-index.bench.ts --run --testTimeout 0
- three local codex review passes: no findings

Notes
- Local benchmark/coverage artifacts were generated but not staged.