### PR TITLE
Add Kafka throughput benchmark gates

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,3 +36,8 @@ pnpm run bench:baseline:kafka-sustained-firehose
 uses the same Vitest benchmark file in `sustained-firehose` mode and sends repeated mixed producer
 batches before waiting for final View Server convergence. Both profiles require exact Kafka lane
 completeness in their summary artifacts: produced rows, engine rows, and committed offsets must agree.
+They also record per-case write-path throughput from benchmark operation timers. The baseline gate
+compares exact produced-row/sample metadata and guards `aggregateRowsPerSecond`, which is total rows
+divided by total measured time across samples; per-sample mean/min rows-per-second stay in the
+artifact for diagnosis but are intentionally not the regression gate because tiny Kafka sample sets
+can contain one unusually fast or slow sample.

--- a/benchmarks/baselines/grouped-admission.json
+++ b/benchmarks/baselines/grouped-admission.json
@@ -495,6 +495,9 @@
     "memoryRssTotalDelta": {
       "maxAbsoluteDeltaBytes": 134217728,
       "maxRatio": 3
+    },
+    "throughputAggregateRowsPerSecond": {
+      "minRatio": 0.5
     }
   }
 }

--- a/benchmarks/baselines/grouped-order-neutral.json
+++ b/benchmarks/baselines/grouped-order-neutral.json
@@ -306,6 +306,9 @@
     "memoryRssTotalDelta": {
       "maxAbsoluteDeltaBytes": 134217728,
       "maxRatio": 3
+    },
+    "throughputAggregateRowsPerSecond": {
+      "minRatio": 0.5
     }
   }
 }

--- a/benchmarks/baselines/kafka-ingest.json
+++ b/benchmarks/baselines/kafka-ingest.json
@@ -8,29 +8,29 @@
       "benchmarks": [
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
-          "maxMs": 3406.2726249999996,
-          "meanMs": 1944.4125413333331,
-          "minMs": 71.838708,
+          "maxMs": 2962.213417,
+          "meanMs": 2117.013111333333,
+          "minMs": 1013.6805839999997,
           "name": "json source batch ingest",
-          "p99Ms": 3406.2726249999996,
+          "p99Ms": 2962.213417,
           "sampleCount": 3
         },
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
-          "maxMs": 2982.8575,
-          "meanMs": 1721.2695416666668,
-          "minMs": 287.6083749999998,
+          "maxMs": 3543.3476660000015,
+          "meanMs": 2087.3185000000008,
+          "minMs": 657.0101250000007,
           "name": "protobuf source batch ingest",
-          "p99Ms": 2982.8575,
+          "p99Ms": 3543.3476660000015,
           "sampleCount": 3
         },
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
-          "maxMs": 18343.525208,
-          "meanMs": 16875.485707999997,
-          "minMs": 16103.604999999996,
+          "maxMs": 16405.198791000003,
+          "meanMs": 15955.671625000003,
+          "minMs": 15722.523917000006,
           "name": "mixed source burst ingest",
-          "p99Ms": 18343.525208,
+          "p99Ms": 16405.198791000003,
           "sampleCount": 3
         }
       ],
@@ -59,7 +59,7 @@
         }
       ],
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 54165504,
+      "memoryRssTotalDeltaBytes": 60243968,
       "minimumSampleCount": 3,
       "mutationCount": 7500,
       "outputJsonPath": "packages/runtime/.artifacts/kafka-ingest-250rows.json",
@@ -68,6 +68,47 @@
       "subscriberCount": 0,
       "summaryPath": "packages/runtime/.artifacts/kafka-ingest-250rows.summary.json",
       "taskLabel": "Kafka ingest 250 rows",
+      "throughputCases": [
+        {
+          "aggregateRowsPerSecond": 118.0970696246749,
+          "maxTotalMs": 2962.1625839999997,
+          "meanConvergenceMs": 2107.5846946666666,
+          "meanProducerSendMs": 9.317958333333308,
+          "meanRowsPerSecond": 145.43281939281385,
+          "meanTotalMs": 2116.9026529999996,
+          "minRowsPerSecond": 84.3977981999924,
+          "name": "json source batch ingest",
+          "producedRowsPerSample": 250,
+          "sampleCount": 3,
+          "totalProducedRows": 750
+        },
+        {
+          "aggregateRowsPerSecond": 125.34805455415228,
+          "maxTotalMs": 16404.941625,
+          "meanConvergenceMs": 15930.856736,
+          "meanProducerSendMs": 22.192333333331288,
+          "meanRowsPerSecond": 125.39712038907889,
+          "meanTotalMs": 15955.572721999999,
+          "minRowsPerSecond": 121.91448441073011,
+          "name": "mixed source burst ingest",
+          "producedRowsPerSample": 2000,
+          "sampleCount": 3,
+          "totalProducedRows": 6000
+        },
+        {
+          "aggregateRowsPerSecond": 119.77642054235885,
+          "maxTotalMs": 3543.2975000000006,
+          "meanConvergenceMs": 2078.2093473333325,
+          "meanProducerSendMs": 9.012819333333331,
+          "meanRowsPerSecond": 190.7868134200885,
+          "meanTotalMs": 2087.222166666666,
+          "minRowsPerSecond": 70.55574644804733,
+          "name": "protobuf source batch ingest",
+          "producedRowsPerSample": 250,
+          "sampleCount": 3,
+          "totalProducedRows": 750
+        }
+      ],
       "topics": ["jsonOrders", "protobufOrders"]
     }
   ],
@@ -83,6 +124,9 @@
     "memoryRssTotalDelta": {
       "maxAbsoluteDeltaBytes": 134217728,
       "maxRatio": 3
+    },
+    "throughputAggregateRowsPerSecond": {
+      "minRatio": 0.75
     }
   }
 }

--- a/benchmarks/baselines/kafka-sustained-firehose.json
+++ b/benchmarks/baselines/kafka-sustained-firehose.json
@@ -8,11 +8,11 @@
       "benchmarks": [
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka sustained firehose runtime benchmark: 250 rows per producer batch",
-          "maxMs": 17703.534,
-          "meanMs": 16595.067319666665,
-          "minMs": 15888.604874999997,
+          "maxMs": 16871.110041,
+          "meanMs": 16266.416902666666,
+          "minMs": 15622.850625,
           "name": "sustained mixed firehose ingest",
-          "p99Ms": 17703.534,
+          "p99Ms": 16871.110041,
           "sampleCount": 3
         }
       ],
@@ -37,7 +37,7 @@
         }
       ],
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 10731520,
+      "memoryRssTotalDeltaBytes": 34209792,
       "minimumSampleCount": 3,
       "mutationCount": 6000,
       "outputJsonPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.json",
@@ -46,6 +46,21 @@
       "subscriberCount": 0,
       "summaryPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.summary.json",
       "taskLabel": "Kafka sustained firehose 250 rows x 4 batches",
+      "throughputCases": [
+        {
+          "aggregateRowsPerSecond": 122.95339022943404,
+          "maxTotalMs": 16870.902042,
+          "meanConvergenceMs": 16221.077291333335,
+          "meanProducerSendMs": 42.13241666666772,
+          "meanRowsPerSecond": 123.0749977311353,
+          "meanTotalMs": 16266.326583333335,
+          "minRowsPerSecond": 118.54730677832241,
+          "name": "sustained mixed firehose ingest",
+          "producedRowsPerSample": 2000,
+          "sampleCount": 3,
+          "totalProducedRows": 6000
+        }
+      ],
       "topics": ["jsonOrders", "protobufOrders"]
     }
   ],
