### PR TITLE
Annotate live subscription notify spans

### DIFF
--- a/packages/column-live-view-engine/src/live-subscription.test.ts
+++ b/packages/column-live-view-engine/src/live-subscription.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option, Schema } from "effect";
+import type { LiveQueryExecution } from "./active-query";
+import { makeLiveSubscription } from "./live-subscription";
+import { makeTopicStoreSubscriptionPermit, TopicStore, topicStoreState } from "./topic-store-state";
+
+const Row = Schema.Struct({
+  id: Schema.String,
+});
+
+type Row = typeof Row.Type;
+
+const emptyEvaluation = {
+  rows: [],
+  keys: [],
+  window: [],
+  totalRows: 0,
+  version: 0,
+};
+
+describe("live subscription observability", () => {
+  it.effect("runs subscriber notification under a named span with topic and query attributes", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("orders", Row, "id", () => {});
+      const permit = makeTopicStoreSubscriptionPermit(store);
+      let observedSpan: {
+        readonly name: string;
+        readonly queryId: unknown;
+        readonly topic: unknown;
+      } | null = null;
+      const execution: LiveQueryExecution<Row> = {
+        initial: (queryId) => ({
+          type: "snapshot",
+          topic: "orders",
+          queryId,
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        }),
+        createCursor: () => ({
+          evaluation: emptyEvaluation,
+        }),
+        next: () =>
+          Effect.gen(function* () {
+            const span = yield* Effect.currentSpan.pipe(Effect.orDie);
+            observedSpan = {
+              name: span.name,
+              queryId: span.attributes.get("queryId"),
+              topic: span.attributes.get("topic"),
+            };
+            return Option.none();
+          }),
+      };
+
+      const subscription = yield* makeLiveSubscription({
+        queryId: "query-1",
+        queueCapacity: 8,
+        execution,
+        permit,
+        release: Effect.void,
+      });
+      const subscribers = Array.from(topicStoreState(store).subscribers);
+
+      expect(subscribers).toHaveLength(1);
+      for (const subscriber of subscribers) {
+        yield* subscriber.notify(store);
+      }
+      expect(observedSpan).toStrictEqual({
+        name: "ColumnLiveViewEngine.liveSubscription.notify",
+        queryId: "query-1",
+        topic: "orders",
+      });
+
+      yield* subscription.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -77,6 +77,35 @@ const closeForBackpressure = Effect.fn(
   );
 });
 
+const notifyLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.notify")(function* <
+  ResultRow extends RowObject,
+>(
+  queryId: string,
+  store: TopicStore,
+  subscriber: LiveTopicSubscriber,
+  queue: Queue.Queue<LiveSubscriptionEvent<ResultRow>, Cause.Done>,
+  execution: LiveQueryExecution<ResultRow>,
+  cursor: ReturnType<LiveQueryExecution<ResultRow>["createCursor"]>,
+  releaseExecution: Effect.Effect<void>,
+) {
+  yield* Effect.annotateCurrentSpan({
+    queryId,
+    topic: store.topic,
+  });
+  const nextEvent = yield* execution.next(queryId, cursor);
+  if (Option.isNone(nextEvent)) {
+    return;
+  }
+  const offered = yield* Queue.offer(queue, nextEvent.value);
+  if (!offered) {
+    yield* closeForBackpressure(store, subscriber, queue, releaseExecution);
+    return;
+  }
+
+  const queueDepth = yield* Queue.size(queue);
+  yield* trackTopicStoreSubscriptionQueueDepth(store, subscriber, queueDepth);
+});
+
 export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.make")(
   function* <ResultRow extends RowObject>(options: MakeLiveSubscriptionOptions<ResultRow>) {
     const { execution, permit, queryId, queueCapacity } = options;
@@ -93,20 +122,15 @@ export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscrip
       topic: store.topic,
       queryId,
       notify: () =>
-        Effect.gen(function* () {
-          const nextEvent = yield* execution.next(queryId, cursor);
-          if (Option.isNone(nextEvent)) {
-            return;
-          }
-          const offered = yield* Queue.offer(queue, nextEvent.value);
-          if (!offered) {
-            yield* closeForBackpressure(store, subscriber, queue, releaseExecution);
-            return;
-          }
-
-          const queueDepth = yield* Queue.size(queue);
-          yield* trackTopicStoreSubscriptionQueueDepth(store, subscriber, queueDepth);
-        }),
+        notifyLiveSubscription(
+          queryId,
+          store,
+          subscriber,
+          queue,
+          execution,
+          cursor,
+          releaseExecution,
+        ),
       queuedEvents: Queue.size(queue),
       end: Queue.end(queue),
       closeWithStatus: (event) =>


### PR DESCRIPTION
## Summary
- move live subscription subscriber notification into a named Effect.fn span
- annotate notify spans with topic and queryId for trace diagnostics
- add an internal regression test proving notification executes under the expected span and attributes

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- pnpm run ready

## Review
- 3 local reviewer agents: no findings after staging fix