### PR TITLE
Add Kafka latest start coverage

### DIFF
--- a/packages/runtime/src/kafka-health.ts
+++ b/packages/runtime/src/kafka-health.ts
@@ -83,7 +83,7 @@ export type ViewServerKafkaHealthLedger<Topics extends ViewServerRuntimeTopicDef
     sourceTopic: string,
     region: string,
     input: {
-      readonly consumerLagMessages: bigint;
+      readonly consumerLagMessages: bigint | null;
       readonly nowMillis: number;
     },
   ) => Effect.Effect<void>;

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -1442,6 +1442,75 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("keeps negative-only Kafka lag samples uninitialized", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      yield* Effect.gen(function* () {
+        const ledger = makeViewServerKafkaHealthLedger<Topics>({
+          regions: kafkaOptions.regions,
+          topics: {
+            [ordersSourceTopic]: {
+              regions: ["local"],
+              viewServerTopic: "orders",
+            },
+          },
+        });
+        let healthRefreshRequestCount = 0;
+        const requestHealthRefresh = Effect.sync(() => {
+          healthRefreshRequestCount += 1;
+        });
+
+        yield* recordKafkaAssignments(
+          ledger,
+          requestHealthRefresh,
+          "local",
+          [ordersSourceTopic],
+          [{ topic: ordersSourceTopic, partitions: [0] }],
+          1_000,
+        );
+        yield* recordKafkaLag(
+          ledger,
+          requestHealthRefresh,
+          "local",
+          [ordersSourceTopic],
+          new Map([[ordersSourceTopic, [-1n]]]),
+          2_000,
+        );
+        const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+        expect({
+          healthRefreshRequestCount,
+          orders: health.kafka?.topics[ordersSourceTopic],
+        }).toStrictEqual({
+          healthRefreshRequestCount: 2,
+          orders: {
+            status: "ready",
+            sourceTopic: ordersSourceTopic,
+            viewServerTopic: "orders",
+            regions: nullRecord({
+              local: {
+                connected: true,
+                assignedPartitions: 1,
+                messagesPerSecond: 0,
+                bytesPerSecond: 0,
+                decodedMessagesPerSecond: 0,
+                decodeFailuresPerSecond: 0,
+                mappingFailuresPerSecond: 0,
+                processingFailuresPerSecond: 0,
+                lastMessageAt: null,
+                lastCommitAt: null,
+                consumerLagMessages: null,
+                lagSampledAt: 2_000,
+                committedOffset: null,
+                lastError: null,
+              },
+            }),
+          },
+        });
+      }).pipe(Effect.ensuring(runtimeCore.close));
+    }),
+  );
+
   it.effect("resets omitted configured source topics from full Kafka lag snapshots", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});

--- a/packages/runtime/src/kafka-ingress.test.ts
+++ b/packages/runtime/src/kafka-ingress.test.ts
@@ -1009,6 +1009,196 @@ describe("@view-server/runtime Kafka ingress", () => {
     }).pipe(Effect.provide(NodeCrypto.layer)),
   );
 
