### PR TITLE
Add Kafka ingest benchmark baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - Health counters should update cheaply and publish at a bounded cadence.
 - Benchmarks must state whether they are localhost CPU/GC stress, browser stress, network-shaped, or production-like.
 - `pnpm run bench:baseline:smoke` is the smoke performance-regression gate. It must compare fresh Vitest benchmark artifacts against `benchmarks/baselines/smoke.json`; use `pnpm run bench:baseline:smoke:update` only when an accepted performance change intentionally moves the baseline.
+- `pnpm run bench:baseline:kafka-ingest` is the real Kafka ingest smoke gate. It starts Apache Kafka via `compose.yaml`, uses `@platformatic/kafka`, and compares JSON/protobuf ingest plus a 2k-message mixed burst against `benchmarks/baselines/kafka-ingest.json`.
 - Do not run competing benchmark suites in parallel when comparing results.
 
 ## Package And Architecture Rules

--- a/benchmarks/baselines/kafka-ingest.json
+++ b/benchmarks/baselines/kafka-ingest.json
@@ -1,0 +1,88 @@
+{
+  "artifactKind": "view-server-benchmark-baseline",
+  "profile": "kafka-ingest",
+  "tasks": [
+    {
+      "artifactKind": "runtime-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
+          "maxMs": 3406.2726249999996,
+          "meanMs": 1944.4125413333331,
+          "minMs": 71.838708,
+          "name": "json source batch ingest",
+          "p99Ms": 3406.2726249999996,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
+          "maxMs": 2982.8575,
+          "meanMs": 1721.2695416666668,
+          "minMs": 287.6083749999998,
+          "name": "protobuf source batch ingest",
+          "p99Ms": 2982.8575,
+          "sampleCount": 3
+        },
+        {
+          "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
+          "maxMs": 18343.525208,
+          "meanMs": 16875.485707999997,
+          "minMs": 16103.604999999996,
+          "name": "mixed source burst ingest",
+          "p99Ms": 18343.525208,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": [
+        "json source batch ingest",
+        "protobuf source batch ingest",
+        "mixed source burst ingest"
+      ],
+      "benchmarkName": "Kafka ingest runtime benchmark",
+      "benchmarkScope": "runtime-kafka-ingest",
+      "cleanupLeakCount": 0,
+      "kafkaIngestLanes": [
+        {
+          "internalTopic": "jsonOrders",
+          "lane": "jsonOrders",
+          "producedRows": 3750,
+          "region": "local",
+          "sourceTopicAlias": "unique-topic-per-run:jsonOrders"
+        },
+        {
+          "internalTopic": "protobufOrders",
+          "lane": "protobufOrders",
+          "producedRows": 3750,
+          "region": "local",
+          "sourceTopicAlias": "unique-topic-per-run:protobufOrders"
+        }
+      ],
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 54165504,
+      "minimumSampleCount": 3,
+      "mutationCount": 7500,
+      "outputJsonPath": "packages/runtime/.artifacts/kafka-ingest-250rows.json",
+      "queuedEventCount": 0,
+      "rowCount": 250,
+      "subscriberCount": 0,
+      "summaryPath": "packages/runtime/.artifacts/kafka-ingest-250rows.summary.json",
+      "taskLabel": "Kafka ingest 250 rows",
+      "topics": ["jsonOrders", "protobufOrders"]
+    }
+  ],
+  "thresholds": {
+    "latencyMean": {
+      "maxAbsoluteDeltaMs": 2000,
+      "maxRatio": 1.5
+    },
+    "latencyP99": {
+      "maxAbsoluteDeltaMs": 2500,
+      "maxRatio": 1.5
+    },
+    "memoryRssTotalDelta": {
+      "maxAbsoluteDeltaBytes": 134217728,
+      "maxRatio": 3
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "bench:baseline:grouped-admission:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission --update-baseline",
     "bench:baseline:grouped-order-neutral": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral",
     "bench:baseline:grouped-order-neutral:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
+    "bench:baseline:kafka-ingest": "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest",
+    "bench:baseline:kafka-ingest:update": "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest --update-baseline",
     "bench:baseline:release": "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     "bench:baseline:release:update": "node scripts/run-benchmark-baseline.mjs --profile=release --update-baseline",
     "bench:baseline:smoke": "node scripts/run-benchmark-baseline.mjs --profile=smoke",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,6 +13,7 @@
     }
   },
   "scripts": {
+    "bench:kafka-ingest": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && sh -c 'status=0; cleanup() { down_status=0; docker compose -f ../../compose.yaml down || down_status=$?; if [ $status -eq 0 ]; then status=$down_status; fi; exit $status; }; trap cleanup EXIT INT TERM; output=${VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON:-.artifacts/kafka-ingest-${VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE:-1000}rows.json}; mkdir -p .artifacts; docker compose -f ../../compose.yaml up -d --wait kafka || status=$?; if [ $status -eq 0 ]; then VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON=$output VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS=${VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS:-localhost:9092} vp test bench src/kafka-ingest.bench.ts --run --testTimeout 0 --outputJson $output || status=$?; fi'",
     "build": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp pack",
     "test": "node ../../scripts/test-runtime.mjs"
   },

