### PR TITLE
Preserve Kafka unknown lag sentinels

### DIFF
--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -1501,7 +1501,7 @@ describe("@view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
-  it.effect("clears Kafka lag to unknown when later samples only contain negative sentinels", () =>
+  it.effect("keeps Kafka all-negative lag sentinels unknown", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
       yield* Effect.gen(function* () {
@@ -1545,36 +1545,97 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         );
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
 
-        expect({
-          healthRefreshRequestCount,
-          orders: health.kafka?.topics[ordersSourceTopic],
-        }).toStrictEqual({
-          healthRefreshRequestCount: 3,
-          orders: {
-            status: "ready",
-            sourceTopic: ordersSourceTopic,
-            viewServerTopic: "orders",
-            regions: nullRecord({
-              local: {
-                connected: true,
-                assignedPartitions: 1,
-                messagesPerSecond: 0,
-                bytesPerSecond: 0,
-                decodedMessagesPerSecond: 0,
-                decodeFailuresPerSecond: 0,
-                mappingFailuresPerSecond: 0,
-                publishFailuresPerSecond: 0,
-                commitFailuresPerSecond: 0,
-                processingFailuresPerSecond: 0,
-                lastMessageAt: null,
-                lastCommitAt: null,
-                consumerLagMessages: null,
-                lagSampledAt: 2_000,
-                committedOffset: null,
-                lastError: null,
-              },
-            }),
+        expect(healthRefreshRequestCount).toBe(3);
+        expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
+          status: "ready",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: true,
+              assignedPartitions: 1,
+              messagesPerSecond: 0,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 0,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 0,
+              processingFailuresPerSecond: 0,
+              lastMessageAt: null,
+              lastCommitAt: null,
+              consumerLagMessages: null,
+              lagSampledAt: 2_000,
+              committedOffset: null,
+              lastError: null,
+            },
+          }),
+        });
+      }).pipe(Effect.ensuring(runtimeCore.close));
+    }),
+  );
+
+  it.effect("keeps Kafka empty lag samples unknown", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      yield* Effect.gen(function* () {
+        const ledger = makeViewServerKafkaHealthLedger<Topics>({
+          regions: kafkaOptions.regions,
+          topics: {
+            [ordersSourceTopic]: {
+              regions: ["local"],
+              viewServerTopic: "orders",
+            },
           },
+        });
+        let healthRefreshRequestCount = 0;
+        const requestHealthRefresh = Effect.sync(() => {
+          healthRefreshRequestCount += 1;
+        });
+
+        yield* recordKafkaAssignments(
+          ledger,
+          requestHealthRefresh,
+          "local",
+          [ordersSourceTopic],
+          [{ topic: ordersSourceTopic, partitions: [0] }],
+          1_000,
+        );
+        yield* recordKafkaLag(
+          ledger,
+          requestHealthRefresh,
+          "local",
+          [ordersSourceTopic],
+          new Map([[ordersSourceTopic, []]]),
+          2_000,
+        );
+        const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+        expect(healthRefreshRequestCount).toBe(2);
+        expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
+          status: "ready",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: true,
+              assignedPartitions: 1,
+              messagesPerSecond: 0,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 0,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 0,
+              processingFailuresPerSecond: 0,
+              lastMessageAt: null,
+              lastCommitAt: null,
+              consumerLagMessages: null,
+              lagSampledAt: 2_000,
+              committedOffset: null,
+              lastError: null,
+            },
+          }),
         });
       }).pipe(Effect.ensuring(runtimeCore.close));
     }),

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -219,11 +219,15 @@ const snapshotKafkaAssignments = (
   }));
 
 const consumerLagMessagesFromLag = (lags: ReadonlyArray<bigint>): bigint | null => {
-  const initializedLags = lags.filter((lag) => lag >= 0n);
-  if (initializedLags.length === 0) {
-    return null;
+  let total = 0n;
+  let hasKnownLag = false;
+  for (const lag of lags) {
+    if (lag >= 0n) {
+      hasKnownLag = true;
+      total += lag;
+    }
   }
-  return initializedLags.reduce((total, lag) => total + lag, 0n);
+  return hasKnownLag ? total : null;
 };
 
 export const kafkaConsumerStartError = (


### PR DESCRIPTION
## Summary
- Preserve unknown Kafka lag when samples are empty or contain only negative sentinels
- Sum known lag values without allocating an intermediate filtered array when mixed known/sentinel partitions arrive
- Add explicit regressions for all-negative and empty lag samples

## Validation
- vp check --fix
- pnpm --filter @view-server/runtime run test