### PR TITLE
Enforce package export seams

### DIFF
--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -1288,9 +1288,140 @@ describe("internal seam checker", () => {
           name: "@view-server/react",
           exports: {
             "./testing": {
+              browser: ["./dist/testing.js", null],
+              default: "./dist/testing.js",
               import: "./dist/testing.js",
+              node: null,
               types: "./dist/testing.d.ts",
             },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed package export fallback arrays", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: [null, "./dist/testing.js"],
+              types: [null, "./dist/testing.d.ts"],
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed conditional objects inside package export fallback arrays", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": [
+              {
+                import: "./dist/testing.js",
+                types: "./dist/testing.d.ts",
+              },
+            ],
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed default conditional package export entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              default: "./dist/testing.js",
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed nested types conditional package export entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              default: "./dist/testing.js",
+              types: {
+                default: "./dist/testing.d.ts",
+              },
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed versioned TypeScript package export entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/testing.js",
+              "types@>=5.2": "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed nested runtime conditional package export entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              node: {
+                import: "./dist/testing.js",
+              },
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed default conditional objects inside package export fallback arrays", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": [
+              {
+                browser: null,
+                default: "./dist/testing.js",
+                types: "./dist/testing.d.ts",
+              },
+            ],
           },
         }),
         packageDirectoryName: "react",
@@ -1309,7 +1440,7 @@ describe("internal seam checker", () => {
     ).toStrictEqual(["@view-server/example"]);
   });
 
-  it("ignores package export specifiers from unsupported top-level export shapes", () => {
+  it("collects root fallback array package export maps as the root specifier", () => {
     expect(
       packageExportSpecifiersForManifest(
         JSON.stringify({
@@ -1317,7 +1448,7 @@ describe("internal seam checker", () => {
           name: "@view-server/example",
         }),
       ),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["@view-server/example"]);
   });
 
   it("ignores package export violations from unsupported top-level export shapes", () => {
@@ -1375,7 +1506,8 @@ describe("internal seam checker", () => {
       }),
     ).toStrictEqual([
       "packages/react/package.json exports @view-server/react/array: add intentional public specifier approval or remove the export.",
-      "packages/react/package.json export ./array has no import target.",
+      "packages/react/package.json export ./array points at ./dist/array.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./array has no types target.",
       "packages/react/package.json exports @view-server/react/null: add intentional public specifier approval or remove the export.",
       "packages/react/package.json export ./null has no import target.",
     ]);
@@ -1395,11 +1527,11 @@ describe("internal seam checker", () => {
       }),
     ).toStrictEqual([
       "packages/react/package.json exports @view-server/react/internal: add intentional public specifier approval or remove the export.",
-      "packages/react/package.json export ./internal has no types target.",
       "packages/react/package.json export ./internal points at ./dist/internal.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./internal has no types target.",
       "packages/react/package.json exports @view-server/react/missing: add intentional public specifier approval or remove the export.",
-      "packages/react/package.json export ./missing has no types target.",
       "packages/react/package.json export ./missing points at ./dist/missing.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./missing has no types target.",
     ]);
   });
 
@@ -1413,6 +1545,57 @@ describe("internal seam checker", () => {
         packageDirectoryName: "react",
       }),
     ).toStrictEqual(["packages/react/package.json export . has no types target."]);
+  });
+
+  it("reports root fallback array package exports through the same target checks", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: ["./dist/live-query-state.js"],
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export . points at ./dist/live-query-state.js without a matching packed src entrypoint.",
+      "packages/react/package.json export . has no types target.",
+    ]);
+  });
+
+  it("reports types-only fallback array exports without runtime import targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": [
+              {
+                types: "./dist/testing.d.ts",
+              },
+            ],
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual(["packages/react/package.json export ./testing has no import target."]);
+  });
+
+  it("does not allow nested types import conditions to satisfy runtime import targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              types: {
+                import: "./dist/testing.d.ts",
+              },
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual(["packages/react/package.json export ./testing has no import target."]);
   });
 
   it("reports package exports that are not approved public specifiers", () => {
@@ -1506,6 +1689,52 @@ describe("internal seam checker", () => {
     ]);
   });
 
