### PR TITLE
Add active-query sharing benchmark gate

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,22 @@ small and noisy; structural metadata, counters, sample counts, and RSS remain st
 
 Do not run benchmark profiles in parallel when comparing results.
 
+Active-query sharing has a focused engine gate:
+
+```bash
+pnpm run bench:baseline:active-query-sharing
+```
+
+Refresh it only when an active-query sharing performance change is intentionally accepted:
+
+```bash
+pnpm run bench:baseline:active-query-sharing:update
+```
+
+This profile runs `raw-live-fanout` across same-window, ten-window, unique-window, and unique-shape
+subscription sets. It exists to catch duplicated materialization/fanout regressions separately from
+the broader smoke gate while still using Vitest benchmark output and committed baselines.
+
 Kafka runtime profiles are separate from the default smoke gate because they start the Apache Kafka
 container and exercise real `@platformatic/kafka` producers/consumers:
 

--- a/benchmarks/baselines/active-query-sharing.json
+++ b/benchmarks/baselines/active-query-sharing.json
@@ -1,0 +1,147 @@
+{
+  "artifactKind": "view-server-benchmark-baseline",
+  "profile": "active-query-sharing",
+  "tasks": [
+    {
+      "activeViewCountBeforeCleanup": 1,
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 10000 rows, 50 subscribers, same-window",
+          "maxMs": 5.539041999999995,
+          "meanMs": 3.458608600000025,
+          "minMs": 2.8460000000000036,
+          "name": "same-window subscribers publish + delta fanout",
+          "p99Ms": 5.539041999999995,
+          "sampleCount": 5
+        }
+      ],
+      "benchmarkCases": ["same-window subscribers publish + delta fanout"],
+      "benchmarkName": "raw live fanout benchmark",
+      "benchmarkScope": "engine-raw-live-fanout",
+      "cleanupLeakCount": 0,
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 58671104,
+      "minimumSampleCount": 5,
+      "mutationCount": 10005,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-same-window-10000rows-50subs.json",
+      "queuedEventCount": 0,
+      "rowCount": 10000,
+      "subscriberCount": 50,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-same-window-10000rows-50subs.summary.json",
+      "taskLabel": "raw live fanout same-window 10000 rows 50 subscribers",
+      "topics": ["orders"]
+    },
+    {
+      "activeViewCountBeforeCleanup": 1,
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 10000 rows, 50 subscribers, ten-window",
+          "maxMs": 5.15583300000003,
+          "meanMs": 3.3253333999999994,
+          "minMs": 2.749750000000006,
+          "name": "ten-window subscribers publish + delta fanout",
+          "p99Ms": 5.15583300000003,
+          "sampleCount": 5
+        }
+      ],
+      "benchmarkCases": ["ten-window subscribers publish + delta fanout"],
+      "benchmarkName": "raw live fanout benchmark",
+      "benchmarkScope": "engine-raw-live-fanout",
+      "cleanupLeakCount": 0,
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 63356928,
+      "minimumSampleCount": 5,
+      "mutationCount": 10005,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-ten-window-10000rows-50subs.json",
+      "queuedEventCount": 0,
+      "rowCount": 10000,
+      "subscriberCount": 50,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-ten-window-10000rows-50subs.summary.json",
+      "taskLabel": "raw live fanout ten-window 10000 rows 50 subscribers",
+      "topics": ["orders"]
+    },
+    {
+      "activeViewCountBeforeCleanup": 1,
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 10000 rows, 50 subscribers, unique-window",
+          "maxMs": 5.1065830000000005,
+          "meanMs": 3.1498915999999895,
+          "minMs": 2.380625000000009,
+          "name": "unique-window subscribers publish + delta fanout",
+          "p99Ms": 5.1065830000000005,
+          "sampleCount": 5
+        }
+      ],
+      "benchmarkCases": ["unique-window subscribers publish + delta fanout"],
+      "benchmarkName": "raw live fanout benchmark",
+      "benchmarkScope": "engine-raw-live-fanout",
+      "cleanupLeakCount": 0,
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 58228736,
+      "minimumSampleCount": 5,
+      "mutationCount": 10005,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-unique-window-10000rows-50subs.json",
+      "queuedEventCount": 0,
+      "rowCount": 10000,
+      "subscriberCount": 50,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-unique-window-10000rows-50subs.summary.json",
+      "taskLabel": "raw live fanout unique-window 10000 rows 50 subscribers",
+      "topics": ["orders"]
+    },
+    {
+      "activeViewCountBeforeCleanup": 50,
+      "artifactKind": "engine-benchmark-summary",
+      "backpressureCount": 0,
+      "benchmarks": [
+        {
+          "groupName": "src/raw-live-fanout.bench.ts > raw live fanout benchmark: 10000 rows, 50 subscribers, unique-shape",
+          "maxMs": 5.533041999999966,
+          "meanMs": 3.4699751999999875,
+          "minMs": 2.848124999999982,
+          "name": "unique-shape subscribers publish + delta fanout",
+          "p99Ms": 5.533041999999966,
+          "sampleCount": 5
+        }
+      ],
+      "benchmarkCases": ["unique-shape subscribers publish + delta fanout"],
+      "benchmarkName": "raw live fanout benchmark",
+      "benchmarkScope": "engine-raw-live-fanout",
+      "cleanupLeakCount": 0,
+      "latencySource": "vitest-output-json",
+      "memoryRssTotalDeltaBytes": 61620224,
+      "minimumSampleCount": 5,
+      "mutationCount": 10005,
+      "outputJsonPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-unique-shape-10000rows-50subs.json",
+      "queuedEventCount": 0,
+      "rowCount": 10000,
+      "subscriberCount": 50,
+      "summaryPath": "packages/column-live-view-engine/.artifacts/raw-live-fanout-unique-shape-10000rows-50subs.summary.json",
+      "taskLabel": "raw live fanout unique-shape 10000 rows 50 subscribers",
+      "topics": ["orders"]
+    }
+  ],
+  "thresholds": {
+    "latencyMean": {
+      "maxAbsoluteDeltaMs": 5,
+      "maxRatio": 8
+    },
+    "latencyP99": {
+      "maxAbsoluteDeltaMs": 10,
+      "maxRatio": 8
+    },
+    "memoryRssTotalDelta": {
+      "maxAbsoluteDeltaBytes": 134217728,
+      "maxRatio": 3
+    },
+    "throughputAggregateRowsPerSecond": {
+      "minRatio": 0.5
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "bench:baseline": "pnpm run bench:baseline:smoke",
+    "bench:baseline:active-query-sharing": "node scripts/run-benchmark-baseline.mjs --profile=active-query-sharing",
+    "bench:baseline:active-query-sharing:update": "node scripts/run-benchmark-baseline.mjs --profile=active-query-sharing --update-baseline",
     "bench:baseline:grouped-admission": "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission",
     "bench:baseline:grouped-admission:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission --update-baseline",
     "bench:baseline:grouped-order-neutral": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral",

--- a/packages/column-live-view-engine/src/benchmark-artifact.ts
+++ b/packages/column-live-view-engine/src/benchmark-artifact.ts
@@ -91,6 +91,7 @@ export type BenchmarkGroupedKeyWidthParameters = {
 };
 
 export type BenchmarkArtifactInput = {
+  readonly activeViewCountBeforeCleanup?: number;
   readonly artifactKind: "engine-benchmark-summary";
   readonly benchmarkName: string;
   readonly benchmarkScope:
@@ -331,6 +332,7 @@ export const writeBenchmarkArtifact = (input: BenchmarkArtifactInput): void => {
     `${JSON.stringify(
       {
         artifactKind: input.artifactKind,
+        activeViewCountBeforeCleanup: input.activeViewCountBeforeCleanup,
         backpressureCount: input.backpressureCount,
         benchmarkCases: input.benchmarkCases,
         benchmarkName: input.benchmarkName,

--- a/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
+++ b/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
@@ -9,10 +9,12 @@ import {
   type ColumnLiveViewSubscription,
 } from "./index";
 import {
+  activeViewCountFromEngineHealth,
   backpressureCountFromEngineHealth,
   benchmarkOutputJsonPath,
   cleanupLeakCountFromEngineHealth,
   failOnBenchmarkCleanupLeaks,
+  isBenchmarkEngineHealth,
   memorySnapshot,
   queuedEventCountFromEngineHealth,
   writeBenchmarkArtifact,
@@ -45,11 +47,11 @@ type Topics = typeof viewServer.topics;
 type Engine = ColumnLiveViewEngine<Topics>;
 type OrderRow = typeof Order.Type;
 type OrderStatus = OrderRow["status"];
-type SelectedOrderRow = Pick<OrderRow, "id" | "customerId" | "price" | "status" | "updatedAt">;
+type SelectedOrderRow = OrderRow;
 type OrderSubscription = ColumnLiveViewSubscription<SelectedOrderRow>;
 type OrderEvent = ColumnLiveViewEngineEvent<SelectedOrderRow>;
 type OrderEventReader = () => Effect.Effect<ReadonlyArray<OrderEvent>, Cause.Done>;
-type FanoutCaseName = "same-window" | "ten-window";
+type FanoutCaseName = "same-window" | "ten-window" | "unique-shape" | "unique-window";
 type CaseSpecificDeltaExpectation = (
   eventChunks: ReadonlyArray<ReadonlyArray<OrderEvent>>,
   rowId: string,
@@ -131,10 +133,17 @@ const fanoutCaseNameFromEnv = (): FanoutCaseName => {
     return defaultFanoutCaseName;
   }
   const trimmed = raw.trim();
-  if (trimmed === "same-window" || trimmed === "ten-window") {
+  if (
+    trimmed === "same-window" ||
+    trimmed === "ten-window" ||
+    trimmed === "unique-shape" ||
+    trimmed === "unique-window"
+  ) {
     return trimmed;
   }
-  throw new Error("VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE must be same-window or ten-window.");
+  throw new Error(
+    "VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE must be same-window, ten-window, unique-window, or unique-shape.",
+  );
 };
 
 const benchmarkRowCount = rowCountFromEnv();
@@ -216,11 +225,21 @@ const deltaOrder = (index: number): OrderRow => ({
   updatedAt: 1_000_000_000 + index,
 });
 
-const fanoutCaseWindowOffset = (caseName: FanoutCaseName): ((index: number) => number) => {
-  if (caseName === "same-window") {
+const fanoutCaseWindowOffset = (caseName: FanoutCaseName) => {
+  if (caseName === "same-window" || caseName === "unique-shape") {
     return () => 0;
   }
-  return (index) => index % 10;
+  if (caseName === "unique-window") {
+    return (index: number) => index;
+  }
+  return (index: number) => index % 10;
+};
+
+const fanoutCaseMinimumPrice = (caseName: FanoutCaseName, index: number): number => {
+  if (caseName === "unique-shape") {
+    return Math.min(index, subscriberCount - 1);
+  }
+  return 0;
 };
 
 const seedEngine = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.seed")(function* (
@@ -260,13 +279,19 @@ const makeEventReader = (
   );
 
 const makeSubscriptions = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.subscribe")(
-  function* (engine: Engine, count: number, windowOffset: (index: number) => number) {
+  function* (
+    engine: Engine,
+    count: number,
+    caseName: FanoutCaseName,
+    windowOffset: (index: number) => number,
+  ) {
     const subscriptions = yield* Effect.forEach(
       Array.from({ length: count }, (_value, index) => index),
       (index) =>
         engine.subscribe("orders", {
-          select: ["id", "customerId", "price", "status", "updatedAt"],
+          select: ["id", "customerId", "status", "price", "region", "updatedAt"],
           where: {
+            price: { gte: fanoutCaseMinimumPrice(caseName, index) },
             status: { eq: "open" },
           },
           orderBy: [{ field: "updatedAt", direction: "desc" }],
@@ -299,6 +324,7 @@ const makeFanoutCase = Effect.fn("ColumnLiveViewEngine.bench.rawLiveFanout.case.
   const subscriptions = yield* makeSubscriptions(
     engine,
     benchmarkProfile.subscriberCount,
+    benchmarkProfile.fanoutCaseName,
     windowOffset,
   );
   fanoutCase.engine = engine;
@@ -358,6 +384,9 @@ const eventIncludesDeltaRow = (event: OrderEvent, rowId: string): boolean => {
   });
 };
 
+const eventHasDeltaOperation = (event: OrderEvent): boolean =>
+  event.type === "delta" && event.operations.length > 0;
+
 const expectSameWindowDeltaRows: CaseSpecificDeltaExpectation = (
   eventChunks,
   rowId,
@@ -368,17 +397,44 @@ const expectSameWindowDeltaRows: CaseSpecificDeltaExpectation = (
   ).toStrictEqual(Array.from({ length: readerCount }, () => true));
 };
 
-const expectTenWindowDeltaRows: CaseSpecificDeltaExpectation = (
-  eventChunks,
-  _rowId,
-  readerCount,
+const expectWindowedDeltaRows = (
+  eventChunks: ReadonlyArray<ReadonlyArray<OrderEvent>>,
+  rowId: string,
+  readerCount: number,
+  includesInsertedRow: (index: number) => boolean,
 ) => {
   expect(eventChunks).toHaveLength(readerCount);
+  expect(
+    eventChunks.map((events) => events.some((event) => eventHasDeltaOperation(event))),
+  ).toStrictEqual(Array.from({ length: readerCount }, () => true));
+  expect(
+    eventChunks.map((events) => events.some((event) => eventIncludesDeltaRow(event, rowId))),
+  ).toStrictEqual(
+    Array.from({ length: readerCount }, (_value, index) => includesInsertedRow(index)),
+  );
 };
+
+const expectTenWindowDeltaRows: CaseSpecificDeltaExpectation = (eventChunks, rowId, readerCount) =>
+  expectWindowedDeltaRows(eventChunks, rowId, readerCount, (index) => index % 10 === 0);
+
+const expectUniqueWindowDeltaRows: CaseSpecificDeltaExpectation = (
+  eventChunks,
+  rowId,
+  readerCount,
+) => expectWindowedDeltaRows(eventChunks, rowId, readerCount, (index) => index === 0);
 
 const expectCaseSpecificDelta: Record<FanoutCaseName, CaseSpecificDeltaExpectation> = {
   "same-window": expectSameWindowDeltaRows,
   "ten-window": expectTenWindowDeltaRows,
+  "unique-shape": expectSameWindowDeltaRows,
+  "unique-window": expectUniqueWindowDeltaRows,
+};
+
+const expectedActiveViewCount = (caseName: FanoutCaseName, subscriberCount: number): number => {
+  if (caseName === "unique-shape") {
+    return subscriberCount;
+  }
+  return 1;
 };
 
 beforeAll(async () => {
@@ -391,23 +447,55 @@ beforeAll(async () => {
 afterAll(async () => {
   const memoryAfterSetup = profile.memoryAfterSetup ?? memoryBefore;
   const mutationCount = profile.fanoutCase.nextDeltaIndex;
+  const engine = profile.fanoutCase.engine;
+  let structuralError: Error | undefined;
+  let preCleanupHealth: unknown = {
+    status: "not-started",
+  };
+  if (engine !== undefined) {
+    const preCleanupHealthExit = await Effect.runPromiseExit(engine.health());
+    if (Exit.isSuccess(preCleanupHealthExit)) {
+      preCleanupHealth = preCleanupHealthExit.value;
+    } else {
+      structuralError = new Error("Raw live fanout benchmark pre-cleanup health read failed.", {
+        cause: preCleanupHealthExit.cause,
+      });
+    }
+  }
+  const activeViewCountBeforeCleanup = isBenchmarkEngineHealth(preCleanupHealth)
+    ? activeViewCountFromEngineHealth(preCleanupHealth)
+    : undefined;
+  const expectedActiveViews = expectedActiveViewCount(
+    profile.fanoutCaseName,
+    profile.subscriberCount,
+  );
+  if (structuralError === undefined) {
+    if (activeViewCountBeforeCleanup === undefined) {
+      structuralError = new Error("Raw live fanout benchmark pre-cleanup health is malformed.");
+    } else if (activeViewCountBeforeCleanup !== expectedActiveViews) {
+      structuralError = new Error(
+        `Raw live fanout benchmark ${profile.fanoutCaseName} expected ${expectedActiveViews} active view(s) before cleanup but saw ${activeViewCountBeforeCleanup}.`,
+      );
+    }
+  }
   await Effect.runPromise(
     closeSubscriptions(profile.fanoutCase.subscriptions, profile.fanoutCase.scope),
   );
   const health =
-    profile.fanoutCase.engine === undefined
+    engine === undefined
       ? {
           status: "not-started",
         }
-      : await Effect.runPromise(profile.fanoutCase.engine.health());
+      : await Effect.runPromise(engine.health());
   const cleanupLeakCount = cleanupLeakCountFromEngineHealth(health);
-  if (profile.fanoutCase.engine !== undefined) {
-    await Effect.runPromise(profile.fanoutCase.engine.close());
+  if (engine !== undefined) {
+    await Effect.runPromise(engine.close());
   }
   profile.fanoutCase = emptyFanoutCaseProfile();
   profile.memoryAfterSetup = undefined;
   const memoryAfterBenchmark = memorySnapshot();
   writeBenchmarkArtifact({
+    ...(activeViewCountBeforeCleanup === undefined ? {} : { activeViewCountBeforeCleanup }),
     artifactKind: "engine-benchmark-summary",
     backpressureCount: backpressureCountFromEngineHealth(health),
     benchmarkCases: [`${profile.fanoutCaseName} subscribers publish + delta fanout`],
@@ -426,14 +514,19 @@ afterAll(async () => {
     notes: [
       "Latency percentiles are emitted by Vitest in outputJsonPath.",
       "mutationCount includes setup seed rows plus live fanout publish benchmark iterations.",
+      "activeViewCountBeforeCleanup records the number of materialized active raw views before subscribers are closed.",
     ],
     outputJsonPath,
+    preCleanupHealth,
     queuedEventCount: queuedEventCountFromEngineHealth(health),
     rowCount: profile.rowCount,
     subscriberCount: profile.subscriberCount,
     topics: ["orders"],
   });
   failOnBenchmarkCleanupLeaks(cleanupLeakCount);
+  if (structuralError !== undefined) {
+    throw structuralError;
+  }
 }, 0);
 
 describe(`raw live fanout benchmark: ${profile.rowCount} rows, ${profile.subscriberCount} subscribers, ${profile.fanoutCaseName}`, () => {

--- a/scripts/benchmark-baseline-runner.mjs
+++ b/scripts/benchmark-baseline-runner.mjs
@@ -500,6 +500,27 @@ export const profiles = new Map([
     ],
   ],
   [
+    "active-query-sharing",
+    [
+      rawLiveFanoutTask("same-window", 10_000, 50, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "1000",
+        ...commonEngineSmokeEnv,
+      }),
+      rawLiveFanoutTask("ten-window", 10_000, 50, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "1000",
+        ...commonEngineSmokeEnv,
+      }),
+      rawLiveFanoutTask("unique-window", 10_000, 50, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "1000",
+        ...commonEngineSmokeEnv,
+      }),
+      rawLiveFanoutTask("unique-shape", 10_000, 50, {
+        VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE: "1000",
+        ...commonEngineSmokeEnv,
+      }),
+    ],
+  ],
+  [
     "grouped-admission",
     [
       groupedWriteTask("incremental", 100_000, groupedAdmissionReleaseEnv),

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -192,6 +192,8 @@ describe("benchmark baseline runner", () => {
     const scripts = JSON.parse(readFileSync("package.json", "utf8")).scripts;
 
     expect({
+      activeQuerySharing: scripts["bench:baseline:active-query-sharing"],
+      activeQuerySharingUpdate: scripts["bench:baseline:active-query-sharing:update"],
       groupedAdmission: scripts["bench:baseline:grouped-admission"],
       groupedAdmissionUpdate: scripts["bench:baseline:grouped-admission:update"],
       groupedOrderNeutral: scripts["bench:baseline:grouped-order-neutral"],
@@ -202,6 +204,10 @@ describe("benchmark baseline runner", () => {
       kafkaSustainedFirehoseUpdate: scripts["bench:baseline:kafka-sustained-firehose:update"],
       release: scripts["bench:baseline:release"],
     }).toStrictEqual({
+      activeQuerySharing:
+        "node scripts/run-benchmark-baseline.mjs --profile=active-query-sharing",
+      activeQuerySharingUpdate:
+        "node scripts/run-benchmark-baseline.mjs --profile=active-query-sharing --update-baseline",
       groupedAdmission: "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission",
       groupedAdmissionUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=grouped-admission --update-baseline",
@@ -217,6 +223,69 @@ describe("benchmark baseline runner", () => {
         "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose --update-baseline",
       release: "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     });
+  });
+
+  it("defines active-query sharing fanout tasks", () => {
+    const activeQuerySharingTasks = profiles.get("active-query-sharing") ?? [];
+
+    expect(
+      activeQuerySharingTasks.map((task) => ({
+        batchSize: task.env["VIEW_SERVER_ENGINE_BENCH_BATCH_SIZE"],
+        benchmarkScope: task.expectedBenchmarkScope,
+        fanoutCase: task.env["VIEW_SERVER_ENGINE_BENCH_FANOUT_CASE"],
+        iterations: task.env["VIEW_SERVER_ENGINE_BENCH_ITERATIONS"],
+        outputJsonPath: task.packageOutputJsonPath,
+        rowCount: task.env["VIEW_SERVER_ENGINE_BENCH_ROWS"],
+        subscriberCount: task.env["VIEW_SERVER_ENGINE_BENCH_SUBSCRIBERS"],
+        task: task.args,
+        timeMs: task.env["VIEW_SERVER_ENGINE_BENCH_TIME_MS"],
+      })),
+    ).toStrictEqual([
+      {
+        batchSize: "1000",
+        benchmarkScope: "engine-raw-live-fanout",
+        fanoutCase: "same-window",
+        iterations: "5",
+        outputJsonPath: ".artifacts/raw-live-fanout-same-window-10000rows-50subs.json",
+        rowCount: "10000",
+        subscriberCount: "50",
+        task: ["run", "--no-cache", "column-live-view-engine#bench:raw-live-fanout"],
+        timeMs: "1",
+      },
+      {
+        batchSize: "1000",
+        benchmarkScope: "engine-raw-live-fanout",
+        fanoutCase: "ten-window",
+        iterations: "5",
+        outputJsonPath: ".artifacts/raw-live-fanout-ten-window-10000rows-50subs.json",
+        rowCount: "10000",
+        subscriberCount: "50",
+        task: ["run", "--no-cache", "column-live-view-engine#bench:raw-live-fanout"],
+        timeMs: "1",
+      },
+      {
+        batchSize: "1000",
+        benchmarkScope: "engine-raw-live-fanout",
+        fanoutCase: "unique-window",
+        iterations: "5",
+        outputJsonPath: ".artifacts/raw-live-fanout-unique-window-10000rows-50subs.json",
+        rowCount: "10000",
+        subscriberCount: "50",
+        task: ["run", "--no-cache", "column-live-view-engine#bench:raw-live-fanout"],
+        timeMs: "1",
+      },
+      {
+        batchSize: "1000",
+        benchmarkScope: "engine-raw-live-fanout",
+        fanoutCase: "unique-shape",
+        iterations: "5",
+        outputJsonPath: ".artifacts/raw-live-fanout-unique-shape-10000rows-50subs.json",
+        rowCount: "10000",
+        subscriberCount: "50",
+        task: ["run", "--no-cache", "column-live-view-engine#bench:raw-live-fanout"],
+        timeMs: "1",
+      },
+    ]);
   });
 
   it("defines the Kafka ingest runtime benchmark task", () => {
@@ -1097,7 +1166,7 @@ describe("benchmark baseline runner", () => {
     }).toStrictEqual({
       exitCode: 1,
       message:
-        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, kafka-sustained-firehose, grouped-admission, grouped-order-neutral, release",
+        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, kafka-sustained-firehose, active-query-sharing, grouped-admission, grouped-order-neutral, release",
     });
   });
 

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -583,6 +583,14 @@ export const readBenchmarkObservation = (task) => {
   }
 
   return {
+    ...(summary.activeViewCountBeforeCleanup === undefined
+      ? {}
+      : {
+          activeViewCountBeforeCleanup: nonNegativeInteger(
+            summary.activeViewCountBeforeCleanup,
+            `${task.summaryPath}.activeViewCountBeforeCleanup`,
+          ),
+        }),
     artifactKind,
     backpressureCount: finiteNumber(
       summary.backpressureCount,
@@ -778,6 +786,14 @@ const validateTask = (task, path) => {
     }
   }
   return {
+    ...(task.activeViewCountBeforeCleanup === undefined
+      ? {}
+      : {
+          activeViewCountBeforeCleanup: nonNegativeInteger(
+            task.activeViewCountBeforeCleanup,
+            `${path}.activeViewCountBeforeCleanup`,
+          ),
+        }),
     artifactKind,
     backpressureCount: finiteNumber(task.backpressureCount, `${path}.backpressureCount`),
     benchmarks,
@@ -1111,6 +1127,15 @@ export const compareBenchmarkBaseline = (baseline, actualBaseline) => {
       actualTask.latencySource,
     );
     compareExactJson(regressions, taskLabel, "browser", baselineTask.browser, actualTask.browser);
+    if (baselineTask.activeViewCountBeforeCleanup !== undefined) {
+      compareExact(
+        regressions,
+        taskLabel,
+        "activeViewCountBeforeCleanup",
+        baselineTask.activeViewCountBeforeCleanup,
+        actualTask.activeViewCountBeforeCleanup,
+      );
+    }
     compareExactJson(
       regressions,
       taskLabel,

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -325,6 +325,27 @@ describe("benchmark baseline comparison", () => {
     });
   });
 
+  it("reads active-query sharing structural counters from summary artifacts", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-observation-"));
+    const summaryPath = join(directory, "actual.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    writeFileSync(
+      summaryPath,
+      `${JSON.stringify({
+        ...summary,
+        activeViewCountBeforeCleanup: 1,
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
+
+    expect(readBenchmarkObservation(taskPaths(summaryPath, outputJsonPath))).toStrictEqual({
+      ...observation,
+      activeViewCountBeforeCleanup: 1,
+      outputJsonPath,
+      summaryPath,
+    });
+  });
+
   it("reads browser benchmark observations without process memory data", () => {
     const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-observation-"));
     const summaryPath = join(directory, "actual.summary.json");
@@ -1570,6 +1591,43 @@ describe("benchmark baseline comparison", () => {
           },
         ],
         memoryRssTotalDeltaBytes: 2048,
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, actual)).toStrictEqual({
+      ok: true,
+      regressions: [],
+    });
+  });
+
+  it("reports active-query sharing structural regressions", () => {
+    const baseline = buildBenchmarkBaseline("active-query-sharing", [
+      {
+        ...observation,
+        activeViewCountBeforeCleanup: 1,
+      },
+    ]);
+    const regressed = buildBenchmarkBaseline("active-query-sharing", [
+      {
+        ...observation,
+        activeViewCountBeforeCleanup: 50,
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, regressed)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a: activeViewCountBeforeCleanup changed from 1 to 50.",
+      ],
+    });
+  });
+
+  it("does not force optional active-query structural counters onto older baselines", () => {
+    const baseline = buildBenchmarkBaseline("smoke", [observation]);
+    const actual = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        activeViewCountBeforeCleanup: 1,
       },
     ]);
 


### PR DESCRIPTION
## Summary
- add an active-query-sharing benchmark baseline profile for same-window, ten-window, unique-window, and unique-shape raw live fanout
- persist and compare activeViewCountBeforeCleanup so shared-query regressions fail structurally, not just by noisy latency
- keep the new structural counter optional for older smoke baselines

## Validation
- vp test run src/raw-live-fanout.bench.ts src/benchmark-artifact.test.ts
- vp test run scripts/benchmark-baseline.test.ts scripts/benchmark-baseline-runner.test.ts
- pnpm --filter @view-server/column-live-view-engine exec tsc -p tsconfig.json --noEmit
- vp check --fix
- pnpm run check:effect
- pnpm run bench:baseline:active-query-sharing:update
- pnpm run bench:baseline:active-query-sharing
- pnpm run bench:baseline:smoke
- pnpm run ready