### PR TITLE
Add pre-gRPC readiness gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - `pnpm run bench:baseline:raw-read-write` is the focused raw engine read/write tradeoff gate. It must cover raw snapshots, predicate-index reads, base writes, and indexed writes so read-path optimizations cannot hide ingestion tax.
 - `pnpm run bench:baseline:kafka-ingest` is the real Kafka ingest smoke gate. It starts Apache Kafka via `compose.yaml`, uses `@platformatic/kafka`, and compares JSON/protobuf ingest plus a 2k-message mixed burst against `benchmarks/baselines/kafka-ingest.json`.
 - `pnpm run bench:baseline:websocket-firehose` is the small runtime WebSocket firehose smoke gate. It uses the production Effect RPC WebSocket + NDJSON path and bounded Vitest benchmark reads; update it only for accepted WebSocket transport or fanout performance changes.
+- `pnpm run pre-grpc:gate` is the serial pre-gRPC release gate. It runs `ready`, smoke, raw read/write, active-query-sharing, grouped admission, grouped order-neutral, WebSocket firehose, Kafka ingest, and Kafka sustained-firehose gates. Run it before starting gRPC work or declaring Kafka/performance readiness.
 - Do not run competing benchmark suites in parallel when comparing results.
 
 ## Package And Architecture Rules

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,17 @@ small and noisy; structural metadata, counters, sample counts, and RSS remain st
 
 Do not run benchmark profiles in parallel when comparing results.
 
+Before starting the gRPC ingress adapter, run the serial pre-gRPC gate:
+
+```bash
+pnpm run pre-grpc:gate
+```
+
+This first runs the full correctness gate (`pnpm run ready`), then runs the strict smoke, raw
+read/write, active-query-sharing, grouped admission, grouped order-neutral, WebSocket firehose, Kafka
+ingest, and Kafka sustained-firehose baseline gates. It intentionally excludes
+`bench:baseline:release`, which is a broad no-compare collection profile rather than a pass/fail gate.
+
 Active-query sharing has a focused engine gate:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:internal-seams": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/node-ambient.d.ts scripts/check-internal-seams.ts && node --experimental-strip-types scripts/check-internal-seams.ts",
     "check:package-exports": "tsc --ignoreConfig --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler scripts/node-ambient.d.ts scripts/check-package-exports.ts && node --experimental-strip-types scripts/check-package-exports.ts",
     "ready": "vp run -r build && pnpm run check:package-exports && pnpm run check:internal-seams && pnpm run test:repository-scripts && vp check && pnpm run check:effect && vp run --filter '@view-server/*' --filter '!@view-server/runtime' test && vp run @view-server/runtime#test",
+    "pre-grpc:gate": "pnpm run ready && pnpm run bench:baseline:smoke && pnpm run bench:baseline:raw-read-write && pnpm run bench:baseline:active-query-sharing && pnpm run bench:baseline:grouped-admission && pnpm run bench:baseline:grouped-order-neutral && pnpm run bench:baseline:websocket-firehose && pnpm run bench:baseline:kafka-ingest && pnpm run bench:baseline:kafka-sustained-firehose",
     "test:benchmark-baseline": "pnpm run test:repository-scripts",
     "test:repository-scripts": "vp test run scripts/benchmark-baseline.test.ts scripts/benchmark-baseline-runner.test.ts scripts/bench-runtime-kafka-ingest.test.ts scripts/check-internal-seams.test.ts --coverage",
     "prepare": "vp config && effect-language-service patch"

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -202,6 +202,7 @@ describe("benchmark baseline runner", () => {
       kafkaIngestUpdate: scripts["bench:baseline:kafka-ingest:update"],
       kafkaSustainedFirehose: scripts["bench:baseline:kafka-sustained-firehose"],
       kafkaSustainedFirehoseUpdate: scripts["bench:baseline:kafka-sustained-firehose:update"],
+      preGrpcGate: scripts["pre-grpc:gate"],
       rawReadWrite: scripts["bench:baseline:raw-read-write"],
       rawReadWriteUpdate: scripts["bench:baseline:raw-read-write:update"],
       release: scripts["bench:baseline:release"],
@@ -225,6 +226,8 @@ describe("benchmark baseline runner", () => {
         "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose",
       kafkaSustainedFirehoseUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose --update-baseline",
+      preGrpcGate:
+        "pnpm run ready && pnpm run bench:baseline:smoke && pnpm run bench:baseline:raw-read-write && pnpm run bench:baseline:active-query-sharing && pnpm run bench:baseline:grouped-admission && pnpm run bench:baseline:grouped-order-neutral && pnpm run bench:baseline:websocket-firehose && pnpm run bench:baseline:kafka-ingest && pnpm run bench:baseline:kafka-sustained-firehose",
       rawReadWrite: "node scripts/run-benchmark-baseline.mjs --profile=raw-read-write",
       rawReadWriteUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=raw-read-write --update-baseline",
@@ -233,6 +236,36 @@ describe("benchmark baseline runner", () => {
       webSocketFirehoseUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=websocket-firehose --update-baseline",
     });
+  });
+
+  it("keeps the pre-gRPC gate covering every strict compare-mode benchmark gate", () => {
+    const scripts = JSON.parse(readFileSync("package.json", "utf8")).scripts;
+    const preGrpcGateSteps = scripts["pre-grpc:gate"].split(" && ");
+    const preGrpcBenchmarkGates = preGrpcGateSteps
+      .slice(1)
+      .map((step: string) => step.replace("pnpm run ", ""));
+    const strictCompareBenchmarkGates = Object.entries(scripts)
+      .filter(([name, command]) =>
+        name.startsWith("bench:baseline:") &&
+        !name.endsWith(":update") &&
+        command === command.replace(" --no-compare", ""),
+      )
+      .map(([name]) => name)
+      .sort();
+
+    expect(preGrpcGateSteps).toStrictEqual([
+      "pnpm run ready",
+      "pnpm run bench:baseline:smoke",
+      "pnpm run bench:baseline:raw-read-write",
+      "pnpm run bench:baseline:active-query-sharing",
+      "pnpm run bench:baseline:grouped-admission",
+      "pnpm run bench:baseline:grouped-order-neutral",
+      "pnpm run bench:baseline:websocket-firehose",
+      "pnpm run bench:baseline:kafka-ingest",
+      "pnpm run bench:baseline:kafka-sustained-firehose",
+    ]);
+    expect(preGrpcBenchmarkGates.toSorted()).toStrictEqual(strictCompareBenchmarkGates);
+    expect(preGrpcBenchmarkGates).not.toContain("bench:baseline:release");
   });
 
   it("defines raw read and write performance gate tasks", () => {


### PR DESCRIPTION
## Summary
- Add pnpm run pre-grpc:gate as the serial go/no-go command before starting gRPC work
- Compose existing strict gates: ready, raw read/write, active-query-sharing, WebSocket firehose, Kafka ingest, Kafka sustained-firehose
- Document the gate in benchmarks/README.md and AGENTS.md
- Cover the new script in repository script tests

## Validation
- vp check --fix
- pnpm run test:repository-scripts