### PR TITLE
Skip unchanged grouped aggregate patch work

### DIFF
--- a/benchmarks/baselines/smoke.json
+++ b/benchmarks/baselines/smoke.json
@@ -668,47 +668,56 @@
       "benchmarks": [
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 1.1857919999999922,
-          "meanMs": 0.5336749999999938,
-          "minMs": 0.3408749999999827,
+          "maxMs": 1.2199999999999704,
+          "meanMs": 0.5418915999999967,
+          "minMs": 0.3348750000000109,
           "name": "grouped publishMany append batch",
-          "p99Ms": 1.1857919999999922,
+          "p99Ms": 1.2199999999999704,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.5226660000000152,
-          "meanMs": 0.34630819999999857,
-          "minMs": 0.2387499999999818,
+          "maxMs": 0.7278749999999832,
+          "meanMs": 0.40629179999999676,
+          "minMs": 0.25925000000000864,
           "name": "grouped publishMany replace extrema batch",
-          "p99Ms": 0.5226660000000152,
+          "p99Ms": 0.7278749999999832,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.38645800000000463,
-          "meanMs": 0.24553339999999935,
-          "minMs": 0.1881249999999568,
+          "maxMs": 0.46195799999998144,
+          "meanMs": 0.26784999999999853,
+          "minMs": 0.19233300000001918,
           "name": "grouped patch aggregate values",
-          "p99Ms": 0.38645800000000463,
+          "p99Ms": 0.46195799999998144,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.32575000000002774,
-          "meanMs": 0.2426245999999992,
-          "minMs": 0.2093330000000151,
+          "maxMs": 0.3508749999999736,
+          "meanMs": 0.26872500000000626,
+          "minMs": 0.2363330000000019,
           "name": "grouped patch group moves",
-          "p99Ms": 0.32575000000002774,
+          "p99Ms": 0.3508749999999736,
           "sampleCount": 5
         },
         {
           "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
-          "maxMs": 0.308166999999969,
-          "meanMs": 0.2115581999999904,
-          "minMs": 0.1716250000000059,
+          "maxMs": 0.3402500000000259,
+          "meanMs": 0.22165860000000065,
+          "minMs": 0.18695900000000165,
           "name": "grouped delete existing rows",
-          "p99Ms": 0.308166999999969,
+          "p99Ms": 0.3402500000000259,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/grouped-write.bench.ts > grouped write engine benchmark: 1000 rows",
+          "maxMs": 0.13712500000002592,
+          "meanMs": 0.10170819999999595,
+          "minMs": 0.08949999999998681,
+          "name": "grouped patch non-aggregate values",
+          "p99Ms": 0.13712500000002592,
           "sampleCount": 5
         }
       ],
@@ -717,7 +726,8 @@
         "grouped publishMany replace extrema batch",
         "grouped patch aggregate values",
         "grouped patch group moves",
-        "grouped delete existing rows"
+        "grouped delete existing rows",
+        "grouped patch non-aggregate values"
       ],
       "benchmarkName": "grouped write engine benchmark",
       "benchmarkScope": "engine-grouped-write",
@@ -734,7 +744,7 @@
         "groupedFullEvaluationCountAfterSetup": 0,
         "groupedFullEvaluationCountBeforeCleanup": 40,
         "groupedPatchedEvaluationCountAfterSetup": 0,
-        "groupedPatchedEvaluationCountBeforeCleanup": 10,
+        "groupedPatchedEvaluationCountBeforeCleanup": 20,
         "incrementalAdmissionLimits": {
           "maxGroups": 8192,
           "maxMembers": 65536,
@@ -743,13 +753,13 @@
         },
         "priceThreshold": 0,
         "seedMutationCount": 1000,
-        "timedMutationCount": 25,
+        "timedMutationCount": 30,
         "writeBatchSize": 1
       },
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 45645824,
+      "memoryRssTotalDeltaBytes": 44122112,
       "minimumSampleCount": 5,
