### PR TITLE
Add Kafka protobuf runtime ingress coverage

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -26,6 +26,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@bufbuild/protobuf": "2.12.0",
     "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",

--- a/packages/runtime/src/kafka-ingress.test.ts
+++ b/packages/runtime/src/kafka-ingress.test.ts
@@ -1,9 +1,17 @@
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, expectTypeOf, it } from "@effect/vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
 import { Admin, Producer, stringSerializers } from "@platformatic/kafka";
 import { defineViewServerConfig, kafka } from "@view-server/config";
+import { Buffer } from "node:buffer";
 import { Crypto, Effect, Schedule, Schema } from "effect";
 import { makeViewServerRuntime } from "./index";
+import {
+  type OrderKey,
+  OrderKeySchema,
+  type OrderValue,
+  OrderValueSchema,
+} from "./test-fixtures/runtime_orders_pb";
 
 const kafkaBootstrapServers =
   process.env["VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS"] ?? "localhost:9092";
@@ -49,6 +57,12 @@ type ProducerMessage = {
   readonly value: string;
 };
 
+type BinaryProducerMessage = {
+  readonly topic: string;
+  readonly key: Buffer;
+  readonly value: Buffer;
+};
+
 const nullRecord = <Value>(entries: Record<string, Value>): Record<string, Value> => {
   const record: Record<string, Value> = Object.create(null);
   return Object.assign(record, entries);
@@ -88,6 +102,28 @@ const sendKafkaMessages = Effect.fn("ViewServerRuntime.kafka.test.produce")(func
         }),
       ),
     (currentProducer) => Effect.promise(() => currentProducer.close()).pipe(Effect.ignore),
+  );
+});
+
+const sendBinaryKafkaMessages = Effect.fn("ViewServerRuntime.kafka.test.produceBinary")(function* (
+  bootstrapServers: string,
+  clientId: string,
+  messages: ReadonlyArray<BinaryProducerMessage>,
+) {
+  const producer = new Producer<Buffer, Buffer, Buffer, Buffer>({
+    bootstrapBrokers: [bootstrapServers],
+    clientId,
+  });
+
+  return yield* Effect.acquireUseRelease(
+    Effect.succeed(producer),
+    (currentProducer) =>
+      Effect.promise(() =>
+        currentProducer.send({
+          messages: [...messages],
+        }),
+      ),
+    (currentProducer) => Effect.promise(() => currentProducer.close()),
   );
 });
 
@@ -356,5 +392,171 @@ describe("@view-server/runtime Kafka ingress", () => {
           (runtime) => runtime.close.pipe(Effect.ignore),
         );
       }).pipe(Effect.provide(NodeCrypto.layer)),
+  );
+
+  it.live("ingests protobuf Kafka key and value messages into a View Server topic", () =>
+    Effect.gen(function* () {
+      const ordersSourceTopic = yield* uniqueTopicName("protobuf-orders");
+      const consumerGroupId = yield* uniqueGroupId();
+      yield* createKafkaTopics(kafkaBootstrapServers, [ordersSourceTopic]);
+
+      const regions = {
+        local: kafkaBootstrapServers,
+      };
+      const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
+
+      yield* Effect.acquireUseRelease(
+        makeViewServerRuntime(viewServer, {
+          host: "127.0.0.1",
+          websocketPort: 0,
+          kafka: {
+            consumerGroupId,
+            regions,
+            topics: {
+              [ordersSourceTopic]: localKafkaTopic({
+                regions: ["local"],
+                value: kafka.protobuf(OrderValueSchema),
+                key: kafka.protobuf(OrderKeySchema),
+                viewServerTopic: "orders",
+                mapping: ({ key, value, region }) => {
+                  expectTypeOf(key).toEqualTypeOf<OrderKey>();
+                  expectTypeOf(value).toEqualTypeOf<OrderValue>();
+                  expectTypeOf(region).toEqualTypeOf<"local">();
+                  return {
+                    id: key.orderId,
+                    customerId: value.customerId,
+                    price: value.price,
+                  };
+                },
+              }),
+            },
+          },
+        }),
+        (runtime) =>
+          Effect.gen(function* () {
+            yield* sendBinaryKafkaMessages(
+              kafkaBootstrapServers,
+              "view-server-kafka-protobuf-ingress-test",
+              [
+                {
+                  topic: ordersSourceTopic,
+                  key: Buffer.from(
+                    toBinary(
+                      OrderKeySchema,
+                      create(OrderKeySchema, {
+                        orderId: "protobuf-order-1",
+                      }),
+                    ),
+                  ),
+                  value: Buffer.from(
+                    toBinary(
+                      OrderValueSchema,
+                      create(OrderValueSchema, {
+                        customerId: "protobuf-customer-1",
+                        price: 42,
+                      }),
+                    ),
+                  ),
+                },
+              ],
+            );
+
+            const ordersSnapshot = yield* runtime.client
+              .snapshot("orders", {
+                select: ["id", "customerId", "price"],
+                orderBy: [{ field: "id", direction: "asc" }],
+                limit: 10,
+              })
+              .pipe(
+                Effect.repeat({
+                  schedule: healthPollSchedule,
+                  until: (snapshot) => snapshot.totalRows === 1,
+                }),
+              );
+            const health = yield* runtime.client.health().pipe(
+              Effect.repeat({
+                schedule: healthPollSchedule,
+                until: (currentHealth) =>
+                  currentHealth.engine.topics.orders.rowCount === 1 &&
+                  currentHealth.kafka?.topics[ordersSourceTopic]?.status === "ready" &&
+                  currentHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]
+                    ?.committedOffset === "1" &&
+                  currentHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]
+                    ?.consumerLagMessages === 0n,
+              }),
+            );
+
+            expect({
+              status: health.status,
+              ordersSnapshot,
+              engineRows: {
+                orders: health.engine.topics.orders.rowCount,
+                trades: health.engine.topics.trades.rowCount,
+              },
+              kafka: health.kafka,
+            }).toStrictEqual({
+              status: "ready",
+              ordersSnapshot: {
+                status: "ready",
+                statusCode: "Ready",
+                rows: [
+                  {
+                    id: "protobuf-order-1",
+                    customerId: "protobuf-customer-1",
+                    price: 42,
+                  },
+                ],
+                totalRows: 1,
+                version: expect.any(Number),
+              },
+              engineRows: {
+                orders: 1,
+                trades: 0,
+              },
+              kafka: {
+                startFrom: {
+                  consumerGroupId,
+                  fallbackMode: "earliest",
+                  mode: "committed",
+                },
+                regions: nullRecord({
+                  local: {
+                    status: "connected",
+                    brokers: kafkaBootstrapServers,
+                    lastConnectedAt: expect.any(Number),
+                    lastError: null,
+                  },
+                }),
+                topics: nullRecord({
+                  [ordersSourceTopic]: {
+                    status: "ready",
+                    sourceTopic: ordersSourceTopic,
+                    viewServerTopic: "orders",
+                    regions: nullRecord({
+                      local: {
+                        connected: true,
+                        assignedPartitions: 1,
+                        messagesPerSecond: expect.any(Number),
+                        bytesPerSecond: expect.any(Number),
+                        decodedMessagesPerSecond: expect.any(Number),
+                        decodeFailuresPerSecond: 0,
+                        mappingFailuresPerSecond: 0,
+                        processingFailuresPerSecond: 0,
+                        lastMessageAt: expect.any(Number),
+                        lastCommitAt: expect.any(Number),
+                        consumerLagMessages: 0n,
+                        lagSampledAt: expect.any(Number),
+                        committedOffset: "1",
+                        lastError: null,
+                      },
+                    }),
+                  },
+                }),
+              },
+            });
+          }),
+        (runtime) => runtime.close.pipe(Effect.ignore),
+      );
+    }).pipe(Effect.provide(NodeCrypto.layer)),
   );
 });

