### PR TITLE
[codex] Harden Kafka mixed-cause handling

### DIFF
--- a/packages/runtime/src/kafka-health.ts
+++ b/packages/runtime/src/kafka-health.ts
@@ -98,6 +98,7 @@ export type ViewServerKafkaHealthLedger<Topics extends ViewServerRuntimeTopicDef
       readonly bytes: number;
       readonly committedOffset: string;
       readonly nowMillis: number;
+      readonly preserveLastError?: boolean;
     },
   ) => Effect.Effect<void>;
   readonly decodeFailed: (
@@ -504,7 +505,9 @@ export const makeViewServerKafkaHealthLedger = <
           ledger.lastMessageAt = input.nowMillis;
           ledger.lastCommitAt = input.nowMillis;
           ledger.committedOffset = input.committedOffset;
-          ledger.lastError = null;
+          if (input.preserveLastError !== true) {
+            ledger.lastError = null;
+          }
           refreshTopicStatus(topic);
         }
       }),

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -61,15 +61,22 @@ import {
   runKafkaMessageStream,
   sourceTopicsForRegion,
   startKafkaRegionConsumers,
+  ViewServerKafkaIngressError,
 } from "./kafka-ingress";
 import type {
   StartedKafkaConsumerResources,
   StartedKafkaRegionConsumer,
   KafkaStreamQueueEvent,
-  ViewServerKafkaIngressError,
 } from "./kafka-ingress";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+class KafkaIngressTestError extends Schema.TaggedErrorClass<KafkaIngressTestError>()(
+  "KafkaIngressTestError",
+  {
+    message: Schema.String,
+  },
+) {}
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -202,6 +209,45 @@ const nullRecord = <Value>(entries: Record<string, Value>): Record<string, Value
   const record: Record<string, Value> = Object.create(null);
   return Object.assign(record, entries);
 };
