### PR TITLE
Use slot comparator for retained replacements

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -812,6 +812,100 @@ describe("column-live-view-engine active query execution", () => {
     }),
   );
 
+  it.effect(
+    "keeps retained replacement batches sorted when multiple rows update before polling",
+    () =>
+      Effect.gen(function* () {
+        const store = new TopicStore(
+          "raw-match-update-batched-replacements",
+          Schema.Struct({
+            id: Schema.String,
+            status: Schema.String,
+            score: Schema.Number,
+          }),
+          "id",
+          () => {},
+        );
+        yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 3 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 1 }, invalidRow);
+
+        const scanLimits: Array<number | undefined> = [];
+        const readModel = topicStoreReadModel(store);
+        const observedReadModel = {
+          ...readModel,
+          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+            scanLimits.push(plan.limit);
+            return readModel.scanRawWindow(plan);
+          },
+        };
+
+        const compiled = yield* prepareRawQuery(
+          "raw-match-update-batched-replacements",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id", "score"],
+            where: {
+              status: "open",
+            },
+            orderBy: [{ field: "score", direction: "desc" }],
+          },
+        );
+
+        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        expect(execution.initial("query").keys).toStrictEqual(["a", "b", "c"]);
+        const cursor = execution.createCursor();
+
+        yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 4 }, invalidRow);
+        yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 5 }, invalidRow);
+
+        const delta = yield* execution.next("query", cursor);
+        expect(Option.getOrThrow(delta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-match-update-batched-replacements",
+          queryId: "query",
+          fromVersion: 3,
+          toVersion: 5,
+          operations: [
+            {
+              type: "move",
+              key: "c",
+              fromIndex: 2,
+              toIndex: 0,
+            },
+            {
+              type: "update",
+              key: "c",
+              row: {
+                id: "c",
+                score: 5,
+              },
+              index: 0,
+            },
+            {
+              type: "move",
+              key: "b",
+              fromIndex: 2,
+              toIndex: 1,
+            },
+            {
+              type: "update",
+              key: "b",
+              row: {
+                id: "b",
+                score: 4,
+              },
+              index: 1,
+            },
+          ],
+          totalRows: 3,
+        });
+        expect(scanLimits).toStrictEqual([undefined]);
+
+        yield* releaseRawQueryExecution(observedReadModel, compiled);
+      }),
+  );
+
   it.effect("falls back when retained match-to-match raw updates touch outside lookahead", () =>
     Effect.gen(function* () {
       const store = new TopicStore(

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -121,7 +121,8 @@ const replaceRetainedMatchingEntry = <Row extends RowObject>(
   windowEntries: ReadonlyArray<RetainedWindowEntry<Row>>,
   key: string,
   row: Row,
-  compare: (left: RetainedWindowEntry<Row>, right: RetainedWindowEntry<Row>) => number,
+  comparePrevious: (left: RetainedWindowEntry<Row>, right: RetainedWindowEntry<Row>) => number,
+  compareInsertion: (left: RetainedWindowEntry<Row>, right: RetainedWindowEntry<Row>) => number,
   retainedLimit: number | undefined,
 ): RetainedReplacementResult<Row> | undefined => {
   let previousIndex = -1;
@@ -137,7 +138,7 @@ const replaceRetainedMatchingEntry = <Row extends RowObject>(
     return undefined;
   }
   const nextEntry: RetainedWindowEntry<Row> = { key, row };
-  if (retainedLimit !== undefined && compare(nextEntry, previousEntry) > 0) {
+  if (retainedLimit !== undefined && comparePrevious(nextEntry, previousEntry) > 0) {
     return undefined;
   }
   const withoutPrevious = [
@@ -147,7 +148,7 @@ const replaceRetainedMatchingEntry = <Row extends RowObject>(
   const insertionIndex = insertionIndexForSortedRetainedEntries(
     withoutPrevious,
     nextEntry,
-    compare,
+    compareInsertion,
   );
   const replaced = [
     ...withoutPrevious.slice(0, insertionIndex),
@@ -193,7 +194,9 @@ const updateBaseEvaluationFromRetainedChanges = (
   let totalRows = evaluation.totalRows;
   let windowEntries = evaluation.window;
   let removedRetainedEntry = false;
+  let replacedRetainedEntry = false;
   const insertedWindowEntries = new Map<string, RetainedWindowEntry>();
+  const compareRetainedEntries = retainedEntrySortComparator(store, compiled, queryWindow);
   for (const batch of batches) {
     for (const change of batch.changes) {
       const previousMatches =
@@ -224,12 +227,14 @@ const updateBaseEvaluationFromRetainedChanges = (
             change.key,
             change.next,
             compiled.plan.compare,
+            compareRetainedEntries,
             queryWindow.limit,
           );
           if (replacedWindow === undefined) {
             return undefined;
           }
           windowEntries = replacedWindow.window;
+          replacedRetainedEntry = true;
           continue;
         }
         if (previousMatches) {
@@ -273,6 +278,10 @@ const updateBaseEvaluationFromRetainedChanges = (
     };
   }
 
+  if (replacedRetainedEntry) {
+    windowEntries = [...windowEntries].sort(compareRetainedEntries);
+  }
+
   const requiredWindowEntries =
     queryWindow.limit === undefined ? undefined : Math.max(0, queryWindow.limit - 1);
   if (
@@ -304,7 +313,6 @@ const updateBaseEvaluationFromRetainedChanges = (
     return undefined;
   }
 
-  const compareRetainedEntries = retainedEntrySortComparator(store, compiled, queryWindow);
   const window = [...windowEntries, ...insertedWindowEntries.values()].sort(compareRetainedEntries);
   const retainedLimit =
     removedRetainedEntry && requiredWindowEntries !== undefined


### PR DESCRIPTION
Summary:
- Split retained replacement comparison into old-vs-new row comparison and insertion comparison.
- Use the slot-aware retained comparator for insertion among current retained rows.
- Sort retained entries after replaying replacement batches so multi-change batches cannot violate sorted-window invariants.
- Add a batched retained replacement regression that verifies no rescan and correct delta order.

Validation:
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --severity error
- VIEW_SERVER_ENGINE_BENCH_ROWS=1000 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=5 VIEW_SERVER_ENGINE_BENCH_RETAINED_CASE=match-update pnpm --filter @view-server/column-live-view-engine run bench:raw-active-retained-delta

Review:
- 3 local reviewer agents ran.
- One reviewer found a real blocker in the first version: current-slot comparator could break sorted-array preconditions during multi-change replay.
- Fixed with post-replay retained sort and regression; 3-agent re-review clean.