--- a/packages/runtime/src/kafka-ingest.bench.ts
+++ b/packages/runtime/src/kafka-ingest.bench.ts
@@ -1,0 +1,669 @@
+// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+import { afterAll, beforeAll, bench, describe } from "vitest";
+import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { Admin, Producer, stringSerializers } from "@platformatic/kafka";
+import { defineViewServerConfig, kafka, type ViewServerHealth } from "@view-server/config";
+import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
+import { Buffer } from "node:buffer";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { Crypto, Effect, Exit, Schedule, Schema } from "effect";
+import { makeViewServerRuntime, type ViewServerRuntime } from "./index";
+import { OrderKeySchema, OrderValueSchema } from "./test-fixtures/runtime_orders_pb";
+
+declare const process: {
+  readonly cwd: () => string;
+  readonly env: Record<string, string | undefined>;
+  readonly memoryUsage: () => {
+    readonly arrayBuffers: number;
+    readonly external: number;
+    readonly heapTotal: number;
+    readonly heapUsed: number;
+    readonly rss: number;
+  };
+};
+
+type BenchmarkMemorySnapshot = {
+  readonly arrayBuffersBytes: number;
+  readonly externalBytes: number;
+  readonly heapTotalBytes: number;
+  readonly heapUsedBytes: number;
+  readonly rssBytes: number;
+};
+
+type BenchmarkProfile = {
+  jsonProducedRows: number;
+  memoryAfterSetup: BenchmarkMemorySnapshot | undefined;
+  protobufProducedRows: number;
+  runtime: ViewServerRuntime<Topics> | undefined;
+  stringProducer: Producer<string, string, string, string> | undefined;
+  binaryProducer: Producer<Buffer, Buffer, Buffer, Buffer> | undefined;
+  sourceTopics:
+    | {
+        jsonOrders: string;
+        protobufOrders: string;
+      }
+    | undefined;
+};
+
+type BenchmarkCase = {
+  readonly name: string;
+  readonly run: () => Promise<void>;
+};
+
+class KafkaIngestBenchmarkError extends Schema.TaggedErrorClass<KafkaIngestBenchmarkError>()(
+  "KafkaIngestBenchmarkError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+const JsonOrder = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  price: Schema.Number,
+});
+
+const ProtobufOrder = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  price: Schema.Number,
+});
+
+const IncomingJsonOrder = Schema.Struct({
+  customerId: Schema.String,
+  price: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    jsonOrders: {
+      schema: JsonOrder,
+      key: "id",
+    },
+    protobufOrders: {
+      schema: ProtobufOrder,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+
+const defaultBatchSize = 1_000;
+const defaultBenchmarkTimeMs = 250;
+const defaultIterations = 3;
+const defaultWarmupIterations = 0;
+const defaultWarmupTimeMs = 0;
+const kafkaBootstrapServers =
+  process.env["VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS"] ?? "localhost:9092";
+const outputJsonPath = benchmarkOutputJsonPath("kafka-ingest-1000rows.json");
+const memoryBefore = memorySnapshot();
+const healthPollSchedule = Schedule.addDelay(Schedule.recurs(2_400), () =>
+  Effect.succeed("25 millis"),
+);
+const ignoreKafkaBenchAdminCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring Kafka ingest benchmark admin close failure.",
+);
+
+const positiveIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/u.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+};
+
+const nonNegativeIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^(0|[1-9]\d*)$/u.test(trimmed)) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return parsed;
+};
+
+const batchSize = positiveIntegerFromEnv(
+  "VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE",
+  defaultBatchSize,
+);
+const burstMultiplier = positiveIntegerFromEnv(
+  "VIEW_SERVER_RUNTIME_BENCH_KAFKA_BURST_MULTIPLIER",
+  4,
+);
+const benchOptions = {
+  iterations: positiveIntegerFromEnv("VIEW_SERVER_RUNTIME_BENCH_ITERATIONS", defaultIterations),
+  time: positiveIntegerFromEnv("VIEW_SERVER_RUNTIME_BENCH_TIME_MS", defaultBenchmarkTimeMs),
+  warmupIterations: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_RUNTIME_BENCH_WARMUP_ITERATIONS",
+    defaultWarmupIterations,
+  ),
+  warmupTime: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_RUNTIME_BENCH_WARMUP_TIME_MS",
+    defaultWarmupTimeMs,
+  ),
+};
+
+const profile: BenchmarkProfile = {
+  binaryProducer: undefined,
+  jsonProducedRows: 0,
+  memoryAfterSetup: undefined,
+  protobufProducedRows: 0,
+  runtime: undefined,
+  sourceTopics: undefined,
+  stringProducer: undefined,
+};
+
+const internalTopicNames = ["jsonOrders", "protobufOrders"] as const;
+
+function memorySnapshot(): BenchmarkMemorySnapshot {
+  const memory = process.memoryUsage();
+  return {
+    arrayBuffersBytes: memory.arrayBuffers,
+    externalBytes: memory.external,
+    heapTotalBytes: memory.heapTotal,
+    heapUsedBytes: memory.heapUsed,
+    rssBytes: memory.rss,
+  };
+}
+
+function memoryDelta(
+  before: BenchmarkMemorySnapshot,
+  after: BenchmarkMemorySnapshot,
+): BenchmarkMemorySnapshot {
+  return {
+    arrayBuffersBytes: after.arrayBuffersBytes - before.arrayBuffersBytes,
+    externalBytes: after.externalBytes - before.externalBytes,
+    heapTotalBytes: after.heapTotalBytes - before.heapTotalBytes,
+    heapUsedBytes: after.heapUsedBytes - before.heapUsedBytes,
+    rssBytes: after.rssBytes - before.rssBytes,
+  };
+}
+
+function benchmarkOutputJsonPath(fallbackName: string): string {
+  const configured = process.env["VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON"];
+  if (configured !== undefined && configured.trim() !== "") {
+    return configured.trim();
+  }
+  return join(".artifacts", fallbackName);
+}
+
+function benchmarkSummaryPath(path: string): string {
+  if (path.endsWith(".json")) {
+    return `${path.slice(0, -".json".length)}.summary.json`;
+  }
+  return `${path}.summary.json`;
+}
+
+function writeJsonFile(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      value,
+      (_key, item: unknown) => (typeof item === "bigint" ? item.toString() : item),
+      2,
+    )}\n`,
+  );
+}
+
+const uniqueName = Effect.fn("ViewServerRuntime.kafka.bench.uniqueName")(function* (
+  prefix: string,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const uuid = yield* crypto.randomUUIDv7;
+  return `view-server-bench-${prefix}-${uuid.replaceAll("-", "")}`;
+});
+
+const createKafkaTopics = Effect.fn("ViewServerRuntime.kafka.bench.createTopics")(function* (
+  bootstrapServers: string,
+  topics: ReadonlyArray<string>,
+) {
+  const admin = new Admin({
+    bootstrapBrokers: [bootstrapServers],
+    clientId: "view-server-kafka-ingest-bench-admin",
+  });
+  return yield* Effect.acquireUseRelease(
+    Effect.succeed(admin),
+    (currentAdmin) =>
+      Effect.promise(() =>
+        currentAdmin.createTopics({
+          partitions: 1,
+          replicas: 1,
+          topics: [...topics],
+        }),
+      ),
+    (currentAdmin) =>
+      Effect.promise(() => currentAdmin.close()).pipe(ignoreKafkaBenchAdminCloseFailure),
+  );
+});
+
+const setupBenchmark = Effect.fn("ViewServerRuntime.kafka.bench.setup")(function* () {
+  const jsonOrdersSourceTopic = yield* uniqueName("json-orders");
+  const protobufOrdersSourceTopic = yield* uniqueName("protobuf-orders");
+  const consumerGroupId = yield* uniqueName("group");
+  yield* createKafkaTopics(kafkaBootstrapServers, [
+    jsonOrdersSourceTopic,
+    protobufOrdersSourceTopic,
+  ]);
+  const regions = {
+    local: kafkaBootstrapServers,
+  };
+  const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
+  const runtime = yield* makeViewServerRuntime(viewServer, {
+    host: "127.0.0.1",
+    websocketPort: 0,
+    kafka: {
+      consumerGroupId,
+      regions,
+      topics: {
+        [jsonOrdersSourceTopic]: localKafkaTopic({
+          regions: ["local"],
+          value: kafka.json(IncomingJsonOrder),
+          key: kafka.stringKey(),
+          viewServerTopic: "jsonOrders",
+          mapping: ({ key, value }) => ({
+            id: key,
+            customerId: value.customerId,
+            price: value.price,
+          }),
+        }),
+        [protobufOrdersSourceTopic]: localKafkaTopic({
+          regions: ["local"],
+          value: kafka.protobuf(OrderValueSchema),
+          key: kafka.protobuf(OrderKeySchema),
+          viewServerTopic: "protobufOrders",
+          mapping: ({ key, value }) => ({
+            id: key.orderId,
+            customerId: value.customerId,
+            price: value.price,
+          }),
+        }),
+      },
+    },
+  });
+  const stringProducer = new Producer<string, string, string, string>({
+    bootstrapBrokers: [kafkaBootstrapServers],
+    clientId: "view-server-kafka-ingest-bench-json-producer",
+    serializers: stringSerializers,
+  });
+  const binaryProducer = new Producer<Buffer, Buffer, Buffer, Buffer>({
+    bootstrapBrokers: [kafkaBootstrapServers],
+    clientId: "view-server-kafka-ingest-bench-protobuf-producer",
+  });
+  return {
+    binaryProducer,
+    runtime,
+    sourceTopics: {
+      jsonOrders: jsonOrdersSourceTopic,
+      protobufOrders: protobufOrdersSourceTopic,
+    },
+    stringProducer,
+  };
+});
+
+const startedRuntime = (): ViewServerRuntime<Topics> => {
+  const runtime = profile.runtime;
+  if (runtime === undefined) {
+    throw new Error("Kafka ingest benchmark runtime is not started.");
+  }
+  return runtime;
+};
+
+const sourceTopics = (): NonNullable<BenchmarkProfile["sourceTopics"]> => {
+  const topics = profile.sourceTopics;
+  if (topics === undefined) {
+    throw new Error("Kafka ingest benchmark source topics are not configured.");
+  }
+  return topics;
+};
+
+const stringProducer = (): Producer<string, string, string, string> => {
+  const producer = profile.stringProducer;
+  if (producer === undefined) {
+    throw new Error("Kafka ingest benchmark string producer is not started.");
+  }
+  return producer;
+};
+
+const binaryProducer = (): Producer<Buffer, Buffer, Buffer, Buffer> => {
+  const producer = profile.binaryProducer;
+  if (producer === undefined) {
+    throw new Error("Kafka ingest benchmark binary producer is not started.");
+  }
+  return producer;
+};
+
+const jsonMessages = (
+  sourceTopic: string,
+  startIndex: number,
+  count: number,
+): Parameters<Producer<string, string, string, string>["send"]>[0]["messages"] =>
+  Array.from({ length: count }, (_value, offset) => {
+    const index = startIndex + offset;
+    return {
+      topic: sourceTopic,
+      key: `json-order-${index}`,
+      value: JSON.stringify({
+        customerId: `customer-${index % 10_000}`,
+        price: index % 1_000,
+      }),
+    };
+  });
+
+const protobufMessages = (
+  sourceTopic: string,
+  startIndex: number,
+  count: number,
+): Parameters<Producer<Buffer, Buffer, Buffer, Buffer>["send"]>[0]["messages"] =>
+  Array.from({ length: count }, (_value, offset) => {
+    const index = startIndex + offset;
+    return {
+      topic: sourceTopic,
+      key: Buffer.from(
+        toBinary(
+          OrderKeySchema,
+          create(OrderKeySchema, {
+            orderId: `protobuf-order-${index}`,
+          }),
+        ),
+      ),
+      value: Buffer.from(
+        toBinary(
+          OrderValueSchema,
+          create(OrderValueSchema, {
+            customerId: `customer-${index % 10_000}`,
+            price: index % 1_000,
+          }),
+        ),
+      ),
+    };
+  });
+
+const waitForRows = Effect.fn("ViewServerRuntime.kafka.bench.waitForRows")(function* (
+  topic: "jsonOrders" | "protobufOrders",
+  expectedRows: number,
+) {
+  const health = yield* startedRuntime()
+    .client.health()
+    .pipe(
+      Effect.repeat({
+        schedule: healthPollSchedule,
+        until: (currentHealth) => currentHealth.engine.topics[topic].rowCount === expectedRows,
+      }),
+    );
+  const actualRows = health.engine.topics[topic].rowCount;
+  if (actualRows !== expectedRows) {
+    return yield* new KafkaIngestBenchmarkError({
+      message: `Kafka ingest benchmark ${topic} did not converge: expected exactly ${expectedRows} row(s), got ${actualRows}.`,
+    });
+  }
+  return health;
+});
+
+const committedOffset = (health: ViewServerHealth<Topics>, sourceTopic: string): number => {
+  const rawOffset = health.kafka?.topics[sourceTopic]?.regions["local"]?.committedOffset;
+  if (rawOffset === undefined || rawOffset === null) {
+    return 0;
+  }
+  const parsedOffset = Number.parseInt(rawOffset, 10);
+  return Number.isSafeInteger(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
+};
+
+const waitForFinalHealth = Effect.fn("ViewServerRuntime.kafka.bench.waitForFinalHealth")(
+  function* () {
+    const topics = sourceTopics();
+    const health = yield* startedRuntime()
+      .client.health()
+      .pipe(
+        Effect.repeat({
+          schedule: healthPollSchedule,
+          until: (health) =>
+            health.engine.topics.jsonOrders.rowCount === profile.jsonProducedRows &&
+            health.engine.topics.protobufOrders.rowCount === profile.protobufProducedRows &&
+            committedOffset(health, topics.jsonOrders) === profile.jsonProducedRows &&
+            committedOffset(health, topics.protobufOrders) === profile.protobufProducedRows,
+        }),
+      );
+    const jsonRows = health.engine.topics.jsonOrders.rowCount;
+    const protobufRows = health.engine.topics.protobufOrders.rowCount;
+    const jsonOffset = committedOffset(health, topics.jsonOrders);
+    const protobufOffset = committedOffset(health, topics.protobufOrders);
+    if (
+      jsonRows !== profile.jsonProducedRows ||
+      protobufRows !== profile.protobufProducedRows ||
+      jsonOffset !== profile.jsonProducedRows ||
+      protobufOffset !== profile.protobufProducedRows
+    ) {
+      return yield* new KafkaIngestBenchmarkError({
+        message: [
+          "Kafka ingest benchmark final health did not converge.",
+          `jsonRows=${jsonRows}/${profile.jsonProducedRows}`,
+          `protobufRows=${protobufRows}/${profile.protobufProducedRows}`,
+          `jsonCommittedOffset=${jsonOffset}/${profile.jsonProducedRows}`,
+          `protobufCommittedOffset=${protobufOffset}/${profile.protobufProducedRows}`,
+        ].join(" "),
+      });
+    }
+    return health;
+  },
+);
+
+const publishJsonBatch = async (count: number): Promise<void> => {
+  const nextTotal = profile.jsonProducedRows + count;
+  await stringProducer().send({
+    messages: jsonMessages(sourceTopics().jsonOrders, profile.jsonProducedRows, count),
+  });
+  profile.jsonProducedRows = nextTotal;
+  await Effect.runPromise(waitForRows("jsonOrders", nextTotal));
+};
+
+const publishProtobufBatch = async (count: number): Promise<void> => {
+  const nextTotal = profile.protobufProducedRows + count;
+  await binaryProducer().send({
+    messages: protobufMessages(sourceTopics().protobufOrders, profile.protobufProducedRows, count),
+  });
+  profile.protobufProducedRows = nextTotal;
+  await Effect.runPromise(waitForRows("protobufOrders", nextTotal));
+};
+
+const publishMixedBatch = async (count: number): Promise<void> => {
+  const results = await Promise.allSettled([publishJsonBatch(count), publishProtobufBatch(count)]);
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      `Kafka ingest benchmark mixed burst failed in ${failures.length} lane(s).`,
+    );
+  }
+};
+
+const topicHealthValues = (health: ViewServerHealth<Topics>) =>
+  internalTopicNames.map((topic) => health.engine.topics[topic]);
+
+const cleanupLeakCountFromHealth = (health: ViewServerHealth<Topics>): number => {
+  let leakCount = 0;
+  for (const topicHealth of topicHealthValues(health)) {
+    leakCount +=
+      topicHealth.activeSubscriptions + topicHealth.activeViews + topicHealth.queuedEvents;
+  }
+  return leakCount;
+};
+
+const queuedEventCountFromHealth = (health: ViewServerHealth<Topics>): number => {
+  let queuedEventCount = 0;
+  for (const topicHealth of topicHealthValues(health)) {
+    queuedEventCount += topicHealth.queuedEvents;
+  }
+  return queuedEventCount;
+};
+
+const backpressureCountFromHealth = (health: ViewServerHealth<Topics>): number => {
+  let backpressureCount = 0;
+  for (const topicHealth of topicHealthValues(health)) {
+    backpressureCount += topicHealth.backpressureEvents;
+  }
+  return backpressureCount;
+};
+
+const benchmarkCases = [
+  "json source batch ingest",
+  "protobuf source batch ingest",
+  "mixed source burst ingest",
+];
+
+beforeAll(async () => {
+  const setup = await Effect.runPromise(setupBenchmark().pipe(Effect.provide(NodeCrypto.layer)));
+  profile.binaryProducer = setup.binaryProducer;
+  profile.runtime = setup.runtime;
+  profile.sourceTopics = setup.sourceTopics;
+  profile.stringProducer = setup.stringProducer;
+  profile.memoryAfterSetup = memorySnapshot();
+}, 0);
+
+afterAll(async () => {
+  const runtime = profile.runtime;
+  if (runtime === undefined) {
+    throw new Error("Kafka ingest benchmark runtime was not started.");
+  }
+  const finalSourceTopics = sourceTopics();
+  const finalHealthExit = await Effect.runPromiseExit(waitForFinalHealth());
+  const health = Exit.isSuccess(finalHealthExit)
+    ? finalHealthExit.value
+    : await Effect.runPromise(runtime.client.health());
+  const producerCloseResults = await Promise.allSettled([
+    profile.stringProducer?.close(),
+    profile.binaryProducer?.close(),
+  ]);
+  if (runtime !== undefined) {
+    await Effect.runPromise(runtime.close);
+  }
+  profile.binaryProducer = undefined;
+  profile.runtime = undefined;
+  profile.sourceTopics = undefined;
+  profile.stringProducer = undefined;
+  const memoryAfterSetup = profile.memoryAfterSetup ?? memoryBefore;
+  const memoryAfterBenchmark = memorySnapshot();
+  const cleanupLeakCount = cleanupLeakCountFromHealth(health);
+  const backpressureCount = backpressureCountFromHealth(health);
+  const queuedEventCount = queuedEventCountFromHealth(health);
+  writeJsonFile(benchmarkSummaryPath(outputJsonPath), {
+    artifactKind: "runtime-benchmark-summary",
+    backpressureCount,
+    benchmarkCases,
+    benchmarkName: "Kafka ingest runtime benchmark",
+    benchmarkScope: "runtime-kafka-ingest",
+    cleanupLeakCount,
+    health,
+    kafka: {
+      bootstrapServers: kafkaBootstrapServers,
+      burstMultiplier,
+      ingestLanes: [
+        {
+          internalTopic: "jsonOrders",
+          lane: "jsonOrders",
+          producedRows: profile.jsonProducedRows,
+          region: "local",
+          sourceTopic: finalSourceTopics.jsonOrders,
+          sourceTopicAlias: "unique-topic-per-run:jsonOrders",
+        },
+        {
+          internalTopic: "protobufOrders",
+          lane: "protobufOrders",
+          producedRows: profile.protobufProducedRows,
+          region: "local",
+          sourceTopic: finalSourceTopics.protobufOrders,
+          sourceTopicAlias: "unique-topic-per-run:protobufOrders",
+        },
+      ],
+      sourceTopics: {
+        jsonOrders: "unique-topic-per-run",
+        protobufOrders: "unique-topic-per-run",
+      },
+    },
+    latency: {
+      outputJsonPath,
+      source: "vitest-output-json",
+    },
+    memory: {
+      afterBenchmark: memoryAfterBenchmark,
+      afterSetup: memoryAfterSetup,
+      before: memoryBefore,
+      setupDelta: memoryDelta(memoryBefore, memoryAfterSetup),
+      totalDelta: memoryDelta(memoryBefore, memoryAfterBenchmark),
+    },
+    mutationCount: profile.jsonProducedRows + profile.protobufProducedRows,
+    notes: [
+      "Latency percentiles are emitted by Vitest in outputJsonPath.",
+      "Timed path keeps Kafka producers and View Server runtime alive, then measures producer send through health-observed runtime ingestion convergence.",
+      "Kafka source topics are unique per run; artifact topics stay stable as internal View Server topic names for baseline comparison.",
+    ],
+    queuedEventCount,
+    rowCount: batchSize,
+    subscriberCount: 0,
+    topics: ["jsonOrders", "protobufOrders"],
+  });
+  if (Exit.isFailure(finalHealthExit)) {
+    throw new Error(
+      `Kafka ingest benchmark final convergence failed: ${String(finalHealthExit.cause)}`,
+    );
+  }
+  if (cleanupLeakCount > 0) {
+    throw new Error(
+      `Kafka ingest benchmark cleanup leaked ${cleanupLeakCount} active resource(s).`,
+    );
+  }
+  const failedProducerCloses = producerCloseResults.filter(
+    (result) => result.status === "rejected",
+  );
+  if (failedProducerCloses.length > 0) {
+    throw new AggregateError(
+      failedProducerCloses.map((result) => result.reason),
+      `Kafka ingest benchmark failed to close ${failedProducerCloses.length} producer(s).`,
+    );
+  }
+}, 0);
+
+describe(`Kafka ingest runtime benchmark: ${batchSize} rows per batch`, () => {
+  const benchmarkDefinitions: ReadonlyArray<BenchmarkCase> = [
+    {
+      name: "json source batch ingest",
+      run: async () => {
+        await publishJsonBatch(batchSize);
+      },
+    },
+    {
+      name: "protobuf source batch ingest",
+      run: async () => {
+        await publishProtobufBatch(batchSize);
+      },
+    },
+    {
+      name: "mixed source burst ingest",
+      run: async () => {
+        const burstBatchSize = batchSize * burstMultiplier;
+        await publishMixedBatch(burstBatchSize);
+      },
+    },
+  ];
+
+  for (const benchmarkCase of benchmarkDefinitions) {
+    bench(benchmarkCase.name, benchmarkCase.run, benchOptions);
+  }
+});

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     coverage: {
       provider: "istanbul",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/**/*.test-d.ts"],
+      exclude: ["src/**/*.bench.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"],
       reporter: ["text"],
       thresholds: {
         "100": true,

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1290,6 +1290,7 @@ pnpm run bench:baseline:smoke
 pnpm run bench:baseline
 pnpm run bench:baseline:grouped-admission
 pnpm run bench:baseline:grouped-order-neutral
+pnpm run bench:baseline:kafka-ingest
 pnpm run bench:baseline:release
 ```
 
