### PR TITLE
Gate grouped benchmark profiles

### DIFF
--- a/benchmarks/baselines/grouped-admission.json
+++ b/benchmarks/baselines/grouped-admission.json
@@ -1,0 +1,500 @@
+{
+  "artifactKind": "view-server-benchmark-baseline",
+  "profile": "grouped-admission",
+  "tasks": [
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 2.0182089999998425,
+          "meanMs": 1.4206253333332672,
+          "minMs": 1.083791999999903,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 2.0182089999998425,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 1.7435840000000553,
+          "meanMs": 1.4801806666667592,
+          "minMs": 1.2840830000000096,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 1.7435840000000553,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 5.545415999999932,
+          "meanMs": 4.97818033333336,
+          "minMs": 4.2625000000000455,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 5.545415999999932,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 5.438791999999921,
+          "meanMs": 5.163319333333372,
+          "minMs": 4.706208000000061,
+          "name": "grouped patch group moves",
+          "p99Ms": 5.438791999999921,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 4.034334000000172,
+          "meanMs": 3.810570000000022,
+          "minMs": 3.5046669999999267,
+          "name": "grouped delete existing rows",
+          "p99Ms": 4.034334000000172,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 0,
+        "activeFallbackGroupedViewsBeforeCleanup": 0,
+        "activeIncrementalGroupedViewsAfterSetup": 2,
+        "activeIncrementalGroupedViewsBeforeCleanup": 2,
+        "activeViewsAfterSetup": 2,
+        "activeViewsBeforeCleanup": 2,
+        "configuredMode": "incremental",
+        "expectedAdmission": "incremental",
+        "groupedFullEvaluationCountAfterSetup": 0,
+        "groupedFullEvaluationCountBeforeCleanup": 489,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 99,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 8192,
+          "maxMembers": 65536,
+          "maxMembersPerGroup": 4096,
+          "maxRetainedValueEntries": 65536
+        },
+        "priceThreshold": 94000,
+        "seedMutationCount": 100000,
+        "timedMutationCount": 480,
+        "writeBatchSize": 32
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 120897536,
+      "minimumSampleCount": 3,
+      "mutationCount": 100480,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-100000rows-32mutations.json",
+      "queuedEventCount": 0,
+      "rowCount": 100000,
+      "subscriberCount": 2,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-100000rows-32mutations.summary.json",
+      "taskLabel": "grouped write incremental 100000 rows 32 mutations",
+      "topics": ["orders"]
+    },
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 2.0808339999985037,
+          "meanMs": 1.4409029999994043,
+          "minMs": 1.089458000000377,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 2.0808339999985037,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 1.8716669999994338,
+          "meanMs": 1.5061669999995502,
+          "minMs": 1.2706249999991996,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 1.8716669999994338,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 5.160791000000245,
+          "meanMs": 4.762555666666837,
+          "minMs": 4.333709000000454,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 5.160791000000245,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 5.323582999999417,
+          "meanMs": 5.107152666666177,
+          "minMs": 4.794625000000451,
+          "name": "grouped patch group moves",
+          "p99Ms": 5.323582999999417,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 4.117292000000816,
+          "meanMs": 3.8419170000003455,
+          "minMs": 3.6181670000005397,
+          "name": "grouped delete existing rows",
+          "p99Ms": 4.117292000000816,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 0,
+        "activeFallbackGroupedViewsBeforeCleanup": 0,
+        "activeIncrementalGroupedViewsAfterSetup": 2,
+        "activeIncrementalGroupedViewsBeforeCleanup": 2,
+        "activeViewsAfterSetup": 2,
+        "activeViewsBeforeCleanup": 2,
+        "configuredMode": "incremental",
+        "expectedAdmission": "incremental",
+        "groupedFullEvaluationCountAfterSetup": 0,
+        "groupedFullEvaluationCountBeforeCleanup": 489,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 99,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 8192,
+          "maxMembers": 65536,
+          "maxMembersPerGroup": 4096,
+          "maxRetainedValueEntries": 65536
+        },
+        "priceThreshold": 994000,
+        "seedMutationCount": 1000000,
+        "timedMutationCount": 480,
+        "writeBatchSize": 32
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 577667072,
+      "minimumSampleCount": 3,
+      "mutationCount": 1000480,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000000rows-32mutations.json",
+      "queuedEventCount": 0,
+      "rowCount": 1000000,
+      "subscriberCount": 2,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000000rows-32mutations.summary.json",
+      "taskLabel": "grouped write incremental 1000000 rows 32 mutations",
+      "topics": ["orders"]
+    },
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 4.599707999999737,
+          "meanMs": 3.548333333333479,
+          "minMs": 2.859167000000525,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 4.599707999999737,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 4.39116599999943,
+          "meanMs": 4.1192496666668985,
+          "minMs": 3.798833000000741,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 4.39116599999943,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 19.092999999998938,
+          "meanMs": 16.581958333332903,
+          "minMs": 14.596749999998792,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 19.092999999998938,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 17.333832999998776,
+          "meanMs": 16.7032916666667,
+          "minMs": 16.07087500000125,
+          "name": "grouped patch group moves",
+          "p99Ms": 17.333832999998776,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 13.278207999999722,
+          "meanMs": 12.888333000000179,
+          "minMs": 12.432082999999693,
+          "name": "grouped delete existing rows",
+          "p99Ms": 13.278207999999722,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 0,
+        "activeFallbackGroupedViewsBeforeCleanup": 0,
+        "activeIncrementalGroupedViewsAfterSetup": 2,
+        "activeIncrementalGroupedViewsBeforeCleanup": 2,
+        "activeViewsAfterSetup": 2,
+        "activeViewsBeforeCleanup": 2,
+        "configuredMode": "incremental",
+        "expectedAdmission": "incremental",
+        "groupedFullEvaluationCountAfterSetup": 0,
+        "groupedFullEvaluationCountBeforeCleanup": 1929,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 387,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 8192,
+          "maxMembers": 65536,
+          "maxMembersPerGroup": 4096,
+          "maxRetainedValueEntries": 65536
+        },
+        "priceThreshold": 994000,
+        "seedMutationCount": 1000000,
+        "timedMutationCount": 1920,
+        "writeBatchSize": 128
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 580059136,
+      "minimumSampleCount": 3,
+      "mutationCount": 1001920,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000000rows-128mutations.json",
+      "queuedEventCount": 0,
+      "rowCount": 1000000,
+      "subscriberCount": 2,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000000rows-128mutations.summary.json",
+      "taskLabel": "grouped write incremental 1000000 rows 128 mutations",
+      "topics": ["orders"]
+    },
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 27.400750000000016,
+          "meanMs": 25.212944666666697,
+          "minMs": 23.994459000000006,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 27.400750000000016,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 24.49862499999972,
+          "meanMs": 24.268680666666643,
+          "minMs": 23.83462499999996,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 24.49862499999972,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 744.8252910000001,
+          "meanMs": 742.4080273333334,
+          "minMs": 739.1792909999999,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 744.8252910000001,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 748.8547499999995,
+          "meanMs": 744.4139859999999,
+          "minMs": 739.3112080000001,
+          "name": "grouped patch group moves",
+          "p99Ms": 748.8547499999995,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 800.4193749999995,
+          "meanMs": 765.2999026666663,
+          "minMs": 722.2349169999998,
+          "name": "grouped delete existing rows",
+          "p99Ms": 800.4193749999995,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 2,
+        "activeFallbackGroupedViewsBeforeCleanup": 2,
+        "activeIncrementalGroupedViewsAfterSetup": 0,
+        "activeIncrementalGroupedViewsBeforeCleanup": 0,
+        "activeViewsAfterSetup": 2,
+        "activeViewsBeforeCleanup": 2,
+        "configuredMode": "incremental",
+        "expectedAdmission": "fallback",
+        "groupedFullEvaluationCountAfterSetup": 2,
+        "groupedFullEvaluationCountBeforeCleanup": 590,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 0,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 1,
+          "maxMembers": 1,
+          "maxMembersPerGroup": 1,
+          "maxRetainedValueEntries": 1
+        },
+        "priceThreshold": 94000,
+        "seedMutationCount": 100000,
+        "timedMutationCount": 480,
+        "writeBatchSize": 32
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 118325248,
+      "minimumSampleCount": 3,
+      "mutationCount": 100480,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-100000rows-32mutations-forced-fallback-admission.json",
+      "queuedEventCount": 0,
+      "rowCount": 100000,
+      "subscriberCount": 2,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-100000rows-32mutations-forced-fallback-admission.summary.json",
+      "taskLabel": "grouped write incremental 100000 rows 32 mutations forced-fallback-admission",
+      "topics": ["orders"]
+    },
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 279.8975839999998,
+          "meanMs": 279.44477766666677,
+          "minMs": 278.7720410000002,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 279.8975839999998,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 277.8409160000001,
+          "meanMs": 276.59056933333324,
+          "minMs": 275.77654200000006,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 277.8409160000001,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 8861.255500000001,
+          "meanMs": 8845.222625,
+          "minMs": 8818.607375000001,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 8861.255500000001,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 8911.643292,
+          "meanMs": 8845.119389000001,
+          "minMs": 8797.370792000002,
+          "name": "grouped patch group moves",
+          "p99Ms": 8911.643292,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 8912.652583000003,
+          "meanMs": 8838.19438866667,
+          "minMs": 8791.29800000001,
+          "name": "grouped delete existing rows",
+          "p99Ms": 8912.652583000003,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 2,
+        "activeFallbackGroupedViewsBeforeCleanup": 2,
+        "activeIncrementalGroupedViewsAfterSetup": 0,
+        "activeIncrementalGroupedViewsBeforeCleanup": 0,
+        "activeViewsAfterSetup": 2,
+        "activeViewsBeforeCleanup": 2,
+        "configuredMode": "fallback",
+        "expectedAdmission": "fallback",
+        "groupedFullEvaluationCountAfterSetup": 2,
+        "groupedFullEvaluationCountBeforeCleanup": 590,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 0,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 1,
+          "maxMembers": 1,
+          "maxMembersPerGroup": 1,
+          "maxRetainedValueEntries": 1
+        },
+        "priceThreshold": null,
+        "seedMutationCount": 100000,
+        "timedMutationCount": 480,
+        "writeBatchSize": 32
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 254935040,
+      "minimumSampleCount": 3,
+      "mutationCount": 100480,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-fallback-100000rows-32mutations-broad-fallback.json",
+      "queuedEventCount": 0,
+      "rowCount": 100000,
+      "subscriberCount": 2,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-fallback-100000rows-32mutations-broad-fallback.summary.json",
+      "taskLabel": "grouped write fallback 100000 rows 32 mutations broad-fallback",
+      "topics": ["orders"]
+    }
+  ],
+  "thresholds": {
+    "latencyMean": {
+      "maxAbsoluteDeltaMs": 5,
+      "maxRatio": 8
+    },
+    "latencyP99": {
+      "maxAbsoluteDeltaMs": 10,
+      "maxRatio": 8
+    },
+    "memoryRssTotalDelta": {
+      "maxAbsoluteDeltaBytes": 134217728,
+      "maxRatio": 3
+    }
+  }
+}

