### PR TITLE
Optimize column write field order

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -427,6 +427,18 @@ it("uses typed column values for ordered slot bound indexes", () => {
   expect(orderedSlotBoundIndex([0, 1], generic, "open", (comparison) => comparison >= 0)).toBe(1);
 });
 
+it("keeps schema field order for aligned column writes", () => {
+  expect(rawQueryCompilerMetadata(Order).fieldOrder).toStrictEqual([
+    "id",
+    "customerId",
+    "status",
+    "price",
+    "region",
+    "updatedAt",
+    "note",
+  ]);
+});
+
 const numericRowField = (row: object, field: string): number => {
   const value = fieldValue(row, field);
   if (typeof value === "number") {
@@ -6337,7 +6349,12 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
   it.effect("clears retained row-change journals on active execution clear and overflow", () =>
     Effect.gen(function* () {
-      const storage = new TopicRowStorage("orders", Order, "id");
+      const storage = new TopicRowStorage("orders", Order, "id", {
+        maxEntries: 4,
+        maxVersions: 3,
+      });
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
       const compiled = yield* prepareGroupedQuery<object, object>(
         "orders",
         rawQueryCompilerMetadata(Order),
@@ -6357,19 +6374,18 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       const baseVersion = storage.version;
       storage.setPreparedMany(
-        Array.from({ length: 65_537 }, (_value, index) => ({
-          key: `row-${index}`,
-          row: order(`row-${index}`, "open", index, index),
-        })),
+        yield* storage.prepareRows(
+          Array.from({ length: 5 }, (_value, index) => order(`row-${index}`, "open", index, index)),
+          invalidRow,
+        ),
       );
       storage.advanceVersion();
       expect(storage.readModel.changesSince(baseVersion)).toBeUndefined();
 
       const recoveredVersion = storage.version;
-      storage.setPrepared({
-        key: "after-overflow",
-        row: order("after-overflow", "closed", 1, 1),
-      });
+      storage.setPrepared(
+        yield* storage.prepareRow(order("after-overflow", "closed", 1, 1), invalidRow),
+      );
       storage.advanceVersion();
       expect(storage.readModel.changesSince(recoveredVersion)).toStrictEqual([
         {
@@ -6385,15 +6401,15 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       ]);
 
       const multiVersionOverflowStart = storage.version;
-      for (let batchIndex = 0; batchIndex < 257; batchIndex += 1) {
+      for (let batchIndex = 0; batchIndex < 3; batchIndex += 1) {
         storage.setPreparedMany(
-          Array.from({ length: 256 }, (_value, rowIndex) => {
-            const key = `multi-version-${batchIndex}-${rowIndex}`;
-            return {
-              key,
-              row: order(key, "open", rowIndex, rowIndex),
-            };
-          }),
+          yield* storage.prepareRows(
+            Array.from({ length: 2 }, (_value, rowIndex) => {
+              const key = `multi-version-${batchIndex}-${rowIndex}`;
+              return order(key, "open", rowIndex, rowIndex);
+            }),
+            invalidRow,
+          ),
         );
         storage.advanceVersion();
       }
@@ -6401,20 +6417,24 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
       yield* clearStoreRawQueryExecutions(storage.readModel);
       expect(yield* activeStoreRawQueryExecutionCount(storage.readModel)).toBe(0);
-      storage.setPrepared({
-        key: "after-clear",
-        row: order("after-clear", "open", 1, 1),
-      });
+      storage.setPrepared(
+        yield* storage.prepareRow(order("after-clear", "open", 1, 1), invalidRow),
+      );
       const afterClearVersion = storage.version;
       storage.advanceVersion();
       expect(storage.readModel.changesSince(afterClearVersion)).toBeUndefined();
 
-      const fallbackStorage = new TopicRowStorage("orders", Order, "id");
+      const fallbackStorage = new TopicRowStorage("orders", Order, "id", {
+        maxEntries: 4,
+        maxVersions: 3,
+      });
       fallbackStorage.setPreparedMany(
-        Array.from({ length: 65_537 }, (_value, index) => ({
-          key: `fallback-${index}`,
-          row: order(`fallback-${index}`, "open", index, index),
-        })),
+        yield* fallbackStorage.prepareRows(
+          Array.from({ length: 5 }, (_value, index) =>
+            order(`fallback-${index}`, "open", index, index),
+          ),
+          invalidRow,
+        ),
       );
       fallbackStorage.advanceVersion();
       yield* acquireMaterializedQueryExecution(fallbackStorage.readModel, "fallback-clear", () =>
@@ -6427,7 +6447,12 @@ describe("ColumnLiveViewEngine subscriptions", () => {
 
   it.effect("releases retained row-change journals after grouped fallback demotion", () =>
     Effect.gen(function* () {
-      const storage = new TopicRowStorage("orders", Order, "id");
+      const storage = new TopicRowStorage("orders", Order, "id", {
+        maxEntries: 4,
+        maxVersions: 3,
+      });
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
       const compiled = yield* prepareGroupedQuery<object, object>(
         "orders",
         rawQueryCompilerMetadata(Order),
@@ -6440,24 +6465,31 @@ describe("ColumnLiveViewEngine subscriptions", () => {
         storage.readModel,
         "demoted-grouped-journal",
         (releaseRetainedChanges) =>
-          makeIncrementalGroupedQueryExecution(storage.readModel, compiled, releaseRetainedChanges),
+          makeIncrementalGroupedQueryExecution(
+            storage.readModel,
+            compiled,
+            releaseRetainedChanges,
+            {
+              ...defaultGroupedIncrementalAdmissionLimits,
+              maxMembers: 4,
+            },
+          ),
       );
       const cursor = execution.createCursor();
 
       storage.setPreparedMany(
-        Array.from({ length: 65_537 }, (_value, index) => ({
-          key: `row-${index}`,
-          row: order(`row-${index}`, "open", index, index),
-        })),
+        yield* storage.prepareRows(
+          Array.from({ length: 5 }, (_value, index) => order(`row-${index}`, "open", index, index)),
+          invalidRow,
+        ),
       );
       storage.advanceVersion();
       yield* execution.next("demoted-grouped-journal", cursor);
 
       const demotedVersion = storage.version;
-      storage.setPrepared({
-        key: "after-demotion",
-        row: order("after-demotion", "closed", 1, 1),
-      });
+      storage.setPrepared(
+        yield* storage.prepareRow(order("after-demotion", "closed", 1, 1), invalidRow),
+      );
       storage.advanceVersion();
       expect(storage.readModel.changesSince(demotedVersion)).toBeUndefined();
 
@@ -11004,6 +11036,7 @@ describe("ColumnLiveViewEngine validation and health", () => {
           price: Schema.Number,
         },
       });
+      expect(metadata.fieldOrder).toStrictEqual(["id", "price"]);
       expect(metadata.fieldNames.has("id")).toBe(true);
       expect(metadata.numericFieldNames.has("id")).toBe(false);
       expect(metadata.numericFieldNames.has("price")).toBe(true);

--- a/packages/column-live-view-engine/src/raw-query-metadata.ts
+++ b/packages/column-live-view-engine/src/raw-query-metadata.ts
@@ -10,6 +10,7 @@ export type RangeValueKind = "number" | "bigint" | "bigDecimal";
 
 export type RawQueryCompilerMetadata = {
   readonly fieldNames: ReadonlySet<string>;
+  readonly fieldOrder: ReadonlyArray<string>;
   readonly fieldMetadata: ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>>;
   readonly structuredFieldNames: ReadonlySet<string>;
   readonly structuredObjectFieldNames: ReadonlySet<string>;
@@ -87,6 +88,9 @@ const isPureBigDecimalAst = (ast: SchemaAST.AST): boolean => {
 
 const schemaFieldNames = (schema: Schema.Decoder<object>): ReadonlySet<string> =>
   isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
+
+const schemaFieldOrder = (schema: Schema.Decoder<object>): ReadonlyArray<string> =>
+  isSchemaWithFields(schema) ? Object.keys(schema.fields) : [];
 
 const schemaFieldMetadata = (
   schema: Schema.Decoder<object>,
@@ -230,6 +234,7 @@ export const rawQueryCompilerMetadata = (
   schema: Schema.Decoder<object>,
 ): RawQueryCompilerMetadata => ({
   fieldNames: schemaFieldNames(schema),
+  fieldOrder: schemaFieldOrder(schema),
   fieldMetadata: schemaFieldMetadata(schema),
   structuredFieldNames: schemaStructuredFieldNames(schema),
   structuredObjectFieldNames: schemaStructuredObjectFieldNames(schema),

--- a/packages/column-live-view-engine/src/topic-row-change-journal.test.ts
+++ b/packages/column-live-view-engine/src/topic-row-change-journal.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "@effect/vitest";
+import { TopicRowChangeJournal } from "./topic-row-change-journal";
+
+const row = (id: string): object => ({ id });
+
+describe("column-live-view-engine topic row change journal", () => {
+  it("normalizes invalid retained limit overrides", () => {
+    const journal = new TopicRowChangeJournal<object>({
+      maxEntries: Number.NaN,
+      maxVersions: 0,
+    });
+
+    journal.retain(0);
+    journal.record({ key: "first", previous: undefined, next: row("first") }, 0);
+    journal.commit(1);
+
+    expect(journal.changesSince(0, 1)).toStrictEqual([
+      {
+        changes: [{ key: "first", previous: undefined, next: row("first") }],
+        version: 1,
+      },
+    ]);
+  });
+
+  it("uses positive retained limit overrides", () => {
+    const journal = new TopicRowChangeJournal<object>({
+      maxEntries: 1,
+      maxVersions: 1,
+    });
+
+    journal.retain(0);
+    journal.record({ key: "first", previous: undefined, next: row("first") }, 0);
+    journal.record({ key: "second", previous: undefined, next: row("second") }, 0);
+    journal.commit(1);
+    expect(journal.changesSince(0, 1)).toBeUndefined();
+
+    journal.record({ key: "third", previous: undefined, next: row("third") }, 1);
+    journal.commit(2);
+    journal.record({ key: "fourth", previous: undefined, next: row("fourth") }, 2);
+    journal.commit(3);
+
+    expect(journal.changesSince(1, 3)).toBeUndefined();
+    expect(journal.changesSince(2, 3)).toStrictEqual([
+      {
+        changes: [{ key: "fourth", previous: undefined, next: row("fourth") }],
+        version: 3,
+      },
+    ]);
+  });
+
+  it("uses default retained limits and reports missing history after clear", () => {
+    const journal = new TopicRowChangeJournal<object>();
+
+    journal.retain(0);
+    expect(journal.changesSince(0, 1)).toBeUndefined();
+
+    journal.clear(1);
+
+    expect(journal.changesSince(0, 1)).toBeUndefined();
+  });
+});

--- a/packages/column-live-view-engine/src/topic-row-change-journal.ts
+++ b/packages/column-live-view-engine/src/topic-row-change-journal.ts
@@ -5,6 +5,18 @@ type RowObject = object;
 const maxRowChangeJournalEntries = 65_536;
 const maxRowChangeJournalVersions = 1_024;
 
+export type TopicRowChangeJournalLimits = {
+  readonly maxEntries?: number;
+  readonly maxVersions?: number;
+};
+
+const positiveSafeIntegerOrDefault = (value: number | undefined, fallback: number): number => {
+  if (value === undefined) {
+    return fallback;
+  }
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+};
+
 export class TopicRowChangeJournal<Row extends RowObject> {
   private pendingChanges: Array<TopicRowChange<Row>> = [];
   private pendingChangesOverflowed = false;
@@ -12,6 +24,16 @@ export class TopicRowChangeJournal<Row extends RowObject> {
   private changeCount = 0;
   private invalidBeforeVersion = 0;
   private refs = 0;
+  private readonly maxEntries: number;
+  private readonly maxVersions: number;
+
+  constructor(limits?: TopicRowChangeJournalLimits) {
+    this.maxEntries = positiveSafeIntegerOrDefault(limits?.maxEntries, maxRowChangeJournalEntries);
+    this.maxVersions = positiveSafeIntegerOrDefault(
+      limits?.maxVersions,
+      maxRowChangeJournalVersions,
+    );
+  }
 
   changesSince(
     version: number,
@@ -24,6 +46,9 @@ export class TopicRowChangeJournal<Row extends RowObject> {
       return undefined;
     }
     if (version < this.invalidBeforeVersion) {
+      return undefined;
+    }
+    if (this.batches.length === 0) {
       return undefined;
     }
     const firstBatch = this.batches[0]!;
@@ -70,7 +95,7 @@ export class TopicRowChangeJournal<Row extends RowObject> {
     if (this.refs === 0 || this.pendingChangesOverflowed) {
       return;
     }
-    if (this.pendingChanges.length + 1 > maxRowChangeJournalEntries) {
+    if (this.pendingChanges.length + 1 > this.maxEntries) {
       this.invalidate(currentVersion + 1);
       this.pendingChangesOverflowed = true;
       return;
@@ -98,11 +123,11 @@ export class TopicRowChangeJournal<Row extends RowObject> {
   }
 
   private trim(currentVersion: number): void {
-    while (this.batches.length > maxRowChangeJournalVersions) {
+    while (this.batches.length > this.maxVersions) {
       const removed = this.batches.shift()!;
       this.changeCount -= removed.changes.length;
     }
-    if (this.changeCount > maxRowChangeJournalEntries) {
+    if (this.changeCount > this.maxEntries) {
       this.invalidate(currentVersion);
     }
   }

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -20,7 +20,10 @@ import {
   createScalarPredicateIndexes,
   removeSlotFromScalarPredicateIndexes,
 } from "./topic-predicate-candidate-index";
-import { TopicRowChangeJournal } from "./topic-row-change-journal";
+import {
+  TopicRowChangeJournal,
+  type TopicRowChangeJournalLimits,
+} from "./topic-row-change-journal";
 import {
   prepareTopicPatch,
   prepareTopicRow,
@@ -52,10 +55,12 @@ export class TopicRowStorage {
   private readonly slots: Array<TopicRowEntry<object>> = [];
   private readonly keyToSlot = new Map<string, number>();
   private readonly columns = new Map<string, MutableTopicColumnValues>();
+  private readonly columnWritePlan: Array<MutableTopicColumnValues> = [];
+  private readonly columnWriteFields: Array<string> = [];
   private readonly reservableColumns: Array<MutableTopicColumnValues> = [];
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
   private readonly scalarPredicateIndexes = createScalarPredicateIndexes();
-  private readonly rowChangeJournal = new TopicRowChangeJournal<object>();
+  private readonly rowChangeJournal: TopicRowChangeJournal<object>;
   private readonly rowPreparation: TopicRowPreparationContext;
   private readonly rawWindowScanState: TopicRawWindowScanState;
   private versionValue = 0;
@@ -64,7 +69,9 @@ export class TopicRowStorage {
     readonly topic: string,
     schema: Schema.Decoder<object>,
     keyField: string,
+    rowChangeJournalLimits?: TopicRowChangeJournalLimits,
   ) {
+    this.rowChangeJournal = new TopicRowChangeJournal<object>(rowChangeJournalLimits);
     this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
     this.rawWindowScanState = {
       columns: this.columns,
@@ -82,6 +89,11 @@ export class TopicRowStorage {
     for (const field of this.rawQueryMetadata.fieldNames) {
       const column = createTopicColumnValues(field, this.rawQueryMetadata);
       this.columns.set(field, column);
+    }
+    for (const field of this.rawQueryMetadata.fieldOrder) {
+      const column = this.columns.get(field)!;
+      this.columnWritePlan.push(column);
+      this.columnWriteFields.push(field);
       if (column.kind === "number") {
         this.reservableColumns.push(column);
       }
@@ -264,8 +276,11 @@ export class TopicRowStorage {
       key: prepared.key,
       row: prepared.row,
     };
-    for (const [field, column] of this.columns) {
-      column.set(slot, fieldValue(prepared.row, field));
+    for (let index = 0; index < this.columnWritePlan.length; index += 1) {
+      this.columnWritePlan[index]!.set(
+        slot,
+        fieldValue(prepared.row, this.columnWriteFields[index]!),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- derive stable schema field order in raw query metadata
- write column vectors with precomputed field/column arrays instead of iterating the column map per row
- add direct row-change journal limit normalization tests and small-limit regression coverage

## Validation
- vp check --fix packages/column-live-view-engine/src/index.test.ts packages/column-live-view-engine/src/raw-query-metadata.ts packages/column-live-view-engine/src/topic-row-change-journal.ts packages/column-live-view-engine/src/topic-row-change-journal.test.ts packages/column-live-view-engine/src/topic-row-preparation.ts packages/column-live-view-engine/src/topic-row-storage.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run ready

## Reviewer loop
- 3 local reviewer agents reviewed the final diff
- only finding was the new journal test file being untracked; fixed by including it in this commit