### PR TITLE
Harden Kafka ingress scoped lifecycle

### DIFF
--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -671,6 +671,98 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("run helper closes Kafka ingress when the main fiber is interrupted", () =>
+    Effect.gen(function* () {
+      let kafkaCloseCount = 0;
+      let runtimeCoreClosed = false;
+      let serverCloseCount = 0;
+      const kafkaStarted = yield* Deferred.make<void>();
+      const serverStarted = yield* Deferred.make<void>();
+      const regions = {
+        local: "localhost:9092",
+      };
+      const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
+      const dependencies: ViewServerRuntimeDependencies<typeof viewServer.topics> = {
+        ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
+        makeRuntimeCore: (config, options) =>
+          makeViewServerRuntimeCore(config, options).pipe(
+            Effect.map((runtimeCore) => ({
+              ...runtimeCore,
+              close: runtimeCore.close.pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    runtimeCoreClosed = true;
+                  }),
+                ),
+              ),
+            })),
+          ),
+        makeServer: () =>
+          Deferred.succeed(serverStarted, undefined).pipe(
+            Effect.as({
+              url: "ws://127.0.0.1:0/rpc",
+              healthUrl: "http://127.0.0.1:0/health",
+              close: Effect.sync(() => {
+                serverCloseCount += 1;
+              }),
+            }),
+          ),
+        makeKafkaIngress: () =>
+          Deferred.succeed(kafkaStarted, undefined).pipe(
+            Effect.as({
+              close: Effect.sync(() => {
+                kafkaCloseCount += 1;
+              }),
+            }),
+          ),
+      };
+
+      const fiber = yield* runViewServerRuntimeWithDependencies(dependencies, viewServer, {
+        kafka: {
+          consumerGroupId: "view-server-test-runtime-interrupt",
+          regions,
+          topics: {
+            "orders-source": localKafkaTopic({
+              regions: ["local"],
+              value: kafka.json(Order),
+              key: kafka.stringKey(),
+              viewServerTopic: "orders",
+              mapping: ({ key, value }) => ({
+                id: key,
+                price: value.price,
+              }),
+            }),
+          },
+        },
+      }).pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(serverStarted);
+      yield* Deferred.await(kafkaStarted);
+      yield* Effect.sleep("10 millis");
+
+      expect({
+        kafkaCloseCount,
+        runtimeCoreClosed,
+        serverCloseCount,
+      }).toStrictEqual({
+        kafkaCloseCount: 0,
+        runtimeCoreClosed: false,
+        serverCloseCount: 0,
+      });
+
+      yield* Fiber.interrupt(fiber);
+
+      expect({
+        kafkaCloseCount,
+        runtimeCoreClosed,
+        serverCloseCount,
+      }).toStrictEqual({
+        kafkaCloseCount: 1,
+        runtimeCoreClosed: true,
+        serverCloseCount: 1,
+      });
+    }),
+  );
+
   it.live("public run helper starts a launchable websocket runtime", () =>
     Effect.gen(function* () {
       const fiber = yield* runViewServerRuntime(viewServer, {

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -28,6 +28,7 @@ import { makeViewServerKafkaHealthLedger as makeViewServerKafkaHealthLedgerBase 
 import type { ViewServerKafkaHealthLedger } from "./kafka-health";
 import {
   assignedPartitionsForSourceTopic,
+  acquireStartedKafkaConsumerResources,
   bootstrapBrokers,
   closeKafkaConsumer,
   closeKafkaConsumerAfterStartFailure,
@@ -44,6 +45,7 @@ import {
   kafkaMessageProcessingError,
   kafkaStreamCloseError,
   kafkaStreamError,
+  makeScopedKafkaIngress,
   makeViewServerKafkaIngress,
   makeStartedKafkaConsumerResourcesFinalizer,
   mapKafkaConsumerStartError,
@@ -767,6 +769,74 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         closeForce: true,
         streamCloseCount: 1,
       });
+    }),
+  );
+
+  it.effect("registers started Kafka resource cleanup atomically after acquire", () =>
+    Effect.gen(function* () {
+      let closeForce: boolean | undefined = undefined;
+      let listenerCloseCount = 0;
+      let streamCloseCount = 0;
+      const scope = yield* Scope.make();
+      const consumer: StartedKafkaConsumerResources["consumer"] = {
+        close: (force?: boolean) => {
+          closeForce = force;
+        },
+      };
+      const stream: StartedKafkaConsumerResources["stream"] = {
+        close: () => {
+          streamCloseCount += 1;
+        },
+      };
+      const resources = yield* acquireStartedKafkaConsumerResources(
+        scope,
+        Effect.succeed({
+          consumer,
+          stream,
+        }),
+      );
+
+      resources.setHealthListeners({
+        close: Effect.sync(() => {
+          listenerCloseCount += 1;
+        }),
+        processed: Effect.succeed(0),
+        waitForProcessed: () => Effect.void,
+      });
+      yield* Scope.close(scope, Exit.void);
+
+      expect({
+        closeForce,
+        listenerCloseCount,
+        streamCloseCount,
+      }).toStrictEqual({
+        closeForce: true,
+        listenerCloseCount: 1,
+        streamCloseCount: 1,
+      });
+    }),
+  );
+
+  it.effect("closes scoped Kafka ingress resources when acquisition is interrupted", () =>
+    Effect.gen(function* () {
+      let scopeFinalizerCount = 0;
+      const consumerStarted = yield* Deferred.make<void>();
+      const ingressFiber = yield* makeScopedKafkaIngress((scope) =>
+        Scope.addFinalizer(
+          scope,
+          Effect.sync(() => {
+            scopeFinalizerCount += 1;
+          }),
+        ).pipe(
+          Effect.andThen(Deferred.succeed(consumerStarted, undefined)),
+          Effect.andThen(Effect.never),
+        ),
+      ).pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(consumerStarted).pipe(Effect.timeout("1 second"));
+      yield* Fiber.interrupt(ingressFiber);
+
+      expect(scopeFinalizerCount).toBe(1);
     }),
   );
 

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -520,6 +520,41 @@ export const closeKafkaConsumerOnPostConsumeStartupFailure = Effect.fn(
   );
 });
 
+export const acquireStartedKafkaConsumerResources = Effect.fn(
+  "ViewServerRuntime.kafka.consumer.acquireStartedResources",
+)(function* <Consumer extends CloseableKafkaConsumer, Stream extends CloseableKafkaStream, E>(
+  scope: Scope.Scope,
+  acquire: Effect.Effect<
+    {
+      readonly consumer: Consumer;
+      readonly stream: Stream;
+    },
+    E
+  >,
+) {
+  return yield* Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const { consumer, stream } = yield* restore(acquire);
+      let healthListeners: KafkaConsumerHealthListenerRegistration | null = null;
+      const resources: StartedKafkaConsumerResources = {
+        consumer,
+        healthListeners: () => healthListeners,
+        stream,
+      };
+      const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
+      yield* registerStartedKafkaConsumerResourcesFinalizer(scope, closeResources);
+      return {
+        consumer,
+        closeResources,
+        setHealthListeners: (registration: KafkaConsumerHealthListenerRegistration) => {
+          healthListeners = registration;
+        },
+        stream,
+      };
+    }),
+  );
+});
+
 const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.decodeForBatch")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     config: ViewServerConfig<Topics>,