+
+const causeReasonSummary = (
+  cause: unknown,
+): ReadonlyArray<{
+  readonly tag: string;
+  readonly message: string | null;
+}> =>
+  Cause.isCause(cause)
+    ? cause.reasons.map((reason) => ({
+        tag: reason._tag,
+        message:
+          reason._tag === "Fail"
+            ? messageFromUnknown(reason.error)
+            : reason._tag === "Die"
+              ? messageFromUnknown(reason.defect)
+              : null,
+      }))
+    : [];
+
+const failedKafkaStreamQueueEvent = (
+  event: KafkaStreamQueueEvent,
+): Effect.Effect<Extract<KafkaStreamQueueEvent, { readonly _tag: "Failed" }>, Error> =>
+  Effect.succeed(event).pipe(
+    Effect.filterOrFail(
+      (value): value is Extract<KafkaStreamQueueEvent, { readonly _tag: "Failed" }> =>
+        value._tag === "Failed",
+      () => new KafkaIngressTestError({ message: "Expected Kafka stream queue failure event." }),
+    ),
+  );
+
+const kafkaIngressErrorSummary = (error: unknown) =>
+  error instanceof ViewServerKafkaIngressError
+    ? {
+        cause: causeReasonSummary(error.cause),
+        message: error.message,
+        region: error.region,
+        sourceTopic: error.sourceTopic,
+      }
+    : null;
 
 const kafkaMessage = (input: {
   readonly topic: string;
@@ -3052,9 +3098,9 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         kafkaTopic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
         error: {
-          message: "Kafka stream failed for region local",
+          message: `Failed to process Kafka message for source topic ${ordersSourceTopic}`,
           region: "local",
-          sourceTopic: undefined,
+          sourceTopic: ordersSourceTopic,
         },
         kafkaTopic: {
           status: "degraded",
@@ -3064,20 +3110,20 @@ describe("@view-server/runtime Kafka ingress internals", () => {
             local: {
               connected: false,
               assignedPartitions: 0,
-              messagesPerSecond: 0,
-              bytesPerSecond: 0,
+              messagesPerSecond: 1,
+              bytesPerSecond: 77,
               decodedMessagesPerSecond: 0,
               decodeFailuresPerSecond: 0,
               mappingFailuresPerSecond: 0,
-              publishFailuresPerSecond: 0,
+              publishFailuresPerSecond: 1,
               commitFailuresPerSecond: 0,
-              processingFailuresPerSecond: 0,
-              lastMessageAt: null,
+              processingFailuresPerSecond: 1,
+              lastMessageAt: 0,
               lastCommitAt: null,
               consumerLagMessages: null,
               lagSampledAt: null,
               committedOffset: null,
-              lastError: "Kafka stream failed for region local",
+              lastError: "publish defect",
             },
           }),
         },
@@ -3481,6 +3527,174 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("records generic Kafka stream defects before iterator creation", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const defectiveStream: AsyncIterable<KafkaMessage> = {
+        [Symbol.asyncIterator]: () => {
+          throw new Error("iterator creation defect");
+        },
+      };
+
+      const error = yield* Effect.flip(
+        runKafkaMessageStream(
+          viewServer,
+          runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          ledger,
+          "local",
+          defectiveStream,
+        ),
+      );
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        error: {
+          cause: messageFromUnknown(error.cause),
+          message: error.message,
+          region: error.region,
+          sourceTopic: error.sourceTopic,
+        },
+        kafkaTopic: health.kafka?.topics[ordersSourceTopic],
+      }).toStrictEqual({
+        error: {
+          cause: "iterator creation defect",
+          message: "Kafka stream failed for region local",
+          region: "local",
+          sourceTopic: undefined,
+        },
+        kafkaTopic: {
+          status: "degraded",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: false,
+              assignedPartitions: 0,
+              messagesPerSecond: 0,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 0,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 0,
+              processingFailuresPerSecond: 0,
+              lastMessageAt: null,
+              lastCommitAt: null,
+              consumerLagMessages: null,
+              lagSampledAt: null,
+              committedOffset: null,
+              lastError: "Kafka stream failed for region local",
+            },
+          }),
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("records generic Kafka stream defects during message metadata construction", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const defectiveMessage = kafkaMessage({
+        topic: ordersSourceTopic,
+        key: "metadata-defect",
+        value: JSON.stringify({
+          customerId: "customer-metadata-defect",
+          price: 10,
+        }),
+      });
+      Object.defineProperty(defectiveMessage, "timestamp", {
+        get: () => {
+          throw new Error("timestamp metadata defect");
+        },
+      });
+
+      const error = yield* Effect.flip(
+        runKafkaMessageStream(
+          viewServer,
+          runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield defectiveMessage;
+          })(),
+        ),
+      );
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        error: {
+          cause: messageFromUnknown(error.cause),
+          message: error.message,
+          region: error.region,
+          sourceTopic: error.sourceTopic,
+        },
+        kafkaTopic: health.kafka?.topics[ordersSourceTopic],
+      }).toStrictEqual({
+        error: {
+          cause: "timestamp metadata defect",
+          message: "Kafka stream failed for region local",
+          region: "local",
+          sourceTopic: undefined,
+        },
+        kafkaTopic: {
+          status: "degraded",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: false,
+              assignedPartitions: 0,
+              messagesPerSecond: 0,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 0,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 0,
+              processingFailuresPerSecond: 0,
+              lastMessageAt: null,
+              lastCommitAt: null,
+              consumerLagMessages: null,
+              lagSampledAt: null,
+              committedOffset: null,
+              lastError: "Kafka stream failed for region local",
+            },
+          }),
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("offers typed Kafka stream producer failures without remapping", () =>
     Effect.gen(function* () {
       const queue = yield* Queue.unbounded<KafkaStreamQueueEvent>();
@@ -3491,6 +3705,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
 
       expect(event).toStrictEqual({
         _tag: "Failed",
+        cause: Cause.fail(streamError),
         error: streamError,
       });
     }),
@@ -3511,6 +3726,111 @@ describe("@view-server/runtime Kafka ingress internals", () => {
       }).toStrictEqual({
         producerInterrupted: true,
         queueEmpty: true,
+      });
+    }),
+  );
+
+  it.effect("preserves mixed Kafka stream producer failures and interrupts", () =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<KafkaStreamQueueEvent>();
+      const streamError = kafkaStreamError("local", "typed producer failure with interrupt");
+
+      yield* offerKafkaStreamProducerFailure(
+        "local",
+        queue,
+        Cause.fromReasons([Cause.makeFailReason(streamError), Cause.makeInterruptReason()]),
+      );
+      const event = yield* Queue.take(queue);
+
+      expect(event).toStrictEqual({
+        _tag: "Failed",
+        cause: Cause.fromReasons([Cause.makeFailReason(streamError), Cause.makeInterruptReason()]),
+        error: streamError,
+      });
+    }),
+  );
+
+  it.effect("preserves raw Kafka stream producer failure reasons", () =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<KafkaStreamQueueEvent>();
+      const rawFailure = new Error("raw producer typed failure");
+
+      yield* offerKafkaStreamProducerFailure(
+        "local",
+        queue,
+        Cause.fromReasons([Cause.makeFailReason(rawFailure), Cause.makeInterruptReason()]),
+      );
+      const event = yield* Queue.take(queue).pipe(Effect.andThen(failedKafkaStreamQueueEvent));
+
+      expect({
+        cause: causeReasonSummary(event.cause),
+        error: {
+          cause: messageFromUnknown(event.error.cause),
+          message: event.error.message,
+          region: event.error.region,
+        },
+      }).toStrictEqual({
+        cause: [
+          {
+            tag: "Fail",
+            message: "Kafka stream failed for region local",
+          },
+          {
+            tag: "Fail",
+            message: "raw producer typed failure",
+          },
+          {
+            tag: "Interrupt",
+            message: null,
+          },
+        ],
+        error: {
+          cause: "raw producer typed failure",
+          message: "Kafka stream failed for region local",
+          region: "local",
+        },
+      });
+    }),
+  );
+
+  it.effect("preserves raw Kafka stream producer failures without optional source context", () =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<KafkaStreamQueueEvent>();
+      const primaryError = new ViewServerKafkaIngressError({
+        cause: "primary producer failure",
+        message: "primary producer failure",
+      });
+      const failureReasons: ReadonlyArray<Cause.Reason<unknown>> = [
+        Cause.makeFailReason(primaryError),
+        Cause.makeFailReason("raw producer failure without context"),
+      ];
+
+      yield* offerKafkaStreamProducerFailure("local", queue, Cause.fromReasons(failureReasons));
+      const event = yield* Queue.take(queue).pipe(Effect.andThen(failedKafkaStreamQueueEvent));
+
+      expect({
+        cause: causeReasonSummary(event.cause),
+        error: {
+          message: event.error.message,
+          region: event.error.region,
+          sourceTopic: event.error.sourceTopic,
+        },
+      }).toStrictEqual({
+        cause: [
+          {
+            tag: "Fail",
+            message: "primary producer failure",
+          },
+          {
+            tag: "Fail",
+            message: "raw producer failure without context",
+          },
+        ],
+        error: {
+          message: "primary producer failure",
+          region: undefined,
+          sourceTopic: undefined,
+        },
       });
     }),
   );
