### PR TITLE
Close pushed health subscriptions on overflow

### DIFF
--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -582,6 +582,265 @@ describe("@view-server/runtime-core", () => {
     }),
   );
 
+  it.effect("closes slow pushed health summary subscriptions with typed backpressure", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+      const liveClient = yield* makeRuntimeCoreLiveClient(
+        engine,
+        health,
+        Effect.sync(() => health.value),
+      );
+      const summary = yield* liveClient.subscribeHealthSummary();
+
+      yield* Effect.forEach(
+        Array.from({ length: 64 }, (_, index) => index),
+        (index) =>
+          Effect.sync(() => {
+            health.update(() => healthFromEngine(engineHealth("ready", index + 1)));
+          }).pipe(Effect.andThen(Effect.yieldNow)),
+      );
+      const events = yield* summary.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "__view_server_health_summary",
+          queryId: "health-summary",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message:
+            "Runtime health subscription closed because its event queue exceeded capacity with 64 queued event(s).",
+        },
+      ]);
+
+      yield* summary.close();
+      yield* liveClient.close;
+    }),
+  );
+
+  it.effect(
+    "keeps detailed health subscription acquisition stable when health changes during refresh",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+        const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+        const refreshStarted = yield* Deferred.make<void>();
+        const releaseRefresh = yield* Deferred.make<void>();
+        const liveClient = yield* makeRuntimeCoreLiveClient(
+          engine,
+          health,
+          Effect.gen(function* () {
+            yield* Deferred.succeed(refreshStarted, undefined);
+            yield* Deferred.await(releaseRefresh);
+            return health.value;
+          }),
+        );
+
+        const detailFiber = yield* liveClient
+          .subscribeHealth()
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(refreshStarted).pipe(Effect.timeout("1 second"));
+        yield* Effect.forEach(
+          Array.from({ length: 128 }, (_, index) => index),
+          (index) =>
+            Effect.sync(() => {
+              health.update(() => healthFromEngine(engineHealth("ready", index + 1)));
+            }),
+        );
+        yield* Deferred.succeed(releaseRefresh, undefined);
+
+        const detail = yield* Fiber.join(detailFiber).pipe(Effect.timeout("1 second"));
+        const events = yield* detail.events.pipe(Stream.take(2), Stream.runCollect);
+
+        expect(Array.from(events)).toStrictEqual([
+          {
+            type: "snapshot",
+            topic: "__view_server_health",
+            queryId: "health",
+            version: 1,
+            keys: ["orders"],
+            rows: [
+              {
+                id: "orders",
+                status: "ready",
+                rowCount: 128,
+                liveRowCount: 128,
+                deletedRowCount: 0,
+                version: 1,
+                lastMutationAt: null,
+                mutationsPerSecond: 0,
+                rowsPerSecond: 0,
+                pendingMutationBatches: 0,
+                activeFallbackGroupedViews: 0,
+                activeIncrementalGroupedViews: 0,
+                activeViews: 0,
+                groupedFullEvaluationCount: 0,
+                groupedPatchedEvaluationCount: 0,
+                activeSubscriptions: 0,
+                queuedEvents: 0,
+                maxQueueDepth: 0,
+                backpressureEvents: 0,
+                memoryBytes: 0,
+                tombstoneCount: 0,
+                compactionPending: false,
+                kafkaLag: 0n,
+                updatedAtNanos: expect.anything(),
+              },
+            ],
+            totalRows: 1,
+          },
+          {
+            type: "snapshot",
+            topic: "__view_server_health",
+            queryId: "health",
+            version: 1,
+            keys: ["orders"],
+            rows: [
+              {
+                id: "orders",
+                status: "ready",
+                rowCount: 128,
+                liveRowCount: 128,
+                deletedRowCount: 0,
+                version: 1,
+                lastMutationAt: null,
+                mutationsPerSecond: 0,
+                rowsPerSecond: 0,
+                pendingMutationBatches: 0,
+                activeFallbackGroupedViews: 0,
+                activeIncrementalGroupedViews: 0,
+                activeViews: 0,
+                groupedFullEvaluationCount: 0,
+                groupedPatchedEvaluationCount: 0,
+                activeSubscriptions: 0,
+                queuedEvents: 0,
+                maxQueueDepth: 0,
+                backpressureEvents: 0,
+                memoryBytes: 0,
+                tombstoneCount: 0,
+                compactionPending: false,
+                kafkaLag: 0n,
+                updatedAtNanos: expect.anything(),
+              },
+            ],
+            totalRows: 1,
+          },
+        ]);
+
+        yield* detail.close();
+        yield* liveClient.close;
+      }),
+  );
+
+  it.effect(
+    "rejects pending pushed health subscriptions when live client closes during refresh",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+        const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+        const refreshStarted = yield* Deferred.make<void>();
+        const releaseRefresh = yield* Deferred.make<void>();
+        const liveClient = yield* makeRuntimeCoreLiveClient(
+          engine,
+          health,
+          Effect.gen(function* () {
+            yield* Deferred.succeed(refreshStarted, undefined);
+            yield* Deferred.await(releaseRefresh);
+            return health.value;
+          }),
+        );
+
+        const summaryFiber = yield* liveClient
+          .subscribeHealthSummary()
+          .pipe(Effect.flip, Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(refreshStarted).pipe(Effect.timeout("1 second"));
+        const closeFiber = yield* liveClient.close.pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Deferred.succeed(releaseRefresh, undefined);
+
+        const closedSummary = yield* Fiber.join(summaryFiber).pipe(Effect.timeout("1 second"));
+        yield* Fiber.join(closeFiber).pipe(Effect.timeout("1 second"));
+
+        expect(closedSummary).toStrictEqual({
+          _tag: "ViewServerRuntimeError",
+          code: "RuntimeUnavailable",
+          message: "Runtime Core is closed.",
+        });
+      }),
+  );
+
+  it.effect("closes slow runtime health summary subscriptions from real health refreshes", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {
+        healthRefreshCadence: "1 minute",
+      });
+      const summary = yield* runtimeCore.liveClient.subscribeHealthSummary();
+
+      yield* Effect.forEach(
+        Array.from({ length: 64 }, (_, index) => index),
+        (index) =>
+          runtimeCore.client
+            .publish("orders", order(`slow-health-${index}`, index))
+            .pipe(Effect.andThen(runtimeCore.client.health()), Effect.andThen(Effect.yieldNow)),
+      );
+      const events = yield* summary.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "__view_server_health_summary",
+          queryId: "health-summary",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message:
+            "Runtime health subscription closed because its event queue exceeded capacity with 64 queued event(s).",
+        },
+      ]);
+
+      yield* summary.close();
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("closes slow pushed detailed health subscriptions with typed backpressure", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+      const liveClient = yield* makeRuntimeCoreLiveClient(
+        engine,
+        health,
+        Effect.sync(() => health.value),
+      );
+      const detail = yield* liveClient.subscribeHealth();
+
+      yield* Effect.forEach(
+        Array.from({ length: 64 }, (_, index) => index),
+        (index) =>
+          Effect.sync(() => {
+            health.update(() => healthFromEngine(engineHealth("ready", index + 1)));
+          }).pipe(Effect.andThen(Effect.yieldNow)),
+      );
+      const events = yield* detail.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "__view_server_health",
+          queryId: "health",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message:
+            "Runtime health subscription closed because its event queue exceeded capacity with 64 queued event(s).",
+        },
+      ]);
+
+      yield* detail.close();
+      yield* liveClient.close;
+    }),
+  );
+
   it.effect("closes active pushed health subscriptions when the live client closes", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -51,6 +51,20 @@ const ignoreRuntimeHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTy
   "Ignoring runtime health refresh failure.",
 );
 
