### PR TITLE
Add Kafka firehose runtime metrics

### DIFF
--- a/benchmarks/baselines/kafka-sustained-firehose.json
+++ b/benchmarks/baselines/kafka-sustained-firehose.json
@@ -8,11 +8,11 @@
       "benchmarks": [
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka sustained firehose runtime benchmark: 250 rows per producer batch",
-          "maxMs": 17182.083125,
-          "meanMs": 16564.81754166667,
-          "minMs": 16095.242000000006,
+          "maxMs": 18123.79325,
+          "meanMs": 17440.216833,
+          "minMs": 17093.851582999996,
           "name": "sustained mixed firehose ingest",
-          "p99Ms": 17182.083125,
+          "p99Ms": 18123.79325,
           "sampleCount": 3
         }
       ],
@@ -37,28 +37,45 @@
         }
       ],
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 37289984,
+      "memoryRssTotalDeltaBytes": 26312704,
       "minimumSampleCount": 3,
       "mutationCount": 6000,
       "outputJsonPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.json",
       "queuedEventCount": 0,
       "rowCount": 250,
+      "runtimeMetrics": {
+        "eventLoopDelay": {
+          "maxMs": 25.591807,
+          "meanMs": 10.712128,
+          "p99Ms": 12.705791
+        },
+        "healthPolling": {
+          "count": 1969,
+          "maxMs": 2.311582999998791,
+          "totalMs": 1497.1916060000103
+        },
+        "kafkaLag": {
+          "maxConsumerLagMessages": "0",
+          "sampledRegionCount": 2,
+          "totalConsumerLagMessages": "0"
+        }
+      },
       "subscriberCount": 0,
       "summaryPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.summary.json",
       "taskLabel": "Kafka sustained firehose 250 rows x 4 batches",
       "throughputCases": [
         {
-          "aggregateRowsPerSecond": 120.73838464668563,
-          "maxTotalMs": 17181.896459000003,
-          "meanConvergenceMs": 16518.631041666667,
-          "meanProducerSendMs": 37.274332999997945,
-          "meanRowsPerSecond": 120.82874704338552,
-          "meanTotalMs": 16564.74041666667,
-          "minRowsPerSecond": 116.40158609804595,
+          "aggregateRowsPerSecond": 114.67800599252743,
+          "maxTotalMs": 18123.630999999998,
+          "meanConvergenceMs": 17393.824889,
+          "meanProducerSendMs": 37.51636100000193,
+          "meanRowsPerSecond": 114.76445271951725,
+          "meanTotalMs": 17440.135819333333,
+          "minRowsPerSecond": 110.3531626747422,
           "name": "sustained mixed firehose ingest",
           "producedRowsPerSample": 2000,
-          "maxReadSnapshotMs": 7.929832999998325,
-          "meanReadSnapshotMs": 6.246944333333279,
+          "maxReadSnapshotMs": 7.44920799999818,
+          "meanReadSnapshotMs": 6.348875000003318,
           "readSnapshotRowsPerSample": 50,
           "sampleCount": 3,
           "totalProducedRows": 6000

--- a/packages/runtime/src/kafka-ingest.bench.ts
+++ b/packages/runtime/src/kafka-ingest.bench.ts
@@ -8,7 +8,7 @@ import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/
 import { Buffer } from "node:buffer";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { performance } from "node:perf_hooks";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { Crypto, Effect, Exit, Schedule, Schema } from "effect";
 import { makeViewServerRuntime, type ViewServerRuntime } from "./index";
 import { OrderKeySchema, OrderValueSchema } from "./test-fixtures/runtime_orders_pb";
@@ -79,6 +79,12 @@ type IngestThroughputCaseSummary = {
   readonly readSnapshotRowsPerSample: number;
   readonly sampleCount: number;
   readonly totalProducedRows: number;
+};
+
+type BenchmarkHealthPollingMetrics = {
+  readonly count: number;
+  readonly maxMs: number;
+  readonly totalMs: number;
 };
 
 class KafkaIngestBenchmarkError extends Schema.TaggedErrorClass<KafkaIngestBenchmarkError>()(
@@ -225,6 +231,12 @@ const profile: BenchmarkProfile = {
 };
 
 const ingestSamples: Array<IngestSample> = [];
+const eventLoopDelay = monitorEventLoopDelay({ resolution: 10 });
+const healthPollingMetrics = {
+  count: 0,
+  maxMs: 0,
+  totalMs: 0,
+};
 const internalTopicNames = ["jsonOrders", "protobufOrders"] as const;
 
 function memorySnapshot(): BenchmarkMemorySnapshot {
@@ -405,6 +417,30 @@ const binaryProducer = (): Producer<Buffer, Buffer, Buffer, Buffer> => {
   return producer;
 };
 
+const readRuntimeHealth = Effect.fn("ViewServerRuntime.kafka.bench.health")(function* () {
+  const startedAt = performance.now();
+  const health = yield* startedRuntime().client.health();
+  const elapsedMs = performance.now() - startedAt;
+  healthPollingMetrics.count += 1;
+  healthPollingMetrics.totalMs += elapsedMs;
+  healthPollingMetrics.maxMs = Math.max(healthPollingMetrics.maxMs, elapsedMs);
+  return health;
+});
+
+const healthPollingSnapshot = (): BenchmarkHealthPollingMetrics => ({
+  count: healthPollingMetrics.count,
+  maxMs: healthPollingMetrics.maxMs,
+  totalMs: healthPollingMetrics.totalMs,
+});
+
+const nanosecondsToMilliseconds = (nanoseconds: number): number => nanoseconds / 1_000_000;
+
+const eventLoopDelaySnapshot = () => ({
+  maxMs: nanosecondsToMilliseconds(eventLoopDelay.max),
+  meanMs: nanosecondsToMilliseconds(eventLoopDelay.mean),
+  p99Ms: nanosecondsToMilliseconds(eventLoopDelay.percentile(99)),
+});
+
 const jsonMessages = (
   sourceTopic: string,
   startIndex: number,
@@ -457,16 +493,14 @@ const waitForRows = Effect.fn("ViewServerRuntime.kafka.bench.waitForRows")(funct
 ) {
   const expectedSourceTopic =
     topic === "jsonOrders" ? sourceTopics().jsonOrders : sourceTopics().protobufOrders;
-  const health = yield* startedRuntime()
-    .client.health()
-    .pipe(
-      Effect.repeat({
-        schedule: healthPollSchedule,
-        until: (currentHealth) =>
-          currentHealth.engine.topics[topic].rowCount === expectedRows &&
-          committedOffset(currentHealth, expectedSourceTopic) === expectedRows,
-      }),
-    );
+  const health = yield* readRuntimeHealth().pipe(
+    Effect.repeat({
+      schedule: healthPollSchedule,
+      until: (currentHealth) =>
+        currentHealth.engine.topics[topic].rowCount === expectedRows &&
+        committedOffset(currentHealth, expectedSourceTopic) === expectedRows,
+    }),
+  );
   const actualRows = health.engine.topics[topic].rowCount;
   const actualCommittedOffset = committedOffset(health, expectedSourceTopic);
   if (actualRows !== expectedRows || actualCommittedOffset !== expectedRows) {
@@ -490,30 +524,86 @@ const committedOffset = (health: ViewServerHealth<Topics>, sourceTopic: string):
   return Number.isSafeInteger(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
 };
 
+const sourceTopicLagIsFreshlyDrained = (
+  health: ViewServerHealth<Topics>,
+  sourceTopic: string,
+): boolean => {
+  const region = health.kafka?.topics[sourceTopic]?.regions["local"];
+  if (region === undefined) {
+    return false;
+  }
+  return (
+    region.consumerLagMessages === 0n &&
+    region.lastCommitAt !== null &&
+    region.lagSampledAt !== null &&
+    region.lagSampledAt >= region.lastCommitAt
+  );
+};
+
+const kafkaLagSummary = (health: ViewServerHealth<Topics>) => {
+  let maxConsumerLagMessages: bigint | null = null;
+  let sampledRegionCount = 0;
+  let totalConsumerLagMessages = 0n;
+  for (const topicHealth of Object.values(health.kafka?.topics ?? {})) {
+    for (const regionHealth of Object.values(topicHealth.regions ?? {})) {
+      const consumerLagMessages = regionHealth.consumerLagMessages;
+      if (consumerLagMessages !== null) {
+        sampledRegionCount += 1;
+        totalConsumerLagMessages += consumerLagMessages;
+        if (maxConsumerLagMessages === null || consumerLagMessages > maxConsumerLagMessages) {
+          maxConsumerLagMessages = consumerLagMessages;
+        }
+      }
+    }
+  }
+  return {
+    maxConsumerLagMessages,
+    sampledRegionCount,
+    totalConsumerLagMessages,
+  };
+};
+
+const kafkaLagIsDrained = (
+  health: ViewServerHealth<Topics>,
+  topics: NonNullable<BenchmarkProfile["sourceTopics"]>,
+): boolean => {
+  return (
+    sourceTopicLagIsFreshlyDrained(health, topics.jsonOrders) &&
+    sourceTopicLagIsFreshlyDrained(health, topics.protobufOrders)
+  );
+};
+
+const finalKafkaLagHasExpectedSamples = (health: ViewServerHealth<Topics>): boolean =>
+  kafkaLagSummary(health).sampledRegionCount === internalTopicNames.length;
+
 const waitForFinalHealth = Effect.fn("ViewServerRuntime.kafka.bench.waitForFinalHealth")(
   function* () {
     const topics = sourceTopics();
-    const health = yield* startedRuntime()
-      .client.health()
-      .pipe(
-        Effect.repeat({
-          schedule: healthPollSchedule,
-          until: (health) =>
-            health.engine.topics.jsonOrders.rowCount === profile.jsonProducedRows &&
-            health.engine.topics.protobufOrders.rowCount === profile.protobufProducedRows &&
-            committedOffset(health, topics.jsonOrders) === profile.jsonProducedRows &&
-            committedOffset(health, topics.protobufOrders) === profile.protobufProducedRows,
-        }),
-      );
+    const health = yield* readRuntimeHealth().pipe(
+      Effect.repeat({
+        schedule: healthPollSchedule,
+        until: (health) =>
+          health.engine.topics.jsonOrders.rowCount === profile.jsonProducedRows &&
+          health.engine.topics.protobufOrders.rowCount === profile.protobufProducedRows &&
+          committedOffset(health, topics.jsonOrders) === profile.jsonProducedRows &&
+          committedOffset(health, topics.protobufOrders) === profile.protobufProducedRows &&
+          (benchmarkMode !== "sustained-firehose" ||
+            (kafkaLagIsDrained(health, topics) && finalKafkaLagHasExpectedSamples(health))),
+      }),
+    );
     const jsonRows = health.engine.topics.jsonOrders.rowCount;
     const protobufRows = health.engine.topics.protobufOrders.rowCount;
     const jsonOffset = committedOffset(health, topics.jsonOrders);
     const protobufOffset = committedOffset(health, topics.protobufOrders);
+    const finalKafkaLag = kafkaLagSummary(health);
     if (
       jsonRows !== profile.jsonProducedRows ||
       protobufRows !== profile.protobufProducedRows ||
       jsonOffset !== profile.jsonProducedRows ||
-      protobufOffset !== profile.protobufProducedRows
+      protobufOffset !== profile.protobufProducedRows ||
+      (benchmarkMode === "sustained-firehose" &&
+        (finalKafkaLag.totalConsumerLagMessages !== 0n ||
+          finalKafkaLag.sampledRegionCount !== internalTopicNames.length))
     ) {
       return yield* new KafkaIngestBenchmarkError({
         message: [
@@ -522,6 +612,7 @@ const waitForFinalHealth = Effect.fn("ViewServerRuntime.kafka.bench.waitForFinal
           `protobufRows=${protobufRows}/${profile.protobufProducedRows}`,
           `jsonCommittedOffset=${jsonOffset}/${profile.jsonProducedRows}`,
           `protobufCommittedOffset=${protobufOffset}/${profile.protobufProducedRows}`,
+          `totalConsumerLagMessages=${finalKafkaLag.totalConsumerLagMessages}`,
         ].join(" "),
       });
     }
@@ -874,6 +965,7 @@ const publishSustainedMixedFirehose = async (): Promise<void> => {
 };
 
 beforeAll(async () => {
+  eventLoopDelay.enable();
   const setup = await Effect.runPromise(setupBenchmark().pipe(Effect.provide(NodeCrypto.layer)));
   profile.binaryProducer = setup.binaryProducer;
   profile.runtime = setup.runtime;
@@ -908,6 +1000,7 @@ afterAll(async () => {
   const cleanupLeakCount = cleanupLeakCountFromHealth(health);
   const backpressureCount = backpressureCountFromHealth(health);
   const queuedEventCount = queuedEventCountFromHealth(health);
+  eventLoopDelay.disable();
   writeJsonFile(benchmarkSummaryPath(outputJsonPath), {
     artifactKind: "runtime-benchmark-summary",
     backpressureCount,
@@ -965,6 +1058,11 @@ afterAll(async () => {
     ],
     queuedEventCount,
     rowCount: batchSize,
+    runtimeMetrics: {
+      eventLoopDelay: eventLoopDelaySnapshot(),
+      healthPolling: healthPollingSnapshot(),
+      kafkaLag: kafkaLagSummary(health),
+    },
     subscriberCount: 0,
     topics: ["jsonOrders", "protobufOrders"],
     throughput: {

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -139,9 +139,6 @@ const arrayValue = (value, path) => {
 const optionalObjectValue = (value, path) =>
   value === undefined ? undefined : objectValue(value, path);
 
-const optionalArrayValue = (value, path) =>
-  value === undefined ? undefined : arrayValue(value, path);
-
 const optionalFiniteNumber = (value, path) =>
   value === undefined ? undefined : finiteNumber(value, path);
 
@@ -149,6 +146,14 @@ const positiveFiniteNumber = (value, path) => {
   const number = finiteNumber(value, path);
   if (number <= 0) {
     throw new Error(`Benchmark artifact field ${path} must be a positive finite number.`);
+  }
+  return number;
+};
+
+const nonNegativeFiniteNumber = (value, path) => {
+  const number = finiteNumber(value, path);
+  if (number < 0) {
+    throw new Error(`Benchmark artifact field ${path} must be a non-negative finite number.`);
   }
   return number;
 };
@@ -202,6 +207,14 @@ const nonNegativeInteger = (value, path) => {
   return number;
 };
 
+const nonNegativeSafeInteger = (value, path) => {
+  const number = nonNegativeInteger(value, path);
+  if (!Number.isSafeInteger(number)) {
+    throw new Error(`Benchmark artifact field ${path} must be a safe non-negative integer.`);
+  }
+  return number;
+};
+
 const comparableBenchmark = (groupName, benchmark) => ({
   groupName,
   maxMs: finiteNumber(benchmark.max, `${benchmark.name}.max`),
@@ -217,7 +230,16 @@ const nonNegativeIntegerString = (value, path) => {
   if (!/^(0|[1-9]\d*)$/u.test(text)) {
     throw new Error(`Benchmark artifact field ${path} must be a non-negative integer string.`);
   }
-  return Number.parseInt(text, 10);
+  return text;
+};
+
+const nonNegativeSafeIntegerString = (value, path) => {
+  const text = nonNegativeIntegerString(value, path);
+  const number = Number.parseInt(text, 10);
+  if (!Number.isSafeInteger(number)) {
+    throw new Error(`Benchmark artifact field ${path} must be a safe integer string.`);
+  }
+  return number;
 };
 
 const kafkaIngestLaneValue = (value, path) => {
@@ -249,6 +271,65 @@ const comparableKafkaIngestLaneValue = (value, path) => {
     region: stringValue(lane.region, `${path}.region`),
     sourceTopicAlias: stringValue(lane.sourceTopicAlias, `${path}.sourceTopicAlias`),
   };
+};
+
+const nonNegativeIntegerStringOrNumber = (value, path) => {
+  if (typeof value === "number") {
+    return String(nonNegativeSafeInteger(value, path));
+  }
+  return nonNegativeIntegerString(value, path);
+};
+
+const optionalNonNegativeIntegerStringOrNumber = (value, path) =>
+  value === null ? null : nonNegativeIntegerStringOrNumber(value, path);
+
+const runtimeMetricsValue = (value, path) => {
+  const metrics = objectValue(value, path);
+  const eventLoopDelay = objectValue(metrics.eventLoopDelay, `${path}.eventLoopDelay`);
+  const healthPolling = objectValue(metrics.healthPolling, `${path}.healthPolling`);
+  const kafkaLag = objectValue(metrics.kafkaLag, `${path}.kafkaLag`);
+  const normalized = {
+    eventLoopDelay: {
+      maxMs: nonNegativeFiniteNumber(eventLoopDelay.maxMs, `${path}.eventLoopDelay.maxMs`),
+      meanMs: nonNegativeFiniteNumber(eventLoopDelay.meanMs, `${path}.eventLoopDelay.meanMs`),
+      p99Ms: nonNegativeFiniteNumber(eventLoopDelay.p99Ms, `${path}.eventLoopDelay.p99Ms`),
+    },
+    healthPolling: {
+      count: nonNegativeInteger(healthPolling.count, `${path}.healthPolling.count`),
+      maxMs: nonNegativeFiniteNumber(healthPolling.maxMs, `${path}.healthPolling.maxMs`),
+      totalMs: nonNegativeFiniteNumber(healthPolling.totalMs, `${path}.healthPolling.totalMs`),
+    },
+    kafkaLag: {
+      maxConsumerLagMessages: optionalNonNegativeIntegerStringOrNumber(
+        kafkaLag.maxConsumerLagMessages,
+        `${path}.kafkaLag.maxConsumerLagMessages`,
+      ),
+      sampledRegionCount: nonNegativeInteger(
+        kafkaLag.sampledRegionCount,
+        `${path}.kafkaLag.sampledRegionCount`,
+      ),
+      totalConsumerLagMessages: nonNegativeIntegerStringOrNumber(
+        kafkaLag.totalConsumerLagMessages,
+        `${path}.kafkaLag.totalConsumerLagMessages`,
+      ),
+    },
+  };
+  if (normalized.eventLoopDelay.p99Ms > normalized.eventLoopDelay.maxMs) {
+    throw new Error(
+      `Benchmark artifact field ${path}.eventLoopDelay.p99Ms must be less than or equal to ${path}.eventLoopDelay.maxMs.`,
+    );
+  }
+  if (normalized.eventLoopDelay.meanMs > normalized.eventLoopDelay.maxMs) {
+    throw new Error(
+      `Benchmark artifact field ${path}.eventLoopDelay.meanMs must be less than or equal to ${path}.eventLoopDelay.maxMs.`,
+    );
+  }
+  if (normalized.healthPolling.totalMs < normalized.healthPolling.maxMs) {
+    throw new Error(
+      `Benchmark artifact field ${path}.healthPolling.totalMs must be greater than or equal to ${path}.healthPolling.maxMs.`,
+    );
+  }
+  return normalized;
 };
 
 const throughputCaseValue = (value, path, options) => {
@@ -460,7 +541,7 @@ const validateRuntimeSummaryIngestCompleteness = (summary, path, mutationCount) 
         `Benchmark artifact field ${path}.health.kafka.topics.${lane.sourceTopic}.viewServerTopic must equal internalTopic ${lane.internalTopic} for Kafka ingest lane ${lane.lane} but was ${viewServerTopic}.`,
       );
     }
-    const committedOffset = nonNegativeIntegerString(
+    const committedOffset = nonNegativeSafeIntegerString(
       objectValue(
         objectValue(
           kafkaTopicHealth.regions,
@@ -634,6 +715,14 @@ export const readBenchmarkObservation = (task) => {
     outputJsonPath: task.outputJsonPath,
     queuedEventCount: finiteNumber(summary.queuedEventCount, `${task.summaryPath}.queuedEventCount`),
     rowCount,
+    ...(summary.runtimeMetrics === undefined
+      ? {}
+      : {
+          runtimeMetrics: runtimeMetricsValue(
+            summary.runtimeMetrics,
+            `${task.summaryPath}.runtimeMetrics`,
+          ),
+        }),
     seedBatchSize: optionalFiniteNumber(summary.seedBatchSize, `${task.summaryPath}.seedBatchSize`),
     subscriberCount: finiteNumber(summary.subscriberCount, `${task.summaryPath}.subscriberCount`),
     summaryPath: task.summaryPath,
@@ -759,8 +848,8 @@ const validateTask = (task, path) => {
   const artifactKind = summaryArtifactKind(task.artifactKind, `${path}.artifactKind`);
   const benchmarkScope = stringValue(task.benchmarkScope, `${path}.benchmarkScope`);
   const mutationCount = nonNegativeInteger(task.mutationCount, `${path}.mutationCount`);
-  const requiresKafkaThroughput =
-    artifactKind === "runtime-benchmark-summary" && benchmarkScope.startsWith("runtime-kafka-");
+  const isKafkaScope = benchmarkScope.startsWith("runtime-kafka-");
+  const requiresKafkaThroughput = artifactKind === "runtime-benchmark-summary" && isKafkaScope;
   const memoryRssTotalDeltaBytes = optionalFiniteNumber(
     task.memoryRssTotalDeltaBytes,
     `${path}.memoryRssTotalDeltaBytes`,
@@ -801,6 +890,17 @@ const validateTask = (task, path) => {
       );
     }
   }
+  const kafkaIngestLanes =
+    task.kafkaIngestLanes === undefined
+      ? undefined
+      : nonEmptyArrayValue(task.kafkaIngestLanes, `${path}.kafkaIngestLanes`).map(
+          (lane, index) => comparableKafkaIngestLaneValue(lane, `${path}.kafkaIngestLanes[${index}]`),
+        );
+  if (isKafkaScope && kafkaIngestLanes === undefined) {
+    throw new Error(
+      `Benchmark artifact field ${path}.kafkaIngestLanes is required for ${benchmarkScope}.`,
+    );
+  }
   return {
     ...(task.activeViewCountBeforeCleanup === undefined
       ? {}
@@ -826,9 +926,7 @@ const validateTask = (task, path) => {
       task.groupedWriteAdmission,
       `${path}.groupedWriteAdmission`,
     ),
-    kafkaIngestLanes: optionalArrayValue(task.kafkaIngestLanes, `${path}.kafkaIngestLanes`)?.map(
-      (lane, index) => comparableKafkaIngestLaneValue(lane, `${path}.kafkaIngestLanes[${index}]`),
-    ),
+    kafkaIngestLanes,
     latencySource: stringValue(task.latencySource, `${path}.latencySource`),
     memoryRssTotalDeltaBytes,
     minimumSampleCount: positiveInteger(task.minimumSampleCount, `${path}.minimumSampleCount`),
@@ -836,6 +934,11 @@ const validateTask = (task, path) => {
     outputJsonPath: stringValue(task.outputJsonPath, `${path}.outputJsonPath`),
     queuedEventCount: finiteNumber(task.queuedEventCount, `${path}.queuedEventCount`),
     rowCount: finiteNumber(task.rowCount, `${path}.rowCount`),
+    ...(task.runtimeMetrics === undefined
+      ? {}
+      : {
+          runtimeMetrics: runtimeMetricsValue(task.runtimeMetrics, `${path}.runtimeMetrics`),
+        }),
     seedBatchSize: optionalFiniteNumber(task.seedBatchSize, `${path}.seedBatchSize`),
     subscriberCount: finiteNumber(task.subscriberCount, `${path}.subscriberCount`),
     summaryPath: stringValue(task.summaryPath, `${path}.summaryPath`),
@@ -1045,6 +1148,41 @@ const compareThroughputCases = (regressions, taskLabel, threshold, baselineCases
   }
 };
 
+const compareReportOnlyRuntimeMetricsPresence = (regressions, taskLabel, baselineTask, actualTask) => {
+  if (baselineTask.runtimeMetrics !== undefined && actualTask.runtimeMetrics === undefined) {
+    pushRegression(regressions, `${taskLabel}: runtimeMetrics presence changed.`);
+  }
+};
+
+const compareKafkaSustainedFirehoseFinalLag = (regressions, taskLabel, actualTask) => {
+  if (actualTask.benchmarkScope !== "runtime-kafka-sustained-firehose") {
+    return;
+  }
+  const kafkaLag = actualTask.runtimeMetrics?.kafkaLag;
+  if (kafkaLag === undefined) {
+    pushRegression(regressions, `${taskLabel}: runtimeMetrics.kafkaLag is required.`);
+    return;
+  }
+  if (kafkaLag.sampledRegionCount !== actualTask.kafkaIngestLanes.length) {
+    pushRegression(
+      regressions,
+      `${taskLabel}: runtimeMetrics.kafkaLag sampled ${kafkaLag.sampledRegionCount} regions but expected ${actualTask.kafkaIngestLanes.length}.`,
+    );
+  }
+  if (kafkaLag.totalConsumerLagMessages !== "0") {
+    pushRegression(
+      regressions,
+      `${taskLabel}: final Kafka lag must be 0 but was ${kafkaLag.totalConsumerLagMessages}.`,
+    );
+  }
+  if (kafkaLag.maxConsumerLagMessages !== "0") {
+    pushRegression(
+      regressions,
+      `${taskLabel}: max final Kafka lag must be 0 but was ${kafkaLag.maxConsumerLagMessages}.`,
+    );
+  }
+};
+
 const benchmarkScopeRequiresExactMutationCount = (benchmarkScope) =>
   benchmarkScope === "runtime-kafka-ingest" || benchmarkScope === "runtime-websocket-firehose";
 
@@ -1169,6 +1307,8 @@ export const compareBenchmarkBaseline = (baseline, actualBaseline) => {
       baselineTask.throughputCases,
       actualTask.throughputCases,
     );
+    compareReportOnlyRuntimeMetricsPresence(regressions, taskLabel, baselineTask, actualTask);
+    compareKafkaSustainedFirehoseFinalLag(regressions, taskLabel, actualTask);
     compareExact(
       regressions,
       taskLabel,

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -181,6 +181,35 @@ const runtimeThroughput = {
 
 const comparableRuntimeThroughputCases = runtimeThroughput.cases;
 
+const rawRuntimeMetrics = {
+  eventLoopDelay: {
+    maxMs: 4,
+    meanMs: 2,
+    p99Ms: 3,
+  },
+  healthPolling: {
+    count: 11,
+    maxMs: 2,
+    totalMs: 7,
+  },
+  kafkaLag: {
+    maxConsumerLagMessages: "9007199254740993",
+    sampledRegionCount: 1,
+    totalConsumerLagMessages: "9007199254740993",
+  },
+};
+
+const runtimeMetrics = rawRuntimeMetrics;
+
+const drainedRuntimeMetrics = {
+  ...runtimeMetrics,
+  kafkaLag: {
+    maxConsumerLagMessages: "0",
+    sampledRegionCount: 1,
+    totalConsumerLagMessages: "0",
+  },
+};
+
 const comparableNonKafkaRuntimeThroughputCases = [
   {
     aggregateRowsPerSecond: 1000,
@@ -428,6 +457,7 @@ describe("benchmark baseline comparison", () => {
           ingestLanes: runtimeThroughputKafkaIngestLanes,
         },
         mutationCount: runtimeThroughputMutationCount,
+        runtimeMetrics: rawRuntimeMetrics,
         throughput: runtimeThroughput,
       })}\n`,
     );
@@ -443,6 +473,7 @@ describe("benchmark baseline comparison", () => {
       kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
       mutationCount: runtimeThroughputMutationCount,
       outputJsonPath,
+      runtimeMetrics,
       summaryPath,
       throughputCases: comparableRuntimeThroughputCases,
     });
@@ -2079,6 +2110,314 @@ describe("benchmark baseline comparison", () => {
 
     expect(() => validateBenchmarkBaseline(baseline)).toThrow(
       "Benchmark artifact field baseline.tasks[0].throughputCases is required for runtime-kafka-sustained-firehose.",
+    );
+  });
+
+  it("reports missing runtime metrics without gating noisy runtime metric values", () => {
+    const withRuntimeMetrics = {
+      ...observation,
+      runtimeMetrics,
+    };
+    const baseline = buildBenchmarkBaseline("smoke", [withRuntimeMetrics]);
+    const changedRuntimeMetrics = buildBenchmarkBaseline("smoke", [
+      {
+        ...withRuntimeMetrics,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          eventLoopDelay: {
+            maxMs: 999,
+            meanMs: 777,
+            p99Ms: 888,
+          },
+        },
+      },
+    ]);
+    const missingRuntimeMetrics = buildBenchmarkBaseline("smoke", [observation]);
+
+    expect(compareBenchmarkBaseline(baseline, changedRuntimeMetrics)).toStrictEqual({
+      ok: true,
+      regressions: [],
+    });
+    expect(compareBenchmarkBaseline(baseline, missingRuntimeMetrics)).toStrictEqual({
+      ok: false,
+      regressions: ["task a: runtimeMetrics presence changed."],
+    });
+  });
+
+  it("preserves Kafka lag precision in runtime metrics", () => {
+    const baseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics,
+      },
+    ]);
+
+    expect(validateBenchmarkBaseline(baseline).tasks[0].runtimeMetrics).toStrictEqual(
+      runtimeMetrics,
+    );
+  });
+
+  it("normalizes safe numeric Kafka lag runtime metrics", () => {
+    const safeNumericLagBaseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          kafkaLag: {
+            maxConsumerLagMessages: 5,
+            sampledRegionCount: 1,
+            totalConsumerLagMessages: 5,
+          },
+        },
+      },
+    ]);
+
+    expect(validateBenchmarkBaseline(safeNumericLagBaseline).tasks[0].runtimeMetrics).toStrictEqual({
+      ...runtimeMetrics,
+      kafkaLag: {
+        maxConsumerLagMessages: "5",
+        sampledRegionCount: 1,
+        totalConsumerLagMessages: "5",
+      },
+    });
+  });
+
+  it("rejects impossible runtime metric durations", () => {
+    const negativeEventLoopDelayBaseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          eventLoopDelay: {
+            ...runtimeMetrics.eventLoopDelay,
+            maxMs: -1,
+          },
+        },
+      },
+    ]);
+    const inconsistentEventLoopMeanBaseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          eventLoopDelay: {
+            maxMs: 4,
+            meanMs: 5,
+            p99Ms: 3,
+          },
+        },
+      },
+    ]);
+    const inconsistentEventLoopP99Baseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          eventLoopDelay: {
+            maxMs: 4,
+            meanMs: 2,
+            p99Ms: 5,
+          },
+        },
+      },
+    ]);
+    const inconsistentHealthPollingBaseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          healthPolling: {
+            ...runtimeMetrics.healthPolling,
+            maxMs: 8,
+            totalMs: 7,
+          },
+        },
+      },
+    ]);
+
+    expect(() => validateBenchmarkBaseline(negativeEventLoopDelayBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].runtimeMetrics.eventLoopDelay.maxMs must be a non-negative finite number.",
+    );
+    expect(() => validateBenchmarkBaseline(inconsistentEventLoopMeanBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].runtimeMetrics.eventLoopDelay.meanMs must be less than or equal to baseline.tasks[0].runtimeMetrics.eventLoopDelay.maxMs.",
+    );
+    expect(() => validateBenchmarkBaseline(inconsistentEventLoopP99Baseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].runtimeMetrics.eventLoopDelay.p99Ms must be less than or equal to baseline.tasks[0].runtimeMetrics.eventLoopDelay.maxMs.",
+    );
+    expect(() => validateBenchmarkBaseline(inconsistentHealthPollingBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].runtimeMetrics.healthPolling.totalMs must be greater than or equal to baseline.tasks[0].runtimeMetrics.healthPolling.maxMs.",
+    );
+  });
+
+  it("rejects unsafe numeric Kafka lag runtime metrics", () => {
+    const unsafeNumericLagBaseline = buildBenchmarkBaseline("smoke", [
+      {
+        ...observation,
+        runtimeMetrics: {
+          ...runtimeMetrics,
+          kafkaLag: {
+            maxConsumerLagMessages: 9_007_199_254_740_992,
+            sampledRegionCount: 1,
+            totalConsumerLagMessages: "0",
+          },
+        },
+      },
+    ]);
+
+    expect(() => validateBenchmarkBaseline(unsafeNumericLagBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].runtimeMetrics.kafkaLag.maxConsumerLagMessages must be a safe non-negative integer.",
+    );
+  });
+
+  it("rejects unsafe Kafka committed offset strings", () => {
+    const directory = mkdtempSync(join(tmpdir(), "view-server-benchmark-runtime-health-"));
+    const summaryPath = join(directory, "unsafe-committed-offset.summary.json");
+    const outputJsonPath = join(directory, "actual.json");
+    writeFileSync(
+      summaryPath,
+      `${JSON.stringify({
+        ...summary,
+        artifactKind: "runtime-benchmark-summary",
+        benchmarkScope: "runtime-kafka-ingest",
+        health: {
+          ...runtimeHealth,
+          kafka: {
+            topics: {
+              sourceOrders: {
+                regions: {
+                  local: {
+                    committedOffset: "9007199254740993",
+                  },
+                },
+                viewServerTopic: "orders",
+              },
+            },
+          },
+        },
+        kafka: {
+          ingestLanes: runtimeKafkaIngestLanes,
+        },
+        throughput: runtimeThroughput,
+      })}\n`,
+    );
+    writeFileSync(outputJsonPath, `${JSON.stringify(vitestOutput)}\n`);
+
+    expect(() => readBenchmarkObservation(runtimeTaskPaths(summaryPath, outputJsonPath))).toThrow(
+      `Benchmark artifact field ${summaryPath}.health.kafka.topics.sourceOrders.regions.local.committedOffset must be a safe integer string.`,
+    );
+  });
+
+  it("requires drained final Kafka lag for sustained firehose baselines", () => {
+    const twoLaneKafkaIngestLanes = [
+      ...comparableRuntimeThroughputKafkaIngestLanes,
+      {
+        internalTopic: "trades",
+        lane: "trades",
+        producedRows: runtimeThroughputMutationCount,
+        region: "local",
+        sourceTopicAlias: "unique-topic-per-run:trades",
+      },
+    ];
+    const sustainedFirehoseObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-sustained-firehose",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: twoLaneKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+      runtimeMetrics: {
+        ...drainedRuntimeMetrics,
+        kafkaLag: {
+          ...drainedRuntimeMetrics.kafkaLag,
+          sampledRegionCount: twoLaneKafkaIngestLanes.length,
+        },
+      },
+      throughputCases: comparableRuntimeThroughputCases,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-sustained-firehose", [
+      sustainedFirehoseObservation,
+    ]);
+    const nonZeroLagBaseline = buildBenchmarkBaseline("kafka-sustained-firehose", [
+      {
+        ...sustainedFirehoseObservation,
+        runtimeMetrics,
+      },
+    ]);
+    const partialLagSampleBaseline = buildBenchmarkBaseline("kafka-sustained-firehose", [
+      {
+        ...sustainedFirehoseObservation,
+        runtimeMetrics: drainedRuntimeMetrics,
+      },
+    ]);
+    const missingMaxLagBaseline = buildBenchmarkBaseline("kafka-sustained-firehose", [
+      {
+        ...sustainedFirehoseObservation,
+        runtimeMetrics: {
+          ...sustainedFirehoseObservation.runtimeMetrics,
+          kafkaLag: {
+            ...sustainedFirehoseObservation.runtimeMetrics.kafkaLag,
+            maxConsumerLagMessages: null,
+          },
+        },
+      },
+    ]);
+    const missingRuntimeMetricsBaseline = buildBenchmarkBaseline("kafka-sustained-firehose", [
+      {
+        ...sustainedFirehoseObservation,
+        runtimeMetrics: undefined,
+      },
+    ]);
+    const missingKafkaIngestLanesBaseline = buildBenchmarkBaseline("kafka-sustained-firehose", [
+      {
+        ...sustainedFirehoseObservation,
+        kafkaIngestLanes: undefined,
+      },
+    ]);
+    const missingKafkaIngestLanesWithArtifactKindDriftBaseline = buildBenchmarkBaseline(
+      "kafka-sustained-firehose",
+      [
+        {
+          ...sustainedFirehoseObservation,
+          artifactKind: "engine-benchmark-summary",
+          kafkaIngestLanes: undefined,
+        },
+      ],
+    );
+
+    expect(compareBenchmarkBaseline(baseline, baseline)).toStrictEqual({
+      ok: true,
+      regressions: [],
+    });
+    expect(compareBenchmarkBaseline(baseline, nonZeroLagBaseline)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a: runtimeMetrics.kafkaLag sampled 1 regions but expected 2.",
+        "task a: final Kafka lag must be 0 but was 9007199254740993.",
+        "task a: max final Kafka lag must be 0 but was 9007199254740993.",
+      ],
+    });
+    expect(compareBenchmarkBaseline(baseline, partialLagSampleBaseline)).toStrictEqual({
+      ok: false,
+      regressions: ["task a: runtimeMetrics.kafkaLag sampled 1 regions but expected 2."],
+    });
+    expect(compareBenchmarkBaseline(baseline, missingMaxLagBaseline)).toStrictEqual({
+      ok: false,
+      regressions: ["task a: max final Kafka lag must be 0 but was null."],
+    });
+    expect(compareBenchmarkBaseline(baseline, missingRuntimeMetricsBaseline)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a: runtimeMetrics presence changed.",
+        "task a: runtimeMetrics.kafkaLag is required.",
+      ],
+    });
+    expect(() => validateBenchmarkBaseline(missingKafkaIngestLanesBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].kafkaIngestLanes is required for runtime-kafka-sustained-firehose.",
+    );
+    expect(() =>
+      validateBenchmarkBaseline(missingKafkaIngestLanesWithArtifactKindDriftBaseline),
+    ).toThrow(
+      "Benchmark artifact field baseline.tasks[0].kafkaIngestLanes is required for runtime-kafka-sustained-firehose.",
     );
   });
 


### PR DESCRIPTION
## Summary
- Add report-only runtime metrics to the Kafka sustained-firehose benchmark: event-loop delay, health polling cost, and final Kafka lag.
- Make sustained-firehose convergence require fresh zero-lag samples for every Kafka ingest lane.
- Harden benchmark baseline parsing/comparison for bigint-like lag precision, missing Kafka lanes, impossible duration metrics, and zero-lag gates.
- Refresh the sustained-firehose baseline with runtimeMetrics and stable RSS.

## Validation
- vp check --fix
- pnpm --filter @view-server/runtime exec tsc -p tsconfig.json --noEmit
- pnpm run test:benchmark-baseline
- pnpm run bench:baseline:kafka-sustained-firehose:update
- pnpm run bench:baseline:kafka-sustained-firehose
- git diff --check
- 3-agent final review: no findings