### PR TITLE
Harden Kafka scoped consumer cleanup

### DIFF
--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -51,6 +51,7 @@ import {
   recordKafkaAssignments,
   recordKafkaLag,
   recordKafkaStreamError,
+  registerStartedKafkaConsumerResourcesFinalizer,
   registerKafkaConsumerHealthListeners,
   runKafkaMessageStream,
   sourceTopicsForRegion,
@@ -697,6 +698,73 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("registers started Kafka resource cleanup on scope close", () =>
+    Effect.gen(function* () {
+      let closeForce: boolean | undefined = undefined;
+      let streamCloseCount = 0;
+      const scope = yield* Scope.make();
+      const resources: StartedKafkaConsumerResources = {
+        consumer: {
+          close: (force) => {
+            closeForce = force;
+          },
+        },
+        stream: {
+          close: () => {
+            streamCloseCount += 1;
+          },
+        },
+        healthListeners: () => null,
+      };
+      const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
+
+      yield* registerStartedKafkaConsumerResourcesFinalizer(scope, closeResources);
+      yield* Scope.close(scope, Exit.void);
+
+      expect({
+        closeForce,
+        streamCloseCount,
+      }).toStrictEqual({
+        closeForce: true,
+        streamCloseCount: 1,
+      });
+    }),
+  );
+
+  it.effect("keeps scoped started Kafka resource cleanup idempotent after explicit close", () =>
+    Effect.gen(function* () {
+      let closeForce: boolean | undefined = undefined;
+      let streamCloseCount = 0;
+      const scope = yield* Scope.make();
+      const resources: StartedKafkaConsumerResources = {
+        consumer: {
+          close: (force) => {
+            closeForce = force;
+          },
+        },
+        stream: {
+          close: () => {
+            streamCloseCount += 1;
+          },
+        },
+        healthListeners: () => null,
+      };
+      const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
+
+      yield* registerStartedKafkaConsumerResourcesFinalizer(scope, closeResources);
+      yield* closeResources;
+      yield* Scope.close(scope, Exit.void);
+
+      expect({
+        closeForce,
+        streamCloseCount,
+      }).toStrictEqual({
+        closeForce: true,
+        streamCloseCount: 1,
+      });
+    }),
+  );
+
   it.effect("requests Kafka stream interruption before closing resources", () =>
     Effect.gen(function* () {
       let closeResourcesCount = 0;
@@ -962,13 +1030,17 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         }),
       };
 
+      const successCloseResources =
+        yield* makeStartedKafkaConsumerResourcesFinalizer(successResources);
+      const failedCloseResources =
+        yield* makeStartedKafkaConsumerResourcesFinalizer(failedResources);
       const success = yield* closeKafkaConsumerOnPostConsumeStartupFailure(
-        successResources,
+        successCloseResources,
         Effect.succeed("started"),
       );
       const failedExit = yield* Effect.exit(
         closeKafkaConsumerOnPostConsumeStartupFailure(
-          failedResources,
+          failedCloseResources,
           Effect.fail(kafkaConsumerStartError("local", "post-consume-down")),
         ),
       );
@@ -980,6 +1052,56 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       expect(failedStreamCloseCount).toBe(1);
       expect(failedListenerCloseCount).toBe(1);
       expect(failedCloseForce).toBe(true);
+    }),
+  );
+
+  it.effect("keeps post-consume startup failure cleanup idempotent with scoped cleanup", () =>
+    Effect.gen(function* () {
+      let closeForce: boolean | undefined = undefined;
+      let listenerCloseCount = 0;
+      let streamCloseCount = 0;
+      const scope = yield* Scope.make();
+      const resources: StartedKafkaConsumerResources = {
+        consumer: {
+          close: (force) => {
+            closeForce = force;
+          },
+        },
+        stream: {
+          close: () => {
+            streamCloseCount += 1;
+          },
+        },
+        healthListeners: () => ({
+          close: Effect.sync(() => {
+            listenerCloseCount += 1;
+          }),
+          processed: Effect.succeed(0),
+          waitForProcessed: () => Effect.void,
+        }),
+      };
+      const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
+
+      yield* registerStartedKafkaConsumerResourcesFinalizer(scope, closeResources);
+      const failedExit = yield* Effect.exit(
+        closeKafkaConsumerOnPostConsumeStartupFailure(
+          closeResources,
+          Effect.fail(kafkaConsumerStartError("local", "post-consume-down")),
+        ),
+      );
+      yield* Scope.close(scope, Exit.void);
+
+      expect({
+        closeForce,
+        failed: Exit.isFailure(failedExit),
+        listenerCloseCount,
+        streamCloseCount,
+      }).toStrictEqual({
+        closeForce: true,
+        failed: true,
+        listenerCloseCount: 1,
+        streamCloseCount: 1,
+      });
     }),
   );
 
