### PR TITLE
Use column slots for retained raw sorting

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -1246,6 +1246,193 @@ describe("column-live-view-engine active query execution", () => {
     }),
   );
 
+  it.effect("sorts retained raw inserts with the storage slot comparator", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-retained-insert-slot-sort",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const compiled = yield* prepareRawQuery(
+        "raw-retained-insert-slot-sort",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      let compareCount = 0;
+      const observedCompiled = {
+        ...compiled,
+        plan: {
+          ...compiled.plan,
+          compare: (
+            left: Parameters<typeof compiled.plan.compare>[0],
+            right: Parameters<typeof compiled.plan.compare>[1],
+          ) => {
+            compareCount += 1;
+            return compiled.plan.compare(left, right);
+          },
+        },
+      };
+
+      const execution = yield* acquireRawQueryExecution(
+        topicStoreReadModel(store),
+        observedCompiled,
+      );
+      expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+      const cursor = execution.createCursor();
+      compareCount = 0;
+
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.isSome(delta)).toBe(true);
+      expect(cursor.evaluation.keys).toStrictEqual(["c", "b"]);
+      expect(compareCount).toBe(0);
+
+      yield* releaseRawQueryExecution(topicStoreReadModel(store), observedCompiled);
+    }),
+  );
+
+  it.effect("falls back to the row comparator when retained raw slot sorting is unavailable", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-retained-insert-row-sort-fallback",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const compiled = yield* prepareRawQuery(
+        "raw-retained-insert-row-sort-fallback",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      let compareCount = 0;
+      const observedCompiled = {
+        ...compiled,
+        plan: {
+          ...compiled.plan,
+          compare: (
+            left: Parameters<typeof compiled.plan.compare>[0],
+            right: Parameters<typeof compiled.plan.compare>[1],
+          ) => {
+            compareCount += 1;
+            return compiled.plan.compare(left, right);
+          },
+        },
+      };
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        compareRawSlots: () => undefined,
+      };
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, observedCompiled);
+      expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+      const cursor = execution.createCursor();
+      compareCount = 0;
+
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.isSome(delta)).toBe(true);
+      expect(cursor.evaluation.keys).toStrictEqual(["c", "b"]);
+      expect(compareCount).toBeGreaterThan(0);
+
+      yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
+    }),
+  );
+
+  it.effect("falls back to the row comparator when retained raw inserted slots disappear", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-retained-insert-missing-slot-fallback",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const compiled = yield* prepareRawQuery(
+        "raw-retained-insert-missing-slot-fallback",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      let compareCount = 0;
+      const observedCompiled = {
+        ...compiled,
+        plan: {
+          ...compiled.plan,
+          compare: (
+            left: Parameters<typeof compiled.plan.compare>[0],
+            right: Parameters<typeof compiled.plan.compare>[1],
+          ) => {
+            compareCount += 1;
+            return compiled.plan.compare(left, right);
+          },
+        },
+      };
+      const readModel = topicStoreReadModel(store);
+      const observedReadModel = {
+        ...readModel,
+        slotForKey: (key: string) => (key === "c" ? undefined : readModel.slotForKey?.(key)),
+      };
+
+      const execution = yield* acquireRawQueryExecution(observedReadModel, observedCompiled);
+      expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
+      const cursor = execution.createCursor();
+      compareCount = 0;
+
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const delta = yield* execution.next("query", cursor);
+      expect(Option.isSome(delta)).toBe(true);
+      expect(cursor.evaluation.keys).toStrictEqual(["c", "b"]);
+      expect(compareCount).toBeGreaterThan(0);
+
+      yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
+    }),
+  );
+
   it.effect(
     "emits the next visible raw delta from the last delivered version after no-op changes",
     () =>

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -121,6 +121,25 @@ const replaceRetainedMatchingEntry = <Row extends RowObject>(
   };
 };
 
