### PR TITLE
Cache raw storage order plans

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -52,6 +52,7 @@ import {
   valuesEqual,
 } from "./row-values";
 import type { TopicRowChangeBatch } from "./row-scan";
+import type { TopicRawOrderByPlan } from "./raw-window-scan";
 import { scanTopicRawWindow } from "./topic-raw-window-scanner";
 import {
   addSlotToScalarPredicateIndexes,
@@ -86,6 +87,7 @@ import {
   compareRangeColumnValue,
 } from "./topic-range-value";
 import { orderedSlotBoundIndex } from "./topic-ordered-window";
+import { rawWindowOrderedSlotIndex } from "./topic-raw-ordered-window-index";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -6638,6 +6640,74 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       });
       expect(invalidStorageOrderColumnLimited.keys).toStrictEqual(["3"]);
       expect(invalidStorageOrderColumnLimited.totalRows).toBe(2);
+
+      expect(
+        readModel.compareRawSlots?.({
+          predicate: {
+            filters: [],
+            callbackRequired: false,
+          },
+          orderBy: [],
+          matches: () => true,
+          compare: compareByKey,
+          offset: 0,
+          limit: 10,
+        }),
+      ).toBeUndefined();
+
+      expect(
+        readModel.compareRawSlots?.({
+          predicate: {
+            filters: [],
+            callbackRequired: false,
+          },
+          orderBy: [{ field: "price", direction: "asc" }],
+          storageOrderBy: [{ field: "missing", direction: "asc" }],
+          matches: () => true,
+          compare: compareByKey,
+          offset: 0,
+          limit: 10,
+        }),
+      ).toBeUndefined();
+
+      const cachedStorageOrderBy: ReadonlyArray<TopicRawOrderByPlan> = [
+        { field: "price", direction: "asc" },
+      ];
+      const cachedComparatorPlan = {
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: cachedStorageOrderBy,
+        storageOrderBy: cachedStorageOrderBy,
+        matches: () => true,
+        compare: compareByKey,
+        offset: 0,
+        limit: 10,
+      };
+      const firstCachedComparator = expectDefined(
+        readModel.compareRawSlots?.(cachedComparatorPlan),
+      );
+      const secondCachedComparator = expectDefined(
+        readModel.compareRawSlots?.(cachedComparatorPlan),
+      );
+      expect(firstCachedComparator(0, 1)).toBe(1);
+      expect(secondCachedComparator(0, 1)).toBe(1);
+
+      const missingOrderedSlotIndex = rawWindowOrderedSlotIndex(
+        {
+          columns: new Map(),
+          orderedSlotIndexes: new Map(),
+          rawQueryMetadata: rawQueryCompilerMetadata(Order),
+          slots: [],
+        },
+        [{ field: "missing", direction: "asc" }],
+      );
+      expect(missingOrderedSlotIndex).toStrictEqual({
+        orderBy: [{ field: "missing", direction: "asc" }],
+        orderColumns: [],
+        slots: [],
+      });
 
       const multiFieldStorageOrderZeroLimit = readModel.scanRawWindow({
         predicate: {

--- a/packages/column-live-view-engine/src/topic-ordered-window.ts
+++ b/packages/column-live-view-engine/src/topic-ordered-window.ts
@@ -9,7 +9,13 @@ import { scalarEqualityKey } from "./row-values";
 import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 import { Order as orderBigDecimal, isBigDecimal } from "effect/BigDecimal";
 
+export type RawStorageOrderColumn = {
+  readonly column: TopicColumnValues;
+  readonly direction: "asc" | "desc";
+};
+
 export type OrderedSlotIndex = {
+  readonly orderColumns: ReadonlyArray<RawStorageOrderColumn>;
   readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
   readonly slots: Array<number>;
 };

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -20,6 +20,7 @@ import {
   type OrderedRawWindow,
   type OrderedRawWindowSpan,
   type OrderedSlotIndex,
+  type RawStorageOrderColumn,
 } from "./topic-ordered-window";
 
 export type RawOrderedWindowIndexState = {
@@ -35,7 +36,7 @@ export const insertSlotIntoRawWindowIndexes = (
 ): void => {
   for (const index of state.orderedSlotIndexes.values()) {
     const insertAt = orderedSlotIndexInsertionPoint(index.slots, slot, (left, right) =>
-      compareSlotsByStorageOrder(state, left, right, index.orderBy),
+      compareSlotsByStorageOrder(state, left, right, index.orderColumns),
     );
     index.slots.splice(insertAt, 0, slot);
   }
@@ -104,10 +105,19 @@ export const rawWindowOrderedSlotIndex = (
   if (existing !== undefined) {
     return existing;
   }
+  const orderColumns = compiledRawStorageOrder(state, storageOrderBy);
+  if (orderColumns === undefined) {
+    return {
+      orderBy: storageOrderBy,
+      orderColumns: [],
+      slots: [],
+    };
+  }
   const slots = Array.from({ length: state.slots.length }, (_value, slot) => slot);
-  slots.sort((left, right) => compareSlotsByStorageOrder(state, left, right, storageOrderBy));
+  slots.sort((left, right) => compareSlotsByStorageOrder(state, left, right, orderColumns));
   const index: OrderedSlotIndex = {
     orderBy: storageOrderBy,
+    orderColumns,
     slots,
   };
   state.orderedSlotIndexes.set(indexKey, index);
@@ -138,24 +148,42 @@ export const rawWindowSlotComparator = (
   if (storageOrderBy === undefined) {
     return undefined;
   }
-  if (!storageOrderByFieldsExist(state, storageOrderBy)) {
+  const orderColumns = compiledRawStorageOrder(state, storageOrderBy);
+  if (orderColumns === undefined) {
     return undefined;
   }
 
   return (left, right) => {
-    return compareSlotsByStorageOrder(state, left, right, storageOrderBy);
+    return compareSlotsByStorageOrder(state, left, right, orderColumns);
   };
 };
 
-const compareSlotsByStorageOrder = (
-  state: RawOrderedWindowIndexState,
+export const compiledRawStorageOrder = (
+  state: Pick<RawOrderedWindowIndexState, "columns">,
+  storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>,
+): ReadonlyArray<RawStorageOrderColumn> | undefined => {
+  const orderColumns: Array<RawStorageOrderColumn> = [];
+  for (const order of storageOrderBy) {
+    const column = state.columns.get(order.field);
+    if (column === undefined) {
+      return undefined;
+    }
+    orderColumns.push({
+      column,
+      direction: order.direction,
+    });
+  }
+  return orderColumns;
+};
+
+export const compareSlotsByStorageOrder = (
+  state: Pick<RawOrderedWindowIndexState, "slots">,
   left: number,
   right: number,
-  storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>,
+  storageOrderBy: ReadonlyArray<RawStorageOrderColumn>,
 ): number => {
   for (const order of storageOrderBy) {
-    const column = state.columns.get(order.field)!;
-    const comparison = compareSlotColumnValues(column, left, right);
+    const comparison = compareSlotColumnValues(order.column, left, right);
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -6,8 +6,12 @@ import type {
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
-import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-window-scan";
-import type { OrderedSlotIndex } from "./topic-ordered-window";
+import type {
+  TopicRawOrderByPlan,
+  TopicRawWindowScanPlan,
+  TopicRawWindowScanResult,
+} from "./raw-window-scan";
+import type { OrderedSlotIndex, RawStorageOrderColumn } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { cloneUnknown, fieldValue } from "./row-values";
 import {
@@ -36,7 +40,10 @@ import {
   scanTopicRawWindow,
   type TopicRawWindowScanState,
 } from "./topic-raw-window-scanner";
-import { rawWindowSlotComparator } from "./topic-raw-ordered-window-index";
+import {
+  compareSlotsByStorageOrder,
+  compiledRawStorageOrder,
+} from "./topic-raw-ordered-window-index";
 
 type RowObject = object;
 
@@ -66,6 +73,10 @@ export class TopicRowStorage {
   private readonly rawProjectionPlans = new WeakMap<
     ReadonlyArray<string>,
     ReadonlyArray<RawProjectionColumn>
+  >();
+  private readonly rawStorageOrderPlans = new WeakMap<
+    ReadonlyArray<TopicRawOrderByPlan>,
+    ReadonlyArray<RawStorageOrderColumn>
   >();
   private readonly reservableColumns: Array<MutableTopicColumnValues> = [];
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
@@ -112,7 +123,7 @@ export class TopicRowStorage {
       activeQueries: createActiveQueryRegistry(),
       topic,
       changesSince: (version) => this.changesSince(version),
-      compareRawSlots: (plan) => rawWindowSlotComparator(this.rawWindowScanState, plan),
+      compareRawSlots: (plan) => this.compareRawSlots(plan),
       projectRawRow: (slot, selectedFields) => this.projectRawRow(slot, selectedFields),
       releaseChanges: () => this.releaseChanges(),
       retainChanges: () => this.retainChanges(),
@@ -242,6 +253,21 @@ export class TopicRowStorage {
     return scanTopicRawWindow(this.rawWindowScanState, plan);
   }
 
+  private compareRawSlots(
+    plan: TopicRawWindowScanPlan<object>,
+  ): ((left: number, right: number) => number) | undefined {
+    const storageOrderBy = plan.storageOrderBy;
+    if (storageOrderBy === undefined) {
+      return undefined;
+    }
+    const orderColumns = this.rawStorageOrderPlan(storageOrderBy);
+    if (orderColumns === undefined) {
+      return undefined;
+    }
+    return (left, right) =>
+      compareSlotsByStorageOrder(this.rawWindowScanState, left, right, orderColumns);
+  }
+
   private projectRawRow(slot: number, selectedFields: ReadonlyArray<string>): RowObject {
     const projected: Record<string, unknown> = {};
     for (const projection of this.rawProjectionPlan(selectedFields)) {
@@ -312,6 +338,20 @@ export class TopicRowStorage {
       };
     });
     this.rawProjectionPlans.set(selectedFields, plan);
+    return plan;
+  }
+
+  private rawStorageOrderPlan(
+    storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>,
+  ): ReadonlyArray<RawStorageOrderColumn> | undefined {
+    const cached = this.rawStorageOrderPlans.get(storageOrderBy);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const plan = compiledRawStorageOrder(this.rawWindowScanState, storageOrderBy);
+    if (plan !== undefined) {
+      this.rawStorageOrderPlans.set(storageOrderBy, plan);
+    }
     return plan;
   }
 


### PR DESCRIPTION
## Summary
- Compile raw storage order plans into column references once instead of looking up columns inside every comparator call.
- Cache compiled storage-order plans in TopicRowStorage by compiler-owned storageOrderBy array.
- Store compiled order columns on ordered slot indexes so indexed inserts reuse the same plan.
- Add coverage for missing storage order, cached comparator reuse, and missing ordered-index construction.

## Validation
- 3 reviewer agents clean.
- vp check --fix packages/column-live-view-engine/src/index.test.ts packages/column-live-view-engine/src/topic-row-storage.ts packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts packages/column-live-view-engine/src/topic-ordered-window.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run bench:baseline:smoke
- pnpm run ready