### PR TITLE
Close remote subscriptions on buffer overflow

### DIFF
--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -529,6 +529,112 @@ describe("remote ViewServer client", () => {
     }),
   );
 
+  it.live(
+    "closes with typed backpressure status when the remote client event buffer overflows",
+    () =>
+      Effect.gen(function* () {
+        const server = yield* makeTestRpcServer();
+        const client = yield* makeViewServerClient(viewServer, {
+          subscriptionBufferSize: 1,
+          url: server.url,
+        });
+        const subscription = yield* client.subscribe("orders", {
+          select: ["id", "price"],
+          limit: 10,
+        });
+
+        yield* server.emitInsert("orders", order("first", 1));
+        yield* server.emitInsert("orders", order("second", 2));
+        const events = yield* subscription.events.pipe(Stream.takeRight(1), Stream.runCollect);
+
+        expect(Array.from(events)).toStrictEqual([
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "remote",
+            status: "closed",
+            code: "BackpressureExceeded",
+            message: "Remote subscription buffer exceeded capacity with 1 queued event(s).",
+          },
+        ]);
+        yield* Effect.sleep("10 millis");
+        expect(server.activeSubscriptions()).toBe(0);
+
+        yield* client.close;
+        yield* server.close;
+      }),
+  );
+
+  it.live("closes with typed backpressure status when the remote client buffer size is zero", () =>
+    Effect.gen(function* () {
+      const server = yield* makeTestRpcServer();
+      const client = yield* makeViewServerClient(viewServer, {
+        subscriptionBufferSize: 0,
+        url: server.url,
+      });
+      const subscription = yield* client.subscribe("orders", {
+        select: ["id", "price"],
+        limit: 10,
+      });
+
+      yield* server.emitInsert("orders", order("first", 1));
+      yield* server.emitInsert("orders", order("second", 2));
+      const events = yield* subscription.events.pipe(Stream.takeRight(1), Stream.runCollect);
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "remote",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "Remote subscription buffer exceeded capacity with 1 queued event(s).",
+        },
+      ]);
+      yield* Effect.sleep("10 millis");
+      expect(server.activeSubscriptions()).toBe(0);
+
+      yield* client.close;
+      yield* server.close;
+    }),
+  );
+
+  it.live(
+    "closes with typed backpressure status when the remote client buffer size is not finite",
+    () =>
+      Effect.gen(function* () {
+        const server = yield* makeTestRpcServer();
+        const client = yield* makeViewServerClient(viewServer, {
+          subscriptionBufferSize: Number.NaN,
+          url: server.url,
+        });
+        const subscription = yield* client.subscribe("orders", {
+          select: ["id", "price"],
+          limit: 10,
+        });
+
+        yield* server.emitInsert("orders", order("first", 1));
+        yield* server.emitInsert("orders", order("second", 2));
+        const events = yield* subscription.events.pipe(Stream.takeRight(1), Stream.runCollect);
+
+        expect(Array.from(events)).toStrictEqual([
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "remote",
+            status: "closed",
+            code: "BackpressureExceeded",
+            message: "Remote subscription buffer exceeded capacity with 1 queued event(s).",
+          },
+        ]);
+        yield* Effect.sleep("10 millis");
+        expect(server.activeSubscriptions()).toBe(0);
+
+        yield* client.close;
+        yield* server.close;
+      }),
+  );
+
   it.live("does not wait for health refresh before delivering the first live event", () =>
     Effect.gen(function* () {
       const server = yield* makeTestRpcServer();

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -53,6 +53,17 @@ export type ViewServerClientOptions = {
 
 export type ViewServerRemoteClient<Topics extends TopicDefinitions> = ViewServerLiveClient<Topics>;
 
+const defaultSubscriptionBufferSize = 1_024;
+
+const normalizeSubscriptionBufferSize = (subscriptionBufferSize: number | undefined): number => {
+  if (subscriptionBufferSize === undefined) {
+    return defaultSubscriptionBufferSize;
+  }
+  return Number.isSafeInteger(subscriptionBufferSize) && subscriptionBufferSize > 0
+    ? subscriptionBufferSize
+    : 1;
+};
+
 class ViewServerRpcClient extends Context.Service<
   ViewServerRpcClient,
   RpcClient.FromGroup<typeof ViewServerRpcs, RpcClientError>
@@ -113,6 +124,18 @@ const subscriptionFailureStatus = <Topic extends string>(
   };
 };
 
+const subscriptionOverflowStatus = <Topic extends string>(
+  topic: Topic,
+  queuedEvents: number,
+): ViewServerStatusEvent<Topic> => ({
+  type: "status",
+  topic,
+  queryId: "remote",
+  status: "closed",
+  code: "BackpressureExceeded",
+  message: `Remote subscription buffer exceeded capacity with ${queuedEvents} queued event(s).`,
+});
+
 export const makeViewServerClient: <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
   options: ViewServerClientOptions,
@@ -134,6 +157,8 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
   const healthRpc = (): Effect.Effect<ViewServerWireHealth, ViewServerRemoteClientError> =>
     rpc["ViewServer.Health"](undefined).pipe(Effect.mapError(mapViewServerRemoteError));
 
+  const subscriptionBufferSize = normalizeSubscriptionBufferSize(options.subscriptionBufferSize);
+
   const subscribeRpc = <Row, Topic extends string = string, Key extends string = string>(
     topic: Topic,
     query: ViewServerWireLiveQuery,
@@ -147,7 +172,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
         query,
       },
       {
-        streamBufferSize: options.subscriptionBufferSize ?? 1_024,
+        streamBufferSize: subscriptionBufferSize,
       },
     ).pipe(Stream.mapError(mapViewServerRemoteError), Stream.mapEffect(decodeEvent));
 
@@ -155,7 +180,6 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     healthRpc().pipe(Effect.flatMap((next) => viewServerDecodeHealth(config, next))),
   );
   const remoteHealth = makeRemoteHealthState(initialHealth);
-  const subscriptionBufferSize = options.subscriptionBufferSize ?? 1_024;
   const clientScope = yield* Scope.make("parallel");
 
   const close = runAllFinalizers([
@@ -179,6 +203,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
       clientScope,
       failureStatus: subscriptionFailureStatus,
       lifecycle,
+      overflowStatus: subscriptionOverflowStatus,
       source,
       subscriptionBufferSize,
       topic,

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit, Fiber, Logger, References, Scope, Stream } from "effect";
+import {
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Logger,
+  Option,
+  References,
+  Scope,
+  Stream,
+} from "effect";
 import type { StatusEvent } from "@view-server/config";
 import type { ViewServerLiveEvent } from "./live-client";
 import { makeRemoteSubscription } from "./remote-subscription";
@@ -45,6 +56,15 @@ const failureStatus = (topic: string, error: string): StatusEvent => ({
   message: error,
 });
 
+const overflowStatus = (topic: string, queuedEvents: number): StatusEvent => ({
+  type: "status",
+  topic,
+  queryId: "remote",
+  status: "closed",
+  code: "BackpressureExceeded",
+  message: `overflow with ${queuedEvents} queued event(s)`,
+});
+
 describe("remote subscription", () => {
   it.effect("streams events and closes without explicit lifecycle hooks", () =>
     Effect.gen(function* () {
@@ -52,6 +72,7 @@ describe("remote subscription", () => {
       const subscription = yield* makeRemoteSubscription({
         clientScope,
         failureStatus,
+        overflowStatus,
         source: Stream.make(snapshot),
         subscriptionBufferSize: 2,
         topic: "orders",
@@ -81,6 +102,7 @@ describe("remote subscription", () => {
             closeCount += 1;
           }),
         },
+        overflowStatus,
         source: Stream.fail("socket closed"),
         subscriptionBufferSize: 2,
         topic: "orders",
@@ -115,6 +137,7 @@ describe("remote subscription", () => {
             closeCount += 1;
           }).pipe(Effect.andThen(Effect.die("close failed"))),
         },
+        overflowStatus,
         source: Stream.make(snapshot),
         subscriptionBufferSize: 2,
         topic: "orders",
@@ -138,6 +161,7 @@ describe("remote subscription", () => {
           failureStatusCount += 1;
           return failureStatus(topic, error);
         },
+        overflowStatus,
         source: Stream.never,
         subscriptionBufferSize: 2,
         topic: "orders",
@@ -159,6 +183,7 @@ describe("remote subscription", () => {
       const subscription = yield* makeRemoteSubscription<Row, string>({
         clientScope,
         failureStatus,
+        overflowStatus,
         source: Stream.die("source defect"),
         subscriptionBufferSize: 2,
         topic: "orders",
@@ -193,6 +218,7 @@ describe("remote subscription", () => {
             return yield* Effect.fail("typed close failure");
           }),
         },
+        overflowStatus,
         source: Stream.make(snapshot),
         subscriptionBufferSize: 2,
         topic: "orders",
@@ -214,4 +240,214 @@ describe("remote subscription", () => {
       Effect.provideService(References.MinimumLogLevel, "Trace"),
     );
   });
+
+  it.effect("closes with typed backpressure status when the local event buffer overflows", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const lifecycleEvents: Array<"open" | "close"> = [];
+      let closeCount = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        lifecycle: {
+          onOpen: Effect.sync(() => {
+            lifecycleEvents.push("open");
+          }),
+          onClose: Effect.sync(() => {
+            lifecycleEvents.push("close");
+            closeCount += 1;
+          }),
+        },
+        overflowStatus,
+        source: Stream.make(snapshot, {
+          ...snapshot,
+          version: 2,
+        }),
+        subscriptionBufferSize: 1,
+        topic: "orders",
+      });
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      expect(closeCount).toBe(1);
+      expect(lifecycleEvents).toStrictEqual(["open", "close"]);
+
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "remote",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "overflow with 1 queued event(s)",
+        },
+      ]);
+      expect(closeCount).toBe(1);
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("propagates overflow close defects from lifecycle finalizers", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      let closeCount = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        lifecycle: {
+          onOpen: Effect.void,
+          onClose: Effect.sync(() => {
+            closeCount += 1;
+          }).pipe(Effect.andThen(Effect.die("overflow close failed"))),
+        },
+        overflowStatus,
+        source: Stream.make(snapshot, {
+          ...snapshot,
+          version: 2,
+        }),
+        subscriptionBufferSize: 1,
+        topic: "orders",
+      });
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      const defectSeen = yield* subscription.events.pipe(
+        Stream.runCollect,
+        Effect.matchCause({
+          onFailure: Cause.hasDies,
+          onSuccess: () => false,
+        }),
+      );
+
+      expect(defectSeen).toBe(true);
+      expect(closeCount).toBe(1);
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("clears stale queued events before waiting for overflow lifecycle close", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const closeStarted = yield* Deferred.make<void>();
+      const closeRelease = yield* Deferred.make<void>();
+      const firstEvents = yield* Deferred.make<ReadonlyArray<ViewServerLiveEvent<Row>>>();
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        lifecycle: {
+          onOpen: Effect.void,
+          onClose: Deferred.succeed(closeStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(closeRelease)),
+          ),
+        },
+        overflowStatus,
+        source: Stream.make(snapshot, {
+          ...snapshot,
+          version: 2,
+        }),
+        subscriptionBufferSize: 1,
+        topic: "orders",
+      });
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Deferred.await(closeStarted).pipe(Effect.timeout("1 second"));
+      yield* subscription.events.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.flatMap((events) => Deferred.succeed(firstEvents, Array.from(events))),
+        Effect.forkChild,
+      );
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      const beforeCloseRelease = yield* Deferred.poll(firstEvents);
+
+      expect(Option.isNone(beforeCloseRelease)).toBe(true);
+
+      yield* Deferred.succeed(closeRelease, undefined);
+      const events = yield* Deferred.await(firstEvents);
+
+      expect(events).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "remote",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "overflow with 1 queued event(s)",
+        },
+      ]);
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("delivers typed backpressure status when the configured buffer size is zero", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        overflowStatus,
+        source: Stream.make(snapshot, {
+          ...snapshot,
+          version: 2,
+        }),
+        subscriptionBufferSize: 0,
+        topic: "orders",
+      });
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "remote",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "overflow with 1 queued event(s)",
+        },
+      ]);
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect(
+    "delivers typed backpressure status when the configured buffer size is not finite",
+    () =>
+      Effect.gen(function* () {
+        const clientScope = yield* Scope.make("parallel");
+        const subscription = yield* makeRemoteSubscription<Row, string>({
+          clientScope,
+          failureStatus,
+          overflowStatus,
+          source: Stream.make(snapshot, {
+            ...snapshot,
+            version: 2,
+          }),
+          subscriptionBufferSize: Number.NaN,
+          topic: "orders",
+        });
+
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        const events = yield* subscription.events.pipe(Stream.runCollect);
+
+        expect(Array.from(events)).toStrictEqual([
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "remote",
+            status: "closed",
+            code: "BackpressureExceeded",
+            message: "overflow with 1 queued event(s)",
+          },
+        ]);
+        yield* Scope.close(clientScope, Exit.void);
+      }),
+  );
 });

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Queue, Scope, Stream } from "effect";
+import { Cause, Effect, Exit, Queue, Ref, Scope, Stream } from "effect";
 import { constant } from "effect/Function";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
 import type {
@@ -30,6 +30,11 @@ const completeQueueFromProducerExit = <Row, Topic extends string, Key extends st
   return Queue.failCause(queue, exit.cause);
 };
 
