### PR TITLE
Coalesce RPC health reads and harden seam scanner

### DIFF
--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -20,6 +20,7 @@ import {
   Cause,
   Deferred,
   Effect,
+  Exit,
   Fiber,
   Layer,
   Logger,
@@ -27,15 +28,18 @@ import {
   References,
   Schema,
   SchemaGetter,
+  Scope,
   Stream,
 } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
 import { AtomRef } from "effect/unstable/reactivity";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
+import * as Socket from "effect/unstable/socket/Socket";
 import * as Net from "node:net";
 import { makeViewServerWebSocketServer } from "./index";
 import { makeViewServerRpcHandlers } from "./rpc-handlers";
+import { closeTrackedSockets, makeTrackedSocket } from "./websocket-tracking";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -63,6 +67,10 @@ const HealthJson = Schema.Struct({
   }),
 });
 
+const TcpAddress = Schema.Struct({
+  port: Schema.Number,
+});
+
 class ServerTestJsonParseError extends Schema.TaggedErrorClass<ServerTestJsonParseError>()(
   "ServerTestJsonParseError",
   {
@@ -72,6 +80,13 @@ class ServerTestJsonParseError extends Schema.TaggedErrorClass<ServerTestJsonPar
 
 class ServerTestMalformedUpgradeError extends Schema.TaggedErrorClass<ServerTestMalformedUpgradeError>()(
   "ServerTestMalformedUpgradeError",
+  {
+    cause: Schema.Unknown,
+  },
+) {}
+
+class ServerTestTcpError extends Schema.TaggedErrorClass<ServerTestTcpError>()(
+  "ServerTestTcpError",
   {
     cause: Schema.Unknown,
   },
@@ -148,6 +163,23 @@ const quote = (id: string, price: string): QuoteRow => ({
   price: fromStringUnsafe(price),
 });
 
+const serverHealthWithOrdersRowCount = (
+  health: ViewServerHealth<typeof viewServer.topics>,
+  rowCount: number,
+): ViewServerHealth<typeof viewServer.topics> => ({
+  ...health,
+  engine: {
+    ...health.engine,
+    topics: {
+      ...health.engine.topics,
+      orders: {
+        ...health.engine.topics.orders,
+        rowCount,
+      },
+    },
+  },
+});
+
 class RawViewServerRpcClient extends Context.Service<
   RawViewServerRpcClient,
   RpcClient.FromGroup<typeof ViewServerRpcs, RpcClientError>
@@ -178,6 +210,33 @@ const fetchJson = Effect.fn("ViewServerServer.test.fetchJson")(function* (url: s
     catch: (cause) => new ServerTestJsonParseError({ cause }),
   });
   return { response, value };
+});
+
+const reserveTcpPort = Effect.fn("ViewServerServer.test.tcp.reservePort")(function* () {
+  const server = yield* Effect.acquireRelease(
+    Effect.callback<Net.Server, ServerTestTcpError>((resume) => {
+      const blocker = Net.createServer();
+      const cleanup = () => {
+        blocker.removeAllListeners();
+      };
+      blocker.once("error", (cause) => {
+        cleanup();
+        resume(Effect.fail(new ServerTestTcpError({ cause })));
+      });
+      blocker.listen(0, "127.0.0.1", () => {
+        cleanup();
+        resume(Effect.succeed(blocker));
+      });
+    }),
+    (server) =>
+      Effect.callback<void>((resume) => {
+        server.close(() => {
+          resume(Effect.void);
+        });
+      }),
+  );
+  const address = yield* Schema.decodeUnknownEffect(TcpAddress)(server.address());
+  return address.port;
 });
 
 const sendMalformedWebSocketUpgrade = Effect.fn("ViewServerServer.test.websocket.malformedUpgrade")(
@@ -422,6 +481,27 @@ describe("@view-server/server", () => {
     }),
   );
 
+  it.live("fails when the websocket server port is unavailable", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const inMemory = createServerTestRuntime(viewServer);
+        const reservedPort = yield* reserveTcpPort();
+
+        const startupExit = yield* makeViewServerWebSocketServer(
+          viewServer,
+          {
+            liveClient: inMemory.liveClient,
+            runtime: inMemory.client,
+          },
+          { host: "127.0.0.1", port: reservedPort },
+        ).pipe(Effect.exit);
+
+        expect(Exit.isFailure(startupExit)).toBe(true);
+        yield* inMemory.close;
+      }),
+    ),
+  );
+
   it.live("closes tracked websocket clients when interrupted during the open hook", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
@@ -455,6 +535,90 @@ describe("@view-server/server", () => {
       expect(openedClients).toBe(1);
       expect(closedClients).toBe(1);
       yield* inMemory.close;
+    }),
+  );
+
+  it.live("tracks active websocket close frames and logs shutdown close failures", () => {
+    const logs: Array<{
+      readonly cause: Cause.Cause<unknown>;
+      readonly logLevel: unknown;
+      readonly message: unknown;
+    }> = [];
+    const logger = Logger.make<unknown, void>((options) => {
+      logs.push({
+        cause: options.cause,
+        logLevel: options.logLevel,
+        message: options.message,
+      });
+    });
+
+    return Effect.gen(function* () {
+      const activeSocketClosers = new Set<Effect.Effect<void, unknown>>();
+      const socketOpened = yield* Deferred.make<void>();
+      const socketClosed = yield* Deferred.make<void>();
+      const writtenChunks: Array<Uint8Array | string | Socket.CloseEvent> = [];
+      const writeFailure = new Socket.SocketError({
+        reason: new Socket.SocketWriteError({ cause: "write failed" }),
+      });
+      const successfulSocket = Socket.make({
+        writer: Effect.succeed((chunk) =>
+          Effect.sync(() => {
+            writtenChunks.push(chunk);
+          }),
+        ),
+        runRaw: (_handler, options) =>
+          Effect.gen(function* () {
+            const onOpen = options?.onOpen ?? Effect.void;
+            yield* onOpen;
+            yield* Deferred.succeed(socketOpened, undefined);
+            return yield* Effect.never;
+          }),
+      });
+      const trackedSocket = makeTrackedSocket(
+        successfulSocket,
+        Effect.void,
+        Deferred.succeed(socketClosed, undefined),
+        activeSocketClosers,
+      );
+
+      const socketFiber = yield* trackedSocket
+        .runRaw(() => Effect.void)
+        .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(socketOpened);
+      expect(activeSocketClosers.size).toBe(1);
+
+      yield* closeTrackedSockets(activeSocketClosers);
+      expect(writtenChunks).toStrictEqual([
+        new Socket.CloseEvent(1001, "View Server shutting down"),
+      ]);
+
+      const failingCloser = Effect.fail(writeFailure);
+      activeSocketClosers.add(failingCloser);
+      yield* closeTrackedSockets(activeSocketClosers);
+      activeSocketClosers.delete(failingCloser);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.message).toStrictEqual(["WebSocket shutdown failed."]);
+      expect(logs[0]?.logLevel).toBe("Warn");
+      expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
+
+      yield* Fiber.interrupt(socketFiber);
+      yield* Deferred.await(socketClosed);
+      expect(activeSocketClosers.size).toBe(0);
+    }).pipe(
+      Effect.provide(Logger.layer([logger])),
+      Effect.provideService(References.MinimumLogLevel, "Trace"),
+    );
+  });
+
+  it.live("does not let a stuck websocket close frame block other tracked sockets", () =>
+    Effect.gen(function* () {
+      const activeSocketClosers = new Set<Effect.Effect<void, unknown>>();
+      const fastCloseRan = yield* Deferred.make<void>();
+      activeSocketClosers.add(Effect.never);
+      activeSocketClosers.add(Deferred.succeed(fastCloseRan, undefined));
+
+      yield* closeTrackedSockets(activeSocketClosers).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(fastCloseRan).pipe(Effect.timeout("1 second"));
     }),
   );
 
@@ -1043,10 +1207,15 @@ describe("@view-server/server", () => {
               }),
           }),
       };
-      const handlers = makeViewServerRpcHandlers(viewServer, {
-        liveClient,
-        runtime: inMemory.client,
-      });
+      const handlerScope = yield* Scope.make("parallel");
+      const handlers = makeViewServerRpcHandlers(
+        viewServer,
+        {
+          liveClient,
+          runtime: inMemory.client,
+        },
+        handlerScope,
+      );
 
       const stream = handlers["ViewServer.Subscribe"]({
         topic: "orders",
@@ -1072,6 +1241,7 @@ describe("@view-server/server", () => {
       expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
       expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
       expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
+      yield* Scope.close(handlerScope, Exit.void);
       yield* inMemory.close;
     }).pipe(
       Effect.provide(Logger.layer([logger])),
@@ -1131,10 +1301,15 @@ describe("@view-server/server", () => {
                 }),
             }),
         };
