### PR TITLE
Maintain raw ordered indexes incrementally

### DIFF
--- a/benchmarks/baselines/smoke.json
+++ b/benchmarks/baselines/smoke.json
@@ -271,6 +271,15 @@
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
+          "maxMs": 6.401499999999999,
+          "meanMs": 5.926566600000013,
+          "minMs": 5.667209000000014,
+          "name": "patch existing rows one by one",
+          "p99Ms": 6.401499999999999,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
           "maxMs": 2.6354580000000283,
           "meanMs": 2.1617250000000015,
           "minMs": 1.74512500000003,
@@ -289,15 +298,6 @@
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.401499999999999,
-          "meanMs": 5.926566600000013,
-          "minMs": 5.667209000000014,
-          "name": "patch existing rows one by one",
-          "p99Ms": 6.401499999999999,
-          "sampleCount": 5
-        },
-        {
-          "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
           "maxMs": 5.605582999999967,
           "meanMs": 4.993016399999988,
           "minMs": 4.413915999999972,
@@ -308,9 +308,9 @@
       ],
       "benchmarkCases": [
         "publish append single row",
+        "patch existing rows one by one",
         "publishMany append batch",
         "publishMany replace existing batch",
-        "patch existing rows one by one",
         "append then delete batch"
       ],
       "benchmarkName": "raw write engine benchmark (base)",
@@ -343,6 +343,33 @@
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
+          "maxMs": 6.150833999999975,
+          "meanMs": 6.041875199999993,
+          "minMs": 5.866833999999983,
+          "name": "patch existing rows one by one",
+          "p99Ms": 6.150833999999975,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
+          "maxMs": 0.5610409999999888,
+          "meanMs": 0.29748339999999873,
+          "minMs": 0.19854099999997743,
+          "name": "replace single row then indexed snapshot",
+          "p99Ms": 0.5610409999999888,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
+          "maxMs": 0.36120799999997644,
+          "meanMs": 0.27156679999999367,
+          "minMs": 0.22658399999994572,
+          "name": "delete non-last row then indexed snapshot",
+          "p99Ms": 0.36120799999997644,
+          "sampleCount": 5
+        },
+        {
+          "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
           "maxMs": 2.746832999999981,
           "meanMs": 2.2046500000000036,
           "minMs": 1.8466660000000275,
@@ -361,15 +388,6 @@
         },
         {
           "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
-          "maxMs": 6.150833999999975,
-          "meanMs": 6.041875199999993,
-          "minMs": 5.866833999999983,
-          "name": "patch existing rows one by one",
-          "p99Ms": 6.150833999999975,
-          "sampleCount": 5
-        },
-        {
-          "groupName": "src/raw-write.bench.ts > raw write engine benchmark: 1000 rows",
           "maxMs": 5.389041999999961,
           "meanMs": 5.065483599999993,
           "minMs": 4.656584000000009,
@@ -380,9 +398,11 @@
       ],
       "benchmarkCases": [
         "publish append single row",
+        "patch existing rows one by one",
+        "replace single row then indexed snapshot",
+        "delete non-last row then indexed snapshot",
         "publishMany append batch",
         "publishMany replace existing batch",
-        "patch existing rows one by one",
         "append then delete batch"
       ],
       "benchmarkName": "raw write engine benchmark (indexed)",
@@ -391,7 +411,7 @@
       "latencySource": "vitest-output-json",
       "memoryRssTotalDeltaBytes": 57294848,
       "minimumSampleCount": 5,
-      "mutationCount": 3508,
+      "mutationCount": 3528,
       "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-write-indexed-1000rows.json",
       "queuedEventCount": 0,
       "rowCount": 1000,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -7840,10 +7840,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       ) => {
         const priceComparison =
           numericRowField(left.row, "price") - numericRowField(right.row, "price");
-        if (priceComparison !== 0) {
-          return priceComparison;
-        }
-        return left.key.localeCompare(right.key);
+        return priceComparison === 0 ? left.key.localeCompare(right.key) : priceComparison;
       };
 
       const readModel = topicStoreReadModel(store);
@@ -7959,10 +7956,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       ) => {
         const priceComparison =
           numericRowField(left.row, "price") - numericRowField(right.row, "price");
-        if (priceComparison !== 0) {
-          return priceComparison;
-        }
-        return left.key.localeCompare(right.key);
+        return priceComparison === 0 ? left.key.localeCompare(right.key) : priceComparison;
       };
       const initial = order("a", "open", 10, 1);
       storage.setPrepared(yield* storage.prepareRow(initial, invalidRow));
@@ -8011,6 +8005,77 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(storage.rowCount).toBe(2);
       expect(rows).toStrictEqual([initial, secondRow]);
       expect(orderedWindow.keys).toStrictEqual(["a", "b"]);
