### PR TITLE
Optimize grouped scalar key construction

### DIFF
--- a/packages/column-live-view-engine/src/grouped-query-plan.ts
+++ b/packages/column-live-view-engine/src/grouped-query-plan.ts
@@ -67,15 +67,58 @@ const groupedQueryPlanCacheKey = (query: GroupedQueryPlanInput): string =>
     query.limit ?? null,
   ]);
 
+const stableScalarGroupedKeyValueTokenString = (value: unknown): string | undefined => {
+  if (value === null) {
+    return `["null"]`;
+  }
+  if (typeof value === "bigint") {
+    return `["bigint",${JSON.stringify(value.toString())}]`;
+  }
+  if (typeof value === "number") {
+    return `["number",${JSON.stringify(Object.is(value, -0) ? "-0" : String(value))}]`;
+  }
+  if (typeof value === "string") {
+    return `["string",${JSON.stringify(value)}]`;
+  }
+  if (typeof value === "boolean") {
+    return `["boolean",${value ? "true" : "false"}]`;
+  }
+  if (value === undefined) {
+    return `["undefined"]`;
+  }
+  return undefined;
+};
+
+const stableScalarGroupedKeyFieldTokenString = (
+  field: string,
+  value: unknown,
+): string | undefined => {
+  const valueToken = stableScalarGroupedKeyValueTokenString(value);
+  if (valueToken === undefined) {
+    return undefined;
+  }
+  return `["array",[["string",${JSON.stringify(field)}],${valueToken}]]`;
+};
+
 const groupedQueryPlanGroupKey = <Row extends RowObject>(
   keyFields: ReadonlyArray<CompiledGroupedKeyField<Row>>,
   row: Row,
 ): string => {
+  const tokens: Array<string> = [];
   const values: Array<readonly [string, unknown]> = [];
   for (const keyField of keyFields) {
-    values.push([keyField.field, keyField.value(row)]);
+    const value = keyField.value(row);
+    values.push([keyField.field, value]);
+    const token = stableScalarGroupedKeyFieldTokenString(keyField.field, value);
+    if (token === undefined) {
+      for (const fallbackKeyField of keyFields.slice(values.length)) {
+        values.push([fallbackKeyField.field, fallbackKeyField.value(row)]);
+      }
+      return stableQueryValueString(values);
+    }
+    tokens.push(token);
   }
-  return stableQueryValueString(values);
+  return `["array",[${tokens.join(",")}]]`;
 };
 
 const compileGroupedKeyFields = <Row extends RowObject>(

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -43,6 +43,7 @@ import {
 } from "./raw-query-compiler";
 import { evaluateCompiledGroupedQuery, prepareGroupedQuery } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
+import { makeGroupedQueryPlan } from "./grouped-query-plan";
 import {
   cloneRecord,
   cloneRow,
@@ -1901,6 +1902,178 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       ]);
     }),
   );
