### PR TITLE
Add Kafka sustained firehose benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,3 +23,16 @@ thresholds intentionally use the wider of the ratio and absolute windows because
 small and noisy; structural metadata, counters, sample counts, and RSS remain strict.
 
 Do not run benchmark profiles in parallel when comparing results.
+
+Kafka runtime profiles are separate from the default smoke gate because they start the Apache Kafka
+container and exercise real `@platformatic/kafka` producers/consumers:
+
+```bash
+pnpm run bench:baseline:kafka-ingest
+pnpm run bench:baseline:kafka-sustained-firehose
+```
+
+`kafka-ingest` measures single JSON/protobuf source batches plus a mixed burst. `kafka-sustained-firehose`
+uses the same Vitest benchmark file in `sustained-firehose` mode and sends repeated mixed producer
+batches before waiting for final View Server convergence. Both profiles require exact Kafka lane
+completeness in their summary artifacts: produced rows, engine rows, and committed offsets must agree.

--- a/benchmarks/baselines/kafka-sustained-firehose.json
+++ b/benchmarks/baselines/kafka-sustained-firehose.json
@@ -1,0 +1,66 @@
+{
+  "artifactKind": "view-server-benchmark-baseline",
+  "profile": "kafka-sustained-firehose",
+  "tasks": [
+    {
+      "artifactKind": "runtime-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/kafka-ingest.bench.ts > Kafka sustained firehose runtime benchmark: 250 rows per producer batch",
+          "maxMs": 17703.534,
+          "meanMs": 16595.067319666665,
+          "minMs": 15888.604874999997,
+          "name": "sustained mixed firehose ingest",
+          "p99Ms": 17703.534,
+          "sampleCount": 3
+        }
+      ],
+      "benchmarkCases": ["sustained mixed firehose ingest"],
+      "benchmarkName": "Kafka sustained firehose runtime benchmark",
+      "benchmarkScope": "runtime-kafka-sustained-firehose",
+      "cleanupLeakCount": 0,
+      "kafkaIngestLanes": [
+        {
+          "internalTopic": "jsonOrders",
+          "lane": "jsonOrders",
+          "producedRows": 3000,
+          "region": "local",
+          "sourceTopicAlias": "unique-topic-per-run:jsonOrders"
+        },
+        {
+          "internalTopic": "protobufOrders",
+          "lane": "protobufOrders",
+          "producedRows": 3000,
+          "region": "local",
+          "sourceTopicAlias": "unique-topic-per-run:protobufOrders"
+        }
+      ],
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 10731520,
+      "minimumSampleCount": 3,
+      "mutationCount": 6000,
+      "outputJsonPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.json",
+      "queuedEventCount": 0,
+      "rowCount": 250,
+      "subscriberCount": 0,
+      "summaryPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.summary.json",
+      "taskLabel": "Kafka sustained firehose 250 rows x 4 batches",
+      "topics": ["jsonOrders", "protobufOrders"]
+    }
+  ],
+  "thresholds": {
+    "latencyMean": {
+      "maxAbsoluteDeltaMs": 5000,
+      "maxRatio": 1.75
+    },
+    "latencyP99": {
+      "maxAbsoluteDeltaMs": 6000,
+      "maxRatio": 1.75
+    },
+    "memoryRssTotalDelta": {
+      "maxAbsoluteDeltaBytes": 134217728,
+      "maxRatio": 3
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "bench:baseline:grouped-order-neutral:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
     "bench:baseline:kafka-ingest": "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest",
     "bench:baseline:kafka-ingest:update": "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest --update-baseline",
+    "bench:baseline:kafka-sustained-firehose": "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose",
+    "bench:baseline:kafka-sustained-firehose:update": "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose --update-baseline",
     "bench:baseline:release": "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     "bench:baseline:release:update": "node scripts/run-benchmark-baseline.mjs --profile=release --update-baseline",
     "bench:baseline:smoke": "node scripts/run-benchmark-baseline.mjs --profile=smoke",

--- a/packages/runtime/src/kafka-ingest.bench.ts
+++ b/packages/runtime/src/kafka-ingest.bench.ts
@@ -94,11 +94,11 @@ type Topics = typeof viewServer.topics;
 const defaultBatchSize = 1_000;
 const defaultBenchmarkTimeMs = 250;
 const defaultIterations = 3;
+const defaultSustainedBatchCount = 4;
 const defaultWarmupIterations = 0;
 const defaultWarmupTimeMs = 0;
 const kafkaBootstrapServers =
   process.env["VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS"] ?? "localhost:9092";
-const outputJsonPath = benchmarkOutputJsonPath("kafka-ingest-1000rows.json");
 const memoryBefore = memorySnapshot();
 const healthPollSchedule = Schedule.addDelay(Schedule.recurs(2_400), () =>
   Effect.succeed("25 millis"),
@@ -147,6 +147,31 @@ const burstMultiplier = positiveIntegerFromEnv(
   "VIEW_SERVER_RUNTIME_BENCH_KAFKA_BURST_MULTIPLIER",
   4,
 );
+const sustainedBatchCount = positiveIntegerFromEnv(
+  "VIEW_SERVER_RUNTIME_BENCH_KAFKA_SUSTAINED_BATCHES",
+  defaultSustainedBatchCount,
+);
+const benchmarkMode = process.env["VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE"] ?? "batch";
+if (benchmarkMode !== "batch" && benchmarkMode !== "sustained-firehose") {
+  throw new Error("VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE must be batch or sustained-firehose.");
+}
+const benchmarkScope =
+  benchmarkMode === "sustained-firehose"
+    ? "runtime-kafka-sustained-firehose"
+    : "runtime-kafka-ingest";
+const benchmarkName =
+  benchmarkMode === "sustained-firehose"
+    ? "Kafka sustained firehose runtime benchmark"
+    : "Kafka ingest runtime benchmark";
+const benchmarkCaseNames =
+  benchmarkMode === "sustained-firehose"
+    ? ["sustained mixed firehose ingest"]
+    : ["json source batch ingest", "protobuf source batch ingest", "mixed source burst ingest"];
+const defaultOutputJsonName =
+  benchmarkMode === "sustained-firehose"
+    ? `kafka-sustained-firehose-${batchSize}rows-${sustainedBatchCount}batches.json`
+    : `kafka-ingest-${batchSize}rows.json`;
+const outputJsonPath = benchmarkOutputJsonPath(defaultOutputJsonName);
 const benchOptions = {
   iterations: positiveIntegerFromEnv("VIEW_SERVER_RUNTIME_BENCH_ITERATIONS", defaultIterations),
   time: positiveIntegerFromEnv("VIEW_SERVER_RUNTIME_BENCH_TIME_MS", defaultBenchmarkTimeMs),
@@ -522,11 +547,36 @@ const backpressureCountFromHealth = (health: ViewServerHealth<Topics>): number =
   return backpressureCount;
 };
 
-const benchmarkCases = [
-  "json source batch ingest",
-  "protobuf source batch ingest",
-  "mixed source burst ingest",
-];
+const publishJsonBatchWithoutWaiting = async (count: number): Promise<void> => {
+  await stringProducer().send({
+    messages: jsonMessages(sourceTopics().jsonOrders, profile.jsonProducedRows, count),
+  });
+  profile.jsonProducedRows += count;
+};
+
+const publishProtobufBatchWithoutWaiting = async (count: number): Promise<void> => {
+  await binaryProducer().send({
+    messages: protobufMessages(sourceTopics().protobufOrders, profile.protobufProducedRows, count),
+  });
+  profile.protobufProducedRows += count;
+};
+
+const publishSustainedMixedFirehose = async (): Promise<void> => {
+  for (let batchIndex = 0; batchIndex < sustainedBatchCount; batchIndex += 1) {
+    const results = await Promise.allSettled([
+      publishJsonBatchWithoutWaiting(batchSize),
+      publishProtobufBatchWithoutWaiting(batchSize),
+    ]);
+    const failures = results.filter((result) => result.status === "rejected");
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `Kafka ingest benchmark sustained firehose batch ${batchIndex} failed in ${failures.length} lane(s).`,
+      );
+    }
+  }
+  await Effect.runPromise(waitForFinalHealth());
+};
 
 beforeAll(async () => {
   const setup = await Effect.runPromise(setupBenchmark().pipe(Effect.provide(NodeCrypto.layer)));
@@ -566,14 +616,16 @@ afterAll(async () => {
   writeJsonFile(benchmarkSummaryPath(outputJsonPath), {
     artifactKind: "runtime-benchmark-summary",
     backpressureCount,
-    benchmarkCases,
-    benchmarkName: "Kafka ingest runtime benchmark",
-    benchmarkScope: "runtime-kafka-ingest",
+    benchmarkCases: benchmarkCaseNames,
+    benchmarkName,
+    benchmarkScope,
     cleanupLeakCount,
     health,
     kafka: {
       bootstrapServers: kafkaBootstrapServers,
       burstMultiplier,
+      mode: benchmarkMode,
+      sustainedBatchCount,
       ingestLanes: [
         {
           internalTopic: "jsonOrders",
@@ -612,6 +664,7 @@ afterAll(async () => {
     notes: [
       "Latency percentiles are emitted by Vitest in outputJsonPath.",
       "Timed path keeps Kafka producers and View Server runtime alive, then measures producer send through health-observed runtime ingestion convergence.",
+      "Sustained firehose mode sends multiple producer batches before waiting for final runtime convergence.",
       "Kafka source topics are unique per run; artifact topics stay stable as internal View Server topic names for baseline comparison.",
     ],
     queuedEventCount,
@@ -640,8 +693,13 @@ afterAll(async () => {
   }
 }, 0);
 
-describe(`Kafka ingest runtime benchmark: ${batchSize} rows per batch`, () => {
-  const benchmarkDefinitions: ReadonlyArray<BenchmarkCase> = [
+const benchmarkGroupName =
+  benchmarkMode === "sustained-firehose"
+    ? `${benchmarkName}: ${batchSize} rows per producer batch`
+    : `${benchmarkName}: ${batchSize} rows per batch`;
+
+describe(benchmarkGroupName, () => {
+  const batchBenchmarkDefinitions: ReadonlyArray<BenchmarkCase> = [
     {
       name: "json source batch ingest",
       run: async () => {
@@ -662,6 +720,16 @@ describe(`Kafka ingest runtime benchmark: ${batchSize} rows per batch`, () => {
       },
     },
   ];
+  const sustainedBenchmarkDefinitions: ReadonlyArray<BenchmarkCase> = [
+    {
+      name: "sustained mixed firehose ingest",
+      run: publishSustainedMixedFirehose,
+    },
+  ];
+  const benchmarkDefinitions =
+    benchmarkMode === "sustained-firehose"
+      ? sustainedBenchmarkDefinitions
+      : batchBenchmarkDefinitions;
 
   for (const benchmarkCase of benchmarkDefinitions) {
     bench(benchmarkCase.name, benchmarkCase.run, benchOptions);

--- a/scripts/benchmark-baseline-runner.mjs
+++ b/scripts/benchmark-baseline-runner.mjs
@@ -408,6 +408,27 @@ const runtimeKafkaIngestTask = (rowCount, env) => {
   });
 };
 
+const runtimeKafkaSustainedFirehoseTask = (rowCount, sustainedBatchCount, env) => {
+  const outputJsonPath = `.artifacts/kafka-sustained-firehose-${rowCount}rows-${sustainedBatchCount}batches.json`;
+  return task({
+    artifactKind: "runtime-benchmark-summary",
+    benchmarkScope: "runtime-kafka-sustained-firehose",
+    env: {
+      VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE: String(rowCount),
+      VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE: "sustained-firehose",
+      VIEW_SERVER_RUNTIME_BENCH_KAFKA_SUSTAINED_BATCHES: String(sustainedBatchCount),
+      VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON: outputJsonPath,
+      ...env,
+    },
+    label: `Kafka sustained firehose ${rowCount} rows x ${sustainedBatchCount} batches`,
+    minimumSampleCount: minimumSampleCountFrom(env, "VIEW_SERVER_RUNTIME_BENCH_ITERATIONS"),
+    outputJsonPath,
+    packageDirectory: runtimePackageDirectory,
+    rowCount,
+    vpTask: "runtime#bench:kafka-ingest",
+  });
+};
+
 export const profiles = new Map([
   [
     "smoke",
@@ -466,6 +487,14 @@ export const profiles = new Map([
     [
       runtimeKafkaIngestTask(250, {
         VIEW_SERVER_RUNTIME_BENCH_KAFKA_BURST_MULTIPLIER: "4",
+        ...commonRuntimeKafkaSmokeEnv,
+      }),
+    ],
+  ],
+  [
+    "kafka-sustained-firehose",
+    [
+      runtimeKafkaSustainedFirehoseTask(250, 4, {
         ...commonRuntimeKafkaSmokeEnv,
       }),
     ],

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -194,6 +194,8 @@ describe("benchmark baseline runner", () => {
       groupedOrderNeutralUpdate: scripts["bench:baseline:grouped-order-neutral:update"],
       kafkaIngest: scripts["bench:baseline:kafka-ingest"],
       kafkaIngestUpdate: scripts["bench:baseline:kafka-ingest:update"],
+      kafkaSustainedFirehose: scripts["bench:baseline:kafka-sustained-firehose"],
+      kafkaSustainedFirehoseUpdate: scripts["bench:baseline:kafka-sustained-firehose:update"],
       release: scripts["bench:baseline:release"],
     }).toStrictEqual({
       groupedAdmission: "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission",
@@ -205,6 +207,10 @@ describe("benchmark baseline runner", () => {
       kafkaIngest: "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest",
       kafkaIngestUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest --update-baseline",
+      kafkaSustainedFirehose:
+        "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose",
+      kafkaSustainedFirehoseUpdate:
+        "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose --update-baseline",
       release: "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     });
   });
@@ -228,6 +234,34 @@ describe("benchmark baseline runner", () => {
         broker: "localhost:9092",
         outputJsonPath: ".artifacts/kafka-ingest-250rows.json",
         rowCount: "250",
+        task: ["run", "--no-cache", "runtime#bench:kafka-ingest"],
+      },
+    ]);
+  });
+
+  it("defines the Kafka sustained firehose runtime benchmark task", () => {
+    const kafkaSustainedFirehoseTasks = profiles.get("kafka-sustained-firehose") ?? [];
+
+    expect(
+      kafkaSustainedFirehoseTasks.map((task) => ({
+        artifactKind: task.expectedArtifactKind,
+        benchmarkMode: task.env["VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE"],
+        benchmarkScope: task.expectedBenchmarkScope,
+        broker: task.env["VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS"],
+        outputJsonPath: task.packageOutputJsonPath,
+        rowCount: task.env["VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE"],
+        sustainedBatches: task.env["VIEW_SERVER_RUNTIME_BENCH_KAFKA_SUSTAINED_BATCHES"],
+        task: task.args,
+      })),
+    ).toStrictEqual([
+      {
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkMode: "sustained-firehose",
+        benchmarkScope: "runtime-kafka-sustained-firehose",
+        broker: "localhost:9092",
+        outputJsonPath: ".artifacts/kafka-sustained-firehose-250rows-4batches.json",
+        rowCount: "250",
+        sustainedBatches: "4",
         task: ["run", "--no-cache", "runtime#bench:kafka-ingest"],
       },
     ]);
@@ -1084,7 +1118,7 @@ describe("benchmark baseline runner", () => {
     }).toStrictEqual({
       exitCode: 1,
       message:
-        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, grouped-admission, grouped-order-neutral, release",
+        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, kafka-sustained-firehose, grouped-admission, grouped-order-neutral, release",
     });
   });
 

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -40,11 +40,25 @@ export const kafkaIngestBenchmarkThresholds = {
   memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
 };
 
+export const kafkaSustainedFirehoseBenchmarkThresholds = {
+  latencyMean: {
+    maxAbsoluteDeltaMs: 5_000,
+    maxRatio: 1.75,
+  },
+  latencyP99: {
+    maxAbsoluteDeltaMs: 6_000,
+    maxRatio: 1.75,
+  },
+  memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+};
+
 export const benchmarkThresholdsForProfile = (profile) =>
   profile === "grouped-order-neutral"
     ? groupedOrderNeutralBenchmarkThresholds
     : profile === "kafka-ingest"
       ? kafkaIngestBenchmarkThresholds
+    : profile === "kafka-sustained-firehose"
+      ? kafkaSustainedFirehoseBenchmarkThresholds
     : defaultBenchmarkThresholds;
 
 const readJsonFile = (path) => JSON.parse(readFileSync(path, "utf8"));

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -10,6 +10,7 @@ import {
   defaultBenchmarkThresholds,
   groupedOrderNeutralBenchmarkThresholds,
   kafkaIngestBenchmarkThresholds,
+  kafkaSustainedFirehoseBenchmarkThresholds,
   readBenchmarkBaseline,
   readBenchmarkObservation,
   validateBenchmarkBaseline,
@@ -201,16 +202,22 @@ describe("benchmark baseline comparison", () => {
     expect({
       groupedOrderNeutral: benchmarkThresholdsForProfile("grouped-order-neutral"),
       kafkaIngest: benchmarkThresholdsForProfile("kafka-ingest"),
+      kafkaSustainedFirehose: benchmarkThresholdsForProfile("kafka-sustained-firehose"),
       smoke: benchmarkThresholdsForProfile("smoke"),
       kafkaIngestBaseline: buildBenchmarkBaseline("kafka-ingest", [observation]).thresholds,
+      kafkaSustainedFirehoseBaseline: buildBenchmarkBaseline("kafka-sustained-firehose", [
+        observation,
+      ]).thresholds,
       smokeBaseline: buildBenchmarkBaseline("smoke", [observation]).thresholds,
       orderNeutralBaseline: buildBenchmarkBaseline("grouped-order-neutral", [observation])
         .thresholds,
     }).toStrictEqual({
       groupedOrderNeutral: groupedOrderNeutralBenchmarkThresholds,
       kafkaIngest: kafkaIngestBenchmarkThresholds,
+      kafkaSustainedFirehose: kafkaSustainedFirehoseBenchmarkThresholds,
       smoke: defaultBenchmarkThresholds,
       kafkaIngestBaseline: kafkaIngestBenchmarkThresholds,
+      kafkaSustainedFirehoseBaseline: kafkaSustainedFirehoseBenchmarkThresholds,
       smokeBaseline: defaultBenchmarkThresholds,
       orderNeutralBaseline: groupedOrderNeutralBenchmarkThresholds,
     });


### PR DESCRIPTION
## Summary
- adds a sustained-firehose mode to the existing Vitest Kafka ingest benchmark
- adds a dedicated kafka-sustained-firehose baseline profile, scripts, and docs
- keeps the real Apache Kafka / @platformatic producer path and validates mixed JSON + protobuf lanes through final health convergence

## Validation
- pnpm run test:repository-scripts
- pnpm run bench:baseline:kafka-sustained-firehose:update
- pnpm run bench:baseline:kafka-sustained-firehose
- vp check --fix
- pnpm run check:effect
- pnpm --filter @view-server/runtime run test
- pnpm run ready
- 3-agent review: 2 no findings, 1 baseline-file finding fixed by staging the new baseline