### PR TITLE
Compile grouped aggregate plans

### DIFF
--- a/packages/column-live-view-engine/src/grouped-aggregate-state.ts
+++ b/packages/column-live-view-engine/src/grouped-aggregate-state.ts
@@ -27,6 +27,11 @@ export type RuntimeGroupedAggregate =
       readonly resultKind: "bigint" | "bigDecimal";
     };
 
+export type GroupedAggregatePlan = {
+  readonly alias: string;
+  readonly aggregate: RuntimeGroupedAggregate;
+};
+
 type CountAggregateState = {
   readonly aggFunc: "count";
   count: bigint;
@@ -386,7 +391,7 @@ export const aggregateStateCompareValue = (state: AggregateState): unknown => {
 export const newGroupState = (
   key: string,
   groupBy: ReadonlyArray<string>,
-  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+  aggregates: ReadonlyArray<GroupedAggregatePlan>,
   row: RowObject,
 ): GroupState => {
   const resultRow: Record<string, unknown> = {};
@@ -394,7 +399,7 @@ export const newGroupState = (
     resultRow[field] = cloneUnknown(fieldValue(row, field));
   }
   const aggregateStates: Record<string, AggregateState> = {};
-  for (const [alias, aggregate] of Object.entries(aggregates)) {
+  for (const { alias, aggregate } of aggregates) {
     aggregateStates[alias] = emptyAggregateState(aggregate);
   }
   return {
@@ -407,7 +412,7 @@ export const newGroupState = (
 export const newIncrementalGroupState = (
   key: string,
   groupBy: ReadonlyArray<string>,
-  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+  aggregates: ReadonlyArray<GroupedAggregatePlan>,
   row: RowObject,
 ): MaterializedIncrementalGroupState => {
   const resultRow: Record<string, unknown> = {};
@@ -415,7 +420,7 @@ export const newIncrementalGroupState = (
     resultRow[field] = cloneUnknown(fieldValue(row, field));
   }
   const aggregateStates: Record<string, ReversibleAggregateState> = {};
-  for (const [alias, aggregate] of Object.entries(aggregates)) {
+  for (const { alias, aggregate } of aggregates) {
     aggregateStates[alias] = emptyReversibleAggregateState(aggregate);
   }
   return {

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -49,7 +49,7 @@ const retainedValueAggregateCount = <Row extends RowObject>(
   plan: GroupedQueryPlan<Row>,
 ): number => {
   let count = 0;
-  for (const aggregate of Object.values(plan.aggregates)) {
+  for (const { aggregate } of plan.aggregatePlans) {
     if (
       aggregate.aggFunc === "countDistinct" ||
       aggregate.aggFunc === "min" ||
@@ -181,7 +181,7 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
     const groupedKey = plan.groupKey(row);
     let group = groups.get(groupedKey);
     if (group === undefined) {
-      group = newIncrementalGroupState(groupedKey, plan.groupBy, plan.aggregates, row);
+      group = newIncrementalGroupState(groupedKey, plan.groupBy, plan.aggregatePlans, row);
       groups.set(groupedKey, group);
     }
     group.members.set(key, row);
@@ -197,7 +197,7 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
       admitted = false;
       return false;
     }
-    for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+    for (const { alias, aggregate } of plan.aggregatePlans) {
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
     return undefined;
@@ -255,7 +255,7 @@ const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
     groups.delete(groupedKey);
     return true;
   }
-  for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+  for (const { alias, aggregate } of plan.aggregatePlans) {
     removeMaterializedAggregateState(dirtyAggregateRecomputes, group, alias, aggregate, row);
   }
   return true;
@@ -374,18 +374,18 @@ const upsertMatchingMaterializedIncrementalGroupedMember = <Row extends RowObjec
   const groupedKey = plan.groupKey(row);
   let group = groups.get(groupedKey);
   if (group === undefined) {
-    group = newIncrementalGroupState(groupedKey, plan.groupBy, plan.aggregates, row);
+    group = newIncrementalGroupState(groupedKey, plan.groupBy, plan.aggregatePlans, row);
     groups.set(groupedKey, group);
   }
   const inserted = !group.members.has(key);
   const previous = group.members.get(key);
   if (previous !== undefined) {
-    for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+    for (const { alias, aggregate } of plan.aggregatePlans) {
       removeMaterializedAggregateState(dirtyAggregateRecomputes, group, alias, aggregate, previous);
     }
   }
   group.members.set(key, row);
-  for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+  for (const { alias, aggregate } of plan.aggregatePlans) {
     updateAggregateState(group.aggregates[alias]!, aggregate, row);
   }
   return {
@@ -404,7 +404,7 @@ const replaceMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   next: Row,
 ): void => {
   group.members.set(key, next);
-  for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+  for (const { alias, aggregate } of plan.aggregatePlans) {
     if (aggregateValueChanged(aggregate, previous, next)) {
       const state = group.aggregates[alias]!;
       markMaterializedAggregateChange(patch, plan, group, alias);

--- a/packages/column-live-view-engine/src/grouped-query-evaluation.ts
+++ b/packages/column-live-view-engine/src/grouped-query-evaluation.ts
@@ -45,10 +45,10 @@ export const evaluateGroupedRows = <Row extends RowObject>(
     const key = plan.groupKey(row);
     let group = groups.get(key);
     if (group === undefined) {
-      group = newGroupState(key, plan.groupBy, plan.aggregates, row);
+      group = newGroupState(key, plan.groupBy, plan.aggregatePlans, row);
       groups.set(key, group);
     }
-    for (const [alias, aggregate] of Object.entries(plan.aggregates)) {
+    for (const { alias, aggregate } of plan.aggregatePlans) {
       updateAggregateState(group.aggregates[alias]!, aggregate, row);
     }
   });

--- a/packages/column-live-view-engine/src/grouped-query-plan.ts
+++ b/packages/column-live-view-engine/src/grouped-query-plan.ts
@@ -1,5 +1,6 @@
 import {
   aggregateStateCompareValue,
+  type GroupedAggregatePlan,
   type GroupState,
   type RuntimeGroupedAggregate,
 } from "./grouped-aggregate-state";
@@ -39,6 +40,7 @@ export type GroupedQueryPlan<Row extends RowObject> = {
   readonly cacheKey: string;
   readonly groupBy: ReadonlyArray<string>;
   readonly aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>;
+  readonly aggregatePlans: ReadonlyArray<GroupedAggregatePlan>;
   readonly orderBy: ReadonlyArray<RuntimeGroupedOrderBy>;
   readonly compiledOrderBy: ReadonlyArray<CompiledGroupedOrderBy>;
   readonly offset: number;
@@ -64,6 +66,14 @@ const groupedQueryPlanGroupKey = <Row extends RowObject>(
   groupBy: ReadonlyArray<string>,
   row: Row,
 ): string => stableQueryValueString(groupBy.map((field) => [field, fieldValue(row, field)]));
+
+const compileGroupedAggregates = (
+  aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
+): ReadonlyArray<GroupedAggregatePlan> =>
+  Object.entries(aggregates).map(([alias, aggregate]) => ({
+    alias,
+    aggregate,
+  }));
 
 const groupedFieldOrderColumn = (
   field: string,
@@ -102,6 +112,7 @@ export const makeGroupedQueryPlan = <Row extends RowObject>(
     cacheKey: groupedQueryPlanCacheKey(query),
     groupBy,
     aggregates: query.aggregates,
+    aggregatePlans: compileGroupedAggregates(query.aggregates),
     orderBy,
     compiledOrderBy: compileGroupedOrderBy(orderBy),
     offset: query.offset ?? 0,


### PR DESCRIPTION
## Summary
- compile grouped aggregate aliases once during grouped query planning
- replace per-row/per-change aggregate record enumeration with plan.aggregatePlans
- keep the original aggregate record on the plan for query identity/debug-style access while hot paths use the compiled entries

## Validation
- vp check --fix packages/column-live-view-engine/src/grouped-aggregate-state.ts packages/column-live-view-engine/src/grouped-query-plan.ts packages/column-live-view-engine/src/grouped-query-evaluation.ts packages/column-live-view-engine/src/grouped-incremental-execution.ts
- pnpm --filter @view-server/column-live-view-engine run test
- forbidden-pattern scan for casts, toEqual, try/catch, coverage ignores, Testing Library, act, flushSync, getByTestId
- pnpm run bench:baseline:smoke
- pnpm run ready

## Review
- 3 reviewer agents reviewed the diff with no findings
- residual risk noted by reviewers: aggregates and aggregatePlans are dual internal representations, coherent through makeGroupedQueryPlan and normal decode/prepare construction paths