+const normalizeSubscriptionBufferSize = (subscriptionBufferSize: number): number =>
+  Number.isSafeInteger(subscriptionBufferSize) && subscriptionBufferSize > 0
+    ? subscriptionBufferSize
+    : 1;
+
 export type RemoteSubscriptionLifecycle = {
   readonly onOpen: Effect.Effect<void>;
   readonly onClose: Effect.Effect<void, unknown>;
@@ -42,12 +47,45 @@ export type RemoteSubscriptionOptions<
   Key extends string = string,
 > = {
   readonly clientScope: Scope.Scope;
+  readonly overflowStatus: (topic: Topic, queuedEvents: number) => ViewServerStatusEvent<Topic>;
   readonly failureStatus: (topic: Topic, error: Error) => ViewServerStatusEvent<Topic>;
   readonly lifecycle?: RemoteSubscriptionLifecycle;
   readonly source: Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>, Error>;
   readonly subscriptionBufferSize: number;
   readonly topic: Topic;
 };
+
+const closeQueueForOverflow = Effect.fn("ViewServerClient.remote.subscription.closeForOverflow")(
+  function* <Row, Topic extends string, Key extends string>(
+    queue: Queue.Queue<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>,
+    event: ViewServerStatusEvent<Topic>,
+  ) {
+    yield* Queue.clear(queue);
+    yield* Queue.offer(queue, event);
+    yield* Queue.end(queue);
+  },
+);
+
+const offerRemoteEvent = Effect.fn("ViewServerClient.remote.subscription.offer")(function* <
+  Row,
+  Topic extends string,
+  Key extends string,
+>(
+  queue: Queue.Queue<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>,
+  event: ViewServerLiveEvent<Row, Topic, Key>,
+  overflowStatus: (topic: Topic, queuedEvents: number) => ViewServerStatusEvent<Topic>,
+  closeLifecycle: Effect.Effect<void>,
+  topic: Topic,
+) {
+  const offered = yield* Queue.offer(queue, event);
+  if (!offered) {
+    const queuedEvents = yield* Queue.size(queue);
+    yield* Queue.clear(queue);
+    yield* closeLifecycle;
+    yield* closeQueueForOverflow(queue, overflowStatus(topic, queuedEvents));
+    return yield* Effect.interrupt;
+  }
+});
 
 export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscription.make")(
   function* <Row, Error, Topic extends string = string, Key extends string = string>({
@@ -57,6 +95,7 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
       onOpen: Effect.void,
       onClose: Effect.void,
     },
+    overflowStatus,
     source,
     subscriptionBufferSize,
     topic,
@@ -69,22 +108,30 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
         );
         return yield* restore(
           Effect.gen(function* () {
+            const lifecycleClosed = yield* Ref.make(false);
+            const closeLifecycle = Effect.uninterruptible(
+              Effect.gen(function* () {
+                const shouldClose = yield* Ref.modify(lifecycleClosed, (closed) => [!closed, true]);
+                if (shouldClose) {
+                  yield* lifecycle.onClose.pipe(ignoreRemoteSubscriptionCloseFailure);
+                }
+              }),
+            );
             const stream = source.pipe(
               Stream.catch((error) => Stream.make(failureStatus(topic, error))),
             );
-            const queue = yield* Queue.bounded<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(
-              subscriptionBufferSize,
+            const queue = yield* Queue.dropping<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(
+              normalizeSubscriptionBufferSize(subscriptionBufferSize),
             );
-            yield* Scope.addFinalizer(
-              scope,
-              lifecycle.onClose.pipe(ignoreRemoteSubscriptionCloseFailure),
-            );
-            yield* Stream.runForEach(stream, (event) => Queue.offer(queue, event)).pipe(
+            yield* Scope.addFinalizer(scope, closeLifecycle);
+            yield* lifecycle.onOpen;
+            yield* Stream.runForEach(stream, (event) =>
+              offerRemoteEvent(queue, event, overflowStatus, closeLifecycle, topic),
+            ).pipe(
               Effect.onExit((exit) => completeQueueFromProducerExit(queue, exit)),
               Effect.forkIn(scope, { startImmediately: true }),
               ignoreRemoteSubscriptionStreamStartFailure,
             );
-            yield* lifecycle.onOpen;
             const subscription = {
               events: Stream.fromQueue(queue).pipe(Stream.ensuring(closeSubscription)),
               close: () => closeSubscription,


### PR DESCRIPTION
## Summary
- switch remote subscriptions to bounded-dropping local queues so slow consumers receive a typed BackpressureExceeded close instead of backpressuring the RPC producer
- normalize invalid subscription buffer sizes to a safe minimum for both RPC streamBufferSize and local queue capacity
- make remote subscription lifecycle close exactly-once and preserve close defects while clearing stale queued events before terminal overflow status

## Validation
- pnpm --filter @view-server/client run test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/client/tsconfig.json --format text --severity error
- pnpm run ready

## Review
- 3-agent review cycle completed after final ordering fix: no findings from all reviewers