-        const handlers = makeViewServerRpcHandlers(viewServer, {
-          liveClient,
-          runtime: inMemory.client,
-        });
+        const handlerScope = yield* Scope.make("parallel");
+        const handlers = makeViewServerRpcHandlers(
+          viewServer,
+          {
+            liveClient,
+            runtime: inMemory.client,
+          },
+          handlerScope,
+        );
 
         const stream = handlers["ViewServer.Subscribe"]({
           topic: "orders",
@@ -1157,6 +1332,7 @@ describe("@view-server/server", () => {
         expect(Cause.hasFails(logs[0]?.cause ?? Cause.empty)).toBe(true);
         expect(Cause.hasDies(logs[0]?.cause ?? Cause.empty)).toBe(false);
         expect(Cause.hasInterrupts(logs[0]?.cause ?? Cause.empty)).toBe(false);
+        yield* Scope.close(handlerScope, Exit.void);
         yield* inMemory.close;
       }).pipe(
         Effect.provide(Logger.layer([logger])),
@@ -1552,6 +1728,335 @@ describe("@view-server/server", () => {
 
       yield* raw.close;
       yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("closes in-flight remote RPC health reads when the websocket server closes", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const readStarted = yield* Deferred.make<void>();
+      const readInterrupted = yield* Deferred.make<void>();
+      let readCount = 0;
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: {
+          health: () =>
+            Effect.sync(() => {
+              readCount += 1;
+            }).pipe(
+              Effect.andThen(Deferred.succeed(readStarted, undefined)),
+              Effect.andThen(Effect.never),
+              Effect.ensuring(Deferred.succeed(readInterrupted, undefined)),
+            ),
+        },
+      });
+      const raw = yield* makeRawRpcClient(server.url);
+
+      const first = yield* raw.rpc["ViewServer.Health"]().pipe(
+        Effect.exit,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(readStarted);
+      const second = yield* raw.rpc["ViewServer.Health"]().pipe(
+        Effect.exit,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Effect.yieldNow;
+      yield* server.close.pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(readInterrupted).pipe(Effect.timeout("1 second"));
+      const [firstExit, secondExit] = yield* Effect.all([Fiber.join(first), Fiber.join(second)], {
+        concurrency: 2,
+      }).pipe(Effect.timeout("1 second"));
+
+      expect(readCount).toBe(1);
+      expect(Exit.isFailure(firstExit)).toBe(true);
+      expect(Exit.isFailure(secondExit)).toBe(true);
+      yield* raw.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("coalesces concurrent RPC health reads while an active read is running", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const firstHealth = serverHealthWithOrdersRowCount(baseHealth, 1);
+      const secondHealth = serverHealthWithOrdersRowCount(baseHealth, 2);
+      const readStarted = yield* Deferred.make<void>();
+      const releaseRead = yield* Deferred.make<void>();
+      let readCount = 0;
+      const healthReads = new Map<
+        number,
+        Effect.Effect<ViewServerHealth<typeof viewServer.topics>>
+      >([
+        [
+          0,
+          Effect.gen(function* () {
+            yield* Deferred.succeed(readStarted, undefined);
+            yield* Deferred.await(releaseRead);
+            return firstHealth;
+          }),
+        ],
+        [1, Effect.succeed(secondHealth)],
+      ]);
+      const handlerScope = yield* Scope.make("parallel");
+      const handlers = makeViewServerRpcHandlers(
+        viewServer,
+        {
+          liveClient: inMemory.liveClient,
+          runtime: {
+            health: () =>
+              Effect.suspend(() => {
+                const nextRead =
+                  healthReads.get(readCount) ??
+                  Effect.die(new Error(`Unexpected health read: ${readCount}`));
+                readCount += 1;
+                return nextRead;
+              }),
+          },
+        },
+        handlerScope,
+      );
+
+      const first = yield* handlers["ViewServer.Health"]().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(readStarted);
+      const second = yield* handlers["ViewServer.Health"]().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.succeed(releaseRead, undefined);
+
+      const [firstResult, secondResult] = yield* Effect.all(
+        [Fiber.join(first), Fiber.join(second)],
+        { concurrency: 2 },
+      ).pipe(Effect.timeout("1 second"));
+      const thirdResult = yield* handlers["ViewServer.Health"]();
+
+      expect(readCount).toBe(2);
+      expect(firstResult).toStrictEqual(firstHealth);
+      expect(secondResult).toStrictEqual(firstHealth);
+      expect(thirdResult).toStrictEqual(secondHealth);
+      yield* Scope.close(handlerScope, Exit.void);
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("clears failed RPC health reads so later callers retry", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const recoveredHealth = serverHealthWithOrdersRowCount(baseHealth, 3);
+      const healthError: ViewServerRuntimeError = {
+        _tag: "ViewServerRuntimeError",
+        code: "RuntimeUnavailable",
+        message: "health unavailable",
+      };
+      let readCount = 0;
+      const healthReads = new Map<
+        number,
+        Effect.Effect<ViewServerHealth<typeof viewServer.topics>, ViewServerRuntimeError>
+      >([
+        [0, Effect.fail(healthError)],
+        [1, Effect.succeed(recoveredHealth)],
+      ]);
+      const handlerScope = yield* Scope.make("parallel");
+      const handlers = makeViewServerRpcHandlers(
+        viewServer,
+        {
+          liveClient: inMemory.liveClient,
+          runtime: {
+            health: () =>
+              Effect.suspend(() => {
+                const nextRead =
+                  healthReads.get(readCount) ??
+                  Effect.die(new Error(`Unexpected health read: ${readCount}`));
+                readCount += 1;
+                return nextRead;
+              }),
+          },
+        },
+        handlerScope,
+      );
+
+      const failedHealth = yield* Effect.flip(handlers["ViewServer.Health"]());
+      const retriedHealth = yield* handlers["ViewServer.Health"]();
+
+      expect(readCount).toBe(2);
+      expect(failedHealth).toStrictEqual(healthError);
+      expect(retriedHealth).toStrictEqual(recoveredHealth);
+      yield* Scope.close(handlerScope, Exit.void);
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("keeps shared RPC health reads alive when the leader caller is interrupted", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const baseHealth = yield* inMemory.client.health();
+      const firstHealth = serverHealthWithOrdersRowCount(baseHealth, 3);
+      const recoveredHealth = serverHealthWithOrdersRowCount(baseHealth, 4);
+      const readStarted = yield* Deferred.make<void>();
+      const releaseRead = yield* Deferred.make<void>();
+      let readCount = 0;
+      const healthReads = new Map<
+        number,
+        Effect.Effect<ViewServerHealth<typeof viewServer.topics>, ViewServerRuntimeError>
+      >([
+        [
+          0,
+          Effect.gen(function* () {
+            readCount += 1;
+            yield* Deferred.succeed(readStarted, undefined);
+            yield* Deferred.await(releaseRead);
+            return firstHealth;
+          }),
+        ],
+        [
+          1,
+          Effect.sync(() => {
+            readCount += 1;
+            return recoveredHealth;
+          }),
+        ],
+      ]);
+      const handlerScope = yield* Scope.make("parallel");
+      const handlers = makeViewServerRpcHandlers(
+        viewServer,
+        {
+          liveClient: inMemory.liveClient,
+          runtime: {
+            health: () =>
+              Effect.suspend(
+                () =>
+                  healthReads.get(readCount) ??
+                  Effect.die(new Error(`Unexpected health read: ${readCount}`)),
+              ),
+          },
+        },
+        handlerScope,
+      );
+
+      const leader = yield* handlers["ViewServer.Health"]().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(readStarted);
+      const follower = yield* handlers["ViewServer.Health"]().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Fiber.interrupt(leader).pipe(
+        Effect.timeout("1 second"),
+        Effect.onError(() => Deferred.succeed(releaseRead, undefined).pipe(Effect.asVoid)),
+      );
+      const leaderExit = yield* Fiber.await(leader).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(releaseRead, undefined);
+      const followerHealth = yield* Fiber.join(follower).pipe(Effect.timeout("1 second"));
+      const retriedHealth = yield* handlers["ViewServer.Health"]();
+
+      expect(followerHealth).toStrictEqual(firstHealth);
+      expect(Exit.hasInterrupts(leaderExit)).toBe(true);
+      expect(readCount).toBe(2);
+      expect(retriedHealth).toStrictEqual(recoveredHealth);
+      yield* Scope.close(handlerScope, Exit.void);
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("interrupts active RPC health reads when the handler scope closes", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const readStarted = yield* Deferred.make<void>();
+      const readInterrupted = yield* Deferred.make<void>();
+      const handlerScope = yield* Scope.make("parallel");
+      const handlers = makeViewServerRpcHandlers(
+        viewServer,
+        {
+          liveClient: inMemory.liveClient,
+          runtime: {
+            health: () =>
+              Deferred.succeed(readStarted, undefined).pipe(
+                Effect.andThen(Effect.never),
+                Effect.ensuring(Deferred.succeed(readInterrupted, undefined)),
+              ),
+          },
+        },
+        handlerScope,
+      );
+
+      const healthFiber = yield* handlers["ViewServer.Health"]().pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(readStarted);
+      yield* Scope.close(handlerScope, Exit.void).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(readInterrupted).pipe(Effect.timeout("1 second"));
+      const healthExit = yield* Fiber.await(healthFiber).pipe(Effect.timeout("1 second"));
+
+      expect(Exit.hasInterrupts(healthExit)).toBe(true);
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live(
+    "does not wait forever when closing handler scope with a non-cancellable active RPC health worker",
+    () =>
+      Effect.gen(function* () {
+        const inMemory = createServerTestRuntime(viewServer);
+        const baseHealth = yield* inMemory.client.health();
+        const readStarted = yield* Deferred.make<void>();
+        const releaseRead = yield* Deferred.make<void>();
+        const workerReadFinished = yield* Deferred.make<void>();
+        const handlerScope = yield* Scope.make("parallel");
+        const handlers = makeViewServerRpcHandlers(
+          viewServer,
+          {
+            liveClient: inMemory.liveClient,
+            runtime: {
+              health: () =>
+                Effect.uninterruptible(
+                  Deferred.succeed(readStarted, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseRead)),
+                    Effect.as(baseHealth),
+                    Effect.ensuring(Deferred.succeed(workerReadFinished, undefined)),
+                  ),
+                ),
+            },
+          },
+          handlerScope,
+        );
+
+        const healthFiber = yield* handlers["ViewServer.Health"]().pipe(
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Deferred.await(readStarted);
+        yield* Scope.close(handlerScope, Exit.void).pipe(Effect.timeout("1 second"));
+        const healthExit = yield* Fiber.await(healthFiber).pipe(Effect.timeout("1 second"));
+        yield* Deferred.succeed(releaseRead, undefined);
+        yield* Deferred.await(workerReadFinished).pipe(Effect.timeout("1 second"));
+        yield* Effect.yieldNow;
+
+        expect(Exit.hasInterrupts(healthExit)).toBe(true);
+        yield* inMemory.close;
+      }),
+  );
+
+  it.live("interrupts RPC health reads started after the handler scope closes", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const handlerScope = yield* Scope.make("parallel");
+      const handlers = makeViewServerRpcHandlers(
+        viewServer,
+        {
+          liveClient: inMemory.liveClient,
+          runtime: inMemory.client,
+        },
+        handlerScope,
+      );
+
+      yield* Scope.close(handlerScope, Exit.void);
+      const healthExit = yield* handlers["ViewServer.Health"]().pipe(Effect.exit);
+
+      expect(Exit.hasInterrupts(healthExit)).toBe(true);
       yield* inMemory.close;
     }),
   );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,9 @@
 import { NodeHttpServer } from "@effect/platform-node";
 import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
 import { ViewServerRpcs } from "@view-server/protocol";
-import { Context, Effect, Layer, ManagedRuntime } from "effect";
+import { Context, Effect, Exit, Layer, ManagedRuntime, Scope } from "effect";
 import { HttpRouter, HttpServer, HttpServerError, HttpServerRequest } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
-import * as Socket from "effect/unstable/socket/Socket";
 import * as Http from "node:http";
 import { makeViewServerHealthRoute } from "./health-route";
 import { makeViewServerRpcHandlers } from "./rpc-handlers";
@@ -15,56 +14,17 @@ import type {
   ViewServerWebSocketServerInput,
   ViewServerWebSocketServerOptions,
 } from "./server-types";
-
-const makeTrackedSocket = (
-  socket: Socket.Socket,
-  clientOpened: Effect.Effect<void>,
-  clientClosed: Effect.Effect<void>,
-): Socket.Socket =>
-  new Proxy(socket, {
-    get(target, property, receiver) {
-      if (property === "runRaw") {
-        const runRaw: Socket.Socket["runRaw"] = (handler, options) => {
-          let closeWhenOpened = Effect.void;
-          const onOpen = Effect.sync(() => {
-            closeWhenOpened = clientClosed;
-          }).pipe(Effect.andThen(clientOpened), Effect.andThen(options?.onOpen ?? Effect.void));
-          const close = Effect.sync(() => closeWhenOpened).pipe(
-            Effect.flatMap((closeEffect) => closeEffect),
-          );
-          return target
-            .runRaw(handler, {
-              ...options,
-              onOpen,
-            })
-            .pipe(Effect.ensuring(close));
-        };
-        return runRaw;
-      }
-      return Reflect.get(target, property, receiver);
-    },
-  });
-
-const makeTrackedUpgradeRequest = (
-  request: HttpServerRequest.HttpServerRequest,
-  clientOpened: Effect.Effect<void>,
-  clientClosed: Effect.Effect<void>,
-): HttpServerRequest.HttpServerRequest =>
-  new Proxy(request, {
-    get(target, property, receiver) {
-      if (property === "upgrade") {
-        return target.upgrade.pipe(
-          Effect.map((socket) => makeTrackedSocket(socket, clientOpened, clientClosed)),
-        );
-      }
-      return Reflect.get(target, property, receiver);
-    },
-  });
+import {
+  closeTrackedSockets,
+  makeTrackedUpgradeRequest,
+  type ActiveSocketClosers,
+} from "./websocket-tracking";
 
 const makeTrackedWebSocketProtocol = Effect.fn("ViewServerServer.websocket.protocol.make")(
   function* <const Topics extends TopicDefinitions>(
     path: `/${string}`,
     input: ViewServerWebSocketServerInput<Topics>,
+    activeSocketClosers: ActiveSocketClosers,
   ) {
     const router = yield* HttpRouter.HttpRouter;
     const clientOpened = input.transport?.clientOpened ?? Effect.void;
@@ -75,7 +35,7 @@ const makeTrackedWebSocketProtocol = Effect.fn("ViewServerServer.websocket.proto
       return yield* httpEffect.pipe(
         Effect.provideService(
           HttpServerRequest.HttpServerRequest,
-          makeTrackedUpgradeRequest(request, clientOpened, clientClosed),
+          makeTrackedUpgradeRequest(request, clientOpened, clientClosed, activeSocketClosers),
         ),
       );
     });
@@ -87,7 +47,9 @@ const makeTrackedWebSocketProtocol = Effect.fn("ViewServerServer.websocket.proto
 const makeTrackedWebSocketProtocolLayer = <const Topics extends TopicDefinitions>(
   path: `/${string}`,
   input: ViewServerWebSocketServerInput<Topics>,
-) => Layer.effect(RpcServer.Protocol)(makeTrackedWebSocketProtocol(path, input));
+  activeSocketClosers: ActiveSocketClosers,
+) =>
+  Layer.effect(RpcServer.Protocol)(makeTrackedWebSocketProtocol(path, input, activeSocketClosers));
 
 export type {
   Jsonify,
@@ -110,10 +72,12 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
 ) {
   const path = options.path ?? "/rpc";
   const healthPath = options.healthPath ?? "/health";
-  const protocol = makeTrackedWebSocketProtocolLayer(path, input).pipe(
+  const handlerScope = yield* Scope.make("parallel");
+  const activeSocketClosers: ActiveSocketClosers = new Set();
+  const protocol = makeTrackedWebSocketProtocolLayer(path, input, activeSocketClosers).pipe(
     Layer.provide(HttpRouter.layer),
   );
-  const handlers = ViewServerRpcs.toLayer(makeViewServerRpcHandlers(config, input));
+  const handlers = ViewServerRpcs.toLayer(makeViewServerRpcHandlers(config, input, handlerScope));
   const healthRoute = makeViewServerHealthRoute(config, input, healthPath);
   const httpApp = Layer.merge(protocol, healthRoute);
   const rpcLayer = RpcServer.layer(ViewServerRpcs, {
@@ -136,7 +100,9 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
     Layer.provide(RpcSerialization.layerNdjson),
   );
   const managedRuntime = ManagedRuntime.make(rpcLayer);
-  const context = yield* managedRuntime.contextEffect;
+  const context = yield* managedRuntime.contextEffect.pipe(
+    Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(handlerScope, exit) : Effect.void)),
+  );
   const server = Context.get(context, HttpServer.HttpServer);
   const httpUrl = HttpServer.formatAddress(server.address);
   const serverUrl = httpUrl.startsWith("http://0.0.0.0:")
@@ -146,7 +112,10 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   return {
     url: `${serverUrl}${path}`,
     healthUrl: `${publicHttpUrl}${healthPath}`,
-    close: managedRuntime.disposeEffect,
+    close: Scope.close(handlerScope, Exit.void).pipe(
+      Effect.andThen(closeTrackedSockets(activeSocketClosers)),
+      Effect.andThen(managedRuntime.disposeEffect),
+    ),
   };
 });
 

--- a/packages/server/src/rpc-handlers.ts
+++ b/packages/server/src/rpc-handlers.ts
@@ -1,6 +1,11 @@
 import { VIEW_SERVER_HEALTH_SUMMARY_TOPIC, VIEW_SERVER_HEALTH_TOPIC } from "@view-server/config";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
-import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
+import type {
+  TopicDefinitions,
+  ViewServerConfig,
+  ViewServerHealth,
+  ViewServerRuntimeError,
+} from "@view-server/config";
 import {
   ViewServerRpcs,
   viewServerDecodeHealth,
@@ -11,19 +16,139 @@ import {
   viewServerEncodeHealthTopicEvent,
   viewServerEncodeLiveEvent,
 } from "@view-server/protocol";
-import { Effect, Exit, Stream } from "effect";
+import { Deferred, Effect, Exit, Fiber, Scope, Semaphore, Stream } from "effect";
 import type { ViewServerWebSocketServerInput } from "./server-types";
 
 const ignoreSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
   "RPC subscription close failed.",
 );
 
+const makeCoalescedHealthRead = <const Topics extends TopicDefinitions>(
+  input: ViewServerWebSocketServerInput<Topics>,
+  scope: Scope.Scope,
+) => {
+  type ActiveRead = {
+    readonly fibers: Array<Fiber.Fiber<void>>;
+    readonly deferred: Deferred.Deferred<ViewServerHealth<Topics>, ViewServerRuntimeError>;
+  };
+  type ReadDecision =
+    | {
+        readonly _tag: "closed";
+      }
+    | {
+        readonly _tag: "leader";
+        readonly active: ActiveRead;
+      }
+    | {
+        readonly _tag: "follower";
+        readonly deferred: Deferred.Deferred<ViewServerHealth<Topics>, ViewServerRuntimeError>;
+      };
+  let activeRead: ActiveRead | undefined = undefined;
+  let closed = false;
+  let scopeFinalizerRegistered = false;
+  const stateLock = Semaphore.makeUnsafe(1);
+
+  const completeActiveRead = (
+    active: ActiveRead,
+    exit: Exit.Exit<ViewServerHealth<Topics>, ViewServerRuntimeError>,
+  ) =>
+    Effect.uninterruptible(
+      stateLock.withPermit(
+        Effect.gen(function* () {
+          yield* Deferred.done(active.deferred, exit);
+          yield* Effect.sync(() => {
+            activeRead = [activeRead].find((read) => read !== active);
+          });
+        }),
+      ),
+    );
+  const interruptActiveRead = Effect.uninterruptible(
+    Effect.gen(function* () {
+      const fibers = yield* stateLock.withPermit(
+        Effect.gen(function* () {
+          const active = activeRead;
+          closed = true;
+          if (active === undefined) {
+            const noFibers: Array<Fiber.Fiber<void>> = [];
+            return noFibers;
+          }
+          activeRead = undefined;
+          yield* Deferred.done(active.deferred, Exit.interrupt());
+          return active.fibers;
+        }),
+      );
+      yield* Effect.forEach(
+        fibers,
+        (fiber) => Effect.forkDetach(Fiber.interrupt(fiber), { startImmediately: true }),
+        { discard: true },
+      );
+    }),
+  );
+  const ensureScopeFinalizer = Effect.gen(function* () {
+    if (scopeFinalizerRegistered) {
+      return;
+    }
+    scopeFinalizerRegistered = true;
+    yield* Scope.addFinalizer(scope, interruptActiveRead);
+  });
+  const forkActiveRead = (active: ActiveRead) =>
+    Effect.suspend(() => input.runtime.health()).pipe(
+      Effect.exit,
+      Effect.flatMap((exit) => completeActiveRead(active, exit)),
+      Effect.forkDetach({ startImmediately: true, uninterruptible: false }),
+    );
+
+  return Effect.fn("ViewServerServer.health.readCoalesced")(function* () {
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        yield* ensureScopeFinalizer;
+        const read = yield* stateLock.withPermit(
+          Effect.gen(function* () {
+            if (closed) {
+              return {
+                _tag: "closed",
+              } satisfies ReadDecision;
+            }
+            if (activeRead !== undefined) {
+              return {
+                _tag: "follower",
+                deferred: activeRead.deferred,
+              } satisfies ReadDecision;
+            }
+            const deferred = yield* Deferred.make<
+              ViewServerHealth<Topics>,
+              ViewServerRuntimeError
+            >();
+            const active: ActiveRead = { deferred, fibers: [] };
+            activeRead = active;
+            const fiber = yield* forkActiveRead(active);
+            active.fibers.push(fiber);
+            return {
+              _tag: "leader",
+              active,
+            } satisfies ReadDecision;
+          }),
+        );
+        if (read._tag === "closed") {
+          return yield* restore(Effect.interrupt);
+        }
+        if (read._tag === "follower") {
+          return yield* restore(Deferred.await(read.deferred));
+        }
+        return yield* restore(Deferred.await(read.active.deferred));
+      }),
+    );
+  });
+};
+
 export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
   input: ViewServerWebSocketServerInput<Topics>,
+  scope: Scope.Scope,
 ) => {
   const streamOpened = input.transport?.streamOpened ?? Effect.void;
   const streamClosed = input.transport?.streamClosed ?? Effect.void;
+  const readHealth = makeCoalescedHealthRead(input, scope);
   const withTransportLifecycle = <A, E, R>(
     stream: Effect.Effect<Stream.Stream<A, E, R>, E, R>,
   ): Stream.Stream<A, E, R> =>
@@ -38,7 +163,7 @@ export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>
   return ViewServerRpcs.of({
     "ViewServer.Health": () =>
       Effect.gen(function* () {
-        const health = yield* input.runtime.health();
+        const health = yield* readHealth();
         return yield* viewServerDecodeHealth(config, health);
       }),
     "ViewServer.Subscribe": (payload) =>

--- a/packages/server/src/websocket-tracking.ts
+++ b/packages/server/src/websocket-tracking.ts
@@ -1,0 +1,85 @@
+import { Effect } from "effect";
+import type { HttpServerRequest } from "effect/unstable/http";
+import * as Socket from "effect/unstable/socket/Socket";
+
+export type ActiveSocketClosers = Set<Effect.Effect<void, unknown>>;
+
+const logWebSocketShutdownCloseFailure = <R>(
+  closeSocket: Effect.Effect<void, unknown, R>,
+): Effect.Effect<void, never, R> =>
+  closeSocket.pipe(
+    Effect.timeoutOption("100 millis"),
+    Effect.asVoid,
+    Effect.catchCause((cause) => Effect.logWarning("WebSocket shutdown failed.", cause)),
+  );
+
+export const closeTrackedSockets = Effect.fn("ViewServerServer.websocket.tracked.close")(function* (
+  activeSocketClosers: ActiveSocketClosers,
+) {
+  const closers = Array.from(activeSocketClosers);
+  yield* Effect.forEach(closers, logWebSocketShutdownCloseFailure, {
+    concurrency: "unbounded",
+    discard: true,
+  });
+});
+
+export const makeTrackedSocket = (
+  socket: Socket.Socket,
+  clientOpened: Effect.Effect<void>,
+  clientClosed: Effect.Effect<void>,
+  activeSocketClosers: ActiveSocketClosers,
+): Socket.Socket =>
+  new Proxy(socket, {
+    get(target, property, receiver) {
+      if (property === "runRaw") {
+        const runRaw: Socket.Socket["runRaw"] = (handler, options) => {
+          let closeWhenOpened = Effect.void;
+          const onOpen = Effect.sync(() => {
+            closeWhenOpened = clientClosed;
+          }).pipe(Effect.andThen(clientOpened), Effect.andThen(options?.onOpen ?? Effect.void));
+          const close = Effect.sync(() => closeWhenOpened).pipe(
+            Effect.flatMap((closeEffect) => closeEffect),
+          );
+          return Effect.scoped(
+            Effect.gen(function* () {
+              const writer = yield* target.writer;
+              const closeSocket = writer(new Socket.CloseEvent(1001, "View Server shutting down"));
+              yield* Effect.sync(() => {
+                activeSocketClosers.add(closeSocket);
+              });
+              yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                  activeSocketClosers.delete(closeSocket);
+                }),
+              );
+              return yield* target.runRaw(handler, {
+                ...options,
+                onOpen,
+              });
+            }),
+          ).pipe(Effect.ensuring(close));
+        };
+        return runRaw;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+export const makeTrackedUpgradeRequest = (
+  request: HttpServerRequest.HttpServerRequest,
+  clientOpened: Effect.Effect<void>,
+  clientClosed: Effect.Effect<void>,
+  activeSocketClosers: ActiveSocketClosers,
+): HttpServerRequest.HttpServerRequest =>
+  new Proxy(request, {
+    get(target, property, receiver) {
+      if (property === "upgrade") {
+        return target.upgrade.pipe(
+          Effect.map((socket) =>
+            makeTrackedSocket(socket, clientOpened, clientClosed, activeSocketClosers),
+          ),
+        );
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -1117,7 +1117,7 @@ describe("internal seam checker", () => {
 
   it("keeps the current repository free of package import violations", () => {
     expect(collectPackageImportViolations()).toStrictEqual([]);
-  }, 10000);
+  }, 30000);
 
   it("ignores import-like text in comments", () => {
     expect(

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -167,6 +167,69 @@ describe("internal seam checker", () => {
     ]);
   });
 
+  it("reports restricted package imports with escaped quoted specifiers", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set([
+        "@view-server/runtime",
+        "@view-server/server",
+        "@view-server/protocol",
+      ]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: [
+          'import "\\u0040view-server/runtime";',
+          'const server = require("\\x40view-server/server");',
+          'const protocol = import.meta.resolve("\\u{40}view-server/protocol");',
+        ].join("\n"),
+        relativePath: "src/index.ts",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.ts imports @view-server/runtime: React production must stay transport-neutral.",
+      "src/index.ts imports @view-server/server: React production must stay transport-neutral.",
+      "src/index.ts imports @view-server/protocol: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("does not report member APIs named import", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'registry.import("@view-server/runtime");',
+          'registry?.import("@view-server/server");',
+          'this.import("@view-server/protocol");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores malformed escaped quoted specifiers", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'import "\\u{}view-server/runtime";',
+          'import "\\u{40view-server/missing-brace";',
+          'import "\\u{110000}view-server/out-of-range";',
+          'import "\\u{zz}view-server/server";',
+          'const protocol = require("\\u12zzview-server/protocol");',
+          'const client = import.meta.resolve("\\xzzview-server/client");',
+          'const unfinished = require("\\',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([
+      "u{}view-server/runtime",
+      "u{40view-server/missing-brace",
+      "u{110000}view-server/out-of-range",
+      "u{zz}view-server/server",
+      "u12zzview-server/protocol",
+      "xzzview-server/client",
+    ]);
+  });
+
   it("reports restricted CommonJS package imports", () => {
     const restriction = {
       forbiddenSpecifiers: new Set(["@view-server/runtime"]),
@@ -186,6 +249,54 @@ describe("internal seam checker", () => {
     ).toStrictEqual([
       "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
     ]);
+  });
+
+  it("reports restricted createRequire package imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'const runtime = createRequire(import.meta.url)("@view-server/runtime");',
+          'const server = createRequire(import.meta.url).resolve("@view-server/server");',
+          'const protocol = createRequire(import.meta.url).resolve.call(require, "@view-server/protocol");',
+          'const client = (createRequire(import.meta.url)).resolve("@view-server/client");',
+          'const config = (createRequire(import.meta.url))["resolve"]("@view-server/config");',
+          'const inMemory = (createRequire(import.meta.url)).resolve.call(require, "@view-server/in-memory");',
+          'function resolveRuntime() { return (createRequire(import.meta.url)).resolve("@view-server/runtime/return"); }',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/protocol",
+      "@view-server/client",
+      "@view-server/config",
+      "@view-server/in-memory",
+      "@view-server/runtime/return",
+    ]);
+  });
+
+  it("does not report member APIs named createRequire", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'factory.createRequire(import.meta.url)("@view-server/runtime");',
+          'this.#createRequire(import.meta.url)("@view-server/server");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores malformed createRequire package imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "const factory = createRequire;",
+          "const inertFactory = createRequire(import.meta.url);",
+          "const inertResolve = createRequire(import.meta.url).resolve;",
+          "const dynamicResolve = createRequire(import.meta.url).resolve(packageName);",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
   });
 
   it("reports restricted CommonJS package resolution", () => {
@@ -288,9 +399,159 @@ describe("internal seam checker", () => {
           'const runtime = require?.("@view-server/runtime");',
           'const server = require.resolve?.("@view-server/server");',
           'const client = require?.resolve?.("@view-server/client");',
+          'const spacedRuntime = require ?. ("@view-server/runtime");',
+          'const spacedServer = require . resolve ?. ("@view-server/server");',
+          'const spacedClient = require ?. resolve("@view-server/client");',
+          'const bracketRuntime = require?.["resolve"]("@view-server/runtime");',
+          'const bracketServer = require["resolve"]?.("@view-server/server");',
+          'const parenthesizedResolveRuntime = (require).resolve("@view-server/runtime/resolve");',
+          'const parenthesizedBracketResolveRuntime = (require)["resolve"]("@view-server/runtime/bracket-resolve");',
+          'const parenthesizedRuntime = (require)("@view-server/runtime");',
+          'function loadRuntime() { return (require)("@view-server/runtime/return"); }',
+          'const voidRuntime = void (require)("@view-server/runtime/void");',
+          'for (;;) (require)("@view-server/runtime/for");',
+          'if (ok) noop(); else (require)("@view-server/runtime/else");',
+          'if (path.endsWith(")")) (require)("@view-server/runtime/if-string");',
+          'if (path.match(/[)]/)) (require)("@view-server/runtime/if-regex");',
+          'if (ok /* ) */) (require)("@view-server/runtime/if-block-comment");',
+          'if (ok // )\n) (require)("@view-server/runtime/if-line-comment");',
+          'do (require)("@view-server/runtime/do"); while (ok);',
+          'const sequenceRuntime = (0, require)("@view-server/runtime/sequence");',
+          'const logicalRuntime = (false || require)("@view-server/runtime/logical");',
+          'const fallbackLogicalRuntime = (require || fallback)("@view-server/runtime/logical-left");',
+          'const parenthesizedFallbackLogicalRuntime = ((require) || fallback)("@view-server/runtime/parenthesized-logical-left");',
+          'const nullishRuntime = (require ?? fallback)("@view-server/runtime/nullish-left");',
+          'const nullishFallbackWithParenRuntime = (require ?? fallback(")"))("@view-server/runtime/nullish-fallback-paren");',
+          'const nullishFallbackRegexRuntime = (require ?? /[)]/)("@view-server/runtime/nullish-fallback-regex");',
+          'const fallbackNullishRuntime = (fallback ?? require)("@view-server/runtime/nullish-right");',
+          'const parenthesizedFallbackNullishRuntime = (fallback ?? (require))("@view-server/runtime/parenthesized-nullish-right");',
+          'const ternaryRuntime = (condition ? require : fallback)("@view-server/runtime/ternary-then");',
+          'const ternaryFallbackWithParenRuntime = (condition ? require : fallback({ text: ")" }))("@view-server/runtime/ternary-fallback-paren");',
+          'const fallbackTernaryRuntime = (condition ? fallback : require)("@view-server/runtime/ternary-else");',
+          'const nestedSequenceRuntime = ((0, require))("@view-server/runtime/nested-sequence");',
+          'const sequenceCalledRuntime = (0, require).call(undefined, "@view-server/runtime/sequence-call");',
+          'const sequenceBoundRuntime = (0, require).bind(undefined)("@view-server/runtime/sequence-bind");',
+          'const nestedRuntime = ((require))("@view-server/runtime/nested");',
+          'const calledRuntime = require.call(undefined, "@view-server/runtime/call");',
+          'const calledServer = (require).call(undefined, "@view-server/server/call");',
+          'const boundRuntime = require.bind(undefined)("@view-server/runtime/bind");',
+          'const boundArgumentRuntime = require.bind(undefined, "@view-server/runtime/bind-argument")();',
+          'const parenthesizedBoundRuntime = (require).bind(undefined)("@view-server/runtime/parenthesized-bind");',
+          'const regexBoundRuntime = require.bind(/,/)("@view-server/runtime/regex-bind");',
+          'const appliedRuntime = require.apply(undefined, ["@view-server/runtime/apply"]);',
+          'const extraAppliedRuntime = require.apply(undefined, ["@view-server/runtime/extra-apply", extra]);',
+          'const regexAppliedRuntime = require.apply(/,/, ["@view-server/runtime/regex-apply"]);',
+          'const nestedApplyRuntime = require.apply(fn("ignored", value), ["@view-server/runtime/nested-apply"]);',
+          'const regexRuntime = require.call(/,/, "@view-server/runtime/regex");',
+          'const quoteRegexRuntime = require.call(/"/, "@view-server/runtime/quote-regex");',
+          'const escapedRuntime = requ\\u0069re("@view-server/runtime/escaped");',
+          'const escapedBraceRuntime = requ\\u{69}re("@view-server/runtime/escaped-brace");',
         ].join("\n"),
       ),
-    ).toStrictEqual(["@view-server/runtime", "@view-server/server", "@view-server/client"]);
+    ).toStrictEqual([
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/client",
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/client",
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/runtime/resolve",
+      "@view-server/runtime/bracket-resolve",
+      "@view-server/runtime",
+      "@view-server/runtime/return",
+      "@view-server/runtime/void",
+      "@view-server/runtime/for",
+      "@view-server/runtime/else",
+      "@view-server/runtime/if-string",
+      "@view-server/runtime/if-regex",
+      "@view-server/runtime/if-block-comment",
+      "@view-server/runtime/if-line-comment",
+      "@view-server/runtime/do",
+      "@view-server/runtime/sequence",
+      "@view-server/runtime/logical",
+      "@view-server/runtime/logical-left",
+      "@view-server/runtime/parenthesized-logical-left",
+      "@view-server/runtime/nullish-left",
+      "@view-server/runtime/nullish-fallback-paren",
+      "@view-server/runtime/nullish-fallback-regex",
+      "@view-server/runtime/nullish-right",
+      "@view-server/runtime/parenthesized-nullish-right",
+      "@view-server/runtime/ternary-then",
+      "@view-server/runtime/ternary-fallback-paren",
+      "@view-server/runtime/ternary-else",
+      "@view-server/runtime/nested-sequence",
+      "@view-server/runtime/sequence-call",
+      "@view-server/runtime/sequence-bind",
+      "@view-server/runtime/nested",
+      "@view-server/runtime/call",
+      "@view-server/server/call",
+      "@view-server/runtime/bind",
+      "@view-server/runtime/bind-argument",
+      "@view-server/runtime/parenthesized-bind",
+      "@view-server/runtime/regex-bind",
+      "@view-server/runtime/apply",
+      "@view-server/runtime/extra-apply",
+      "@view-server/runtime/regex-apply",
+      "@view-server/runtime/nested-apply",
+      "@view-server/runtime/regex",
+      "@view-server/runtime/quote-regex",
+      "@view-server/runtime/escaped",
+      "@view-server/runtime/escaped-brace",
+    ]);
+  });
+
+  it("ignores malformed optional CommonJS accessors", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "require;",
+          "const inertSequence = (0, require);",
+          "const inertSequenceCall = (0, require).call(undefined);",
+          'const localLoader = (require && localLoader)("@view-server/runtime");',
+          "const inertParenthesizedNullish = (fallback ?? (require));",
+          "const inertNestedParenthesizedNullish = ((fallback ?? (require)));",
+          'const unfinishedNullishWrapper = (require ?? fallback("@view-server/runtime");',
+          'const unfinishedTernaryWrapper = (condition ? require : fallback("@view-server/runtime");',
+          'const runtime = require ? ("@view-server/runtime") : undefined;',
+          'const server = require ? resolveCandidate("@view-server/server") : undefined;',
+          'const client = module ? requireCandidate("@view-server/client") : undefined;',
+          'const runtimeCandidate = module.load("@view-server/runtime");',
+          'const serverCandidate = module?.load("@view-server/server");',
+          'const parenthesizedRuntimeCandidate = (require).load("@view-server/runtime");',
+          'const parenthesizedServerCandidate = (module).load("@view-server/server");',
+          'const protocolCandidate = require["load"]("@view-server/protocol");',
+          'const missingBracket = require["resolve"("@view-server/runtime");',
+          'const malformedEscapedRequire = requ\\u{zz}re("@view-server/runtime");',
+          'const malformedCodePointRequire = requ\\u{110000}re("@view-server/runtime");',
+          'const malformedFixedEscapedRequire = requ\\u00zzre("@view-server/server");',
+          'const indirectLoader = makeLoader(require)("@view-server/runtime");',
+          'const indirectResolver = makeResolver(require.resolve)("@view-server/runtime");',
+          'const indirectParenthesizedResolver = makeResolver((require).resolve)("@view-server/runtime");',
+          'const indirectParenthesizedModuleRequire = makeResolver((module).require)("@view-server/runtime");',
+          'const indirectParenthesizedImportMetaResolve = makeResolver((import.meta).resolve).call(undefined, "@view-server/runtime");',
+          'const indirectImportMetaResolver = makeResolver(import.meta.resolve).call(undefined, "@view-server/runtime");',
+          'const malformedControl = if ok) (require)("@view-server/runtime");',
+          'const malformedOpenControl = if (ok (require)("@view-server/runtime");',
+          "const bindProperty = require.bind;",
+          "const inertBind = require.bind(undefined);",
+          "const unfinishedBind = require.bind(undefined",
+          "const applyProperty = require.apply;",
+          "const parenthesizedApplyProperty = (require).apply;",
+          "const unfinishedNoCommaApply = require.apply(undefined",
+          'const stringApply = require.apply(undefined, "@view-server/runtime");',
+          'const missingApplyArgument = require.apply(undefined);',
+          "const dynamicApply = require.apply(undefined, packageName);",
+          "const emptyApply = require.apply(undefined, []);",
+          "const unfinishedEmptyApply = require.apply(undefined, [",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+    expect(importSpecifiersFromSource("const unfinished = (require ?? fallback")).toStrictEqual([]);
+    expect(importSpecifiersFromSource("const unfinished = (condition ? require : fallback")).toStrictEqual(
+      [],
+    );
   });
 
   it("detects bracketed CommonJS package resolution", () => {
@@ -299,9 +560,121 @@ describe("internal seam checker", () => {
         [
           'const runtime = require["resolve"]("@view-server/runtime");',
           "const server = require['resolve']('@view-server/server');",
+          'const parenthesizedRuntime = (require.resolve)("@view-server/runtime/parenthesized");',
+          'const parenthesizedBaseRuntime = ((require).resolve)("@view-server/runtime/parenthesized-base");',
+          'for (const item of items) (require.resolve)("@view-server/server/for-of");',
+          'for await (const item of items) (require.resolve)("@view-server/server/for-await");',
+          'while (path.endsWith(")")) (require.resolve)("@view-server/runtime/while-string");',
+          'const ternaryParenthesizedResolve = (condition ? (require.resolve) : fallback)("@view-server/runtime/ternary-parenthesized-resolve");',
+          'const sequenceServer = (0, require.resolve)("@view-server/server/sequence");',
+          'const sequenceCalledServer = (0, require.resolve).call(require, "@view-server/server/sequence-call");',
+          'const calledRuntime = require.resolve.call(require, "@view-server/runtime/call");',
+          'const regexRuntime = require.resolve.call(/,/, "@view-server/runtime/regex");',
+          'const appliedServer = require.resolve.apply(require, ["@view-server/server/apply", { paths: [] }]);',
+          'const escapedServer = require.res\\u006flve("@view-server/server/escaped");',
         ].join("\n"),
       ),
-    ).toStrictEqual(["@view-server/runtime", "@view-server/server"]);
+    ).toStrictEqual([
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/runtime/parenthesized",
+      "@view-server/runtime/parenthesized-base",
+      "@view-server/server/for-of",
+      "@view-server/server/for-await",
+      "@view-server/runtime/while-string",
+      "@view-server/runtime/ternary-parenthesized-resolve",
+      "@view-server/server/sequence",
+      "@view-server/server/sequence-call",
+      "@view-server/runtime/call",
+      "@view-server/runtime/regex",
+      "@view-server/server/apply",
+      "@view-server/server/escaped",
+    ]);
+  });
+
+  it("detects import meta package resolution", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'const runtime = import.meta.resolve("@view-server/runtime");',
+          'const server = import.meta.resolve?.("@view-server/server");',
+          'const protocol = import.meta["resolve"]("@view-server/protocol");',
+          'const client = (import.meta.resolve)("@view-server/client");',
+          'async function resolveRuntime() { return await (import.meta.resolve)("@view-server/runtime/await"); }',
+          'const sequenceClient = (0, import.meta.resolve)("@view-server/client/sequence");',
+          'const nestedSequenceClient = ((0, import.meta.resolve))("@view-server/client/nested-sequence");',
+          'const sequenceCalledClient = (0, import.meta.resolve).call(import.meta, "@view-server/client/sequence-call");',
+          'const ternaryParenthesizedCalledClient = (condition ? fallback : (import.meta.resolve)).call(import.meta, "@view-server/client/ternary-parenthesized-call");',
+          'const config = (import.meta["resolve"])?.("@view-server/config");',
+          'const parenthesizedBaseRuntime = (import.meta).resolve("@view-server/runtime/parenthesized-base");',
+          'const parenthesizedBaseServer = (import.meta)["resolve"]("@view-server/server/parenthesized-base");',
+          'const rpc = import.meta.resolve.call(import.meta, "@view-server/protocol/rpc");',
+          'const health = (import.meta.resolve).call(import.meta, "@view-server/protocol/health");',
+          'const runtimeAgain = import.meta.resolve.call(getMeta("ignored", import.meta), "@view-server/runtime/internal");',
+          'const regexClient = import.meta.resolve.call(/,/, "@view-server/client/regex");',
+          'const appliedClient = import.meta.resolve.apply(/,/, ["@view-server/client/apply"]);',
+          'const boundArgumentClient = import.meta.resolve.bind(import.meta, "@view-server/client/bind-argument")();',
+          'const nestedRuntime = ((import.meta.resolve))("@view-server/runtime/nested");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/protocol",
+      "@view-server/client",
+      "@view-server/runtime/await",
+      "@view-server/client/sequence",
+      "@view-server/client/nested-sequence",
+      "@view-server/client/sequence-call",
+      "@view-server/client/ternary-parenthesized-call",
+      "@view-server/config",
+      "@view-server/runtime/parenthesized-base",
+      "@view-server/server/parenthesized-base",
+      "@view-server/protocol/rpc",
+      "@view-server/protocol/health",
+      "@view-server/runtime/internal",
+      "@view-server/client/regex",
+      "@view-server/client/apply",
+      "@view-server/client/bind-argument",
+      "@view-server/runtime/nested",
+    ]);
+  });
+
+  it("ignores malformed import meta package resolution", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'const runtime = import.meta.load("@view-server/runtime");',
+          'const server = import.metadata.resolve("@view-server/server");',
+          'const protocol = import ? meta.resolve("@view-server/protocol") : undefined;',
+          "const client = import.meta.resolve(packageName);",
+          "const clientResolver = (import.meta.resolve);",
+          "const config = import.meta.resolve.call;",
+          'const effectUtils = import.meta.resolve.call("ignored");',
+          'const serverPackage = import.meta.resolve.call("ignored", packageName);',
+          'const runtimePackage = import.meta.resolve.call("quoted, comma");',
+          "const unterminatedCall = import.meta.resolve.call(import.meta",
+          'const falseRuntime = registry.import.meta.resolve("@view-server/runtime");',
+          'const falseServer = registry.import.meta.resolve.call(registry, "@view-server/server");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not report import meta resolution specifiers from call context arguments", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: 'const fs = import.meta.resolve.call(["ignored", "@view-server/runtime"], "node:fs");',
+        relativePath: "src/index.ts",
+        restriction,
+      }),
+    ).toStrictEqual([]);
   });
 
   it("detects Node module.require literal calls", () => {
@@ -309,10 +682,51 @@ describe("internal seam checker", () => {
       importSpecifiersFromSource(
         [
           'const runtime = module.require("@view-server/runtime");',
+          'const server = module?.require("@view-server/server");',
+          'const protocol = module?.require?.("@view-server/protocol");',
           'const client = module.require("@view-server/client");',
+          'const spacedRuntime = module ?. require("@view-server/runtime");',
+          'const spacedServer = module?. require("@view-server/server");',
+          'const spacedProtocol = module ?. require ?. ("@view-server/protocol");',
+          'const bracketRuntime = module["require"]("@view-server/runtime");',
+          'const bracketServer = module?.["require"]("@view-server/server");',
+          'const bracketProtocol = module["require"]?.("@view-server/protocol");',
+          'const parenthesizedBaseRuntime = (module).require("@view-server/runtime/base");',
+          'const parenthesizedBaseServer = (module)["require"]("@view-server/server/base");',
+          'const parenthesizedRuntime = (module.require)("@view-server/runtime/parenthesized");',
+          'if (ok) (module.require)("@view-server/runtime/if");',
+          'if (isEnabled()) (module.require)("@view-server/runtime/if-call");',
+          'const calledRuntime = module.require.call(module, "@view-server/runtime/call");',
+          'const boundRuntime = module.require.bind(module)("@view-server/runtime/bind");',
+          'const boundArgumentRuntime = module.require.bind(module, "@view-server/runtime/bind-argument")();',
+          'const appliedRuntime = module.require.apply(module, ["@view-server/runtime/apply"]);',
+          'const regexRuntime = module.require.call(/,/, "@view-server/runtime/regex");',
+          'const escapedProtocol = module.requ\\u0069re("@view-server/protocol/escaped");',
         ].join("\n"),
       ),
-    ).toStrictEqual(["@view-server/runtime", "@view-server/client"]);
+    ).toStrictEqual([
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/protocol",
+      "@view-server/client",
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/protocol",
+      "@view-server/runtime",
+      "@view-server/server",
+      "@view-server/protocol",
+      "@view-server/runtime/base",
+      "@view-server/server/base",
+      "@view-server/runtime/parenthesized",
+      "@view-server/runtime/if",
+      "@view-server/runtime/if-call",
+      "@view-server/runtime/call",
+      "@view-server/runtime/bind",
+      "@view-server/runtime/bind-argument",
+      "@view-server/runtime/apply",
+      "@view-server/runtime/regex",
+      "@view-server/protocol/escaped",
+    ]);
   });
 
   it("ignores Node module.require calls without quoted specifiers", () => {
@@ -362,6 +776,80 @@ describe("internal seam checker", () => {
     ).toStrictEqual(["@view-server/${packageName}", "@view-server/${packageName}"]);
   });
 
+  it("ignores comments while scanning template expressions for CommonJS imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "const value = `${// }",
+          'require("@view-server/runtime")',
+          "}`;",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+    expect(importSpecifiersFromSource("const unfinished = `${// }")).toStrictEqual([]);
+    expect(importSpecifiersFromSource("const unfinished = `${/* }")).toStrictEqual([]);
+  });
+
+  it("does not treat regex literal slash pairs as comments in template expressions", () => {
+    expect(
+      importSpecifiersFromSource(
+        'const value = `${/\\\\//.test(path) && require("@view-server/runtime")}`;',
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+    expect(
+      importSpecifiersFromSource(
+        'const value = `${"source" in /\\\\// && require("@view-server/server")}`;',
+      ),
+    ).toStrictEqual(["@view-server/server"]);
+  });
+
+  it("does not treat regex literal slash pairs as comments before CommonJS imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        'const value = /\\\\//.test(path) && require("@view-server/runtime");',
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+    expect(
+      importSpecifiersFromSource(
+        'const value = /[/]/gi.test(path) && require("@view-server/server");',
+      ),
+    ).toStrictEqual(["@view-server/server"]);
+    expect(
+      importSpecifiersFromSource(
+        'if ("source" in /\\\\// && require("@view-server/protocol")) {}',
+      ),
+    ).toStrictEqual(["@view-server/protocol"]);
+    expect(
+      importSpecifiersFromSource(
+        'if (path) /\\\\//.test(path) && require("@view-server/client");',
+      ),
+    ).toStrictEqual(["@view-server/client"]);
+    expect(
+      importSpecifiersFromSource(
+        'if (fn({ value: true })) /[//]/.test(path) && require("@view-server/runtime");',
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+    expect(
+      importSpecifiersFromSource(
+        [
+          "if (",
+          "  path",
+          ') /[//]/.test(path) && require("@view-server/client");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/client"]);
+    expect(
+      importSpecifiersFromSource(
+        'for (;;) /[//]/.test(path) && require("@view-server/server");',
+      ),
+    ).toStrictEqual(["@view-server/server"]);
+    expect(
+      importSpecifiersFromSource(
+        'for (const value of /\\\\//) require("@view-server/protocol");',
+      ),
+    ).toStrictEqual(["@view-server/protocol"]);
+  });
+
   it("detects no-substitution CommonJS template specifiers", () => {
     expect(
       importSpecifiersFromSource(
@@ -395,6 +883,65 @@ describe("internal seam checker", () => {
     expect(
       packageImportViolationsFor({
         contents: 'const node = <Panel />; const runtime = require("@view-server/runtime");',
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("ignores comments while scanning JSX expressions for CommonJS imports", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: '<Panel value={/* } */ require("@view-server/runtime")} />',
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+    expect(
+      packageImportViolationsFor({
+        contents: ['<Panel value={// }', 'require("@view-server/runtime")} />'].join("\n"),
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+    expect(packageImportViolationsFor({
+      contents: "<Panel value={// }",
+      relativePath: "src/index.tsx",
+      restriction,
+    })).toStrictEqual([]);
+  });
+
+  it("does not treat regex literal slash pairs as comments in JSX expressions", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: '<Panel value={/\\\\//.test(path) && require("@view-server/runtime")} />',
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+    expect(
+      packageImportViolationsFor({
+        contents: '<Panel value={"source" in /\\\\// && require("@view-server/runtime")} />',
         relativePath: "src/index.tsx",
         restriction,
       }),
@@ -570,7 +1117,7 @@ describe("internal seam checker", () => {
 
   it("keeps the current repository free of package import violations", () => {
     expect(collectPackageImportViolations()).toStrictEqual([]);
-  });
+  }, 10000);
 
   it("ignores import-like text in comments", () => {
     expect(
@@ -589,6 +1136,27 @@ describe("internal seam checker", () => {
         "",
         'const example = "import from comment-like string";',
       ].join("\n"),
+    );
+  });
+
+  it("keeps regex literals while stripping comments", () => {
+    expect(
+      sourceWithoutComments(
+        [
+          'const value = /\\\\//.test(path) && require("@view-server/runtime");',
+          'const unfinished = /unterminated',
+          '// require("@view-server/server");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual(
+      [
+        'const value = /\\\\//.test(path) && require("@view-server/runtime");',
+        "const unfinished = /unterminated",
+        "",
+      ].join("\n"),
+    );
+    expect(sourceWithoutComments("const unfinished = /unterminated")).toStrictEqual(
+      "const unfinished = /unterminated",
     );
   });
 

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -167,6 +167,242 @@ describe("internal seam checker", () => {
     ]);
   });
 
+  it("reports restricted CommonJS package imports", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: [
+          'const runtime = require("@view-server/runtime");',
+          'const client = require("@view-server/client");',
+        ].join("\n"),
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("reports restricted CommonJS package resolution", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: [
+          'const runtime = require.resolve("@view-server/runtime");',
+          'const client = require.resolve("@view-server/client");',
+        ].join("\n"),
+        relativePath: "src/index.ts",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.ts imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("does not hide CommonJS imports inside generic calls", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: 'const runtime = loader<Runtime>(require("@view-server/runtime"));',
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("does not hide CommonJS imports after TypeScript angle-bracket assertions", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: 'const cast = <Runtime>value; const runtime = require("@view-server/runtime");',
+        relativePath: "src/index.ts",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.ts imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("does not hide CommonJS imports after less-than expressions", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: 'const ok = a < b; const runtime = require("@view-server/runtime");',
+        relativePath: "src/index.ts",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.ts imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
+  it("ignores require identifiers that are not literal calls", () => {
+    expect(importSpecifiersFromSource("const label = require;")).toStrictEqual([]);
+  });
+
+  it("ignores require calls without quoted specifiers", () => {
+    expect(importSpecifiersFromSource("const runtime = require(packageName);")).toStrictEqual([]);
+  });
+
+  it("ignores require resolve calls without quoted specifiers", () => {
+    expect(importSpecifiersFromSource("const runtime = require.resolve(packageName);")).toStrictEqual(
+      [],
+    );
+  });
+
+  it("ignores require resolve property reads", () => {
+    expect(importSpecifiersFromSource("const runtime = require.resolve;")).toStrictEqual([]);
+  });
+
+  it("detects optional CommonJS literal calls", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'const runtime = require?.("@view-server/runtime");',
+          'const server = require.resolve?.("@view-server/server");',
+          'const client = require?.resolve?.("@view-server/client");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime", "@view-server/server", "@view-server/client"]);
+  });
+
+  it("detects bracketed CommonJS package resolution", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'const runtime = require["resolve"]("@view-server/runtime");',
+          "const server = require['resolve']('@view-server/server');",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime", "@view-server/server"]);
+  });
+
+  it("detects Node module.require literal calls", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'const runtime = module.require("@view-server/runtime");',
+          'const client = module.require("@view-server/client");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime", "@view-server/client"]);
+  });
+
+  it("ignores Node module.require calls without quoted specifiers", () => {
+    expect(importSpecifiersFromSource("const runtime = module.require(packageName);")).toStrictEqual(
+      [],
+    );
+  });
+
+  it("ignores member APIs named module.require", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'loader.module.require("@view-server/runtime");',
+          'this.#module.require("@view-server/server");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores private member APIs named require", () => {
+    expect(
+      importSpecifiersFromSource('class Loader { load() { return this.#require("@view-server/runtime"); } }'),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores interpolated CommonJS template specifiers", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "const packageName = 'runtime';",
+          "const runtime = require(`@external/${packageName}`);",
+          "const resolved = require.resolve(`@external/${packageName}`);",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("reports interpolated View Server CommonJS template specifiers conservatively", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "const packageName = 'runtime';",
+          "const runtime = require(`@view-server/${packageName}`);",
+          "const resolved = require.resolve(`@view-server/${packageName}`);",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/${packageName}", "@view-server/${packageName}"]);
+  });
+
+  it("detects no-substitution CommonJS template specifiers", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "const runtime = require(`@view-server/runtime`);",
+          "const server = require.resolve(`@view-server/server`);",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime", "@view-server/server"]);
+  });
+
+  it("ignores member APIs named require", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          'validator.require("@view-server/runtime");',
+          'this.require("@view-server/server");',
+          'loader?.require("@view-server/client");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not hide CommonJS imports after self-closing JSX", () => {
+    const restriction = {
+      forbiddenSpecifiers: new Set(["@view-server/runtime"]),
+      message: "React production must stay transport-neutral.",
+      packageName: "react",
+    };
+
+    expect(
+      packageImportViolationsFor({
+        contents: 'const node = <Panel />; const runtime = require("@view-server/runtime");',
+        relativePath: "src/index.tsx",
+        restriction,
+      }),
+    ).toStrictEqual([
+      "src/index.tsx imports @view-server/runtime: React production must stay transport-neutral.",
+    ]);
+  });
+
   it("rejects deep imports even when the package root is allowed", () => {
     const restriction = {
       allowedSpecifiers: new Set(["@view-server/client"]),
@@ -367,6 +603,152 @@ describe("internal seam checker", () => {
         ].join("\n"),
       ),
     ).toStrictEqual(["@view-server/client", "@view-server/runtime"]);
+  });
+
+  it("does not treat import-like JSX text as imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <p>Install from \"@view-server/runtime\" and import from \"@view-server/server\".</p>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not treat import-like JSX fragment text as imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <>Install from \"@view-server/runtime\" and import from \"@view-server/server\".</>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not treat import-like JSX text after logical operators as imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return condition && <p>Install from \"@view-server/runtime\".</p>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return fallback || <>Install from \"@view-server/server\".</>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not treat import-like JSX text inside underscore or dollar components as imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <_Panel>Install from \"@view-server/runtime\".</_Panel>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <$Panel>Install from \"@view-server/server\".</$Panel>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not treat import-like JSX text after nested self-closing children as imports", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <Panel><Icon />Install from \"@view-server/runtime\".</Panel>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not strip code after JSX text that looks like a block comment", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <p>/*</p>;",
+          "}",
+          'const runtime = require("@view-server/runtime");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+  });
+
+  it("does not strip code after JSX text that looks like a line comment", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function HelpText() {",
+          "  return <p>//</p>;",
+          "}",
+          'const runtime = require("@view-server/runtime");',
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+  });
+
+  it("detects imports inside JSX expressions", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function Loader() {",
+          "  return <Panel>{import(\"@view-server/runtime\")}</Panel>;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+  });
+
+  it("detects imports inside self-closing JSX expressions", () => {
+    expect(
+      importSpecifiersFromSource(
+        [
+          "export function Loader() {",
+          "  return <Panel value={import(\"@view-server/runtime\")} />;",
+          "}",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["@view-server/runtime"]);
+  });
+
+  it("handles unfinished JSX tag expressions conservatively", () => {
+    expect(importSpecifiersFromSource("export const node = <Panel value={import(")).toStrictEqual(
+      [],
+    );
+  });
+
+  it("handles unfinished JSX tags conservatively", () => {
+    expect(importSpecifiersFromSource("export const node = <Panel")).toStrictEqual([]);
+  });
+
+  it("handles unfinished JSX child expressions conservatively", () => {
+    expect(importSpecifiersFromSource("export const node = <Panel>{import(")).toStrictEqual([]);
+  });
+
+  it("handles unfinished JSX roots conservatively", () => {
+    expect(importSpecifiersFromSource("export const node = <Panel>")).toStrictEqual([]);
   });
 
   it("detects imports inside template literal expressions", () => {

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -72,6 +72,82 @@ type RestrictedPackageImport = {
 const isViewServerSpecifier = (specifier: string): boolean =>
   specifier === "@view-server" || specifier.startsWith("@view-server/");
 
+const previousNonWhitespaceCharacter = (contents: string, index: number): string | undefined => {
+  let nextIndex = index;
+  while (nextIndex >= 0) {
+    const character = contents.charAt(nextIndex);
+    if (!/\s/.test(character)) {
+      return character;
+    }
+    nextIndex -= 1;
+  }
+  return undefined;
+};
+
+const isRegexLiteralStartContext = (contents: string, index: number): boolean => {
+  const previous = previousNonWhitespaceCharacter(contents, index - 1);
+  const previousSource = contents.slice(0, index).trimEnd();
+  return (
+    previous === undefined ||
+    previous === "(" ||
+    previous === "[" ||
+    previous === "{" ||
+    previous === "=" ||
+    previous === ":" ||
+    previous === "," ||
+    previous === "?" ||
+    previous === ">" ||
+    previous === ";" ||
+    previous === "&" ||
+    previous === "|" ||
+    previous === "!" ||
+    previous === "+" ||
+    previous === "-" ||
+    previous === "*" ||
+    previous === "~" ||
+    previous === "^" ||
+    previous === "<" ||
+    /\b(?:return|throw|case|yield|await|typeof|void|delete|in|of|instanceof|else|do)$/.test(previousSource) ||
+    /\b(?:if|while|for|with)\s*\([\s\S]*\)$/.test(previousSource)
+  );
+};
+
+const skipRegexLiteral = (contents: string, index: number): number => {
+  let insideCharacterClass = false;
+  let nextIndex = index + 1;
+
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    if (character === "\n") {
+      return index + 1;
+    }
+    if (character === "\\") {
+      nextIndex += 2;
+      continue;
+    }
+    if (character === "[") {
+      insideCharacterClass = true;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === "]") {
+      insideCharacterClass = false;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === "/" && !insideCharacterClass) {
+      nextIndex += 1;
+      while (/[A-Za-z]/.test(contents.charAt(nextIndex))) {
+        nextIndex += 1;
+      }
+      return nextIndex;
+    }
+    nextIndex += 1;
+  }
+
+  return index + 1;
+};
+
 export const sourceWithoutComments = (contents: string): string => {
   let output = "";
   let index = 0;
@@ -127,6 +203,18 @@ export const sourceWithoutComments = (contents: string): string => {
       continue;
     }
 
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, index)
+    ) {
+      const nextIndex = skipRegexLiteral(contents, index);
+      output += contents.slice(index, nextIndex);
+      index = nextIndex;
+      continue;
+    }
+
     if (character === "/" && nextCharacter === "/") {
       lineComment = true;
       index += 2;
@@ -163,10 +251,73 @@ const identifierCharacterPattern = /[A-Za-z0-9_$]/;
 const isIdentifierCharacter = (character: string | undefined): boolean =>
   character !== undefined && identifierCharacterPattern.test(character);
 
-const sourceHasKeywordAt = (contents: string, index: number, keyword: string): boolean =>
-  contents.startsWith(keyword, index) &&
-  !isIdentifierCharacter(contents[index - 1]) &&
-  !isIdentifierCharacter(contents[index + keyword.length]);
+const isValidCodePoint = (codePoint: number): boolean =>
+  Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff;
+
+const readEscapedIdentifierCharacter = (
+  contents: string,
+  index: number,
+): { readonly character: string; readonly nextIndex: number } | undefined => {
+  if (contents.charAt(index) !== "\\" || contents.charAt(index + 1) !== "u") {
+    return undefined;
+  }
+  if (contents.charAt(index + 2) === "{") {
+    const closeBraceIndex = contents.indexOf("}", index + 3);
+    const hex = contents.slice(index + 3, Math.max(index + 3, closeBraceIndex));
+    const codePoint = Number.parseInt(hex, 16);
+    return /^[0-9A-Fa-f]+$/.test(hex) && isValidCodePoint(codePoint)
+      ? {
+          character: String.fromCodePoint(codePoint),
+          nextIndex: closeBraceIndex + 1,
+        }
+      : undefined;
+  }
+  const hex = contents.slice(index + 2, index + 6);
+  const codePoint = Number.parseInt(hex, 16);
+  return /^[0-9A-Fa-f]{4}$/.test(hex) && isValidCodePoint(codePoint)
+    ? {
+        character: String.fromCodePoint(codePoint),
+        nextIndex: index + 6,
+      }
+    : undefined;
+};
+
+const readIdentifierNameAt = (
+  contents: string,
+  index: number,
+): { readonly name: string; readonly nextIndex: number } | undefined => {
+  let name = "";
+  let nextIndex = index;
+  while (nextIndex < contents.length) {
+    const escaped = readEscapedIdentifierCharacter(contents, nextIndex);
+    if (escaped !== undefined) {
+      name += escaped.character;
+      nextIndex = escaped.nextIndex;
+      continue;
+    }
+    const character = contents.charAt(nextIndex);
+    if (!isIdentifierCharacter(character)) {
+      break;
+    }
+    name += character;
+    nextIndex += 1;
+  }
+  return name === ""
+    ? undefined
+    : {
+        name,
+        nextIndex,
+      };
+};
+
+const afterKeywordAt = (contents: string, index: number, keyword: string): number | undefined => {
+  const identifier = readIdentifierNameAt(contents, index);
+  return identifier?.name === keyword &&
+    !isIdentifierCharacter(contents[index - 1]) &&
+    !isIdentifierCharacter(contents[identifier.nextIndex])
+    ? identifier.nextIndex
+    : undefined;
+};
 
 const skipWhitespace = (contents: string, index: number): number => {
   let nextIndex = index;
@@ -174,6 +325,64 @@ const skipWhitespace = (contents: string, index: number): number => {
     nextIndex += 1;
   }
   return nextIndex;
+};
+
+const readBracketAccessorAt = (
+  contents: string,
+  index: number,
+  property: string,
+): number | undefined => {
+  if (contents.charAt(index) !== "[") {
+    return undefined;
+  }
+  const propertySpecifier = readQuotedSpecifier(contents, skipWhitespace(contents, index + 1));
+  if (propertySpecifier?.specifier !== property) {
+    return undefined;
+  }
+  const closeBracketIndex = skipWhitespace(contents, propertySpecifier.nextIndex);
+  return contents.charAt(closeBracketIndex) === "]" ? closeBracketIndex + 1 : undefined;
+};
+
+const readPropertyAccessor = (
+  contents: string,
+  index: number,
+  property: string,
+): number | undefined => {
+  const nextIndex = skipWhitespace(contents, index);
+  if (contents.charAt(nextIndex) === ".") {
+    const propertyIndex = skipWhitespace(contents, nextIndex + 1);
+    return afterKeywordAt(contents, propertyIndex, property);
+  }
+  const bracketAccessor = readBracketAccessorAt(contents, nextIndex, property);
+  if (bracketAccessor !== undefined) {
+    return bracketAccessor;
+  }
+  if (contents.charAt(nextIndex) !== "?") {
+    return undefined;
+  }
+  const dotIndex = skipWhitespace(contents, nextIndex + 1);
+  if (contents.charAt(dotIndex) !== ".") {
+    return undefined;
+  }
+  const propertyIndex = skipWhitespace(contents, dotIndex + 1);
+  const optionalBracketAccessor = readBracketAccessorAt(contents, propertyIndex, property);
+  if (optionalBracketAccessor !== undefined) {
+    return optionalBracketAccessor;
+  }
+  return afterKeywordAt(contents, propertyIndex, property);
+};
+
+const readOptionalCallOpenParen = (contents: string, index: number): number | undefined => {
+  const nextIndex = skipWhitespace(contents, index);
+  if (contents.charAt(nextIndex) !== "?") {
+    return undefined;
+  }
+  const dotIndex = skipWhitespace(contents, nextIndex + 1);
+  if (contents.charAt(dotIndex) !== ".") {
+    return undefined;
+  }
+  const openParenIndex = skipWhitespace(contents, dotIndex + 1);
+  return contents.charAt(openParenIndex) === "(" ? openParenIndex : undefined;
 };
 
 const readQuotedSpecifier = (
@@ -191,9 +400,39 @@ const readQuotedSpecifier = (
     const character = contents.charAt(nextIndex);
     const nextCharacter = contents.charAt(nextIndex + 1);
     if (character === "\\") {
-      specifier += character;
+      if (nextCharacter === "u") {
+        if (contents.charAt(nextIndex + 2) === "{") {
+          const closeBraceIndex = contents.indexOf("}", nextIndex + 3);
+          const hex = contents.slice(
+            nextIndex + 3,
+            Math.max(nextIndex + 3, closeBraceIndex),
+          );
+          const codePoint = Number.parseInt(hex, 16);
+          if (/^[0-9A-Fa-f]+$/.test(hex) && isValidCodePoint(codePoint)) {
+            specifier += String.fromCodePoint(codePoint);
+            nextIndex = closeBraceIndex + 1;
+            continue;
+          }
+        }
+        const hex = contents.slice(nextIndex + 2, nextIndex + 6);
+        const codePoint = Number.parseInt(hex, 16);
+        if (/^[0-9A-Fa-f]{4}$/.test(hex) && isValidCodePoint(codePoint)) {
+          specifier += String.fromCodePoint(codePoint);
+          nextIndex += 6;
+          continue;
+        }
+      }
+      if (nextCharacter === "x") {
+        const hex = contents.slice(nextIndex + 2, nextIndex + 4);
+        const codePoint = Number.parseInt(hex, 16);
+        if (/^[0-9A-Fa-f]{2}$/.test(hex) && isValidCodePoint(codePoint)) {
+          specifier += String.fromCodePoint(codePoint);
+          nextIndex += 4;
+          continue;
+        }
+      }
       specifier += nextCharacter;
-      nextIndex += 2;
+      nextIndex += nextCharacter === "" ? 1 : 2;
       continue;
     }
     if (character === quote) {
@@ -265,21 +504,33 @@ const isNestedJsxTagStart = (contents: string, index: number): boolean => {
   return contents.charAt(index) === "<" && (nextCharacter === ">" || /[A-Za-z_$/.]/.test(nextCharacter));
 };
 
-const isFreeRequireAt = (contents: string, index: number): boolean => {
-  const previous = contents.slice(0, index).trimEnd().at(-1);
-  return sourceHasKeywordAt(contents, index, "require") && previous !== "." && previous !== "#";
+const freeRequireKeywordEndAt = (contents: string, index: number): number | undefined => {
+  const previous = previousNonWhitespaceCharacter(contents, index - 1);
+  const afterRequire = afterKeywordAt(contents, index, "require");
+  return afterRequire !== undefined && previous !== "." && previous !== "#" ? afterRequire : undefined;
 };
 
-const isModuleRequireAt = (contents: string, index: number): boolean => {
-  const previous = contents.slice(0, index).trimEnd().at(-1);
+const freeCreateRequireKeywordEndAt = (
+  contents: string,
+  index: number,
+): number | undefined => {
+  const previous = previousNonWhitespaceCharacter(contents, index - 1);
+  const afterCreateRequire = afterKeywordAt(contents, index, "createRequire");
+  return afterCreateRequire !== undefined && previous !== "." && previous !== "#"
+    ? afterCreateRequire
+    : undefined;
+};
+
+const moduleRequireAccessorAt = (contents: string, index: number): number | undefined => {
+  const previous = previousNonWhitespaceCharacter(contents, index - 1);
   if (previous === "." || previous === "#") {
-    return false;
+    return undefined;
   }
-  if (!sourceHasKeywordAt(contents, index, "module")) {
-    return false;
+  const afterModule = afterKeywordAt(contents, index, "module");
+  if (afterModule === undefined) {
+    return undefined;
   }
-  const afterModule = skipWhitespace(contents, index + "module".length);
-  return contents.startsWith(".require", afterModule);
+  return readAccessorAfterCallee(contents, index, afterModule, "require");
 };
 
 const callOpenParenIndex = (contents: string, index: number): number | undefined => {
@@ -287,26 +538,36 @@ const callOpenParenIndex = (contents: string, index: number): number | undefined
   if (contents[nextIndex] === "(") {
     return nextIndex;
   }
-  return contents.startsWith("?.(", nextIndex) ? nextIndex + "?.".length : undefined;
+  return readOptionalCallOpenParen(contents, nextIndex);
 };
 
-const resolveAccessorAfterRequire = (contents: string, index: number): number | undefined => {
-  const nextIndex = skipWhitespace(contents, index);
-  if (contents.startsWith(".resolve", nextIndex)) {
-    return nextIndex + ".resolve".length;
+const resolveAccessorAfterRequire = (
+  contents: string,
+  requireStartIndex: number,
+  index: number,
+): number | undefined => {
+  return readAccessorAfterCallee(contents, requireStartIndex, index, "resolve");
+};
+
+const importMetaResolveAccessorAt = (contents: string, index: number): number | undefined => {
+  const previous = previousNonWhitespaceCharacter(contents, index - 1);
+  if (previous === "." || previous === "#") {
+    return undefined;
   }
-  if (contents.startsWith("?.resolve", nextIndex)) {
-    return nextIndex + "?.resolve".length;
+  const afterImportKeyword = afterKeywordAt(contents, index, "import");
+  if (afterImportKeyword === undefined) {
+    return undefined;
   }
-  const bracketResolve = '["resolve"]';
-  if (contents.startsWith(bracketResolve, nextIndex)) {
-    return nextIndex + bracketResolve.length;
+  const afterImport = skipWhitespace(contents, afterImportKeyword);
+  if (contents.charAt(afterImport) !== ".") {
+    return undefined;
   }
-  const singleQuoteBracketResolve = "['resolve']";
-  if (contents.startsWith(singleQuoteBracketResolve, nextIndex)) {
-    return nextIndex + singleQuoteBracketResolve.length;
+  const metaIndex = skipWhitespace(contents, afterImport + 1);
+  const afterMeta = afterKeywordAt(contents, metaIndex, "meta");
+  if (afterMeta === undefined) {
+    return undefined;
   }
-  return undefined;
+  return readAccessorAfterCallee(contents, index, afterMeta, "resolve");
 };
 
 const readCallSpecifier = (
@@ -320,6 +581,520 @@ const readCallSpecifier = (
   return readStaticQuotedSpecifier(contents, skipWhitespace(contents, openParen + 1));
 };
 
+const readCallSecondSpecifier = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const openParen = callOpenParenIndex(contents, index);
+  if (openParen === undefined) {
+    return undefined;
+  }
+  let depth = 0;
+  let nextIndex = skipWhitespace(contents, openParen + 1);
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    const nextCharacter = contents.charAt(nextIndex + 1);
+    if (character === '"' || character === "'" || character === "`") {
+      nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, nextIndex)
+    ) {
+      nextIndex = skipRegexLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "(" || character === "[" || character === "{") {
+      depth += 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === ")" && depth === 0) {
+      return undefined;
+    }
+    if (character === ")" || character === "]" || character === "}") {
+      depth -= 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === "," && depth === 0) {
+      return readStaticQuotedSpecifier(contents, skipWhitespace(contents, nextIndex + 1));
+    }
+    nextIndex += 1;
+  }
+  return undefined;
+};
+
+const readCallExpressionEnd = (contents: string, index: number): number | undefined => {
+  const openParen = callOpenParenIndex(contents, index);
+  if (openParen === undefined) {
+    return undefined;
+  }
+  let depth = 0;
+  let nextIndex = openParen + 1;
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    const nextCharacter = contents.charAt(nextIndex + 1);
+    if (character === '"' || character === "'" || character === "`") {
+      nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, nextIndex)
+    ) {
+      nextIndex = skipRegexLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "(" || character === "[" || character === "{") {
+      depth += 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === ")" && depth === 0) {
+      return nextIndex + 1;
+    }
+    if (character === ")" || character === "]" || character === "}") {
+      depth -= 1;
+      nextIndex += 1;
+      continue;
+    }
+    nextIndex += 1;
+  }
+  return undefined;
+};
+
+const readApplyArraySpecifier = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const openParen = callOpenParenIndex(contents, index);
+  if (openParen === undefined) {
+    return undefined;
+  }
+  let depth = 0;
+  let nextIndex = openParen + 1;
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    const nextCharacter = contents.charAt(nextIndex + 1);
+    if (character === '"' || character === "'" || character === "`") {
+      nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, nextIndex)
+    ) {
+      nextIndex = skipRegexLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "(" || character === "[" || character === "{") {
+      depth += 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === ")" && depth === 0) {
+      return undefined;
+    }
+    if (character === ")" || character === "]" || character === "}") {
+      depth -= 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === "," && depth === 0) {
+      const openArrayIndex = skipWhitespace(contents, nextIndex + 1);
+      if (contents.charAt(openArrayIndex) !== "[") {
+        return undefined;
+      }
+      const specifier = readStaticQuotedSpecifier(
+        contents,
+        skipWhitespace(contents, openArrayIndex + 1),
+      );
+      if (specifier === undefined) {
+        return undefined;
+      }
+      return {
+        nextIndex: specifier.nextIndex,
+        specifier: specifier.specifier,
+      };
+    }
+    nextIndex += 1;
+  }
+  return undefined;
+};
+
+const matchingCloseParenIndexFromOpen = (
+  contents: string,
+  openParenIndex: number,
+): number | undefined => {
+  let depth = 0;
+  let nextIndex = openParenIndex + 1;
+  let closeParenIndex: number | undefined;
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    const nextCharacter = contents.charAt(nextIndex + 1);
+    if (character === '"' || character === "'" || character === "`") {
+      nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, nextIndex)
+    ) {
+      nextIndex = skipRegexLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "(") {
+      depth += 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === ")") {
+      if (depth === 0) {
+        closeParenIndex = nextIndex;
+        break;
+      }
+      depth -= 1;
+      nextIndex += 1;
+      continue;
+    }
+    nextIndex += 1;
+  }
+  return closeParenIndex;
+};
+
+const endsWithControlCondition = (contents: string): boolean => {
+  const trimmed = contents.trimEnd();
+  const controlKeywords = ["if", "while", "with", "for", "switch"];
+  let index = 0;
+  while (index < trimmed.length) {
+    for (const keyword of controlKeywords) {
+      const afterKeyword = afterKeywordAt(trimmed, index, keyword);
+      if (afterKeyword === undefined) {
+        continue;
+      }
+      let openParenIndex = skipWhitespace(trimmed, afterKeyword);
+      if (keyword === "for") {
+        const afterAwait = afterKeywordAt(trimmed, openParenIndex, "await");
+        if (afterAwait !== undefined) {
+          openParenIndex = skipWhitespace(trimmed, afterAwait);
+        }
+      }
+      if (trimmed.charAt(openParenIndex) !== "(") {
+        continue;
+      }
+      const closeParenIndex = matchingCloseParenIndexFromOpen(trimmed, openParenIndex);
+      if (closeParenIndex !== undefined && skipWhitespace(trimmed, closeParenIndex + 1) === trimmed.length) {
+        return true;
+      }
+    }
+    index += 1;
+  }
+  return false;
+};
+
+const wrappingOpenParenCountBefore = (contents: string, index: number): number => {
+  let count = 0;
+  let nextIndex = index;
+  while (nextIndex > 0) {
+    const before = contents.slice(0, nextIndex).trimEnd();
+    if (before.at(-1) !== "(") {
+      return count;
+    }
+    const beforeOpenParen = before.slice(0, -1).trimEnd();
+    const precedingCharacter = beforeOpenParen.at(-1);
+    const previousToken = beforeOpenParen.match(/[A-Za-z_$][\w$]*$/)?.[0];
+    const followsKeyword =
+      previousToken === "return" ||
+      previousToken === "await" ||
+      previousToken === "void" ||
+      previousToken === "throw" ||
+      previousToken === "yield" ||
+      previousToken === "delete" ||
+      previousToken === "typeof" ||
+      previousToken === "new" ||
+      previousToken === "else" ||
+      previousToken === "do";
+    const followsControlCondition =
+      precedingCharacter === ")" && endsWithControlCondition(beforeOpenParen);
+    const isExpressionGrouping =
+      precedingCharacter === undefined ||
+      precedingCharacter === "(" ||
+      followsKeyword ||
+      followsControlCondition ||
+      "([{=,:;!?&|+-*/%~^<>".includes(precedingCharacter);
+    if (!isExpressionGrouping) {
+      return 0;
+    }
+    count += 1;
+    nextIndex = before.length - 1;
+  }
+  return count;
+};
+
+const afterWrappingCloseParens = (
+  contents: string,
+  index: number,
+  count: number,
+): number | undefined => {
+  let nextIndex = skipWhitespace(contents, index);
+  for (let parenIndex = 0; parenIndex < count; parenIndex += 1) {
+    if (contents.charAt(nextIndex) !== ")") {
+      return undefined;
+    }
+    nextIndex = skipWhitespace(contents, nextIndex + 1);
+  }
+  return nextIndex;
+};
+
+const readAccessorAfterCallee = (
+  contents: string,
+  calleeStartIndex: number,
+  afterCalleeIndex: number,
+  property: string,
+): number | undefined => {
+  const directAccessor = readPropertyAccessor(contents, afterCalleeIndex, property);
+  if (directAccessor !== undefined) {
+    return directAccessor;
+  }
+  const wrappingOpenParens = wrappingOpenParenCountBefore(contents, calleeStartIndex);
+  if (wrappingOpenParens === 0) {
+    return undefined;
+  }
+  for (let parenCount = wrappingOpenParens; parenCount > 0; parenCount -= 1) {
+    const afterWrappedCallee = afterWrappingCloseParens(contents, afterCalleeIndex, parenCount);
+    if (afterWrappedCallee === undefined) {
+      continue;
+    }
+    const wrappedAccessor = readPropertyAccessor(contents, afterWrappedCallee, property);
+    if (wrappedAccessor !== undefined) {
+      return wrappedAccessor;
+    }
+  }
+  return undefined;
+};
+
+const readBoundOrAppliedSpecifier = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const afterBindAccessor = readPropertyAccessor(contents, index, "bind");
+  if (afterBindAccessor !== undefined) {
+    const boundSpecifier = readCallSecondSpecifier(contents, afterBindAccessor);
+    if (boundSpecifier !== undefined) {
+      return boundSpecifier;
+    }
+    const afterBindCall = readCallExpressionEnd(contents, afterBindAccessor);
+    if (afterBindCall !== undefined) {
+      const boundCall = readCallSpecifier(contents, afterBindCall);
+      if (boundCall !== undefined) {
+        return boundCall;
+      }
+    }
+  }
+
+  const afterApplyAccessor = readPropertyAccessor(contents, index, "apply");
+  return afterApplyAccessor === undefined
+    ? undefined
+    : readApplyArraySpecifier(contents, afterApplyAccessor);
+};
+
+const expressionWrapperCloseParenIndex = (contents: string, index: number): number | undefined => {
+  let depth = 0;
+  let nextIndex = index;
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    const nextCharacter = contents.charAt(nextIndex + 1);
+    if (character === '"' || character === "'" || character === "`") {
+      nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, nextIndex)
+    ) {
+      nextIndex = skipRegexLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "(" || character === "[" || character === "{") {
+      depth += 1;
+      nextIndex += 1;
+      continue;
+    }
+    if (character === ")" && depth === 0) {
+      return nextIndex;
+    }
+    if (character === ")" || character === "]" || character === "}") {
+      depth -= 1;
+      nextIndex += 1;
+      continue;
+    }
+    nextIndex += 1;
+  }
+  return undefined;
+};
+
+const readSpecifierAfterCallableExpression = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const directCall = readCallSpecifier(contents, index);
+  if (directCall !== undefined) {
+    return directCall;
+  }
+  const afterCallAccessor = readPropertyAccessor(contents, index, "call");
+  if (afterCallAccessor !== undefined) {
+    const calledSpecifier = readCallSecondSpecifier(contents, afterCallAccessor);
+    if (calledSpecifier !== undefined) {
+      return calledSpecifier;
+    }
+  }
+  return readBoundOrAppliedSpecifier(contents, index);
+};
+
+const afterExpressionWrappedCallee = (
+  contents: string,
+  calleeStartIndex: number,
+  afterCalleeIndex: number,
+): number | undefined => {
+  let previous = contents.slice(0, calleeStartIndex).trimEnd();
+  while (previous.endsWith("(")) {
+    previous = previous.slice(0, -1).trimEnd();
+  }
+  const hasExpressionWrapper =
+    previous.endsWith(",") ||
+    previous.endsWith("||") ||
+    previous.endsWith("&&") ||
+    previous.endsWith("?") ||
+    previous.endsWith(":") ||
+    previous.endsWith("??");
+  if (!hasExpressionWrapper) {
+    const afterCallee = skipWhitespace(contents, afterCalleeIndex);
+    const startsWrappedExpression =
+      contents.startsWith("??", afterCallee) ||
+      contents.startsWith("||", afterCallee) ||
+      contents.startsWith(":", afterCallee);
+    if (!startsWrappedExpression) {
+      return undefined;
+    }
+    const closeParenIndex = expressionWrapperCloseParenIndex(contents, afterCallee + 1);
+    return closeParenIndex === undefined ? undefined : closeParenIndex + 1;
+  }
+  const afterCallee = skipWhitespace(contents, afterCalleeIndex);
+  if (contents.charAt(afterCallee) === ")") {
+    return afterCallee + 1;
+  }
+  const startsTernaryTail = previous.endsWith("?") && contents.charAt(afterCallee) === ":";
+  if (!startsTernaryTail) {
+    return undefined;
+  }
+  const closeParenIndex = expressionWrapperCloseParenIndex(contents, afterCallee + 1);
+  return closeParenIndex === undefined ? undefined : closeParenIndex + 1;
+};
+
+const readCalleeCallSpecifier = (
+  contents: string,
+  calleeStartIndex: number,
+  afterCalleeIndex: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const directCall = readCallSpecifier(contents, afterCalleeIndex);
+  if (directCall !== undefined) {
+    return directCall;
+  }
+
+  const boundOrApplied = readBoundOrAppliedSpecifier(contents, afterCalleeIndex);
+  if (boundOrApplied !== undefined) {
+    return boundOrApplied;
+  }
+
+  const afterExpressionWrapper = afterExpressionWrappedCallee(
+    contents,
+    calleeStartIndex,
+    afterCalleeIndex,
+  );
+  if (afterExpressionWrapper !== undefined) {
+    let nextExpressionWrapper = skipWhitespace(contents, afterExpressionWrapper);
+    while (nextExpressionWrapper < contents.length) {
+      const expressionWrappedSpecifier = readSpecifierAfterCallableExpression(
+        contents,
+        nextExpressionWrapper,
+      );
+      if (expressionWrappedSpecifier !== undefined) {
+        return expressionWrappedSpecifier;
+      }
+      if (contents.charAt(nextExpressionWrapper) !== ")") {
+        break;
+      }
+      nextExpressionWrapper = skipWhitespace(contents, nextExpressionWrapper + 1);
+    }
+  }
+
+  const wrappingOpenParens = wrappingOpenParenCountBefore(contents, calleeStartIndex);
+  if (wrappingOpenParens > 0) {
+    for (let parenCount = wrappingOpenParens; parenCount > 0; parenCount -= 1) {
+      const afterWrappedCallee = afterWrappingCloseParens(contents, afterCalleeIndex, parenCount);
+      if (afterWrappedCallee === undefined) {
+        continue;
+      }
+      const parenthesizedCall = readCallSpecifier(contents, afterWrappedCallee);
+      if (parenthesizedCall !== undefined) {
+        return parenthesizedCall;
+      }
+      const afterParenthesizedCallAccessor = readPropertyAccessor(
+        contents,
+        afterWrappedCallee,
+        "call",
+      );
+      if (afterParenthesizedCallAccessor !== undefined) {
+        return readCallSecondSpecifier(contents, afterParenthesizedCallAccessor);
+      }
+      const parenthesizedBoundOrApplied = readBoundOrAppliedSpecifier(contents, afterWrappedCallee);
+      if (parenthesizedBoundOrApplied !== undefined) {
+        return parenthesizedBoundOrApplied;
+      }
+      const afterWrappedExpressionWrapper = afterExpressionWrappedCallee(
+        contents,
+        calleeStartIndex,
+        afterWrappedCallee,
+      );
+      if (afterWrappedExpressionWrapper !== undefined) {
+        let nextWrappedExpression = skipWhitespace(contents, afterWrappedExpressionWrapper);
+        while (nextWrappedExpression < contents.length) {
+          const wrappedExpressionSpecifier = readSpecifierAfterCallableExpression(
+            contents,
+            nextWrappedExpression,
+          );
+          if (wrappedExpressionSpecifier !== undefined) {
+            return wrappedExpressionSpecifier;
+          }
+          if (contents.charAt(nextWrappedExpression) !== ")") {
+            break;
+          }
+          nextWrappedExpression = skipWhitespace(contents, nextWrappedExpression + 1);
+        }
+      }
+    }
+  }
+
+  const afterCallAccessor = readPropertyAccessor(contents, afterCalleeIndex, "call");
+  if (afterCallAccessor !== undefined) {
+    return readCallSecondSpecifier(contents, afterCallAccessor);
+  }
+
+  return undefined;
+};
+
 const readTemplateExpression = (
   contents: string,
   index: number,
@@ -329,8 +1104,28 @@ const readTemplateExpression = (
 
   while (nextIndex < contents.length) {
     const character = contents.charAt(nextIndex);
+    const nextCharacter = contents.charAt(nextIndex + 1);
     if (isImportQuote(character)) {
       nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (
+      character === "/" &&
+      nextCharacter !== "/" &&
+      nextCharacter !== "*" &&
+      isRegexLiteralStartContext(contents, nextIndex)
+    ) {
+      nextIndex = skipRegexLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "/" && nextCharacter === "/") {
+      const nextLineIndex = contents.indexOf("\n", nextIndex + 2);
+      nextIndex = nextLineIndex + 1 || contents.length;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "*") {
+      const commentEndIndex = contents.indexOf("*/", nextIndex + 2);
+      nextIndex = commentEndIndex === -1 ? contents.length : commentEndIndex + 2;
       continue;
     }
     if (character === "{") {
@@ -391,9 +1186,6 @@ const templateExpressionImportSpecifiers = (
     specifiers,
   };
 };
-
-const previousNonWhitespaceCharacter = (contents: string, index: number): string | undefined =>
-  contents.slice(0, index + 1).trimEnd().at(-1);
 
 const readJsxTag = (
   contents: string,
@@ -538,10 +1330,11 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
       continue;
     }
 
-    if (sourceHasKeywordAt(source, index, "from")) {
+    const afterFromKeyword = afterKeywordAt(source, index, "from");
+    if (afterFromKeyword !== undefined) {
       const specifier = readStaticQuotedSpecifier(
         source,
-        skipWhitespace(source, index + "from".length),
+        skipWhitespace(source, afterFromKeyword),
       );
       if (specifier !== undefined) {
         specifiers.push(specifier.specifier);
@@ -550,8 +1343,15 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
       }
     }
 
-    if (sourceHasKeywordAt(source, index, "import")) {
-      const afterImport = skipWhitespace(source, index + "import".length);
+    const afterImportKeyword = afterKeywordAt(source, index, "import");
+    if (afterImportKeyword !== undefined) {
+      const previousImportCharacter = previousNonWhitespaceCharacter(source, index - 1);
+      const isFreeImport = previousImportCharacter !== "." && previousImportCharacter !== "#";
+      if (!isFreeImport) {
+        index += 1;
+        continue;
+      }
+      const afterImport = skipWhitespace(source, afterImportKeyword);
       const sideEffectSpecifier = readStaticQuotedSpecifier(source, afterImport);
       if (sideEffectSpecifier !== undefined) {
         specifiers.push(sideEffectSpecifier.specifier);
@@ -571,17 +1371,32 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
       }
     }
 
-    if (isFreeRequireAt(source, index)) {
-      const afterRequire = skipWhitespace(source, index + "require".length);
-      const requireSpecifier = readCallSpecifier(source, afterRequire);
+    const afterImportMetaResolveAccessor = importMetaResolveAccessorAt(source, index);
+    if (afterImportMetaResolveAccessor !== undefined) {
+      const resolvedSpecifier = readCalleeCallSpecifier(
+        source,
+        index,
+        afterImportMetaResolveAccessor,
+      );
+      if (resolvedSpecifier !== undefined) {
+        specifiers.push(resolvedSpecifier.specifier);
+        index = resolvedSpecifier.nextIndex;
+        continue;
+      }
+    }
+
+    const afterRequireKeyword = freeRequireKeywordEndAt(source, index);
+    if (afterRequireKeyword !== undefined) {
+      const afterRequire = skipWhitespace(source, afterRequireKeyword);
+      const requireSpecifier = readCalleeCallSpecifier(source, index, afterRequire);
       if (requireSpecifier !== undefined) {
         specifiers.push(requireSpecifier.specifier);
         index = requireSpecifier.nextIndex;
         continue;
       }
-      const afterResolve = resolveAccessorAfterRequire(source, afterRequire);
+      const afterResolve = resolveAccessorAfterRequire(source, index, afterRequire);
       if (afterResolve !== undefined) {
-        const resolvedSpecifier = readCallSpecifier(source, afterResolve);
+        const resolvedSpecifier = readCalleeCallSpecifier(source, index, afterResolve);
         if (resolvedSpecifier !== undefined) {
           specifiers.push(resolvedSpecifier.specifier);
           index = resolvedSpecifier.nextIndex;
@@ -590,10 +1405,41 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
       }
     }
 
-    if (isModuleRequireAt(source, index)) {
-      const afterModule = skipWhitespace(source, index + "module".length);
-      const afterRequire = skipWhitespace(source, afterModule + ".require".length);
-      const moduleRequireSpecifier = readCallSpecifier(source, afterRequire);
+    const afterCreateRequireKeyword = freeCreateRequireKeywordEndAt(source, index);
+    if (afterCreateRequireKeyword !== undefined) {
+      const afterCreateRequireFactory = readCallExpressionEnd(source, afterCreateRequireKeyword);
+      if (afterCreateRequireFactory !== undefined) {
+        const createRequireSpecifier = readCalleeCallSpecifier(
+          source,
+          index,
+          afterCreateRequireFactory,
+        );
+        if (createRequireSpecifier !== undefined) {
+          specifiers.push(createRequireSpecifier.specifier);
+          index = createRequireSpecifier.nextIndex;
+          continue;
+        }
+        const afterResolve = readAccessorAfterCallee(
+          source,
+          index,
+          afterCreateRequireFactory,
+          "resolve",
+        );
+        if (afterResolve !== undefined) {
+          const resolvedSpecifier = readCalleeCallSpecifier(source, index, afterResolve);
+          if (resolvedSpecifier !== undefined) {
+            specifiers.push(resolvedSpecifier.specifier);
+            index = resolvedSpecifier.nextIndex;
+            continue;
+          }
+        }
+      }
+    }
+
+    const afterRequireAccessor = moduleRequireAccessorAt(source, index);
+    if (afterRequireAccessor !== undefined) {
+      const afterRequire = skipWhitespace(source, afterRequireAccessor);
+      const moduleRequireSpecifier = readCalleeCallSpecifier(source, index, afterRequire);
       if (moduleRequireSpecifier !== undefined) {
         specifiers.push(moduleRequireSpecifier.specifier);
         index = moduleRequireSpecifier.nextIndex;

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -119,6 +119,14 @@ export const sourceWithoutComments = (contents: string): string => {
       continue;
     }
 
+    if (isJsxTagStart(contents, index)) {
+      const jsxElement = jsxElementImportSpecifiers(contents, index);
+      const nextIndex = jsxElement.nextIndex;
+      output += contents.slice(index, nextIndex);
+      index = nextIndex;
+      continue;
+    }
+
     if (character === "/" && nextCharacter === "/") {
       lineComment = true;
       index += 2;
@@ -201,8 +209,116 @@ const readQuotedSpecifier = (
   return undefined;
 };
 
+const readStaticQuotedSpecifier = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const quoted = readQuotedSpecifier(contents, index);
+  if (quoted === undefined) {
+    return undefined;
+  }
+  if (
+    contents.charAt(index) === "`" &&
+    quoted.specifier.includes("${") &&
+    !isViewServerSpecifier(quoted.specifier)
+  ) {
+    return undefined;
+  }
+  return quoted;
+};
+
 const skipQuotedLiteral = (contents: string, index: number): number =>
   readQuotedSpecifier(contents, index)?.nextIndex ?? index + 1;
+
+const isJsxStartContext = (contents: string, index: number): boolean => {
+  const previous = previousNonWhitespaceCharacter(contents, index - 1);
+  const previousSource = contents.slice(0, index).trimEnd();
+  return (
+    previous === undefined ||
+    previous === "(" ||
+    previous === "[" ||
+    previous === "{" ||
+    previous === "=" ||
+    previous === ":" ||
+    previous === "," ||
+    previous === "?" ||
+    previous === ">" ||
+    previous === ";" ||
+    previous === "&" ||
+    previous === "|" ||
+    previous === "!" ||
+    /\breturn$/.test(previousSource)
+  );
+};
+
+const isJsxTagStart = (contents: string, index: number): boolean => {
+  const nextCharacter = contents.charAt(index + 1);
+  return (
+    contents.charAt(index) === "<" &&
+    (nextCharacter === ">" || /[A-Za-z_$/.]/.test(nextCharacter)) &&
+    isJsxStartContext(contents, index)
+  );
+};
+
+const isNestedJsxTagStart = (contents: string, index: number): boolean => {
+  const nextCharacter = contents.charAt(index + 1);
+  return contents.charAt(index) === "<" && (nextCharacter === ">" || /[A-Za-z_$/.]/.test(nextCharacter));
+};
+
+const isFreeRequireAt = (contents: string, index: number): boolean => {
+  const previous = contents.slice(0, index).trimEnd().at(-1);
+  return sourceHasKeywordAt(contents, index, "require") && previous !== "." && previous !== "#";
+};
+
+const isModuleRequireAt = (contents: string, index: number): boolean => {
+  const previous = contents.slice(0, index).trimEnd().at(-1);
+  if (previous === "." || previous === "#") {
+    return false;
+  }
+  if (!sourceHasKeywordAt(contents, index, "module")) {
+    return false;
+  }
+  const afterModule = skipWhitespace(contents, index + "module".length);
+  return contents.startsWith(".require", afterModule);
+};
+
+const callOpenParenIndex = (contents: string, index: number): number | undefined => {
+  const nextIndex = skipWhitespace(contents, index);
+  if (contents[nextIndex] === "(") {
+    return nextIndex;
+  }
+  return contents.startsWith("?.(", nextIndex) ? nextIndex + "?.".length : undefined;
+};
+
+const resolveAccessorAfterRequire = (contents: string, index: number): number | undefined => {
+  const nextIndex = skipWhitespace(contents, index);
+  if (contents.startsWith(".resolve", nextIndex)) {
+    return nextIndex + ".resolve".length;
+  }
+  if (contents.startsWith("?.resolve", nextIndex)) {
+    return nextIndex + "?.resolve".length;
+  }
+  const bracketResolve = '["resolve"]';
+  if (contents.startsWith(bracketResolve, nextIndex)) {
+    return nextIndex + bracketResolve.length;
+  }
+  const singleQuoteBracketResolve = "['resolve']";
+  if (contents.startsWith(singleQuoteBracketResolve, nextIndex)) {
+    return nextIndex + singleQuoteBracketResolve.length;
+  }
+  return undefined;
+};
+
+const readCallSpecifier = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifier: string } | undefined => {
+  const openParen = callOpenParenIndex(contents, index);
+  if (openParen === undefined) {
+    return undefined;
+  }
+  return readStaticQuotedSpecifier(contents, skipWhitespace(contents, openParen + 1));
+};
 
 const readTemplateExpression = (
   contents: string,
@@ -276,6 +392,128 @@ const templateExpressionImportSpecifiers = (
   };
 };
 
+const previousNonWhitespaceCharacter = (contents: string, index: number): string | undefined =>
+  contents.slice(0, index + 1).trimEnd().at(-1);
+
+const readJsxTag = (
+  contents: string,
+  index: number,
+): {
+  readonly _tag: "complete";
+  readonly closing: boolean;
+  readonly nextIndex: number;
+  readonly selfClosing: boolean;
+  readonly specifiers: ReadonlyArray<string>;
+} | {
+  readonly _tag: "incomplete";
+  readonly nextIndex: number;
+  readonly specifiers: ReadonlyArray<string>;
+} => {
+  const specifiers: Array<string> = [];
+  const closing = contents.charAt(index + 1) === "/";
+  let nextIndex = index + 1;
+
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    if (isImportQuote(character)) {
+      nextIndex = skipQuotedLiteral(contents, nextIndex);
+      continue;
+    }
+    if (character === "{") {
+      const expression = readTemplateExpression(contents, nextIndex + 1);
+      if (expression === undefined) {
+        return {
+          _tag: "incomplete",
+          nextIndex: contents.length,
+          specifiers,
+        };
+      }
+      specifiers.push(...importSpecifiersFromSource(expression.expression));
+      nextIndex = expression.nextIndex;
+      continue;
+    }
+    if (character === ">") {
+      return {
+        _tag: "complete",
+        closing,
+        nextIndex: nextIndex + 1,
+        selfClosing: previousNonWhitespaceCharacter(contents, nextIndex - 1) === "/",
+        specifiers,
+      };
+    }
+    nextIndex += 1;
+  }
+
+  return {
+    _tag: "incomplete",
+    nextIndex,
+    specifiers,
+  };
+};
+
+const jsxElementImportSpecifiers = (
+  contents: string,
+  index: number,
+): { readonly nextIndex: number; readonly specifiers: ReadonlyArray<string> } => {
+  const specifiers: Array<string> = [];
+  let depth = 0;
+  let nextIndex = index;
+
+  while (nextIndex < contents.length) {
+    const character = contents.charAt(nextIndex);
+    if (character === "<" && isNestedJsxTagStart(contents, nextIndex)) {
+      const tag = readJsxTag(contents, nextIndex);
+      if (tag._tag === "incomplete") {
+        return {
+          nextIndex: index + 1,
+          specifiers: [],
+        };
+      }
+      specifiers.push(...tag.specifiers);
+      nextIndex = tag.nextIndex;
+      if (tag.closing) {
+        depth -= 1;
+        if (depth <= 0) {
+          return {
+            nextIndex,
+            specifiers,
+          };
+        }
+        continue;
+      }
+      if (!tag.selfClosing) {
+        depth += 1;
+        continue;
+      }
+      if (depth > 0) {
+        continue;
+      }
+      return {
+        nextIndex,
+        specifiers,
+      };
+    }
+    if (character === "{") {
+      const expression = readTemplateExpression(contents, nextIndex + 1);
+      if (expression === undefined) {
+        return {
+          nextIndex: contents.length,
+          specifiers,
+        };
+      }
+      specifiers.push(...importSpecifiersFromSource(expression.expression));
+      nextIndex = expression.nextIndex;
+      continue;
+    }
+    nextIndex += 1;
+  }
+
+  return {
+    nextIndex: index + 1,
+    specifiers: [],
+  };
+};
+
 export const importSpecifiersFromSource = (contents: string): ReadonlyArray<string> => {
   const source = sourceWithoutComments(contents);
   const specifiers: Array<string> = [];
@@ -283,6 +521,12 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
 
   while (index < source.length) {
     const character = source.charAt(index);
+    if (isJsxTagStart(source, index)) {
+      const jsxElement = jsxElementImportSpecifiers(source, index);
+      specifiers.push(...jsxElement.specifiers);
+      index = jsxElement.nextIndex;
+      continue;
+    }
     if (character === "`") {
       const template = templateExpressionImportSpecifiers(source, index);
       specifiers.push(...template.specifiers);
@@ -295,7 +539,10 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
     }
 
     if (sourceHasKeywordAt(source, index, "from")) {
-      const specifier = readQuotedSpecifier(source, skipWhitespace(source, index + "from".length));
+      const specifier = readStaticQuotedSpecifier(
+        source,
+        skipWhitespace(source, index + "from".length),
+      );
       if (specifier !== undefined) {
         specifiers.push(specifier.specifier);
         index = specifier.nextIndex;
@@ -305,14 +552,14 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
 
     if (sourceHasKeywordAt(source, index, "import")) {
       const afterImport = skipWhitespace(source, index + "import".length);
-      const sideEffectSpecifier = readQuotedSpecifier(source, afterImport);
+      const sideEffectSpecifier = readStaticQuotedSpecifier(source, afterImport);
       if (sideEffectSpecifier !== undefined) {
         specifiers.push(sideEffectSpecifier.specifier);
         index = sideEffectSpecifier.nextIndex;
         continue;
       }
       if (source[afterImport] === "(") {
-        const dynamicSpecifier = readQuotedSpecifier(
+        const dynamicSpecifier = readStaticQuotedSpecifier(
           source,
           skipWhitespace(source, afterImport + 1),
         );
@@ -321,6 +568,36 @@ export const importSpecifiersFromSource = (contents: string): ReadonlyArray<stri
           index = dynamicSpecifier.nextIndex;
           continue;
         }
+      }
+    }
+
+    if (isFreeRequireAt(source, index)) {
+      const afterRequire = skipWhitespace(source, index + "require".length);
+      const requireSpecifier = readCallSpecifier(source, afterRequire);
+      if (requireSpecifier !== undefined) {
+        specifiers.push(requireSpecifier.specifier);
+        index = requireSpecifier.nextIndex;
+        continue;
+      }
+      const afterResolve = resolveAccessorAfterRequire(source, afterRequire);
+      if (afterResolve !== undefined) {
+        const resolvedSpecifier = readCallSpecifier(source, afterResolve);
+        if (resolvedSpecifier !== undefined) {
+          specifiers.push(resolvedSpecifier.specifier);
+          index = resolvedSpecifier.nextIndex;
+          continue;
+        }
+      }
+    }
+
+    if (isModuleRequireAt(source, index)) {
+      const afterModule = skipWhitespace(source, index + "module".length);
+      const afterRequire = skipWhitespace(source, afterModule + ".require".length);
+      const moduleRequireSpecifier = readCallSpecifier(source, afterRequire);
+      if (moduleRequireSpecifier !== undefined) {
+        specifiers.push(moduleRequireSpecifier.specifier);
+        index = moduleRequireSpecifier.nextIndex;
+        continue;
       }
     }
 


### PR DESCRIPTION
Summary
- Coalesce concurrent unary RPC health reads under the server handler scope.
- Interrupt/resolve in-flight health reads during server shutdown and prevent remote callers from hanging.
- Track active WebSocket close-frame writes and make shutdown close attempts bounded/concurrent.
- Harden the internal seam scanner for CommonJS optional require/resolve, Node module.require, JSX text, and template cases.

Validation
- pnpm run ready
- 3-agent review loop completed; final seam-scanner and shutdown findings addressed.