+const retainedEntrySortComparator = <Row extends RowObject, ResultRow extends RowObject>(
+  store: TopicRawWindowScan<Row>,
+  compiled: CompiledRawQuery<Row, ResultRow>,
+  queryWindow: RawQueryPlanWindow,
+): ((left: RetainedWindowEntry<Row>, right: RetainedWindowEntry<Row>) => number) => {
+  const compareSlots = store.compareRawSlots?.(rawQueryWindowScanPlan(compiled.plan, queryWindow));
+  const slotForKey = store.slotForKey;
+  if (compareSlots === undefined || slotForKey === undefined) {
+    return compiled.plan.compare;
+  }
+  return (left, right) => {
+    const leftSlot = slotForKey(left.key);
+    const rightSlot = slotForKey(right.key);
+    return leftSlot === undefined || rightSlot === undefined
+      ? compiled.plan.compare(left, right)
+      : compareSlots(leftSlot, rightSlot);
+  };
+};
+
 const updateBaseEvaluationFromRetainedChanges = (
   store: ActiveQueryStoreState,
   compiled: CompiledRawQuery<object, object>,
@@ -247,7 +266,8 @@ const updateBaseEvaluationFromRetainedChanges = (
     return undefined;
   }
 
-  const window = [...windowEntries, ...insertedWindowEntries.values()].sort(compiled.plan.compare);
+  const compareRetainedEntries = retainedEntrySortComparator(store, compiled, queryWindow);
+  const window = [...windowEntries, ...insertedWindowEntries.values()].sort(compareRetainedEntries);
   const retainedLimit =
     removedRetainedEntry && requiredWindowEntries !== undefined
       ? requiredWindowEntries

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -85,6 +85,7 @@ import {
   compareExactRangeColumnValue,
   compareRangeColumnValue,
 } from "./topic-range-value";
+import { orderedSlotBoundIndex } from "./topic-ordered-window";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -384,6 +385,46 @@ it("keeps scalar range helpers exact for numeric runtime domains", () => {
   expect(columnValueDoesNotEqual(1, Number.NaN)).toBe(false);
   expect(columnValueDoesNotEqual(true, false)).toBe(true);
   expect(columnValueDoesNotEqual("1", 1)).toBe(false);
+});
+
+it("uses typed column values for ordered slot bound indexes", () => {
+  const Metric = Schema.Struct({
+    decimalPrice: Schema.BigDecimal,
+    id: Schema.String,
+    price: Schema.Number,
+    quantity: Schema.BigInt,
+    status: Schema.String,
+  });
+  const metadata = rawQueryCompilerMetadata(Metric);
+  const status = createTopicColumnValuesFromArray("status", metadata, ["closed", "open", "open"]);
+  const sparseStatus = createTopicColumnValuesFromArray("status", metadata, [undefined, "open"]);
+  const price = createTopicColumnValuesFromArray("price", metadata, [1, 2, 3]);
+  const nonFinitePrice = createTopicColumnValuesFromArray("price", metadata, [Number.NaN]);
+  const quantity = createTopicColumnValuesFromArray("quantity", metadata, [1n, 2n, 3n]);
+  const decimalPrice = createTopicColumnValuesFromArray("decimalPrice", metadata, [
+    fromStringUnsafe("1"),
+    fromStringUnsafe("2"),
+    fromStringUnsafe("3"),
+  ]);
+  const generic = createTopicColumnValuesFromArray("unknown", metadata, ["closed", "open"]);
+
+  expect(orderedSlotBoundIndex([0, 1, 2], status, "open", (comparison) => comparison >= 0)).toBe(1);
+  expect(orderedSlotBoundIndex([0, 1, 2], status, "open", (comparison) => comparison > 0)).toBe(3);
+  expect(orderedSlotBoundIndex([0, 1], sparseStatus, "open", (comparison) => comparison >= 0)).toBe(
+    1,
+  );
+  expect(orderedSlotBoundIndex([0, 1, 2], price, 2, (comparison) => comparison >= 0)).toBe(1);
+  expect(orderedSlotBoundIndex([0], nonFinitePrice, 1, (comparison) => comparison > 0)).toBe(0);
+  expect(orderedSlotBoundIndex([0, 1, 2], quantity, 2n, (comparison) => comparison >= 0)).toBe(1);
+  expect(
+    orderedSlotBoundIndex(
+      [0, 1, 2],
+      decimalPrice,
+      fromStringUnsafe("2"),
+      (comparison) => comparison >= 0,
+    ),
+  ).toBe(1);
+  expect(orderedSlotBoundIndex([0, 1], generic, "open", (comparison) => comparison >= 0)).toBe(1);
 });
 
 const numericRowField = (row: object, field: string): number => {

--- a/packages/column-live-view-engine/src/raw-window-scan.ts
+++ b/packages/column-live-view-engine/src/raw-window-scan.ts
@@ -29,6 +29,9 @@ export type TopicRawWindowScanResult<Row extends RowObject> = {
 };
 
 export type TopicRawWindowScan<Row extends RowObject> = {
+  readonly compareRawSlots?: (
+    plan: TopicRawWindowScanPlan<Row>,
+  ) => ((leftSlot: number, rightSlot: number) => number) | undefined;
   readonly projectRawRow?: (slot: number, selectedFields: ReadonlyArray<string>) => RowObject;
   readonly scanRawWindow: (plan: TopicRawWindowScanPlan<Row>) => TopicRawWindowScanResult<Row>;
   readonly slotForKey?: (key: string) => number | undefined;

--- a/packages/column-live-view-engine/src/topic-ordered-window.ts
+++ b/packages/column-live-view-engine/src/topic-ordered-window.ts
@@ -7,6 +7,7 @@ import {
 } from "./raw-query-compiler";
 import { scalarEqualityKey } from "./row-values";
 import { columnValue, type TopicColumnValues } from "./topic-column-vector";
+import { Order as orderBigDecimal, isBigDecimal } from "effect/BigDecimal";
 
 export type OrderedSlotIndex = {
   readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
@@ -230,7 +231,7 @@ export const orderedSlotBoundIndex = (
   let high = slots.length;
   while (low < high) {
     const middle = Math.floor((low + high) / 2);
-    const comparison = compareOrderedRangeValue(columnValue(column, slots[middle]!), value);
+    const comparison = compareOrderedSlotRangeValue(column, slots[middle]!, value);
     if (predicate(comparison)) {
       high = middle;
     } else {
@@ -238,6 +239,38 @@ export const orderedSlotBoundIndex = (
     }
   }
   return low;
+};
+
+const compareOrderedSlotRangeValue = (
+  column: TopicColumnValues,
+  slot: number,
+  value: unknown,
+): number => {
+  if (column.kind === "string" && typeof value === "string") {
+    const slotValue = column.stringAt(slot);
+    if (slotValue !== undefined) {
+      return slotValue === value ? 0 : slotValue < value ? -1 : 1;
+    }
+  }
+  if (column.kind === "number" && typeof value === "number") {
+    const slotValue = column.numberAt(slot);
+    if (slotValue !== undefined && Number.isFinite(slotValue) && Number.isFinite(value)) {
+      return slotValue === value ? 0 : slotValue < value ? -1 : 1;
+    }
+  }
+  if (column.kind === "bigint" && typeof value === "bigint") {
+    const slotValue = column.bigintAt(slot);
+    if (slotValue !== undefined) {
+      return slotValue === value ? 0 : slotValue < value ? -1 : 1;
+    }
+  }
+  if (column.kind === "bigDecimal" && isBigDecimal(value)) {
+    const slotValue = column.bigDecimalAt(slot);
+    if (slotValue !== undefined) {
+      return orderBigDecimal(slotValue, value);
+    }
+  }
+  return compareOrderedRangeValue(columnValue(column, slot), value);
 };
 
 export const orderedWindowSpansInIndexOrder = (

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -33,6 +33,7 @@ import {
   scanTopicRawWindow,
   type TopicRawWindowScanState,
 } from "./topic-raw-window-scanner";
+import { rawWindowSlotComparator } from "./topic-raw-ordered-window-index";
 
 type RowObject = object;
 
@@ -89,6 +90,7 @@ export class TopicRowStorage {
       activeQueries: createActiveQueryRegistry(),
       topic,
       changesSince: (version) => this.changesSince(version),
+      compareRawSlots: (plan) => rawWindowSlotComparator(this.rawWindowScanState, plan),
       projectRawRow: (slot, selectedFields) => this.projectRawRow(slot, selectedFields),
       releaseChanges: () => this.releaseChanges(),
       retainChanges: () => this.retainChanges(),


### PR DESCRIPTION
## Summary
- Add a TopicRawWindowScan slot-comparator seam backed by TopicRowStorage raw ordered-window state.
- Use the storage slot comparator when sorting retained raw insert deltas, with row-comparator fallbacks when unavailable or when a slot disappears.
- Compare ordered-window range bounds through typed column vector accessors for string, number, bigint, and BigDecimal before falling back to generic row values.

## Validation
- vp check --fix packages/column-live-view-engine/src/active-raw-query.ts packages/column-live-view-engine/src/raw-window-scan.ts packages/column-live-view-engine/src/topic-row-storage.ts packages/column-live-view-engine/src/topic-ordered-window.ts packages/column-live-view-engine/src/active-query.test.ts packages/column-live-view-engine/src/index.test.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run check:effect
- pnpm run ready

## Notes
- Local Vitest bench command was attempted with VIEW_SERVER_ENGINE_BENCH_ROWS=1000, but sandboxed Vite config temp-file writes failed with EPERM; unsandboxed escalation was rejected by the sandbox reviewer. No ad hoc benchmark was run.