+const runtimeHealthBackpressureStatus = <Topic extends string>(
+  topic: Topic,
+  queryId: string,
+  queuedEvents: number,
+) =>
+  ({
+    type: "status",
+    topic,
+    queryId,
+    status: "closed",
+    code: "BackpressureExceeded",
+    message: `Runtime health subscription closed because its event queue exceeded capacity with ${queuedEvents} queued event(s).`,
+  }) satisfies ViewServerLiveEvent<never, Topic, never>;
+
 export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveClient.make")(
   <const Topics extends DecodableTopicDefinitions>(
     engine: ColumnLiveViewEngine<Topics>,
@@ -114,7 +128,12 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
           ),
         );
       };
-      const activeHealthSubscriptions = new Set<{ close: Effect.Effect<void> }>();
+      type ActiveHealthSubscription = {
+        close: Effect.Effect<void>;
+        claimClosed: () => boolean;
+        finishClosed: Effect.Effect<void>;
+      };
+      const activeHealthSubscriptions = new Set<ActiveHealthSubscription>();
       const healthSubscriptionLock = Semaphore.makeUnsafe(1);
       let healthSubscriptionsClosed = false;
       const closeActiveHealthSubscriptions = Effect.suspend(() =>
@@ -123,13 +142,16 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
             Effect.sync(() => {
               healthSubscriptionsClosed = true;
               const subscriptions = Array.from(activeHealthSubscriptions);
+              const claimedSubscriptions = subscriptions.filter((subscription) =>
+                subscription.claimClosed(),
+              );
               activeHealthSubscriptions.clear();
-              return subscriptions;
+              return claimedSubscriptions;
             }),
           )
           .pipe(
             Effect.andThen((subscriptions) =>
-              runAllFinalizers(subscriptions.map((subscription) => subscription.close)),
+              runAllFinalizers(subscriptions.map((subscription) => subscription.finishClosed)),
             ),
           ),
       ).pipe(ignoreHealthSubscriptionCloseFailure);