+  it("reports unpacked import and types fallback array targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: ["./dist/live-query-state.js"],
+              types: ["./dist/live-query-state.d.ts"],
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing points at ./dist/live-query-state.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing points at ./dist/live-query-state.d.ts without a matching packed src entrypoint.",
+    ]);
+  });
+
+  it("reports unpacked conditional package export targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              browser: {
+                default: "./dist/live-query-state.js",
+              },
+              default: "./dist/internal.js",
+              import: "./dist/testing.js",
+              node: ["./dist/internal.js"],
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing condition browser.default points at ./dist/live-query-state.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing condition default points at ./dist/internal.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing condition node[0] points at ./dist/internal.js without a matching packed src entrypoint.",
+    ]);
+  });
+
   it("reports package exports without a Vite+ pack config", () => {
     expect(
       packageExportViolationsForManifest({
@@ -1586,6 +1815,25 @@ describe("internal seam checker", () => {
     ]);
   });
 
+  it("does not report mismatch noise when the import target is unpacked", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/live-query-state.js",
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing points at ./dist/live-query-state.js without a matching packed src entrypoint.",
+    ]);
+  });
+
   it("reports package exports with declaration targets that do not match import targets", () => {
     expect(
       packageExportViolationsForManifest({
@@ -1602,6 +1850,46 @@ describe("internal seam checker", () => {
       }),
     ).toStrictEqual([
       "packages/react/package.json export ./testing types target ./dist/index.d.ts does not match import target ./dist/testing.js.",
+    ]);
+  });
+
+  it("reports package exports with runtime condition targets that do not match import targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              browser: "./dist/index.js",
+              import: "./dist/testing.js",
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing condition browser target ./dist/index.js does not match import target ./dist/testing.js.",
+    ]);
+  });
+
+  it("reports package exports with versioned declaration targets that do not match import targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/testing.js",
+              types: "./dist/testing.d.ts",
+              "types@>=5.2": "./dist/index.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing condition types@>=5.2 target ./dist/index.d.ts does not match import target ./dist/testing.js.",
     ]);
   });
 

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -4,16 +4,22 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import {
   assertNoPackageImportViolations,
+  assertNoPackageExportViolations,
   assertNoEngineSeamViolations,
   collectEngineSeamViolations,
+  collectPackageExportViolations,
   collectPackageImportViolations,
   importSpecifiersFromSource,
+  packageExportSpecifiersForManifest,
+  packageExportViolationMessage,
+  packageExportViolationsForManifest,
   packageImportViolationsFor,
   packageImportViolationsForFile,
   packageImportViolationMessage,
   packageRelativeImportViolationsFor,
   sourceFiles,
   sourceWithoutComments,
+  staleApprovedPackageExportViolations,
   topicStoreHelperViolationMessage,
   topicStoreHelperViolationsForFile,
   topicStoreStateExportViolationMessage,
@@ -1118,6 +1124,280 @@ describe("internal seam checker", () => {
   it("keeps the current repository free of package import violations", () => {
     expect(collectPackageImportViolations()).toStrictEqual([]);
   }, 30000);
+
+  it("collects package export specifiers from package manifests", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          name: "@view-server/example",
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+            "./testing": {
+              import: "./dist/testing.js",
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+      ),
+    ).toStrictEqual(["@view-server/example", "@view-server/example/testing"]);
+  });
+
+  it("ignores manifests without object export maps", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          exports: "./dist/index.js",
+          name: "@view-server/example",
+        }),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores package export specifiers when the manifest has no package name", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+          },
+        }),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("collects package export specifiers from string targets", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          name: "@view-server/example",
+          exports: {
+            ".": "./dist/index.js",
+            "./array": ["./dist/array.js"],
+            "./null": null,
+          },
+        }),
+      ),
+    ).toStrictEqual(["@view-server/example", "@view-server/example/array", "@view-server/example/null"]);
+  });
+
+  it("reports unsupported package export map targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./array": ["./dist/array.js"],
+            "./null": null,
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json exports @view-server/react/array: add intentional public specifier approval or remove the export.",
+      "packages/react/package.json export ./array has no import target.",
+      "packages/react/package.json exports @view-server/react/null: add intentional public specifier approval or remove the export.",
+      "packages/react/package.json export ./null has no import target.",
+    ]);
+  });
+
+  it("reports package string exports through the same approval and source checks", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./internal": "./dist/internal.js",
+            "./missing": "./dist/missing.js",
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json exports @view-server/react/internal: add intentional public specifier approval or remove the export.",
+      "packages/react/package.json export ./internal has no types target.",
+      "packages/react/package.json exports @view-server/react/missing: add intentional public specifier approval or remove the export.",
+      "packages/react/package.json export ./missing has no types target.",
+      "packages/react/package.json export ./missing points at ./dist/missing.js without a matching src entrypoint.",
+    ]);
+  });
+
+  it("ignores manifests without supported export maps when checking violations", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: "./dist/index.js",
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("reports package exports that are not approved public specifiers", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./internal": {
+              import: "./dist/internal.js",
+              types: "./dist/internal.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json exports @view-server/react/internal: add intentional public specifier approval or remove the export.",
+    ]);
+  });
+
+  it("reports package exports from nameless manifests using the package directory label", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json exports packages/react: add intentional public specifier approval or remove the export.",
+    ]);
+  });
+
+  it("reports package exports without import targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual(["packages/react/package.json export ./testing has no import target."]);
+  });
+
+  it("reports package exports without types targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/testing.js",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual(["packages/react/package.json export ./testing has no types target."]);
+  });
+
+  it("reports package exports without matching source entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/missing.js",
+              types: "./dist/missing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing points at ./dist/missing.js without a matching src entrypoint.",
+      "packages/react/package.json export ./testing points at ./dist/missing.d.ts without a matching src entrypoint.",
+    ]);
+  });
+
+  it("reports package exports with import targets outside dist entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./generated/testing.js",
+              types: "./generated/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing points at ./generated/testing.js without a matching src entrypoint.",
+      "packages/react/package.json export ./testing points at ./generated/testing.d.ts without a matching src entrypoint.",
+    ]);
+  });
+
+  it("reports package exports with declaration targets that do not match import targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/testing.js",
+              types: "./dist/index.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing types target ./dist/index.d.ts does not match import target ./dist/testing.js.",
+    ]);
+  });
+
+  it("reports stale approved public package export specifiers", () => {
+    expect(
+      staleApprovedPackageExportViolations({
+        approvedSpecifiers: new Set(["@view-server/client", "@view-server/client/missing"]),
+        exportedSpecifiers: new Set(["@view-server/client"]),
+      }),
+    ).toStrictEqual([
+      "@view-server/client/missing is approved as public but is not exported by any package.json.",
+    ]);
+  });
+
+  it("formats and throws package export violation summaries", () => {
+    const violations = [
+      "packages/react/package.json exports @view-server/react/internal: remove it.",
+    ];
+
+    expect(packageExportViolationMessage(violations)).toStrictEqual(
+      [
+        "Package public export violations found.",
+        "- packages/react/package.json exports @view-server/react/internal: remove it.",
+      ].join("\n"),
+    );
+    expect(() => assertNoPackageExportViolations(violations)).toThrowError(
+      "Package public export violations found.",
+    );
+    expect(assertNoPackageExportViolations([])).toStrictEqual(undefined);
+  });
+
+  it("keeps the current repository free of package export violations", () => {
+    expect(collectPackageExportViolations()).toStrictEqual([]);
+  });
 
   it("ignores import-like text in comments", () => {
     expect(

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -10,14 +10,19 @@ import {
   collectPackageExportViolations,
   collectPackageImportViolations,
   importSpecifiersFromSource,
+  libraryPackEntrypointPaths,
   packageExportSpecifiersForManifest,
   packageExportViolationMessage,
   packageExportViolationsForManifest,
+  packedEntrypointsFromViteConfigContents,
+  packedPackageEntrypointsForPackage,
   packageImportViolationsFor,
   packageImportViolationsForFile,
   packageImportViolationMessage,
   packageRelativeImportViolationsFor,
   sourceFiles,
+  sourceEntrypointForPackEntry,
+  sourceEntrypointForRelativeDistEntrypoint,
   sourceWithoutComments,
   staleApprovedPackageExportViolations,
   topicStoreHelperViolationMessage,
@@ -1145,7 +1150,155 @@ describe("internal seam checker", () => {
     ).toStrictEqual(["@view-server/example", "@view-server/example/testing"]);
   });
 
-  it("ignores manifests without object export maps", () => {
+  it("parses Vite+ libraryPack entrypoint declarations", () => {
+    expect(libraryPackEntrypointPaths('export default { pack: libraryPack("src/index.ts") };')).toStrictEqual([
+      "src/index.ts",
+    ]);
+    expect(
+      libraryPackEntrypointPaths(
+        [
+          "export default {",
+          "  pack: libraryPack([",
+          '    "src/index.ts",',
+          '    // "src/internal.ts",',
+          '    "src/testing.tsx",',
+          "  ]),",
+          "};",
+        ].join("\n"),
+      ),
+    ).toStrictEqual(["src/index.ts", "src/testing.tsx"]);
+    expect(libraryPackEntrypointPaths("export default { fmt: {} };")).toStrictEqual([]);
+  });
+
+  it("normalizes safe libraryPack source entrypoints only", () => {
+    expect(sourceEntrypointForPackEntry("src/index.ts")).toStrictEqual("index");
+    expect(sourceEntrypointForPackEntry("src/testing.tsx")).toStrictEqual("testing");
+    expect(sourceEntrypointForPackEntry("generated/index.ts")).toStrictEqual(undefined);
+    expect(sourceEntrypointForPackEntry("src/index.js")).toStrictEqual(undefined);
+    expect(sourceEntrypointForPackEntry("src/../index.ts")).toStrictEqual(undefined);
+  });
+
+  it("collects packed entrypoints from Vite+ config contents", () => {
+    expect(
+      Array.from(
+        packedEntrypointsFromViteConfigContents(
+          [
+            "export default {",
+            "  pack: libraryPack([",
+            '    "generated/index.ts",',
+            '    "src/index.ts",',
+            '    "src/feature.tsx",',
+            '    "src/../escape.ts",',
+            "  ]),",
+            "};",
+          ].join("\n"),
+        ),
+      ).sort(),
+    ).toStrictEqual(["feature", "index"]);
+  });
+
+  it("collects packed entrypoints from package Vite+ config files", () => {
+    expect(Array.from(packedPackageEntrypointsForPackage("react")).sort()).toStrictEqual(["index", "testing"]);
+    expect(Array.from(packedPackageEntrypointsForPackage("missing-package"))).toStrictEqual([]);
+  });
+
+  it("resolves package source entrypoint files without normalizing missing files into existence", () => {
+    expect(sourceEntrypointForRelativeDistEntrypoint("react", "testing")?.endsWith("src/testing.tsx")).toStrictEqual(
+      true,
+    );
+    expect(sourceEntrypointForRelativeDistEntrypoint("react", "missing")).toStrictEqual(undefined);
+  });
+
+  it("collects root conditional package export maps as the root specifier", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          name: "@view-server/client",
+          exports: {
+            import: "./dist/index.js",
+            types: "./dist/index.d.ts",
+          },
+        }),
+      ),
+    ).toStrictEqual(["@view-server/client"]);
+  });
+
+  it("collects types-only root conditional package export maps as the root specifier", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          name: "@view-server/client",
+          exports: {
+            types: "./dist/index.d.ts",
+          },
+        }),
+      ),
+    ).toStrictEqual(["@view-server/client"]);
+  });
+
+  it("collects default-only root conditional package export maps as the root specifier", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          name: "@view-server/client",
+          exports: {
+            default: "./dist/index.js",
+          },
+        }),
+      ),
+    ).toStrictEqual(["@view-server/client"]);
+  });
+
+  it("keeps non-subpath keys readable in mixed package export maps", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          name: "@view-server/example",
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+            types: "./dist/index.d.ts",
+          },
+        }),
+      ),
+    ).toStrictEqual(["@view-server/example", "@view-server/example/types"]);
+  });
+
+  it("accepts root conditional package export maps for packed entries", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/client",
+          exports: {
+            import: "./dist/index.js",
+            types: "./dist/index.d.ts",
+          },
+        }),
+        packageDirectoryName: "client",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts packed TSX package export entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/testing.js",
+              types: "./dist/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("collects root string package export maps as the root specifier", () => {
     expect(
       packageExportSpecifiersForManifest(
         JSON.stringify({
@@ -1153,6 +1306,28 @@ describe("internal seam checker", () => {
           name: "@view-server/example",
         }),
       ),
+    ).toStrictEqual(["@view-server/example"]);
+  });
+
+  it("ignores package export specifiers from unsupported top-level export shapes", () => {
+    expect(
+      packageExportSpecifiersForManifest(
+        JSON.stringify({
+          exports: ["./dist/index.js"],
+          name: "@view-server/example",
+        }),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores package export violations from unsupported top-level export shapes", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+        }),
+        packageDirectoryName: "react",
+      }),
     ).toStrictEqual([]);
   });
 