@@ -1305,19 +1306,66 @@ accepted.
 `bench:baseline:release` is the release-quality serial profile and runs the documented row
 counts/browser profiles in separate processes. It intentionally executes one benchmark process at a
 time so GC, RSS, browser state, and artifact files are not polluted by competing benchmark suites.
-The grouped-admission and grouped-order-neutral profiles are committed comparison profiles. Release
-remains report-only/no-compare by default because it is heavy; use
-`bench:baseline:release:update` only when accepting a release baseline manifest.
+The grouped-admission, grouped-order-neutral, and Kafka-ingest profiles are committed comparison
+profiles. The Kafka-ingest profile starts Apache Kafka from `compose.yaml`, uses
+`@platformatic/kafka`, creates unique source topics per run, and measures JSON/protobuf
+produce-to-health-observed runtime ingest convergence. Release remains report-only/no-compare by default
+because it is heavy; use `bench:baseline:release:update` only when accepting a release baseline
+manifest.
 
 The serial runner is `scripts/run-benchmark-baseline.mjs`. It supports
-`VIEW_SERVER_BENCH_BASELINE_PROFILE=smoke|release|grouped-admission|grouped-order-neutral` or
-`--profile=smoke|release|grouped-admission|grouped-order-neutral`; an explicit
+`VIEW_SERVER_BENCH_BASELINE_PROFILE=smoke|kafka-ingest|release|grouped-admission|grouped-order-neutral`
+or `--profile=smoke|kafka-ingest|release|grouped-admission|grouped-order-neutral`; an explicit
 `--profile` argument wins over the environment variable, so the root package scripts always run the
 profile they name. Use the environment variable only when invoking the Node script directly. The
 runner scrubs benchmark-specific environment variables before each child process so stale local
 tuning cannot pollute baseline runs. Pass `--update-baseline` to write
 `benchmarks/baselines/<profile>.json` from the fresh artifacts, or `--no-compare` to run a profile as
 serial benchmarks only.