--- a/packages/runtime/src/test-fixtures/runtime_orders_pb.ts
+++ b/packages/runtime/src/test-fixtures/runtime_orders_pb.ts
@@ -1,0 +1,59 @@
+// Generated-style protobuf fixture for runtime Kafka e2e tests.
+import type { Message } from "@bufbuild/protobuf";
+import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv2";
+import type { GenFile, GenMessage } from "@bufbuild/protobuf/codegenv2";
+
+/**
+ * Describes the file viewserver/runtime/test.proto.
+ */
+export const file_viewserver_runtime_test: GenFile = fileDesc(
+  "Ch12aWV3c2VydmVyL3J1bnRpbWUvdGVzdC5wcm90bxIXdmlld3NlcnZlci5ydW50aW1lLnRlc3QiLAoKT3JkZXJWYWx1ZRIRCgtjdXN0b21lcl9pZBgBKAkSCwoFcHJpY2UYAigBIhoKCE9yZGVyS2V5Eg4KCG9yZGVyX2lkGAEoCWIGcHJvdG8z",
+);
+
+/**
+ * @generated from message viewserver.runtime.test.OrderValue
+ */
+export type OrderValue = Message<"viewserver.runtime.test.OrderValue"> & {
+  readonly customerId: string;
+  readonly price: number;
+};
+
+/**
+ * @generated from message viewserver.runtime.test.OrderValue
+ */
+export type OrderValueJson = {
+  readonly customerId?: string;
+  readonly price?: number;
+};
+
+/**
+ * Describes the message viewserver.runtime.test.OrderValue.
+ * Use `create(OrderValueSchema)` to create a new message.
+ */
+export const OrderValueSchema: GenMessage<OrderValue, { jsonType: OrderValueJson }> = messageDesc(
+  file_viewserver_runtime_test,
+  0,
+);
+
+/**
+ * @generated from message viewserver.runtime.test.OrderKey
+ */
+export type OrderKey = Message<"viewserver.runtime.test.OrderKey"> & {
+  readonly orderId: string;
+};
+
+/**
+ * @generated from message viewserver.runtime.test.OrderKey
+ */
+export type OrderKeyJson = {
+  readonly orderId?: string;
+};
+
+/**
+ * Describes the message viewserver.runtime.test.OrderKey.
+ * Use `create(OrderKeySchema)` to create a new message.
+ */
+export const OrderKeySchema: GenMessage<OrderKey, { jsonType: OrderKeyJson }> = messageDesc(
+  file_viewserver_runtime_test,
+  1,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-beta.70
     devDependencies:
+      '@bufbuild/protobuf':
+        specifier: 2.12.0
+        version: 2.12.0
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.70(effect@4.0.0-beta.70)(ioredis@5.10.1)


### PR DESCRIPTION
## Summary
- add a runtime Kafka e2e that produces binary protobuf key/value payloads through @platformatic/kafka
- decode with kafka.protobuf(...) using a generated-style Protobuf-ES fixture and map into the View Server topic
- assert snapshot materialization plus full Kafka health/lag shape for the protobuf source topic

## Validation
- vp check --fix packages/runtime/src/kafka-ingress.test.ts packages/runtime/src/test-fixtures/runtime_orders_pb.ts packages/runtime/package.json pnpm-lock.yaml
- pnpm --filter @view-server/runtime run test
- pnpm run ready