### PR TITLE
Deduplicate protocol JSON field context

### DIFF
--- a/packages/protocol/src/protocol-aggregate-row-codec.ts
+++ b/packages/protocol/src/protocol-aggregate-row-codec.ts
@@ -3,8 +3,8 @@ import { viewServerSchemaFieldMetadata } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import {
-  decodeJsonFieldValue,
-  encodeJsonFieldValue,
+  decodeContextualJsonFieldValue,
+  encodeContextualJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 import type { ViewServerWireAggregate } from "./protocol-query-schema";
@@ -74,9 +74,11 @@ const decodeAggregateEnvelope = Effect.fn("ViewServerProtocol.row.aggregate.enve
 const encodeAggregateJsonFieldValue = Effect.fn(
   "ViewServerProtocol.row.aggregate.jsonField.encode",
 )(function* (topic: string, field: string, schema: JsonFieldSchema, value: unknown) {
-  return yield* encodeJsonFieldValue(schema, value, {
-    invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
-    notJsonSafe: (message) => invalidRow(topic, `Field ${field} is not JSON-safe: ${message}`),
+  return yield* encodeContextualJsonFieldValue(schema, value, {
+    invalid: (message) => invalidRow(topic, message),
+    invalidMessage: (message) => `Invalid field ${field}: ${message}`,
+    notJsonSafe: (message) => invalidRow(topic, message),
+    notJsonSafeMessage: (message) => `Field ${field} is not JSON-safe: ${message}`,
   });
 });
 
@@ -139,8 +141,9 @@ const decodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.jso
         invalidRow(topic, `Aggregate ${field} must be a JSON aggregate envelope.`),
       );
     }
-    return yield* decodeJsonFieldValue(schema, envelope.value, {
-      invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+    return yield* decodeContextualJsonFieldValue(schema, envelope.value, {
+      invalid: (message) => invalidRow(topic, message),
+      invalidMessage: (message) => `Invalid field ${field}: ${message}`,
     });
   },
 );

--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -1,8 +1,8 @@
 import { viewServerSchemaFieldMetadata, type ViewServerRuntimeError } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import {
-  decodeJsonFieldValue,
-  encodeJsonFieldValue,
+  decodeContextualJsonFieldValue,
+  encodeContextualJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 
@@ -40,9 +40,11 @@ const encodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* encodeJsonFieldValue(schema, value, {
-    invalid: (message) => invalidQuery(topic, `Invalid filter for ${field}: ${message}`),
-    notJsonSafe: (message) => invalidQuery(topic, `Filter ${field} is not JSON-safe: ${message}`),
+  return yield* encodeContextualJsonFieldValue(schema, value, {
+    invalid: (message) => invalidQuery(topic, message),
+    invalidMessage: (message) => `Invalid filter for ${field}: ${message}`,
+    notJsonSafe: (message) => invalidQuery(topic, message),
+    notJsonSafeMessage: (message) => `Filter ${field} is not JSON-safe: ${message}`,
   });
 });
 
@@ -52,8 +54,9 @@ const decodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* decodeJsonFieldValue(schema, value, {
-    invalid: (message) => invalidQuery(topic, `Invalid filter for ${field}: ${message}`),
+  return yield* decodeContextualJsonFieldValue(schema, value, {
+    invalid: (message) => invalidQuery(topic, message),
+    invalidMessage: (message) => `Invalid filter for ${field}: ${message}`,
   });
 });
 

--- a/packages/protocol/src/protocol-json-field-codec.ts
+++ b/packages/protocol/src/protocol-json-field-codec.ts
@@ -7,6 +7,16 @@ type JsonFieldCodecErrors<E> = {
   readonly notJsonSafe: (message: string) => E;
 };
 
+type JsonFieldCodecContext<E> = {
+  readonly invalid: (message: string) => E;
+  readonly invalidMessage: (message: string) => string;
+};
+
+type JsonFieldEncodeContext<E> = JsonFieldCodecContext<E> & {
+  readonly notJsonSafe: (message: string) => E;
+  readonly notJsonSafeMessage: (message: string) => string;
+};
+
 export const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.encode")(function* <E>(
   schema: JsonFieldSchema,
   value: unknown,
@@ -28,4 +38,21 @@ export const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.deco
   return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
     Effect.mapError((error) => errors.invalid(error.message)),
   );
+});
+
+export const encodeContextualJsonFieldValue = Effect.fn(
+  "ViewServerProtocol.jsonField.contextual.encode",
+)(function* <E>(schema: JsonFieldSchema, value: unknown, context: JsonFieldEncodeContext<E>) {
+  return yield* encodeJsonFieldValue(schema, value, {
+    invalid: (message) => context.invalid(context.invalidMessage(message)),
+    notJsonSafe: (message) => context.notJsonSafe(context.notJsonSafeMessage(message)),
+  });
+});
+
+export const decodeContextualJsonFieldValue = Effect.fn(
+  "ViewServerProtocol.jsonField.contextual.decode",
+)(function* <E>(schema: JsonFieldSchema, value: unknown, context: JsonFieldCodecContext<E>) {
+  return yield* decodeJsonFieldValue(schema, value, {
+    invalid: (message) => context.invalid(context.invalidMessage(message)),
+  });
 });

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -3,8 +3,8 @@ import { Effect, Schema } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
 import {
-  decodeJsonFieldValue,
-  encodeJsonFieldValue,
+  decodeContextualJsonFieldValue,
+  encodeContextualJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 import type { ViewServerEventGroupedQuery, ViewServerEventQuery } from "./protocol-query-schema";
@@ -26,9 +26,23 @@ const encodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.enco
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* encodeJsonFieldValue(schema, value, {
-    invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
-    notJsonSafe: (message) => invalidRow(topic, `Field ${field} is not JSON-safe: ${message}`),
+  return yield* encodeContextualJsonFieldValue(schema, value, {
+    invalid: (message) => invalidRow(topic, message),
+    invalidMessage: (message) => `Invalid field ${field}: ${message}`,
+    notJsonSafe: (message) => invalidRow(topic, message),
+    notJsonSafeMessage: (message) => `Field ${field} is not JSON-safe: ${message}`,
+  });
+});
+
+const decodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.decode")(function* (
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+) {
+  return yield* decodeContextualJsonFieldValue(schema, value, {
+    invalid: (message) => invalidRow(topic, message),
+    invalidMessage: (message) => `Invalid field ${field}: ${message}`,
   });
 });
 
@@ -85,9 +99,7 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
       );
     }
     const fieldSchema = config.topics[topic]!.schema.fields[field]!;
-    output[field] = yield* decodeJsonFieldValue(fieldSchema, value, {
-      invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
-    });
+    output[field] = yield* decodeEventJsonFieldValue(topic, field, fieldSchema, value);
   }
   return output;
 });
@@ -169,9 +181,7 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   for (const [field, value] of Object.entries(row)) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
-      output[field] = yield* decodeJsonFieldValue(fieldSchema, value, {
-        invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
-      });
+      output[field] = yield* decodeEventJsonFieldValue(topic, field, fieldSchema, value);
     } else if (aggregateAliases.has(field)) {
       const aggregate = query.aggregates[field];
       if (aggregate === undefined) {


### PR DESCRIPTION
## Summary
- add shared contextual JSON field encode/decode helpers in protocol-json-field-codec
- route row, filter, and aggregate JSON field error wrapping through the shared helper
- preserve existing wire encoding and contextual error messages

## Validation
- pnpm --filter @view-server/protocol run test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/protocol/tsconfig.json --format text --strict
- pnpm run ready

## Review loop
- 3-agent review: no blockers