+
+Current Kafka ingest benchmark harness:
+
+```bash
+pnpm run bench:baseline:kafka-ingest
+pnpm run bench:baseline:kafka-ingest:update
+```
+
+The profile runs `runtime#bench:kafka-ingest` through the serial benchmark runner. It starts the
+Apache Kafka service from `compose.yaml`, which uses tmpfs storage, auto-topic creation, and
+`KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0`. The benchmark still creates unique source topics per run
+so Kafka state cannot bleed across samples.
+
+Kafka ingest benchmark cases:
+
+- JSON source batch ingest: publish one JSON batch, wait until the runtime consumes it and health sees
+  the new rows.
+- Protobuf source batch ingest: publish one protobuf key/value batch generated from Buf schemas, wait
+  until the runtime consumes it and health sees the new rows.
+- Mixed source burst ingest: publish JSON and protobuf bursts concurrently. The committed baseline
+  uses `250` rows per source and a burst multiplier of `4`, which is `2,000` Kafka messages per timed
+  sample. The larger 10k+/sec Kafka firehose profile remains a manual/future benchmark until runtime
+  ingest throughput is optimized enough for a stable baseline gate.
+
+Kafka ingest knobs:
+
+- `VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE`: per-source sustained batch size.
+- `VIEW_SERVER_RUNTIME_BENCH_KAFKA_BURST_MULTIPLIER`: multiplier for the mixed burst case.
+- `VIEW_SERVER_RUNTIME_BENCH_ITERATIONS`: benchmark iterations per case.
+- `VIEW_SERVER_RUNTIME_BENCH_TIME_MS`: benchmark time budget per case.
+- `VIEW_SERVER_RUNTIME_BENCH_WARMUP_ITERATIONS`: warmup iterations per case.
+- `VIEW_SERVER_RUNTIME_BENCH_WARMUP_TIME_MS`: warmup time budget per case.
+- `VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON`: Vitest timing artifact path.
+
+Kafka ingest artifacts:
+
+- `packages/runtime/.artifacts/kafka-ingest-250rows.json`
+- `packages/runtime/.artifacts/kafka-ingest-250rows.summary.json`
+- `benchmarks/baselines/kafka-ingest.json`
+
+The sidecar summary records runtime health, per-lane Kafka committed offsets, RSS deltas, cleanup
+leaks, queued events, and backpressure counters. It intentionally keeps
+`topics` stable as internal View Server topic names while source Kafka topic names remain unique per
+run.
 
 Current engine raw benchmark harness:
 

