### PR TITLE
Batch Kafka health refresh after commits

### DIFF
--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -2942,11 +2942,16 @@ describe("@view-server/runtime Kafka ingress internals", () => {
               operations.push(`publishMany:${topic}:${rows.length}`);
             }).pipe(Effect.andThen(runtimeCore.client.publishMany(topic, rows))),
         };
+        let healthRefreshes = 0;
+        const requestHealthRefresh = Effect.sync(() => {
+          healthRefreshes += 1;
+          operations.push("healthRefresh");
+        });
 
         yield* runKafkaMessageStream(
           viewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
+          requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -2997,11 +3002,13 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
         expect({
+          healthRefreshes,
           operations,
           snapshot,
           kafkaTopic: health.kafka?.topics[ordersSourceTopic],
         }).toStrictEqual({
-          operations: ["publishMany:orders:3", "commit:1", "commit:2", "commit:3"],
+          healthRefreshes: 1,
+          operations: ["publishMany:orders:3", "commit:1", "commit:2", "commit:3", "healthRefresh"],
           snapshot: {
             status: "ready",
             statusCode: "Ready",

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -647,35 +647,36 @@ const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit"
   region: string,
   messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
 ) {
-  for (const message of messages) {
-    yield* Effect.uninterruptible(
-      Effect.tryPromise({
-        try: () => Promise.resolve(message.message.commit()),
-        catch: (cause) => kafkaMessageCommitError(region, message.sourceTopic, cause),
-      }).pipe(
-        Effect.matchEffect({
-          onFailure: (error) =>
-            health
-              .messageProcessingFailed(message.sourceTopic, region, {
-                bytes: message.messageBytes,
-                message: `${error.message}: ${messageFromUnknown(error.cause)}`,
-                nowMillis: message.nowMillis,
-              })
-              .pipe(
-                Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh)),
-                Effect.andThen(Effect.fail(error)),
-              ),
-          onSuccess: () =>
-            health.messageDecoded(message.sourceTopic, region, {
-              bytes: message.messageBytes,
-              committedOffset: String(message.message.offset + 1n),
-              nowMillis: message.nowMillis,
-            }),
-        }),
-        Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh)),
-      ),
-    );
+  if (messages.length === 0) {
+    return;
   }
+  yield* Effect.gen(function* () {
+    for (const message of messages) {
+      yield* Effect.uninterruptible(
+        Effect.tryPromise({
+          try: () => Promise.resolve(message.message.commit()),
+          catch: (cause) => kafkaMessageCommitError(region, message.sourceTopic, cause),
+        }).pipe(
+          Effect.matchEffect({
+            onFailure: (error) =>
+              health
+                .messageProcessingFailed(message.sourceTopic, region, {
+                  bytes: message.messageBytes,
+                  message: `${error.message}: ${messageFromUnknown(error.cause)}`,
+                  nowMillis: message.nowMillis,
+                })
+                .pipe(Effect.andThen(Effect.fail(error))),
+            onSuccess: () =>
+              health.messageDecoded(message.sourceTopic, region, {
+                bytes: message.messageBytes,
+                committedOffset: String(message.message.offset + 1n),
+                nowMillis: message.nowMillis,
+              }),
+          }),
+        ),
+      );
+    }
+  }).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
 });
 
 export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messageBatch.process")(


### PR DESCRIPTION
## Summary
- Batch Kafka health refresh requests once per non-empty committed decoded-message batch instead of after every committed message.
- Preserve manual publish-before-commit semantics: this does not enable @platformatic/kafka autocommit and does not use private high-water offset APIs.
- Add internal coverage proving a microbatch commits each message but requests health refresh once.

## Notes
- @platformatic/kafka autocommit queues offsets before messages are processed, so it is not safe for View Server crash semantics.
- Public message commit remains per-message because the exposed stream message API does not provide enough stable metadata for a safe public high-water commit.
- The final health refresh is attached with Effect.ensuring so success, failure, and interruption after committed work still request a health snapshot refresh.

## Review Loop
- 3-agent review pass found an interruption hole in the first version.
- Fixed with Effect.ensuring around the non-empty commit loop.
- 3-agent re-review: no findings.

## Validation
- pnpm --filter @view-server/runtime run test
- vp check --fix
- pnpm run check:effect
- pnpm run bench:baseline:kafka-ingest
- pnpm run ready