+  it.live("starts Kafka from latest without backfilling old rows", () =>
+    Effect.gen(function* () {
+      const ordersSourceTopic = yield* uniqueTopicName("latest-start-orders");
+      const consumerGroupId = yield* uniqueGroupId();
+      yield* createKafkaTopics(kafkaBootstrapServers, [ordersSourceTopic]);
+
+      const regions = {
+        local: kafkaBootstrapServers,
+      };
+      const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
+      const runtimeOptions = {
+        host: "127.0.0.1",
+        websocketPort: 0,
+        kafka: {
+          consumerGroupId,
+          regions,
+          startFrom: "latest" as const,
+          topics: {
+            [ordersSourceTopic]: localKafkaTopic({
+              regions: ["local"],
+              value: kafka.json(IncomingOrder),
+              key: kafka.stringKey(),
+              viewServerTopic: "orders",
+              mapping: ({ key, value }) => ({
+                id: key,
+                customerId: value.customerId,
+                price: value.price,
+              }),
+            }),
+          },
+        },
+      };
+
+      yield* sendKafkaMessages(kafkaBootstrapServers, "view-server-kafka-latest-start-test", [
+        {
+          topic: ordersSourceTopic,
+          key: "order-1",
+          value: JSON.stringify({
+            customerId: "customer-1-before-latest-start",
+            price: 10,
+          }),
+        },
+        {
+          topic: ordersSourceTopic,
+          key: "order-2",
+          value: JSON.stringify({
+            customerId: "customer-2-before-latest-start",
+            price: 20,
+          }),
+        },
+      ]);
+
+      const result = yield* Effect.acquireUseRelease(
+        makeViewServerRuntime(viewServer, runtimeOptions),
+        (runtime) =>
+          Effect.gen(function* () {
+            const startHealth = yield* runtime.client.health().pipe(
+              Effect.repeat({
+                schedule: kafkaRestartPollSchedule,
+                until: (currentHealth) =>
+                  currentHealth.engine.topics.orders.rowCount === 0 &&
+                  currentHealth.kafka?.startFrom.mode === "latest" &&
+                  currentHealth.kafka.topics[ordersSourceTopic]?.status === "ready" &&
+                  currentHealth.kafka.topics[ordersSourceTopic]?.regions["local"]
+                    ?.assignedPartitions === 1 &&
+                  currentHealth.kafka.topics[ordersSourceTopic]?.regions["local"]
+                    ?.consumerLagMessages === 0n,
+              }),
+            );
+
+            yield* sendKafkaMessages(kafkaBootstrapServers, "view-server-kafka-latest-start-test", [
+              {
+                topic: ordersSourceTopic,
+                key: "order-3",
+                value: JSON.stringify({
+                  customerId: "customer-3-after-latest-start",
+                  price: 30,
+                }),
+              },
+            ]);
+
+            const snapshot = yield* runtime.client
+              .snapshot("orders", {
+                select: ["id", "customerId", "price"],
+                orderBy: [{ field: "id", direction: "asc" }],
+                limit: 10,
+              })
+              .pipe(
+                Effect.repeat({
+                  schedule: kafkaRestartPollSchedule,
+                  until: (currentSnapshot) =>
+                    currentSnapshot.totalRows === 1 &&
+                    currentSnapshot.rows[0]?.customerId === "customer-3-after-latest-start",
+                }),
+              );
+            const finalHealth = yield* runtime.client.health().pipe(
+              Effect.repeat({
+                schedule: kafkaRestartPollSchedule,
+                until: (currentHealth) =>
+                  currentHealth.engine.topics.orders.rowCount === 1 &&
+                  currentHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]
+                    ?.committedOffset === "3" &&
+                  currentHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]
+                    ?.consumerLagMessages === 0n,
+              }),
+            );
+            return {
+              finalHealth,
+              snapshot,
+              startHealth,
+            };
+          }),
+        (runtime) => runtime.close.pipe(Effect.ignore),
+      );
+
+      expect({
+        startHealth: {
+          status: result.startHealth.status,
+          startFrom: result.startHealth.kafka?.startFrom,
+          engineRows: result.startHealth.engine.topics.orders.rowCount,
+          kafkaTopic: result.startHealth.kafka?.topics[ordersSourceTopic],
+        },
+        snapshot: result.snapshot,
+        finalHealth: {
+          status: result.finalHealth.status,
+          startFrom: result.finalHealth.kafka?.startFrom,
+          engineRows: result.finalHealth.engine.topics.orders.rowCount,
+          committedOffset:
+            result.finalHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]?.committedOffset,
+        },
+      }).toStrictEqual({
+        startHealth: {
+          status: "ready",
+          startFrom: {
+            consumerGroupId,
+            fallbackMode: "latest",
+            mode: "latest",
+          },
+          engineRows: 0,
+          kafkaTopic: {
+            status: "ready",
+            sourceTopic: ordersSourceTopic,
+            viewServerTopic: "orders",
+            regions: nullRecord({
+              local: {
+                connected: true,
+                assignedPartitions: 1,
+                messagesPerSecond: 0,
+                bytesPerSecond: 0,
+                decodedMessagesPerSecond: 0,
+                decodeFailuresPerSecond: 0,
+                mappingFailuresPerSecond: 0,
+                processingFailuresPerSecond: 0,
+                lastMessageAt: null,
+                lastCommitAt: null,
+                consumerLagMessages: 0n,
+                lagSampledAt: expect.any(Number),
+                committedOffset: null,
+                lastError: null,
+              },
+            }),
+          },
+        },
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [
+            {
+              id: "order-3",
+              customerId: "customer-3-after-latest-start",
+              price: 30,
+            },
+          ],
+          totalRows: 1,
+          version: expect.any(Number),
+        },
+        finalHealth: {
+          status: "ready",
+          startFrom: {
+            consumerGroupId,
+            fallbackMode: "latest",
+            mode: "latest",
+          },
+          engineRows: 1,
+          committedOffset: "3",
+        },
+      });
+    }).pipe(Effect.provide(NodeCrypto.layer)),
+  );
+
   it.live("resumes committed Kafka offsets after restart without rebuilding old rows", () =>
     Effect.gen(function* () {
       const ordersSourceTopic = yield* uniqueTopicName("committed-restart-orders");

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -217,8 +217,13 @@ const snapshotKafkaAssignments = (
     partitions: [...assignment.partitions],
   }));
 
-const consumerLagMessagesFromLag = (lags: ReadonlyArray<bigint>): bigint =>
-  lags.reduce((total, lag) => (lag >= 0n ? total + lag : total), 0n);
+const consumerLagMessagesFromLag = (lags: ReadonlyArray<bigint>): bigint | null => {
+  const initializedLags = lags.filter((lag) => lag >= 0n);
+  if (initializedLags.length === 0) {
+    return null;
+  }
+  return initializedLags.reduce((total, lag) => total + lag, 0n);
+};
 
 export const kafkaConsumerStartError = (
   region: string,
@@ -360,11 +365,14 @@ export const recordKafkaLag = Effect.fn("ViewServerRuntime.kafka.consumer.record
   yield* health.regionRecovered(region, nowMillis);
   yield* Effect.forEach(
     topics,
-    (sourceTopic) =>
-      health.topicLagSampled(sourceTopic, region, {
-        consumerLagMessages: consumerLagMessagesFromLag(lag.get(sourceTopic) ?? []),
+    (sourceTopic) => {
+      const sourceTopicLag = lag.get(sourceTopic);
+      return health.topicLagSampled(sourceTopic, region, {
+        consumerLagMessages:
+          sourceTopicLag === undefined ? 0n : consumerLagMessagesFromLag(sourceTopicLag),
         nowMillis,
-      }),
+      });
+    },
     { discard: true },
   );
   yield* requestKafkaHealthRefresh(requestHealthRefresh);

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1140,7 +1140,7 @@ Recovery tests:
 
 - Start runtime, ingest rows, stop runtime, restart from earliest, verify snapshot converges.
 - Start runtime in committed mode, ingest and commit rows, stop runtime, append new rows, restart with a distinct top-level `consumerGroupId` and `startFrom.committedConsumerGroup` pointing at the committed group, verify committed mode follows the committed group's offsets and only newly consumed rows are present unless durable state/checkpoints are added.
-- Start from latest, verify old rows are intentionally absent and health reports the policy.
+- Start from latest, verify old rows are intentionally absent, newly appended rows are consumed, and health reports the no-backfill policy.
 - Restart during active subscriptions, clients reconnect and receive fresh snapshots.
 
 ### Query Semantics


### PR DESCRIPTION
## Summary

- Add a real Kafka e2e for `startFrom: "latest"` proving historical rows are not backfilled and newly appended rows are consumed.
- Keep negative-only Kafka lag samples as `null`, so assigned-but-uninitialized partitions do not masquerade as zero lag.
- Document the latest no-backfill recovery policy in the v2 plan.

## Validation

- `vp run @view-server/runtime#test -- src/kafka-ingress.internal.test.ts src/kafka-ingress.test.ts`
- `pnpm run ready`
- 3 reviewer agents: no findings
