### PR TITLE
Harden Kafka ingest benchmark baselines

### DIFF
--- a/benchmarks/baselines/kafka-ingest.json
+++ b/benchmarks/baselines/kafka-ingest.json
@@ -8,29 +8,29 @@
       "benchmarks": [
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
-          "maxMs": 2533.4852079999996,
-          "meanMs": 2298.160986,
-          "minMs": 2109.7225829999998,
+          "maxMs": 2538.8830829999997,
+          "meanMs": 2287.320902666667,
+          "minMs": 2080.4348340000006,
           "name": "json source batch ingest",
-          "p99Ms": 2533.4852079999996,
+          "p99Ms": 2538.8830829999997,
           "sampleCount": 3
         },
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
-          "maxMs": 2153.0751249999994,
-          "meanMs": 2116.1499443333328,
-          "minMs": 2088.107582999999,
+          "maxMs": 2144.5018330000003,
+          "meanMs": 2106.863069333333,
+          "minMs": 2074.5623749999995,
           "name": "protobuf source batch ingest",
-          "p99Ms": 2153.0751249999994,
+          "p99Ms": 2144.5018330000003,
           "sampleCount": 3
         },
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka ingest runtime benchmark: 250 rows per batch",
-          "maxMs": 16569.319375,
-          "meanMs": 16139.604819666667,
-          "minMs": 15593.121958999996,
+          "maxMs": 16213.991791,
+          "meanMs": 16088.247277999997,
+          "minMs": 15919.793958999995,
           "name": "mixed source burst ingest",
-          "p99Ms": 16569.319375,
+          "p99Ms": 16213.991791,
           "sampleCount": 3
         }
       ],
@@ -59,60 +59,83 @@
         }
       ],
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 56590336,
+      "memoryRssTotalDeltaBytes": 37421056,
       "minimumSampleCount": 3,
       "mutationCount": 7500,
       "outputJsonPath": "packages/runtime/.artifacts/kafka-ingest-250rows.json",
       "queuedEventCount": 0,
       "rowCount": 250,
+      "runtimeMetrics": {
+        "eventLoopDelay": {
+          "maxMs": 26.591231,
+          "meanMs": 10.68847808229469,
+          "p99Ms": 12.345343
+        },
+        "healthPolling": {
+          "count": 3270,
+          "maxMs": 5.768416999999317,
+          "totalMs": 1899.3315689999897
+        },
+        "kafkaLag": {
+          "maxConsumerLagMessages": "6",
+          "sampledRegionCount": 2,
+          "totalConsumerLagMessages": "6"
+        }
+      },
       "subscriberCount": 0,
       "summaryPath": "packages/runtime/.artifacts/kafka-ingest-250rows.summary.json",
       "taskLabel": "Kafka ingest 250 rows",
       "throughputCases": [
         {
-          "aggregateRowsPerSecond": 108.79134060662271,
-          "maxTotalMs": 2533.103957999999,
-          "meanConvergenceMs": 2283.0477913333334,
-          "meanProducerSendMs": 12.318458666666706,
-          "meanRowsPerSecond": 109.41644010806944,
-          "meanTotalMs": 2297.977013666666,
-          "minRowsPerSecond": 98.69314648948968,
+          "aggregateRowsPerSecond": 109.30683576988758,
+          "maxTotalMs": 2538.4730010000003,
+          "meanConvergenceMs": 2273.094639,
+          "meanProducerSendMs": 11.38161133333324,
+          "meanRowsPerSecond": 110.04483740471808,
+          "meanTotalMs": 2287.1396673333334,
+          "minRowsPerSecond": 98.48440377404667,
           "name": "json source batch ingest",
           "producedRowsPerSample": 250,
-          "maxReadSnapshotMs": 4.888124999999491,
-          "meanReadSnapshotMs": 2.610763666666268,
+          "maxCommitObservedMs": 2517.157792,
+          "maxReadSnapshotMs": 5.690792000000329,
+          "meanCommitObservedMs": 2273.094639,
+          "meanReadSnapshotMs": 2.663417000000057,
           "readSnapshotRowsPerSample": 25,
           "sampleCount": 3,
           "totalProducedRows": 750
         },
         {
-          "aggregateRowsPerSecond": 123.91960018889995,
-          "maxTotalMs": 16569.055875,
-          "meanConvergenceMs": 16106.038819333335,
-          "meanProducerSendMs": 24.933527666667334,
-          "meanRowsPerSecond": 123.9992585296269,
-          "meanTotalMs": 16139.496874999999,
-          "minRowsPerSecond": 120.70693798659185,
+          "aggregateRowsPerSecond": 124.31523499452655,
+          "maxTotalMs": 16213.725542,
+          "meanConvergenceMs": 16054.225819666666,
+          "meanProducerSendMs": 24.90818033333259,
+          "meanRowsPerSecond": 124.32262097374655,
+          "meanTotalMs": 16088.13272233333,
+          "minRowsPerSecond": 123.35227920438177,
           "name": "mixed source burst ingest",
           "producedRowsPerSample": 2000,
-          "maxReadSnapshotMs": 5.827582999998413,
-          "meanReadSnapshotMs": 5.1210279999989625,
+          "maxCommitObservedMs": 16175.847042000001,
+          "maxReadSnapshotMs": 6.9864159999997355,
+          "meanCommitObservedMs": 16054.225819666666,
+          "meanReadSnapshotMs": 5.708499333332536,
           "readSnapshotRowsPerSample": 50,
           "sampleCount": 3,
           "totalProducedRows": 6000
         },
         {
-          "aggregateRowsPerSecond": 118.14869345273647,
-          "maxTotalMs": 2153.0212079999983,
-          "meanConvergenceMs": 2103.2847080000006,
-          "meanProducerSendMs": 11.470791999999468,
-          "meanRowsPerSecond": 118.1683546067115,
-          "meanTotalMs": 2115.9776946666666,
-          "minRowsPerSecond": 116.11590218947819,
+          "aggregateRowsPerSecond": 118.66827687598811,
+          "maxTotalMs": 2144.405917,
+          "meanConvergenceMs": 2095.155945000001,
+          "meanProducerSendMs": 10.308250000000044,
+          "meanRowsPerSecond": 118.69047837088006,
+          "meanTotalMs": 2106.712986666668,
+          "minRowsPerSecond": 116.58240541965452,
           "name": "protobuf source batch ingest",
           "producedRowsPerSample": 250,
-          "maxReadSnapshotMs": 1.5628749999996217,
-          "meanReadSnapshotMs": 1.2221946666668373,
+          "maxCommitObservedMs": 2131.8569590000006,
+          "maxReadSnapshotMs": 1.8126250000004802,
+          "meanCommitObservedMs": 2095.155945000001,
+          "meanReadSnapshotMs": 1.2487916666668752,
           "readSnapshotRowsPerSample": 25,
           "sampleCount": 3,
           "totalProducedRows": 750
@@ -122,6 +145,14 @@
     }
   ],
   "thresholds": {
+    "commitObservedMean": {
+      "maxAbsoluteDeltaMs": 2000,
+      "maxRatio": 1.5
+    },
+    "commitObservedMax": {
+      "maxAbsoluteDeltaMs": 2500,
+      "maxRatio": 1.5
+    },
     "latencyMean": {
       "maxAbsoluteDeltaMs": 2000,
       "maxRatio": 1.5
@@ -131,8 +162,8 @@
       "maxRatio": 1.5
     },
     "memoryRssTotalDelta": {
-      "maxAbsoluteDeltaBytes": 134217728,
-      "maxRatio": 3
+      "maxAbsoluteDeltaBytes": 268435456,
+      "maxRatio": 64
     },
     "throughputAggregateRowsPerSecond": {
       "minRatio": 0.75

--- a/benchmarks/baselines/kafka-sustained-firehose.json
+++ b/benchmarks/baselines/kafka-sustained-firehose.json
@@ -8,11 +8,11 @@
       "benchmarks": [
         {
           "groupName": "src/kafka-ingest.bench.ts > Kafka sustained firehose runtime benchmark: 250 rows per producer batch",
-          "maxMs": 18123.79325,
-          "meanMs": 17440.216833,
-          "minMs": 17093.851582999996,
+          "maxMs": 18137.986084,
+          "meanMs": 17089.841361333336,
+          "minMs": 16067.873250000004,
           "name": "sustained mixed firehose ingest",
-          "p99Ms": 18123.79325,
+          "p99Ms": 18137.986084,
           "sampleCount": 3
         }
       ],
@@ -37,7 +37,7 @@
         }
       ],
       "latencySource": "vitest-output-json",
