### PR TITLE
Carry raw window slots for projection

### DIFF
--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -41,6 +41,7 @@ type ActiveQueryBaseEvaluation<Row extends RowObject> = {
 type RetainedWindowEntry<Row extends RowObject = RowObject> = TopicRowEntry<Row> & {
   readonly key: string;
   readonly row: Row;
+  readonly slot?: number;
 };
 
 type RetainedReplacementResult<Row extends RowObject> = {
@@ -96,10 +97,18 @@ const evaluateBaseQuery = <Row extends RowObject, ResultRow extends RowObject>(
 ): ActiveQueryBaseEvaluation<Row> => {
   const version = store.version();
   const scanResult = store.scanRawWindow(rawQueryWindowScanPlan(compiled.plan, queryWindow));
-  const window = scanResult.window.map((entry) => ({
-    key: entry.key,
-    row: entry.row,
-  }));
+  const window = scanResult.window.map((entry) =>
+    entry.slot === undefined
+      ? {
+          key: entry.key,
+          row: entry.row,
+        }
+      : {
+          key: entry.key,
+          row: entry.row,
+          slot: entry.slot,
+        },
+  );
   return {
     ...scanResult,
     retainedWindowFilled: retainedWindowFilled(window, scanResult.totalRows, queryWindow),
@@ -378,7 +387,11 @@ const projectRetainedEntry = <Row extends RowObject, ResultRow extends RowObject
   compiled: CompiledRawQuery<Row, ResultRow>,
   entry: RetainedWindowEntry<Row>,
 ): ResultRow => {
-  const slot = store.slotForKey?.(entry.key);
+  const carriedSlot =
+    entry.slot !== undefined && store.keyAtSlot?.(entry.slot) === entry.key
+      ? entry.slot
+      : undefined;
+  const slot = carriedSlot ?? store.slotForKey?.(entry.key);
   const projectRawRow = store.projectRawRow;
   return slot === undefined || projectRawRow === undefined
     ? compiled.plan.project(entry.row)

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -3791,6 +3791,193 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
     }),
   );
 
+  it.effect("projects raw snapshots from carried storage slots", () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id", "price"],
+        },
+      );
+      let slotForKeyCalls = 0;
+      const evaluation = evaluateRawQuery(
+        {
+          keyAtSlot: (slot) => `key-at-slot-${slot}`,
+          projectRawRow: (slot) => ({
+            id: `projected-from-slot-${slot}`,
+            price: slot * 10,
+          }),
+          scanRawWindow: () => ({
+            keys: ["key-at-slot-2"],
+            window: [
+              {
+                key: "key-at-slot-2",
+                row: order("row-object-should-not-project", "open", 1, 1),
+                slot: 2,
+              },
+            ],
+            totalRows: 1,
+          }),
+          slotForKey: () => {
+            slotForKeyCalls += 1;
+            return 99;
+          },
+          version: () => 1,
+        },
+        compiled,
+      );
+
+      expect(evaluation).toStrictEqual({
+        keys: ["key-at-slot-2"],
+        rows: [
+          {
+            id: "projected-from-slot-2",
+            price: 20,
+          },
+        ],
+        totalRows: 1,
+        version: 1,
+        window: [
+          {
+            key: "key-at-slot-2",
+            row: {
+              id: "projected-from-slot-2",
+              price: 20,
+            },
+          },
+        ],
+      });
+      expect(slotForKeyCalls).toBe(0);
+    }),
+  );
+
+  it.effect("falls back to key lookup when a carried storage slot is stale", () =>
+    Effect.gen(function* () {
+      const compiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id", "price"],
+        },
+      );
+      let slotForKeyCalls = 0;
+      const slotsByKey = new Map([["moved-row", 3]]);
+      const evaluation = evaluateRawQuery(
+        {
+          keyAtSlot: (slot) => `different-key-at-slot-${slot}`,
+          projectRawRow: (slot) => ({
+            id: `projected-from-slot-${slot}`,
+            price: slot * 10,
+          }),
+          scanRawWindow: () => ({
+            keys: ["moved-row"],
+            window: [
+              {
+                key: "moved-row",
+                row: order("row-object-should-not-project", "open", 1, 1),
+                slot: 0,
+              },
+            ],
+            totalRows: 1,
+          }),
+          slotForKey: (key) => {
+            slotForKeyCalls += 1;
+            return slotsByKey.get(key);
+          },
+          version: () => 2,
+        },
+        compiled,
+      );
+
+      expect(evaluation).toStrictEqual({
+        keys: ["moved-row"],
+        rows: [
+          {
+            id: "projected-from-slot-3",
+            price: 30,
+          },
+        ],
+        totalRows: 1,
+        version: 2,
+        window: [
+          {
+            key: "moved-row",
+            row: {
+              id: "projected-from-slot-3",
+              price: 30,
+            },
+          },
+        ],
+      });
+      expect(slotForKeyCalls).toBe(1);
+    }),
+  );
+
+  it.effect("projects raw snapshots correctly after storage delete compacts slots", () =>
+    Effect.gen(function* () {
+      const storage = new TopicRowStorage("orders", Order, "id");
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
+      storage.setPrepared(yield* storage.prepareRow(order("deleted", "open", 10, 1), invalidRow));
+      storage.advanceVersion();
+      storage.setPrepared(yield* storage.prepareRow(order("retained", "open", 20, 2), invalidRow));
+      storage.advanceVersion();
+      storage.setPrepared(yield* storage.prepareRow(order("moved", "open", 30, 3), invalidRow));
+      storage.advanceVersion();
+
+      storage.delete("retained");
+      storage.advanceVersion();
+
+      const compiled = yield* prepareRawQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          select: ["id", "price", "updatedAt"],
+          orderBy: [{ field: "price", direction: "desc" }],
+          limit: 2,
+        },
+      );
+      const evaluation = evaluateRawQuery(storage.readModel, compiled);
+
+      expect(evaluation).toStrictEqual({
+        keys: ["moved", "deleted"],
+        rows: [
+          {
+            id: "moved",
+            price: 30,
+            updatedAt: 3,
+          },
+          {
+            id: "deleted",
+            price: 10,
+            updatedAt: 1,
+          },
+        ],
+        totalRows: 2,
+        version: 4,
+        window: [
+          {
+            key: "moved",
+            row: {
+              id: "moved",
+              price: 30,
+              updatedAt: 3,
+            },
+          },
+          {
+            key: "deleted",
+            row: {
+              id: "deleted",
+              price: 10,
+              updatedAt: 1,
+            },
+          },
+        ],
+      });
+    }),
+  );
+
   it.effect("passes scalar ordering semantics to custom storage scanners", () =>
     Effect.gen(function* () {
       const active = { key: "active", row: position("active", "AAPL", 1n, "1", true) };

--- a/packages/column-live-view-engine/src/raw-window-scan.ts
+++ b/packages/column-live-view-engine/src/raw-window-scan.ts
@@ -24,14 +24,19 @@ export type TopicRawWindowScanPlan<Row extends RowObject> = {
 
 export type TopicRawWindowScanResult<Row extends RowObject> = {
   readonly keys: ReadonlyArray<string>;
-  readonly window: ReadonlyArray<TopicRowEntry<Row>>;
+  readonly window: ReadonlyArray<TopicRawWindowEntry<Row>>;
   readonly totalRows: number;
+};
+
+export type TopicRawWindowEntry<Row extends RowObject> = TopicRowEntry<Row> & {
+  readonly slot?: number;
 };
 
 export type TopicRawWindowScan<Row extends RowObject> = {
   readonly compareRawSlots?: (
     plan: TopicRawWindowScanPlan<Row>,
   ) => ((leftSlot: number, rightSlot: number) => number) | undefined;
+  readonly keyAtSlot?: (slot: number) => string | undefined;
   readonly projectRawRow?: (slot: number, selectedFields: ReadonlyArray<string>) => RowObject;
   readonly scanRawWindow: (plan: TopicRawWindowScanPlan<Row>) => TopicRawWindowScanResult<Row>;
   readonly slotForKey?: (key: string) => number | undefined;

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -1,6 +1,10 @@
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
-import type { TopicRawWindowScanPlan, TopicRawWindowScanResult } from "./raw-window-scan";
+import type {
+  TopicRawWindowEntry,
+  TopicRawWindowScanPlan,
+  TopicRawWindowScanResult,
+} from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
 import type { TopicColumnValues } from "./topic-column-vector";
 import {
@@ -434,7 +438,10 @@ const rawWindowScanResult = (
   windowSlots: ReadonlyArray<number>,
   totalRows: number,
 ): TopicRawWindowScanResult<RowObject> => {
-  const window = windowSlots.map((slot) => state.slots[slot]!);
+  const window: Array<TopicRawWindowEntry<RowObject>> = windowSlots.map((slot) => ({
+    ...state.slots[slot]!,
+    slot,
+  }));
   return {
     keys: window.map((entry) => entry.key),
     window,

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -131,6 +131,7 @@ export class TopicRowStorage {
       topic,
       changesSince: (version) => this.changesSince(version),
       compareRawSlots: (plan) => this.compareRawSlots(plan),
+      keyAtSlot: (slot) => this.keyAtSlot(slot),
       projectRawRow: (slot, selectedFields) => this.projectRawRow(slot, selectedFields),
       releaseChanges: () => this.releaseChanges(),
       retainChanges: () => this.retainChanges(),
@@ -286,6 +287,10 @@ export class TopicRowStorage {
 
   slotForKey(key: string): number | undefined {
     return this.keyToSlot.get(key);
+  }
+
+  keyAtSlot(slot: number): string | undefined {
+    return this.slots[slot]?.key;
   }
 
   prepareRow = Effect.fn("ColumnLiveViewEngine.topicRowStorage.row.prepare")(function* <


### PR DESCRIPTION
Summary:
- Carry optional raw window slot metadata from storage scans into active raw query evaluation.
- Use keyAtSlot validation before slot-based column projection, falling back to slotForKey or row projection when stale or unavailable.
- Add projection tests for carried slots, stale-slot fallback, and real TopicRowStorage delete compaction.

Validation:
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error
- vp run @view-server/column-live-view-engine#build
- VIEW_SERVER_ENGINE_BENCH_ROWS=1000 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=3 VIEW_SERVER_ENGINE_BENCH_TIME_MS=1 VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS=0 VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS=0 pnpm --filter @view-server/column-live-view-engine run bench:raw-snapshot

Review:
- 3 local reviewer agents: clean after second review pass.
- Non-blocker noted: synthetic stale-slot test covers stale retained slot, real-storage test covers fresh projection after delete compaction.