@@ -1221,13 +1396,14 @@ describe("internal seam checker", () => {
     ).toStrictEqual([
       "packages/react/package.json exports @view-server/react/internal: add intentional public specifier approval or remove the export.",
       "packages/react/package.json export ./internal has no types target.",
+      "packages/react/package.json export ./internal points at ./dist/internal.js without a matching packed src entrypoint.",
       "packages/react/package.json exports @view-server/react/missing: add intentional public specifier approval or remove the export.",
       "packages/react/package.json export ./missing has no types target.",
-      "packages/react/package.json export ./missing points at ./dist/missing.js without a matching src entrypoint.",
+      "packages/react/package.json export ./missing points at ./dist/missing.js without a matching packed src entrypoint.",
     ]);
   });
 
-  it("ignores manifests without supported export maps when checking violations", () => {
+  it("reports root string package exports through the same target checks", () => {
     expect(
       packageExportViolationsForManifest({
         manifestContents: JSON.stringify({
@@ -1236,7 +1412,7 @@ describe("internal seam checker", () => {
         }),
         packageDirectoryName: "react",
       }),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["packages/react/package.json export . has no types target."]);
   });
 
   it("reports package exports that are not approved public specifiers", () => {
@@ -1255,6 +1431,8 @@ describe("internal seam checker", () => {
       }),
     ).toStrictEqual([
       "packages/react/package.json exports @view-server/react/internal: add intentional public specifier approval or remove the export.",
+      "packages/react/package.json export ./internal points at ./dist/internal.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./internal points at ./dist/internal.d.ts without a matching packed src entrypoint.",
     ]);
   });
 
@@ -1323,8 +1501,28 @@ describe("internal seam checker", () => {
         packageDirectoryName: "react",
       }),
     ).toStrictEqual([
-      "packages/react/package.json export ./testing points at ./dist/missing.js without a matching src entrypoint.",
-      "packages/react/package.json export ./testing points at ./dist/missing.d.ts without a matching src entrypoint.",
+      "packages/react/package.json export ./testing points at ./dist/missing.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing points at ./dist/missing.d.ts without a matching packed src entrypoint.",
+    ]);
+  });
+
+  it("reports package exports without a Vite+ pack config", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/client",
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "missing-package",
+      }),
+    ).toStrictEqual([
+      "packages/missing-package/package.json export . points at ./dist/index.js without a matching packed src entrypoint.",
+      "packages/missing-package/package.json export . points at ./dist/index.d.ts without a matching packed src entrypoint.",
     ]);
   });
 