+    }),
+  );
+
+  it.effect("applies stale prepared no-op patches when the current row changed", () =>
+    Effect.gen(function* () {
+      const storage = new TopicRowStorage("orders", Order, "id");
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
+      const compareByPriceThenKey = (
+        left: { readonly key: string; readonly row: object },
+        right: { readonly key: string; readonly row: object },
+      ) => {
+        const priceComparison =
+          numericRowField(left.row, "price") - numericRowField(right.row, "price");
+        return priceComparison === 0 ? left.key.localeCompare(right.key) : priceComparison;
+      };
+      const initial = order("a", "open", 10, 1);
+      storage.setPrepared(yield* storage.prepareRow(initial, invalidRow));
+
+      const staleSinglePatch = yield* storage.preparePatch("a", { price: 10 }, invalidRow);
+      storage.setPrepared(yield* storage.prepareRow(order("a", "open", 20, 2), invalidRow));
+      storage.setPrepared(staleSinglePatch);
+
+      const rowsAfterSingle: Array<object> = [];
+      storage.scanRows((_key, row) => {
+        rowsAfterSingle.push(row);
+      });
+      expect(rowsAfterSingle).toStrictEqual([initial]);
+
+      const staleBatchPatch = yield* storage.preparePatch("a", { price: 10 }, invalidRow);
+      const retained = order("b", "open", 40, 4);
+      storage.setPrepared(yield* storage.prepareRow(retained, invalidRow));
+      storage.scanRawWindow({
+        predicate: {
+          callbackRequired: false,
+          callbackSkippable: true,
+          filters: [],
+        },
+        orderBy: [{ direction: "asc", field: "price" }],
+        storageOrderBy: [{ direction: "asc", field: "price" }],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 0,
+        limit: 2,
+      });
+      storage.setPrepared(yield* storage.prepareRow(order("a", "open", 30, 3), invalidRow));
+      storage.setPreparedMany([
+        staleBatchPatch,
+        yield* storage.prepareRow(order("c", "open", 50, 5), invalidRow),
+      ]);
+
+      const rowsAfterBatch: Array<object> = [];
+      storage.scanRows((_key, row) => {
+        rowsAfterBatch.push(row);
+      });
+      const orderedWindow = storage.scanRawWindow({
+        predicate: {
+          callbackRequired: false,
+          callbackSkippable: true,
+          filters: [],
+        },
+        orderBy: [{ direction: "asc", field: "price" }],
+        storageOrderBy: [{ direction: "asc", field: "price" }],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 0,
+        limit: 3,
+      });
+
+      expect(rowsAfterBatch).toStrictEqual([initial, retained, order("c", "open", 50, 5)]);
+      expect(orderedWindow.keys).toStrictEqual(["a", "b", "c"]);
     }),
   );
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -76,6 +76,7 @@ import {
   closeTopicStoreSubscriptions,
   collectTopicStoreHealth,
   deleteTopicStoreRow,
+  patchTopicStoreRow,
   publishTopicStoreRow,
   publishTopicStoreRows,
   registerTopicStoreSubscription,
@@ -88,8 +89,11 @@ import {
   compareExactRangeColumnValue,
   compareRangeColumnValue,
 } from "./topic-range-value";
-import { orderedSlotBoundIndex } from "./topic-ordered-window";
-import { rawWindowOrderedSlotIndex } from "./topic-raw-ordered-window-index";
+import { orderedSlotBoundIndex, type OrderedSlotIndex } from "./topic-ordered-window";
+import {
+  rawWindowOrderedSlotIndex,
+  removeSlotFromRawWindowIndexes,
+} from "./topic-raw-ordered-window-index";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -445,6 +449,30 @@ it("uses typed column values for ordered slot bound indexes", () => {
     ),
   ).toBe(1);
   expect(orderedSlotBoundIndex([0, 1], generic, "open", (comparison) => comparison >= 0)).toBe(1);
+
+  const priceAscendingOrderBy: ReadonlyArray<TopicRawOrderByPlan> = [
+    { field: "price", direction: "asc" },
+  ];
+  const orderedSlotIndexes = new Map<string, OrderedSlotIndex>([
+    [
+      "5:price:asc",
+      {
+        orderBy: priceAscendingOrderBy,
+        orderColumns: [],
+        slots: [0, 1, 2],
+      },
+    ],
+  ]);
+  removeSlotFromRawWindowIndexes(
+    {
+      columns: new Map(),
+      orderedSlotIndexes,
+      rawQueryMetadata: metadata,
+      slots: [],
+    },
+    99,
+  );
+  expect(orderedSlotIndexes.get("5:price:asc")?.slots).toStrictEqual([0, 1, 2]);
 });
 
 it("keeps schema field order for aligned column writes", () => {
@@ -6987,6 +7015,7 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       yield* publishTopicStoreRow(store, order("1", "open", 10, 1), invalidRow);
       expect(notifyCount).toBe(1);
 
+      yield* patchTopicStoreRow(store, "1", { price: 10 }, invalidRow);
       yield* deleteTopicStoreRow(store, "missing");
       yield* publishTopicStoreRows(store, [], invalidRow);
 
@@ -7850,6 +7879,172 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       expect(cappedLargeWindow.keys).toStrictEqual([]);
       expect(cappedLargeWindow.window).toStrictEqual([]);
       expect(cappedLargeWindow.totalRows).toBe(5);
+    }),
+  );
+
+  it.effect("keeps ordered raw indexes current after single-row replacements", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("a", "open", 10, 1),
+        order("b", "open", 20, 2),
+        order("c", "open", 30, 3),
+      ]);
+
+      const warmed = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 3,
+      });
+      expect(rowIds(warmed.rows)).toStrictEqual(["a", "b", "c"]);
+
+      yield* engine.publish("orders", order("b", "open", 5, 4));
+
+      const replaced = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 3,
+      });
+      expect(replaced.rows).toStrictEqual([
+        { id: "b", price: 5 },
+        { id: "a", price: 10 },
+        { id: "c", price: 30 },
+      ]);
+
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("keeps ordered raw indexes current after patches that do not change order fields", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("a", "open", 10, 1),
+        order("b", "open", 20, 2),
+        order("c", "open", 30, 3),
+      ]);
+
+      const warmed = yield* engine.snapshot("orders", {
+        select: ["id", "price", "updatedAt"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 3,
+      });
+      expect(rowIds(warmed.rows)).toStrictEqual(["a", "b", "c"]);
+
+      yield* engine.patch("orders", "b", { updatedAt: 9 });
+
+      const patched = yield* engine.snapshot("orders", {
+        select: ["id", "price", "updatedAt"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 3,
+      });
+      expect(patched.rows).toStrictEqual([
+        { id: "a", price: 10, updatedAt: 1 },
+        { id: "b", price: 20, updatedAt: 9 },
+        { id: "c", price: 30, updatedAt: 3 },
+      ]);
+
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("ignores prepared no-op patches in storage replacement paths", () =>
+    Effect.gen(function* () {
+      const storage = new TopicRowStorage("orders", Order, "id");
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
+      const compareByPriceThenKey = (
+        left: { readonly key: string; readonly row: object },
+        right: { readonly key: string; readonly row: object },
+      ) => {
+        const priceComparison =
+          numericRowField(left.row, "price") - numericRowField(right.row, "price");
+        if (priceComparison !== 0) {
+          return priceComparison;
+        }
+        return left.key.localeCompare(right.key);
+      };
+      const initial = order("a", "open", 10, 1);
+      storage.setPrepared(yield* storage.prepareRow(initial, invalidRow));
+      const firstNoOpPatch = yield* storage.preparePatch("a", { price: 10 }, invalidRow);
+      storage.setPrepared(firstNoOpPatch);
+      const secondNoOpPatch = yield* storage.preparePatch("a", { updatedAt: 1 }, invalidRow);
+      storage.setPreparedMany([secondNoOpPatch]);
+      const secondRow = order("b", "open", 20, 2);
+      storage.setPrepared(yield* storage.prepareRow(secondRow, invalidRow));
+      storage.scanRawWindow({
+        predicate: {
+          callbackRequired: false,
+          callbackSkippable: true,
+          filters: [],
+        },
+        orderBy: [{ direction: "asc", field: "price" }],
+        storageOrderBy: [{ direction: "asc", field: "price" }],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 0,
+        limit: 2,
+      });
+      storage.setPreparedMany([
+        yield* storage.preparePatch("a", { price: 10 }, invalidRow),
+        yield* storage.preparePatch("b", { price: 20 }, invalidRow),
+      ]);
+
+      const rows: Array<object> = [];
+      storage.scanRows((_key, row) => {
+        rows.push(row);
+      });
+      const orderedWindow = storage.scanRawWindow({
+        predicate: {
+          callbackRequired: false,
+          callbackSkippable: true,
+          filters: [],
+        },
+        orderBy: [{ direction: "asc", field: "price" }],
+        storageOrderBy: [{ direction: "asc", field: "price" }],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 0,
+        limit: 2,
+      });
+
+      expect(storage.rowCount).toBe(2);
+      expect(rows).toStrictEqual([initial, secondRow]);
+      expect(orderedWindow.keys).toStrictEqual(["a", "b"]);
+    }),
+  );
+
+  it.effect("keeps ordered raw indexes current after deletes move the last slot", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publishMany("orders", [
+        order("a", "open", 10, 1),
+        order("b", "open", 20, 2),
+        order("c", "open", 30, 3),
+        order("d", "open", 40, 4),
+      ]);
+
+      const warmed = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 4,
+      });
+      expect(rowIds(warmed.rows)).toStrictEqual(["a", "b", "c", "d"]);
+
+      yield* engine.delete("orders", "b");
+
+      const deleted = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 4,
+      });
+      expect(deleted.rows).toStrictEqual([
+        { id: "a", price: 10 },
+        { id: "c", price: 30 },
+        { id: "d", price: 40 },
+      ]);
+
+      yield* engine.close();
     }),
   );
 

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -8079,6 +8079,77 @@ describe("ColumnLiveViewEngine subscriptions", () => {
     }),
   );
 