@@ -1117,19 +1152,15 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
   topics: ReadonlyArray<string>,
   scope: Scope.Scope,
 ) {
-  const { consumer, stream } = yield* makeKafkaConsumer(region, brokers, topics, options.consume);
-  let healthListeners: KafkaConsumerHealthListenerRegistration | null = null;
-  const resources: StartedKafkaConsumerResources = {
-    consumer,
-    healthListeners: () => healthListeners,
-    stream,
-  };
-  const closeResources = yield* makeStartedKafkaConsumerResourcesFinalizer(resources);
-  yield* registerStartedKafkaConsumerResourcesFinalizer(scope, closeResources);
+  const { consumer, stream, closeResources, setHealthListeners } =
+    yield* acquireStartedKafkaConsumerResources(
+      scope,
+      makeKafkaConsumer(region, brokers, topics, options.consume),
+    );
   return yield* closeKafkaConsumerOnPostConsumeStartupFailure(
     closeResources,
     Effect.gen(function* () {
-      healthListeners = yield* registerKafkaConsumerHealthListeners(
+      const healthListeners = yield* registerKafkaConsumerHealthListeners(
         consumer,
         health,
         requestHealthRefresh,
@@ -1137,6 +1168,7 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
         topics,
         scope,
       );
+      setHealthListeners(healthListeners);
       yield* startKafkaLagMonitoring(consumer, topics);
       const nowMillis = yield* Clock.currentTimeMillis;
       yield* health.regionConnected(region, nowMillis);
@@ -1219,6 +1251,27 @@ const makeIdempotentKafkaIngressClose = (
   );
 };
 
+export const makeScopedKafkaIngress = Effect.fn("ViewServerRuntime.kafka.ingress.makeScoped")(
+  function* <E>(
+    startConsumers: (
+      scope: Scope.Scope,
+    ) => Effect.Effect<ReadonlyArray<StartedKafkaRegionConsumer>, E>,
+  ) {
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const scope = yield* Scope.make("parallel");
+        const consumers = yield* restore(startConsumers(scope)).pipe(
+          Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)),
+        );
+        const close = yield* makeKafkaIngressClose(consumers, scope);
+        return {
+          close,
+        };
+      }),
+    );
+  },
+);
+
 export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
@@ -1234,10 +1287,8 @@ export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntime
   options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
   health: ViewServerKafkaHealthLedger<Topics>,
 ) {
-  const scope = yield* Scope.make("parallel");
-  const consumers = yield* startKafkaRegionConsumers(
-    Object.entries(options.regions),
-    (region, brokers) => {
+  return yield* makeScopedKafkaIngress((scope) =>
+    startKafkaRegionConsumers(Object.entries(options.regions), (region, brokers) => {
       const topics = sourceTopicsForRegion(options, region);
       if (topics.length === 0) {
         return Effect.succeed({
@@ -1255,10 +1306,6 @@ export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntime
         topics,
         scope,
       );
-    },
-  ).pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)));
-  const close = yield* makeKafkaIngressClose(consumers, scope);
-  return {
-    close,
-  };
+    }),
+  );
 });


### PR DESCRIPTION
## Summary
- Make Kafka ingress startup scope close on interrupted acquisition before the close handle is returned.
- Register started Kafka consumer/stream finalizers atomically immediately after acquisition.
- Add runtime and internal regression coverage for interruption cleanup paths.

## Validation
- vp run @view-server/runtime#test -- src/kafka-ingress.internal.test.ts src/index.test.ts
- vp check --fix
- pnpm run ready

## Review loop
- 3 local reviewer agents found no blocking issues after the fix.