@@ -144,6 +166,8 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         Key extends string,
         Row extends { readonly id: Key },
       >(
+        topic: Topic,
+        queryId: string,
         snapshotFromHealth: (
           nextHealth: ViewServerHealth<Topics>,
           updatedAtNanos: bigint,
@@ -151,48 +175,125 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
       ) {
         return yield* Effect.uninterruptible(
           Effect.gen(function* () {
-            const queue = yield* Queue.bounded<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(
+            const queue = yield* Queue.dropping<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(
               64,
             );
             const updates = yield* Queue.sliding<ViewServerHealth<Topics>, Cause.Done>(1);
             const subscriptionScope = yield* Scope.make("parallel");
             const closeSubscriptionScope = Scope.close(subscriptionScope, Exit.void);
-            const subscription = { close: Effect.void };
             let subscriptionClosed = false;
+            let unsubscribe: () => void;
+            const claimClosed = () => {
+              if (subscriptionClosed) {
+                return false;
+              }
+              subscriptionClosed = true;
+              unsubscribe();
+              return true;
+            };
+            const subscription: ActiveHealthSubscription = {
+              close: Effect.void,
+              claimClosed,
+              finishClosed: Effect.void,
+            };
+            type HealthSubscriptionCloseReason =
+              | {
+                  readonly _tag: "normal";
+                }
+              | {
+                  readonly _tag: "backpressure";
+                  readonly queuedEvents: number;
+                };
+            type HealthSnapshotOfferResult =
+              | {
+                  readonly _tag: "offered";
+                }
+              | {
+                  readonly _tag: "closed";
+                }
+              | {
+                  readonly _tag: "backpressure";
+                  readonly queuedEvents: number;
+                };
+            const releaseSubscriptionResources = Effect.fn(
+              "ViewServerRuntimeCore.health.subscription.releaseResources",
+            )(function* () {
+              yield* Queue.end(updates);
+              yield* closeSubscriptionScope;
+            });
+            const finishClosedSubscription = Effect.fn(
+              "ViewServerRuntimeCore.health.subscription.finishClosed",
+            )(function* (reason: HealthSubscriptionCloseReason) {
+              if (reason._tag === "backpressure") {
+                yield* Queue.clear(queue);
+                yield* Queue.offer(
+                  queue,
+                  runtimeHealthBackpressureStatus(topic, queryId, reason.queuedEvents),
+                );
+              }
+              yield* Queue.end(queue);
+              yield* releaseSubscriptionResources();
+            });
+            const closeSubscription = Effect.fn("ViewServerRuntimeCore.health.subscription.close")(
+              function* (reason: HealthSubscriptionCloseReason) {
+                const shouldClose = yield* healthSubscriptionLock.withPermit(
+                  Effect.sync(() => {
+                    const claimed = subscription.claimClosed();
+                    if (claimed) {
+                      activeHealthSubscriptions.delete(subscription);
+                    }
+                    return claimed;
+                  }),
+                );
+                if (shouldClose) {
+                  yield* finishClosedSubscription(reason);
+                }
+              },
+            );
+            const releaseSubscriptionAndEndQueue = () => closeSubscription({ _tag: "normal" });
+            subscription.finishClosed = finishClosedSubscription({ _tag: "normal" });
             const offerSnapshot = Effect.fn("ViewServerRuntimeCore.health.snapshot.offer")(
               function* (nextHealth: ViewServerHealth<Topics>) {
                 const updatedAtNanos = yield* Clock.currentTimeNanos;
-                yield* Queue.offer(queue, snapshotFromHealth(nextHealth, updatedAtNanos));
+                const snapshot = snapshotFromHealth(nextHealth, updatedAtNanos);
+                const offerResult: HealthSnapshotOfferResult =
+                  yield* healthSubscriptionLock.withPermit(
+                    Effect.gen(function* () {
+                      if (subscriptionClosed || healthSubscriptionsClosed) {
+                        const closed: HealthSnapshotOfferResult = { _tag: "closed" };
+                        return closed;
+                      }
+                      const offered = yield* Queue.offer(queue, snapshot);
+                      if (offered) {
+                        const offeredResult: HealthSnapshotOfferResult = { _tag: "offered" };
+                        return offeredResult;
+                      }
+                      const queuedEvents = yield* Queue.size(queue);
+                      subscriptionClosed = true;
+                      unsubscribe();
+                      activeHealthSubscriptions.delete(subscription);
+                      const backpressure: HealthSnapshotOfferResult = {
+                        _tag: "backpressure",
+                        queuedEvents,
+                      };
+                      return backpressure;
+                    }),
+                  );
+                if (offerResult._tag === "closed") {
+                  return yield* Effect.fail(runtimeClosedError);
+                }
+                if (offerResult._tag === "backpressure") {
+                  yield* finishClosedSubscription(offerResult);
+                  return yield* Effect.interrupt;
+                }
               },
             );
-            yield* Stream.fromQueue(updates).pipe(
-              Stream.runForEach(offerSnapshot),
-              Effect.forkIn(subscriptionScope, { startImmediately: true }),
-            );
-            const unsubscribe = health.subscribe((nextHealth) => {
+            unsubscribe = health.subscribe((nextHealth) => {
               Queue.offerUnsafe(updates, nextHealth);
-            });
-            const releaseSubscription = Effect.gen(function* () {
-              const shouldClose = yield* healthSubscriptionLock.withPermit(
-                Effect.sync(() => {
-                  if (subscriptionClosed) {
-                    return false;
-                  }
-                  subscriptionClosed = true;
-                  unsubscribe();
-                  activeHealthSubscriptions.delete(subscription);
-                  return true;
-                }),
-              );
-              if (shouldClose) {
-                yield* Queue.end(updates);
-                yield* closeSubscriptionScope;
-                yield* Queue.end(queue);
-              }
             });
             const registered = yield* healthSubscriptionLock.withPermit(
               Effect.sync(() => {
-                subscription.close = releaseSubscription;
+                subscription.close = releaseSubscriptionAndEndQueue();
                 if (healthSubscriptionsClosed) {
                   return false;
                 }
@@ -201,13 +302,17 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
               }),
             );
             if (!registered) {
-              yield* releaseSubscription;
+              yield* releaseSubscriptionAndEndQueue();
               return yield* Effect.fail(runtimeClosedError);
             }
             const latestHealth = yield* refreshHealth.pipe(
-              Effect.onError(() => releaseSubscription),
+              Effect.onError(() => releaseSubscriptionAndEndQueue()),
             );
             yield* offerSnapshot(latestHealth);
+            yield* Stream.fromQueue(updates).pipe(
+              Stream.runForEach(offerSnapshot),
+              Effect.forkIn(subscriptionScope, { startImmediately: true }),
+            );
             return {
               events: Stream.fromQueue(queue).pipe(Stream.ensuring(subscription.close)),
               close: () => subscription.close,
@@ -223,7 +328,7 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
             typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
             "summary",
             ViewServerHealthSummaryRow<Topics>
-          >((nextHealth, updatedAtNanos) => ({
+          >(VIEW_SERVER_HEALTH_SUMMARY_TOPIC, "health-summary", (nextHealth, updatedAtNanos) => ({
             type: "snapshot",
             topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
             queryId: "health-summary",
@@ -237,7 +342,7 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
             typeof VIEW_SERVER_HEALTH_TOPIC,
             Extract<keyof Topics, string>,
             ViewServerHealthTopicRow<Extract<keyof Topics, string>>
-          >((nextHealth, updatedAtNanos) => {
+          >(VIEW_SERVER_HEALTH_TOPIC, "health", (nextHealth, updatedAtNanos) => {
             const rows = viewServerHealthTopicRowsFromHealth(nextHealth, updatedAtNanos);
             return {
               type: "snapshot",


### PR DESCRIPTION
## Summary
- bound pushed runtime health summary/detail subscriptions with dropping queues
- emit typed BackpressureExceeded terminal status when slow health consumers overflow
- linearize normal close, global close, close-during-refresh, and backpressure close ownership under the health subscription lock
- add runtime-core regressions for slow summary/detail consumers, close during refresh, and queued refresh-time health updates

## Validation
- pnpm --filter @view-server/runtime-core run test
- pnpm exec effect-language-service diagnostics --project packages/runtime-core/tsconfig.json --format text --severity error
- vp check --fix
- pnpm run ready

## Review
- 3-agent review loop completed; final race-fix reviewers found no actionable issues