+  it.effect("applies later stale no-op patches against earlier rows in the same batch", () =>
+    Effect.gen(function* () {
+      const storage = new TopicRowStorage("orders", Order, "id");
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
+      const initial = order("a", "open", 10, 1);
+      storage.setPrepared(yield* storage.prepareRow(initial, invalidRow));
+
+      const pricePatch = yield* storage.preparePatch("a", { price: 20 }, invalidRow);
+      const staleNoOpPatch = yield* storage.preparePatch("a", { updatedAt: 1 }, invalidRow);
+      storage.setPreparedMany([pricePatch, staleNoOpPatch]);
+
+      const rows: Array<object> = [];
+      storage.scanRows((_key, row) => {
+        rows.push(row);
+      });
+      expect(rows).toStrictEqual([initial]);
+    }),
+  );
+
+  it.effect("updates ordered indexes using apply-time fields for stale prepared patches", () =>
+    Effect.gen(function* () {
+      const storage = new TopicRowStorage("orders", Order, "id");
+      const invalidRow = (topic: string, message: string) =>
+        InvalidRowError.make({ topic, message });
+      const compareByPriceThenKey = (
+        left: { readonly key: string; readonly row: object },
+        right: { readonly key: string; readonly row: object },
+      ) => {
+        const priceComparison =
+          numericRowField(left.row, "price") - numericRowField(right.row, "price");
+        return priceComparison === 0 ? left.key.localeCompare(right.key) : priceComparison;
+      };
+      storage.setPrepared(yield* storage.prepareRow(order("a", "open", 10, 1), invalidRow));
+      storage.setPrepared(yield* storage.prepareRow(order("b", "open", 20, 2), invalidRow));
+      storage.scanRawWindow({
+        predicate: {
+          callbackRequired: false,
+          callbackSkippable: true,
+          filters: [],
+        },
+        orderBy: [{ direction: "asc", field: "price" }],
+        storageOrderBy: [{ direction: "asc", field: "price" }],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 0,
+        limit: 2,
+      });
+
+      const stalePatch = yield* storage.preparePatch("a", { updatedAt: 2 }, invalidRow);
+      storage.setPrepared(yield* storage.prepareRow(order("a", "open", 30, 3), invalidRow));
+      storage.setPrepared(stalePatch);
+
+      const orderedWindow = storage.scanRawWindow({
+        predicate: {
+          callbackRequired: false,
+          callbackSkippable: true,
+          filters: [],
+        },
+        orderBy: [{ direction: "asc", field: "price" }],
+        storageOrderBy: [{ direction: "asc", field: "price" }],
+        matches: () => true,
+        compare: compareByPriceThenKey,
+        offset: 0,
+        limit: 2,
+      });
+
+      expect(orderedWindow.keys).toStrictEqual(["a", "b"]);
+    }),
+  );
+
   it.effect("keeps ordered raw indexes current after deletes move the last slot", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -7018,6 +7018,8 @@ describe("ColumnLiveViewEngine subscriptions", () => {
       yield* patchTopicStoreRow(store, "1", { price: 10 }, invalidRow);
       yield* deleteTopicStoreRow(store, "missing");
       yield* publishTopicStoreRows(store, [], invalidRow);
+      yield* publishTopicStoreRow(store, order("1", "open", 10, 1), invalidRow);
+      yield* publishTopicStoreRows(store, [order("1", "open", 10, 1)], invalidRow);
 
       const health = yield* collectTopicStoreHealth(store, false);
       expect(notifyCount).toBe(1);

--- a/packages/column-live-view-engine/src/raw-write.bench.ts
+++ b/packages/column-live-view-engine/src/raw-write.bench.ts
@@ -52,8 +52,15 @@ type BenchmarkProfile = {
   nextAppendIndex: number;
   nextDeleteIndex: number;
   nextPatchGeneration: number;
+  nextReadAfterDeleteGeneration: number;
+  nextReadAfterReplaceGeneration: number;
   nextReplaceGeneration: number;
   rowCount: number;
+};
+
+type BenchmarkCase = {
+  readonly name: string;
+  readonly run: () => Promise<void>;
 };
 
 const defaultBatchSize = 1_000;
@@ -152,6 +159,8 @@ const profile: BenchmarkProfile = {
   nextAppendIndex: benchmarkRowCount,
   nextDeleteIndex: 0,
   nextPatchGeneration: 0,
+  nextReadAfterDeleteGeneration: 0,
+  nextReadAfterReplaceGeneration: 0,
   nextReplaceGeneration: 0,
   rowCount: benchmarkRowCount,
 };
@@ -181,7 +190,21 @@ const benchmarkMutationCount = (): number =>
   (profile.nextAppendIndex - benchmarkRowCount) +
   profile.nextReplaceGeneration * batchSize +
   profile.nextPatchGeneration * batchSize +
-  profile.nextDeleteIndex * 2;
+  profile.nextDeleteIndex * 2 +
+  (writeMode === "indexed"
+    ? profile.nextReadAfterReplaceGeneration + profile.nextReadAfterDeleteGeneration * 3
+    : 0);
+
+const benchmarkCases = [
+  "publish append single row",
+  "patch existing rows one by one",
+  ...(writeMode === "indexed"
+    ? ["replace single row then indexed snapshot", "delete non-last row then indexed snapshot"]
+    : []),
+  "publishMany append batch",
+  "publishMany replace existing batch",
+  "append then delete batch",
+];
 
 const seedOrder = (index: number): OrderRow => ({
   id: `order-${index}`,
@@ -321,13 +344,7 @@ afterAll(async () => {
   writeBenchmarkArtifact({
     artifactKind: "engine-benchmark-summary",
     backpressureCount: backpressureCountFromEngineHealth(health),
-    benchmarkCases: [
-      "publish append single row",
-      "publishMany append batch",
-      "publishMany replace existing batch",
-      "patch existing rows one by one",
-      "append then delete batch",
-    ],
+    benchmarkCases,
     benchmarkName: `raw write engine benchmark (${writeMode})`,
     benchmarkScope: "engine-raw-write",
     cleanupLeakCount,
@@ -343,7 +360,7 @@ afterAll(async () => {
     notes: [
       "Latency percentiles are emitted by Vitest in outputJsonPath.",
       writeMode === "indexed"
-        ? "Indexed write mode pre-warms scalar predicate buckets and one ordered raw window index before timed writes. Single-row appends pay ordered-index insertion cost; batch writes measure scalar maintenance plus the current ordered-index invalidation/clear behavior."
+        ? "Indexed write mode pre-warms scalar predicate buckets and three ordered raw window indexes before timed writes. Single-row appends, replacements, patches, and deletes maintain affected ordered indexes incrementally; multi-row batch writes still measure scalar maintenance plus ordered-index invalidation/clear behavior."
         : "Base write mode measures decoded engine writes without pre-warmed read-path indexes.",
       `Seed row count: ${profile.rowCount}. Final tracked row count: ${profile.currentRowCount}.`,
     ],
@@ -357,75 +374,121 @@ afterAll(async () => {
 }, 0);
 
 describe(`raw write engine benchmark: ${profile.rowCount} rows`, () => {
-  bench(
-    "publish append single row",
-    async () => {
-      const engine = profileEngine(profile);
-      const index = profile.nextAppendIndex;
-      profile.nextAppendIndex += 1;
-      profile.currentRowCount += 1;
-      await Effect.runPromise(
-        engine.publish("orders", generatedOrder("single-append", index, index)),
-      );
-    },
-    benchOptions,
-  );
-
-  bench(
-    "publishMany append batch",
-    async () => {
-      const engine = profileEngine(profile);
-      const rows = writeBatch("append", profile.nextAppendIndex, profile.nextAppendIndex);
-      profile.nextAppendIndex += batchSize;
-      profile.currentRowCount += batchSize;
-      await Effect.runPromise(engine.publishMany("orders", rows));
-    },
-    benchOptions,
-  );
-
-  bench(
-    "publishMany replace existing batch",
-    async () => {
-      const engine = profileEngine(profile);
-      const rows = writeBatch("order", 0, profile.nextReplaceGeneration);
-      profile.nextReplaceGeneration += 1;
-      await Effect.runPromise(engine.publishMany("orders", rows));
-    },
-    benchOptions,
-  );
-
-  bench(
-    "patch existing rows one by one",
-    async () => {
-      const engine = profileEngine(profile);
-      const generation = profile.nextPatchGeneration;
-      profile.nextPatchGeneration += 1;
-      for (let offset = 0; offset < batchSize; offset += 1) {
+  const benchmarkDefinitions: ReadonlyArray<BenchmarkCase> = [
+    {
+      name: "publish append single row",
+      run: async () => {
+        const engine = profileEngine(profile);
+        const index = profile.nextAppendIndex;
+        profile.nextAppendIndex += 1;
+        profile.currentRowCount += 1;
         await Effect.runPromise(
-          engine.patch("orders", `order-${offset}`, {
-            price: generation + offset,
-            quantity: BigInt(generation + offset),
-            decimalPrice: fromStringUnsafe(String(generation + offset)),
-            updatedAt: 2_000_000_000 + generation + offset,
-          }),
+          engine.publish("orders", generatedOrder("single-append", index, index)),
         );
-      }
+      },
     },
-    benchOptions,
-  );
+    ...(writeMode === "indexed"
+      ? [
+          {
+            name: "replace single row then indexed snapshot",
+            run: async () => {
+              const engine = profileEngine(profile);
+              const generation = profile.nextReadAfterReplaceGeneration;
+              profile.nextReadAfterReplaceGeneration += 1;
+              await Effect.runPromise(
+                engine.publish("orders", generatedOrder("order", 0, generation)),
+              );
+              await Effect.runPromise(
+                engine.snapshot("orders", {
+                  select: ["id", "price", "updatedAt"],
+                  where: {
+                    price: { gte: 0 },
+                  },
+                  orderBy: [{ field: "price", direction: "asc" }],
+                  limit: 50,
+                }),
+              );
+            },
+          },
+          {
+            name: "delete non-last row then indexed snapshot",
+            run: async () => {
+              const engine = profileEngine(profile);
+              const generation = profile.nextReadAfterDeleteGeneration;
+              profile.nextReadAfterDeleteGeneration += 1;
+              const deletedRow = generatedOrder("delete-read", generation * 2, generation);
+              const movedRow = generatedOrder("delete-read", generation * 2 + 1, generation);
+              await Effect.runPromise(engine.publish("orders", deletedRow));
+              await Effect.runPromise(engine.publish("orders", movedRow));
+              await Effect.runPromise(engine.delete("orders", deletedRow.id));
+              profile.currentRowCount += 1;
+              await Effect.runPromise(
+                engine.snapshot("orders", {
+                  select: ["id", "price", "updatedAt"],
+                  where: {
+                    price: { gte: 0 },
+                  },
+                  orderBy: [{ field: "price", direction: "asc" }],
+                  limit: 50,
+                }),
+              );
+            },
+          },
+        ]
+      : []),
+    {
+      name: "patch existing rows one by one",
+      run: async () => {
+        const engine = profileEngine(profile);
+        const generation = profile.nextPatchGeneration;
+        profile.nextPatchGeneration += 1;
+        for (let offset = 0; offset < batchSize; offset += 1) {
+          await Effect.runPromise(
+            engine.patch("orders", `order-${offset}`, {
+              price: generation + offset,
+              quantity: BigInt(generation + offset),
+              decimalPrice: fromStringUnsafe(String(generation + offset)),
+              updatedAt: 2_000_000_000 + generation + offset,
+            }),
+          );
+        }
+      },
+    },
+    {
+      name: "publishMany append batch",
+      run: async () => {
+        const engine = profileEngine(profile);
+        const rows = writeBatch("append", profile.nextAppendIndex, profile.nextAppendIndex);
+        profile.nextAppendIndex += batchSize;
+        profile.currentRowCount += batchSize;
+        await Effect.runPromise(engine.publishMany("orders", rows));
+      },
+    },
+    {
+      name: "publishMany replace existing batch",
+      run: async () => {
+        const engine = profileEngine(profile);
+        const rows = writeBatch("order", 0, profile.nextReplaceGeneration);
+        profile.nextReplaceGeneration += 1;
+        await Effect.runPromise(engine.publishMany("orders", rows));
+      },
+    },
+    {
+      name: "append then delete batch",
+      run: async () => {
+        const engine = profileEngine(profile);
+        const startIndex = profile.nextDeleteIndex;
+        const rows = writeBatch("delete", startIndex, startIndex);
+        profile.nextDeleteIndex += batchSize;
+        await Effect.runPromise(engine.publishMany("orders", rows));
+        for (const row of rows) {
+          await Effect.runPromise(engine.delete("orders", row.id));
+        }
+      },
+    },
+  ];
 
-  bench(
-    "append then delete batch",
-    async () => {
-      const engine = profileEngine(profile);
-      const startIndex = profile.nextDeleteIndex;
-      const rows = writeBatch("delete", startIndex, startIndex);
-      profile.nextDeleteIndex += batchSize;
-      await Effect.runPromise(engine.publishMany("orders", rows));
-      for (const row of rows) {
-        await Effect.runPromise(engine.delete("orders", row.id));
-      }
-    },
-    benchOptions,
-  );
+  for (const benchmarkCase of benchmarkDefinitions) {
+    bench(benchmarkCase.name, benchmarkCase.run, benchOptions);
+  }
 });

--- a/packages/column-live-view-engine/src/raw-write.bench.ts
+++ b/packages/column-live-view-engine/src/raw-write.bench.ts
@@ -387,6 +387,24 @@ describe(`raw write engine benchmark: ${profile.rowCount} rows`, () => {
         );
       },
     },
+    {
+      name: "patch existing rows one by one",
+      run: async () => {
+        const engine = profileEngine(profile);
+        const generation = profile.nextPatchGeneration;
+        profile.nextPatchGeneration += 1;
+        for (let offset = 0; offset < batchSize; offset += 1) {
+          await Effect.runPromise(
+            engine.patch("orders", `order-${offset}`, {
+              price: generation + offset,
+              quantity: BigInt(generation + offset),
+              decimalPrice: fromStringUnsafe(String(generation + offset)),
+              updatedAt: 2_000_000_000 + generation + offset,
+            }),
+          );
+        }
+      },
+    },
     ...(writeMode === "indexed"
       ? [
           {
@@ -436,24 +454,6 @@ describe(`raw write engine benchmark: ${profile.rowCount} rows`, () => {
           },
         ]
       : []),
-    {
-      name: "patch existing rows one by one",
-      run: async () => {
-        const engine = profileEngine(profile);
-        const generation = profile.nextPatchGeneration;
-        profile.nextPatchGeneration += 1;
-        for (let offset = 0; offset < batchSize; offset += 1) {
-          await Effect.runPromise(
-            engine.patch("orders", `order-${offset}`, {
-              price: generation + offset,
-              quantity: BigInt(generation + offset),
-              decimalPrice: fromStringUnsafe(String(generation + offset)),
-              updatedAt: 2_000_000_000 + generation + offset,
-            }),
-          );
-        }
-      },
-    },
     {
       name: "publishMany append batch",
       run: async () => {

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -35,10 +35,34 @@ export const insertSlotIntoRawWindowIndexes = (
   slot: number,
 ): void => {
   for (const index of state.orderedSlotIndexes.values()) {
-    const insertAt = orderedSlotIndexInsertionPoint(index.slots, slot, (left, right) =>
-      compareSlotsByStorageOrder(state, left, right, index.orderColumns),
-    );
-    index.slots.splice(insertAt, 0, slot);
+    insertSlotIntoRawWindowIndex(state, index, slot);
+  }
+};
+
+export const insertSlotIntoRawWindowIndex = (
+  state: Pick<RawOrderedWindowIndexState, "slots">,
+  index: OrderedSlotIndex,
+  slot: number,
+): void => {
+  const insertAt = orderedSlotIndexInsertionPoint(index.slots, slot, (left, right) =>
+    compareSlotsByStorageOrder(state, left, right, index.orderColumns),
+  );
+  index.slots.splice(insertAt, 0, slot);
+};
+
+export const removeSlotFromRawWindowIndexes = (
+  state: RawOrderedWindowIndexState,
+  slot: number,
+): void => {
+  for (const index of state.orderedSlotIndexes.values()) {
+    removeSlotFromRawWindowIndex(index, slot);
+  }
+};
+
+export const removeSlotFromRawWindowIndex = (index: OrderedSlotIndex, slot: number): void => {
+  const slotIndex = index.slots.indexOf(slot);
+  if (slotIndex >= 0) {
+    index.slots.splice(slotIndex, 1);
   }
 };
 

--- a/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
+++ b/packages/column-live-view-engine/src/topic-raw-window-scanner.ts
@@ -87,6 +87,11 @@ export const scanTopicRawWindow = (
 };
 
 export { insertSlotIntoRawWindowIndexes };
+export {
+  insertSlotIntoRawWindowIndex,
+  removeSlotFromRawWindowIndex,
+  removeSlotFromRawWindowIndexes,
+} from "./topic-raw-ordered-window-index";
 
 const countRawWindowSlots = (
   state: TopicRawWindowScanState,

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -10,6 +10,7 @@ export type PreparedTopicRow = {
   readonly changedFields?: TopicRowChangedFields;
   readonly key: string;
   readonly row: object;
+  readonly source: "patch" | "row";
 };
 
 export type TopicRowPreparationContext = {
@@ -86,6 +87,7 @@ export const prepareTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.prepare"
   return {
     key,
     row: decoded,
+    source: "row",
   } satisfies PreparedTopicRow;
 });
 
@@ -116,12 +118,17 @@ export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.
       return {
         key,
         row: decoded,
+        source: "patch",
       } satisfies PreparedTopicRow;
     }
     return {
       changedFields: topicRowChangedFields,
       key,
       row: decoded,
+      source: "patch",
     } satisfies PreparedTopicRow;
   },
 );
+
+export const preparedTopicRowChangesRow = (prepared: PreparedTopicRow): boolean =>
+  prepared.source === "row" || prepared.changedFields !== undefined;

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -129,6 +129,3 @@ export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.
     } satisfies PreparedTopicRow;
   },
 );
-
-export const preparedTopicRowChangesRow = (prepared: PreparedTopicRow): boolean =>
-  prepared.source === "row" || prepared.changedFields !== undefined;

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -3,6 +3,7 @@ import { createActiveQueryRegistry, type ActiveQueryStoreState } from "./active-
 import type {
   TopicRowChange,
   TopicRowChangeBatch,
+  TopicRowChangedFields,
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
@@ -32,12 +33,16 @@ import {
 import {
   prepareTopicPatch,
   prepareTopicRow,
+  preparedTopicRowChangesRow,
   type InvalidRowErrorFactory,
   type PreparedTopicRow,
   type TopicRowPreparationContext,
 } from "./topic-row-preparation";
 import {
+  insertSlotIntoRawWindowIndex,
   insertSlotIntoRawWindowIndexes,
+  removeSlotFromRawWindowIndex,
+  removeSlotFromRawWindowIndexes,
   scanTopicRawWindow,
   type TopicRawWindowScanState,
 } from "./topic-raw-window-scanner";
@@ -171,12 +176,16 @@ export class TopicRowStorage {
   setPrepared(prepared: PreparedTopicRow): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
+      if (!preparedTopicRowChangesRow(prepared)) {
+        return;
+      }
       const previous = this.slots[existingSlot]!.row;
       this.removeSlotFromScalarIndexes(existingSlot);
+      this.removeSlotFromReplacementOrderedIndexes(existingSlot, prepared.changedFields);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
       this.recordPreparedReplacementChange(prepared, previous);
-      this.orderedSlotIndexes.clear();
+      this.insertSlotIntoReplacementOrderedIndexes(existingSlot, prepared.changedFields);
       return;
     }
 
@@ -193,17 +202,25 @@ export class TopicRowStorage {
   }
 
   setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
-    const appendReservation = this.createAppendBatchReservation(preparedRows);
-    if (preparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
+    const changedPreparedRows = preparedRows.filter((prepared) => {
+      const existingSlot = this.keyToSlot.get(prepared.key);
+      return existingSlot === undefined || preparedTopicRowChangesRow(prepared);
+    });
+    const appendReservation = this.createAppendBatchReservation(changedPreparedRows);
+    if (changedPreparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
       this.orderedSlotIndexes.clear();
-      for (let index = 0; index < preparedRows.length; index += 1) {
-        this.setPreparedWithoutIndexMaintenance(preparedRows[index]!, appendReservation, index);
+      for (let index = 0; index < changedPreparedRows.length; index += 1) {
+        this.setPreparedWithoutIndexMaintenance(
+          changedPreparedRows[index]!,
+          appendReservation,
+          index,
+        );
       }
       return;
     }
 
-    for (let index = 0; index < preparedRows.length; index += 1) {
-      this.setPreparedInBatch(preparedRows[index]!, appendReservation, index);
+    for (let index = 0; index < changedPreparedRows.length; index += 1) {
+      this.setPreparedInBatch(changedPreparedRows[index]!, appendReservation, index);
     }
   }
 
@@ -213,20 +230,22 @@ export class TopicRowStorage {
       return 0;
     }
 
-    this.orderedSlotIndexes.clear();
     const lastSlot = this.slots.length - 1;
     const lastEntry = this.slots[lastSlot]!;
     const previous = this.slots[slot]!.row;
     this.removeSlotFromScalarIndexes(slot);
+    this.removeSlotFromOrderedIndexes(slot);
     this.keyToSlot.delete(key);
     if (slot !== lastSlot) {
       this.removeSlotFromScalarIndexes(lastSlot);
+      this.removeSlotFromOrderedIndexes(lastSlot);
       this.slots[slot] = lastEntry;
       this.keyToSlot.set(lastEntry.key, slot);
       for (const column of this.columns.values()) {
         column.copySlot(slot, lastSlot);
       }
       this.addSlotToScalarIndexes(slot);
+      this.insertSlotIntoOrderedIndexes(slot);
     }
     this.slots.pop();
     for (const column of this.columns.values()) {
@@ -402,10 +421,11 @@ export class TopicRowStorage {
     if (existingSlot !== undefined) {
       const previous = this.slots[existingSlot]!.row;
       this.removeSlotFromScalarIndexes(existingSlot);
+      this.removeSlotFromReplacementOrderedIndexes(existingSlot, prepared.changedFields);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
       this.recordPreparedReplacementChange(prepared, previous);
-      this.orderedSlotIndexes.clear();
+      this.insertSlotIntoReplacementOrderedIndexes(existingSlot, prepared.changedFields);
       return;
     }
 
@@ -424,6 +444,39 @@ export class TopicRowStorage {
 
   private insertSlotIntoOrderedIndexes(slot: number): void {
     insertSlotIntoRawWindowIndexes(this.rawWindowScanState, slot);
+  }
+
+  private removeSlotFromOrderedIndexes(slot: number): void {
+    removeSlotFromRawWindowIndexes(this.rawWindowScanState, slot);
+  }
+
+  private insertSlotIntoReplacementOrderedIndexes(
+    slot: number,
+    changedFields: TopicRowChangedFields | undefined,
+  ): void {
+    for (const index of this.replacementOrderedIndexes(changedFields)) {
+      insertSlotIntoRawWindowIndex(this.rawWindowScanState, index, slot);
+    }
+  }
+
+  private removeSlotFromReplacementOrderedIndexes(
+    slot: number,
+    changedFields: TopicRowChangedFields | undefined,
+  ): void {
+    for (const index of this.replacementOrderedIndexes(changedFields)) {
+      removeSlotFromRawWindowIndex(index, slot);
+    }
+  }
+
+  private replacementOrderedIndexes(
+    changedFields: TopicRowChangedFields | undefined,
+  ): ReadonlyArray<OrderedSlotIndex> {
+    if (changedFields === undefined) {
+      return [...this.orderedSlotIndexes.values()];
+    }
+    return [...this.orderedSlotIndexes.values()].filter((index) =>
+      index.orderBy.some((order) => changedFields.fields.has(order.field)),
+    );
   }
 
   private setPreparedWithoutIndexMaintenance(

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -15,7 +15,7 @@ import type {
 import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { OrderedSlotIndex, RawStorageOrderColumn } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
-import { cloneUnknown, trustedFieldValue } from "./row-values";
+import { cloneUnknown, rowsEqual, trustedFieldValue } from "./row-values";
 import {
   columnValue,
   createTopicColumnValues,
@@ -176,7 +176,7 @@ export class TopicRowStorage {
   setPrepared(prepared: PreparedTopicRow): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
-      if (!preparedTopicRowChangesRow(prepared)) {
+      if (!this.preparedRowChangesCurrentSlot(prepared, existingSlot)) {
         return;
       }
       const previous = this.slots[existingSlot]!.row;
@@ -204,7 +204,9 @@ export class TopicRowStorage {
   setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
     const changedPreparedRows = preparedRows.filter((prepared) => {
       const existingSlot = this.keyToSlot.get(prepared.key);
-      return existingSlot === undefined || preparedTopicRowChangesRow(prepared);
+      return (
+        existingSlot === undefined || this.preparedRowChangesCurrentSlot(prepared, existingSlot)
+      );
     });
     const appendReservation = this.createAppendBatchReservation(changedPreparedRows);
     if (changedPreparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
@@ -504,6 +506,10 @@ export class TopicRowStorage {
       previous: undefined,
       next: prepared.row,
     });
+  }
+
+  private preparedRowChangesCurrentSlot(prepared: PreparedTopicRow, slot: number): boolean {
+    return preparedTopicRowChangesRow(prepared) || !rowsEqual(this.slots[slot]!.row, prepared.row);
   }
 
   private recordRowChange(change: TopicRowChange<object>): void {

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -7,6 +7,7 @@ import type {
   TopicRowEntry,
   TopicRowVisitor,
 } from "./row-scan";
+import { topicRowChangedFieldsFromRows } from "./row-scan";
 import type {
   TopicRawOrderByPlan,
   TopicRawWindowScanPlan,
@@ -33,7 +34,6 @@ import {
 import {
   prepareTopicPatch,
   prepareTopicRow,
-  preparedTopicRowChangesRow,
   type InvalidRowErrorFactory,
   type PreparedTopicRow,
   type TopicRowPreparationContext,
@@ -62,6 +62,11 @@ type RawProjectionColumn = {
 
 type AppendBatchReservation = {
   reserveFrom(startIndex: number): void;
+};
+
+type PreparedTopicRowReplacement = {
+  readonly changedFields: TopicRowChangedFields | undefined;
+  readonly previous: object;
 };
 
 const noopAppendBatchReservation: AppendBatchReservation = {
@@ -176,16 +181,16 @@ export class TopicRowStorage {
   setPrepared(prepared: PreparedTopicRow): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
-      if (!this.preparedRowChangesCurrentSlot(prepared, existingSlot)) {
+      const replacement = this.preparedReplacementForCurrentSlot(prepared, existingSlot);
+      if (replacement === undefined) {
         return;
       }
-      const previous = this.slots[existingSlot]!.row;
       this.removeSlotFromScalarIndexes(existingSlot);
-      this.removeSlotFromReplacementOrderedIndexes(existingSlot, prepared.changedFields);
+      this.removeSlotFromReplacementOrderedIndexes(existingSlot, replacement.changedFields);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
-      this.recordPreparedReplacementChange(prepared, previous);
-      this.insertSlotIntoReplacementOrderedIndexes(existingSlot, prepared.changedFields);
+      this.recordPreparedReplacementChange(prepared, replacement);
+      this.insertSlotIntoReplacementOrderedIndexes(existingSlot, replacement.changedFields);
       return;
     }
 
@@ -202,27 +207,17 @@ export class TopicRowStorage {
   }
 
   setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
-    const changedPreparedRows = preparedRows.filter((prepared) => {
-      const existingSlot = this.keyToSlot.get(prepared.key);
-      return (
-        existingSlot === undefined || this.preparedRowChangesCurrentSlot(prepared, existingSlot)
-      );
-    });
-    const appendReservation = this.createAppendBatchReservation(changedPreparedRows);
-    if (changedPreparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
+    const appendReservation = this.createAppendBatchReservation(preparedRows);
+    if (preparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
       this.orderedSlotIndexes.clear();
-      for (let index = 0; index < changedPreparedRows.length; index += 1) {
-        this.setPreparedWithoutIndexMaintenance(
-          changedPreparedRows[index]!,
-          appendReservation,
-          index,
-        );
+      for (let index = 0; index < preparedRows.length; index += 1) {
+        this.setPreparedWithoutIndexMaintenance(preparedRows[index]!, appendReservation, index);
       }
       return;
     }
 
-    for (let index = 0; index < changedPreparedRows.length; index += 1) {
-      this.setPreparedInBatch(changedPreparedRows[index]!, appendReservation, index);
+    for (let index = 0; index < preparedRows.length; index += 1) {
+      this.setPreparedInBatch(preparedRows[index]!, appendReservation, index);
     }
   }
 
@@ -421,13 +416,16 @@ export class TopicRowStorage {
   ): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
-      const previous = this.slots[existingSlot]!.row;
+      const replacement = this.preparedReplacementForCurrentSlot(prepared, existingSlot);
+      if (replacement === undefined) {
+        return;
+      }
       this.removeSlotFromScalarIndexes(existingSlot);
-      this.removeSlotFromReplacementOrderedIndexes(existingSlot, prepared.changedFields);
+      this.removeSlotFromReplacementOrderedIndexes(existingSlot, replacement.changedFields);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
-      this.recordPreparedReplacementChange(prepared, previous);
-      this.insertSlotIntoReplacementOrderedIndexes(existingSlot, prepared.changedFields);
+      this.recordPreparedReplacementChange(prepared, replacement);
+      this.insertSlotIntoReplacementOrderedIndexes(existingSlot, replacement.changedFields);
       return;
     }
 
@@ -488,11 +486,14 @@ export class TopicRowStorage {
   ): void {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
-      const previous = this.slots[existingSlot]!.row;
+      const replacement = this.preparedReplacementForCurrentSlot(prepared, existingSlot);
+      if (replacement === undefined) {
+        return;
+      }
       this.removeSlotFromScalarIndexes(existingSlot);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
-      this.recordPreparedReplacementChange(prepared, previous);
+      this.recordPreparedReplacementChange(prepared, replacement);
       return;
     }
 
@@ -508,27 +509,50 @@ export class TopicRowStorage {
     });
   }
 
-  private preparedRowChangesCurrentSlot(prepared: PreparedTopicRow, slot: number): boolean {
-    return preparedTopicRowChangesRow(prepared) || !rowsEqual(this.slots[slot]!.row, prepared.row);
+  private preparedReplacementForCurrentSlot(
+    prepared: PreparedTopicRow,
+    slot: number,
+  ): PreparedTopicRowReplacement | undefined {
+    const previous = this.slots[slot]!.row;
+    if (rowsEqual(previous, prepared.row)) {
+      return undefined;
+    }
+    if (prepared.source === "row") {
+      return {
+        changedFields: undefined,
+        previous,
+      };
+    }
+    return {
+      changedFields: topicRowChangedFieldsFromRows(
+        previous,
+        prepared.row,
+        this.rawQueryMetadata.fieldNames,
+      ),
+      previous,
+    };
   }
 
   private recordRowChange(change: TopicRowChange<object>): void {
     this.rowChangeJournal.record(change, this.versionValue);
   }
 
-  private recordPreparedReplacementChange(prepared: PreparedTopicRow, previous: object): void {
-    if (prepared.changedFields === undefined) {
+  private recordPreparedReplacementChange(
+    prepared: PreparedTopicRow,
+    replacement: PreparedTopicRowReplacement,
+  ): void {
+    if (replacement.changedFields === undefined) {
       this.recordRowChange({
         key: prepared.key,
-        previous,
+        previous: replacement.previous,
         next: prepared.row,
       });
       return;
     }
     this.recordRowChange({
-      changedFields: prepared.changedFields,
+      changedFields: replacement.changedFields,
       key: prepared.key,
-      previous,
+      previous: replacement.previous,
       next: prepared.row,
     });
   }

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -178,12 +178,12 @@ export class TopicRowStorage {
     this.versionValue = 0;
   }
 
-  setPrepared(prepared: PreparedTopicRow): void {
+  setPrepared(prepared: PreparedTopicRow): number {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
       const replacement = this.preparedReplacementForCurrentSlot(prepared, existingSlot);
       if (replacement === undefined) {
-        return;
+        return 0;
       }
       this.removeSlotFromScalarIndexes(existingSlot);
       this.removeSlotFromReplacementOrderedIndexes(existingSlot, replacement.changedFields);
@@ -191,7 +191,7 @@ export class TopicRowStorage {
       this.addSlotToScalarIndexes(existingSlot);
       this.recordPreparedReplacementChange(prepared, replacement);
       this.insertSlotIntoReplacementOrderedIndexes(existingSlot, replacement.changedFields);
-      return;
+      return 1;
     }
 
     const slot = this.slots.length;
@@ -204,21 +204,29 @@ export class TopicRowStorage {
       next: prepared.row,
     });
     this.insertSlotIntoOrderedIndexes(slot);
+    return 1;
   }
 
-  setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): void {
+  setPreparedMany(preparedRows: ReadonlyArray<PreparedTopicRow>): number {
     const appendReservation = this.createAppendBatchReservation(preparedRows);
     if (preparedRows.length > 1 && this.orderedSlotIndexes.size > 0) {
       this.orderedSlotIndexes.clear();
+      let rowsChanged = 0;
       for (let index = 0; index < preparedRows.length; index += 1) {
-        this.setPreparedWithoutIndexMaintenance(preparedRows[index]!, appendReservation, index);
+        rowsChanged += this.setPreparedWithoutIndexMaintenance(
+          preparedRows[index]!,
+          appendReservation,
+          index,
+        );
       }
-      return;
+      return rowsChanged;
     }
 
+    let rowsChanged = 0;
     for (let index = 0; index < preparedRows.length; index += 1) {
-      this.setPreparedInBatch(preparedRows[index]!, appendReservation, index);
+      rowsChanged += this.setPreparedInBatch(preparedRows[index]!, appendReservation, index);
     }
+    return rowsChanged;
   }
 
   delete(key: string): number {
@@ -413,12 +421,12 @@ export class TopicRowStorage {
     prepared: PreparedTopicRow,
     appendReservation: AppendBatchReservation,
     batchIndex: number,
-  ): void {
+  ): number {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
       const replacement = this.preparedReplacementForCurrentSlot(prepared, existingSlot);
       if (replacement === undefined) {
-        return;
+        return 0;
       }
       this.removeSlotFromScalarIndexes(existingSlot);
       this.removeSlotFromReplacementOrderedIndexes(existingSlot, replacement.changedFields);
@@ -426,7 +434,7 @@ export class TopicRowStorage {
       this.addSlotToScalarIndexes(existingSlot);
       this.recordPreparedReplacementChange(prepared, replacement);
       this.insertSlotIntoReplacementOrderedIndexes(existingSlot, replacement.changedFields);
-      return;
+      return 1;
     }
 
     appendReservation.reserveFrom(batchIndex);
@@ -440,6 +448,7 @@ export class TopicRowStorage {
       next: prepared.row,
     });
     this.insertSlotIntoOrderedIndexes(slot);
+    return 1;
   }
 
   private insertSlotIntoOrderedIndexes(slot: number): void {
@@ -483,18 +492,18 @@ export class TopicRowStorage {
     prepared: PreparedTopicRow,
     appendReservation: AppendBatchReservation,
     batchIndex: number,
-  ): void {
+  ): number {
     const existingSlot = this.keyToSlot.get(prepared.key);
     if (existingSlot !== undefined) {
       const replacement = this.preparedReplacementForCurrentSlot(prepared, existingSlot);
       if (replacement === undefined) {
-        return;
+        return 0;
       }
       this.removeSlotFromScalarIndexes(existingSlot);
       this.writeSlot(existingSlot, prepared);
       this.addSlotToScalarIndexes(existingSlot);
       this.recordPreparedReplacementChange(prepared, replacement);
-      return;
+      return 1;
     }
 
     appendReservation.reserveFrom(batchIndex);
@@ -507,6 +516,7 @@ export class TopicRowStorage {
       previous: undefined,
       next: prepared.row,
     });
+    return 1;
   }
 
   private preparedReplacementForCurrentSlot(

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -1,6 +1,10 @@
 import { Clock, Effect, Semaphore } from "effect";
 import type { TopicRowStorage } from "./topic-row-storage";
-import type { InvalidRowErrorFactory, PreparedTopicRow } from "./topic-row-preparation";
+import {
+  preparedTopicRowChangesRow,
+  type InvalidRowErrorFactory,
+  type PreparedTopicRow,
+} from "./topic-row-preparation";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 import { topicStoreState, type TopicStore } from "./topic-store-state";
@@ -108,6 +112,9 @@ const topicStoreMutationContext = (state: TopicStoreMutationState): TopicStoreMu
   patch: (key, patch, invalidRow) =>
     Effect.gen(function* () {
       const prepared = yield* state.storage.preparePatch(key, patch, invalidRow);
+      if (!preparedTopicRowChangesRow(prepared)) {
+        return 0;
+      }
       state.storage.setPrepared(prepared);
       return 1;
     }),

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -1,10 +1,6 @@
 import { Clock, Effect, Semaphore } from "effect";
 import type { TopicRowStorage } from "./topic-row-storage";
-import {
-  preparedTopicRowChangesRow,
-  type InvalidRowErrorFactory,
-  type PreparedTopicRow,
-} from "./topic-row-preparation";
+import type { InvalidRowErrorFactory, PreparedTopicRow } from "./topic-row-preparation";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 import { topicStoreState, type TopicStore } from "./topic-store-state";
@@ -101,22 +97,12 @@ const recordTopicStoreMutation = (
 };
 
 const topicStoreMutationContext = (state: TopicStoreMutationState): TopicStoreMutationContext => ({
-  publishPrepared: (prepared) => {
-    state.storage.setPrepared(prepared);
-    return 1;
-  },
-  publishPreparedMany: (preparedRows) => {
-    state.storage.setPreparedMany(preparedRows);
-    return preparedRows.length;
-  },
+  publishPrepared: (prepared) => state.storage.setPrepared(prepared),
+  publishPreparedMany: (preparedRows) => state.storage.setPreparedMany(preparedRows),
   patch: (key, patch, invalidRow) =>
     Effect.gen(function* () {
       const prepared = yield* state.storage.preparePatch(key, patch, invalidRow);
-      if (!preparedTopicRowChangesRow(prepared)) {
-        return 0;
-      }
-      state.storage.setPrepared(prepared);
-      return 1;
+      return state.storage.setPrepared(prepared);
     }),
   delete: (key) => state.storage.delete(key),
 });


### PR DESCRIPTION
## Summary
- maintain warmed raw ordered window indexes incrementally for single-row replacements and deletes
- distinguish full row replacements from no-op patches so no-op prepared patches do not invalidate or notify
- add regression coverage for replacement, patch, delete/moved-slot, and no-op prepared batch paths
- extend raw write Vitest benchmarks and smoke baselines for warmed indexed read-after-write cases

## Validation
- vp check --fix
- pnpm --filter @view-server/column-live-view-engine run test -- --testNamePattern "ordered raw indexes current|typed column values for ordered slot bound indexes|does not notify topic-store subscribers for no-op mutations|ignores prepared no-op patches"
- pnpm run bench:baseline:smoke
- pnpm run ready

## Review
- Sagan: no findings
- Turing: found benchmark-order issue; fixed and reran smoke baseline + ready
- Ramanujan: no findings