### PR TITLE
Compile raw storage order comparators

### DIFF
--- a/packages/column-live-view-engine/src/topic-ordered-window.ts
+++ b/packages/column-live-view-engine/src/topic-ordered-window.ts
@@ -10,7 +10,7 @@ import { columnValue, type TopicColumnValues } from "./topic-column-vector";
 import { Order as orderBigDecimal, isBigDecimal } from "effect/BigDecimal";
 
 export type RawStorageOrderColumn = {
-  readonly column: TopicColumnValues;
+  readonly compareSlots: (left: number, right: number) => number;
   readonly direction: "asc" | "desc";
 };
 

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -169,7 +169,7 @@ export const compiledRawStorageOrder = (
       return undefined;
     }
     orderColumns.push({
-      column,
+      compareSlots: rawStorageOrderColumnComparator(column),
       direction: order.direction,
     });
   }
@@ -183,7 +183,7 @@ export const compareSlotsByStorageOrder = (
   storageOrderBy: ReadonlyArray<RawStorageOrderColumn>,
 ): number => {
   for (const order of storageOrderBy) {
-    const comparison = compareSlotColumnValues(order.column, left, right);
+    const comparison = order.compareSlots(left, right);
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
@@ -193,43 +193,77 @@ export const compareSlotsByStorageOrder = (
   return Number(leftKey > rightKey) - Number(leftKey < rightKey);
 };
 
-const compareSlotColumnValues = (
+const rawStorageOrderColumnComparator = (
   column: TopicColumnValues,
+): ((left: number, right: number) => number) => {
+  if (column.kind === "string") {
+    return (left, right) => compareStringColumnSlots(column, left, right);
+  }
+  if (column.kind === "number") {
+    return (left, right) => compareNumberColumnSlots(column, left, right);
+  }
+  if (column.kind === "bigint") {
+    return (left, right) => compareBigIntColumnSlots(column, left, right);
+  }
+  if (column.kind === "bigDecimal") {
+    return (left, right) => compareBigDecimalColumnSlots(column, left, right);
+  }
+  return (left, right) => compareQueryValue(columnValue(column, left), columnValue(column, right));
+};
+
+const compareStringColumnSlots = (
+  column: TopicColumnValues & { readonly kind: "string" },
   left: number,
   right: number,
 ): number => {
-  if (column.kind === "string") {
-    const leftValue = column.stringAt(left);
-    const rightValue = column.stringAt(right);
-    if (leftValue !== undefined && rightValue !== undefined) {
-      return Number(leftValue > rightValue) - Number(leftValue < rightValue);
-    }
+  const leftValue = column.stringAt(left);
+  const rightValue = column.stringAt(right);
+  if (leftValue !== undefined && rightValue !== undefined) {
+    return Number(leftValue > rightValue) - Number(leftValue < rightValue);
   }
-  if (column.kind === "number") {
-    const leftValue = column.numberAt(left);
-    const rightValue = column.numberAt(right);
-    if (
-      leftValue !== undefined &&
-      rightValue !== undefined &&
-      Number.isFinite(leftValue) &&
-      Number.isFinite(rightValue)
-    ) {
-      return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
-    }
+  return compareQueryValue(columnValue(column, left), columnValue(column, right));
+};
+
+const compareNumberColumnSlots = (
+  column: TopicColumnValues & { readonly kind: "number" },
+  left: number,
+  right: number,
+): number => {
+  const leftValue = column.numberAt(left);
+  const rightValue = column.numberAt(right);
+  if (
+    leftValue !== undefined &&
+    rightValue !== undefined &&
+    Number.isFinite(leftValue) &&
+    Number.isFinite(rightValue)
+  ) {
+    return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
   }
-  if (column.kind === "bigint") {
-    const leftValue = column.bigintAt(left);
-    const rightValue = column.bigintAt(right);
-    if (leftValue !== undefined && rightValue !== undefined) {
-      return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
-    }
+  return compareQueryValue(columnValue(column, left), columnValue(column, right));
+};
+
+const compareBigIntColumnSlots = (
+  column: TopicColumnValues & { readonly kind: "bigint" },
+  left: number,
+  right: number,
+): number => {
+  const leftValue = column.bigintAt(left);
+  const rightValue = column.bigintAt(right);
+  if (leftValue !== undefined && rightValue !== undefined) {
+    return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
   }
-  if (column.kind === "bigDecimal") {
-    const leftValue = column.bigDecimalAt(left);
-    const rightValue = column.bigDecimalAt(right);
-    if (leftValue !== undefined && rightValue !== undefined) {
-      return orderBigDecimal(leftValue, rightValue);
-    }
+  return compareQueryValue(columnValue(column, left), columnValue(column, right));
+};
+
+const compareBigDecimalColumnSlots = (
+  column: TopicColumnValues & { readonly kind: "bigDecimal" },
+  left: number,
+  right: number,
+): number => {
+  const leftValue = column.bigDecimalAt(left);
+  const rightValue = column.bigDecimalAt(right);
+  if (leftValue !== undefined && rightValue !== undefined) {
+    return orderBigDecimal(leftValue, rightValue);
   }
   return compareQueryValue(columnValue(column, left), columnValue(column, right));
 };


### PR DESCRIPTION
## Summary
- Compile raw storage order plans into per-column slot comparator functions.
- Remove per-comparison column-kind branching from raw storage order sorting.
- Preserve fallback compareQueryValue behavior for missing/non-finite values.

## Validation
- 3 reviewer agents clean.
- vp check --fix packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts packages/column-live-view-engine/src/topic-ordered-window.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run bench:baseline:smoke
- pnpm run ready