### PR TITLE
Deduplicate protocol JSON field errors

### DIFF
--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -1613,6 +1613,7 @@ describe("@view-server/protocol", () => {
         }),
       );
       expect(invalidFilter.code).toBe("InvalidQuery");
+      expect(invalidFilter.message).toBe('Invalid filter for price: Expected number, got "nope"');
 
       const invalidEncodeStartsWith = yield* Effect.flip(
         viewServerEncodeRawQuery(viewServer, "orders", {
@@ -1628,7 +1629,7 @@ describe("@view-server/protocol", () => {
           where: { id: { startsWith: 1 } },
         }),
       );
-      expect(invalidStringStartsWith.message).toMatch(/Invalid filter for id/);
+      expect(invalidStringStartsWith.message).toBe("Invalid filter for id: expected string");
 
       const invalidDecodeStartsWith = yield* Effect.flip(
         viewServerDecodeRawQuery(viewServer, "orders", {
@@ -1644,7 +1645,7 @@ describe("@view-server/protocol", () => {
           where: { id: { startsWith: 1 } },
         }),
       );
-      expect(invalidDecodedStringStartsWith.message).toMatch(/Invalid filter for id/);
+      expect(invalidDecodedStringStartsWith.message).toBe("Invalid filter for id: expected string");
 
       const trimmedViewServer = defineViewServerConfig({
         topics: {
@@ -1817,7 +1818,9 @@ describe("@view-server/protocol", () => {
           where: { id: { eq: "x" } },
         }),
       );
-      expect(nonJsonFilter.message).toMatch(/Filter id is not JSON-safe/);
+      expect(nonJsonFilter.message).toBe(
+        "Filter id is not JSON-safe: Expected JSON value, got Symbol(not-json)",
+      );
 
       const badDecodedField = yield* Effect.flip(
         viewServerDecodeRawQuery(viewServer, "orders", {
@@ -1894,6 +1897,9 @@ describe("@view-server/protocol", () => {
         }),
       );
       expect(invalidEncodeFieldType.code).toBe("InvalidRow");
+      expect(invalidEncodeFieldType.message).toBe(
+        'Invalid field price: Expected number, got "nope"',
+      );
 
       const extraField = yield* Effect.flip(
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
@@ -1948,6 +1954,9 @@ describe("@view-server/protocol", () => {
         ),
       );
       expect(invalidFieldType.code).toBe("InvalidRow");
+      expect(invalidFieldType.message).toBe(
+        'Invalid field price: Expected "Infinity" | "-Infinity" | "NaN", got "nope"',
+      );
 
       const nonJsonRow = yield* Effect.flip(
         viewServerEncodeLiveEvent(viewServer, "badjson", idQuery, {
@@ -1960,7 +1969,9 @@ describe("@view-server/protocol", () => {
           totalRows: 1,
         }),
       );
-      expect(nonJsonRow.message).toMatch(/Field id is not JSON-safe/);
+      expect(nonJsonRow.message).toBe(
+        "Field id is not JSON-safe: Expected JSON value, got Symbol(not-json)",
+      );
 
       const BadJsonAggregateRow = Schema.Struct({
         id: Schema.String,
@@ -2151,7 +2162,7 @@ describe("@view-server/protocol", () => {
           },
         ),
       );
-      expect(invalidGroupedField.message).toMatch(/Invalid field id/);
+      expect(invalidGroupedField.message).toBe("Invalid field id: Expected string, got 10");
 
       const missingDecodedGroupedField = yield* Effect.flip(
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
@@ -2465,7 +2476,9 @@ describe("@view-server/protocol", () => {
           },
         ),
       );
-      expect(invalidJsonAggregateValue.message).toMatch(/Invalid field minPrice/);
+      expect(invalidJsonAggregateValue.message).toBe(
+        'Invalid field minPrice: Expected "Infinity" | "-Infinity" | "NaN", got "not-a-number"',
+      );
 
       const missingAggregateSourceField = yield* Effect.flip(
         viewServerEncodeLiveEvent(

--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -1,8 +1,8 @@
 import { viewServerSchemaFieldMetadata, type ViewServerRuntimeError } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import {
-  decodeContextualJsonFieldValue,
-  encodeContextualJsonFieldValue,
+  decodeNamedJsonFieldValue,
+  encodeNamedJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 
@@ -40,11 +40,11 @@ const encodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* encodeContextualJsonFieldValue(schema, value, {
+  return yield* encodeNamedJsonFieldValue(schema, value, {
+    field,
     invalid: (message) => invalidQuery(topic, message),
-    invalidMessage: (message) => `Invalid filter for ${field}: ${message}`,
-    notJsonSafe: (message) => invalidQuery(topic, message),
-    notJsonSafeMessage: (message) => `Filter ${field} is not JSON-safe: ${message}`,
+    invalidPrefix: "Invalid filter for",
+    notJsonSafePrefix: "Filter",
   });
 });
 
@@ -54,9 +54,10 @@ const decodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* decodeContextualJsonFieldValue(schema, value, {
+  return yield* decodeNamedJsonFieldValue(schema, value, {
+    field,
     invalid: (message) => invalidQuery(topic, message),
-    invalidMessage: (message) => `Invalid filter for ${field}: ${message}`,
+    invalidPrefix: "Invalid filter for",
   });
 });
 

--- a/packages/protocol/src/protocol-json-field-codec.ts
+++ b/packages/protocol/src/protocol-json-field-codec.ts
@@ -17,6 +17,16 @@ type JsonFieldEncodeContext<E> = JsonFieldCodecContext<E> & {
   readonly notJsonSafeMessage: (message: string) => string;
 };
 
+type NamedJsonFieldCodecContext<E> = {
+  readonly field: string;
+  readonly invalid: (message: string) => E;
+  readonly invalidPrefix: string;
+};
+
+type NamedJsonFieldEncodeContext<E> = NamedJsonFieldCodecContext<E> & {
+  readonly notJsonSafePrefix: string;
+};
+
 export const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.encode")(function* <E>(
   schema: JsonFieldSchema,
   value: unknown,
@@ -56,3 +66,31 @@ export const decodeContextualJsonFieldValue = Effect.fn(
     invalid: (message) => context.invalid(context.invalidMessage(message)),
   });
 });
+
+export const encodeNamedJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.named.encode")(
+  function* <E>(
+    schema: JsonFieldSchema,
+    value: unknown,
+    { field, invalid, invalidPrefix, notJsonSafePrefix }: NamedJsonFieldEncodeContext<E>,
+  ) {
+    return yield* encodeContextualJsonFieldValue(schema, value, {
+      invalid,
+      invalidMessage: (message) => `${invalidPrefix} ${field}: ${message}`,
+      notJsonSafe: invalid,
+      notJsonSafeMessage: (message) => `${notJsonSafePrefix} ${field} is not JSON-safe: ${message}`,
+    });
+  },
+);
+
+export const decodeNamedJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.named.decode")(
+  function* <E>(
+    schema: JsonFieldSchema,
+    value: unknown,
+    { field, invalid, invalidPrefix }: NamedJsonFieldCodecContext<E>,
+  ) {
+    return yield* decodeContextualJsonFieldValue(schema, value, {
+      invalid,
+      invalidMessage: (message) => `${invalidPrefix} ${field}: ${message}`,
+    });
+  },
+);

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -3,8 +3,8 @@ import { Effect, Schema } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
 import {
-  decodeContextualJsonFieldValue,
-  encodeContextualJsonFieldValue,
+  decodeNamedJsonFieldValue,
+  encodeNamedJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 import type { ViewServerEventGroupedQuery, ViewServerEventQuery } from "./protocol-query-schema";
@@ -26,11 +26,11 @@ const encodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.enco
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* encodeContextualJsonFieldValue(schema, value, {
+  return yield* encodeNamedJsonFieldValue(schema, value, {
+    field,
     invalid: (message) => invalidRow(topic, message),
-    invalidMessage: (message) => `Invalid field ${field}: ${message}`,
-    notJsonSafe: (message) => invalidRow(topic, message),
-    notJsonSafeMessage: (message) => `Field ${field} is not JSON-safe: ${message}`,
+    invalidPrefix: "Invalid field",
+    notJsonSafePrefix: "Field",
   });
 });
 
@@ -40,9 +40,10 @@ const decodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.deco
   schema: JsonFieldSchema,
   value: unknown,
 ) {
-  return yield* decodeContextualJsonFieldValue(schema, value, {
+  return yield* decodeNamedJsonFieldValue(schema, value, {
+    field,
     invalid: (message) => invalidRow(topic, message),
-    invalidMessage: (message) => `Invalid field ${field}: ${message}`,
+    invalidPrefix: "Invalid field",
   });
 });
 


### PR DESCRIPTION
## Summary
- Add an internal named JSON field codec helper for repeated field-name error formatting.
- Use it from filter and row codecs while preserving existing wire/error semantics.
- Add exact-message regressions for helper-backed invalid filter, row, JSON-safe, grouped field, and grouped JSON aggregate paths.

## Validation
- pnpm --filter @view-server/protocol run test
- vp check --fix
- pnpm run check:effect
- pnpm run check:package-exports

## Review
- 3 local reviewer agents ran.
- First round found a testing gap around exact wire error messages.
- Added exact-message regressions and reran review.
- Second round found no blocking issues.