+
+  it("keeps scalar grouped key strings compatible with stable query value strings", () => {
+    const plan = makeGroupedQueryPlan<object>({
+      groupBy: [
+        "status",
+        "price",
+        "notANumber",
+        "positiveInfinity",
+        "negativeInfinity",
+        "negativeZero",
+        "quantity",
+        "active",
+        "closed",
+        "missing",
+        "note",
+      ],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+      },
+    });
+    const row = {
+      status: "open",
+      price: 10,
+      notANumber: Number.NaN,
+      positiveInfinity: Number.POSITIVE_INFINITY,
+      negativeInfinity: Number.NEGATIVE_INFINITY,
+      negativeZero: -0,
+      quantity: 5n,
+      active: true,
+      closed: false,
+      missing: null,
+      note: undefined,
+    };
+
+    expect(plan.groupKey(row)).toBe(
+      stableQueryValueString([
+        ["status", "open"],
+        ["price", 10],
+        ["notANumber", Number.NaN],
+        ["positiveInfinity", Number.POSITIVE_INFINITY],
+        ["negativeInfinity", Number.NEGATIVE_INFINITY],
+        ["negativeZero", -0],
+        ["quantity", 5n],
+        ["active", true],
+        ["closed", false],
+        ["missing", null],
+        ["note", undefined],
+      ]),
+    );
+  });
+
+  it("keeps BigDecimal grouped key fallback compatible with stable query value strings", () => {
+    const plan = makeGroupedQueryPlan<object>({
+      groupBy: ["status", "decimalPrice", "venue"],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+      },
+    });
+    const decimalPrice = fromStringUnsafe("1.50");
+    const row = {
+      status: "open",
+      decimalPrice,
+      venue: "xnys",
+    };
+
+    expect(plan.groupKey(row)).toBe(
+      stableQueryValueString([
+        ["status", "open"],
+        ["decimalPrice", decimalPrice],
+        ["venue", "xnys"],
+      ]),
+    );
+  });
+
+  it("keeps structured grouped key fallback compatible with stable query value strings", () => {
+    const plan = makeGroupedQueryPlan<object>({
+      groupBy: ["status", "payload", "venue"],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+      },
+    });
+    const payload = new Map([["venue", "xnys"]]);
+    const row = {
+      status: "open",
+      payload,
+      venue: "xnys",
+    };
+
+    expect(plan.groupKey(row)).toBe(
+      stableQueryValueString([
+        ["status", "open"],
+        ["payload", payload],
+        ["venue", "xnys"],
+      ]),
+    );
+  });
+
+  it("reads each grouped key field once when fallback is needed", () => {
+    const plan = makeGroupedQueryPlan<object>({
+      groupBy: ["status", "payload", "venue"],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+      },
+    });
+    let statusReads = 0;
+    let payloadReads = 0;
+    let venueReads = 0;
+    const row = Object.defineProperties(
+      {},
+      {
+        status: {
+          enumerable: true,
+          get() {
+            statusReads += 1;
+            return "open";
+          },
+        },
+        payload: {
+          enumerable: true,
+          get() {
+            payloadReads += 1;
+            return new Map([["venue", "xnys"]]);
+          },
+        },
+        venue: {
+          enumerable: true,
+          get() {
+            venueReads += 1;
+            return "xnys";
+          },
+        },
+      },
+    );
+
+    plan.groupKey(row);
+
+    expect(statusReads).toBe(1);
+    expect(payloadReads).toBe(1);
+    expect(venueReads).toBe(1);
+  });
+
+  it("does not add extra object probes before grouped key fallback", () => {
+    const plan = makeGroupedQueryPlan<object>({
+      groupBy: ["status", "payload"],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+      },
+    });
+    let hasProbeCount = 0;
+    const payload = new Proxy(
+      {},
+      {
+        has(target, key) {
+          hasProbeCount += 1;
+          return key in target;
+        },
+      },
+    );
+    stableQueryValueString([
+      ["status", "open"],
+      ["payload", payload],
+    ]);
+    const baselineHasProbeCount = hasProbeCount;
+    hasProbeCount = 0;
+
+    plan.groupKey({
+      status: "open",
+      payload,
+    });
+
+    expect(hasProbeCount).toBe(baselineHasProbeCount);
+  });
 
   it.effect("evaluates grouped bigint aggregate states", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Add a primitive scalar fast path for grouped query key construction.
- Preserve the exact previous `stableQueryValueString([[field, value], ...])` key format.
- Keep BigDecimal and structured values on the existing serializer fallback to avoid extra object/proxy probes.
- Add regressions for primitive scalar compatibility, BigDecimal fallback, structured fallback, single-pass field reads, and proxy probe parity with the baseline serializer.

## Validation

- `vp check --fix packages/column-live-view-engine/src/grouped-query-plan.ts packages/column-live-view-engine/src/index.test.ts`
- `pnpm --filter @view-server/column-live-view-engine run test`
- `pnpm exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict`
- `pnpm --filter @view-server/column-live-view-engine run bench:grouped-key-width`
- `pnpm run bench:baseline:smoke`

## Benchmark Signal

Final local `bench:grouped-key-width`, 100k rows:

| profile | mean |
| --- | ---: |
| groupBy one key | 27.03ms |
| groupBy two keys | 40.56ms |
| groupBy four keys | 72.73ms |
| groupBy eight keys | 122.19ms |
| groupBy eight ordered keys | 117.81ms |

Smoke baseline comparison passed. These numbers are directional local benchmark results, not a new committed baseline.