--- a/benchmarks/baselines/grouped-order-neutral.json
+++ b/benchmarks/baselines/grouped-order-neutral.json
@@ -1,0 +1,311 @@
+{
+  "artifactKind": "view-server-benchmark-baseline",
+  "profile": "grouped-order-neutral",
+  "tasks": [
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 0.9559999999999036,
+          "meanMs": 0.49513933333332716,
+          "minMs": 0.24870900000018992,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 0.9559999999999036,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 0.6888330000001588,
+          "meanMs": 0.4134580000000672,
+          "minMs": 0.26104099999997743,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 0.6888330000001588,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 0.3610830000000078,
+          "meanMs": 0.24602766666665352,
+          "minMs": 0.17650000000003274,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 0.3610830000000078,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 0.3374579999999696,
+          "meanMs": 0.25445833333325635,
+          "minMs": 0.17574999999987995,
+          "name": "grouped patch group moves",
+          "p99Ms": 0.3374579999999696,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 100000 rows",
+          "maxMs": 0.30204200000002857,
+          "meanMs": 0.24722266666670598,
+          "minMs": 0.14916700000003402,
+          "name": "grouped delete existing rows",
+          "p99Ms": 0.30204200000002857,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 0,
+        "activeFallbackGroupedViewsBeforeCleanup": 0,
+        "activeIncrementalGroupedViewsAfterSetup": 1,
+        "activeIncrementalGroupedViewsBeforeCleanup": 1,
+        "activeViewsAfterSetup": 1,
+        "activeViewsBeforeCleanup": 1,
+        "configuredMode": "incremental",
+        "expectedAdmission": "incremental",
+        "groupedFullEvaluationCountAfterSetup": 0,
+        "groupedFullEvaluationCountBeforeCleanup": 9,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 6,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 8192,
+          "maxMembers": 65536,
+          "maxMembersPerGroup": 4096,
+          "maxRetainedValueEntries": 65536
+        },
+        "priceThreshold": 94000,
+        "readerProfile": "order-neutral",
+        "seedMutationCount": 100000,
+        "timedMutationCount": 15,
+        "writeBatchSize": 1
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 109428736,
+      "minimumSampleCount": 3,
+      "mutationCount": 100015,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-order-neutral-100000rows-1mutations.json",
+      "queuedEventCount": 0,
+      "rowCount": 100000,
+      "subscriberCount": 1,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-order-neutral-100000rows-1mutations.summary.json",
+      "taskLabel": "grouped write incremental order-neutral 100000 rows 1 mutations",
+      "topics": ["orders"]
+    },
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 0.8881670000009763,
+          "meanMs": 0.5539860000001985,
+          "minMs": 0.27829100000053586,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 0.8881670000009763,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 0.7651249999998981,
+          "meanMs": 0.4704863333330043,
+          "minMs": 0.29204199999912817,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 0.7651249999998981,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 0.41045800000028976,
+          "meanMs": 0.3174443333336967,
+          "minMs": 0.16187499999978172,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 0.41045800000028976,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 0.389166999999361,
+          "meanMs": 0.29638866666634084,
+          "minMs": 0.18816599999991013,
+          "name": "grouped patch group moves",
+          "p99Ms": 0.389166999999361,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000000 rows",
+          "maxMs": 0.258083999999144,
+          "meanMs": 0.19237533333337828,
+          "minMs": 0.11887500000011642,
+          "name": "grouped delete existing rows",
+          "p99Ms": 0.258083999999144,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 0,
+        "activeFallbackGroupedViewsBeforeCleanup": 0,
+        "activeIncrementalGroupedViewsAfterSetup": 1,
+        "activeIncrementalGroupedViewsBeforeCleanup": 1,
+        "activeViewsAfterSetup": 1,
+        "activeViewsBeforeCleanup": 1,
+        "configuredMode": "incremental",
+        "expectedAdmission": "incremental",
+        "groupedFullEvaluationCountAfterSetup": 0,
+        "groupedFullEvaluationCountBeforeCleanup": 9,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 6,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 8192,
+          "maxMembers": 65536,
+          "maxMembersPerGroup": 4096,
+          "maxRetainedValueEntries": 65536
+        },
+        "priceThreshold": 994000,
+        "readerProfile": "order-neutral",
+        "seedMutationCount": 1000000,
+        "timedMutationCount": 15,
+        "writeBatchSize": 1
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 576503808,
+      "minimumSampleCount": 3,
+      "mutationCount": 1000015,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-order-neutral-1000000rows-1mutations.json",
+      "queuedEventCount": 0,
+      "rowCount": 1000000,
+      "subscriberCount": 1,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-order-neutral-1000000rows-1mutations.summary.json",
+      "taskLabel": "grouped write incremental order-neutral 1000000 rows 1 mutations",
+      "topics": ["orders"]
+    },
+    {
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 5000000 rows",
+          "maxMs": 1.1085829999938142,
+          "meanMs": 0.5638193333288655,
+          "minMs": 0.28087499999674037,
+          "name": "grouped publishMany append batch",
+          "p99Ms": 1.1085829999938142,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 5000000 rows",
+          "maxMs": 0.47162500000558794,
+          "meanMs": 0.36313900000338134,
+          "minMs": 0.21954200000618584,
+          "name": "grouped publishMany replace extrema batch",
+          "p99Ms": 0.47162500000558794,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 5000000 rows",
+          "maxMs": 0.44470799999544397,
+          "meanMs": 0.270041666663019,
+          "minMs": 0.17799999999988358,
+          "name": "grouped patch aggregate values",
+          "p99Ms": 0.44470799999544397,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 5000000 rows",
+          "maxMs": 0.3635409999988042,
+          "meanMs": 0.26026366666095174,
+          "minMs": 0.1829159999906551,
+          "name": "grouped patch group moves",
+          "p99Ms": 0.3635409999988042,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 5000000 rows",
+          "maxMs": 0.33279200000106357,
+          "meanMs": 0.19070866666637207,
+          "minMs": 0.11941700000897981,
+          "name": "grouped delete existing rows",
+          "p99Ms": 0.33279200000106357,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "grouped publishMany append batch",
+        "grouped publishMany replace extrema batch",
+        "grouped patch aggregate values",
+        "grouped patch group moves",
+        "grouped delete existing rows"
+      ],
+      "benchmarkName": "grouped write engine benchmark",
+      "benchmarkScope": "engine-grouped-write",
+      "cleanupLeakCount": 0,
+      "groupedWriteAdmission": {
+        "activeFallbackGroupedViewsAfterSetup": 0,
+        "activeFallbackGroupedViewsBeforeCleanup": 0,
+        "activeIncrementalGroupedViewsAfterSetup": 1,
+        "activeIncrementalGroupedViewsBeforeCleanup": 1,
+        "activeViewsAfterSetup": 1,
+        "activeViewsBeforeCleanup": 1,
+        "configuredMode": "incremental",
+        "expectedAdmission": "incremental",
+        "groupedFullEvaluationCountAfterSetup": 0,
+        "groupedFullEvaluationCountBeforeCleanup": 9,
+        "groupedPatchedEvaluationCountAfterSetup": 0,
+        "groupedPatchedEvaluationCountBeforeCleanup": 6,
+        "incrementalAdmissionLimits": {
+          "maxGroups": 8192,
+          "maxMembers": 65536,
+          "maxMembersPerGroup": 4096,
+          "maxRetainedValueEntries": 65536
+        },
+        "priceThreshold": 998800,
+        "readerProfile": "order-neutral",
+        "seedMutationCount": 5000000,
+        "timedMutationCount": 15,
+        "writeBatchSize": 1
+      },
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 2682535936,
+      "minimumSampleCount": 3,
+      "mutationCount": 5000015,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-order-neutral-5000000rows-1mutations.json",
+      "queuedEventCount": 0,
+      "rowCount": 5000000,
+      "subscriberCount": 1,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-order-neutral-5000000rows-1mutations.summary.json",
+      "taskLabel": "grouped write incremental order-neutral 5000000 rows 1 mutations",
+      "topics": ["orders"]
+    }
+  ],
+  "thresholds": {
+    "latencyMean": {
+      "maxAbsoluteDeltaMs": 0.5,
+      "maxRatio": 6
+    },
+    "latencyP99": {
+      "maxAbsoluteDeltaMs": 1,
+      "maxRatio": 6
+    },
+    "memoryRssTotalDelta": {
+      "maxAbsoluteDeltaBytes": 134217728,
+      "maxRatio": 3
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "bench:baseline": "pnpm run bench:baseline:smoke",
-    "bench:baseline:grouped-admission": "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission --no-compare",
+    "bench:baseline:grouped-admission": "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission",
     "bench:baseline:grouped-admission:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission --update-baseline",
-    "bench:baseline:grouped-order-neutral": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --no-compare",
+    "bench:baseline:grouped-order-neutral": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral",
     "bench:baseline:grouped-order-neutral:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
     "bench:baseline:release": "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     "bench:baseline:release:update": "node scripts/run-benchmark-baseline.mjs --profile=release --update-baseline",

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1288,6 +1288,8 @@ Preferred serial benchmark runner:
 ```bash
 pnpm run bench:baseline:smoke
 pnpm run bench:baseline
+pnpm run bench:baseline:grouped-admission
+pnpm run bench:baseline:grouped-order-neutral
 pnpm run bench:baseline:release
 ```
 
@@ -1303,12 +1305,13 @@ accepted.
 `bench:baseline:release` is the release-quality serial profile and runs the documented row
 counts/browser profiles in separate processes. It intentionally executes one benchmark process at a
 time so GC, RSS, browser state, and artifact files are not polluted by competing benchmark suites.
-The release and grouped-admission profiles currently run without comparison by default; use their
-`:update` scripts when committing dedicated release baseline manifests.
+The grouped-admission and grouped-order-neutral profiles are committed comparison profiles. Release
+remains report-only/no-compare by default because it is heavy; use
+`bench:baseline:release:update` only when accepting a release baseline manifest.
 
 The serial runner is `scripts/run-benchmark-baseline.mjs`. It supports
-`VIEW_SERVER_BENCH_BASELINE_PROFILE=smoke|release|grouped-admission` or
-`--profile=smoke|release|grouped-admission`; an explicit
+`VIEW_SERVER_BENCH_BASELINE_PROFILE=smoke|release|grouped-admission|grouped-order-neutral` or
+`--profile=smoke|release|grouped-admission|grouped-order-neutral`; an explicit
 `--profile` argument wins over the environment variable, so the root package scripts always run the
 profile they name. Use the environment variable only when invoking the Node script directly. The
 runner scrubs benchmark-specific environment variables before each child process so stale local
@@ -1614,7 +1617,10 @@ for the same row count and write batch. The summary sidecar includes `groupedWri
 `preCleanupHealth`, so every run records whether grouped subscriptions were admitted as incremental
 views or demoted to fallback before cleanup. `groupedWriteAdmission` also records grouped full
 evaluation and patched-evaluation counters after setup and before cleanup, so order-neutral patch
-regressions are visible in baseline comparisons.
+regressions are visible in baseline comparisons. The default command compares fresh artifacts against
+`benchmarks/baselines/grouped-admission.json`; use
+`pnpm run bench:baseline:grouped-admission:update` only when accepting a new grouped-admission
+baseline.
 
 Order-neutral grouped evaluation patching uses a dedicated serial baseline profile:
 
@@ -1626,7 +1632,10 @@ That profile sets `VIEW_SERVER_ENGINE_BENCH_GROUPED_WRITE_READER_PROFILE=order-n
 same 100k, 1M, and 5M grouped write row counts as the release grouped-write profile. It keeps only
 the field-ordered grouped subscription open, so `grouped patch aggregate values` isolates the
 order-neutral evaluation patch path instead of mixing it with an aggregate-ordered subscriber that
-must rebuild the grouped window.
+must rebuild the grouped window. The default command compares fresh artifacts against
+`benchmarks/baselines/grouped-order-neutral.json`; use
+`pnpm run bench:baseline:grouped-order-neutral:update` only when accepting a new order-neutral
+baseline.
 
 Grouped write benchmark cases:
 

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readBenchmarkBaseline, writeBenchmarkBaseline } from "./benchmark-baseline.mjs";
@@ -178,6 +178,26 @@ describe("benchmark baseline runner", () => {
       nonJsonSummary: ".artifacts/result.summary.json",
       summary: ".artifacts/result.summary.json",
       unknownSignalExitCode: 1,
+    });
+  });
+
+  it("keeps targeted grouped baseline scripts in compare mode by default", () => {
+    const scripts = JSON.parse(readFileSync("package.json", "utf8")).scripts;
+
+    expect({
+      groupedAdmission: scripts["bench:baseline:grouped-admission"],
+      groupedAdmissionUpdate: scripts["bench:baseline:grouped-admission:update"],
+      groupedOrderNeutral: scripts["bench:baseline:grouped-order-neutral"],
+      groupedOrderNeutralUpdate: scripts["bench:baseline:grouped-order-neutral:update"],
+      release: scripts["bench:baseline:release"],
+    }).toStrictEqual({
+      groupedAdmission: "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission",
+      groupedAdmissionUpdate:
+        "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission --update-baseline",
+      groupedOrderNeutral: "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral",
+      groupedOrderNeutralUpdate:
+        "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
+      release: "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     });
   });
 

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -16,6 +16,23 @@ export const defaultBenchmarkThresholds = {
   },
 };
 
+export const groupedOrderNeutralBenchmarkThresholds = {
+  latencyMean: {
+    maxAbsoluteDeltaMs: 0.5,
+    maxRatio: 6,
+  },
+  latencyP99: {
+    maxAbsoluteDeltaMs: 1,
+    maxRatio: 6,
+  },
+  memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+};
+
+export const benchmarkThresholdsForProfile = (profile) =>
+  profile === "grouped-order-neutral"
+    ? groupedOrderNeutralBenchmarkThresholds
+    : defaultBenchmarkThresholds;
+
 const readJsonFile = (path) => JSON.parse(readFileSync(path, "utf8"));
 
 const writeJsonFile = (path, value) => {
@@ -228,7 +245,7 @@ export const buildBenchmarkBaseline = (profile, observations) => ({
   artifactKind: "view-server-benchmark-baseline",
   profile,
   tasks: observations,
-  thresholds: defaultBenchmarkThresholds,
+  thresholds: benchmarkThresholdsForProfile(profile),
 });
 
 const writableBenchmarkBaseline = (path, baseline) => {
@@ -256,7 +273,7 @@ const nonEmptyArrayValue = (value, path) => {
   return array;
 };
 
-const thresholdsValue = (value, path) => {
+const thresholdsValue = (value, path, expectedThresholds) => {
   const thresholds = objectValue(value, path);
   const validatedThresholds = {
     latencyMean: {
@@ -285,8 +302,8 @@ const thresholdsValue = (value, path) => {
       ),
     },
   };
-  if (JSON.stringify(validatedThresholds) !== JSON.stringify(defaultBenchmarkThresholds)) {
-    throw new Error(`Benchmark artifact field ${path} must match code-owned default thresholds.`);
+  if (JSON.stringify(validatedThresholds) !== JSON.stringify(expectedThresholds)) {
+    throw new Error(`Benchmark artifact field ${path} must match code-owned profile thresholds.`);
   }
   return validatedThresholds;
 };
@@ -346,17 +363,22 @@ const validateTask = (task, path) => {
   };
 };
 
-export const validateBenchmarkBaseline = (baseline, path = "baseline") => ({
-  artifactKind: baselineArtifactKind(
-    objectValue(baseline, path).artifactKind,
-    `${path}.artifactKind`,
-  ),
-  profile: stringValue(baseline.profile, `${path}.profile`),
-  tasks: nonEmptyArrayValue(baseline.tasks, `${path}.tasks`).map((task, index) =>
-    validateTask(task, `${path}.tasks[${index}]`),
-  ),
-  thresholds: thresholdsValue(baseline.thresholds, `${path}.thresholds`),
-});
+export const validateBenchmarkBaseline = (baseline, path = "baseline") => {
+  const baselineObject = objectValue(baseline, path);
+  const profile = stringValue(baselineObject.profile, `${path}.profile`);
+  return {
+    artifactKind: baselineArtifactKind(baselineObject.artifactKind, `${path}.artifactKind`),
+    profile,
+    tasks: nonEmptyArrayValue(baselineObject.tasks, `${path}.tasks`).map((task, index) =>
+      validateTask(task, `${path}.tasks[${index}]`),
+    ),
+    thresholds: thresholdsValue(
+      baselineObject.thresholds,
+      `${path}.thresholds`,
+      benchmarkThresholdsForProfile(profile),
+    ),
+  };
+};
 
 const mapByUniqueKey = (values, key, path, label) => {
   const entries = [];
@@ -440,7 +462,7 @@ const compareRss = (regressions, taskLabel, threshold, baseline, actual) => {
 export const compareBenchmarkBaseline = (baseline, actualBaseline) => {
   const validatedBaseline = validateBenchmarkBaseline(baseline, "baseline");
   const validatedActual = validateBenchmarkBaseline(actualBaseline, "actual");
-  const thresholds = defaultBenchmarkThresholds;
+  const thresholds = validatedBaseline.thresholds;
   const baselineTasks = taskByLabel(validatedBaseline.tasks, "baseline.tasks");
   const actualTasks = taskByLabel(validatedActual.tasks, "actual.tasks");
   const regressions = [];

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -3,9 +3,12 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  benchmarkThresholdsForProfile,
   buildBenchmarkBaseline,
   comparableBenchmarksFromVitestOutput,
   compareBenchmarkBaseline,
+  defaultBenchmarkThresholds,
+  groupedOrderNeutralBenchmarkThresholds,
   readBenchmarkBaseline,
   readBenchmarkObservation,
   validateBenchmarkBaseline,
@@ -136,6 +139,21 @@ describe("benchmark baseline comparison", () => {
         sampleCount: 7,
       },
     ]);
+  });
+
+  it("uses profile-specific baseline thresholds", () => {
+    expect({
+      groupedOrderNeutral: benchmarkThresholdsForProfile("grouped-order-neutral"),
+      smoke: benchmarkThresholdsForProfile("smoke"),
+      smokeBaseline: buildBenchmarkBaseline("smoke", [observation]).thresholds,
+      orderNeutralBaseline: buildBenchmarkBaseline("grouped-order-neutral", [observation])
+        .thresholds,
+    }).toStrictEqual({
+      groupedOrderNeutral: groupedOrderNeutralBenchmarkThresholds,
+      smoke: defaultBenchmarkThresholds,
+      smokeBaseline: defaultBenchmarkThresholds,
+      orderNeutralBaseline: groupedOrderNeutralBenchmarkThresholds,
+    });
   });
 
   it("reads benchmark observations from summary and Vitest artifacts", () => {
@@ -363,6 +381,42 @@ describe("benchmark baseline comparison", () => {
     expect(compareBenchmarkBaseline(baseline, actual)).toStrictEqual({
       ok: true,
       regressions: [],
+    });
+  });
+
+  it("rejects large relative latency regressions for grouped order-neutral baselines", () => {
+    const subMillisecondObservation = {
+      ...observation,
+      benchmarks: [
+        {
+          ...observation.benchmarks[0],
+          meanMs: 0.2,
+          p99Ms: 0.3,
+        },
+      ],
+    };
+    const baseline = buildBenchmarkBaseline("grouped-order-neutral", [
+      subMillisecondObservation,
+    ]);
+    const actual = buildBenchmarkBaseline("grouped-order-neutral", [
+      {
+        ...subMillisecondObservation,
+        benchmarks: [
+          {
+            ...subMillisecondObservation.benchmarks[0],
+            meanMs: 1.3,
+            p99Ms: 2,
+          },
+        ],
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, actual)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a / src/example.bench.ts > example benchmark group / case a: mean regressed from 0.200ms to 1.300ms; allowed <= 1.200ms.",
+        "task a / src/example.bench.ts > example benchmark group / case a: p99 regressed from 0.300ms to 2.000ms; allowed <= 1.800ms.",
+      ],
     });
   });
 
@@ -716,7 +770,7 @@ describe("benchmark baseline comparison", () => {
     };
 
     expect(() => validateBenchmarkBaseline(baseline)).toThrow(
-      "Benchmark artifact field baseline.thresholds must match code-owned default thresholds.",
+      "Benchmark artifact field baseline.thresholds must match code-owned profile thresholds.",
     );
   });
 


### PR DESCRIPTION
## Summary
- make grouped-admission and grouped-order-neutral baseline scripts compare by default
- add committed grouped baseline manifests
- add profile-specific order-neutral latency thresholds so sub-ms patch regressions are not hidden by smoke defaults
- document grouped profile gates and update script contract coverage

## Validation
- vp check --fix
- pnpm run test:benchmark-baseline
- pnpm run bench:baseline:grouped-order-neutral
- pnpm run bench:baseline:grouped-admission
- pnpm run ready

## Review loop
- 3-agent review found manifest tracking and loose order-neutral threshold risks
- fixed both issues
- follow-up reviewers confirmed no remaining blockers