### PR TITLE
Record Kafka stream producer defects

### DIFF
--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -18,6 +18,8 @@ import {
   Exit,
   Fiber,
   Logger,
+  Option,
+  Queue,
   References,
   Schema,
   Scope,
@@ -47,6 +49,7 @@ import {
   mapKafkaConsumerStartError,
   mapKafkaStreamError,
   messageFromUnknown,
+  offerKafkaStreamProducerFailure,
   processKafkaMessage,
   recordKafkaAssignments,
   recordKafkaLag,
@@ -60,6 +63,7 @@ import {
 import type {
   StartedKafkaConsumerResources,
   StartedKafkaRegionConsumer,
+  KafkaStreamQueueEvent,
   ViewServerKafkaIngressError,
 } from "./kafka-ingress";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
@@ -3036,6 +3040,120 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       });
 
       yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("offers typed Kafka stream producer failures without remapping", () =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<KafkaStreamQueueEvent>();
+      const streamError = kafkaStreamError("local", "typed producer failure");
+
+      yield* offerKafkaStreamProducerFailure("local", queue, Cause.fail(streamError));
+      const event = yield* Queue.take(queue);
+
+      expect(event).toStrictEqual({
+        _tag: "Failed",
+        error: streamError,
+      });
+    }),
+  );
+
+  it.effect("does not enqueue Kafka stream producer interrupts as failures", () =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<KafkaStreamQueueEvent>();
+
+      const producerExit = yield* Effect.exit(
+        offerKafkaStreamProducerFailure("local", queue, Cause.interrupt()),
+      );
+      const queueEvent = yield* Queue.poll(queue);
+
+      expect({
+        producerInterrupted: Exit.hasInterrupts(producerExit),
+        queueEmpty: Option.isNone(queueEvent),
+      }).toStrictEqual({
+        producerInterrupted: true,
+        queueEmpty: true,
+      });
+    }),
+  );
+
+  it.effect("records Kafka stream producer defects that happen before iterator creation", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      yield* Effect.gen(function* () {
+        const ledger = makeViewServerKafkaHealthLedger<Topics>({
+          regions: kafkaOptions.regions,
+          topics: {
+            [ordersSourceTopic]: {
+              regions: ["local"],
+              viewServerTopic: "orders",
+            },
+          },
+        });
+        yield* ledger.regionConnected("local", 1_000);
+        yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+        const defectiveStream: AsyncIterable<KafkaMessage> = {
+          [Symbol.asyncIterator]: () => {
+            throw new Error("stream-iterator-defect");
+          },
+        };
+
+        const error = yield* Effect.flip(
+          runKafkaMessageStream(
+            viewServer,
+            runtimeCore.client,
+            runtimeCore.requestHealthRefresh,
+            kafkaOptions,
+            ledger,
+            "local",
+            defectiveStream,
+          ).pipe(
+            Effect.timeout("1 second"),
+            Effect.catchTag("TimeoutError", (error) =>
+              Effect.fail(kafkaStreamError("local", error)),
+            ),
+          ),
+        );
+        const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+        expect({
+          error: {
+            message: error.message,
+            region: error.region,
+            sourceTopic: error.sourceTopic,
+          },
+          kafkaTopic: health.kafka?.topics[ordersSourceTopic],
+        }).toStrictEqual({
+          error: {
+            message: "Kafka stream failed for region local",
+            region: "local",
+            sourceTopic: undefined,
+          },
+          kafkaTopic: {
+            status: "degraded",
+            sourceTopic: ordersSourceTopic,
+            viewServerTopic: "orders",
+            regions: nullRecord({
+              local: {
+                connected: false,
+                assignedPartitions: 0,
+                messagesPerSecond: 0,
+                bytesPerSecond: 0,
+                decodedMessagesPerSecond: 0,
+                decodeFailuresPerSecond: 0,
+                mappingFailuresPerSecond: 0,
+                processingFailuresPerSecond: 0,
+                lastMessageAt: null,
+                lastCommitAt: null,
+                consumerLagMessages: null,
+                lagSampledAt: null,
+                committedOffset: null,
+                lastError: "Kafka stream failed for region local",
+              },
+            }),
+          },
+        });
+      }).pipe(Effect.ensuring(runtimeCore.close));
     }),
   );
 

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -76,7 +76,7 @@ export type StartedKafkaConsumerResources = {
 };
 type KafkaMessageBytes = Buffer | null | undefined;
 type KafkaConsumerMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
-type KafkaStreamQueueEvent =
+export type KafkaStreamQueueEvent =
   | {
       readonly _tag: "Message";
       readonly message: KafkaConsumerMessage;
@@ -794,6 +794,26 @@ const closeKafkaAsyncIterator = Effect.fn("ViewServerRuntime.kafka.stream.closeI
   },
 );
 
+export const offerKafkaStreamProducerFailure = Effect.fn(
+  "ViewServerRuntime.kafka.stream.offerProducerFailure",
+)(function* (
+  region: string,
+  queue: Queue.Enqueue<KafkaStreamQueueEvent>,
+  cause: Cause.Cause<unknown>,
+) {
+  if (Cause.hasInterruptsOnly(cause)) {
+    return yield* Effect.failCause(cause);
+  }
+  const error = Cause.findErrorOption(cause).pipe(
+    Option.filter((value) => value instanceof ViewServerKafkaIngressError),
+    Option.getOrElse(() => kafkaStreamError(region, Cause.squash(cause))),
+  );
+  yield* Queue.offer(queue, {
+    _tag: "Failed",
+    error,
+  });
+});
+
 const takeKafkaMessageBatch: (
   queue: Queue.Dequeue<KafkaStreamQueueEvent>,
 ) => Effect.Effect<KafkaMessageBatchTakeResult> = Effect.fn(
@@ -861,6 +881,7 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
     Effect.gen(function* () {
       const queue = yield* Queue.bounded<KafkaStreamQueueEvent>(kafkaMessageQueueCapacity);
       yield* produceKafkaStreamQueueEvents(region, stream, queue).pipe(
+        Effect.catchCause((cause) => offerKafkaStreamProducerFailure(region, queue, cause)),
         Effect.forkScoped({ startImmediately: true }),
       );
       while (true) {


### PR DESCRIPTION
## Summary
- Bridge producer-side Kafka stream defects into the stream queue so consumers do not hang waiting on Queue.take.
- Preserve interrupt-only causes as interrupts and preserve typed ViewServerKafkaIngressError failures without remapping.
- Add internal regressions for typed producer failures, interrupt-only causes, and pre-iterator producer defects degrading Kafka health.

## Validation
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict
- pnpm run check:effect
- vp run @view-server/runtime#build
- vp test run src/kafka-ingress.internal.test.ts (from packages/runtime)
- vp run --filter '@view-server/*' --filter '!@view-server/runtime' test
- pnpm run check:package-exports
- pnpm run check:internal-seams

## Local blocker
- pnpm --filter @view-server/runtime run test is blocked locally because OrbStack/Docker socket is unavailable: unix:///Users/bruno/.orbstack/run/docker.sock.