-      "mutationCount": 1025,
+      "mutationCount": 1030,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/grouped-write-incremental-1000rows-1mutations.json",
       "queuedEventCount": 0,
       "rowCount": 1000,

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -20,7 +20,12 @@ import {
   type GroupedIncrementalAdmissionLimits,
 } from "./grouped-incremental-admission";
 import type { QueryEvaluation } from "./query-result";
-import type { TopicRowChangeBatch, TopicRowScan } from "./row-scan";
+import {
+  isTopicRowChangedFields,
+  type TopicRowChangedFields,
+  type TopicRowChangeBatch,
+  type TopicRowScan,
+} from "./row-scan";
 import { trustedFieldValue, valuesEqual } from "./row-values";
 
 type RowObject = object;
@@ -399,9 +404,13 @@ const aggregateValueChanged = <Row extends RowObject>(
   aggregate: GroupedQueryPlan<Row>["aggregates"][string],
   previous: Row,
   next: Row,
+  changedFields: TopicRowChangedFields | undefined,
 ): boolean => {
   if (!("field" in aggregate)) {
     return false;
+  }
+  if (isTopicRowChangedFields(changedFields)) {
+    return changedFields.fields.has(aggregate.field);
   }
   return !valuesEqual(
     trustedFieldValue(previous, aggregate.field),
@@ -447,10 +456,11 @@ const replaceMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   key: string,
   previous: Row,
   next: Row,
+  changedFields: TopicRowChangedFields | undefined,
 ): void => {
   group.members.set(key, next);
   for (const { alias, aggregate } of plan.aggregatePlans) {
-    if (aggregateValueChanged(aggregate, previous, next)) {
+    if (aggregateValueChanged(aggregate, previous, next, changedFields)) {
       const state = group.aggregates[alias]!;
       markMaterializedAggregateChange(patch, plan, group, alias);
       markDirtyAggregateRecompute(
@@ -532,6 +542,7 @@ const applyMaterializedIncrementalGroupedQueryBatch = <Row extends RowObject>(
           change.key,
           change.previous,
           change.next,
+          change.changedFields,
         );
         continue;
       }

--- a/packages/column-live-view-engine/src/grouped-write.bench.ts
+++ b/packages/column-live-view-engine/src/grouped-write.bench.ts
@@ -34,6 +34,7 @@ declare const process: {
 
 const Order = Schema.Struct({
   id: Schema.String,
+  note: Schema.String,
   price: Schema.Finite,
   quantity: Schema.BigInt,
   region: Schema.String,
@@ -83,7 +84,9 @@ type BenchmarkProfile = {
   nextDeleteKeyIndex: number;
   nextExtremeReplaceIndex: number;
   nextGroupMoveKeyIndex: number;
+  nextNonAggregatePatchKeyIndex: number;
   nextSameGroupPatchKeyIndex: number;
+  nonAggregatePatchKeys: ReadonlyArray<string>;
   regionStatusReader: GroupedEventReader | undefined;
   regionStatusScope: Scope.Closeable | undefined;
   regionStatusSubscription: GroupedSubscription | undefined;
@@ -293,7 +296,9 @@ const profile: BenchmarkProfile = {
   nextDeleteKeyIndex: 0,
   nextExtremeReplaceIndex: 0,
   nextGroupMoveKeyIndex: 0,
+  nextNonAggregatePatchKeyIndex: 0,
   nextSameGroupPatchKeyIndex: 0,
+  nonAggregatePatchKeys: [],
   regionStatusReader: undefined,
   regionStatusScope: undefined,
   regionStatusSubscription: undefined,
@@ -350,6 +355,7 @@ const region = (index: number): string => {
 
 const seedOrder = (index: number): OrderRow => ({
   id: `order-${index}`,
+  note: `seed-note-${index}`,
   price: index % 1_000_000,
   quantity: BigInt((index % 997) + 1),
   region: region(index),
@@ -359,6 +365,7 @@ const seedOrder = (index: number): OrderRow => ({
 
 const generatedOrder = (prefix: string, index: number, generation: number): OrderRow => ({
   id: `${prefix}-${index}`,
+  note: `${prefix}-note-${generation}-${index}`,
   price: (index + generation) % 1_000_000,
   quantity: BigInt(((index + generation) % 997) + 1),
   region: region(index + generation),
@@ -413,6 +420,33 @@ const matchingSeedKeysForStatus = (
   if (keys.length !== requiredCount) {
     throw new Error(
       `Expected ${requiredCount} seeded ${status} key(s) for grouped write benchmark, found ${keys.length}.`,
+    );
+  }
+  return keys;
+};
+
+const matchingSeedKeysForStatusExcluding = (
+  searchStartIndex: number,
+  requiredCount: number,
+  status: OrderStatus,
+  excludedKeys: ReadonlySet<string>,
+): ReadonlyArray<string> => {
+  const keys: Array<string> = [];
+  let index = searchStartIndex;
+  while (index < benchmarkRowCount && keys.length < requiredCount) {
+    const key = `order-${index}`;
+    if (
+      !excludedKeys.has(key) &&
+      orderStatus(index) === status &&
+      rowMatchesGroupedWriteMode(index)
+    ) {
+      keys.push(key);
+    }
+    index += 1;
+  }
+  if (keys.length !== requiredCount) {
+    throw new Error(
+      `Expected ${requiredCount} non-excluded seeded ${status} key(s) for grouped write benchmark, found ${keys.length}.`,
     );
   }
   return keys;
@@ -723,6 +757,17 @@ beforeAll(async () => {
   );
   profile.memoryAfterSetup = memorySnapshot();
   profile.sameGroupPatchKeys = matchingSeedKeysForStatus(0, requiredMutationKeys, "open");
+  profile.nonAggregatePatchKeys = matchingSeedKeysForStatusExcluding(
+    Math.floor(benchmarkRowCount * 0.5),
+    requiredMutationKeys,
+    "open",
+    new Set([
+      ...profile.deleteKeys,
+      ...profile.extremeReplaceIndexes.map((index) => `order-${index}`),
+      ...profile.groupMoveKeys,
+      ...profile.sameGroupPatchKeys,
+    ]),
+  );
   profile.setupActiveFallbackGroupedViews = setupCounts.activeFallbackGroupedViews;
   profile.setupActiveIncrementalGroupedViews = setupCounts.activeIncrementalGroupedViews;
   profile.setupActiveViews = setupCounts.activeViews;
@@ -802,6 +847,7 @@ afterAll(async () => {
   profile.deleteKeys = [];
   profile.extremeReplaceIndexes = [];
   profile.groupMoveKeys = [];
+  profile.nonAggregatePatchKeys = [];
   profile.sameGroupPatchKeys = [];
   profile.statusReader = undefined;
   const memoryAfterBenchmark = memorySnapshot();
@@ -815,6 +861,7 @@ afterAll(async () => {
       "grouped patch aggregate values",
       "grouped patch group moves",
       "grouped delete existing rows",
+      "grouped patch non-aggregate values",
     ],
     benchmarkName: "grouped write engine benchmark",
     benchmarkScope: "engine-grouped-write",
@@ -851,7 +898,7 @@ afterAll(async () => {
     mutationCount: profile.rowMutationCount,
     notes: [
       "Latency percentiles are emitted by Vitest in outputJsonPath.",
-      "Timed bodies include the grouped write operation and draining one delta from each active grouped subscription.",
+      "Timed bodies include the grouped write operation and draining one delta from each active grouped subscription when the write changes the grouped result.",
       groupedWriteMode === "incremental"
         ? "Incremental mode uses selective grouped subscriptions sized under the current grouped incremental admission limits."
         : "Fallback mode intentionally uses broad grouped subscriptions with forced fallback admission limits and measures full grouped fallback rebuild pressure.",
@@ -864,6 +911,7 @@ afterAll(async () => {
         ? `Incremental mode price threshold: ${incrementalPriceThreshold(benchmarkRowCount)}.`
         : "Fallback mode has no selective price threshold.",
       `Grouped write engine versions during timed samples: ${profile.deltaVersionCount}.`,
+      "The grouped patch non-aggregate values case is expected to produce no grouped result delta.",
     ],
     outputJsonPath,
     preCleanupHealth,
@@ -974,6 +1022,27 @@ describe(`grouped write engine benchmark: ${profile.rowCount} rows`, () => {
         profile.rowMutationCount += 1;
         await Effect.runPromise(engine.delete("orders", key));
         await drainDeltas(profile, "grouped delete existing rows");
+      }
+    },
+    benchOptions,
+  );
+
+  bench(
+    "grouped patch non-aggregate values",
+    async () => {
+      const engine = profileEngine(profile);
+      for (let offset = 0; offset < mutationBatchSize; offset += 1) {
+        const key = profile.nonAggregatePatchKeys[profile.nextNonAggregatePatchKeyIndex];
+        if (key === undefined) {
+          throw new Error("Grouped write benchmark exhausted non-aggregate patch keys.");
+        }
+        profile.nextNonAggregatePatchKeyIndex += 1;
+        profile.rowMutationCount += 1;
+        await Effect.runPromise(
+          engine.patch("orders", key, {
+            note: `non-aggregate-note-${profile.rowMutationCount}-${offset}`,
+          }),
+        );
       }
     },
     benchOptions,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -2833,7 +2833,6 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
           },
         },
       );
-
       expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
         {
           status: "cancelled",
@@ -2974,6 +2973,77 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
       expect(scanCount).toBe(1);
       expect(fullEvaluationCount).toBe(0);
       expect(patchedEvaluationCount).toBe(3);
+    }),
+  );
+
+  it.effect("ignores unbranded changed-field metadata from manual grouped scans", () =>
+    Effect.gen(function* () {
+      let version = 0;
+      let batches: ReadonlyArray<TopicRowChangeBatch<object>> = [];
+      const rows = new Map<string, object>([
+        ["open-a", order("open-a", "open", 10, 2, "emea")],
+        ["open-b", order("open-b", "open", 20, 3, "emea")],
+      ]);
+      const store = {
+        changesSince: () => batches,
+        scanRows: (visitor: (key: string, row: object) => void) => {
+          for (const [key, row] of rows) {
+            visitor(key, row);
+          }
+        },
+        version: () => version,
+      };
+      const compiled = yield* prepareGroupedQuery<object, object>(
+        "orders",
+        rawQueryCompilerMetadata(Order),
+        {
+          groupBy: ["status"],
+          aggregates: {
+            totalPrice: { aggFunc: "sum", field: "price" },
+          },
+          orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+          limit: 1,
+        },
+      );
+      const execution = makeIncrementalGroupedQueryExecution(
+        store,
+        compiled,
+        () => {},
+        defaultGroupedIncrementalAdmissionLimits,
+      );
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "open",
+          totalPrice: "30",
+        },
+      ]);
+
+      const previous = order("open-b", "open", 20, 3, "emea");
+      const next = order("open-b", "open", 25, 4, "emea");
+      rows.set("open-b", next);
+      version = 1;
+      batches = [
+        {
+          version,
+          changes: [
+            {
+              // @ts-expect-error manual row scans cannot forge trusted changed-field metadata.
+              changedFields: new Set(["updatedAt"]),
+              key: "open-b",
+              previous,
+              next,
+            },
+          ],
+        },
+      ];
+
+      expect(normalizeDecimalAndBigIntFields(execution.latest().rows)).toStrictEqual([
+        {
+          status: "open",
+          totalPrice: "35",
+        },
+      ]);
     }),
   );
 
@@ -5266,6 +5336,91 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
 
       yield* subscription.close();
     }),
+  );
+
+  it.effect(
+    "skips grouped deltas for non-aggregate patches and preserves next delta versions",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* makeEngine();
+        yield* engine.publishMany("orders", [
+          { ...order("1", "open", 10, 1, "emea"), note: "before" },
+          order("2", "open", 20, 2, "emea"),
+        ]);
+        const query = {
+          groupBy: ["status"],
+          aggregates: {
+            maxPrice: { aggFunc: "max", field: "price" },
+            rowCount: { aggFunc: "count" },
+            totalPrice: { aggFunc: "sum", field: "price" },
+          },
+          orderBy: [{ field: "status", direction: "asc" }],
+          limit: 1,
+        } satisfies {
+          readonly groupBy: readonly ["status"];
+          readonly aggregates: {
+            readonly maxPrice: { readonly aggFunc: "max"; readonly field: "price" };
+            readonly rowCount: { readonly aggFunc: "count" };
+            readonly totalPrice: { readonly aggFunc: "sum"; readonly field: "price" };
+          };
+          readonly orderBy: readonly [{ readonly field: "status"; readonly direction: "asc" }];
+          readonly limit: 1;
+        };
+
+        const subscription = yield* engine.subscribe("orders", query);
+        const read = yield* makeEventReader(subscription);
+        const snapshot = firstEvent(yield* read(1));
+        expectSnapshotEvent(snapshot);
+        const groupKey = expectDefined(snapshot.keys[0]);
+        expect(snapshot).toStrictEqual({
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 1,
+          rows: [
+            {
+              status: "open",
+              maxPrice: 20,
+              rowCount: 2n,
+              totalPrice: fromStringUnsafe("30"),
+            },
+          ],
+          keys: [groupKey],
+          totalRows: 1,
+        });
+
+        yield* engine.patch("orders", "1", { note: "after" });
+        const afterNonAggregatePatchHealth = yield* engine.health();
+        expect(afterNonAggregatePatchHealth.queuedEvents).toBe(0);
+        expect(afterNonAggregatePatchHealth.topics["orders"].queuedEvents).toBe(0);
+
+        yield* engine.patch("orders", "1", { price: 15 });
+        const delta = firstEvent(yield* read(1));
+        expectDeltaEvent(delta);
+        expect(delta).toStrictEqual({
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 1,
+          toVersion: 3,
+          operations: [
+            {
+              type: "update",
+              key: groupKey,
+              row: {
+                status: "open",
+                maxPrice: 20,
+                rowCount: 2n,
+                totalPrice: fromStringUnsafe("35"),
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        });
+
+        yield* subscription.close();
+      }),
   );
 
   it.effect("keeps grouped aggregate state exact across duplicate removals", () =>

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -1,4 +1,13 @@
+import { fieldValue, valuesEqual } from "./row-values";
+
 type RowObject = object;
+
+const changedFieldsTypeId = Symbol("view-server/TopicRowChangedFields");
+
+export type TopicRowChangedFields = {
+  readonly fields: ReadonlySet<string>;
+  readonly [changedFieldsTypeId]: typeof changedFieldsTypeId;
+};
 
 export type TopicRowEntry<Row extends RowObject> = {
   readonly key: string;
@@ -8,9 +17,38 @@ export type TopicRowEntry<Row extends RowObject> = {
 export type TopicRowVisitor<Row extends RowObject> = (key: string, row: Row) => false | void;
 
 export type TopicRowChange<Row extends RowObject> = {
+  readonly changedFields?: TopicRowChangedFields;
   readonly key: string;
   readonly next: Row | undefined;
   readonly previous: Row | undefined;
+};
+
+function makeTopicRowChangedFields(fields: Iterable<string>): TopicRowChangedFields | undefined {
+  const changedFields = new Set(fields);
+  if (changedFields.size === 0) {
+    return undefined;
+  }
+  return {
+    [changedFieldsTypeId]: changedFieldsTypeId,
+    fields: changedFields,
+  };
+}
+
+export const isTopicRowChangedFields = (value: unknown): value is TopicRowChangedFields =>
+  typeof value === "object" && value !== null && Object.hasOwn(value, changedFieldsTypeId);
+
+export const topicRowChangedFieldsFromRows = (
+  previous: RowObject,
+  next: RowObject,
+  fields: Iterable<string>,
+): TopicRowChangedFields | undefined => {
+  const changedFields = new Set<string>();
+  for (const field of fields) {
+    if (!valuesEqual(fieldValue(previous, field), fieldValue(next, field))) {
+      changedFields.add(field);
+    }
+  }
+  return makeTopicRowChangedFields(changedFields);
 };
 
 export type TopicRowChangeBatch<Row extends RowObject> = {

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -1,4 +1,5 @@
 import { Effect, Schema } from "effect";
+import { topicRowChangedFieldsFromRows, type TopicRowChangedFields } from "./row-scan";
 import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
 
 type RowObject = object;
@@ -6,6 +7,7 @@ type RowObject = object;
 export type InvalidRowErrorFactory<Error> = (topic: string, message: string) => Error;
 
 export type PreparedTopicRow = {
+  readonly changedFields?: TopicRowChangedFields;
   readonly key: string;
   readonly row: object;
 };
@@ -104,7 +106,20 @@ export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.
     if (decodedKey !== key) {
       return yield* Effect.fail(invalidRow(context.topic, "Patch must not change the row key."));
     }
+    const decodedFieldNames = new Set([...Object.keys(current), ...Object.keys(decoded)]);
+    const topicRowChangedFields = topicRowChangedFieldsFromRows(
+      current,
+      decoded,
+      decodedFieldNames,
+    );
+    if (topicRowChangedFields === undefined) {
+      return {
+        key,
+        row: decoded,
+      } satisfies PreparedTopicRow;
+    }
     return {
+      changedFields: topicRowChangedFields,
       key,
       row: decoded,
     } satisfies PreparedTopicRow;

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -175,11 +175,7 @@ export class TopicRowStorage {
       this.removeSlotFromScalarIndexes(existingSlot);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
-      this.recordRowChange({
-        key: prepared.key,
-        previous,
-        next: prepared.row,
-      });
+      this.recordPreparedReplacementChange(prepared, previous);
       this.orderedSlotIndexes.clear();
       return;
     }
@@ -408,11 +404,7 @@ export class TopicRowStorage {
       this.removeSlotFromScalarIndexes(existingSlot);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
-      this.recordRowChange({
-        key: prepared.key,
-        previous,
-        next: prepared.row,
-      });
+      this.recordPreparedReplacementChange(prepared, previous);
       this.orderedSlotIndexes.clear();
       return;
     }
@@ -445,11 +437,7 @@ export class TopicRowStorage {
       this.removeSlotFromScalarIndexes(existingSlot);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
-      this.recordRowChange({
-        key: prepared.key,
-        previous,
-        next: prepared.row,
-      });
+      this.recordPreparedReplacementChange(prepared, previous);
       return;
     }
 
@@ -467,6 +455,23 @@ export class TopicRowStorage {
 
   private recordRowChange(change: TopicRowChange<object>): void {
     this.rowChangeJournal.record(change, this.versionValue);
+  }
+
+  private recordPreparedReplacementChange(prepared: PreparedTopicRow, previous: object): void {
+    if (prepared.changedFields === undefined) {
+      this.recordRowChange({
+        key: prepared.key,
+        previous,
+        next: prepared.row,
+      });
+      return;
+    }
+    this.recordRowChange({
+      changedFields: prepared.changedFields,
+      key: prepared.key,
+      previous,
+      next: prepared.row,
+    });
   }
 
   private addSlotToScalarIndexes(slot: number): void {


### PR DESCRIPTION
## Summary
- add trusted changed-field metadata for decoded patch replacements
- skip same-group grouped aggregate recomputation when patched fields do not affect aggregate inputs
- add non-aggregate grouped patch benchmark case and update the grouped-write smoke baseline
- add regression coverage for unbranded metadata fallback and non-aggregate patch no-delta version behavior

## Validation
- pnpm run ready
- pnpm --filter @view-server/column-live-view-engine run bench:grouped-write
- pnpm run bench:baseline:smoke