### PR TITLE
Optimize row equality for shared references

### DIFF
--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -11372,6 +11372,20 @@ describe("ColumnLiveViewEngine validation and health", () => {
     expect(rowsEqual({ id: "1" }, { id: "1", note: "new" })).toBe(false);
   });
 
+  it("treats identical row references as equal without structural comparison", () => {
+    let getterReads = 0;
+    const row = {
+      id: "1",
+      get status() {
+        getterReads += 1;
+        return "open";
+      },
+    };
+
+    expect(rowsEqual(row, row)).toBe(true);
+    expect(getterReads).toBe(0);
+  });
+
   it("does not structurally compare map and set values on row hot paths", () => {
     expect(valuesEqual(new Map([["venue", "xnys"]]), new Map([["venue", "xnys"]]))).toBe(false);
     expect(valuesEqual(new Set(["xnys"]), new Set(["xnys"]))).toBe(false);

--- a/packages/column-live-view-engine/src/row-values.ts
+++ b/packages/column-live-view-engine/src/row-values.ts
@@ -114,6 +114,9 @@ export function scalarEqualityKey(value: unknown): string | undefined {
 }
 
 export const rowsEqual = <Row extends RowObject>(left: Row, right: Row): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
   const rightKeys = new Set(Object.keys(right));
   const leftKeys = Object.keys(left);
   if (leftKeys.length !== rightKeys.size) {


### PR DESCRIPTION
## Summary
- Short-circuit rowsEqual when both sides are the same row object reference.
- Add a regression test proving identical references do not trigger structural property reads.

## Performance signal
- Query-delta replacement benchmark, 10k rows / 64 replacements / 10 iterations:
  - head: ~2.60ms mean
  - middle: ~2.63ms mean
  - tail: ~2.65ms mean
- Previous local post-#186 run was roughly ~5ms in the same replacement-heavy cases.

## Validation
- vp check --fix packages/column-live-view-engine/src/row-values.ts packages/column-live-view-engine/src/index.test.ts
- pnpm --filter @view-server/column-live-view-engine run test
- pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
- pnpm run bench:baseline:smoke
- 3-agent review cycle: one non-blocking test-strength concern fixed; remaining reviews clean.