@@ -1343,8 +1541,48 @@ describe("internal seam checker", () => {
         packageDirectoryName: "react",
       }),
     ).toStrictEqual([
-      "packages/react/package.json export ./testing points at ./generated/testing.js without a matching src entrypoint.",
-      "packages/react/package.json export ./testing points at ./generated/testing.d.ts without a matching src entrypoint.",
+      "packages/react/package.json export ./testing points at ./generated/testing.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing points at ./generated/testing.d.ts without a matching packed src entrypoint.",
+    ]);
+  });
+
+  it("reports package exports with traversal in dist entrypoint targets", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/../src/testing.js",
+              types: "./dist/../src/testing.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing points at ./dist/../src/testing.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing points at ./dist/../src/testing.d.ts without a matching packed src entrypoint.",
+    ]);
+  });
+
+  it("reports package exports that target unpacked source entrypoints", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "@view-server/react",
+          exports: {
+            "./testing": {
+              import: "./dist/live-query-state.js",
+              types: "./dist/live-query-state.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "react",
+      }),
+    ).toStrictEqual([
+      "packages/react/package.json export ./testing points at ./dist/live-query-state.js without a matching packed src entrypoint.",
+      "packages/react/package.json export ./testing points at ./dist/live-query-state.d.ts without a matching packed src entrypoint.",
     ]);
   });
 

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -1513,6 +1513,235 @@ const approvedPublicViewServerSpecifiers = new Set([
   "@view-server/runtime-core",
   "@view-server/server",
 ]);
