### PR TITLE
Cache raw predicate slot matchers

### DIFF
--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -1,4 +1,5 @@
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
 import type { TopicColumnValues } from "./topic-column-vector";
@@ -19,7 +20,7 @@ import {
   type OrderedRawWindow,
   type OrderedSlotIndex,
 } from "./topic-ordered-window";
-import { rawPredicateSlotMatcher } from "./topic-slot-predicate";
+import { rawPredicateSlotFilterMatcher, type SlotFilterMatcher } from "./topic-slot-predicate";
 
 type RowObject = object;
 
@@ -27,6 +28,7 @@ export type TopicRawWindowScanState = {
   readonly columns: ReadonlyMap<string, TopicColumnValues>;
   readonly orderedSlotIndexes: Map<string, OrderedSlotIndex>;
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
+  readonly rawPredicateSlotMatchers?: WeakMap<TopicRawPredicatePlan, SlotFilterMatcher>;
   readonly scalarPredicateIndexes: PredicateCandidateSlotIndexState["scalarPredicateIndexes"];
   readonly slots: ReadonlyArray<TopicRowEntry<object>>;
 };
@@ -410,11 +412,21 @@ const rawPredicateMatchesSlot = (
   state: TopicRawWindowScanState,
   plan: TopicRawWindowScanPlan<object>,
 ): ((slot: number) => boolean) => {
-  const matcher = rawPredicateSlotMatcher(plan, state.columns);
-  if (matcher.kind === "slot") {
-    return matcher.matchesSlot;
+  if (plan.predicate.callbackSkippable !== true) {
+    const matchesFilters = rawPredicateSlotFilterMatcher(
+      plan.predicate.filters,
+      state.columns,
+      false,
+    );
+    return (slot) => matchesFilters(slot) && plan.matches(state.slots[slot]!.row);
   }
-  return (slot) => matcher.matchesEntry(slot, state.slots[slot]!);
+
+  let matchesSlot = state.rawPredicateSlotMatchers?.get(plan.predicate);
+  if (matchesSlot === undefined) {
+    matchesSlot = rawPredicateSlotFilterMatcher(plan.predicate.filters, state.columns, true);
+    state.rawPredicateSlotMatchers?.set(plan.predicate, matchesSlot);
+  }
+  return matchesSlot;
 };
 
 const rawWindowScanResult = (

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -11,6 +11,7 @@ import type {
   TopicRawWindowScanPlan,
   TopicRawWindowScanResult,
 } from "./raw-window-scan";
+import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { OrderedSlotIndex, RawStorageOrderColumn } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
 import { cloneUnknown, fieldValue } from "./row-values";
@@ -40,6 +41,7 @@ import {
   scanTopicRawWindow,
   type TopicRawWindowScanState,
 } from "./topic-raw-window-scanner";
+import type { SlotFilterMatcher } from "./topic-slot-predicate";
 import {
   compareSlotsByStorageOrder,
   compiledRawStorageOrder,
@@ -78,6 +80,10 @@ export class TopicRowStorage {
     ReadonlyArray<TopicRawOrderByPlan>,
     ReadonlyArray<RawStorageOrderColumn>
   >();
+  private readonly rawPredicateSlotMatchers = new WeakMap<
+    TopicRawPredicatePlan,
+    SlotFilterMatcher
+  >();
   private readonly reservableColumns: Array<MutableTopicColumnValues> = [];
   private readonly orderedSlotIndexes = new Map<string, OrderedSlotIndex>();
   private readonly scalarPredicateIndexes = createScalarPredicateIndexes();
@@ -97,6 +103,7 @@ export class TopicRowStorage {
     this.rawWindowScanState = {
       columns: this.columns,
       orderedSlotIndexes: this.orderedSlotIndexes,
+      rawPredicateSlotMatchers: this.rawPredicateSlotMatchers,
       rawQueryMetadata: this.rawQueryMetadata,
       scalarPredicateIndexes: this.scalarPredicateIndexes,
       slots: this.slots,

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -1,6 +1,4 @@
 import type { TopicRawPredicateFilterPlan } from "./raw-predicate-plan";
-import type { TopicRawWindowScanPlan } from "./raw-window-scan";
-import type { TopicRowEntry } from "./row-scan";
 import { valuesEqual } from "./row-values";
 import {
   columnValueDoesNotEqual,
@@ -15,49 +13,25 @@ import {
 } from "./topic-column-vector";
 import { equals as bigDecimalEquals, isBigDecimal } from "effect/BigDecimal";
 
-type RowObject = object;
-
-type SlotFilterMatcher = (slot: number) => boolean;
+export type SlotFilterMatcher = (slot: number) => boolean;
 type RangePredicateFilter = TopicRawPredicateFilterPlan & {
   readonly operator: "gt" | "gte" | "lt" | "lte";
   readonly value: unknown;
 };
 
-export type RawPredicateSlotMatcher<Row extends RowObject> =
-  | {
-      readonly kind: "slot";
-      readonly matchesSlot: (slot: number) => boolean;
-    }
-  | {
-      readonly kind: "entry";
-      readonly matchesEntry: (slot: number, entry: TopicRowEntry<Row>) => boolean;
-    };
-
-export const rawPredicateSlotMatcher = <Row extends RowObject>(
-  plan: TopicRawWindowScanPlan<Row>,
+export const rawPredicateSlotFilterMatcher = (
+  filters: ReadonlyArray<TopicRawPredicateFilterPlan>,
   columns: ReadonlyMap<string, TopicColumnValues>,
-): RawPredicateSlotMatcher<Row> => {
-  const exact = plan.predicate.callbackSkippable === true;
-  const filterMatchers = slotFilterMatchers(plan.predicate.filters, columns, exact);
-  const matchesFilters = (slot: number): boolean => {
+  exact: boolean,
+): SlotFilterMatcher => {
+  const filterMatchers = slotFilterMatchers(filters, columns, exact);
+  return (slot) => {
     for (const matcher of filterMatchers) {
       if (!matcher(slot)) {
         return false;
       }
     }
     return true;
-  };
-
-  if (exact) {
-    return {
-      kind: "slot",
-      matchesSlot: matchesFilters,
-    };
-  }
-
-  return {
-    kind: "entry",
-    matchesEntry: (slot, entry) => matchesFilters(slot) && plan.matches(entry.row),
   };
 };
 


### PR DESCRIPTION
## Summary
- Cache compiled raw slot predicate matchers on TopicRowStorage for callback-skippable predicates.
- Keep callback-required scans uncached so row-level plan.matches cannot become stale.
- Remove the old union matcher wrapper and expose the pure slot-filter compiler internally.

## Validation
- 3 reviewer agents clean.
- vp check --fix packages/column-live-view-engine/src/topic-raw-window-scanner.ts packages/column-live-view-engine/src/topic-row-storage.ts packages/column-live-view-engine/src/topic-slot-predicate.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run bench:baseline:smoke
- pnpm run ready