-      "memoryRssTotalDeltaBytes": 26312704,
+      "memoryRssTotalDeltaBytes": 21676032,
       "minimumSampleCount": 3,
       "mutationCount": 6000,
       "outputJsonPath": "packages/runtime/.artifacts/kafka-sustained-firehose-250rows-4batches.json",
@@ -45,14 +45,14 @@
       "rowCount": 250,
       "runtimeMetrics": {
         "eventLoopDelay": {
-          "maxMs": 25.591807,
-          "meanMs": 10.712128,
-          "p99Ms": 12.705791
+          "maxMs": 22.478847,
+          "meanMs": 10.709345536261491,
+          "p99Ms": 12.402687
         },
         "healthPolling": {
-          "count": 1969,
-          "maxMs": 2.311582999998791,
-          "totalMs": 1497.1916060000103
+          "count": 1949,
+          "maxMs": 1.7385420000009617,
+          "totalMs": 1180.5179880000126
         },
         "kafkaLag": {
           "maxConsumerLagMessages": "0",
@@ -65,17 +65,19 @@
       "taskLabel": "Kafka sustained firehose 250 rows x 4 batches",
       "throughputCases": [
         {
-          "aggregateRowsPerSecond": 114.67800599252743,
-          "maxTotalMs": 18123.630999999998,
-          "meanConvergenceMs": 17393.824889,
-          "meanProducerSendMs": 37.51636100000193,
-          "meanRowsPerSecond": 114.76445271951725,
-          "meanTotalMs": 17440.135819333333,
-          "minRowsPerSecond": 110.3531626747422,
+          "aggregateRowsPerSecond": 117.02903556125037,
+          "maxTotalMs": 18137.843417,
+          "meanConvergenceMs": 17045.588527666663,
+          "meanProducerSendMs": 34.56661066666584,
+          "meanRowsPerSecond": 117.31572675479136,
+          "meanTotalMs": 17089.775972333333,
+          "minRowsPerSecond": 110.26669235249139,
           "name": "sustained mixed firehose ingest",
           "producedRowsPerSample": 2000,
-          "maxReadSnapshotMs": 7.44920799999818,
-          "meanReadSnapshotMs": 6.348875000003318,
+          "maxCommitObservedMs": 18082.6865,
+          "maxReadSnapshotMs": 7.347750000000815,
+          "meanCommitObservedMs": 17045.588527666663,
+          "meanReadSnapshotMs": 6.232693999998446,
           "readSnapshotRowsPerSample": 50,
           "sampleCount": 3,
           "totalProducedRows": 6000
@@ -85,6 +87,14 @@
     }
   ],
   "thresholds": {
+    "commitObservedMean": {
+      "maxAbsoluteDeltaMs": 5000,
+      "maxRatio": 1.75
+    },
+    "commitObservedMax": {
+      "maxAbsoluteDeltaMs": 6000,
+      "maxRatio": 1.75
+    },
     "latencyMean": {
       "maxAbsoluteDeltaMs": 5000,
       "maxRatio": 1.75
@@ -94,8 +104,8 @@
       "maxRatio": 1.75
     },
     "memoryRssTotalDelta": {
-      "maxAbsoluteDeltaBytes": 134217728,
-      "maxRatio": 3
+      "maxAbsoluteDeltaBytes": 268435456,
+      "maxRatio": 64
     },
     "throughputAggregateRowsPerSecond": {
       "minRatio": 0.75

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check:package-exports": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/node-ambient.d.ts scripts/check-package-exports.ts && node --experimental-strip-types scripts/check-package-exports.ts",
     "ready": "vp run -r build && pnpm run check:package-exports && pnpm run check:internal-seams && pnpm run test:repository-scripts && vp check && pnpm run check:effect && vp run --filter '@view-server/*' --filter '!@view-server/runtime' test && vp run @view-server/runtime#test",
     "test:benchmark-baseline": "pnpm run test:repository-scripts",
-    "test:repository-scripts": "vp test run scripts/benchmark-baseline.test.ts scripts/benchmark-baseline-runner.test.ts scripts/check-internal-seams.test.ts --coverage",
+    "test:repository-scripts": "vp test run scripts/benchmark-baseline.test.ts scripts/benchmark-baseline-runner.test.ts scripts/bench-runtime-kafka-ingest.test.ts scripts/check-internal-seams.test.ts --coverage",
     "prepare": "vp config && effect-language-service patch"
   },
   "devDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "bench:kafka-ingest": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && sh -c 'status=0; cleanup() { down_status=0; docker compose -f ../../compose.yaml down || down_status=$?; if [ $status -eq 0 ]; then status=$down_status; fi; exit $status; }; trap cleanup EXIT INT TERM; output=${VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON:-.artifacts/kafka-ingest-${VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE:-1000}rows.json}; mkdir -p .artifacts; docker compose -f ../../compose.yaml up -d --wait kafka || status=$?; if [ $status -eq 0 ]; then VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON=$output VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS=${VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS:-localhost:9092} vp test bench src/kafka-ingest.bench.ts --run --testTimeout 0 --outputJson $output || status=$?; fi'",
+    "bench:kafka-ingest": "node ../../scripts/run-runtime-kafka-ingest-bench.mjs",
     "bench:websocket-firehose": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && output=${VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON:-.artifacts/websocket-firehose-${VIEW_SERVER_RUNTIME_BENCH_WEBSOCKET_CASE:-same-window}-${VIEW_SERVER_RUNTIME_BENCH_WEBSOCKET_ROWS:-1000}rows-${VIEW_SERVER_RUNTIME_BENCH_WEBSOCKET_SUBSCRIBERS:-10}subs.json} && mkdir -p .artifacts && VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON=$output vp test bench src/websocket-firehose.bench.ts --run --testTimeout 0 --outputJson $output",
     "build": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp pack",
     "test": "node ../../scripts/test-runtime.mjs"

--- a/packages/runtime/src/kafka-ingest.bench.ts
+++ b/packages/runtime/src/kafka-ingest.bench.ts
@@ -54,6 +54,7 @@ type BenchmarkCase = {
 };
 
 type IngestSample = {
+  readonly commitObservedMs: number;
   readonly convergenceMs: number;
   readonly readSnapshotMs: number;
   readonly readSnapshotRows: number;
@@ -66,8 +67,10 @@ type IngestSample = {
 
 type IngestThroughputCaseSummary = {
   readonly aggregateRowsPerSecond: number;
+  readonly maxCommitObservedMs: number;
   readonly maxReadSnapshotMs: number;
   readonly maxTotalMs: number;
+  readonly meanCommitObservedMs: number;
   readonly meanConvergenceMs: number;
   readonly meanProducerSendMs: number;
   readonly meanReadSnapshotMs: number;
@@ -655,6 +658,7 @@ const timed = async <A>(operation: () => Promise<A>): Promise<readonly [A, numbe
 };
 
 const recordIngestSample = ({
+  commitObservedMs,
   convergenceMs,
   name,
   producerSendMs,
@@ -664,6 +668,7 @@ const recordIngestSample = ({
   totalMs,
 }: Omit<IngestSample, "rowsPerSecond">): void => {
   ingestSamples.push({
+    commitObservedMs,
     convergenceMs,
     name,
     producerSendMs,
@@ -724,8 +729,10 @@ const ingestThroughputCases = (): ReadonlyArray<IngestThroughputCaseSummary> => 
       const totalMs = samples.reduce((total, sample) => total + sample.totalMs, 0);
       return {
         aggregateRowsPerSecond: totalProducedRows / (totalMs / 1_000),
+        maxCommitObservedMs: Math.max(...samples.map((sample) => sample.commitObservedMs)),
         maxReadSnapshotMs: Math.max(...samples.map((sample) => sample.readSnapshotMs)),
         maxTotalMs: Math.max(...samples.map((sample) => sample.totalMs)),
+        meanCommitObservedMs: mean(samples.map((sample) => sample.commitObservedMs)),
         meanConvergenceMs: mean(samples.map((sample) => sample.convergenceMs)),
         meanProducerSendMs: mean(samples.map((sample) => sample.producerSendMs)),
         meanReadSnapshotMs: mean(samples.map((sample) => sample.readSnapshotMs)),
@@ -753,6 +760,7 @@ const ingestThroughputCases = (): ReadonlyArray<IngestThroughputCaseSummary> => 
 };
 
 type ConvergedIngestSample = {
+  readonly commitObservedMs: number;
   readonly convergenceMs: number;
   readonly producerSendMs: number;
   readonly rows: number;
@@ -816,6 +824,7 @@ const publishJsonBatchThroughConvergenceTimed = async (
     Effect.runPromise(waitForRows("jsonOrders", nextTotal)),
   );
   return {
+    commitObservedMs: convergenceMs,
     convergenceMs,
     producerSendMs,
     rows: count,
@@ -850,6 +859,7 @@ const publishProtobufBatchThroughConvergenceTimed = async (
     Effect.runPromise(waitForRows("protobufOrders", nextTotal)),
   );
   return {
+    commitObservedMs: convergenceMs,
     convergenceMs,
     producerSendMs,
     rows: count,
@@ -915,6 +925,7 @@ const publishMixedBatch = async (count: number): Promise<void> => {
   const samples = settledValuesOrThrow(results, "Kafka ingest benchmark mixed burst failed.");
   const { readSnapshotMs, readSnapshotRows } = await readBothSnapshotsTimed();
   recordIngestSample({
+    commitObservedMs: Math.max(...samples.map((sample) => sample.commitObservedMs)),
     convergenceMs: Math.max(...samples.map((sample) => sample.convergenceMs)),
     name: "mixed source burst ingest",
     producerSendMs: Math.max(...samples.map((sample) => sample.producerSendMs)),
@@ -954,6 +965,7 @@ const publishSustainedMixedFirehose = async (): Promise<void> => {
   const [_health, convergenceMs] = await timed(() => Effect.runPromise(waitForFinalHealth()));
   const { readSnapshotMs, readSnapshotRows } = await readBothSnapshotsTimed();
   recordIngestSample({
+    commitObservedMs: convergenceMs,
     convergenceMs,
     name: "sustained mixed firehose ingest",
     producerSendMs,

--- a/scripts/bench-runtime-kafka-ingest.mjs
+++ b/scripts/bench-runtime-kafka-ingest.mjs
@@ -1,0 +1,254 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const defaultRootDirectory = fileURLToPath(new URL("../", import.meta.url));
+const defaultRuntimeDirectory = fileURLToPath(new URL("../packages/runtime/", import.meta.url));
+
+const exitCodeForSignal = (signal) =>
+  signal === "SIGINT" ? 130 : signal === "SIGTERM" ? 143 : 129;
+
+const exitCodeForChildSignal = (signal) =>
+  signal === "SIGINT"
+    ? 130
+    : signal === "SIGTERM"
+      ? 143
+    : signal === "SIGHUP"
+      ? 129
+    : signal === "SIGKILL"
+      ? 137
+    : 1;
+
+export const createKafkaIngestBenchmarkRunner = ({
+  env,
+  rootDirectory = defaultRootDirectory,
+  runtimeDirectory = defaultRuntimeDirectory,
+  outputExists,
+  processId = process.pid,
+  removeOutput,
+  spawnProcess,
+  stdio,
+}) => {
+  const kafkaBootstrapServers = env.VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS ?? "localhost:9092";
+  const batchSize = env.VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE ?? "1000";
+  const benchmarkMode = env.VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE ?? "batch";
+  const defaultOutputName =
+    benchmarkMode === "sustained-firehose"
+      ? `.artifacts/kafka-sustained-firehose-${batchSize}rows-${env.VIEW_SERVER_RUNTIME_BENCH_KAFKA_SUSTAINED_BATCHES ?? "4"}batches.json`
+      : `.artifacts/kafka-ingest-${batchSize}rows.json`;
+  const outputJsonPath = env.VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON ?? defaultOutputName;
+  const resolvedOutputJsonPath = isAbsolute(outputJsonPath)
+    ? outputJsonPath
+    : resolve(runtimeDirectory, outputJsonPath);
+  const composeProjectName = `view-server-kafka-ingest-${processId}`;
+
+  let activeChild = undefined;
+  let activeRun = undefined;
+  let cleanupPromise = undefined;
+  let interruptedSignal = undefined;
+  let isCleaning = false;
+  let shouldCleanupDocker = false;
+
+  const run = (command, args, options = {}) => {
+    let child = undefined;
+    try {
+      child = spawnProcess(command, args, {
+        cwd: options.cwd ?? runtimeDirectory,
+        env: options.env ?? env,
+        stdio,
+      });
+    } catch {
+      activeChild = undefined;
+      activeRun = Promise.resolve(1);
+      return activeRun;
+    }
+    activeChild = child;
+    activeRun = new Promise((resolveExitCode) => {
+      child.once("error", () => {
+        if (activeChild === child) {
+          activeChild = undefined;
+        }
+        resolveExitCode(1);
+      });
+      child.once("close", (code, signal) => {
+        if (activeChild === child) {
+          activeChild = undefined;
+        }
+        resolveExitCode(code ?? exitCodeForChildSignal(signal));
+      });
+    });
+    return activeRun;
+  };
+
+  const terminateActiveChild = () => {
+    if (isCleaning || activeChild === undefined || activeChild.killed === true) {
+      return;
+    }
+    activeChild.kill("SIGTERM");
+  };
+
+  const cleanup = async () => {
+    if (!shouldCleanupDocker) {
+      return 0;
+    }
+    if (cleanupPromise !== undefined) {
+      return cleanupPromise;
+    }
+    isCleaning = true;
+    cleanupPromise = yieldDockerDown().finally(() => {
+      isCleaning = false;
+    });
+    return cleanupPromise;
+  };
+
+  const yieldDockerDown = () =>
+    run("docker", ["compose", "-f", "compose.yaml", "down"], {
+      cwd: rootDirectory,
+      env: {
+        ...env,
+        COMPOSE_PROJECT_NAME: composeProjectName,
+      },
+    });
+
+  const returnInterrupted = async () => {
+    const cleanupExitCode = await cleanup();
+    return cleanupExitCode === 0 ? exitCodeForSignal(interruptedSignal) : cleanupExitCode;
+  };
+
+  const handleSignal = async (signal) => {
+    interruptedSignal = signal;
+    terminateActiveChild();
+    await activeRun;
+    return returnInterrupted();
+  };
+
+  const runMain = async () => {
+    let exitCode = await run("vp", ["run", "-t", "@view-server/effect-utils#build"]);
+    if (interruptedSignal !== undefined) {
+      return returnInterrupted();
+    }
+
+    if (exitCode === 0) {
+      exitCode = await run("vp", ["run", "-t", "@view-server/runtime-core#build"]);
+      if (interruptedSignal !== undefined) {
+        return returnInterrupted();
+      }
+    }
+
+    if (exitCode === 0) {
+      exitCode = await run("vp", ["run", "-t", "@view-server/server#build"]);
+      if (interruptedSignal !== undefined) {
+        return returnInterrupted();
+      }
+    }
+
+    if (exitCode === 0) {
+      mkdirSync(dirname(resolvedOutputJsonPath), { recursive: true });
+      shouldCleanupDocker = true;
+      try {
+        exitCode = await run(
+          "docker",
+          ["compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+          {
+            cwd: rootDirectory,
+            env: {
+              ...env,
+              COMPOSE_PROJECT_NAME: composeProjectName,
+            },
+          },
+        );
+        if (interruptedSignal !== undefined) {
+          return returnInterrupted();
+        }
+
+        if (exitCode === 0) {
+          removeOutput(resolvedOutputJsonPath);
+          exitCode = await run(
+            "vp",
+            [
+              "test",
+              "bench",
+              "src/kafka-ingest.bench.ts",
+              "--run",
+              "--testTimeout",
+              "0",
+              "--outputJson",
+              outputJsonPath,
+            ],
+            {
+              env: {
+                ...env,
+                VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS: kafkaBootstrapServers,
+                VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON: outputJsonPath,
+              },
+            },
+          );
+          if (interruptedSignal !== undefined) {
+            return returnInterrupted();
+          }
+        }
+
+        if (exitCode === 0 && !outputExists(resolvedOutputJsonPath)) {
+          exitCode = 1;
+        }
+      } catch {
+        exitCode = 1;
+      }
+    }
+
+    const cleanupExitCode = await cleanup();
+    return exitCode === 0 ? cleanupExitCode : exitCode;
+  };
+
+  return {
+    cleanup,
+    handleSignal,
+    runMain,
+  };
+};
+
+export const runKafkaIngestBenchmarkCli = async ({
+  env,
+  exit,
+  processEvents,
+  rootDirectory,
+  runtimeDirectory,
+  outputExists,
+  processId,
+  removeOutput,
+  spawnProcess,
+  stdio,
+}) => {
+  const runner = createKafkaIngestBenchmarkRunner({
+    env,
+    outputExists,
+    processId,
+    removeOutput,
+    rootDirectory,
+    runtimeDirectory,
+    spawnProcess,
+    stdio,
+  });
+  let isExiting = false;
+  let signalExitPromise = undefined;
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    processEvents.on(signal, () => {
+      if (isExiting) {
+        return;
+      }
+      isExiting = true;
+      signalExitPromise = runner.handleSignal(signal).then((exitCode) => {
+        exit(exitCode);
+        return exitCode;
+      });
+    });
+  }
+  const exitCode = await runner.runMain();
+  if (signalExitPromise !== undefined) {
+    return signalExitPromise;
+  }
+  isExiting = true;
+  exit(exitCode);
+  return exitCode;
+};

--- a/scripts/bench-runtime-kafka-ingest.test.ts
+++ b/scripts/bench-runtime-kafka-ingest.test.ts
@@ -339,13 +339,20 @@ describe("Kafka ingest benchmark wrapper", () => {
 
   it("cleans Docker when benchmark process spawning throws after startup", async () => {
     const fakeSpawn = createFakeSpawn();
+    let spawnIndex = 0;
+    const throwingSpawn = () => {
+      throw new Error("cannot spawn benchmark");
+    };
+    const spawnSteps = [
+      fakeSpawn.spawnProcess,
+      fakeSpawn.spawnProcess,
+      fakeSpawn.spawnProcess,
+      fakeSpawn.spawnProcess,
+      throwingSpawn,
+      fakeSpawn.spawnProcess,
+    ];
     const runner = createRunner(fakeSpawn, {
-      spawnProcess: (command, args, options) => {
-        if (command === "vp" && args[0] === "test") {
-          throw new Error("cannot spawn benchmark");
-        }
-        return fakeSpawn.spawnProcess(command, args, options);
-      },
+      spawnProcess: (command, args, options) => spawnSteps[spawnIndex++](command, args, options),
     });
 
     const exitCodePromise = runner.runMain();

--- a/scripts/bench-runtime-kafka-ingest.test.ts
+++ b/scripts/bench-runtime-kafka-ingest.test.ts
@@ -1,0 +1,892 @@
+import { describe, expect, it } from "@effect/vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createKafkaIngestBenchmarkRunner, runKafkaIngestBenchmarkCli } from "./bench-runtime-kafka-ingest.mjs";
+
+type SpawnOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdio?: string;
+};
+
+type SpawnCall = {
+  args: ReadonlyArray<string>;
+  command: string;
+  options: SpawnOptions;
+};
+
+class FakeChildProcess extends EventEmitter {
+  killed = false;
+  readonly killSignals: Array<string> = [];
+
+  kill(signal = "SIGTERM") {
+    this.killed = true;
+    this.killSignals.push(signal);
+    this.emit("close", null, signal);
+    return true;
+  }
+}
+
+const createFakeSpawn = () => {
+  const calls: Array<SpawnCall> = [];
+  const children: Array<FakeChildProcess> = [];
+  const spawnProcess = (command: string, args: ReadonlyArray<string>, options: SpawnOptions) => {
+    const child = new FakeChildProcess();
+    calls.push({
+      args,
+      command,
+      options,
+    });
+    children.push(child);
+    return child;
+  };
+  return {
+    calls,
+    children,
+    spawnProcess,
+  };
+};
+
+const createRunner = (
+  fakeSpawn: ReturnType<typeof createFakeSpawn>,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    outputExists?: (path: string) => boolean;
+    processId?: number;
+    removeOutput?: (path: string) => void;
+    rootDirectory?: string;
+    runtimeDirectory?: string;
+    spawnProcess?: (
+      command: string,
+      args: ReadonlyArray<string>,
+      options: SpawnOptions,
+    ) => FakeChildProcess;
+  } = {},
+) =>
+  createKafkaIngestBenchmarkRunner({
+    env: options.env ?? {},
+    outputExists: options.outputExists ?? (() => true),
+    processId: options.processId ?? 12345,
+    removeOutput: options.removeOutput ?? (() => {}),
+    rootDirectory: options.rootDirectory ?? mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-root-")),
+    runtimeDirectory:
+      options.runtimeDirectory ?? mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-runtime-")),
+    spawnProcess: options.spawnProcess ?? fakeSpawn.spawnProcess,
+    stdio: "ignore",
+  });
+
+const settleSpawn = async (children: ReadonlyArray<FakeChildProcess>, index: number, code: number) => {
+  await Promise.resolve();
+  expect(children).toHaveLength(index + 1);
+  children[index].emit("close", code);
+};
+
+const settleSpawnSignal = async (
+  children: ReadonlyArray<FakeChildProcess>,
+  index: number,
+  signal: string,
+) => {
+  await Promise.resolve();
+  expect(children).toHaveLength(index + 1);
+  children[index].emit("close", null, signal);
+};
+
+describe("Kafka ingest benchmark wrapper", () => {
+  it("runs build, docker, benchmark, and cleanup commands in order", async () => {
+    const runtimeDirectory = mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-runtime-"));
+    const rootDirectory = mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-root-"));
+    const fakeSpawn = createFakeSpawn();
+    const removedOutputPaths: Array<string> = [];
+    const runner = createRunner(fakeSpawn, {
+      env: {
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE: "250",
+      },
+      removeOutput: (path) => {
+        removedOutputPaths.push(path);
+      },
+      rootDirectory,
+      runtimeDirectory,
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(0);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      [
+        "vp",
+        "test",
+        "bench",
+        "src/kafka-ingest.bench.ts",
+        "--run",
+        "--testTimeout",
+        "0",
+        "--outputJson",
+        ".artifacts/kafka-ingest-250rows.json",
+      ],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+    expect(fakeSpawn.calls.map(({ options }) => options.cwd)).toStrictEqual([
+      runtimeDirectory,
+      runtimeDirectory,
+      runtimeDirectory,
+      rootDirectory,
+      runtimeDirectory,
+      rootDirectory,
+    ]);
+    expect(fakeSpawn.calls.map(({ options }) => options.env?.COMPOSE_PROJECT_NAME)).toStrictEqual([
+      undefined,
+      undefined,
+      undefined,
+      "view-server-kafka-ingest-12345",
+      undefined,
+      "view-server-kafka-ingest-12345",
+    ]);
+    expect(removedOutputPaths).toStrictEqual([
+      resolve(runtimeDirectory, ".artifacts/kafka-ingest-250rows.json"),
+    ]);
+  });
+
+  it("skips Docker startup, benchmark, and cleanup when the first build fails", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 1);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("uses repository and runtime directory defaults when none are injected", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createKafkaIngestBenchmarkRunner({
+      env: {},
+      outputExists: () => true,
+      removeOutput: () => {},
+      spawnProcess: fakeSpawn.spawnProcess,
+      stdio: "ignore",
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 1);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls).toStrictEqual([
+      {
+        args: ["run", "-t", "@view-server/effect-utils#build"],
+        command: "vp",
+        options: {
+          cwd: fileURLToPath(new URL("../packages/runtime/", import.meta.url)),
+          env: {},
+          stdio: "ignore",
+        },
+      },
+    ]);
+  });
+
+  it("returns Docker startup failures after cleanup", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 4);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(exitCodePromise).resolves.toBe(4);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("ignores caller Compose project names so cleanup targets only this benchmark run", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      env: {
+        COMPOSE_PROJECT_NAME: "developer-project",
+        VIEW_SERVER_RUNTIME_BENCH_COMPOSE_PROJECT_NAME: "legacy-benchmark-project",
+      },
+      processId: 98765,
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(0);
+    expect(
+      fakeSpawn.calls
+        .filter(({ command }) => command === "docker")
+        .map(({ options }) => options.env?.COMPOSE_PROJECT_NAME),
+    ).toStrictEqual(["view-server-kafka-ingest-98765", "view-server-kafka-ingest-98765"]);
+  });
+
+  it("returns benchmark failures after cleanup", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 9);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(9);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      [
+        "vp",
+        "test",
+        "bench",
+        "src/kafka-ingest.bench.ts",
+        "--run",
+        "--testTimeout",
+        "0",
+        "--outputJson",
+        ".artifacts/kafka-ingest-1000rows.json",
+      ],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("returns failure after cleanup when stale output removal fails", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      removeOutput: () => {
+        throw new Error("cannot remove stale output");
+      },
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("cleans Docker when stale output removal throws after startup", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      removeOutput: () => {
+        throw new Error("cannot remove old artifact");
+      },
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("cleans Docker when benchmark process spawning throws after startup", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      spawnProcess: (command, args, options) => {
+        if (command === "vp" && args[0] === "test") {
+          throw new Error("cannot spawn benchmark");
+        }
+        return fakeSpawn.spawnProcess(command, args, options);
+      },
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("returns failure when the benchmark output file is missing", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      outputExists: () => false,
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      [
+        "vp",
+        "test",
+        "bench",
+        "src/kafka-ingest.bench.ts",
+        "--run",
+        "--testTimeout",
+        "0",
+        "--outputJson",
+        ".artifacts/kafka-ingest-1000rows.json",
+      ],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("uses sustained-firehose output naming and caller-provided Kafka bootstrap servers", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      env: {
+        VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS: "kafka.local:9092",
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE: "25",
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE: "sustained-firehose",
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_SUSTAINED_BATCHES: "8",
+      },
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(0);
+    expect(fakeSpawn.calls[4].args).toStrictEqual([
+      "test",
+      "bench",
+      "src/kafka-ingest.bench.ts",
+      "--run",
+      "--testTimeout",
+      "0",
+      "--outputJson",
+      ".artifacts/kafka-sustained-firehose-25rows-8batches.json",
+    ]);
+    expect(fakeSpawn.calls[4].options.env?.VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS).toBe(
+      "kafka.local:9092",
+    );
+  });
+
+  it("passes absolute output paths through to Vitest bench", async () => {
+    const absoluteOutputPath = resolve(tmpdir(), "view-server-kafka-wrapper-output.json");
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      env: {
+        VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON: absoluteOutputPath,
+      },
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(0);
+    expect(fakeSpawn.calls[4].args).toStrictEqual([
+      "test",
+      "bench",
+      "src/kafka-ingest.bench.ts",
+      "--run",
+      "--testTimeout",
+      "0",
+      "--outputJson",
+      absoluteOutputPath,
+    ]);
+  });
+
+  it("uses the default sustained-firehose batch count when none is configured", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn, {
+      env: {
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_BATCH_SIZE: "10",
+        VIEW_SERVER_RUNTIME_BENCH_KAFKA_MODE: "sustained-firehose",
+      },
+    });
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(0);
+    expect(fakeSpawn.calls[4].args).toStrictEqual([
+      "test",
+      "bench",
+      "src/kafka-ingest.bench.ts",
+      "--run",
+      "--testTimeout",
+      "0",
+      "--outputJson",
+      ".artifacts/kafka-sustained-firehose-10rows-4batches.json",
+    ]);
+  });
+
+  it("returns spawn errors before Docker startup without cleanup", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(1);
+    fakeSpawn.children[0].emit("error", new Error("build failed"));
+    await expect(runner.cleanup()).resolves.toBe(0);
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("returns failure when spawning a child throws synchronously", async () => {
+    const runner = createKafkaIngestBenchmarkRunner({
+      env: {},
+      outputExists: () => true,
+      removeOutput: () => {},
+      spawnProcess: () => {
+        throw new Error("spawn unavailable");
+      },
+      stdio: "ignore",
+    });
+
+    await expect(runner.runMain()).resolves.toBe(1);
+    await expect(runner.cleanup()).resolves.toBe(0);
+  });
+
+  it("preserves Docker cleanup failures across repeated cleanup calls", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 4);
+    await settleSpawn(fakeSpawn.children, 4, 7);
+
+    await expect(exitCodePromise).resolves.toBe(4);
+    await expect(runner.cleanup()).resolves.toBe(7);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("maps signalled child exits and still cleans Docker", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawnSignal(fakeSpawn.children, 0, "SIGKILL");
+
+    await expect(exitCodePromise).resolves.toBe(137);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("maps interrupted child exits and still cleans Docker", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawnSignal(fakeSpawn.children, 0, "SIGINT");
+
+    await expect(exitCodePromise).resolves.toBe(130);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("maps hung-up child exits and still cleans Docker", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawnSignal(fakeSpawn.children, 0, "SIGHUP");
+
+    await expect(exitCodePromise).resolves.toBe(129);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("maps unknown child signal exits to failure and still cleans Docker", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+
+    await settleSpawnSignal(fakeSpawn.children, 0, "SIGUSR1");
+
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("stops before server build when interrupted during runtime-core build", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(2);
+    const interruptPromise = runner.handleSignal("SIGINT");
+
+    await expect(interruptPromise).resolves.toBe(130);
+    await expect(exitCodePromise).resolves.toBe(130);
+    expect(fakeSpawn.children[1].killSignals).toStrictEqual(["SIGTERM"]);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+    ]);
+  });
+
+  it("stops before Docker startup when interrupted during server build", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(3);
+    const interruptPromise = runner.handleSignal("SIGINT");
+
+    await expect(interruptPromise).resolves.toBe(130);
+    await expect(exitCodePromise).resolves.toBe(130);
+    expect(fakeSpawn.children[2].killSignals).toStrictEqual(["SIGTERM"]);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+    ]);
+  });
+
+  it("cleans Docker when interrupted during the benchmark run", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(5);
+    const interruptPromise = runner.handleSignal("SIGINT");
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(interruptPromise).resolves.toBe(130);
+    await expect(exitCodePromise).resolves.toBe(130);
+    expect(fakeSpawn.children[4].killSignals).toStrictEqual(["SIGTERM"]);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      [
+        "vp",
+        "test",
+        "bench",
+        "src/kafka-ingest.bench.ts",
+        "--run",
+        "--testTimeout",
+        "0",
+        "--outputJson",
+        ".artifacts/kafka-ingest-1000rows.json",
+      ],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("does not let stale child errors clear the active cleanup child", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    const cleanupPromise = runner.cleanup();
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(5);
+    fakeSpawn.children[3].emit("error", new Error("stale startup failed"));
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(cleanupPromise).resolves.toBe(0);
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("does not let stale child closes clear the active cleanup child", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const runner = createRunner(fakeSpawn);
+
+    const exitCodePromise = runner.runMain();
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    const cleanupPromise = runner.cleanup();
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(5);
+    fakeSpawn.children[3].emit("close", 1);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(cleanupPromise).resolves.toBe(0);
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("maps handled signals to process exit codes without an active child", async () => {
+    const interruptSpawn = createFakeSpawn();
+    const hangupSpawn = createFakeSpawn();
+    const interruptRunner = createRunner(interruptSpawn);
+    const hangupRunner = createRunner(hangupSpawn);
+
+    const interruptPromise = interruptRunner.handleSignal("SIGINT");
+    const hangupPromise = hangupRunner.handleSignal("SIGHUP");
+
+    await expect(interruptPromise).resolves.toBe(130);
+    await expect(hangupPromise).resolves.toBe(129);
+    expect(interruptSpawn.calls).toStrictEqual([]);
+    expect(hangupSpawn.calls).toStrictEqual([]);
+  });
+
+  it("terminates the active child without Docker cleanup before Compose starts", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const processEvents = new EventEmitter();
+    const exitCodes: Array<number> = [];
+    const exitCodePromise = runKafkaIngestBenchmarkCli({
+      env: {},
+      exit: (code?: number | string | null) => {
+        exitCodes.push(Number(code));
+      },
+      outputExists: () => true,
+      removeOutput: () => {},
+      processEvents,
+      rootDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-root-")),
+      runtimeDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-runtime-")),
+      spawnProcess: fakeSpawn.spawnProcess,
+      stdio: "ignore",
+    });
+
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(1);
+    processEvents.emit("SIGTERM");
+
+    await expect(exitCodePromise).resolves.toBe(143);
+    expect(exitCodes).toStrictEqual([143]);
+    expect(fakeSpawn.children[0].killSignals).toStrictEqual(["SIGTERM"]);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+    ]);
+  });
+
+  it("returns cleanup failure when a signal arrives after Compose starts and Docker cleanup fails", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const processEvents = new EventEmitter();
+    const exitCodes: Array<number> = [];
+    const exitCodePromise = runKafkaIngestBenchmarkCli({
+      env: {},
+      exit: (code?: number | string | null) => {
+        exitCodes.push(Number(code));
+      },
+      outputExists: () => true,
+      removeOutput: () => {},
+      processEvents,
+      rootDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-root-")),
+      runtimeDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-runtime-")),
+      spawnProcess: fakeSpawn.spawnProcess,
+      stdio: "ignore",
+    });
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(4);
+    processEvents.emit("SIGTERM");
+    await settleSpawn(fakeSpawn.children, 4, 7);
+
+    await expect(exitCodePromise).resolves.toBe(7);
+    expect(exitCodes).toStrictEqual([7]);
+    expect(fakeSpawn.children[3].killSignals).toStrictEqual(["SIGTERM"]);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+
+  it("exits once with the normal run result when no signal arrives", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const processEvents = new EventEmitter();
+    const exitCodes: Array<number> = [];
+    const exitCodePromise = runKafkaIngestBenchmarkCli({
+      env: {},
+      exit: (code?: number | string | null) => {
+        exitCodes.push(Number(code));
+      },
+      outputExists: () => true,
+      removeOutput: () => {},
+      processEvents,
+      rootDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-root-")),
+      runtimeDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-runtime-")),
+      spawnProcess: fakeSpawn.spawnProcess,
+      stdio: "ignore",
+    });
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await settleSpawn(fakeSpawn.children, 3, 0);
+    await settleSpawn(fakeSpawn.children, 4, 0);
+    await settleSpawn(fakeSpawn.children, 5, 0);
+
+    await expect(exitCodePromise).resolves.toBe(0);
+    expect(exitCodes).toStrictEqual([0]);
+  });
+
+  it("does not terminate Docker cleanup when another signal arrives during cleanup", async () => {
+    const fakeSpawn = createFakeSpawn();
+    const processEvents = new EventEmitter();
+    const exitCodes: Array<number> = [];
+    const exitCodePromise = runKafkaIngestBenchmarkCli({
+      env: {},
+      exit: (code?: number | string | null) => {
+        exitCodes.push(Number(code));
+      },
+      outputExists: () => true,
+      removeOutput: () => {},
+      processEvents,
+      rootDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-root-")),
+      runtimeDirectory: mkdtempSync(join(tmpdir(), "view-server-kafka-wrapper-runtime-")),
+      spawnProcess: fakeSpawn.spawnProcess,
+      stdio: "ignore",
+    });
+
+    await settleSpawn(fakeSpawn.children, 0, 0);
+    await settleSpawn(fakeSpawn.children, 1, 0);
+    await settleSpawn(fakeSpawn.children, 2, 0);
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(4);
+    processEvents.emit("SIGTERM");
+    await Promise.resolve();
+    expect(fakeSpawn.children).toHaveLength(5);
+    processEvents.emit("SIGINT");
+    await settleSpawn(fakeSpawn.children, 4, 0);
+
+    await expect(exitCodePromise).resolves.toBe(143);
+    expect(exitCodes).toStrictEqual([143]);
+    expect(fakeSpawn.children[4].killSignals).toStrictEqual([]);
+    expect(fakeSpawn.calls.map(({ command, args }) => [command, ...args])).toStrictEqual([
+      ["vp", "run", "-t", "@view-server/effect-utils#build"],
+      ["vp", "run", "-t", "@view-server/runtime-core#build"],
+      ["vp", "run", "-t", "@view-server/server#build"],
+      ["docker", "compose", "-f", "compose.yaml", "up", "-d", "--wait", "kafka"],
+      ["docker", "compose", "-f", "compose.yaml", "down"],
+    ]);
+  });
+});

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -30,6 +30,11 @@ const kafkaReadSnapshotThresholds = {
   },
 };
 
+const kafkaRssReportThresholds = {
+  maxAbsoluteDeltaBytes: 256 * 1024 * 1024,
+  maxRatio: 64,
+};
+
 export const groupedOrderNeutralBenchmarkThresholds = {
   latencyMean: {
     maxAbsoluteDeltaMs: 0.5,
@@ -45,6 +50,14 @@ export const groupedOrderNeutralBenchmarkThresholds = {
 };
 
 export const kafkaIngestBenchmarkThresholds = {
+  commitObservedMean: {
+    maxAbsoluteDeltaMs: 2_000,
+    maxRatio: 1.5,
+  },
+  commitObservedMax: {
+    maxAbsoluteDeltaMs: 2_500,
+    maxRatio: 1.5,
+  },
   latencyMean: {
     maxAbsoluteDeltaMs: 2_000,
     maxRatio: 1.5,
@@ -53,7 +66,7 @@ export const kafkaIngestBenchmarkThresholds = {
     maxAbsoluteDeltaMs: 2_500,
     maxRatio: 1.5,
   },
-  memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+  memoryRssTotalDelta: kafkaRssReportThresholds,
   throughputAggregateRowsPerSecond: {
     minRatio: 0.75,
   },
@@ -61,6 +74,14 @@ export const kafkaIngestBenchmarkThresholds = {
 };
 
 export const kafkaSustainedFirehoseBenchmarkThresholds = {
+  commitObservedMean: {
+    maxAbsoluteDeltaMs: 5_000,
+    maxRatio: 1.75,
+  },
+  commitObservedMax: {
+    maxAbsoluteDeltaMs: 6_000,
+    maxRatio: 1.75,
+  },
   latencyMean: {
     maxAbsoluteDeltaMs: 5_000,
     maxRatio: 1.75,
@@ -69,7 +90,7 @@ export const kafkaSustainedFirehoseBenchmarkThresholds = {
     maxAbsoluteDeltaMs: 6_000,
     maxRatio: 1.75,
   },
-  memoryRssTotalDelta: defaultBenchmarkThresholds.memoryRssTotalDelta,
+  memoryRssTotalDelta: kafkaRssReportThresholds,
   throughputAggregateRowsPerSecond: {
     minRatio: 0.75,
   },
@@ -127,6 +148,18 @@ const objectValue = (value, path) => {
     throw new Error(`Benchmark artifact field ${path} must be an object.`);
   }
   return value;
+};
+
+const exactObjectValue = (value, path, expectedKeys) => {
+  const object = objectValue(value, path);
+  const actualKeys = Object.keys(object).sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(sortedExpectedKeys)) {
+    throw new Error(
+      `Benchmark artifact field ${path} must contain exactly these keys: ${sortedExpectedKeys.join(", ")}.`,
+    );
+  }
+  return object;
 };
 
 const arrayValue = (value, path) => {
@@ -337,9 +370,17 @@ const throughputCaseValue = (value, path, options) => {
   const readSnapshotMetrics =
     options.requireReadSnapshot === true
       ? {
+          maxCommitObservedMs: positiveFiniteNumber(
+            throughputCase.maxCommitObservedMs,
+            `${path}.maxCommitObservedMs`,
+          ),
           maxReadSnapshotMs: positiveFiniteNumber(
             throughputCase.maxReadSnapshotMs,
             `${path}.maxReadSnapshotMs`,
+          ),
+          meanCommitObservedMs: positiveFiniteNumber(
+            throughputCase.meanCommitObservedMs,
+            `${path}.meanCommitObservedMs`,
           ),
           meanReadSnapshotMs: positiveFiniteNumber(
             throughputCase.meanReadSnapshotMs,
@@ -417,6 +458,21 @@ const throughputCaseValue = (value, path, options) => {
     );
   }
   if (options.requireReadSnapshot === true) {
+    if (result.meanCommitObservedMs > result.maxCommitObservedMs) {
+      throw new Error(
+        `Benchmark artifact field ${path}.meanCommitObservedMs must be less than or equal to maxCommitObservedMs.`,
+      );
+    }
+    if (result.maxCommitObservedMs > result.maxTotalMs) {
+      throw new Error(
+        `Benchmark artifact field ${path}.maxCommitObservedMs must be less than or equal to maxTotalMs.`,
+      );
+    }
+    if (result.meanCommitObservedMs > result.meanTotalMs) {
+      throw new Error(
+        `Benchmark artifact field ${path}.meanCommitObservedMs must be less than or equal to meanTotalMs.`,
+      );
+    }
     if (result.meanReadSnapshotMs > result.maxReadSnapshotMs) {
       throw new Error(
         `Benchmark artifact field ${path}.meanReadSnapshotMs must be less than or equal to maxReadSnapshotMs.`,
@@ -765,68 +821,79 @@ const nonEmptyArrayValue = (value, path) => {
 };
 
 const thresholdsValue = (value, path, expectedThresholds) => {
-  const thresholds = objectValue(value, path);
-  const validatedThresholds = {
-    latencyMean: {
+  const thresholds = exactObjectValue(value, path, Object.keys(expectedThresholds));
+  const validatedThresholds = {};
+  const deltaThresholdValue = (threshold, thresholdPath) => {
+    const thresholdObject = exactObjectValue(threshold, thresholdPath, [
+      "maxAbsoluteDeltaMs",
+      "maxRatio",
+    ]);
+    return {
       maxAbsoluteDeltaMs: finiteNumber(
-        objectValue(thresholds.latencyMean, `${path}.latencyMean`).maxAbsoluteDeltaMs,
-        `${path}.latencyMean.maxAbsoluteDeltaMs`,
+        thresholdObject.maxAbsoluteDeltaMs,
+        `${thresholdPath}.maxAbsoluteDeltaMs`,
       ),
-      maxRatio: finiteNumber(thresholds.latencyMean.maxRatio, `${path}.latencyMean.maxRatio`),
-    },
-    latencyP99: {
-      maxAbsoluteDeltaMs: finiteNumber(
-        objectValue(thresholds.latencyP99, `${path}.latencyP99`).maxAbsoluteDeltaMs,
-        `${path}.latencyP99.maxAbsoluteDeltaMs`,
-      ),
-      maxRatio: finiteNumber(thresholds.latencyP99.maxRatio, `${path}.latencyP99.maxRatio`),
-    },
-    memoryRssTotalDelta: {
-      maxAbsoluteDeltaBytes: finiteNumber(
-        objectValue(thresholds.memoryRssTotalDelta, `${path}.memoryRssTotalDelta`)
-          .maxAbsoluteDeltaBytes,
-        `${path}.memoryRssTotalDelta.maxAbsoluteDeltaBytes`,
-      ),
-      maxRatio: finiteNumber(
-        thresholds.memoryRssTotalDelta.maxRatio,
-        `${path}.memoryRssTotalDelta.maxRatio`,
-      ),
-    },
-    throughputAggregateRowsPerSecond: {
-      minRatio: finiteNumber(
-        objectValue(
-          thresholds.throughputAggregateRowsPerSecond,
-          `${path}.throughputAggregateRowsPerSecond`,
-        ).minRatio,
-        `${path}.throughputAggregateRowsPerSecond.minRatio`,
-      ),
-    },
-  };
-  if (expectedThresholds.throughputReadSnapshotMax !== undefined) {
-    validatedThresholds.throughputReadSnapshotMax = {
-      maxAbsoluteDeltaMs: finiteNumber(
-        objectValue(thresholds.throughputReadSnapshotMax, `${path}.throughputReadSnapshotMax`)
-          .maxAbsoluteDeltaMs,
-        `${path}.throughputReadSnapshotMax.maxAbsoluteDeltaMs`,
-      ),
-      maxRatio: finiteNumber(
-        thresholds.throughputReadSnapshotMax.maxRatio,
-        `${path}.throughputReadSnapshotMax.maxRatio`,
-      ),
+      maxRatio: finiteNumber(thresholdObject.maxRatio, `${thresholdPath}.maxRatio`),
     };
+  };
+  const throughputThresholdValue = (threshold, thresholdPath) => {
+    const thresholdObject = exactObjectValue(threshold, thresholdPath, ["minRatio"]);
+    return {
+      minRatio: finiteNumber(thresholdObject.minRatio, `${thresholdPath}.minRatio`),
+    };
+  };
+  const memoryThresholdValue = (threshold, thresholdPath) => {
+    const thresholdObject = exactObjectValue(threshold, thresholdPath, [
+      "maxAbsoluteDeltaBytes",
+      "maxRatio",
+    ]);
+    return {
+      maxAbsoluteDeltaBytes: finiteNumber(
+        thresholdObject.maxAbsoluteDeltaBytes,
+        `${thresholdPath}.maxAbsoluteDeltaBytes`,
+      ),
+      maxRatio: finiteNumber(thresholdObject.maxRatio, `${thresholdPath}.maxRatio`),
+    };
+  };
+  if (expectedThresholds.commitObservedMean !== undefined) {
+    validatedThresholds.commitObservedMean = deltaThresholdValue(
+      thresholds.commitObservedMean,
+      `${path}.commitObservedMean`,
+    );
+  }
+  if (expectedThresholds.commitObservedMax !== undefined) {
+    validatedThresholds.commitObservedMax = deltaThresholdValue(
+      thresholds.commitObservedMax,
+      `${path}.commitObservedMax`,
+    );
+  }
+  validatedThresholds.latencyMean = deltaThresholdValue(
+    thresholds.latencyMean,
+    `${path}.latencyMean`,
+  );
+  validatedThresholds.latencyP99 = deltaThresholdValue(
+    thresholds.latencyP99,
+    `${path}.latencyP99`,
+  );
+  validatedThresholds.memoryRssTotalDelta = memoryThresholdValue(
+    thresholds.memoryRssTotalDelta,
+    `${path}.memoryRssTotalDelta`,
+  );
+  validatedThresholds.throughputAggregateRowsPerSecond = throughputThresholdValue(
+    thresholds.throughputAggregateRowsPerSecond,
+    `${path}.throughputAggregateRowsPerSecond`,
+  );
+  if (expectedThresholds.throughputReadSnapshotMax !== undefined) {
+    validatedThresholds.throughputReadSnapshotMax = deltaThresholdValue(
+      thresholds.throughputReadSnapshotMax,
+      `${path}.throughputReadSnapshotMax`,
+    );
   }
   if (expectedThresholds.throughputReadSnapshotMean !== undefined) {
-    validatedThresholds.throughputReadSnapshotMean = {
-      maxAbsoluteDeltaMs: finiteNumber(
-        objectValue(thresholds.throughputReadSnapshotMean, `${path}.throughputReadSnapshotMean`)
-          .maxAbsoluteDeltaMs,
-        `${path}.throughputReadSnapshotMean.maxAbsoluteDeltaMs`,
-      ),
-      maxRatio: finiteNumber(
-        thresholds.throughputReadSnapshotMean.maxRatio,
-        `${path}.throughputReadSnapshotMean.maxRatio`,
-      ),
-    };
+    validatedThresholds.throughputReadSnapshotMean = deltaThresholdValue(
+      thresholds.throughputReadSnapshotMean,
+      `${path}.throughputReadSnapshotMean`,
+    );
   }
   if (JSON.stringify(validatedThresholds) !== JSON.stringify(expectedThresholds)) {
     throw new Error(`Benchmark artifact field ${path} must match code-owned profile thresholds.`);
@@ -1119,6 +1186,24 @@ const compareThroughputCases = (regressions, taskLabel, threshold, baselineCases
       actualCase.aggregateRowsPerSecond,
     );
     if (threshold.throughputReadSnapshotMean !== undefined) {
+      compareLatency(
+        regressions,
+        taskLabel,
+        baselineCase.name,
+        "meanCommitObservedMs",
+        threshold.commitObservedMean,
+        baselineCase.meanCommitObservedMs,
+        actualCase.meanCommitObservedMs,
+      );
+      compareLatency(
+        regressions,
+        taskLabel,
+        baselineCase.name,
+        "maxCommitObservedMs",
+        threshold.commitObservedMax,
+        baselineCase.maxCommitObservedMs,
+        actualCase.maxCommitObservedMs,
+      );
       compareExact(
         regressions,
         taskLabel,

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -162,8 +162,10 @@ const runtimeThroughput = {
   cases: [
     {
       aggregateRowsPerSecond: 1000,
+      maxCommitObservedMs: 80,
       maxReadSnapshotMs: 6,
       maxTotalMs: 100,
+      meanCommitObservedMs: 75,
       meanConvergenceMs: 75,
       meanProducerSendMs: 25,
       meanReadSnapshotMs: 5,
@@ -1945,6 +1947,45 @@ describe("benchmark baseline comparison", () => {
     });
   });
 
+  it("reports Kafka commit-observed latency regressions", () => {
+    const kafkaObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+      throughputCases: comparableRuntimeThroughputCases,
+    };
+    const baseline = buildBenchmarkBaseline("kafka-ingest", [kafkaObservation]);
+    const regressedCommitObserved = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            aggregateRowsPerSecond: 100_000 / 2_100,
+            maxCommitObservedMs: 2_600,
+            maxTotalMs: 2_600,
+            meanCommitObservedMs: 2_076,
+            meanRowsPerSecond: 100_000 / 2_100,
+            meanTotalMs: 2_100,
+            minRowsPerSecond: 40,
+          },
+        ],
+      },
+    ]);
+
+    expect(compareBenchmarkBaseline(baseline, regressedCommitObserved)).toStrictEqual({
+      ok: false,
+      regressions: [
+        "task a / case a: aggregateRowsPerSecond throughput regressed from 1000.000 rows/sec to 47.619 rows/sec; allowed >= 750.000 rows/sec.",
+        "task a / case a: meanCommitObservedMs regressed from 75.000ms to 2076.000ms; allowed <= 2075.000ms.",
+        "task a / case a: maxCommitObservedMs regressed from 80.000ms to 2600.000ms; allowed <= 2580.000ms.",
+      ],
+    });
+  });
+
   it("reports Kafka read snapshot workload and latency regressions", () => {
     const kafkaObservation = {
       ...observation,
@@ -2234,6 +2275,53 @@ describe("benchmark baseline comparison", () => {
         },
       },
     ]);
+    const kafkaThroughputObservation = {
+      ...observation,
+      artifactKind: "runtime-benchmark-summary",
+      benchmarkScope: "runtime-kafka-ingest",
+      groupedWriteAdmission: undefined,
+      kafkaIngestLanes: comparableRuntimeThroughputKafkaIngestLanes,
+      mutationCount: runtimeThroughputMutationCount,
+      throughputCases: comparableRuntimeThroughputCases,
+    };
+    const inconsistentCommitMeanBaseline = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaThroughputObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            maxCommitObservedMs: 10,
+            meanCommitObservedMs: 11,
+          },
+        ],
+      },
+    ]);
+    const impossibleCommitMaxBaseline = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaThroughputObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            maxCommitObservedMs: 101,
+          },
+        ],
+      },
+    ]);
+    const impossibleCommitMeanBaseline = buildBenchmarkBaseline("kafka-ingest", [
+      {
+        ...kafkaThroughputObservation,
+        throughputCases: [
+          {
+            ...comparableRuntimeThroughputCases[0],
+            aggregateRowsPerSecond: 100_000 / 79,
+            maxCommitObservedMs: 90,
+            meanCommitObservedMs: 80,
+            meanRowsPerSecond: 100_000 / 79,
+            meanTotalMs: 79,
+          },
+        ],
+      },
+    ]);
 
     expect(() => validateBenchmarkBaseline(negativeEventLoopDelayBaseline)).toThrow(
       "Benchmark artifact field baseline.tasks[0].runtimeMetrics.eventLoopDelay.maxMs must be a non-negative finite number.",
@@ -2246,6 +2334,15 @@ describe("benchmark baseline comparison", () => {
     );
     expect(() => validateBenchmarkBaseline(inconsistentHealthPollingBaseline)).toThrow(
       "Benchmark artifact field baseline.tasks[0].runtimeMetrics.healthPolling.totalMs must be greater than or equal to baseline.tasks[0].runtimeMetrics.healthPolling.maxMs.",
+    );
+    expect(() => validateBenchmarkBaseline(inconsistentCommitMeanBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases[0].meanCommitObservedMs must be less than or equal to maxCommitObservedMs.",
+    );
+    expect(() => validateBenchmarkBaseline(impossibleCommitMaxBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases[0].maxCommitObservedMs must be less than or equal to maxTotalMs.",
+    );
+    expect(() => validateBenchmarkBaseline(impossibleCommitMeanBaseline)).toThrow(
+      "Benchmark artifact field baseline.tasks[0].throughputCases[0].meanCommitObservedMs must be less than or equal to meanTotalMs.",
     );
   });
 
@@ -2722,6 +2819,40 @@ describe("benchmark baseline comparison", () => {
 
     expect(() => validateBenchmarkBaseline(baseline)).toThrow(
       "Benchmark artifact field baseline.thresholds must match code-owned profile thresholds.",
+    );
+  });
+
+  it("rejects stale extra baseline threshold keys", () => {
+    const baseline = {
+      ...buildBenchmarkBaseline("smoke", [observation]),
+      thresholds: {
+        ...defaultBenchmarkThresholds,
+        commitObservedMean: {
+          maxAbsoluteDeltaMs: 10,
+          maxRatio: 2,
+        },
+      },
+    };
+
+    expect(() => validateBenchmarkBaseline(baseline)).toThrow(
+      "Benchmark artifact field baseline.thresholds must contain exactly these keys: latencyMean, latencyP99, memoryRssTotalDelta, throughputAggregateRowsPerSecond.",
+    );
+  });
+
+  it("rejects stale extra nested baseline threshold keys", () => {
+    const baseline = {
+      ...buildBenchmarkBaseline("smoke", [observation]),
+      thresholds: {
+        ...defaultBenchmarkThresholds,
+        latencyMean: {
+          ...defaultBenchmarkThresholds.latencyMean,
+          staleKey: 123,
+        },
+      },
+    };
+
+    expect(() => validateBenchmarkBaseline(baseline)).toThrow(
+      "Benchmark artifact field baseline.thresholds.latencyMean must contain exactly these keys: maxAbsoluteDeltaMs, maxRatio.",
     );
   });
 

--- a/scripts/run-runtime-kafka-ingest-bench.mjs
+++ b/scripts/run-runtime-kafka-ingest-bench.mjs
@@ -1,0 +1,18 @@
+import { spawn } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { runKafkaIngestBenchmarkCli } from "./bench-runtime-kafka-ingest.mjs";
+
+void runKafkaIngestBenchmarkCli({
+  env: process.env,
+  exit: process.exit,
+  outputExists: existsSync,
+  removeOutput: (path) => {
+    rmSync(path, { force: true });
+  },
+  processEvents: process,
+  rootDirectory: fileURLToPath(new URL("../", import.meta.url)),
+  runtimeDirectory: fileURLToPath(new URL("../packages/runtime/", import.meta.url)),
+  spawnProcess: spawn,
+  stdio: "inherit",
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
         "scripts/benchmark-baseline.mjs",
         "scripts/benchmark-baseline-cli.mjs",
         "scripts/benchmark-baseline-runner.mjs",
+        "scripts/bench-runtime-kafka-ingest.mjs",
         "scripts/check-internal-seams.ts",
       ],
       reporter: ["text"],


### PR DESCRIPTION
## Summary
- add a covered Kafka ingest benchmark wrapper with async child lifecycle, signal cleanup, owned Docker Compose project names, stale-output removal, and missing-output detection
- add commit-observed Kafka ingest metrics and baseline threshold comparison
- scope Kafka RSS thresholds separately and reject stale nested threshold keys

## Validation
- pnpm run test:repository-scripts
- vp check
- pnpm run bench:baseline:kafka-sustained-firehose
- pnpm run bench:baseline:kafka-ingest
- pnpm run ready