+
+type PackageManifestExportTarget = {
+  readonly import?: unknown;
+  readonly types?: unknown;
+};
+
+type PackageManifest = {
+  readonly name?: unknown;
+  readonly exports?: unknown;
+};
+
+const packageManifestPath = (packageName: string): string =>
+  join(repoRoot, "packages", packageName, "package.json");
+
+const parsePackageManifest = (contents: string): PackageManifest => JSON.parse(contents);
+
+const manifestExportObject = (manifest: PackageManifest): object | undefined => {
+  if (typeof manifest.exports !== "object" || manifest.exports === null || Array.isArray(manifest.exports)) {
+    return undefined;
+  }
+  return manifest.exports;
+};
+
+const manifestExportKeys = (manifest: PackageManifest): ReadonlyArray<string> =>
+  Object.keys(manifestExportObject(manifest) ?? {});
+
+const importTargetForExportTarget = (
+  target: unknown,
+):
+  | {
+      readonly _tag: "ExportTarget";
+      readonly importTarget: string | undefined;
+      readonly typesTarget: string | undefined;
+    }
+  | { readonly _tag: "Unsupported" } => {
+  if (typeof target === "string") {
+    return {
+      _tag: "ExportTarget",
+      importTarget: target,
+      typesTarget: undefined,
+    };
+  }
+  if (typeof target !== "object" || target === null || Array.isArray(target)) {
+    return {
+      _tag: "Unsupported",
+    };
+  }
+  const exportTarget: PackageManifestExportTarget = target;
+  return {
+    _tag: "ExportTarget",
+    importTarget: typeof exportTarget.import === "string" ? exportTarget.import : undefined,
+    typesTarget: typeof exportTarget.types === "string" ? exportTarget.types : undefined,
+  };
+};
+
+const exportSpecifierFor = (packageSpecifier: string, exportKey: string): string =>
+  exportKey === "." ? packageSpecifier : `${packageSpecifier}/${exportKey.slice("./".length)}`;
+
+export const packageExportSpecifiersForManifest = (
+  manifestContents: string,
+): ReadonlyArray<string> => {
+  const manifest = parsePackageManifest(manifestContents);
+  const packageSpecifier = manifest.name;
+  if (typeof packageSpecifier !== "string") {
+    return [];
+  }
+  return manifestExportKeys(manifest).map((exportKey) => exportSpecifierFor(packageSpecifier, exportKey));
+};
+
+const distTargetEntrypoint = (target: string, suffix: ".d.ts" | ".js"): string | undefined => {
+  const prefix = "./dist/";
+  if (!target.startsWith(prefix) || !target.endsWith(suffix)) {
+    return undefined;
+  }
+  return target.slice(prefix.length, -suffix.length);
+};
+
+const sourceEntrypointForRelativeDistEntrypoint = (
+  packageName: string,
+  relativeEntrypoint: string,
+): string | undefined => {
+  const sourceBase = join(repoRoot, "packages", packageName, "src", relativeEntrypoint);
+  const tsEntrypoint = `${sourceBase}.ts`;
+  if (existsSync(tsEntrypoint)) {
+    return tsEntrypoint;
+  }
+  const tsxEntrypoint = `${sourceBase}.tsx`;
+  return existsSync(tsxEntrypoint) ? tsxEntrypoint : undefined;
+};
+
+export const packageExportViolationsForManifest = ({
+  manifestContents,
+  packageDirectoryName,
+}: {
+  readonly manifestContents: string;
+  readonly packageDirectoryName: string;
+}): ReadonlyArray<string> => {
+  const manifest = parsePackageManifest(manifestContents);
+  const packageSpecifier =
+    typeof manifest.name === "string" ? manifest.name : `packages/${packageDirectoryName}`;
+  const violations: Array<string> = [];
+
+  for (const [exportKey, target] of Object.entries(manifestExportObject(manifest) ?? {})) {
+    const specifier = exportSpecifierFor(packageSpecifier, exportKey);
+    if (!approvedPublicViewServerSpecifiers.has(specifier)) {
+      violations.push(
+        `packages/${packageDirectoryName}/package.json exports ${specifier}: add intentional public specifier approval or remove the export.`,
+      );
+    }
+    const importTarget = importTargetForExportTarget(target);
+    if (importTarget._tag === "Unsupported") {
+      violations.push(
+        `packages/${packageDirectoryName}/package.json export ${exportKey} has no import target.`,
+      );
+      continue;
+    }
+    if (importTarget.importTarget === undefined) {
+      violations.push(
+        `packages/${packageDirectoryName}/package.json export ${exportKey} has no import target.`,
+      );
+      continue;
+    }
+    if (importTarget.typesTarget === undefined) {
+      violations.push(
+        `packages/${packageDirectoryName}/package.json export ${exportKey} has no types target.`,
+      );
+    }
+    const importEntrypoint = distTargetEntrypoint(importTarget.importTarget, ".js");
+    if (
+      importEntrypoint === undefined ||
+      sourceEntrypointForRelativeDistEntrypoint(packageDirectoryName, importEntrypoint) === undefined
+    ) {
+      violations.push(
+        `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.importTarget} without a matching src entrypoint.`,
+      );
+    }
+    if (importTarget.typesTarget !== undefined) {
+      const typesEntrypoint = distTargetEntrypoint(importTarget.typesTarget, ".d.ts");
+      if (
+        typesEntrypoint === undefined ||
+        sourceEntrypointForRelativeDistEntrypoint(packageDirectoryName, typesEntrypoint) === undefined
+      ) {
+        violations.push(
+          `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.typesTarget} without a matching src entrypoint.`,
+        );
+      }
+      if (importEntrypoint !== undefined && typesEntrypoint !== undefined && importEntrypoint !== typesEntrypoint) {
+        violations.push(
+          `packages/${packageDirectoryName}/package.json export ${exportKey} types target ${importTarget.typesTarget} does not match import target ${importTarget.importTarget}.`,
+        );
+      }
+    }
+  }
+
+  return violations;
+};
+
+const viewServerPackageDirectories = [
+  "client",
+  "column-live-view-engine",
+  "config",
+  "effect-utils",
+  "in-memory",
+  "protocol",
+  "react",
+  "runtime",
+  "runtime-core",
+  "server",
+] as const;
+
+export const staleApprovedPackageExportViolations = ({
+  approvedSpecifiers,
+  exportedSpecifiers,
+}: {
+  readonly approvedSpecifiers: ReadonlySet<string>;
+  readonly exportedSpecifiers: ReadonlySet<string>;
+}): ReadonlyArray<string> => {
+  const violations: Array<string> = [];
+  for (const approvedSpecifier of approvedSpecifiers) {
+    if (!exportedSpecifiers.has(approvedSpecifier)) {
+      violations.push(
+        `${approvedSpecifier} is approved as public but is not exported by any package.json.`,
+      );
+    }
+  }
+  return violations;
+};
+
+export const collectPackageExportViolations = (): ReadonlyArray<string> => {
+  const violations: Array<string> = [];
+  const exportedSpecifiers = new Set<string>();
+
+  for (const packageDirectoryName of viewServerPackageDirectories) {
+    const manifestContents = readFileSync(packageManifestPath(packageDirectoryName), "utf8");
+    for (const specifier of packageExportSpecifiersForManifest(manifestContents)) {
+      exportedSpecifiers.add(specifier);
+    }
+    violations.push(
+      ...packageExportViolationsForManifest({
+        manifestContents,
+        packageDirectoryName,
+      }),
+    );
+  }
+
+  violations.push(
+    ...staleApprovedPackageExportViolations({
+      approvedSpecifiers: approvedPublicViewServerSpecifiers,
+      exportedSpecifiers,
+    }),
+  );
+
+  return violations;
+};
+
+export const packageExportViolationMessage = (violations: ReadonlyArray<string>): string =>
+  [
+    "Package public export violations found.",
+    ...violations.map((violation) => `- ${violation}`),
+  ].join("\n");
+
+export const assertNoPackageExportViolations = (violations: ReadonlyArray<string>) => {
+  if (violations.length === 0) {
+    return;
+  }
+  throw new Error(packageExportViolationMessage(violations));
+};
+
+assertNoPackageExportViolations(collectPackageExportViolations());
 
 const isInsideDirectory = (parentDirectory: string, childPath: string): boolean => {
   const relativeChildPath = relative(parentDirectory, childPath);

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1514,9 +1514,10 @@ const approvedPublicViewServerSpecifiers = new Set([
   "@view-server/server",
 ]);
 
-type PackageManifestExportTarget = {
-  readonly import?: unknown;
-  readonly types?: unknown;
+type PackageExportConditionTarget = {
+  readonly condition: string;
+  readonly suffix: ".d.ts" | ".js";
+  readonly target: string;
 };
 
 type PackageManifest = {
@@ -1542,7 +1543,7 @@ const manifestExportsAreRootConditionMap = (exportsObject: object): boolean => {
 };
 
 const manifestExportEntries = (manifest: PackageManifest): ReadonlyArray<readonly [string, unknown]> => {
-  if (typeof manifest.exports === "string") {
+  if (typeof manifest.exports === "string" || Array.isArray(manifest.exports)) {
     return [[".", manifest.exports]];
   }
   const exportsObject = manifestExportObject(manifest);
@@ -1567,24 +1568,139 @@ const importTargetForExportTarget = (
       readonly typesTarget: string | undefined;
     }
   | { readonly _tag: "Unsupported" } => {
-  if (typeof target === "string") {
-    return {
-      _tag: "ExportTarget",
-      importTarget: target,
-      typesTarget: undefined,
-    };
-  }
-  if (typeof target !== "object" || target === null || Array.isArray(target)) {
+  if (typeof target !== "string" && !Array.isArray(target) && (typeof target !== "object" || target === null)) {
     return {
       _tag: "Unsupported",
     };
   }
-  const exportTarget: PackageManifestExportTarget = target;
+
+  const firstRuntimeTargetString = (target: unknown, conditionPath: string): string | undefined => {
+    if (typeof target === "string") {
+      return conditionPathIsTypes(conditionPath) ? undefined : target;
+    }
+    if (Array.isArray(target)) {
+      for (const conditionTarget of target) {
+        const nestedTarget = firstRuntimeTargetString(conditionTarget, conditionPath);
+        if (nestedTarget !== undefined) {
+          return nestedTarget;
+        }
+      }
+    }
+    if (typeof target === "object" && target !== null) {
+      for (const [condition, conditionTarget] of Object.entries(target)) {
+        const childConditionPath = conditionPath === "" ? condition : `${conditionPath}.${condition}`;
+        const nestedTarget = firstRuntimeTargetString(conditionTarget, childConditionPath);
+        if (nestedTarget !== undefined) {
+          return nestedTarget;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  const firstTypesTargetString = (target: unknown, conditionPath: string): string | undefined => {
+    if (typeof target === "string") {
+      return conditionPathIsTypes(conditionPath) ? target : undefined;
+    }
+    if (Array.isArray(target)) {
+      for (const conditionTarget of target) {
+        const nestedTarget = firstTypesTargetString(conditionTarget, conditionPath);
+        if (nestedTarget !== undefined) {
+          return nestedTarget;
+        }
+      }
+    }
+    if (typeof target === "object" && target !== null) {
+      for (const [condition, conditionTarget] of Object.entries(target)) {
+        const childConditionPath = conditionPath === "" ? condition : `${conditionPath}.${condition}`;
+        const nestedTarget = firstTypesTargetString(conditionTarget, childConditionPath);
+        if (nestedTarget !== undefined) {
+          return nestedTarget;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  const firstNamedRuntimeConditionTargetString = (
+    target: unknown,
+    condition: string,
+    conditionPath: string,
+  ): string | undefined => {
+    if (Array.isArray(target)) {
+      for (const conditionTarget of target) {
+        const nestedTarget = firstNamedRuntimeConditionTargetString(conditionTarget, condition, conditionPath);
+        if (nestedTarget !== undefined) {
+          return nestedTarget;
+        }
+      }
+    }
+    if (typeof target === "object" && target !== null) {
+      for (const [conditionKey, conditionTarget] of Object.entries(target)) {
+        const childConditionPath = conditionPath === "" ? conditionKey : `${conditionPath}.${conditionKey}`;
+        const nestedTarget =
+          conditionKey === condition
+            ? firstRuntimeTargetString(conditionTarget, childConditionPath)
+            : firstNamedRuntimeConditionTargetString(conditionTarget, condition, childConditionPath);
+        if (nestedTarget !== undefined) {
+          return nestedTarget;
+        }
+      }
+    }
+    return undefined;
+  };
+
   return {
     _tag: "ExportTarget",
-    importTarget: typeof exportTarget.import === "string" ? exportTarget.import : undefined,
-    typesTarget: typeof exportTarget.types === "string" ? exportTarget.types : undefined,
+    importTarget:
+      firstNamedRuntimeConditionTargetString(target, "import", "") ?? firstRuntimeTargetString(target, ""),
+    typesTarget: firstTypesTargetString(target, ""),
   };
+};
+
+const conditionTargetSuffix = (condition: string): ".d.ts" | ".js" =>
+  conditionPathIsTypes(condition) ? ".d.ts" : ".js";
+
+function conditionWithoutArrayIndexes(condition: string): string {
+  return condition.replace(/\[\d+\]/g, "");
+}
+
+const conditionPartIsTypes = (conditionPart: string): boolean =>
+  conditionPart === "types" || conditionPart.startsWith("types@");
+
+const conditionPathIsTypes = (condition: string): boolean =>
+  conditionWithoutArrayIndexes(condition)
+    .split(".")
+    .some(conditionPartIsTypes);
+
+const stringConditionTargetsForExportTarget = (
+  target: unknown,
+  conditionPath: string,
+): ReadonlyArray<PackageExportConditionTarget> => {
+  if (typeof target === "string") {
+    return [
+      {
+        condition: conditionPath === "" ? "import" : conditionPath,
+        suffix: conditionTargetSuffix(conditionPath),
+        target,
+      },
+    ];
+  }
+  if (Array.isArray(target)) {
+    return target.flatMap((conditionTarget, index) =>
+      stringConditionTargetsForExportTarget(
+        conditionTarget,
+        conditionPath === "" ? "" : `${conditionPath}[${index}]`,
+      ),
+    );
+  }
+  if (typeof target !== "object" || target === null) {
+    return [];
+  }
+  return Object.entries(target).flatMap(([condition, conditionTarget]) => {
+    const childConditionPath = conditionPath === "" ? condition : `${conditionPath}.${condition}`;
+    return stringConditionTargetsForExportTarget(conditionTarget, childConditionPath);
+  });
 };
 
 const exportSpecifierFor = (packageSpecifier: string, exportKey: string): string =>
@@ -1681,6 +1797,44 @@ const hasPackedSourceEntrypoint = (packageName: string, relativeEntrypoint: stri
   isPackedPackageEntrypoint(packageName, relativeEntrypoint) &&
   sourceEntrypointForRelativeDistEntrypoint(packageName, relativeEntrypoint) !== undefined;
 
+const packageExportTargetViolation = ({
+  condition,
+  exportKey,
+  packageDirectoryName,
+  target,
+}: {
+  readonly condition: string;
+  readonly exportKey: string;
+  readonly packageDirectoryName: string;
+  readonly target: string;
+}): string => {
+  const normalizedCondition = conditionWithoutArrayIndexes(condition);
+  if (normalizedCondition === "import" || normalizedCondition === "types") {
+    return `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${target} without a matching packed src entrypoint.`;
+  }
+  return `packages/${packageDirectoryName}/package.json export ${exportKey} condition ${condition} points at ${target} without a matching packed src entrypoint.`;
+};
+
+const packageExportTargetMismatchViolation = ({
+  condition,
+  exportKey,
+  importTarget,
+  packageDirectoryName,
+  target,
+}: {
+  readonly condition: string;
+  readonly exportKey: string;
+  readonly importTarget: string;
+  readonly packageDirectoryName: string;
+  readonly target: string;
+}): string => {
+  const normalizedCondition = conditionWithoutArrayIndexes(condition);
+  if (normalizedCondition === "types") {
+    return `packages/${packageDirectoryName}/package.json export ${exportKey} types target ${target} does not match import target ${importTarget}.`;
+  }
+  return `packages/${packageDirectoryName}/package.json export ${exportKey} condition ${condition} target ${target} does not match import target ${importTarget}.`;
+};
+
 export const packageExportViolationsForManifest = ({
   manifestContents,
   packageDirectoryName,
@@ -1699,6 +1853,22 @@ export const packageExportViolationsForManifest = ({
       violations.push(
         `packages/${packageDirectoryName}/package.json exports ${specifier}: add intentional public specifier approval or remove the export.`,
       );
+    }
+    for (const conditionTarget of stringConditionTargetsForExportTarget(target, "")) {
+      const targetEntrypoint = distTargetEntrypoint(conditionTarget.target, conditionTarget.suffix);
+      if (
+        targetEntrypoint === undefined ||
+        !hasPackedSourceEntrypoint(packageDirectoryName, targetEntrypoint)
+      ) {
+        violations.push(
+          packageExportTargetViolation({
+            condition: conditionTarget.condition,
+            exportKey,
+            packageDirectoryName,
+            target: conditionTarget.target,
+          }),
+        );
+      }
     }
     const importTarget = importTargetForExportTarget(target);
     if (importTarget._tag === "Unsupported") {
@@ -1720,27 +1890,26 @@ export const packageExportViolationsForManifest = ({
     }
     const importEntrypoint = distTargetEntrypoint(importTarget.importTarget, ".js");
     if (
-      importEntrypoint === undefined ||
-      !hasPackedSourceEntrypoint(packageDirectoryName, importEntrypoint)
+      importEntrypoint !== undefined &&
+      hasPackedSourceEntrypoint(packageDirectoryName, importEntrypoint)
     ) {
-      violations.push(
-        `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.importTarget} without a matching packed src entrypoint.`,
-      );
-    }
-    if (importTarget.typesTarget !== undefined) {
-      const typesEntrypoint = distTargetEntrypoint(importTarget.typesTarget, ".d.ts");
-      if (
-        typesEntrypoint === undefined ||
-        !hasPackedSourceEntrypoint(packageDirectoryName, typesEntrypoint)
-      ) {
-        violations.push(
-          `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.typesTarget} without a matching packed src entrypoint.`,
-        );
-      }
-      if (importEntrypoint !== undefined && typesEntrypoint !== undefined && importEntrypoint !== typesEntrypoint) {
-        violations.push(
-          `packages/${packageDirectoryName}/package.json export ${exportKey} types target ${importTarget.typesTarget} does not match import target ${importTarget.importTarget}.`,
-        );
+      for (const conditionTarget of stringConditionTargetsForExportTarget(target, "")) {
+        const targetEntrypoint = distTargetEntrypoint(conditionTarget.target, conditionTarget.suffix);
+        if (
+          targetEntrypoint !== undefined &&
+          hasPackedSourceEntrypoint(packageDirectoryName, targetEntrypoint) &&
+          targetEntrypoint !== importEntrypoint
+        ) {
+          violations.push(
+            packageExportTargetMismatchViolation({
+              condition: conditionTarget.condition,
+              exportKey,
+              importTarget: importTarget.importTarget,
+              packageDirectoryName,
+              target: conditionTarget.target,
+            }),
+          );
+        }
       }
     }
   }

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1536,8 +1536,27 @@ const manifestExportObject = (manifest: PackageManifest): object | undefined => 
   return manifest.exports;
 };
 
+const manifestExportsAreRootConditionMap = (exportsObject: object): boolean => {
+  const keys = Object.keys(exportsObject);
+  return keys.length > 0 && keys.every((key) => !key.startsWith("."));
+};
+
+const manifestExportEntries = (manifest: PackageManifest): ReadonlyArray<readonly [string, unknown]> => {
+  if (typeof manifest.exports === "string") {
+    return [[".", manifest.exports]];
+  }
+  const exportsObject = manifestExportObject(manifest);
+  if (exportsObject === undefined) {
+    return [];
+  }
+  if (manifestExportsAreRootConditionMap(exportsObject)) {
+    return [[".", exportsObject]];
+  }
+  return Object.entries(exportsObject);
+};
+
 const manifestExportKeys = (manifest: PackageManifest): ReadonlyArray<string> =>
-  Object.keys(manifestExportObject(manifest) ?? {});
+  manifestExportEntries(manifest).map(([exportKey]) => exportKey);
 
 const importTargetForExportTarget = (
   target: unknown,
@@ -1569,7 +1588,9 @@ const importTargetForExportTarget = (
 };
 
 const exportSpecifierFor = (packageSpecifier: string, exportKey: string): string =>
-  exportKey === "." ? packageSpecifier : `${packageSpecifier}/${exportKey.slice("./".length)}`;
+  exportKey === "."
+    ? packageSpecifier
+    : `${packageSpecifier}/${exportKey.startsWith("./") ? exportKey.slice("./".length) : exportKey}`;
 
 export const packageExportSpecifiersForManifest = (
   manifestContents: string,
@@ -1587,10 +1608,15 @@ const distTargetEntrypoint = (target: string, suffix: ".d.ts" | ".js"): string |
   if (!target.startsWith(prefix) || !target.endsWith(suffix)) {
     return undefined;
   }
-  return target.slice(prefix.length, -suffix.length);
+  const entrypoint = target.slice(prefix.length, -suffix.length);
+  const segments = entrypoint.split(/[\\/]/);
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    return undefined;
+  }
+  return entrypoint;
 };
 
-const sourceEntrypointForRelativeDistEntrypoint = (
+export const sourceEntrypointForRelativeDistEntrypoint = (
   packageName: string,
   relativeEntrypoint: string,
 ): string | undefined => {
@@ -1602,6 +1628,58 @@ const sourceEntrypointForRelativeDistEntrypoint = (
   const tsxEntrypoint = `${sourceBase}.tsx`;
   return existsSync(tsxEntrypoint) ? tsxEntrypoint : undefined;
 };
+
+export const sourceEntrypointForPackEntry = (entryPath: string): string | undefined => {
+  if (!entryPath.startsWith("src/") || (!entryPath.endsWith(".ts") && !entryPath.endsWith(".tsx"))) {
+    return undefined;
+  }
+  const sourceExtension = entryPath.endsWith(".tsx") ? ".tsx" : ".ts";
+  const relativeEntrypoint = entryPath.slice("src/".length, -sourceExtension.length);
+  const segments = relativeEntrypoint.split(/[\\/]/);
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    return undefined;
+  }
+  return relativeEntrypoint;
+};
+
+export const libraryPackEntrypointPaths = (viteConfigContents: string): ReadonlyArray<string> => {
+  const viteConfigSource = sourceWithoutComments(viteConfigContents);
+  const stringMatch = /pack:\s*libraryPack\(\s*"[^"]+"\s*\)/m.exec(viteConfigSource);
+  if (stringMatch !== null) {
+    const callSource = stringMatch[0];
+    return [callSource.slice(callSource.indexOf('"') + 1, callSource.lastIndexOf('"'))];
+  }
+  const arrayMatch = /pack:\s*libraryPack\(\s*\[[\s\S]*?\]\s*\)/m.exec(viteConfigSource);
+  if (arrayMatch === null) {
+    return [];
+  }
+  const callSource = arrayMatch[0];
+  const arrayEntrypoints = callSource.slice(callSource.indexOf("[") + 1, callSource.lastIndexOf("]"));
+  return Array.from(arrayEntrypoints.matchAll(/"[^"]+"/g), (entrypointMatch) => entrypointMatch[0].slice(1, -1));
+};
+
+export const packedEntrypointsFromViteConfigContents = (viteConfigContents: string): ReadonlySet<string> => {
+  const entrypoints = libraryPackEntrypointPaths(viteConfigContents).flatMap((entryPath) => {
+    const entrypoint = sourceEntrypointForPackEntry(entryPath);
+    return entrypoint === undefined ? [] : [entrypoint];
+  });
+  return new Set(entrypoints);
+};
+
+export const packedPackageEntrypointsForPackage = (packageName: string): ReadonlySet<string> => {
+  const viteConfigPath = join(repoRoot, "packages", packageName, "vite.config.ts");
+  if (!existsSync(viteConfigPath)) {
+    return new Set();
+  }
+  return packedEntrypointsFromViteConfigContents(readFileSync(viteConfigPath, "utf8"));
+};
+
+const isPackedPackageEntrypoint = (packageName: string, relativeEntrypoint: string): boolean =>
+  packedPackageEntrypointsForPackage(packageName).has(relativeEntrypoint);
+
+const hasPackedSourceEntrypoint = (packageName: string, relativeEntrypoint: string): boolean =>
+  isPackedPackageEntrypoint(packageName, relativeEntrypoint) &&
+  sourceEntrypointForRelativeDistEntrypoint(packageName, relativeEntrypoint) !== undefined;
 
 export const packageExportViolationsForManifest = ({
   manifestContents,
@@ -1615,7 +1693,7 @@ export const packageExportViolationsForManifest = ({
     typeof manifest.name === "string" ? manifest.name : `packages/${packageDirectoryName}`;
   const violations: Array<string> = [];
 
-  for (const [exportKey, target] of Object.entries(manifestExportObject(manifest) ?? {})) {
+  for (const [exportKey, target] of manifestExportEntries(manifest)) {
     const specifier = exportSpecifierFor(packageSpecifier, exportKey);
     if (!approvedPublicViewServerSpecifiers.has(specifier)) {
       violations.push(
@@ -1643,20 +1721,20 @@ export const packageExportViolationsForManifest = ({
     const importEntrypoint = distTargetEntrypoint(importTarget.importTarget, ".js");
     if (
       importEntrypoint === undefined ||
-      sourceEntrypointForRelativeDistEntrypoint(packageDirectoryName, importEntrypoint) === undefined
+      !hasPackedSourceEntrypoint(packageDirectoryName, importEntrypoint)
     ) {
       violations.push(
-        `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.importTarget} without a matching src entrypoint.`,
+        `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.importTarget} without a matching packed src entrypoint.`,
       );
     }
     if (importTarget.typesTarget !== undefined) {
       const typesEntrypoint = distTargetEntrypoint(importTarget.typesTarget, ".d.ts");
       if (
         typesEntrypoint === undefined ||
-        sourceEntrypointForRelativeDistEntrypoint(packageDirectoryName, typesEntrypoint) === undefined
+        !hasPackedSourceEntrypoint(packageDirectoryName, typesEntrypoint)
       ) {
         violations.push(
-          `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.typesTarget} without a matching src entrypoint.`,
+          `packages/${packageDirectoryName}/package.json export ${exportKey} points at ${importTarget.typesTarget} without a matching packed src entrypoint.`,
         );
       }
       if (importEntrypoint !== undefined && typesEntrypoint !== undefined && importEntrypoint !== typesEntrypoint) {

--- a/scripts/node-ambient.d.ts
+++ b/scripts/node-ambient.d.ts
@@ -11,6 +11,8 @@ declare module "node:fs" {
   ): Array<Dirent>;
 
   export function readFileSync(path: string, encoding: "utf8"): string;
+
+  export function existsSync(path: string): boolean;
 }
 
 declare module "node:path" {


### PR DESCRIPTION
## Summary
- Extend the internal seam checker to validate package.json public exports, including approved specifiers, stale approvals, runtime import targets, declaration targets, and matching source entrypoints.
- Add coverage for string export targets, unsupported export target shapes, missing import/types targets, mismatched import/types targets, stale approvals, and current repo cleanliness.
- Update the script Node ambient declarations for the stricter standalone seam check.

## Validation
- vp check --fix
- pnpm run check:internal-seams
- pnpm run test:repository-scripts
- pnpm run check:effect
- pnpm run ready

## Review
- 3 local reviewer agents completed the second pass with no findings.