--- a/scripts/benchmark-baseline-runner.mjs
+++ b/scripts/benchmark-baseline-runner.mjs
@@ -10,6 +10,7 @@ import {
 
 const enginePackageDirectory = "packages/column-live-view-engine";
 const reactPackageDirectory = "packages/react";
+const runtimePackageDirectory = "packages/runtime";
 
 export const baselinePath = (profile) => `benchmarks/baselines/${profile}.json`;
 
@@ -37,6 +38,14 @@ const commonReactSmokeEnv = {
   VIEW_SERVER_REACT_BENCH_TIME_MS: "1",
   VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS: "0",
   VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS: "0",
+};
+
+const commonRuntimeKafkaSmokeEnv = {
+  VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS: "localhost:9092",
+  VIEW_SERVER_RUNTIME_BENCH_ITERATIONS: "3",
+  VIEW_SERVER_RUNTIME_BENCH_TIME_MS: "1",
+  VIEW_SERVER_RUNTIME_BENCH_WARMUP_ITERATIONS: "0",
+  VIEW_SERVER_RUNTIME_BENCH_WARMUP_TIME_MS: "0",
 };
 
 const retainedDeltaSmokeEnv = {
@@ -380,6 +389,25 @@ const reactInMemoryTask = (browser, rowCount, env = {}) => {
   });
 };
 
