### PR TITLE
Use trusted row reads in engine hot paths

### DIFF
--- a/packages/column-live-view-engine/src/grouped-aggregate-state.ts
+++ b/packages/column-live-view-engine/src/grouped-aggregate-state.ts
@@ -9,7 +9,7 @@ import {
 } from "effect/BigDecimal";
 import { compareQueryValue, stableQueryValueString } from "./raw-query-compiler";
 import type { StoredRowOf } from "./query-result";
-import { cloneUnknown, fieldValue } from "./row-values";
+import { cloneUnknown, trustedFieldValue } from "./row-values";
 
 type RowObject = object;
 
@@ -204,7 +204,7 @@ const emptyReversibleAggregateState = (
 };
 
 const aggregateFieldValue = (row: RowObject, aggregate: RuntimeGroupedAggregate): unknown =>
-  "field" in aggregate ? fieldValue(row, aggregate.field) : undefined;
+  "field" in aggregate ? trustedFieldValue(row, aggregate.field) : undefined;
 
 export const updateAggregateState = (
   state: AggregateState,
@@ -396,7 +396,7 @@ export const newGroupState = (
 ): GroupState => {
   const resultRow: Record<string, unknown> = {};
   for (const field of groupBy) {
-    resultRow[field] = cloneUnknown(fieldValue(row, field));
+    resultRow[field] = cloneUnknown(trustedFieldValue(row, field));
   }
   const aggregateStates: Record<string, AggregateState> = {};
   for (const { alias, aggregate } of aggregates) {
@@ -417,7 +417,7 @@ export const newIncrementalGroupState = (
 ): MaterializedIncrementalGroupState => {
   const resultRow: Record<string, unknown> = {};
   for (const field of groupBy) {
-    resultRow[field] = cloneUnknown(fieldValue(row, field));
+    resultRow[field] = cloneUnknown(trustedFieldValue(row, field));
   }
   const aggregateStates: Record<string, ReversibleAggregateState> = {};
   for (const { alias, aggregate } of aggregates) {

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -21,7 +21,7 @@ import {
 } from "./grouped-incremental-admission";
 import type { QueryEvaluation } from "./query-result";
 import type { TopicRowChangeBatch, TopicRowScan } from "./row-scan";
-import { fieldValue, valuesEqual } from "./row-values";
+import { trustedFieldValue, valuesEqual } from "./row-values";
 
 type RowObject = object;
 
@@ -403,7 +403,10 @@ const aggregateValueChanged = <Row extends RowObject>(
   if (!("field" in aggregate)) {
     return false;
   }
-  return !valuesEqual(fieldValue(previous, aggregate.field), fieldValue(next, aggregate.field));
+  return !valuesEqual(
+    trustedFieldValue(previous, aggregate.field),
+    trustedFieldValue(next, aggregate.field),
+  );
 };
 
 const upsertMatchingMaterializedIncrementalGroupedMember = <Row extends RowObject>(

--- a/packages/column-live-view-engine/src/grouped-query-plan.ts
+++ b/packages/column-live-view-engine/src/grouped-query-plan.ts
@@ -6,7 +6,7 @@ import {
 } from "./grouped-aggregate-state";
 import { stableQueryValueString } from "./query-value";
 import type { StoredRowOf } from "./query-result";
-import { fieldValue } from "./row-values";
+import { trustedFieldValue } from "./row-values";
 
 type RowObject = object;
 
@@ -83,7 +83,7 @@ const compileGroupedKeyFields = <Row extends RowObject>(
 ): ReadonlyArray<CompiledGroupedKeyField<Row>> =>
   groupBy.map((field) => ({
     field,
-    value: (row) => fieldValue(row, field),
+    value: (row) => trustedFieldValue(row, field),
   }));
 
 const compileGroupedAggregates = (
@@ -99,8 +99,8 @@ const groupedFieldOrderColumn = (
   direction: "asc" | "desc",
 ): CompiledGroupedOrderBy => ({
   direction,
-  groupValue: (group) => fieldValue(group.row, field),
-  rowValue: (entry) => fieldValue(entry.row, field),
+  groupValue: (group) => trustedFieldValue(group.row, field),
+  rowValue: (entry) => trustedFieldValue(entry.row, field),
 });
 
 const groupedAggregateOrderColumn = (
@@ -109,7 +109,7 @@ const groupedAggregateOrderColumn = (
 ): CompiledGroupedOrderBy => ({
   direction,
   groupValue: (group) => aggregateStateCompareValue(group.aggregates[aggregate]!),
-  rowValue: (entry) => fieldValue(entry.row, aggregate),
+  rowValue: (entry) => trustedFieldValue(entry.row, aggregate),
 });
 
 const compileGroupedOrderBy = (

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -49,6 +49,7 @@ import {
   fieldValue,
   rowsEqual,
   scalarEqualityKey,
+  trustedFieldValue,
   valuesEqual,
 } from "./row-values";
 import type { TopicRowChangeBatch, TopicRowEntry } from "./row-scan";
@@ -197,6 +198,22 @@ const position = (
 
 const makeEngine = (): Effect.Effect<Engine> =>
   createColumnLiveViewEngine({ topics: viewServer.topics });
+
+const withObjectPrototypeValue = <Value, Error, Requirements>(
+  field: string,
+  value: unknown,
+  effect: Effect.Effect<Value, Error, Requirements>,
+): Effect.Effect<Value, Error, Requirements> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      Reflect.set(Object.prototype, field, value);
+    }),
+    () => effect,
+    () =>
+      Effect.sync(() => {
+        Reflect.deleteProperty(Object.prototype, field);
+      }),
+  );
 
 const registerTestTopicStoreSubscriber = (
   store: TopicStore,
@@ -5971,6 +5988,38 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expect(snapshot.totalRows).toBe(1);
     }),
   );
+
+  it.effect("keeps missing optional fields isolated from object prototype values", () =>
+    withObjectPrototypeValue(
+      "note",
+      "polluted",
+      Effect.gen(function* () {
+        const engine = yield* makeEngine();
+        yield* engine.publishMany("orders", [
+          order("missing-note", "open", 10, 1),
+          { ...order("own-note", "open", 20, 2), note: "polluted" },
+        ]);
+
+        const projected = yield* engine.snapshot("orders", {
+          select: ["id", "note"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const polluted = yield* engine.snapshot("orders", {
+          select: ["id"],
+          where: {
+            note: { eq: "polluted" },
+          },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+
+        expect(projected.rows).toStrictEqual([
+          { id: "missing-note", note: undefined },
+          { id: "own-note", note: "polluted" },
+        ]);
+        expect(rowIds(polluted.rows)).toStrictEqual(["own-note"]);
+      }),
+    ),
+  );
 });
 
 describe("ColumnLiveViewEngine subscriptions", () => {
@@ -11409,6 +11458,7 @@ describe("ColumnLiveViewEngine validation and health", () => {
     expect(cloneRecord(inheritedRecord)).toStrictEqual({ id: "1", status: "open" });
     expect(cloneRow(inheritedRow)).toStrictEqual({ id: "1", status: "open" });
     expect(fieldValue(inheritedRow, "inherited")).toBeUndefined();
+    expect(trustedFieldValue(inheritedRow, "inherited")).toBe("hidden");
     expect(rowsEqual(inheritedRow, { id: "1", status: "open" })).toBe(true);
   });
 

--- a/packages/column-live-view-engine/src/raw-predicate-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-compiler.ts
@@ -7,7 +7,7 @@ import {
   type TopicRawPredicatePlan,
 } from "./raw-predicate-plan";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
-import { fieldValue, isPlainRecord, valuesEqual } from "./row-values";
+import { isPlainRecord, trustedFieldValue, valuesEqual } from "./row-values";
 
 type RowObject = object;
 
@@ -236,7 +236,7 @@ export const compileRawPredicate = <Row extends RowObject>(
     plan: parts.plan,
     matches: (row) => {
       for (const clause of parts.clauses) {
-        if (!clause.matches(fieldValue(row, clause.field))) {
+        if (!clause.matches(trustedFieldValue(row, clause.field))) {
           return false;
         }
       }

--- a/packages/column-live-view-engine/src/raw-query-plan.ts
+++ b/packages/column-live-view-engine/src/raw-query-plan.ts
@@ -5,7 +5,7 @@ import type { RuntimeRawQuery } from "./raw-query-decoder";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
 import type { TopicRawOrderByPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
-import { cloneUnknown, fieldValue } from "./row-values";
+import { cloneUnknown, trustedFieldValue } from "./row-values";
 
 type RowObject = object;
 
@@ -70,15 +70,15 @@ const compareRowFieldValues = <Row extends RowObject>(
   left: Row,
   right: Row,
   field: string,
-): number => compareQueryValue(fieldValue(left, field), fieldValue(right, field));
+): number => compareQueryValue(trustedFieldValue(left, field), trustedFieldValue(right, field));
 
 const compareStringRowFieldValues = <Row extends RowObject>(
   left: Row,
   right: Row,
   field: string,
 ): number => {
-  const leftValue = fieldValue(left, field);
-  const rightValue = fieldValue(right, field);
+  const leftValue = trustedFieldValue(left, field);
+  const rightValue = trustedFieldValue(right, field);
   if (typeof leftValue === "string" && typeof rightValue === "string") {
     return Number(leftValue > rightValue) - Number(leftValue < rightValue);
   }
@@ -90,8 +90,8 @@ const compareNumberRowFieldValues = <Row extends RowObject>(
   right: Row,
   field: string,
 ): number => {
-  const leftValue = fieldValue(left, field);
-  const rightValue = fieldValue(right, field);
+  const leftValue = trustedFieldValue(left, field);
+  const rightValue = trustedFieldValue(right, field);
   if (
     typeof leftValue === "number" &&
     typeof rightValue === "number" &&
@@ -108,8 +108,8 @@ const compareBigintRowFieldValues = <Row extends RowObject>(
   right: Row,
   field: string,
 ): number => {
-  const leftValue = fieldValue(left, field);
-  const rightValue = fieldValue(right, field);
+  const leftValue = trustedFieldValue(left, field);
+  const rightValue = trustedFieldValue(right, field);
   if (typeof leftValue === "bigint" && typeof rightValue === "bigint") {
     return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
   }
@@ -121,8 +121,8 @@ const compareBigDecimalRowFieldValues = <Row extends RowObject>(
   right: Row,
   field: string,
 ): number => {
-  const leftValue = fieldValue(left, field);
-  const rightValue = fieldValue(right, field);
+  const leftValue = trustedFieldValue(left, field);
+  const rightValue = trustedFieldValue(right, field);
   if (isBigDecimal(leftValue) && isBigDecimal(rightValue)) {
     return orderBigDecimal(leftValue, rightValue);
   }
@@ -174,7 +174,7 @@ const compareRows = <Row extends RowObject>(
 const projectRow = (row: RowObject, select: ReadonlyArray<string>): RowObject => {
   const projected: Record<string, unknown> = {};
   for (const field of select) {
-    projected[field] = cloneUnknown(fieldValue(row, field));
+    projected[field] = cloneUnknown(trustedFieldValue(row, field));
   }
   return projected;
 };

--- a/packages/column-live-view-engine/src/row-values.ts
+++ b/packages/column-live-view-engine/src/row-values.ts
@@ -65,6 +65,10 @@ export const fieldValue = (row: RowObject, field: string): unknown => {
   return Reflect.get(row, field);
 };
 
+// Use only after the engine has decoded and shadowed schema fields as own properties.
+export const trustedFieldValue = (row: RowObject, field: string): unknown =>
+  Reflect.get(row, field);
+
 export const valuesEqual = (left: unknown, right: unknown): boolean => {
   if (isBigDecimal(left) && isBigDecimal(right)) {
     return equals(left, right);

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -25,7 +25,18 @@ const decodeTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decode")(functio
   return yield* Effect.try({
     try: () => {
       const decoded = Schema.decodeUnknownSync(context.schema)(row);
-      return cloneRow(decoded);
+      const cloned = cloneRow(decoded);
+      for (const field of context.fieldNames) {
+        if (!Object.hasOwn(cloned, field)) {
+          Object.defineProperty(cloned, field, {
+            configurable: true,
+            enumerable: false,
+            value: undefined,
+            writable: true,
+          });
+        }
+      }
+      return cloned;
     },
     catch: (cause) => invalidRow(context.topic, String(cause)),
   });

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -14,7 +14,7 @@ import type {
 import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { OrderedSlotIndex, RawStorageOrderColumn } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
-import { cloneUnknown, fieldValue } from "./row-values";
+import { cloneUnknown, trustedFieldValue } from "./row-values";
 import {
   columnValue,
   createTopicColumnValues,
@@ -328,7 +328,7 @@ export class TopicRowStorage {
     for (let index = 0; index < this.columnWritePlan.length; index += 1) {
       this.columnWritePlan[index]!.set(
         slot,
-        fieldValue(prepared.row, this.columnWriteFields[index]!),
+        trustedFieldValue(prepared.row, this.columnWriteFields[index]!),
       );
     }
   }


### PR DESCRIPTION
## Summary
- Add `trustedFieldValue` for engine-owned row hot paths so raw predicates, raw order/projection, grouped aggregates/order, and column writes avoid repeated own-property checks.
- Preserve boundary safety by keeping `fieldValue` defensive for external/unprepared rows.
- During topic row preparation, shadow missing schema fields as non-enumerable own `undefined` properties after Schema decode/clone. This makes trusted reads immune to `Object.prototype` pollution without changing enumerable row shape or `Schema.optionalKey` patch-spread behavior.
- Add a regression proving missing optional fields do not read polluted prototype values in projection or filtering.

## Review Cycle
- Initial 3-agent review found a real blocker: optional missing fields could read inherited values.
- Fixed by non-enumerable schema-field shadowing during preparation.
- Fresh 3-agent review after the fix: no findings.

## Validation
- `vp check --fix` on changed files
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict`
- `pnpm --filter @view-server/column-live-view-engine run bench:raw-snapshot`
- `pnpm --filter @view-server/column-live-view-engine run bench:raw-write`
- `pnpm run bench:baseline:smoke`
