### PR TITLE
Compile raw row comparators

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -51,7 +51,7 @@ import {
   scalarEqualityKey,
   valuesEqual,
 } from "./row-values";
-import type { TopicRowChangeBatch } from "./row-scan";
+import type { TopicRowChangeBatch, TopicRowEntry } from "./row-scan";
 import type { TopicRawOrderByPlan } from "./raw-window-scan";
 import { scanTopicRawWindow } from "./topic-raw-window-scanner";
 import {
@@ -440,6 +440,164 @@ it("keeps schema field order for aligned column writes", () => {
     "note",
   ]);
 });
+
+it.effect("uses compiled raw row comparators for schema scalar fields and stable key ties", () =>
+  Effect.gen(function* () {
+    const compiled = yield* prepareRawQuery<PositionRow, object>(
+      "positions",
+      rawQueryCompilerMetadata(Position),
+      {
+        select: ["id", "accountId", "symbol", "active", "quantity", "price"],
+        orderBy: [
+          { field: "symbol", direction: "asc" },
+          { field: "quantity", direction: "desc" },
+          { field: "price", direction: "asc" },
+        ],
+      },
+    );
+    const rows: ReadonlyArray<TopicRowEntry<PositionRow>> = [
+      {
+        key: "tie-b",
+        row: {
+          id: "tie-b",
+          accountId: "A",
+          symbol: "MSFT",
+          active: true,
+          quantity: 10n,
+          price: fromStringUnsafe("2"),
+        },
+      },
+      {
+        key: "aapl",
+        row: {
+          id: "aapl",
+          accountId: "A",
+          symbol: "AAPL",
+          active: true,
+          quantity: 1n,
+          price: fromStringUnsafe("9"),
+        },
+      },
+      {
+        key: "tie-a",
+        row: {
+          id: "tie-a",
+          accountId: "A",
+          symbol: "MSFT",
+          active: true,
+          quantity: 10n,
+          price: fromStringUnsafe("2"),
+        },
+      },
+      {
+        key: "msft-cheap",
+        row: {
+          id: "msft-cheap",
+          accountId: "A",
+          symbol: "MSFT",
+          active: true,
+          quantity: 10n,
+          price: fromStringUnsafe("1"),
+        },
+      },
+      {
+        key: "msft-low-quantity",
+        row: {
+          id: "msft-low-quantity",
+          accountId: "A",
+          symbol: "MSFT",
+          active: true,
+          quantity: 1n,
+          price: fromStringUnsafe("1"),
+        },
+      },
+    ];
+
+    expect(rows.toSorted(compiled.plan.compare).map((entry) => entry.key)).toStrictEqual([
+      "aapl",
+      "msft-cheap",
+      "tie-a",
+      "tie-b",
+      "msft-low-quantity",
+    ]);
+  }),
+);
+
+it.effect("falls back to stable raw row comparison for abnormal scalar order values", () =>
+  Effect.gen(function* () {
+    const compiled = yield* prepareRawQuery<object, object>(
+      "orders",
+      rawQueryCompilerMetadata(Order),
+      {
+        select: ["id", "price", "note", "updatedAt"],
+        orderBy: [
+          { field: "updatedAt", direction: "asc" },
+          { field: "note", direction: "asc" },
+        ],
+      },
+    );
+    const rows: ReadonlyArray<TopicRowEntry<object>> = [
+      { key: "nan", row: { id: "nan", price: 1, note: "b", updatedAt: Number.NaN } },
+      { key: "finite-b", row: { id: "finite-b", price: 1, note: "b", updatedAt: 1 } },
+      { key: "finite-a", row: { id: "finite-a", price: 1, note: "a", updatedAt: 1 } },
+      { key: "missing-note", row: { id: "missing-note", price: 1, updatedAt: 1 } },
+      { key: "infinite", row: { id: "infinite", price: 1, note: "c", updatedAt: Infinity } },
+    ];
+
+    expect(rows.toSorted(compiled.plan.compare).map((entry) => entry.key)).toStrictEqual([
+      "missing-note",
+      "finite-a",
+      "finite-b",
+      "infinite",
+      "nan",
+    ]);
+  }),
+);
+
+it.effect(
+  "falls back to stable raw row comparison for abnormal bigint and BigDecimal order values",
+  () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery<object, object>(
+        "positions",
+        rawQueryCompilerMetadata(Position),
+        {
+          select: ["id", "quantity", "price"],
+          orderBy: [
+            { field: "quantity", direction: "asc" },
+            { field: "price", direction: "asc" },
+          ],
+        },
+      );
+      const rows: ReadonlyArray<TopicRowEntry<object>> = [
+        {
+          key: "bigint-smaller",
+          row: { id: "bigint-smaller", quantity: 1n, price: fromStringUnsafe("9") },
+        },
+        {
+          key: "bigint-good-expensive",
+          row: { id: "bigint-good-expensive", quantity: 2n, price: fromStringUnsafe("2") },
+        },
+        {
+          key: "bigint-good-cheap",
+          row: { id: "bigint-good-cheap", quantity: 2n, price: fromStringUnsafe("1") },
+        },
+        { key: "missing-price", row: { id: "missing-price", quantity: 2n } },
+        {
+          key: "string-quantity",
+          row: { id: "string-quantity", quantity: "2", price: fromStringUnsafe("1") },
+        },
+      ];
+
+      expect(rows.toSorted(compiled.plan.compare).map((entry) => entry.key)).toStrictEqual([
+        "bigint-smaller",
+        "missing-price",
+        "bigint-good-cheap",
+        "bigint-good-expensive",
+        "string-quantity",
+      ]);
+    }),
+);
 
 const numericRowField = (row: object, field: string): number => {
   const value = fieldValue(row, field);

--- a/packages/column-live-view-engine/src/raw-query-plan.ts
+++ b/packages/column-live-view-engine/src/raw-query-plan.ts
@@ -1,3 +1,4 @@
+import { isBigDecimal, Order as orderBigDecimal } from "effect/BigDecimal";
 import { compareQueryValue, stableQueryValueString } from "./query-value";
 import { compileRawPredicate, type CompiledRawPredicate } from "./raw-predicate-compiler";
 import type { RuntimeRawQuery } from "./raw-query-decoder";
@@ -26,6 +27,11 @@ export type RawQueryPlan<Row extends RowObject, ResultRow extends RowObject> = {
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
   readonly project: (row: Row) => ResultRow;
   readonly window: RawQueryPlanWindow;
+};
+
+type RawRowOrderColumn<Row extends RowObject> = {
+  readonly compareRows: (left: Row, right: Row) => number;
+  readonly direction: "asc" | "desc";
 };
 
 const rawQueryShapeCacheKey = (query: RuntimeRawQuery): string => {
@@ -60,16 +66,104 @@ export const rawQueryPlanWindow = (
 const rawQueryPlanWindowFromQuery = (query: RuntimeRawQuery): RawQueryPlanWindow =>
   rawQueryPlanWindow(query.offset ?? 0, query.limit);
 
+const compareRowFieldValues = <Row extends RowObject>(
+  left: Row,
+  right: Row,
+  field: string,
+): number => compareQueryValue(fieldValue(left, field), fieldValue(right, field));
+
+const compareStringRowFieldValues = <Row extends RowObject>(
+  left: Row,
+  right: Row,
+  field: string,
+): number => {
+  const leftValue = fieldValue(left, field);
+  const rightValue = fieldValue(right, field);
+  if (typeof leftValue === "string" && typeof rightValue === "string") {
+    return Number(leftValue > rightValue) - Number(leftValue < rightValue);
+  }
+  return compareQueryValue(leftValue, rightValue);
+};
+
+const compareNumberRowFieldValues = <Row extends RowObject>(
+  left: Row,
+  right: Row,
+  field: string,
+): number => {
+  const leftValue = fieldValue(left, field);
+  const rightValue = fieldValue(right, field);
+  if (
+    typeof leftValue === "number" &&
+    typeof rightValue === "number" &&
+    Number.isFinite(leftValue) &&
+    Number.isFinite(rightValue)
+  ) {
+    return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+  }
+  return compareQueryValue(leftValue, rightValue);
+};
+
+const compareBigintRowFieldValues = <Row extends RowObject>(
+  left: Row,
+  right: Row,
+  field: string,
+): number => {
+  const leftValue = fieldValue(left, field);
+  const rightValue = fieldValue(right, field);
+  if (typeof leftValue === "bigint" && typeof rightValue === "bigint") {
+    return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+  }
+  return compareQueryValue(leftValue, rightValue);
+};
+
+const compareBigDecimalRowFieldValues = <Row extends RowObject>(
+  left: Row,
+  right: Row,
+  field: string,
+): number => {
+  const leftValue = fieldValue(left, field);
+  const rightValue = fieldValue(right, field);
+  if (isBigDecimal(leftValue) && isBigDecimal(rightValue)) {
+    return orderBigDecimal(leftValue, rightValue);
+  }
+  return compareQueryValue(leftValue, rightValue);
+};
+
+const rawRowOrderColumnComparator = <Row extends RowObject>(
+  metadata: RawQueryCompilerMetadata,
+  field: string,
+): ((left: Row, right: Row) => number) => {
+  if (metadata.stringFieldNames.has(field)) {
+    return (left, right) => compareStringRowFieldValues(left, right, field);
+  }
+  if (metadata.numberFieldNames.has(field)) {
+    return (left, right) => compareNumberRowFieldValues(left, right, field);
+  }
+  if (metadata.bigintFieldNames.has(field)) {
+    return (left, right) => compareBigintRowFieldValues(left, right, field);
+  }
+  if (metadata.bigDecimalFieldNames.has(field)) {
+    return (left, right) => compareBigDecimalRowFieldValues(left, right, field);
+  }
+  return (left, right) => compareRowFieldValues(left, right, field);
+};
+
+const compiledRawRowOrder = <Row extends RowObject>(
+  metadata: RawQueryCompilerMetadata,
+  orderBy: ReadonlyArray<TopicRawOrderByPlan>,
+): ReadonlyArray<RawRowOrderColumn<Row>> =>
+  orderBy.map((order) => ({
+    compareRows: rawRowOrderColumnComparator<Row>(metadata, order.field),
+    direction: order.direction,
+  }));
+
 const compareRows = <Row extends RowObject>(
   left: TopicRowEntry<Row>,
   right: TopicRowEntry<Row>,
-  orderBy: ReadonlyArray<TopicRawOrderByPlan>,
+  orderBy: ReadonlyArray<RawRowOrderColumn<Row>>,
 ): number => {
   for (const order of orderBy) {
-    const comparison = compareQueryValue(
-      fieldValue(left.row, order.field),
-      fieldValue(right.row, order.field),
-    );
+    const comparison = order.compareRows(left.row, right.row);
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
@@ -98,6 +192,7 @@ export const makeRawQueryPlan = <Row extends RowObject, ResultRow extends RowObj
   query: RuntimeRawQuery,
 ): RawQueryPlan<Row, ResultRow> => {
   const orderBy = query.orderBy ?? [];
+  const rowOrderBy = compiledRawRowOrder<Row>(metadata, orderBy);
   const selectedFields = [...query.select];
   const predicate = compileRawPredicate<Row>(metadata, query.where);
   return {
@@ -106,7 +201,7 @@ export const makeRawQueryPlan = <Row extends RowObject, ResultRow extends RowObj
     predicate,
     orderBy,
     storageOrderBy: orderBy,
-    compare: (left, right) => compareRows(left, right, orderBy),
+    compare: (left, right) => compareRows(left, right, rowOrderBy),
     project: (row) => projectCompiledRow(row, selectedFields),
     window: rawQueryPlanWindowFromQuery(query),
   };


### PR DESCRIPTION
## Summary
- compile fallback raw row comparators once per raw query plan
- add schema-derived scalar fast paths for string, number, bigint, and BigDecimal order fields
- cover normal scalar ordering, stable row-key ties, and abnormal fallback values

## Validation
- vp check --fix packages/column-live-view-engine/src/index.test.ts packages/column-live-view-engine/src/raw-query-plan.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm run bench:baseline:smoke
- pnpm run ready

## Review
- 3 local reviewer agents: no findings