@@ -4021,6 +4341,200 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("preserves mixed Kafka publish failures and defects", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+      const publishFailure = Cause.fromReasons([
+        Cause.makeFailReason(runtimeUnavailable),
+        Cause.makeDieReason(new Error("publish finalizer defect")),
+      ]);
+      const publishManyFailingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(Effect.failCause(publishFailure))),
+      };
+
+      const exit = yield* Effect.exit(
+        runKafkaMessageStream(
+          viewServer,
+          publishManyFailingClient,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "mixed-publish-failure",
+              value: JSON.stringify({
+                customerId: "customer-mixed-publish-failure",
+                price: 10,
+              }),
+              offset: 1n,
+            });
+          })(),
+        ),
+      );
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+      const exitSummary = Exit.match(exit, {
+        onFailure: (cause) => {
+          const error = Cause.findErrorOption(cause);
+          return {
+            error: Option.match(error, {
+              onNone: () => null,
+              onSome: (value) => ({
+                cause: causeReasonSummary(value.cause),
+                message: value.message,
+              }),
+            }),
+            topLevel: causeReasonSummary(cause),
+          };
+        },
+        onSuccess: () => ({ error: null, topLevel: [] }),
+      });
+
+      expect({
+        exit: exitSummary,
+        operations,
+        topicHealth: {
+          lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+          publishFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.publishFailuresPerSecond,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+      }).toStrictEqual({
+        exit: {
+          error: {
+            cause: [
+              {
+                tag: "Fail",
+                message: "publish failed",
+              },
+              {
+                tag: "Die",
+                message: "publish finalizer defect",
+              },
+            ],
+            message: `Failed to process Kafka message for source topic ${ordersSourceTopic}`,
+          },
+          topLevel: [
+            {
+              tag: "Fail",
+              message: `Failed to process Kafka message for source topic ${ordersSourceTopic}`,
+            },
+            {
+              tag: "Fail",
+              message: "publish failed",
+            },
+            {
+              tag: "Die",
+              message: "publish finalizer defect",
+            },
+          ],
+        },
+        operations: ["publishMany:orders:1"],
+        topicHealth: {
+          lastError: "publish failed",
+          publishFailuresPerSecond: 1,
+          status: "degraded",
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("combines batch processing and same-batch terminal stream failures", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+      const publishManyFailingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(Effect.fail(runtimeUnavailable))),
+      };
+
+      const exit = yield* Effect.exit(
+        runKafkaMessageStream(
+          viewServer,
+          publishManyFailingClient,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "same-batch-terminal-failure",
+              value: JSON.stringify({
+                customerId: "customer-same-batch-terminal-failure",
+                price: 10,
+              }),
+              offset: 1n,
+            });
+            throw new Error("producer terminal failure");
+          })(),
+        ),
+      );
+      const exitSummary = Exit.match(exit, {
+        onFailure: causeReasonSummary,
+        onSuccess: () => [],
+      });
+
+      expect({
+        exit: exitSummary,
+        operations,
+      }).toStrictEqual({
+        exit: [
+          {
+            tag: "Fail",
+            message: `Failed to process Kafka message for source topic ${ordersSourceTopic}`,
+          },
+          {
+            tag: "Fail",
+            message: "publish failed",
+          },
+          {
+            tag: "Fail",
+            message: "Kafka stream failed for region local",
+          },
+        ],
+        operations: ["publishMany:orders:1"],
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("flushes decoded Kafka microbatch messages before a later decode failure", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
@@ -4152,9 +4666,740 @@ describe("@view-server/runtime Kafka ingress internals", () => {
               consumerLagMessages: null,
               lagSampledAt: null,
               committedOffset: "3",
-              lastError: "Failed to decode Kafka message for source topic orders-source",
+              lastError: "Failed to parse Kafka JSON payload",
             },
           }),
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("flushes decoded Kafka microbatch messages before a later codec defect", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const defectingKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
+        consumerGroupId: "view-server-codec-defect-microbatch-test",
+        ...committedKafkaStart("view-server-codec-defect-microbatch-test"),
+        regions,
+        topics: {
+          [ordersSourceTopic]: localKafkaTopic({
+            regions: ["local"],
+            value: kafka.codec({
+              name: "defecting-value-codec",
+              decode: (input) => {
+                const raw = Buffer.from(input.bytes).toString("utf8");
+                const defect = Effect.die(new Error("decode defect"));
+                const [customerId = "", price = "0"] = raw.split(":");
+                return raw === "defect"
+                  ? defect
+                  : Effect.succeed({
+                      customerId,
+                      price: Number(price),
+                    });
+              },
+            }),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              customerId: value.customerId,
+              price: value.price,
+            }),
+          }),
+        },
+      };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: defectingKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+      const batchingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(runtimeCore.client.publishMany(topic, rows))),
+      };
+      const firstMessage = kafkaMessage({
+        topic: ordersSourceTopic,
+        key: "defect-batch-1",
+        value: "customer-defect-batch-1:10",
+        offset: 1n,
+        onCommit: () => {
+          operations.push("commit:1");
+        },
+      });
+      const secondMessage = kafkaMessage({
+        topic: ordersSourceTopic,
+        key: "defect-batch-2",
+        value: "customer-defect-batch-2:20",
+        offset: 2n,
+        onCommit: () => {
+          operations.push("commit:2");
+        },
+      });
+      const defectMessage = kafkaMessage({
+        topic: ordersSourceTopic,
+        key: "defect-batch-3",
+        value: "defect",
+        offset: 3n,
+        onCommit: () => {
+          operations.push("commit:3");
+        },
+      });
+      const expectedMessageBytes = [firstMessage, secondMessage, defectMessage].reduce(
+        (totalBytes, message) =>
+          totalBytes + (message.key?.byteLength ?? 0) + (message.value?.byteLength ?? 0),
+        0,
+      );
+
+      const error = yield* Effect.flip(
+        runKafkaMessageStream(
+          viewServer,
+          batchingClient,
+          runtimeCore.requestHealthRefresh,
+          defectingKafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield firstMessage;
+            yield secondMessage;
+            yield defectMessage;
+          })(),
+        ),
+      );
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id", "customerId", "price"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        error: {
+          causeHasDefect: Cause.isCause(error.cause) && Cause.hasDies(error.cause),
+          causeIsCause: Cause.isCause(error.cause),
+          message: error.message,
+          region: error.region,
+          sourceTopic: error.sourceTopic,
+        },
+        operations,
+        snapshot,
+        topicHealth: {
+          bytesPerSecond: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.bytesPerSecond,
+          committedOffset:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.committedOffset,
+          decodeFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+          decodedMessagesPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodedMessagesPerSecond,
+          lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+          messagesPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.messagesPerSecond,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+      }).toStrictEqual({
+        error: {
+          causeHasDefect: true,
+          causeIsCause: true,
+          message: `Failed to decode Kafka message for source topic ${ordersSourceTopic}`,
+          region: "local",
+          sourceTopic: ordersSourceTopic,
+        },
+        operations: ["publishMany:orders:2", "commit:1", "commit:2"],
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [
+            {
+              id: "defect-batch-1",
+              customerId: "customer-defect-batch-1",
+              price: 10,
+            },
+            {
+              id: "defect-batch-2",
+              customerId: "customer-defect-batch-2",
+              price: 20,
+            },
+          ],
+          totalRows: 2,
+          version: 1,
+        },
+        topicHealth: {
+          bytesPerSecond: expectedMessageBytes,
+          committedOffset: "3",
+          decodeFailuresPerSecond: 1,
+          decodedMessagesPerSecond: 2,
+          lastError: "decode defect",
+          messagesPerSecond: 3,
+          status: "degraded",
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("preserves poison-message cause when recovery commit fails", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+
+      const batchingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(runtimeCore.client.publishMany(topic, rows))),
+      };
+      const commitFailure = new Error("recovery commit failed");
+
+      const exit = yield* Effect.exit(
+        runKafkaMessageStream(
+          viewServer,
+          batchingClient,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "recovery-commit-failure-1",
+              value: JSON.stringify({
+                customerId: "customer-recovery-commit-failure-1",
+                price: 10,
+              }),
+              offset: 1n,
+              commitFailure,
+            });
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "recovery-commit-failure-2",
+              value: JSON.stringify({
+                customerId: "customer-recovery-commit-failure-2",
+                price: 20,
+              }),
+              offset: 2n,
+              onCommit: () => {
+                operations.push("commit:2");
+              },
+            });
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "bad-json",
+              value: "{",
+              offset: 3n,
+            });
+          })(),
+        ),
+      );
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+      const exitSummary = Exit.match(exit, {
+        onFailure: causeReasonSummary,
+        onSuccess: () => [],
+      });
+
+      expect({
+        exit: exitSummary,
+        operations,
+        snapshot,
+        topicHealth: {
+          commitFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.commitFailuresPerSecond,
+          decodeFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+      }).toStrictEqual({
+        exit: [
+          {
+            tag: "Fail",
+            message: `Failed to decode Kafka message for source topic ${ordersSourceTopic}`,
+          },
+          {
+            tag: "Fail",
+            message: "Failed to parse Kafka JSON payload",
+          },
+          {
+            tag: "Fail",
+            message: `Failed to commit Kafka message for source topic ${ordersSourceTopic}`,
+          },
+        ],
+        operations: ["publishMany:orders:2"],
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [
+            {
+              id: "recovery-commit-failure-1",
+            },
+            {
+              id: "recovery-commit-failure-2",
+            },
+          ],
+          totalRows: 2,
+          version: 1,
+        },
+        topicHealth: {
+          commitFailuresPerSecond: 1,
+          decodeFailuresPerSecond: 1,
+          status: "degraded",
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("preserves mixed codec typed failures and interrupts", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const operations: Array<string> = [];
+      const mixedInterruptKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
+        consumerGroupId: "view-server-codec-mixed-interrupt-test",
+        ...committedKafkaStart("view-server-codec-mixed-interrupt-test"),
+        regions,
+        topics: {
+          [ordersSourceTopic]: localKafkaTopic({
+            regions: ["local"],
+            value: kafka.codec({
+              name: "mixed-interrupt-value-codec",
+              decode: (input) => {
+                const raw = Buffer.from(input.bytes).toString("utf8");
+                const [customerId = "", price = "0"] = raw.split(":");
+                return raw === "typed-failure-with-interrupt"
+                  ? Effect.failCause(
+                      Cause.fromReasons([
+                        Cause.makeFailReason("typed decode interrupted"),
+                        Cause.makeInterruptReason(),
+                      ]),
+                    )
+                  : Effect.succeed({
+                      customerId,
+                      price: Number(price),
+                    });
+              },
+            }),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              customerId: value.customerId,
+              price: value.price,
+            }),
+          }),
+        },
+      };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: mixedInterruptKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const batchingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(runtimeCore.client.publishMany(topic, rows))),
+      };
+
+      const exit = yield* Effect.exit(
+        runKafkaMessageStream(
+          viewServer,
+          batchingClient,
+          runtimeCore.requestHealthRefresh,
+          mixedInterruptKafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "mixed-interrupt-batch-1",
+              value: "customer-mixed-interrupt-batch-1:10",
+              offset: 1n,
+              onCommit: () => {
+                operations.push("commit:1");
+              },
+            });
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "mixed-interrupt-batch-2",
+              value: "typed-failure-with-interrupt",
+              offset: 2n,
+            });
+          })(),
+        ),
+      );
+      const exitSummary = Exit.match(exit, {
+        onFailure: (cause) => {
+          const error = Cause.findErrorOption(cause);
+          return {
+            error: Option.match(error, {
+              onNone: () => null,
+              onSome: (value) => ({
+                cause: causeReasonSummary(value.cause),
+                message: value.message,
+              }),
+            }),
+            topLevel: causeReasonSummary(cause),
+          };
+        },
+        onSuccess: () => ({ error: null, topLevel: [] }),
+      });
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        exit: exitSummary,
+        operations,
+        snapshot,
+        topicHealth: {
+          decodeFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+          lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+      }).toStrictEqual({
+        exit: {
+          error: {
+            cause: [
+              {
+                tag: "Fail",
+                message: "typed decode interrupted",
+              },
+              {
+                tag: "Interrupt",
+                message: null,
+              },
+            ],
+            message: `Failed to decode Kafka message for source topic ${ordersSourceTopic}`,
+          },
+          topLevel: [
+            {
+              tag: "Fail",
+              message: `Failed to decode Kafka message for source topic ${ordersSourceTopic}`,
+            },
+            {
+              tag: "Fail",
+              message: "typed decode interrupted",
+            },
+            {
+              tag: "Interrupt",
+              message: null,
+            },
+          ],
+        },
+        operations: ["publishMany:orders:1", "commit:1"],
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [
+            {
+              id: "mixed-interrupt-batch-1",
+            },
+          ],
+          totalRows: 1,
+          version: 1,
+        },
+        topicHealth: {
+          decodeFailuresPerSecond: 1,
+          lastError: "typed decode interrupted",
+          status: "degraded",
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("preserves mixed codec typed failures and finalizer defects", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const mixedCauseKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
+        consumerGroupId: "view-server-codec-mixed-cause-test",
+        ...committedKafkaStart("view-server-codec-mixed-cause-test"),
+        regions,
+        topics: {
+          [ordersSourceTopic]: localKafkaTopic({
+            regions: ["local"],
+            value: kafka.codec({
+              name: "mixed-cause-value-codec",
+              decode: () =>
+                Effect.failCause(
+                  Cause.fromReasons([
+                    Cause.makeFailReason("typed decode failed"),
+                    Cause.makeDieReason(new Error("decode finalizer defect")),
+                  ]),
+                ),
+            }),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key }) => ({
+              id: key,
+              customerId: "unreachable",
+              price: 0,
+            }),
+          }),
+        },
+      };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: mixedCauseKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+
+      const exit = yield* Effect.exit(
+        runKafkaMessageStream(
+          viewServer,
+          runtimeCore.client,
+          runtimeCore.requestHealthRefresh,
+          mixedCauseKafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "mixed-cause-batch-1",
+              value: "typed-failure-with-defect",
+              offset: 1n,
+            });
+          })(),
+        ),
+      );
+      const exitSummary = Exit.match(exit, {
+        onFailure: (cause) => {
+          const error = Cause.findErrorOption(cause);
+          return {
+            error: Option.match(error, {
+              onNone: () => null,
+              onSome: kafkaIngressErrorSummary,
+            }),
+            topLevel: causeReasonSummary(cause),
+          };
+        },
+        onSuccess: () => ({ error: null, topLevel: [] }),
+      });
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        exit: exitSummary,
+        topicHealth: {
+          decodeFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+          lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+      }).toStrictEqual({
+        exit: {
+          error: {
+            cause: [
+              {
+                tag: "Fail",
+                message: "typed decode failed",
+              },
+              {
+                tag: "Die",
+                message: "decode finalizer defect",
+              },
+            ],
+            message: `Failed to decode Kafka message for source topic ${ordersSourceTopic}`,
+            region: "local",
+            sourceTopic: ordersSourceTopic,
+          },
+          topLevel: [
+            {
+              tag: "Fail",
+              message: `Failed to decode Kafka message for source topic ${ordersSourceTopic}`,
+            },
+            {
+              tag: "Fail",
+              message: "typed decode failed",
+            },
+            {
+              tag: "Die",
+              message: "decode finalizer defect",
+            },
+          ],
+        },
+        topicHealth: {
+          decodeFailuresPerSecond: 1,
+          lastError: "typed decode failed",
+          status: "degraded",
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("does not record Kafka stream failures when microbatch decoding is interrupted", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const interruptingKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
+        consumerGroupId: "view-server-codec-interrupt-microbatch-test",
+        ...committedKafkaStart("view-server-codec-interrupt-microbatch-test"),
+        regions,
+        topics: {
+          [ordersSourceTopic]: localKafkaTopic({
+            regions: ["local"],
+            value: kafka.codec({
+              name: "interrupting-value-codec",
+              decode: (input) => {
+                const raw = Buffer.from(input.bytes).toString("utf8");
+                const [customerId = "", price = "0"] = raw.split(":");
+                return raw === "interrupt"
+                  ? Effect.interrupt
+                  : Effect.succeed({
+                      customerId,
+                      price: Number(price),
+                    });
+              },
+            }),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              customerId: value.customerId,
+              price: value.price,
+            }),
+          }),
+        },
+      };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: interruptingKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+      const batchingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(runtimeCore.client.publishMany(topic, rows))),
+      };
+
+      const exit = yield* Effect.exit(
+        runKafkaMessageStream(
+          viewServer,
+          batchingClient,
+          runtimeCore.requestHealthRefresh,
+          interruptingKafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "interrupt-batch-1",
+              value: "customer-interrupt-batch-1:10",
+              offset: 1n,
+              onCommit: () => {
+                operations.push("commit:1");
+              },
+            });
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "interrupt-batch-2",
+              value: "interrupt",
+              offset: 2n,
+              onCommit: () => {
+                operations.push("commit:2");
+              },
+            });
+          })(),
+        ),
+      );
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        interrupted: Exit.hasInterrupts(exit),
+        operations,
+        snapshot,
+        topicHealth: {
+          connected: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.connected,
+          decodeFailuresPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+          decodedMessagesPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodedMessagesPerSecond,
+          lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+          messagesPerSecond:
+            health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.messagesPerSecond,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+      }).toStrictEqual({
+        interrupted: true,
+        operations: [],
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [],
+          totalRows: 0,
+          version: 0,
+        },
+        topicHealth: {
+          connected: true,
+          decodeFailuresPerSecond: 0,
+          decodedMessagesPerSecond: 0,
+          lastError: null,
+          messagesPerSecond: 0,
+          status: "ready",
         },
       });
 

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -4676,6 +4676,185 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("clears unaffected source topic errors during poison-message recovery flush", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const multiSourceKafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
+        consumerGroupId: "view-server-unaffected-source-recovery-test",
+        ...committedKafkaStart("view-server-unaffected-source-recovery-test"),
+        regions,
+        topics: {
+          [ordersSourceTopic]: localKafkaTopic({
+            regions: ["local"],
+            value: kafka.json(IncomingOrder),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              customerId: value.customerId,
+              price: value.price,
+            }),
+          }),
+          [paymentsSourceTopic]: localKafkaTopic({
+            regions: ["local"],
+            value: kafka.json(IncomingOrder),
+            key: kafka.stringKey(),
+            viewServerTopic: "orders",
+            mapping: ({ key, value }) => ({
+              id: key,
+              customerId: value.customerId,
+              price: value.price,
+            }),
+          }),
+        },
+      };
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: multiSourceKafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+          [paymentsSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      yield* ledger.topicConnected(paymentsSourceTopic, "local", 1, 1_000);
+      yield* ledger.decodeFailed(ordersSourceTopic, "local", {
+        bytes: 1,
+        message: "stale orders decode error",
+        nowMillis: 0,
+      });
+      const operations: Array<string> = [];
+      const batchingClient: ViewServerRuntimeClient<Topics> = {
+        ...runtimeCore.client,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishMany: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(runtimeCore.client.publishMany(topic, rows))),
+      };
+
+      const error = yield* Effect.flip(
+        runKafkaMessageStream(
+          viewServer,
+          batchingClient,
+          runtimeCore.requestHealthRefresh,
+          multiSourceKafkaOptions,
+          ledger,
+          "local",
+          (async function* () {
+            yield kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "orders-prefix",
+              value: JSON.stringify({
+                customerId: "customer-orders-prefix",
+                price: 10,
+              }),
+              offset: 1n,
+              onCommit: () => {
+                operations.push("commit:orders-prefix");
+              },
+            });
+            yield kafkaMessage({
+              topic: paymentsSourceTopic,
+              key: "payments-poison",
+              value: "{",
+              offset: 2n,
+              onCommit: () => {
+                operations.push("commit:payments-poison");
+              },
+            });
+          })(),
+        ),
+      );
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id", "customerId", "price"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+      yield* ledger.regionRecovered("local", 2_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 2_000);
+      yield* ledger.topicConnected(paymentsSourceTopic, "local", 1, 2_000);
+      const reconnectedHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        afterReconnect: {
+          ordersSource: {
+            lastError:
+              reconnectedHealth.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+            status: reconnectedHealth.kafka?.topics[ordersSourceTopic]?.status,
+          },
+          paymentsSource: {
+            lastError:
+              reconnectedHealth.kafka?.topics[paymentsSourceTopic]?.regions["local"]?.lastError,
+            status: reconnectedHealth.kafka?.topics[paymentsSourceTopic]?.status,
+          },
+        },
+        error: {
+          message: error.message,
+          region: error.region,
+          sourceTopic: error.sourceTopic,
+        },
+        operations,
+        ordersSource: {
+          lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+          status: health.kafka?.topics[ordersSourceTopic]?.status,
+        },
+        paymentsSource: {
+          lastError: health.kafka?.topics[paymentsSourceTopic]?.regions["local"]?.lastError,
+          status: health.kafka?.topics[paymentsSourceTopic]?.status,
+        },
+        snapshot,
+      }).toStrictEqual({
+        afterReconnect: {
+          ordersSource: {
+            lastError: null,
+            status: "ready",
+          },
+          paymentsSource: {
+            lastError: "Failed to parse Kafka JSON payload",
+            status: "degraded",
+          },
+        },
+        error: {
+          message: `Failed to decode Kafka message for source topic ${paymentsSourceTopic}`,
+          region: "local",
+          sourceTopic: paymentsSourceTopic,
+        },
+        operations: ["publishMany:orders:1", "commit:orders-prefix"],
+        ordersSource: {
+          lastError: `Failed to decode Kafka message for source topic ${paymentsSourceTopic}`,
+          status: "degraded",
+        },
+        paymentsSource: {
+          lastError: "Failed to parse Kafka JSON payload",
+          status: "degraded",
+        },
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [
+            {
+              id: "orders-prefix",
+              customerId: "customer-orders-prefix",
+              price: 10,
+            },
+          ],
+          totalRows: 1,
+          version: 1,
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("flushes decoded Kafka microbatch messages before a later codec defect", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -83,6 +83,7 @@ export type KafkaStreamQueueEvent =
     }
   | {
       readonly _tag: "Failed";
+      readonly cause: Cause.Cause<ViewServerKafkaIngressError>;
       readonly error: ViewServerKafkaIngressError;
     }
   | {
@@ -312,6 +313,48 @@ export const kafkaMessageProcessingError = (
     sourceTopic,
   });
 
+const isNonFailureKafkaCauseReason = (
+  reason: Cause.Reason<unknown>,
+): reason is Cause.Die | Cause.Interrupt =>
+  Cause.isDieReason(reason) || Cause.isInterruptReason(reason);
+
+const kafkaFailureCause = (error: unknown, cause: Cause.Cause<unknown>): unknown =>
+  cause.reasons.length > 1 || Cause.hasDies(cause) || Cause.hasInterrupts(cause) ? cause : error;
+
+const preservedKafkaFailureError = (
+  primaryError: ViewServerKafkaIngressError,
+  error: unknown,
+): ViewServerKafkaIngressError =>
+  error instanceof ViewServerKafkaIngressError
+    ? error
+    : new ViewServerKafkaIngressError({
+        cause: error,
+        message: messageFromUnknown(error),
+        ...(primaryError.region === undefined ? {} : { region: primaryError.region }),
+        ...(primaryError.sourceTopic === undefined
+          ? {}
+          : { sourceTopic: primaryError.sourceTopic }),
+      });
+
+const kafkaIngressFailureCause = (
+  error: ViewServerKafkaIngressError,
+  cause: Cause.Cause<unknown>,
+): Cause.Cause<ViewServerKafkaIngressError> => {
+  const failureReasons = cause.reasons
+    .filter(Cause.isFailReason)
+    .map((reason) => Cause.makeFailReason(preservedKafkaFailureError(error, reason.error)));
+  const nonFailureReasons = cause.reasons.filter(isNonFailureKafkaCauseReason);
+  const hasPrimaryFailure = failureReasons.some((reason) => reason.error === error);
+  return Cause.fromReasons([
+    ...(hasPrimaryFailure ? [] : [Cause.makeFailReason(error)]),
+    ...failureReasons,
+    ...nonFailureReasons,
+  ]);
+};
+
+const kafkaNonFailureCause = (cause: Cause.Cause<unknown>): Cause.Cause<never> =>
+  Cause.fromReasons(cause.reasons.filter(isNonFailureKafkaCauseReason));
+
 export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
@@ -323,6 +366,19 @@ export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTop
   health
     .regionDisconnected(region, error.message, options)
     .pipe(Effect.andThen(Effect.fail(error)));
+
+const recordKafkaStreamCause = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  health: ViewServerKafkaHealthLedger<Topics>,
+  region: string,
+  error: ViewServerKafkaIngressError,
+  cause: Cause.Cause<ViewServerKafkaIngressError>,
+  options?: {
+    readonly preserveTopicErrors?: boolean;
+  },
+): Effect.Effect<never, ViewServerKafkaIngressError> =>
+  health
+    .regionDisconnected(region, error.message, options)
+    .pipe(Effect.andThen(Effect.failCause(cause)));
 
 const requestKafkaHealthRefresh = (requestHealthRefresh: ViewServerKafkaHealthRefreshRequest) =>
   requestHealthRefresh.pipe(ignoreKafkaHealthRefreshFailure);
@@ -596,29 +652,78 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
       region,
       metadata,
     }).pipe(
-      Effect.matchEffect({
-        onFailure: (error) => {
-          if (kafkaErrorIsMapping(error)) {
+      Effect.matchCauseEffect({
+        onFailure: (cause) => {
+          const error = Cause.findErrorOption(cause);
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.failCause(kafkaNonFailureCause(cause));
+          }
+          if (Option.isSome(error)) {
+            if (kafkaErrorIsMapping(error.value)) {
+              return health
+                .mappingFailed(sourceTopic, region, {
+                  bytes: messageBytes,
+                  message: messageFromUnknown(error.value),
+                  nowMillis,
+                })
+                .pipe(
+                  Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
+                  Effect.andThen(
+                    Effect.failCause(
+                      kafkaIngressFailureCause(
+                        kafkaMessageMappingError(
+                          region,
+                          sourceTopic,
+                          kafkaFailureCause(error.value, cause),
+                        ),
+                        cause,
+                      ),
+                    ),
+                  ),
+                );
+            }
             return health
-              .mappingFailed(sourceTopic, region, {
+              .decodeFailed(sourceTopic, region, {
                 bytes: messageBytes,
-                message: messageFromUnknown(error),
+                message: messageFromUnknown(error.value),
                 nowMillis,
               })
               .pipe(
                 Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
-                Effect.andThen(Effect.fail(kafkaMessageMappingError(region, sourceTopic, error))),
+                Effect.andThen(
+                  Effect.failCause(
+                    kafkaIngressFailureCause(
+                      kafkaMessageDecodeError(
+                        region,
+                        sourceTopic,
+                        kafkaFailureCause(error.value, cause),
+                      ),
+                      cause,
+                    ),
+                  ),
+                ),
               );
           }
           return health
             .decodeFailed(sourceTopic, region, {
               bytes: messageBytes,
-              message: messageFromUnknown(error),
+              message: messageFromUnknown(Cause.squash(cause)),
               nowMillis,
             })
             .pipe(
               Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
-              Effect.andThen(Effect.fail(kafkaMessageDecodeError(region, sourceTopic, error))),
+              Effect.andThen(
+                Effect.failCause(
+                  kafkaIngressFailureCause(
+                    kafkaMessageDecodeError(
+                      region,
+                      sourceTopic,
+                      kafkaFailureCause(Cause.squash(cause), cause),
+                    ),
+                    cause,
+                  ),
+                ),
+              ),
             );
         },
         onSuccess: (decodedMessage) => Effect.succeed(decodedMessage),
@@ -666,22 +771,33 @@ const publishKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.publis
   }
   for (const [topic, group] of rowsByTopic) {
     yield* client.publishMany(topic, group.rows).pipe(
-      Effect.matchEffect({
+      Effect.matchCauseEffect({
         onFailure: (cause) => {
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.failCause(kafkaNonFailureCause(cause));
+          }
+          const error = Cause.findErrorOption(cause);
+          const failure = Option.match(error, {
+            onNone: () => Cause.squash(cause),
+            onSome: (value) => value,
+          });
+          const processingError = kafkaMessageProcessingError(
+            region,
+            group.sourceTopic,
+            kafkaFailureCause(failure, cause),
+          );
           return Effect.forEach(
             group.messages,
             (message) =>
               health.messagePublishFailed(message.sourceTopic, region, {
                 bytes: message.messageBytes,
-                message: messageFromUnknown(cause),
+                message: messageFromUnknown(failure),
                 nowMillis: message.nowMillis,
               }),
             { discard: true },
           ).pipe(
             Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh)),
-            Effect.andThen(
-              Effect.fail(kafkaMessageProcessingError(region, group.sourceTopic, cause)),
-            ),
+            Effect.andThen(Effect.failCause(kafkaIngressFailureCause(processingError, cause))),
           );
         },
         onSuccess: () => Effect.succeed(true),
@@ -697,6 +813,9 @@ const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit"
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
   messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
+  options?: {
+    readonly preserveLastError?: boolean;
+  },
 ) {
   if (messages.length === 0) {
     return;
@@ -722,6 +841,7 @@ const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit"
                 bytes: message.messageBytes,
                 committedOffset: String(message.message.offset + 1n),
                 nowMillis: message.nowMillis,
+                ...(options?.preserveLastError === true ? { preserveLastError: true } : {}),
               }),
           }),
         ),
@@ -750,20 +870,32 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
         region,
         message,
       ).pipe(
-        Effect.catch((error: ViewServerKafkaIngressError) =>
-          publishKafkaDecodedBatch(
-            client,
-            requestHealthRefresh,
-            health,
-            region,
-            decodedMessages,
-          ).pipe(
-            Effect.andThen(
-              commitKafkaDecodedBatch(requestHealthRefresh, health, region, decodedMessages),
+        Effect.catchCause((cause) => {
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.failCause(cause);
+          }
+          return Effect.exit(
+            publishKafkaDecodedBatch(
+              client,
+              requestHealthRefresh,
+              health,
+              region,
+              decodedMessages,
+            ).pipe(
+              Effect.andThen(
+                commitKafkaDecodedBatch(requestHealthRefresh, health, region, decodedMessages, {
+                  preserveLastError: true,
+                }),
+              ),
             ),
-            Effect.andThen(Effect.fail(error)),
-          ),
-        ),
+          ).pipe(
+            Effect.andThen((flushExit) =>
+              Exit.isFailure(flushExit)
+                ? Effect.failCause(Cause.combine(cause, flushExit.cause))
+                : Effect.failCause(cause),
+            ),
+          );
+        }),
       );
       if (Option.isSome(decoded)) {
         decodedMessages.push(decoded.value);
@@ -809,6 +941,7 @@ const produceKafkaStreamQueueEvents = Effect.fn(
       Effect.catch((error: ViewServerKafkaIngressError) =>
         Queue.offer(queue, {
           _tag: "Failed",
+          cause: Cause.fail(error),
           error,
         }).pipe(Effect.as(undefined)),
       ),
@@ -854,6 +987,7 @@ export const offerKafkaStreamProducerFailure = Effect.fn(
   );
   yield* Queue.offer(queue, {
     _tag: "Failed",
+    cause: kafkaIngressFailureCause(error, cause),
     error,
   });
 });
@@ -935,41 +1069,57 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
           if (terminal._tag === "End") {
             return;
           }
-          return yield* terminal.error;
+          return yield* Effect.failCause(terminal.cause);
         }
-        yield* processKafkaMessageBatch(
-          config,
-          client,
-          requestHealthRefresh,
-          options,
-          health,
-          region,
-          next.batch,
+        const processExit = yield* Effect.exit(
+          processKafkaMessageBatch(
+            config,
+            client,
+            requestHealthRefresh,
+            options,
+            health,
+            region,
+            next.batch,
+          ),
         );
         const terminal = next.terminal;
+        if (Exit.isFailure(processExit)) {
+          if (terminal?._tag === "Failed") {
+            return yield* Effect.failCause(Cause.combine(processExit.cause, terminal.cause));
+          }
+          return yield* Effect.failCause(processExit.cause);
+        }
         if (terminal?._tag === "End") {
           return;
         }
         if (terminal?._tag === "Failed") {
-          return yield* terminal.error;
+          return yield* Effect.failCause(terminal.cause);
         }
       }
     }),
   ).pipe(
     Effect.catchCause((cause) => {
       if (Cause.hasInterruptsOnly(cause)) {
-        return Effect.failCause(cause);
+        return Effect.failCause(kafkaNonFailureCause(cause));
       }
       const error = Cause.findErrorOption(cause);
       if (Option.isSome(error) && error.value instanceof ViewServerKafkaIngressError) {
-        return recordKafkaStreamError(health, region, error.value, {
-          preserveTopicErrors: true,
-        }).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
+        return recordKafkaStreamCause(
+          health,
+          region,
+          error.value,
+          kafkaIngressFailureCause(error.value, cause),
+          {
+            preserveTopicErrors: true,
+          },
+        ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
       }
-      return recordKafkaStreamError(
+      const streamError = kafkaStreamError(region, Cause.squash(cause));
+      return recordKafkaStreamCause(
         health,
         region,
-        kafkaStreamError(region, Cause.squash(cause)),
+        streamError,
+        kafkaIngressFailureCause(streamError, cause),
       ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
     }),
   );

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -814,7 +814,7 @@ const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit"
   region: string,
   messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
   options?: {
-    readonly preserveLastError?: boolean;
+    readonly preserveLastErrorForSourceTopic: string | undefined;
   },
 ) {
   if (messages.length === 0) {
@@ -841,7 +841,9 @@ const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit"
                 bytes: message.messageBytes,
                 committedOffset: String(message.message.offset + 1n),
                 nowMillis: message.nowMillis,
-                ...(options?.preserveLastError === true ? { preserveLastError: true } : {}),
+                ...(options?.preserveLastErrorForSourceTopic === message.sourceTopic
+                  ? { preserveLastError: true }
+                  : {}),
               }),
           }),
         ),