@@ -3708,6 +3830,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         emptyKafkaOptions,
         ledger,
       );
+      yield* ingress.close;
       yield* ingress.close;
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -496,6 +496,12 @@ export const makeStartedKafkaConsumerResourcesFinalizer = Effect.fn(
   ),
 );
 
+export const registerStartedKafkaConsumerResourcesFinalizer = Effect.fn(
+  "ViewServerRuntime.kafka.consumer.registerStartedResourcesFinalizer",
+)(function* (scope: Scope.Scope, closeResources: Effect.Effect<void, ViewServerKafkaIngressError>) {
+  yield* Scope.addFinalizer(scope, closeResources.pipe(ignoreKafkaStartedResourceCloseFailure));
+});
+
 export const closeStartedKafkaRegionConsumers = Effect.fn(
   "ViewServerRuntime.kafka.regions.closeStartedConsumers",
 )(function* (consumers: ReadonlyArray<StartedKafkaRegionConsumer>) {
@@ -504,11 +510,12 @@ export const closeStartedKafkaRegionConsumers = Effect.fn(
 
 export const closeKafkaConsumerOnPostConsumeStartupFailure = Effect.fn(
   "ViewServerRuntime.kafka.consumer.closeOnPostConsumeStartupFailure",
-)(function* <A, E>(resources: StartedKafkaConsumerResources, startup: Effect.Effect<A, E>) {
+)(function* <A, E>(
+  closeResources: Effect.Effect<void, ViewServerKafkaIngressError>,
+  startup: Effect.Effect<A, E>,
+) {
   return yield* startup.pipe(
-    Effect.onExit((exit) =>
-      Exit.isFailure(exit) ? closeStartedKafkaConsumerResources(resources) : Effect.void,
-    ),
+    Effect.onExit((exit) => (Exit.isFailure(exit) ? closeResources : Effect.void)),
   );
 });
 
@@ -1096,8 +1103,9 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
     stream,
   };
   const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
+  yield* registerStartedKafkaConsumerResourcesFinalizer(scope, closeResources);
   return yield* closeKafkaConsumerOnPostConsumeStartupFailure(
-    resources,
+    closeResources,
     Effect.gen(function* () {
       healthListeners = yield* registerKafkaConsumerHealthListeners(
         consumer,
@@ -1158,6 +1166,37 @@ export const startKafkaRegionConsumers = Effect.fn("ViewServerRuntime.kafka.regi
   },
 );
 
+const makeKafkaIngressClose = (
+  consumers: ReadonlyArray<StartedKafkaRegionConsumer>,
+  scope: Scope.Scope,
+) =>
+  Ref.make(false).pipe(
+    Effect.map((closed) => makeIdempotentKafkaIngressClose(consumers, scope, closed)),
+  );
+
+const makeIdempotentKafkaIngressClose = (
+  consumers: ReadonlyArray<StartedKafkaRegionConsumer>,
+  scope: Scope.Scope,
+  closed: Ref.Ref<boolean>,
+): Effect.Effect<void> => {
+  const closeLock = Semaphore.makeUnsafe(1);
+  return Effect.uninterruptible(
+    closeLock.withPermits(1)(
+      Effect.gen(function* () {
+        const alreadyClosed = yield* Ref.get(closed);
+        if (alreadyClosed) {
+          return;
+        }
+        yield* closeStartedKafkaRegionConsumers(consumers).pipe(
+          ignoreKafkaStartedResourceCloseFailure,
+          Effect.ensuring(Scope.close(scope, Exit.void)),
+        );
+        yield* Ref.set(closed, true);
+      }),
+    ),
+  );
+};
+
 export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
@@ -1196,10 +1235,8 @@ export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntime
       );
     },
   ).pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)));
+  const close = yield* makeKafkaIngressClose(consumers, scope);
   return {
-    close: closeStartedKafkaRegionConsumers(consumers).pipe(
-      ignoreKafkaStartedResourceCloseFailure,
-      Effect.ensuring(Scope.close(scope, Exit.void)),
-    ),
+    close,
   };
 });


### PR DESCRIPTION
## Summary
- register started Kafka consumer resources on the ingress scope so parent-scope shutdown releases partially-started consumers
- route post-consume startup failure cleanup through the same idempotent close finalizer
- add regressions for scoped cleanup, explicit close + scope close, and startup failure + scope close double-close behavior

## Validation
- pnpm --filter @view-server/runtime run test
- pnpm exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict
- vp check --fix
- pnpm run ready

## Review
- 3 reviewer agents found the original double-close bug
- after the fix, all 3 reviewer agents reported no blockers