@@ -61,6 +76,9 @@
     "memoryRssTotalDelta": {
       "maxAbsoluteDeltaBytes": 134217728,
       "maxRatio": 3
+    },
+    "throughputAggregateRowsPerSecond": {
+      "minRatio": 0.75
     }
   }
 }

--- a/benchmarks/baselines/smoke.json
+++ b/benchmarks/baselines/smoke.json
@@ -1077,6 +1077,9 @@
     "memoryRssTotalDelta": {
       "maxAbsoluteDeltaBytes": 134217728,
       "maxRatio": 3
+    },
+    "throughputAggregateRowsPerSecond": {
+      "minRatio": 0.5
     }
   }
 }

--- a/packages/runtime/src/kafka-ingest.bench.ts
+++ b/packages/runtime/src/kafka-ingest.bench.ts
@@ -8,6 +8,7 @@ import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/
 import { Buffer } from "node:buffer";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { Crypto, Effect, Exit, Schedule, Schema } from "effect";
 import { makeViewServerRuntime, type ViewServerRuntime } from "./index";
 import { OrderKeySchema, OrderValueSchema } from "./test-fixtures/runtime_orders_pb";
@@ -50,6 +51,29 @@ type BenchmarkProfile = {
 type BenchmarkCase = {
   readonly name: string;
   readonly run: () => Promise<void>;
+};
+
+type IngestSample = {
+  readonly convergenceMs: number;
+  readonly name: string;
+  readonly producerSendMs: number;
+  readonly rows: number;
+  readonly rowsPerSecond: number;
+  readonly totalMs: number;
+};
+
+type IngestThroughputCaseSummary = {
+  readonly aggregateRowsPerSecond: number;
+  readonly maxTotalMs: number;
+  readonly meanConvergenceMs: number;
+  readonly meanProducerSendMs: number;
+  readonly meanRowsPerSecond: number;
+  readonly meanTotalMs: number;
+  readonly minRowsPerSecond: number;
+  readonly name: string;
+  readonly producedRowsPerSample: number;
+  readonly sampleCount: number;
+  readonly totalProducedRows: number;
 };
 
 class KafkaIngestBenchmarkError extends Schema.TaggedErrorClass<KafkaIngestBenchmarkError>()(
@@ -195,6 +219,7 @@ const profile: BenchmarkProfile = {
   stringProducer: undefined,
 };
 
+const ingestSamples: Array<IngestSample> = [];
 const internalTopicNames = ["jsonOrders", "protobufOrders"] as const;
 
 function memorySnapshot(): BenchmarkMemorySnapshot {
@@ -425,18 +450,27 @@ const waitForRows = Effect.fn("ViewServerRuntime.kafka.bench.waitForRows")(funct
   topic: "jsonOrders" | "protobufOrders",
   expectedRows: number,
 ) {
+  const expectedSourceTopic =
+    topic === "jsonOrders" ? sourceTopics().jsonOrders : sourceTopics().protobufOrders;
   const health = yield* startedRuntime()
     .client.health()
     .pipe(
       Effect.repeat({
         schedule: healthPollSchedule,
-        until: (currentHealth) => currentHealth.engine.topics[topic].rowCount === expectedRows,
+        until: (currentHealth) =>
+          currentHealth.engine.topics[topic].rowCount === expectedRows &&
+          committedOffset(currentHealth, expectedSourceTopic) === expectedRows,
       }),
     );
   const actualRows = health.engine.topics[topic].rowCount;
-  if (actualRows !== expectedRows) {
+  const actualCommittedOffset = committedOffset(health, expectedSourceTopic);
+  if (actualRows !== expectedRows || actualCommittedOffset !== expectedRows) {
     return yield* new KafkaIngestBenchmarkError({
-      message: `Kafka ingest benchmark ${topic} did not converge: expected exactly ${expectedRows} row(s), got ${actualRows}.`,
+      message: [
+        `Kafka ingest benchmark ${topic} did not converge.`,
+        `rows=${actualRows}/${expectedRows}`,
+        `committedOffset=${actualCommittedOffset}/${expectedRows}`,
+      ].join(" "),
     });
   }
   return health;
@@ -490,35 +524,6 @@ const waitForFinalHealth = Effect.fn("ViewServerRuntime.kafka.bench.waitForFinal
   },
 );
 
-const publishJsonBatch = async (count: number): Promise<void> => {
-  const nextTotal = profile.jsonProducedRows + count;
-  await stringProducer().send({
-    messages: jsonMessages(sourceTopics().jsonOrders, profile.jsonProducedRows, count),
-  });
-  profile.jsonProducedRows = nextTotal;
-  await Effect.runPromise(waitForRows("jsonOrders", nextTotal));
-};
-
-const publishProtobufBatch = async (count: number): Promise<void> => {
-  const nextTotal = profile.protobufProducedRows + count;
-  await binaryProducer().send({
-    messages: protobufMessages(sourceTopics().protobufOrders, profile.protobufProducedRows, count),
-  });
-  profile.protobufProducedRows = nextTotal;
-  await Effect.runPromise(waitForRows("protobufOrders", nextTotal));
-};
-
-const publishMixedBatch = async (count: number): Promise<void> => {
-  const results = await Promise.allSettled([publishJsonBatch(count), publishProtobufBatch(count)]);
-  const failures = results.filter((result) => result.status === "rejected");
-  if (failures.length > 0) {
-    throw new AggregateError(
-      failures.map((failure) => failure.reason),
-      `Kafka ingest benchmark mixed burst failed in ${failures.length} lane(s).`,
-    );
-  }
-};
-
 const topicHealthValues = (health: ViewServerHealth<Topics>) =>
   internalTopicNames.map((topic) => health.engine.topics[topic]);
 
@@ -547,35 +552,194 @@ const backpressureCountFromHealth = (health: ViewServerHealth<Topics>): number =
   return backpressureCount;
 };
 
-const publishJsonBatchWithoutWaiting = async (count: number): Promise<void> => {
-  await stringProducer().send({
-    messages: jsonMessages(sourceTopics().jsonOrders, profile.jsonProducedRows, count),
-  });
-  profile.jsonProducedRows += count;
+const timed = async <A>(operation: () => Promise<A>): Promise<readonly [A, number]> => {
+  const startedAt = performance.now();
+  const value = await operation();
+  return [value, performance.now() - startedAt];
 };
 
-const publishProtobufBatchWithoutWaiting = async (count: number): Promise<void> => {
-  await binaryProducer().send({
-    messages: protobufMessages(sourceTopics().protobufOrders, profile.protobufProducedRows, count),
+const recordIngestSample = ({
+  convergenceMs,
+  name,
+  producerSendMs,
+  rows,
+  totalMs,
+}: Omit<IngestSample, "rowsPerSecond">): void => {
+  ingestSamples.push({
+    convergenceMs,
+    name,
+    producerSendMs,
+    rows,
+    rowsPerSecond: rows / (totalMs / 1_000),
+    totalMs,
   });
+};
+
+const mean = (values: ReadonlyArray<number>): number =>
+  values.reduce((total, value) => total + value, 0) / values.length;
+
+const settledValuesOrThrow = <A>(
+  results: ReadonlyArray<PromiseSettledResult<A>>,
+  message: string,
+): ReadonlyArray<A> => {
+  const values: Array<A> = [];
+  const failures: Array<unknown> = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      values.push(result.value);
+    } else {
+      failures.push(result.reason);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, message);
+  }
+  return values;
+};
+
+const ingestThroughputCases = (): ReadonlyArray<IngestThroughputCaseSummary> => {
+  const samplesByName = Map.groupBy(ingestSamples, (sample) => sample.name);
+  return [...samplesByName.entries()]
+    .map(([name, samples]) => {
+      const totalProducedRows = samples.reduce((total, sample) => total + sample.rows, 0);
+      const totalMs = samples.reduce((total, sample) => total + sample.totalMs, 0);
+      return {
+        aggregateRowsPerSecond: totalProducedRows / (totalMs / 1_000),
+        maxTotalMs: Math.max(...samples.map((sample) => sample.totalMs)),
+        meanConvergenceMs: mean(samples.map((sample) => sample.convergenceMs)),
+        meanProducerSendMs: mean(samples.map((sample) => sample.producerSendMs)),
+        meanRowsPerSecond: mean(samples.map((sample) => sample.rowsPerSecond)),
+        meanTotalMs: mean(samples.map((sample) => sample.totalMs)),
+        minRowsPerSecond: Math.min(...samples.map((sample) => sample.rowsPerSecond)),
+        name,
+        producedRowsPerSample: samples[0]?.rows ?? 0,
+        sampleCount: samples.length,
+        totalProducedRows,
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+};
+
+const publishJsonBatchTimed = async (count: number) => {
+  const nextTotal = profile.jsonProducedRows + count;
+  const [_sendResult, producerSendMs] = await timed(() =>
+    stringProducer().send({
+      messages: jsonMessages(sourceTopics().jsonOrders, profile.jsonProducedRows, count),
+    }),
+  );
+  profile.jsonProducedRows = nextTotal;
+  const [_health, convergenceMs] = await timed(() =>
+    Effect.runPromise(waitForRows("jsonOrders", nextTotal)),
+  );
+  return {
+    convergenceMs,
+    producerSendMs,
+    rows: count,
+    totalMs: producerSendMs + convergenceMs,
+  };
+};
+
+const publishProtobufBatchTimed = async (count: number) => {
+  const nextTotal = profile.protobufProducedRows + count;
+  const [_sendResult, producerSendMs] = await timed(() =>
+    binaryProducer().send({
+      messages: protobufMessages(
+        sourceTopics().protobufOrders,
+        profile.protobufProducedRows,
+        count,
+      ),
+    }),
+  );
+  profile.protobufProducedRows = nextTotal;
+  const [_health, convergenceMs] = await timed(() =>
+    Effect.runPromise(waitForRows("protobufOrders", nextTotal)),
+  );
+  return {
+    convergenceMs,
+    producerSendMs,
+    rows: count,
+    totalMs: producerSendMs + convergenceMs,
+  };
+};
+
+const publishJsonBatchWithoutWaiting = async (count: number): Promise<number> => {
+  const [_sendResult, producerSendMs] = await timed(() =>
+    stringProducer().send({
+      messages: jsonMessages(sourceTopics().jsonOrders, profile.jsonProducedRows, count),
+    }),
+  );
+  profile.jsonProducedRows += count;
+  return producerSendMs;
+};
+
+const publishProtobufBatchWithoutWaiting = async (count: number): Promise<number> => {
+  const [_sendResult, producerSendMs] = await timed(() =>
+    binaryProducer().send({
+      messages: protobufMessages(
+        sourceTopics().protobufOrders,
+        profile.protobufProducedRows,
+        count,
+      ),
+    }),
+  );
   profile.protobufProducedRows += count;
+  return producerSendMs;
+};
+
+const publishJsonBatch = async (count: number): Promise<void> => {
+  const sample = await publishJsonBatchTimed(count);
+  recordIngestSample({
+    ...sample,
+    name: "json source batch ingest",
+  });
+};
+
+const publishProtobufBatch = async (count: number): Promise<void> => {
+  const sample = await publishProtobufBatchTimed(count);
+  recordIngestSample({
+    ...sample,
+    name: "protobuf source batch ingest",
+  });
+};
+
+const publishMixedBatch = async (count: number): Promise<void> => {
+  const startedAt = performance.now();
+  const results = await Promise.allSettled([
+    publishJsonBatchTimed(count),
+    publishProtobufBatchTimed(count),
+  ]);
+  const samples = settledValuesOrThrow(results, "Kafka ingest benchmark mixed burst failed.");
+  recordIngestSample({
+    convergenceMs: Math.max(...samples.map((sample) => sample.convergenceMs)),
+    name: "mixed source burst ingest",
+    producerSendMs: Math.max(...samples.map((sample) => sample.producerSendMs)),
+    rows: samples.reduce((total, sample) => total + sample.rows, 0),
+    totalMs: performance.now() - startedAt,
+  });
 };
 
 const publishSustainedMixedFirehose = async (): Promise<void> => {
+  const startedAt = performance.now();
+  let producerSendMs = 0;
   for (let batchIndex = 0; batchIndex < sustainedBatchCount; batchIndex += 1) {
     const results = await Promise.allSettled([
       publishJsonBatchWithoutWaiting(batchSize),
       publishProtobufBatchWithoutWaiting(batchSize),
     ]);
-    const failures = results.filter((result) => result.status === "rejected");
-    if (failures.length > 0) {
-      throw new AggregateError(
-        failures.map((failure) => failure.reason),
-        `Kafka ingest benchmark sustained firehose batch ${batchIndex} failed in ${failures.length} lane(s).`,
-      );
-    }
+    const sendDurations = settledValuesOrThrow(
+      results,
+      `Kafka ingest benchmark sustained firehose batch ${batchIndex} failed.`,
+    );
+    producerSendMs += Math.max(...sendDurations);
   }
-  await Effect.runPromise(waitForFinalHealth());
+  const [_health, convergenceMs] = await timed(() => Effect.runPromise(waitForFinalHealth()));
+  recordIngestSample({
+    convergenceMs,
+    name: "sustained mixed firehose ingest",
+    producerSendMs,
+    rows: batchSize * sustainedBatchCount * 2,
+    totalMs: performance.now() - startedAt,
+  });
 };
 
 beforeAll(async () => {
@@ -671,6 +835,10 @@ afterAll(async () => {
     rowCount: batchSize,
     subscriberCount: 0,
     topics: ["jsonOrders", "protobufOrders"],
+    throughput: {
+      cases: ingestThroughputCases(),
+      source: "benchmark-operation-timers",
+    },
   });
   if (Exit.isFailure(finalHealthExit)) {
     throw new Error(

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -647,6 +647,7 @@ describe("benchmark baseline runner", () => {
             groupedKeyWidthParameters: undefined,
             outputJsonPath: task.outputJsonPath,
             summaryPath: task.summaryPath,
+            throughputCases: undefined,
           },
         ],
         thresholds: {
@@ -661,6 +662,9 @@ describe("benchmark baseline runner", () => {
           memoryRssTotalDelta: {
             maxAbsoluteDeltaBytes: 134217728,
             maxRatio: 3,
+          },
+          throughputAggregateRowsPerSecond: {
+            minRatio: 0.5,
           },
         },
       },
@@ -828,6 +832,9 @@ describe("benchmark baseline runner", () => {
         memoryRssTotalDelta: {
           maxAbsoluteDeltaBytes: 134217728,
           maxRatio: 3,
+        },
+        throughputAggregateRowsPerSecond: {
+          minRatio: 0.5,
         },
       },
     });

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -14,6 +14,9 @@ export const defaultBenchmarkThresholds = {
     maxAbsoluteDeltaBytes: 128 * 1024 * 1024,
     maxRatio: 3,
   },
+  throughputAggregateRowsPerSecond: {
+    minRatio: 0.5,
+  },
 };
 
 export const groupedOrderNeutralBenchmarkThresholds = {
@@ -26,6 +29,8 @@ export const groupedOrderNeutralBenchmarkThresholds = {
     maxRatio: 6,
   },
   memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+  throughputAggregateRowsPerSecond:
+    defaultBenchmarkThresholds.throughputAggregateRowsPerSecond,
 };
 
 export const kafkaIngestBenchmarkThresholds = {
@@ -38,6 +43,9 @@ export const kafkaIngestBenchmarkThresholds = {
     maxRatio: 1.5,
   },
   memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+  throughputAggregateRowsPerSecond: {
+    minRatio: 0.75,
+  },
 };
 
 export const kafkaSustainedFirehoseBenchmarkThresholds = {
@@ -50,6 +58,9 @@ export const kafkaSustainedFirehoseBenchmarkThresholds = {
     maxRatio: 1.75,
   },
   memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+  throughputAggregateRowsPerSecond: {
+    minRatio: 0.75,
+  },
 };
 
 export const benchmarkThresholdsForProfile = (profile) =>
@@ -104,6 +115,14 @@ const optionalArrayValue = (value, path) =>
 
 const optionalFiniteNumber = (value, path) =>
   value === undefined ? undefined : finiteNumber(value, path);
+
+const positiveFiniteNumber = (value, path) => {
+  const number = finiteNumber(value, path);
+  if (number <= 0) {
+    throw new Error(`Benchmark artifact field ${path} must be a positive finite number.`);
+  }
+  return number;
+};
 
 const stringArrayValue = (value, path) =>
   arrayValue(value, path).map((item, index) => stringValue(item, `${path}[${index}]`));
@@ -201,6 +220,130 @@ const comparableKafkaIngestLaneValue = (value, path) => {
     region: stringValue(lane.region, `${path}.region`),
     sourceTopicAlias: stringValue(lane.sourceTopicAlias, `${path}.sourceTopicAlias`),
   };
+};
+
+const throughputCaseValue = (value, path) => {
+  const throughputCase = objectValue(value, path);
+  const result = {
+    aggregateRowsPerSecond: positiveFiniteNumber(
+      throughputCase.aggregateRowsPerSecond,
+      `${path}.aggregateRowsPerSecond`,
+    ),
+    maxTotalMs: positiveFiniteNumber(throughputCase.maxTotalMs, `${path}.maxTotalMs`),
+    meanConvergenceMs: positiveFiniteNumber(
+      throughputCase.meanConvergenceMs,
+      `${path}.meanConvergenceMs`,
+    ),
+    meanProducerSendMs: positiveFiniteNumber(
+      throughputCase.meanProducerSendMs,
+      `${path}.meanProducerSendMs`,
+    ),
+    meanRowsPerSecond: positiveFiniteNumber(
+      throughputCase.meanRowsPerSecond,
+      `${path}.meanRowsPerSecond`,
+    ),
+    meanTotalMs: positiveFiniteNumber(throughputCase.meanTotalMs, `${path}.meanTotalMs`),
+    minRowsPerSecond: positiveFiniteNumber(throughputCase.minRowsPerSecond, `${path}.minRowsPerSecond`),
+    name: stringValue(throughputCase.name, `${path}.name`),
+    producedRowsPerSample: positiveInteger(
+      throughputCase.producedRowsPerSample,
+      `${path}.producedRowsPerSample`,
+    ),
+    sampleCount: positiveInteger(throughputCase.sampleCount, `${path}.sampleCount`),
+    totalProducedRows: positiveInteger(
+      throughputCase.totalProducedRows,
+      `${path}.totalProducedRows`,
+    ),
+  };
+  const expectedTotalProducedRows = result.producedRowsPerSample * result.sampleCount;
+  if (result.totalProducedRows !== expectedTotalProducedRows) {
+    throw new Error(
+      `Benchmark artifact field ${path}.totalProducedRows must equal producedRowsPerSample * sampleCount (${expectedTotalProducedRows}).`,
+    );
+  }
+  const expectedAggregateRowsPerSecond = (result.producedRowsPerSample * 1000) / result.meanTotalMs;
+  const aggregateTolerance = Math.max(1e-9, expectedAggregateRowsPerSecond * 1e-9);
+  if (Math.abs(result.aggregateRowsPerSecond - expectedAggregateRowsPerSecond) > aggregateTolerance) {
+    throw new Error(
+      `Benchmark artifact field ${path}.aggregateRowsPerSecond must match producedRowsPerSample * 1000 / meanTotalMs.`,
+    );
+  }
+  if (result.minRowsPerSecond > result.meanRowsPerSecond) {
+    throw new Error(
+      `Benchmark artifact field ${path}.minRowsPerSecond must be less than or equal to meanRowsPerSecond.`,
+    );
+  }
+  if (result.meanTotalMs > result.maxTotalMs) {
+    throw new Error(
+      `Benchmark artifact field ${path}.meanTotalMs must be less than or equal to maxTotalMs.`,
+    );
+  }
+  if (result.meanProducerSendMs > result.meanTotalMs) {
+    throw new Error(
+      `Benchmark artifact field ${path}.meanProducerSendMs must be less than or equal to meanTotalMs.`,
+    );
+  }
+  if (result.meanConvergenceMs > result.meanTotalMs) {
+    throw new Error(
+      `Benchmark artifact field ${path}.meanConvergenceMs must be less than or equal to meanTotalMs.`,
+    );
+  }
+  return result;
+};
+
+const throughputCasesValue = (value, path) => {
+  const throughput = objectValue(value, path);
+  const source = stringValue(throughput.source, `${path}.source`);
+  if (source !== "benchmark-operation-timers") {
+    throw new Error(`Benchmark artifact field ${path}.source must be benchmark-operation-timers.`);
+  }
+  return nonEmptyArrayValue(throughput.cases, `${path}.cases`).map((throughputCase, index) =>
+    throughputCaseValue(throughputCase, `${path}.cases[${index}]`),
+  );
+};
+
+const validateThroughputCasesMatchBenchmarks = (throughputCases, benchmarks, path) => {
+  const benchmarkSampleCountByName = new Map();
+  for (const benchmark of benchmarks) {
+    const previousSampleCount = benchmarkSampleCountByName.get(benchmark.name);
+    if (previousSampleCount !== undefined && previousSampleCount !== benchmark.sampleCount) {
+      throw new Error(
+        `Benchmark artifact field ${path}.benchmarks contains ambiguous benchmark sampleCount values for ${benchmark.name}.`,
+      );
+    }
+    benchmarkSampleCountByName.set(benchmark.name, benchmark.sampleCount);
+  }
+  const throughputByName = throughputCaseByName(throughputCases, path);
+  for (const [benchmarkName, benchmarkSampleCount] of benchmarkSampleCountByName) {
+    const throughputCase = throughputByName.get(benchmarkName);
+    if (throughputCase === undefined) {
+      throw new Error(`Benchmark artifact field ${path} is missing throughput case ${benchmarkName}.`);
+    }
+    if (throughputCase.sampleCount !== benchmarkSampleCount) {
+      throw new Error(
+        `Benchmark artifact field ${path}.${benchmarkName}.sampleCount must equal benchmark sampleCount ${benchmarkSampleCount} but was ${throughputCase.sampleCount}.`,
+      );
+    }
+  }
+  for (const throughputCase of throughputCases) {
+    if (!benchmarkSampleCountByName.has(throughputCase.name)) {
+      throw new Error(
+        `Benchmark artifact field ${path} contains throughput case without matching benchmark: ${throughputCase.name}.`,
+      );
+    }
+  }
+};
+
+const validateThroughputCasesMatchMutationCount = (throughputCases, mutationCount, path) => {
+  const totalProducedRows = throughputCases.reduce(
+    (total, throughputCase) => total + throughputCase.totalProducedRows,
+    0,
+  );
+  if (totalProducedRows !== mutationCount) {
+    throw new Error(
+      `Benchmark artifact field ${path} totalProducedRows must equal mutationCount ${mutationCount} but was ${totalProducedRows}.`,
+    );
+  }
 };
 
 const validateRuntimeSummaryIngestCompleteness = (summary, path, mutationCount) => {
@@ -364,10 +507,35 @@ export const readBenchmarkObservation = (task) => {
   const benchmarkCases = stringArrayValue(summary.benchmarkCases, `${task.summaryPath}.benchmarkCases`);
   const mutationCount = nonNegativeInteger(summary.mutationCount, `${task.summaryPath}.mutationCount`);
   const topics = stringArrayValue(summary.topics, `${task.summaryPath}.topics`);
+  const requiresKafkaThroughput =
+    artifactKind === "runtime-benchmark-summary" && benchmarkScope.startsWith("runtime-kafka-");
   const kafkaIngestLanes =
     artifactKind === "runtime-benchmark-summary"
       ? validateRuntimeSummaryIngestCompleteness(summary, task.summaryPath, mutationCount)
       : undefined;
+  const throughputCases =
+    summary.throughput === undefined
+      ? undefined
+      : throughputCasesValue(summary.throughput, `${task.summaryPath}.throughput`);
+  if (requiresKafkaThroughput && throughputCases === undefined) {
+    throw new Error(
+      `Benchmark artifact field ${task.summaryPath}.throughput is required for ${benchmarkScope}.`,
+    );
+  }
+  if (throughputCases !== undefined) {
+    validateThroughputCasesMatchBenchmarks(
+      throughputCases,
+      benchmarks,
+      `${task.summaryPath}.throughput.cases`,
+    );
+    if (requiresKafkaThroughput) {
+      validateThroughputCasesMatchMutationCount(
+        throughputCases,
+        mutationCount,
+        `${task.summaryPath}.throughput.cases`,
+      );
+    }
+  }
 
   return {
     artifactKind,
@@ -401,6 +569,7 @@ export const readBenchmarkObservation = (task) => {
     subscriberCount: finiteNumber(summary.subscriberCount, `${task.summaryPath}.subscriberCount`),
     summaryPath: task.summaryPath,
     taskLabel: task.label,
+    throughputCases,
     topics,
   };
 };
@@ -465,6 +634,15 @@ const thresholdsValue = (value, path, expectedThresholds) => {
         `${path}.memoryRssTotalDelta.maxRatio`,
       ),
     },
+    throughputAggregateRowsPerSecond: {
+      minRatio: finiteNumber(
+        objectValue(
+          thresholds.throughputAggregateRowsPerSecond,
+          `${path}.throughputAggregateRowsPerSecond`,
+        ).minRatio,
+        `${path}.throughputAggregateRowsPerSecond.minRatio`,
+      ),
+    },
   };
   if (JSON.stringify(validatedThresholds) !== JSON.stringify(expectedThresholds)) {
     throw new Error(`Benchmark artifact field ${path} must match code-owned profile thresholds.`);
@@ -484,6 +662,10 @@ const validateBenchmark = (benchmark, path) => ({
 
 const validateTask = (task, path) => {
   const artifactKind = summaryArtifactKind(task.artifactKind, `${path}.artifactKind`);
+  const benchmarkScope = stringValue(task.benchmarkScope, `${path}.benchmarkScope`);
+  const mutationCount = nonNegativeInteger(task.mutationCount, `${path}.mutationCount`);
+  const requiresKafkaThroughput =
+    artifactKind === "runtime-benchmark-summary" && benchmarkScope.startsWith("runtime-kafka-");
   const memoryRssTotalDeltaBytes = optionalFiniteNumber(
     task.memoryRssTotalDeltaBytes,
     `${path}.memoryRssTotalDeltaBytes`,
@@ -497,15 +679,38 @@ const validateTask = (task, path) => {
       `Benchmark artifact field ${path}.memoryRssTotalDeltaBytes is required for ${artifactKind}.`,
     );
   }
+  const benchmarks = nonEmptyArrayValue(task.benchmarks, `${path}.benchmarks`).map(
+    (benchmark, index) => validateBenchmark(benchmark, `${path}.benchmarks[${index}]`),
+  );
+  const throughputCases =
+    task.throughputCases === undefined
+      ? undefined
+      : nonEmptyArrayValue(task.throughputCases, `${path}.throughputCases`).map(
+          (throughputCase, index) =>
+            throughputCaseValue(throughputCase, `${path}.throughputCases[${index}]`),
+        );
+  if (requiresKafkaThroughput && throughputCases === undefined) {
+    throw new Error(
+      `Benchmark artifact field ${path}.throughputCases is required for ${benchmarkScope}.`,
+    );
+  }
+  if (throughputCases !== undefined) {
+    validateThroughputCasesMatchBenchmarks(throughputCases, benchmarks, `${path}.throughputCases`);
+    if (requiresKafkaThroughput) {
+      validateThroughputCasesMatchMutationCount(
+        throughputCases,
+        mutationCount,
+        `${path}.throughputCases`,
+      );
+    }
+  }
   return {
     artifactKind,
     backpressureCount: finiteNumber(task.backpressureCount, `${path}.backpressureCount`),
-    benchmarks: nonEmptyArrayValue(task.benchmarks, `${path}.benchmarks`).map((benchmark, index) =>
-      validateBenchmark(benchmark, `${path}.benchmarks[${index}]`),
-    ),
+    benchmarks,
     benchmarkCases: stringArrayValue(task.benchmarkCases, `${path}.benchmarkCases`),
     benchmarkName: stringValue(task.benchmarkName, `${path}.benchmarkName`),
-    benchmarkScope: stringValue(task.benchmarkScope, `${path}.benchmarkScope`),
+    benchmarkScope,
     browser: optionalObjectValue(task.browser, `${path}.browser`),
     cleanupLeakCount: finiteNumber(task.cleanupLeakCount, `${path}.cleanupLeakCount`),
     groupedKeyWidthParameters: optionalObjectValue(
@@ -522,7 +727,7 @@ const validateTask = (task, path) => {
     latencySource: stringValue(task.latencySource, `${path}.latencySource`),
     memoryRssTotalDeltaBytes,
     minimumSampleCount: positiveInteger(task.minimumSampleCount, `${path}.minimumSampleCount`),
-    mutationCount: nonNegativeInteger(task.mutationCount, `${path}.mutationCount`),
+    mutationCount,
     outputJsonPath: stringValue(task.outputJsonPath, `${path}.outputJsonPath`),
     queuedEventCount: finiteNumber(task.queuedEventCount, `${path}.queuedEventCount`),
     rowCount: finiteNumber(task.rowCount, `${path}.rowCount`),
@@ -530,6 +735,7 @@ const validateTask = (task, path) => {
     subscriberCount: finiteNumber(task.subscriberCount, `${path}.subscriberCount`),
     summaryPath: stringValue(task.summaryPath, `${path}.summaryPath`),
     taskLabel: stringValue(task.taskLabel, `${path}.taskLabel`),
+    throughputCases,
     topics: stringArrayValue(task.topics, `${path}.topics`),
   };
 };
@@ -570,6 +776,9 @@ const taskByLabel = (tasks, path) =>
 
 const benchmarkByName = (benchmarks, path) =>
   mapByUniqueKey(benchmarks, benchmarkKey, path, "benchmark case");
+
+const throughputCaseByName = (throughputCases, path) =>
+  mapByUniqueKey(throughputCases, (throughputCase) => throughputCase.name, path, "throughput case");
 
 const pushRegression = (regressions, message) => {
   regressions.push(message);
@@ -626,6 +835,80 @@ const compareRss = (regressions, taskLabel, threshold, baseline, actual) => {
       `${taskLabel}: total RSS delta regressed from ${baseline} bytes to ${actual} bytes; allowed <= ${Math.round(
         limit,
       )} bytes.`,
+    );
+  }
+};
+
+const compareThroughput = (
+  regressions,
+  taskLabel,
+  caseName,
+  metricName,
+  threshold,
+  baseline,
+  actual,
+) => {
+  const minimum = baseline * threshold.minRatio;
+  if (actual < minimum) {
+    pushRegression(
+      regressions,
+      `${taskLabel} / ${caseName}: ${metricName} throughput regressed from ${baseline.toFixed(
+        3,
+      )} rows/sec to ${actual.toFixed(3)} rows/sec; allowed >= ${minimum.toFixed(3)} rows/sec.`,
+    );
+  }
+};
+
+const compareThroughputCases = (regressions, taskLabel, threshold, baselineCases, actualCases) => {
+  if (baselineCases === undefined && actualCases === undefined) {
+    return;
+  }
+  if (baselineCases === undefined || actualCases === undefined) {
+    pushRegression(regressions, `${taskLabel}: throughputCases presence changed.`);
+    return;
+  }
+  const baselineByName = throughputCaseByName(baselineCases, `baseline.tasks[${taskLabel}]`);
+  const actualByName = throughputCaseByName(actualCases, `actual.tasks[${taskLabel}]`);
+  for (const caseName of actualByName.keys()) {
+    if (!baselineByName.has(caseName)) {
+      pushRegression(regressions, `${taskLabel}: unexpected throughput case ${caseName}.`);
+    }
+  }
+  for (const baselineCase of baselineCases) {
+    const actualCase = actualByName.get(baselineCase.name);
+    if (actualCase === undefined) {
+      pushRegression(regressions, `${taskLabel}: missing throughput case ${baselineCase.name}.`);
+      continue;
+    }
+    compareExact(
+      regressions,
+      taskLabel,
+      `${baselineCase.name} throughput producedRowsPerSample`,
+      baselineCase.producedRowsPerSample,
+      actualCase.producedRowsPerSample,
+    );
+    compareExact(
+      regressions,
+      taskLabel,
+      `${baselineCase.name} throughput sampleCount`,
+      baselineCase.sampleCount,
+      actualCase.sampleCount,
+    );
+    compareExact(
+      regressions,
+      taskLabel,
+      `${baselineCase.name} throughput totalProducedRows`,
+      baselineCase.totalProducedRows,
+      actualCase.totalProducedRows,
+    );
+    compareThroughput(
+      regressions,
+      taskLabel,
+      baselineCase.name,
+      "aggregateRowsPerSecond",
+      threshold,
+      baselineCase.aggregateRowsPerSecond,
+      actualCase.aggregateRowsPerSecond,
     );
   }
 };
@@ -734,6 +1017,13 @@ export const compareBenchmarkBaseline = (baseline, actualBaseline) => {
       "kafkaIngestLanes",
       baselineTask.kafkaIngestLanes,
       actualTask.kafkaIngestLanes,
+    );
+    compareThroughputCases(
+      regressions,
+      taskLabel,
+      thresholds.throughputAggregateRowsPerSecond,
+      baselineTask.throughputCases,
+      actualTask.throughputCases,
     );
     compareExact(
       regressions,

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -111,6 +111,72 @@ const comparableRuntimeKafkaIngestLanes = [
   },
 ];
 
+const runtimeThroughputMutationCount = 700;
+
+const runtimeThroughputHealth = {
+  engine: {
+    topics: {
+      orders: {
+        rowCount: runtimeThroughputMutationCount,
+      },
+    },
+  },
+  kafka: {
+    topics: {
+      sourceOrders: {
+        regions: {
+          local: {
+            committedOffset: String(runtimeThroughputMutationCount),
+          },
+        },
+        viewServerTopic: "orders",
+      },
+    },
+  },
+};
+
+const runtimeThroughputKafkaIngestLanes = [
+  {
+    internalTopic: "orders",
+    lane: "orders",
+    producedRows: runtimeThroughputMutationCount,
+    region: "local",
+    sourceTopic: "sourceOrders",
+    sourceTopicAlias: "unique-topic-per-run:orders",
+  },
+];
+
+const comparableRuntimeThroughputKafkaIngestLanes = [
+  {
+    internalTopic: "orders",
+    lane: "orders",
+    producedRows: runtimeThroughputMutationCount,
+    region: "local",
+    sourceTopicAlias: "unique-topic-per-run:orders",
+  },
+];
+
+const runtimeThroughput = {
+  source: "benchmark-operation-timers",
+  cases: [
+    {
+      aggregateRowsPerSecond: 1000,
+      maxTotalMs: 100,
+      meanConvergenceMs: 75,
+      meanProducerSendMs: 25,
+      meanRowsPerSecond: 1000,
+      meanTotalMs: 100,
+      minRowsPerSecond: 900,
+      name: "case a",
+      producedRowsPerSample: 100,
+      sampleCount: 7,
+      totalProducedRows: 700,
+    },
+  ],
+};
+
+const comparableRuntimeThroughputCases = runtimeThroughput.cases;
+
 const observation = {
   artifactKind: "engine-benchmark-summary",
   backpressureCount: 0,
@@ -147,6 +213,7 @@ const observation = {
   subscriberCount: 1,
   summaryPath: "actual.summary.json",
   taskLabel: "task a",
+  throughputCases: undefined,
   topics: ["orders"],
 };
 
@@ -278,6 +345,27 @@ describe("benchmark baseline comparison", () => {
     });
   });
 
+  it("reads non-Kafka throughput observations without Kafka mutation reconciliation", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-observation-"));
+    const summaryPath = join(directory, "actual.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    writeFileSync(
+      summaryPath,
+      `${JSON.stringify({
+        ...summary,
+        throughput: runtimeThroughput,
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
+
+    expect(readBenchmarkObservation(taskPaths(summaryPath, outputJsonPath))).toStrictEqual({
+      ...observation,
+      outputJsonPath,
+      summaryPath,
+      throughputCases: comparableRuntimeThroughputCases,
+    });
+  });
+
   it("reads runtime benchmark observations with process memory data", () => {
     const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-observation-"));
     const summaryPath = join(directory, "actual.summary.json");
@@ -289,10 +377,12 @@ describe("benchmark baseline comparison", () => {
         artifactKind: "runtime-benchmark-summary",
         benchmarkScope: "runtime-kafka-ingest",
         groupedWriteAdmission: undefined,
-        health: runtimeHealth,
+        health: runtimeThroughputHealth,
         kafka: {
-          ingestLanes: runtimeKafkaIngestLanes,
+          ingestLanes: runtimeThroughputKafkaIngestLanes,
         },
+        mutationCount: runtimeThroughputMutationCount,
+        throughput: runtimeThroughput,
       })}\n`,
     );
     writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
@@ -304,10 +394,530 @@ describe("benchmark baseline comparison", () => {
       artifactKind: "runtime-benchmark-summary",
       benchmarkScope: "runtime-kafka-ingest",
       groupedWriteAdmission: undefined,
-      kafkaIngestLanes: comparableRuntimeKafkaIngestLanes,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
       outputJsonPath,
       summaryPath,
+      throughputCases: comparableRuntimeThroughputCases,
     });
+  });
+
+  it("accepts duplicate throughput benchmark names across groups with matching sample counts", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-throughput-groups-"));
+    const summaryPath = join(directory, "actual.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    const duplicateGroupVitestOutput = {
+      files: [
+        {
+          groups: [
+            {
+              fullName: "src/example-a.bench.ts > first group",
+              benchmarks: [
+                {
+                  max: 3,
+                  mean: 2,
+                  min: 1,
+                  name: "case a",
+                  p99: 3,
+                  sampleCount: 7,
+                },
+              ],
+            },
+            {
+              fullName: "src/example-b.bench.ts > second group",
+              benchmarks: [
+                {
+                  max: 4,
+                  mean: 3,
+                  min: 2,
+                  name: "case a",
+                  p99: 4,
+                  sampleCount: 7,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    writeFileSync(
+      summaryPath,
+      `${JSON.stringify({
+        ...summary,
+        throughput: runtimeThroughput,
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(duplicateGroupVitestOutput)}\n`);
+
+    expect(readBenchmarkObservation(taskPaths(summaryPath, outputJsonPath))).toStrictEqual({
+      ...observation,
+      benchmarks: [
+        {
+          groupName: "src/example-a.bench.ts > first group",
+          maxMs: 3,
+          meanMs: 2,
+          minMs: 1,
+          name: "case a",
+          p99Ms: 3,
+          sampleCount: 7,
+        },
+        {
+          groupName: "src/example-b.bench.ts > second group",
+          maxMs: 4,
+          meanMs: 3,
+          minMs: 2,
+          name: "case a",
+          p99Ms: 4,
+          sampleCount: 7,
+        },
+      ],
+      outputJsonPath,
+      summaryPath,
+      throughputCases: comparableRuntimeThroughputCases,
+    });
+  });
+
+  it("rejects ambiguous throughput benchmark sample counts across groups", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-throughput-groups-"));
+    const summaryPath = join(directory, "actual.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    const ambiguousGroupVitestOutput = {
+      files: [
+        {
+          groups: [
+            {
+              fullName: "src/example-a.bench.ts > first group",
+              benchmarks: [
+                {
+                  max: 3,
+                  mean: 2,
+                  min: 1,
+                  name: "case a",
+                  p99: 3,
+                  sampleCount: 7,
+                },
+              ],
+            },
+            {
+              fullName: "src/example-b.bench.ts > second group",
+              benchmarks: [
+                {
+                  max: 4,
+                  mean: 3,
+                  min: 2,
+                  name: "case a",
+                  p99: 4,
+                  sampleCount: 8,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    writeFileSync(
+      summaryPath,
+      `${JSON.stringify({
+        ...summary,
+        throughput: runtimeThroughput,
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(ambiguousGroupVitestOutput)}\n`);
+
+    expect(() => readBenchmarkObservation(taskPaths(summaryPath, outputJsonPath))).toThrow(
+      `Benchmark artifact field ${summaryPath}.throughput.cases.benchmarks contains ambiguous benchmark sampleCount values for case a.`,
+    );
+  });
+
+  it("rejects runtime benchmark observations with malformed throughput", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-throughput-"));
+    const invalidSourceSummaryPath = join(directory, "invalid-source.summary.json");
+    const invalidRowsSummaryPath = join(directory, "invalid-rows.summary.json");
+    const invalidTotalRowsSummaryPath = join(directory, "invalid-total-rows.summary.json");
+    const invalidPositiveRateSummaryPath = join(directory, "invalid-positive-rate.summary.json");
+    const invalidAggregateSummaryPath = join(directory, "invalid-aggregate.summary.json");
+    const invalidMinRowsSummaryPath = join(directory, "invalid-min-rows.summary.json");
+    const invalidMaxTotalSummaryPath = join(directory, "invalid-max-total.summary.json");
+    const invalidProducerTimerSummaryPath = join(directory, "invalid-producer-timer.summary.json");
+    const invalidConvergenceTimerSummaryPath = join(
+      directory,
+      "invalid-convergence-timer.summary.json",
+    );
+    const mismatchedNameSummaryPath = join(directory, "mismatched-name.summary.json");
+    const mismatchedSampleCountSummaryPath = join(
+      directory,
+      "mismatched-sample-count.summary.json",
+    );
+    const extraThroughputCaseSummaryPath = join(directory, "extra-throughput-case.summary.json");
+    const mismatchedMutationTotalSummaryPath = join(
+      directory,
+      "mismatched-mutation-total.summary.json",
+    );
+    const missingThroughputSummaryPath = join(directory, "missing-throughput.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    writeFileSync(
+      missingThroughputSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidSourceSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          source: "other-timer",
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              producedRowsPerSample: 0,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidTotalRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              totalProducedRows: 699,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidAggregateSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              aggregateRowsPerSecond: 999,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidPositiveRateSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              aggregateRowsPerSecond: 0,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidMinRowsSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              meanRowsPerSecond: 900,
+              minRowsPerSecond: 901,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidMaxTotalSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              maxTotalMs: 99,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidProducerTimerSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              meanProducerSendMs: 101,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      invalidConvergenceTimerSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              meanConvergenceMs: 101,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      mismatchedNameSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              name: "case b",
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      mismatchedSampleCountSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            {
+              ...runtimeThroughput.cases[0],
+              sampleCount: 6,
+              totalProducedRows: 600,
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      extraThroughputCaseSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: {
+          ...runtimeThroughput,
+          cases: [
+            runtimeThroughput.cases[0],
+            {
+              ...runtimeThroughput.cases[0],
+              name: "case b",
+            },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      mismatchedMutationTotalSummaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        groupedWriteAdmission: undefined,
+        health: runtimeHealth,
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: runtimeThroughput,
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
+
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(missingThroughputSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${missingThroughputSummaryPath}.throughput is required for runtime-kafka-ingest.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidSourceSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidSourceSummaryPath}.throughput.source must be benchmark-operation-timers.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidRowsSummaryPath}.throughput.cases[0].producedRowsPerSample must be a positive integer.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidTotalRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidTotalRowsSummaryPath}.throughput.cases[0].totalProducedRows must equal producedRowsPerSample * sampleCount (700).`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidAggregateSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidAggregateSummaryPath}.throughput.cases[0].aggregateRowsPerSecond must match producedRowsPerSample * 1000 / meanTotalMs.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidPositiveRateSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidPositiveRateSummaryPath}.throughput.cases[0].aggregateRowsPerSecond must be a positive finite number.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidMinRowsSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidMinRowsSummaryPath}.throughput.cases[0].minRowsPerSecond must be less than or equal to meanRowsPerSecond.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidMaxTotalSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidMaxTotalSummaryPath}.throughput.cases[0].meanTotalMs must be less than or equal to maxTotalMs.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(invalidProducerTimerSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${invalidProducerTimerSummaryPath}.throughput.cases[0].meanProducerSendMs must be less than or equal to meanTotalMs.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(
+        runtimeTaskPaths(invalidConvergenceTimerSummaryPath, outputJsonPath),
+      ),
+    ).toThrow(
+      `Benchmark artifact field ${invalidConvergenceTimerSummaryPath}.throughput.cases[0].meanConvergenceMs must be less than or equal to meanTotalMs.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(mismatchedNameSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${mismatchedNameSummaryPath}.throughput.cases is missing throughput case case a.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(mismatchedSampleCountSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${mismatchedSampleCountSummaryPath}.throughput.cases.case a.sampleCount must equal benchmark sampleCount 7 but was 6.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(extraThroughputCaseSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${extraThroughputCaseSummaryPath}.throughput.cases contains throughput case without matching benchmark: case b.`,
+    );
+    expect(() =>
+      readBenchmarkObservation(runtimeTaskPaths(mismatchedMutationTotalSummaryPath, outputJsonPath)),
+    ).toThrow(
+      `Benchmark artifact field ${mismatchedMutationTotalSummaryPath}.throughput.cases totalProducedRows must equal mutationCount 100 but was 700.`,
+    );
   });
 
   it("rejects incomplete runtime benchmark health", () => {
@@ -1012,19 +1622,243 @@ describe("benchmark baseline comparison", () => {
       artifactKind: "runtime-benchmark-summary",
       benchmarkScope: "runtime-kafka-ingest",
       groupedWriteAdmission: undefined,
-      kafkaIngestLanes: comparableRuntimeKafkaIngestLanes,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+      throughputCases: comparableRuntimeThroughputCases,
     };
     const baseline = buildBenchmarkBaseline("kafka-ingest", [kafkaObservation]);
     const changedMutationCount = buildBenchmarkBaseline("kafka-ingest", [
       {
         ...kafkaObservation,
-        mutationCount: 99,
+        mutationCount: 1400,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            aggregateRowsPerSecond: 2000,
+            meanRowsPerSecond: 2000,
+            minRowsPerSecond: 1800,
+            producedRowsPerSample: 200,
+            totalProducedRows: 1400,
+          },
+        ],
       },
     ]);
 
     expect(compareBenchmarkBaseline(baseline, changedMutationCount)).toStrictEqual({
       ok: false,
-      regressions: ["task a: mutationCount changed from 100 to 99."],
+      regressions: [
+        "task a: mutationCount changed from 700 to 1400.",
+        "task a: case a throughput producedRowsPerSample changed from 100 to 200.",
+        "task a: case a throughput totalProducedRows changed from 700 to 1400.",
+      ],
+    });
+  });
+
+  it("reports Kafka ingest throughput regressions", () => {
+    const kafkaObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+      throughputCases: comparableRuntimeThroughputCases,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-ingest", [kafkaObservation]);
+    const regressedThroughput = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            aggregateRowsPerSecond: 400,
+            maxTotalMs: 250,
+            meanTotalMs: 250,
+          },
+        ],
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, regressedThroughput)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a / case a: aggregateRowsPerSecond throughput regressed from 1000.000 rows/sec to 400.000 rows/sec; allowed >= 750.000 rows/sec.",
+      ],
+    });
+  });
+
+  it("uses the Kafka profile throughput threshold", () => {
+    const kafkaObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+      throughputCases: comparableRuntimeThroughputCases,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-ingest", [kafkaObservation]);
+    const thresholdThroughput = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            aggregateRowsPerSecond: 750,
+            maxTotalMs: 133.33333333333334,
+            meanRowsPerSecond: 750,
+            meanTotalMs: 133.33333333333334,
+            minRowsPerSecond: 700,
+          },
+        ],
+      },
+    ]);
+    const belowThresholdThroughput = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            aggregateRowsPerSecond: 749,
+            maxTotalMs: 133.5113484646195,
+            meanRowsPerSecond: 749,
+            meanTotalMs: 133.5113484646195,
+            minRowsPerSecond: 700,
+          },
+        ],
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, thresholdThroughput)).toStrictEqual({
+      ok: true,
+      regressions: [],
+    });
+    expect(compareBenchmarkBaseline(baseline, belowThresholdThroughput)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a / case a: aggregateRowsPerSecond throughput regressed from 1000.000 rows/sec to 749.000 rows/sec; allowed >= 750.000 rows/sec.",
+      ],
+    });
+  });
+
+  it("requires throughput cases in committed Kafka baselines", () => {
+    const kafkaObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-ingest", [kafkaObservation]);
+    const completeBaseline = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: comparableRuntimeThroughputCases,
+      },
+    ]);
+    const emptyThroughputBaseline = {
+      ...completeBaseline,
+      tasks: [
+        {
+          ...completeBaseline.tasks[0],
+          throughputCases: [],
+        },
+      ],
+    };
+    const renamedThroughputBaseline = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            name: "case b",
+          },
+        ],
+      },
+    ]);
+    const mismatchedSampleCountBaseline = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            sampleCount: 6,
+            totalProducedRows: 600,
+          },
+        ],
+      },
+    ]);
+
+    expect(() => validateBenchmarkBaseline(baseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases is required for runtime-kafka-ingest.",
+    );
+    expect(() => validateBenchmarkBaseline(emptyThroughputBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases must be a non-empty array.",
+    );
+    expect(() => validateBenchmarkBaseline(renamedThroughputBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases is missing throughput case case a.",
+    );
+    expect(() => validateBenchmarkBaseline(mismatchedSampleCountBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases.case a.sampleCount must equal benchmark sampleCount 7 but was 6.",
+    );
+  });
+
+  it("requires throughput cases in committed Kafka sustained firehose baselines", () => {
+    const kafkaObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-sustained-firehose",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-sustained-firehose", [kafkaObservation]);
+
+    expect(() => validateBenchmarkBaseline(baseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases is required for runtime-kafka-sustained-firehose.",
+    );
+  });
+
+  it("reports throughput metadata drift", () => {
+    const withThroughput = {
+      ...observation,
+      throughputCases: comparableRuntimeThroughputCases,
+    };
+    const baseline = buildBenchmarkBaseline("smoke", [withThroughput]);
+    const missingThroughput = buildBenchmarkBaseline("smoke", [observation]);
+    const renamedThroughput = buildBenchmarkBaseline("smoke", [
+      {
+        ...withThroughput,
+        benchmarks: [
+          {
+            ...observation.benchmarks[0],
+            name: "case b",
+          },
+        ],
+        benchmarkCases: ["case b"],
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            name: "case b",
+          },
+        ],
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, missingThroughput)).toStrictEqual({
+      ok: false,
+      regressions: ["task a: throughputCases presence changed."],
+    });
+    expect(compareBenchmarkBaseline(baseline, renamedThroughput)).toStrictEqual({
+      ok: false,
+      regressions: [
+        'task a: benchmarkCases changed from ["case a"] to ["case b"].',
+        "task a: unexpected throughput case case b.",
+        "task a: missing throughput case case a.",
+        "task a: unexpected benchmark case src/example.bench.ts > example benchmark group / case b.",
+        "task a: missing benchmark case src/example.bench.ts > example benchmark group / case a.",
+      ],
     });
   });
 
@@ -1288,6 +2122,9 @@ describe("benchmark baseline comparison", () => {
         memoryRssTotalDelta: {
           maxAbsoluteDeltaBytes: 134217728,
           maxRatio: 3,
+        },
+        throughputAggregateRowsPerSecond: {
+          minRatio: 0.75,
         },
       },
     };


### PR DESCRIPTION
## Summary
- record Kafka producer-send and convergence timing in Vitest benchmark summaries
- add throughput case validation, profile-owned throughput thresholds, and Kafka mutation reconciliation to baseline comparison
- regenerate Kafka ingest/sustained-firehose baselines with throughput artifacts and add threshold metadata to all baseline manifests

## Validation
- pnpm run test:repository-scripts
- vp check --fix
- pnpm run bench:baseline:kafka-ingest
- pnpm run bench:baseline:kafka-sustained-firehose
- pnpm run ready

## Review loop
- 3 local reviewer agents completed with no actionable findings after fixes.