@@ -874,6 +876,9 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
           if (Cause.hasInterruptsOnly(cause)) {
             return Effect.failCause(cause);
           }
+          const preserveLastErrorForSourceTopic = Option.getOrUndefined(
+            Option.map(Cause.findErrorOption(cause), (error) => error.sourceTopic),
+          );
           return Effect.exit(
             publishKafkaDecodedBatch(
               client,
@@ -884,7 +889,7 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
             ).pipe(
               Effect.andThen(
                 commitKafkaDecodedBatch(requestHealthRefresh, health, region, decodedMessages, {
-                  preserveLastError: true,
+                  preserveLastErrorForSourceTopic,
                 }),
               ),
             ),


### PR DESCRIPTION
## What changed

- Preserves full Kafka ingestion causes for mixed fail, die, and interrupt paths instead of collapsing to the first typed error.
- Keeps pure interruption as cancellation-only so shutdown does not mark Kafka health degraded.
- Preserves poison-message lastError when a decoded prefix is successfully flushed and committed during recovery.
- Combines same-batch processing failures with terminal stream failures so no cause is lost.
- Adds exact Cause-summary tests for producer, decode, publish, commit, and stream terminal edge cases.

## Why

Kafka hardening needs deterministic failure semantics before gRPC work. Mixed Effect causes were too easy to partially lose when normalized back into the typed Kafka ingress error channel.

## Validation

- vp check --fix packages/runtime/src/kafka-ingress.ts packages/runtime/src/kafka-health.ts packages/runtime/src/kafka-ingress.internal.test.ts
- pnpm --filter @view-server/runtime run test -- kafka-ingress.internal.test.ts
- pnpm --filter @view-server/runtime run test
- pnpm exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --severity error
- pnpm --filter @view-server/runtime exec tsc -p tsconfig.json --noEmit
- git diff --check
- pnpm run ready

Reviewer loop: 3 local agents reviewed the Kafka correctness scope and reported clean.