+const runtimeKafkaIngestTask = (rowCount, env) => {
+  const outputJsonPath = `.artifacts/kafka-ingest-${rowCount}rows.json`;
+  return task({
+    artifactKind: "runtime-benchmark-summary",
+    benchmarkScope: "runtime-kafka-ingest",
+    env: {
+      VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE: String(rowCount),
+      VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON: outputJsonPath,
+      ...env,
+    },
+    label: `Kafka ingest ${rowCount} rows`,
+    minimumSampleCount: minimumSampleCountFrom(env, "VIEW_SERVER_RUNTIME_BENCH_ITERATIONS"),
+    outputJsonPath,
+    packageDirectory: runtimePackageDirectory,
+    rowCount,
+    vpTask: "runtime#bench:kafka-ingest",
+  });
+};
+
 export const profiles = new Map([
   [
     "smoke",
@@ -430,6 +458,15 @@ export const profiles = new Map([
       reactInMemoryTask("chromium", 20, {
         VIEW_SERVER_REACT_BENCH_BATCH_SIZE: "10",
         ...commonReactSmokeEnv,
+      }),
+    ],
+  ],
+  [
+    "kafka-ingest",
+    [
+      runtimeKafkaIngestTask(250, {
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_BURST_MULTIPLIER: "4",
+        ...commonRuntimeKafkaSmokeEnv,
       }),
     ],
   ],
@@ -537,8 +574,10 @@ export const profiles = new Map([
 
 export const isBenchmarkEnvironmentKey = (key) =>
   key === "VIEW_SERVER_BENCH_BASELINE_PROFILE" ||
+  key === "VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS" ||
   key.startsWith("VIEW_SERVER_ENGINE_BENCH_") ||
   key.startsWith("VIEW_SERVER_REACT_BENCH_") ||
+  key.startsWith("VIEW_SERVER_RUNTIME_BENCH_") ||
   key.startsWith("VITE_VIEW_SERVER_REACT_BENCH_");
 
 export const cleanBenchmarkEnvironment = (environment) =>

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -85,6 +85,7 @@ const observation = {
   browser: undefined,
   cleanupLeakCount: 0,
   groupedWriteAdmission: undefined,
+  kafkaIngestLanes: undefined,
   latencySource: "vitest-output-json",
   memoryRssTotalDeltaBytes: 1024,
   minimumSampleCount: 5,
@@ -162,7 +163,9 @@ describe("benchmark baseline runner", () => {
         KEEP_ME: "yes",
         VIEW_SERVER_BENCH_BASELINE_PROFILE: "smoke",
         VIEW_SERVER_ENGINE_BENCH_ROWS: "100",
+        VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS: "localhost:19092",
         VIEW_SERVER_REACT_BENCH_ROWS: "100",
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE: "100",
         VITE_VIEW_SERVER_REACT_BENCH_ROWS: "100",
       }),
       knownSignalExitCode: exitCodeForSignal("SIGTERM"),
@@ -189,6 +192,8 @@ describe("benchmark baseline runner", () => {
       groupedAdmissionUpdate: scripts["bench:baseline:grouped-admission:update"],
       groupedOrderNeutral: scripts["bench:baseline:grouped-order-neutral"],
       groupedOrderNeutralUpdate: scripts["bench:baseline:grouped-order-neutral:update"],
+      kafkaIngest: scripts["bench:baseline:kafka-ingest"],
+      kafkaIngestUpdate: scripts["bench:baseline:kafka-ingest:update"],
       release: scripts["bench:baseline:release"],
     }).toStrictEqual({
       groupedAdmission: "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission",
@@ -197,8 +202,35 @@ describe("benchmark baseline runner", () => {
       groupedOrderNeutral: "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral",
       groupedOrderNeutralUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
+      kafkaIngest: "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest",
+      kafkaIngestUpdate:
+        "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest --update-baseline",
       release: "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     });
+  });
+
+  it("defines the Kafka ingest runtime benchmark task", () => {
+    const kafkaIngestTasks = profiles.get("kafka-ingest") ?? [];
+
+    expect(
+      kafkaIngestTasks.map((task) => ({
+        artifactKind: task.expectedArtifactKind,
+        benchmarkScope: task.expectedBenchmarkScope,
+        broker: task.env["VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS"],
+        outputJsonPath: task.packageOutputJsonPath,
+        rowCount: task.env["VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE"],
+        task: task.args,
+      })),
+    ).toStrictEqual([
+      {
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        broker: "localhost:9092",
+        outputJsonPath: ".artifacts/kafka-ingest-250rows.json",
+        rowCount: "250",
+        task: ["run", "--no-cache", "runtime#bench:kafka-ingest"],
+      },
+    ]);
   });
 
   it("defines isolated grouped order-neutral tasks without changing dual grouped-write artifacts", () => {
@@ -1052,7 +1084,7 @@ describe("benchmark baseline runner", () => {
     }).toStrictEqual({
       exitCode: 1,
       message:
-        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, grouped-admission, grouped-order-neutral, release",
+        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, grouped-admission, grouped-order-neutral, release",
     });
   });
 

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -28,9 +28,23 @@ export const groupedOrderNeutralBenchmarkThresholds = {
   memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
 };
 
+export const kafkaIngestBenchmarkThresholds = {
+  latencyMean: {
+    maxAbsoluteDeltaMs: 2_000,
+    maxRatio: 1.5,
+  },
+  latencyP99: {
+    maxAbsoluteDeltaMs: 2_500,
+    maxRatio: 1.5,
+  },
+  memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+};
+
 export const benchmarkThresholdsForProfile = (profile) =>
   profile === "grouped-order-neutral"
     ? groupedOrderNeutralBenchmarkThresholds
+    : profile === "kafka-ingest"
+      ? kafkaIngestBenchmarkThresholds
     : defaultBenchmarkThresholds;
 
 const readJsonFile = (path) => JSON.parse(readFileSync(path, "utf8"));
@@ -71,6 +85,9 @@ const arrayValue = (value, path) => {
 const optionalObjectValue = (value, path) =>
   value === undefined ? undefined : objectValue(value, path);
 
+const optionalArrayValue = (value, path) =>
+  value === undefined ? undefined : arrayValue(value, path);
+
 const optionalFiniteNumber = (value, path) =>
   value === undefined ? undefined : finiteNumber(value, path);
 
@@ -97,10 +114,11 @@ const summaryArtifactKind = (value, path) => {
   const artifactKind = stringValue(value, path);
   if (
     artifactKind !== "engine-benchmark-summary" &&
-    artifactKind !== "react-browser-benchmark-summary"
+    artifactKind !== "react-browser-benchmark-summary" &&
+    artifactKind !== "runtime-benchmark-summary"
   ) {
     throw new Error(
-      `Benchmark artifact field ${path} must be engine-benchmark-summary or react-browser-benchmark-summary.`,
+      `Benchmark artifact field ${path} must be engine-benchmark-summary, react-browser-benchmark-summary, or runtime-benchmark-summary.`,
     );
   }
   return artifactKind;
@@ -131,6 +149,125 @@ const comparableBenchmark = (groupName, benchmark) => ({
   p99Ms: finiteNumber(benchmark.p99, `${benchmark.name}.p99`),
   sampleCount: positiveInteger(benchmark.sampleCount, `${benchmark.name}.sampleCount`),
 });
+
+const nonNegativeIntegerString = (value, path) => {
+  const text = stringValue(value, path);
+  if (!/^(0|[1-9]\d*)$/u.test(text)) {
+    throw new Error(`Benchmark artifact field ${path} must be a non-negative integer string.`);
+  }
+  return Number.parseInt(text, 10);
+};
+
+const kafkaIngestLaneValue = (value, path) => {
+  const lane = objectValue(value, path);
+  return {
+    internalTopic: stringValue(lane.internalTopic, `${path}.internalTopic`),
+    lane: stringValue(lane.lane, `${path}.lane`),
+    producedRows: nonNegativeInteger(lane.producedRows, `${path}.producedRows`),
+    region: stringValue(lane.region, `${path}.region`),
+    sourceTopic: stringValue(lane.sourceTopic, `${path}.sourceTopic`),
+    sourceTopicAlias: stringValue(lane.sourceTopicAlias, `${path}.sourceTopicAlias`),
+  };
+};
+
+const comparableKafkaIngestLane = (lane) => ({
+  internalTopic: lane.internalTopic,
+  lane: lane.lane,
+  producedRows: lane.producedRows,
+  region: lane.region,
+  sourceTopicAlias: lane.sourceTopicAlias,
+});
+
+const comparableKafkaIngestLaneValue = (value, path) => {
+  const lane = objectValue(value, path);
+  return {
+    internalTopic: stringValue(lane.internalTopic, `${path}.internalTopic`),
+    lane: stringValue(lane.lane, `${path}.lane`),
+    producedRows: nonNegativeInteger(lane.producedRows, `${path}.producedRows`),
+    region: stringValue(lane.region, `${path}.region`),
+    sourceTopicAlias: stringValue(lane.sourceTopicAlias, `${path}.sourceTopicAlias`),
+  };
+};
+
+const validateRuntimeSummaryIngestCompleteness = (summary, path, mutationCount) => {
+  const health = objectValue(summary.health, `${path}.health`);
+  const engine = objectValue(health.engine, `${path}.health.engine`);
+  const engineTopics = objectValue(engine.topics, `${path}.health.engine.topics`);
+  const kafka = objectValue(health.kafka, `${path}.health.kafka`);
+  const kafkaTopics = objectValue(kafka.topics, `${path}.health.kafka.topics`);
+  const lanes = nonEmptyArrayValue(
+    objectValue(summary.kafka, `${path}.kafka`).ingestLanes,
+    `${path}.kafka.ingestLanes`,
+  ).map((lane, index) => kafkaIngestLaneValue(lane, `${path}.kafka.ingestLanes[${index}]`));
+  const uniqueKeys = new Map();
+  const requireUniqueLaneKey = (key, label, lane) => {
+    const previousLane = uniqueKeys.get(`${label}:${key}`);
+    if (previousLane !== undefined) {
+      throw new Error(
+        `Benchmark artifact field ${path}.kafka.ingestLanes contains duplicate ${label} ${key} in lanes ${previousLane} and ${lane}.`,
+      );
+    }
+    uniqueKeys.set(`${label}:${key}`, lane);
+  };
+
+  let totalProducedRows = 0;
+  for (const lane of lanes) {
+    requireUniqueLaneKey(lane.lane, "lane", lane.lane);
+    requireUniqueLaneKey(lane.internalTopic, "internalTopic", lane.lane);
+    requireUniqueLaneKey(lane.sourceTopicAlias, "sourceTopicAlias", lane.lane);
+    requireUniqueLaneKey(`${lane.sourceTopic}:${lane.region}`, "sourceTopic+region", lane.lane);
+    totalProducedRows += lane.producedRows;
+    const topicHealth = objectValue(
+      engineTopics[lane.internalTopic],
+      `${path}.health.engine.topics.${lane.internalTopic}`,
+    );
+    const rowCount = nonNegativeInteger(
+      topicHealth.rowCount,
+      `${path}.health.engine.topics.${lane.internalTopic}.rowCount`,
+    );
+    if (rowCount !== lane.producedRows) {
+      throw new Error(
+        `Benchmark artifact field ${path}.health.engine.topics.${lane.internalTopic}.rowCount must equal producedRows ${lane.producedRows} for Kafka ingest lane ${lane.lane} but was ${rowCount}.`,
+      );
+    }
+
+    const kafkaTopicHealth = objectValue(
+      kafkaTopics[lane.sourceTopic],
+      `${path}.health.kafka.topics.${lane.sourceTopic}`,
+    );
+    const viewServerTopic = stringValue(
+      kafkaTopicHealth.viewServerTopic,
+      `${path}.health.kafka.topics.${lane.sourceTopic}.viewServerTopic`,
+    );
+    if (viewServerTopic !== lane.internalTopic) {
+      throw new Error(
+        `Benchmark artifact field ${path}.health.kafka.topics.${lane.sourceTopic}.viewServerTopic must equal internalTopic ${lane.internalTopic} for Kafka ingest lane ${lane.lane} but was ${viewServerTopic}.`,
+      );
+    }
+    const committedOffset = nonNegativeIntegerString(
+      objectValue(
+        objectValue(
+          kafkaTopicHealth.regions,
+          `${path}.health.kafka.topics.${lane.sourceTopic}.regions`,
+        )[lane.region],
+        `${path}.health.kafka.topics.${lane.sourceTopic}.regions.${lane.region}`,
+      ).committedOffset,
+      `${path}.health.kafka.topics.${lane.sourceTopic}.regions.${lane.region}.committedOffset`,
+    );
+    if (committedOffset !== lane.producedRows) {
+      throw new Error(
+        `Benchmark artifact field ${path}.health.kafka.topics.${lane.sourceTopic}.regions.${lane.region}.committedOffset must equal producedRows ${lane.producedRows} for Kafka ingest lane ${lane.lane} but was ${committedOffset}.`,
+      );
+    }
+  }
+  if (totalProducedRows !== mutationCount) {
+    throw new Error(
+      `Benchmark artifact field ${path}.kafka.ingestLanes producedRows total must equal mutationCount ${mutationCount} but was ${totalProducedRows}.`,
+    );
+  }
+
+  return lanes.map(comparableKafkaIngestLane);
+};
 
 export const comparableBenchmarksFromVitestOutput = (vitestOutput) =>
   arrayValue(objectValue(vitestOutput, "vitestOutput").files, "vitestOutput.files").flatMap(
@@ -173,7 +310,11 @@ export const readBenchmarkObservation = (task) => {
     totalDelta === undefined
       ? undefined
       : optionalFiniteNumber(totalDelta.rssBytes, `${task.summaryPath}.memory.totalDelta.rssBytes`);
-  if (artifactKind === "engine-benchmark-summary" && rssBytes === undefined) {
+  if (
+    (artifactKind === "engine-benchmark-summary" ||
+      artifactKind === "runtime-benchmark-summary") &&
+    rssBytes === undefined
+  ) {
     throw new Error(
       `Benchmark artifact field ${task.summaryPath}.memory.totalDelta.rssBytes is required for ${artifactKind}.`,
     );
@@ -206,6 +347,14 @@ export const readBenchmarkObservation = (task) => {
     }
   }
 
+  const benchmarkCases = stringArrayValue(summary.benchmarkCases, `${task.summaryPath}.benchmarkCases`);
+  const mutationCount = nonNegativeInteger(summary.mutationCount, `${task.summaryPath}.mutationCount`);
+  const topics = stringArrayValue(summary.topics, `${task.summaryPath}.topics`);
+  const kafkaIngestLanes =
+    artifactKind === "runtime-benchmark-summary"
+      ? validateRuntimeSummaryIngestCompleteness(summary, task.summaryPath, mutationCount)
+      : undefined;
+
   return {
     artifactKind,
     backpressureCount: finiteNumber(
@@ -213,7 +362,7 @@ export const readBenchmarkObservation = (task) => {
       `${task.summaryPath}.backpressureCount`,
     ),
     benchmarks,
-    benchmarkCases: stringArrayValue(summary.benchmarkCases, `${task.summaryPath}.benchmarkCases`),
+    benchmarkCases,
     benchmarkName: stringValue(summary.benchmarkName, `${task.summaryPath}.benchmarkName`),
     benchmarkScope,
     browser: optionalObjectValue(summary.browser, `${task.summaryPath}.browser`),
@@ -226,10 +375,11 @@ export const readBenchmarkObservation = (task) => {
       summary.groupedWriteAdmission,
       `${task.summaryPath}.groupedWriteAdmission`,
     ),
+    kafkaIngestLanes,
     latencySource,
     memoryRssTotalDeltaBytes: rssBytes,
     minimumSampleCount,
-    mutationCount: nonNegativeInteger(summary.mutationCount, `${task.summaryPath}.mutationCount`),
+    mutationCount,
     outputJsonPath: task.outputJsonPath,
     queuedEventCount: finiteNumber(summary.queuedEventCount, `${task.summaryPath}.queuedEventCount`),
     rowCount,
@@ -237,7 +387,7 @@ export const readBenchmarkObservation = (task) => {
     subscriberCount: finiteNumber(summary.subscriberCount, `${task.summaryPath}.subscriberCount`),
     summaryPath: task.summaryPath,
     taskLabel: task.label,
-    topics: stringArrayValue(summary.topics, `${task.summaryPath}.topics`),
+    topics,
   };
 };
 
@@ -324,7 +474,11 @@ const validateTask = (task, path) => {
     task.memoryRssTotalDeltaBytes,
     `${path}.memoryRssTotalDeltaBytes`,
   );
-  if (artifactKind === "engine-benchmark-summary" && memoryRssTotalDeltaBytes === undefined) {
+  if (
+    (artifactKind === "engine-benchmark-summary" ||
+      artifactKind === "runtime-benchmark-summary") &&
+    memoryRssTotalDeltaBytes === undefined
+  ) {
     throw new Error(
       `Benchmark artifact field ${path}.memoryRssTotalDeltaBytes is required for ${artifactKind}.`,
     );
@@ -347,6 +501,9 @@ const validateTask = (task, path) => {
     groupedWriteAdmission: optionalObjectValue(
       task.groupedWriteAdmission,
       `${path}.groupedWriteAdmission`,
+    ),
+    kafkaIngestLanes: optionalArrayValue(task.kafkaIngestLanes, `${path}.kafkaIngestLanes`)?.map(
+      (lane, index) => comparableKafkaIngestLaneValue(lane, `${path}.kafkaIngestLanes[${index}]`),
     ),
     latencySource: stringValue(task.latencySource, `${path}.latencySource`),
     memoryRssTotalDeltaBytes,
@@ -524,13 +681,23 @@ export const compareBenchmarkBaseline = (baseline, actualBaseline) => {
       actualTask.benchmarkCases,
     );
     compareExact(regressions, taskLabel, "rowCount", baselineTask.rowCount, actualTask.rowCount);
-    compareMinimumCount(
-      regressions,
-      taskLabel,
-      "mutationCount",
-      baselineTask.mutationCount,
-      actualTask.mutationCount,
-    );
+    if (baselineTask.benchmarkScope === "runtime-kafka-ingest") {
+      compareExact(
+        regressions,
+        taskLabel,
+        "mutationCount",
+        baselineTask.mutationCount,
+        actualTask.mutationCount,
+      );
+    } else {
+      compareMinimumCount(
+        regressions,
+        taskLabel,
+        "mutationCount",
+        baselineTask.mutationCount,
+        actualTask.mutationCount,
+      );
+    }
     compareExact(
       regressions,
       taskLabel,
@@ -547,6 +714,13 @@ export const compareBenchmarkBaseline = (baseline, actualBaseline) => {
       actualTask.latencySource,
     );
     compareExactJson(regressions, taskLabel, "browser", baselineTask.browser, actualTask.browser);
+    compareExactJson(
+      regressions,
+      taskLabel,
+      "kafkaIngestLanes",
+      baselineTask.kafkaIngestLanes,
+      actualTask.kafkaIngestLanes,
+    );
     compareExact(
       regressions,
       taskLabel,

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -9,6 +9,7 @@ import {
   compareBenchmarkBaseline,
   defaultBenchmarkThresholds,
   groupedOrderNeutralBenchmarkThresholds,
+  kafkaIngestBenchmarkThresholds,
   readBenchmarkBaseline,
   readBenchmarkObservation,
   validateBenchmarkBaseline,
@@ -66,6 +67,49 @@ const summary = {
   topics: ["orders"],
 };
 
+const runtimeHealth = {
+  engine: {
+    topics: {
+      orders: {
+        rowCount: 100,
+      },
+    },
+  },
+  kafka: {
+    topics: {
+      sourceOrders: {
+        regions: {
+          local: {
+            committedOffset: "100",
+          },
+        },
+        viewServerTopic: "orders",
+      },
+    },
+  },
+};
+
+const runtimeKafkaIngestLanes = [
+  {
+    internalTopic: "orders",
+    lane: "orders",
+    producedRows: 100,
+    region: "local",
+    sourceTopic: "sourceOrders",
+    sourceTopicAlias: "unique-topic-per-run:orders",
+  },
+];
+
+const comparableRuntimeKafkaIngestLanes = [
+  {
+    internalTopic: "orders",
+    lane: "orders",
+    producedRows: 100,
+    region: "local",
+    sourceTopicAlias: "unique-topic-per-run:orders",
+  },
+];
+
 const observation = {
   artifactKind: "engine-benchmark-summary",
   backpressureCount: 0,
@@ -90,6 +134,7 @@ const observation = {
     configuredMode: "incremental",
     expectedAdmission: "incremental",
   },
+  kafkaIngestLanes: undefined,
   latencySource: "vitest-output-json",
   memoryRssTotalDeltaBytes: 1024,
   minimumSampleCount: 5,
@@ -126,6 +171,17 @@ const browserTaskPaths = (summaryPath: string, outputJsonPath: string) => ({
   summaryPath,
 });
 
+const runtimeTaskPaths = (summaryPath: string, outputJsonPath: string) => ({
+  expectedArtifactKind: "runtime-benchmark-summary",
+  expectedBenchmarkScope: "runtime-kafka-ingest",
+  expectedRowCount: 100,
+  label: "task a",
+  minimumSampleCount: 5,
+  outputJsonPath,
+  packageOutputJsonPath: "actual.json",
+  summaryPath,
+});
+
 describe("benchmark baseline comparison", () => {
   it("extracts comparable benchmark metrics from Vitest output", () => {
     expect(comparableBenchmarksFromVitestOutput(vitestOutput)).toStrictEqual([
@@ -144,13 +200,17 @@ describe("benchmark baseline comparison", () => {
   it("uses profile-specific baseline thresholds", () => {
     expect({
       groupedOrderNeutral: benchmarkThresholdsForProfile("grouped-order-neutral"),
+      kafkaIngest: benchmarkThresholdsForProfile("kafka-ingest"),
       smoke: benchmarkThresholdsForProfile("smoke"),
+      kafkaIngestBaseline: buildBenchmarkBaseline("kafka-ingest", [observation]).thresholds,
       smokeBaseline: buildBenchmarkBaseline("smoke", [observation]).thresholds,
       orderNeutralBaseline: buildBenchmarkBaseline("grouped-order-neutral", [observation])
         .thresholds,
     }).toStrictEqual({
       groupedOrderNeutral: groupedOrderNeutralBenchmarkThresholds,
+      kafkaIngest: kafkaIngestBenchmarkThresholds,
       smoke: defaultBenchmarkThresholds,
+      kafkaIngestBaseline: kafkaIngestBenchmarkThresholds,
       smokeBaseline: defaultBenchmarkThresholds,
       orderNeutralBaseline: groupedOrderNeutralBenchmarkThresholds,
     });
@@ -211,6 +271,440 @@ describe("benchmark baseline comparison", () => {
     });
   });
 
+  it("reads runtime benchmark observations with process memory data", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-observation-"));
+    const summaryPath = join(directory, "actual.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    writeFileSync(
+      summaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
+
+    expect(
+      readBenchmarkObservation(runtimeTaskPaths(summaryPath, outputJsonPath)),
+    ).toStrictEqual({
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeKafkaIngestLanes,
+      outputJsonPath,
+      summaryPath,
+    });
+  });
+
+  it("rejects incomplete runtime benchmark health", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-runtime-health-"));
+    const duplicateLaneSummaryPath = join(directory, "duplicate-lane.summary.json");
+    const malformedOffsetSummaryPath = join(directory, "malformed-offset.summary.json");
+    const mismatchedProducedRowsSummaryPath = join(directory, "mismatched-produced-rows.summary.json");
+    const extraRowsSummaryPath = join(directory, "extra-rows.summary.json");
+    const extraOffsetsSummaryPath = join(directory, "extra-offsets.summary.json");
+    const missingViewServerTopicSummaryPath = join(
+      directory,
+      "missing-view-server-topic.summary.json",
+    );
+    const staleRowsSummaryPath = join(directory, "stale-rows.summary.json");
+    const staleSecondLaneRowsSummaryPath = join(directory, "stale-second-lane-rows.summary.json");
+    const staleOffsetsSummaryPath = join(directory, "stale-offsets.summary.json");
+    const wrongViewServerTopicSummaryPath = join(directory, "wrong-view-server-topic.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    writeFileSync(
+      duplicateLaneSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          engine: {
+            topics: {
+              orders: {
+                rowCount: 100,
+              },
+              trades: {
+                rowCount: 100,
+              },
+            },
+          },
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "100",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+              sourceTrades: {
+                regions: {
+                  local: {
+                    committedOffset: "100",
+                  },
+                },
+                viewServerTopic: "trades",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: [
+            {
+              internalTopic: "orders",
+              lane: "orders",
+              producedRows: 100,
+              region: "local",
+              sourceTopic: "sourceOrders",
+              sourceTopicAlias: "unique-topic-per-run:orders",
+            },
+            {
+              internalTopic: "trades",
+              lane: "orders",
+              producedRows: 100,
+              region: "local",
+              sourceTopic: "sourceTrades",
+              sourceTopicAlias: "unique-topic-per-run:trades",
+            },
+          ],
+        },
+        mutationCount: 200,
+        topics: ["orders", "trades"],
+      })}\n`,
+    );
+    writeFileSync(
+      malformedOffsetSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "not-an-offset",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      missingViewServerTopicSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "100",
+                  },
+                },
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      mismatchedProducedRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          engine: {
+            topics: {
+              orders: {
+                rowCount: 99,
+              },
+            },
+          },
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "99",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: [
+            {
+              ...runtimeKafkaIngestLanes[0],
+              producedRows: 99,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      extraRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          engine: {
+            topics: {
+              orders: {
+                rowCount: 101,
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      extraOffsetsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "101",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      staleRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          engine: {
+            topics: {
+              orders: {
+                rowCount: 99,
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      staleSecondLaneRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          engine: {
+            topics: {
+              orders: {
+                rowCount: 100,
+              },
+              trades: {
+                rowCount: 0,
+              },
+            },
+          },
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "100",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+              sourceTrades: {
+                regions: {
+                  local: {
+                    committedOffset: "100",
+                  },
+                },
+                viewServerTopic: "trades",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: [
+            {
+              internalTopic: "orders",
+              lane: "orders",
+              producedRows: 100,
+              region: "local",
+              sourceTopic: "sourceOrders",
+              sourceTopicAlias: "unique-topic-per-run:orders",
+            },
+            {
+              internalTopic: "trades",
+              lane: "trades",
+              producedRows: 100,
+              region: "local",
+              sourceTopic: "sourceTrades",
+              sourceTopicAlias: "unique-topic-per-run:trades",
+            },
+          ],
+        },
+        mutationCount: 200,
+        topics: ["orders", "trades"],
+      })}\n`,
+    );
+    writeFileSync(
+      staleOffsetsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "99",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      wrongViewServerTopicSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "100",
+                  },
+                },
+                viewServerTopic: "trades",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
+
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(duplicateLaneSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${duplicateLaneSummaryPath}.kafka.ingestLanes contains duplicate lane orders in lanes orders and orders.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(malformedOffsetSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${malformedOffsetSummaryPath}.health.kafka.topics.sourceOrders.regions.local.committedOffset must be a non-negative integer string.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(missingViewServerTopicSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${missingViewServerTopicSummaryPath}.health.kafka.topics.sourceOrders.viewServerTopic must be a non-empty string.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(mismatchedProducedRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${mismatchedProducedRowsSummaryPath}.kafka.ingestLanes producedRows total must equal mutationCount 100 but was 99.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(staleRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${staleRowsSummaryPath}.health.engine.topics.orders.rowCount must equal producedRows 100 for Kafka ingest lane orders but was 99.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(extraRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${extraRowsSummaryPath}.health.engine.topics.orders.rowCount must equal producedRows 100 for Kafka ingest lane orders but was 101.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(staleSecondLaneRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${staleSecondLaneRowsSummaryPath}.health.engine.topics.trades.rowCount must equal producedRows 100 for Kafka ingest lane trades but was 0.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(staleOffsetsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${staleOffsetsSummaryPath}.health.kafka.topics.sourceOrders.regions.local.committedOffset must equal producedRows 100 for Kafka ingest lane orders but was 99.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(wrongViewServerTopicSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${wrongViewServerTopicSummaryPath}.health.kafka.topics.sourceOrders.viewServerTopic must equal internalTopic orders for Kafka ingest lane orders but was trades.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(extraOffsetsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${extraOffsetsSummaryPath}.health.kafka.topics.sourceOrders.regions.local.committedOffset must equal producedRows 100 for Kafka ingest lane orders but was 101.`,
+    );
+  });
+
   it("rejects engine benchmark observations with missing RSS memory data", () => {
     const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-observation-"));
     const summaryPath = join(directory, "actual.summary.json");
@@ -241,7 +735,7 @@ describe("benchmark baseline comparison", () => {
     expect(() =>
       readBenchmarkObservation(taskPaths(summaryPath, outputJsonPath)),
     ).toThrow(
-      `Benchmark artifact field ${summaryPath}.artifactKind must be engine-benchmark-summary or react-browser-benchmark-summary.`,
+      `Benchmark artifact field ${summaryPath}.artifactKind must be engine-benchmark-summary, react-browser-benchmark-summary, or runtime-benchmark-summary.`,
     );
   });
 
@@ -502,6 +996,28 @@ describe("benchmark baseline comparison", () => {
         "task a: unexpected benchmark case src/example.bench.ts > example benchmark group / case b.",
         "task a: missing benchmark case src/example.bench.ts > example benchmark group / case a.",
       ],
+    });
+  });
+
+  it("requires exact Kafka ingest mutation counts", () => {
+    const kafkaObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeKafkaIngestLanes,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-ingest", [kafkaObservation]);
+    const changedMutationCount = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        mutationCount: 99,
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, changedMutationCount)).toStrictEqual({
+      ok: false,
+      regressions: ["task a: mutationCount changed from 100 to 99."],
     });
   });
 


### PR DESCRIPTION
## Summary
- add a Docker-backed Vitest bench for runtime Kafka ingest using real @platformatic/kafka producers
- cover JSON and protobuf source topics with unique source topics/group IDs per run
- add a committed kafka-ingest baseline and baseline runner profile
- harden baseline parsing with exact row/offset counts, lane uniqueness, and viewServerTopic correlation
- document the Kafka ingest benchmark gate in AGENTS.md and the v2 plan

## Validation
- pnpm run test:repository-scripts
- vp check --fix
- pnpm run check:effect
- pnpm run bench:baseline:kafka-ingest
- pnpm run ready

## Review
- 3 local review agents found duplicate-lane and Kafka health correlation gaps; both are fixed and final re-review reported no findings.

Holding before gRPC by design.