### PR TITLE
Preserve retained lookahead after safe inserts

### DIFF
--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -2578,6 +2578,182 @@ describe("column-live-view-engine active query execution", () => {
     }),
   );
 
+  it.effect(
+    "preserves large retained lookahead when matching inserts safely refill a removal batch",
+    () =>
+      Effect.gen(function* () {
+        const store = new TopicStore(
+          "raw-visible-delete-insert-preserves-lookahead",
+          Schema.Struct({
+            id: Schema.String,
+            status: Schema.String,
+            score: Schema.Number,
+          }),
+          "id",
+          () => {},
+        );
+        yield* publishTopicStoreRows(
+          store,
+          Array.from({ length: 220 }, (_value, index) => ({
+            id: `row-${index}`,
+            status: "open",
+            score: index,
+          })),
+          invalidRow,
+        );
+
+        const scanLimits: Array<number | undefined> = [];
+        const readModel = topicStoreReadModel(store);
+        const observedReadModel = {
+          ...readModel,
+          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+            scanLimits.push(plan.limit);
+            return readModel.scanRawWindow(plan);
+          },
+        };
+
+        const wideCompiled = yield* prepareRawQuery(
+          "raw-visible-delete-insert-preserves-lookahead",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id", "score"],
+            where: {
+              status: "open",
+            },
+            orderBy: [{ field: "score", direction: "desc" }],
+            limit: 128,
+          },
+        );
+        const narrowCompiled = yield* prepareRawQuery(
+          "raw-visible-delete-insert-preserves-lookahead",
+          topicStoreRawQueryMetadata(store),
+          {
+            select: ["id", "score"],
+            where: {
+              status: "open",
+            },
+            orderBy: [{ field: "score", direction: "desc" }],
+            limit: 2,
+          },
+        );
+
+        const wideExecution = yield* acquireRawQueryExecution(observedReadModel, wideCompiled);
+        const narrowExecution = yield* acquireRawQueryExecution(observedReadModel, narrowCompiled);
+        expect(wideExecution.initial("wide-query").keys.slice(0, 3)).toStrictEqual([
+          "row-219",
+          "row-218",
+          "row-217",
+        ]);
+        expect(narrowExecution.initial("query").keys).toStrictEqual(["row-219", "row-218"]);
+        const cursor = narrowExecution.createCursor();
+
+        yield* publishTopicStoreRows(
+          store,
+          [
+            ...Array.from({ length: 16 }, (_value, offset) => ({
+              id: `row-${219 - offset}`,
+              status: "closed",
+              score: 219 - offset,
+            })),
+            ...Array.from({ length: 16 }, (_value, offset) => ({
+              id: `new-${offset}`,
+              status: "open",
+              score: 1_000 + offset,
+            })),
+          ],
+          invalidRow,
+        );
+        const firstDelta = yield* narrowExecution.next("query", cursor);
+        expect(Option.getOrThrow(firstDelta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-visible-delete-insert-preserves-lookahead",
+          queryId: "query",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "remove",
+              key: "row-219",
+            },
+            {
+              type: "remove",
+              key: "row-218",
+            },
+            {
+              type: "insert",
+              key: "new-15",
+              row: {
+                id: "new-15",
+                score: 1015,
+              },
+              index: 0,
+            },
+            {
+              type: "insert",
+              key: "new-14",
+              row: {
+                id: "new-14",
+                score: 1014,
+              },
+              index: 1,
+            },
+          ],
+          totalRows: 220,
+        });
+
+        yield* publishTopicStoreRows(
+          store,
+          Array.from({ length: 16 }, (_value, offset) => ({
+            id: `new-${offset}`,
+            status: "closed",
+            score: 1_000 + offset,
+          })),
+          invalidRow,
+        );
+        const secondDelta = yield* narrowExecution.next("query", cursor);
+        expect(Option.getOrThrow(secondDelta)).toStrictEqual({
+          type: "delta",
+          topic: "raw-visible-delete-insert-preserves-lookahead",
+          queryId: "query",
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            {
+              type: "remove",
+              key: "new-15",
+            },
+            {
+              type: "remove",
+              key: "new-14",
+            },
+            {
+              type: "insert",
+              key: "row-203",
+              row: {
+                id: "row-203",
+                score: 203,
+              },
+              index: 0,
+            },
+            {
+              type: "insert",
+              key: "row-202",
+              row: {
+                id: "row-202",
+                score: 202,
+              },
+              index: 1,
+            },
+          ],
+          totalRows: 204,
+        });
+        expect(scanLimits).toStrictEqual([192]);
+
+        yield* releaseRawQueryExecution(observedReadModel, narrowCompiled);
+        yield* releaseRawQueryExecution(observedReadModel, wideCompiled);
+      }),
+  );
+
   it.effect("shrinks shared base windows immediately when larger windows release", () =>
     Effect.gen(function* () {
       const store = new TopicStore(

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -152,6 +152,30 @@ const retainedEntrySortComparator = <Row extends RowObject, ResultRow extends Ro
   };
 };
 
+const retainedLimitAfterInsertedChanges = (
+  compareRetainedEntries: (
+    left: RetainedWindowEntry<RowObject>,
+    right: RetainedWindowEntry<RowObject>,
+  ) => number,
+  insertedWindowEntries: ReadonlyMap<string, RetainedWindowEntry>,
+  queryWindow: RawQueryPlanWindow,
+  requiredWindowEntries: number | undefined,
+  removedRetainedEntry: boolean,
+  windowEntries: ReadonlyArray<RetainedWindowEntry>,
+): number | undefined => {
+  if (!removedRetainedEntry || requiredWindowEntries === undefined) {
+    return queryWindow.limit;
+  }
+  const retainedTail = windowEntries[windowEntries.length - 1]!;
+  let safeInsertedEntries = 0;
+  for (const insertedEntry of insertedWindowEntries.values()) {
+    if (compareRetainedEntries(insertedEntry, retainedTail) <= 0) {
+      safeInsertedEntries += 1;
+    }
+  }
+  return Math.min(queryWindow.limit!, windowEntries.length + safeInsertedEntries);
+};
+
 const updateBaseEvaluationFromRetainedChanges = (
   store: ActiveQueryStoreState,
   compiled: CompiledRawQuery<object, object>,
@@ -301,10 +325,14 @@ const updateBaseEvaluationFromRetainedChanges = (
   }
 
   const window = [...windowEntries, ...insertedWindowEntries.values()].sort(compareRetainedEntries);
-  const retainedLimit =
-    removedRetainedEntry && requiredWindowEntries !== undefined
-      ? requiredWindowEntries
-      : queryWindow.limit;
+  const retainedLimit = retainedLimitAfterInsertedChanges(
+    compareRetainedEntries,
+    insertedWindowEntries,
+    queryWindow,
+    requiredWindowEntries,
+    removedRetainedEntry,
+    windowEntries,
+  );
   const limitedWindow = retainedLimit === undefined ? window : window.slice(0, retainedLimit);
   return {
     keyIndex: retainedWindowKeyIndex(limitedWindow),


### PR DESCRIPTION
## Summary
- preserve retained lookahead when mixed batches remove retained rows and insert matching rows that safely sort above the retained tail
- add an active-query regression proving a mixed close+insert batch keeps the large retained cushion and avoids a later fallback scan

## Validation
- pnpm --filter @view-server/column-live-view-engine run test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- VIEW_SERVER_ENGINE_BENCH_ROWS=100000 VIEW_SERVER_ENGINE_BENCH_ITERATIONS=4 VIEW_SERVER_ENGINE_BENCH_TIME_MS=0 VIEW_SERVER_ENGINE_BENCH_WARMUP_ITERATIONS=0 VIEW_SERVER_ENGINE_BENCH_WARMUP_TIME_MS=0 VIEW_SERVER_ENGINE_BENCH_RETAINED_CASE=visible-delete-batch VIEW_SERVER_ENGINE_BENCH_RETAINED_WINDOW_LIMIT=1000 VIEW_SERVER_ENGINE_BENCH_REPLACEMENT_BATCH_SIZE=16 pnpm --filter @view-server/column-live-view-engine run bench:raw-active-retained-delta

## Review loop
- 3 local reviewer agents reviewed the slice
- final reviewer pass: no findings
- residual risks noted: fixed +64 lookahead remains heuristic; conservative fallback still leaves some future mixed-batch optimization on the table