### PR TITLE
Deduplicate protocol JSON field wrappers

### DIFF
--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -1,8 +1,8 @@
 import { viewServerSchemaFieldMetadata, type ViewServerRuntimeError } from "@view-server/config";
 import { Effect, Schema } from "effect";
 import {
-  decodeNamedJsonFieldValue,
-  encodeNamedJsonFieldValue,
+  decodeTopicNamedJsonFieldValue,
+  encodeTopicNamedJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 
@@ -34,32 +34,11 @@ const invalidQuery = (topic: string, message: string): ViewServerRuntimeError =>
   topic,
 });
 
-const encodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.encode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  return yield* encodeNamedJsonFieldValue(schema, value, {
-    field,
-    invalid: (message) => invalidQuery(topic, message),
-    invalidPrefix: "Invalid filter for",
-    notJsonSafePrefix: "Filter",
-  });
-});
-
-const decodeFilterJsonFieldValue = Effect.fn("ViewServerProtocol.field.decode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  return yield* decodeNamedJsonFieldValue(schema, value, {
-    field,
-    invalid: (message) => invalidQuery(topic, message),
-    invalidPrefix: "Invalid filter for",
-  });
-});
+const filterJsonFieldContext = {
+  invalid: invalidQuery,
+  invalidPrefix: "Invalid filter for",
+  notJsonSafePrefix: "Filter",
+};
 
 const encodeStringFilterValue = Effect.fn("ViewServerProtocol.filter.string.encode")(function* (
   topic: string,
@@ -116,12 +95,18 @@ const encodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.
   for (const [operator, operatorValue] of Object.entries(value)) {
     if (operator === "in" && Array.isArray(operatorValue)) {
       output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
-        encodeFilterJsonFieldValue(topic, field, schema, entry),
+        encodeTopicNamedJsonFieldValue(topic, field, schema, entry, filterJsonFieldContext),
       );
     } else if (operator === "startsWith") {
       output[operator] = yield* encodeStringFilterValue(topic, field, schema, operatorValue);
     } else {
-      output[operator] = yield* encodeFilterJsonFieldValue(topic, field, schema, operatorValue);
+      output[operator] = yield* encodeTopicNamedJsonFieldValue(
+        topic,
+        field,
+        schema,
+        operatorValue,
+        filterJsonFieldContext,
+      );
     }
   }
   return output;
@@ -138,12 +123,18 @@ const decodeOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operator.
   for (const [operator, operatorValue] of Object.entries(value)) {
     if (operator === "in" && Array.isArray(operatorValue)) {
       output[operator] = yield* Effect.forEach(operatorValue, (entry) =>
-        decodeFilterJsonFieldValue(topic, field, schema, entry),
+        decodeTopicNamedJsonFieldValue(topic, field, schema, entry, filterJsonFieldContext),
       );
     } else if (operator === "startsWith") {
       output[operator] = yield* decodeStringFilterValue(topic, field, schema, operatorValue);
     } else {
-      output[operator] = yield* decodeFilterJsonFieldValue(topic, field, schema, operatorValue);
+      output[operator] = yield* decodeTopicNamedJsonFieldValue(
+        topic,
+        field,
+        schema,
+        operatorValue,
+        filterJsonFieldContext,
+      );
     }
   }
   return output;
@@ -156,14 +147,23 @@ export const encodeFilterValue = Effect.fn("ViewServerProtocol.filter.encode")(f
   value: unknown,
 ) {
   if (!isFilterObject(value)) {
-    return yield* encodeFilterJsonFieldValue(topic, field, schema, value);
+    return yield* encodeTopicNamedJsonFieldValue(
+      topic,
+      field,
+      schema,
+      value,
+      filterJsonFieldContext,
+    );
   }
   return yield* Effect.matchEffect(encodeOperatorFilterValue(topic, field, schema, value), {
     onFailure: (operatorError) =>
-      Effect.matchEffect(encodeFilterJsonFieldValue(topic, field, schema, value), {
-        onFailure: () => Effect.fail(operatorError),
-        onSuccess: Effect.succeed,
-      }),
+      Effect.matchEffect(
+        encodeTopicNamedJsonFieldValue(topic, field, schema, value, filterJsonFieldContext),
+        {
+          onFailure: () => Effect.fail(operatorError),
+          onSuccess: Effect.succeed,
+        },
+      ),
     onSuccess: Effect.succeed,
   });
 });
@@ -175,14 +175,23 @@ export const decodeFilterValue = Effect.fn("ViewServerProtocol.filter.decode")(f
   value: unknown,
 ) {
   if (!isFilterObject(value)) {
-    return yield* decodeFilterJsonFieldValue(topic, field, schema, value);
+    return yield* decodeTopicNamedJsonFieldValue(
+      topic,
+      field,
+      schema,
+      value,
+      filterJsonFieldContext,
+    );
   }
   return yield* Effect.matchEffect(decodeOperatorFilterValue(topic, field, schema, value), {
     onFailure: (operatorError) =>
-      Effect.matchEffect(decodeFilterJsonFieldValue(topic, field, schema, value), {
-        onFailure: () => Effect.fail(operatorError),
-        onSuccess: Effect.succeed,
-      }),
+      Effect.matchEffect(
+        decodeTopicNamedJsonFieldValue(topic, field, schema, value, filterJsonFieldContext),
+        {
+          onFailure: () => Effect.fail(operatorError),
+          onSuccess: Effect.succeed,
+        },
+      ),
     onSuccess: Effect.succeed,
   });
 });

--- a/packages/protocol/src/protocol-json-field-codec.ts
+++ b/packages/protocol/src/protocol-json-field-codec.ts
@@ -27,6 +27,15 @@ type NamedJsonFieldEncodeContext<E> = NamedJsonFieldCodecContext<E> & {
   readonly notJsonSafePrefix: string;
 };
 
+type TopicNamedJsonFieldCodecContext<E> = {
+  readonly invalid: (topic: string, message: string) => E;
+  readonly invalidPrefix: string;
+};
+
+type TopicNamedJsonFieldEncodeContext<E> = TopicNamedJsonFieldCodecContext<E> & {
+  readonly notJsonSafePrefix: string;
+};
+
 export const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.encode")(function* <E>(
   schema: JsonFieldSchema,
   value: unknown,
@@ -94,3 +103,36 @@ export const decodeNamedJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField
     });
   },
 );
+
+export const encodeTopicNamedJsonFieldValue = Effect.fn(
+  "ViewServerProtocol.jsonField.topicNamed.encode",
+)(function* <E>(
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+  context: TopicNamedJsonFieldEncodeContext<E>,
+) {
+  return yield* encodeNamedJsonFieldValue(schema, value, {
+    field,
+    invalid: (message) => context.invalid(topic, message),
+    invalidPrefix: context.invalidPrefix,
+    notJsonSafePrefix: context.notJsonSafePrefix,
+  });
+});
+
+export const decodeTopicNamedJsonFieldValue = Effect.fn(
+  "ViewServerProtocol.jsonField.topicNamed.decode",
+)(function* <E>(
+  topic: string,
+  field: string,
+  schema: JsonFieldSchema,
+  value: unknown,
+  context: TopicNamedJsonFieldCodecContext<E>,
+) {
+  return yield* decodeNamedJsonFieldValue(schema, value, {
+    field,
+    invalid: (message) => context.invalid(topic, message),
+    invalidPrefix: context.invalidPrefix,
+  });
+});

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -3,9 +3,8 @@ import { Effect, Schema } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
 import {
-  decodeNamedJsonFieldValue,
-  encodeNamedJsonFieldValue,
-  type JsonFieldSchema,
+  decodeTopicNamedJsonFieldValue,
+  encodeTopicNamedJsonFieldValue,
 } from "./protocol-json-field-codec";
 import type { ViewServerEventGroupedQuery, ViewServerEventQuery } from "./protocol-query-schema";
 
@@ -16,36 +15,15 @@ const invalidRow = (topic: string, message: string): ViewServerRuntimeError => (
   topic,
 });
 
+const rowJsonFieldContext = {
+  invalid: invalidRow,
+  invalidPrefix: "Invalid field",
+  notJsonSafePrefix: "Field",
+};
+
 export const isViewServerEventGroupedQuery = (
   query: ViewServerEventQuery,
 ): query is ViewServerEventGroupedQuery => "groupBy" in query;
-
-const encodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.encode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  return yield* encodeNamedJsonFieldValue(schema, value, {
-    field,
-    invalid: (message) => invalidRow(topic, message),
-    invalidPrefix: "Invalid field",
-    notJsonSafePrefix: "Field",
-  });
-});
-
-const decodeEventJsonFieldValue = Effect.fn("ViewServerProtocol.event.field.decode")(function* (
-  topic: string,
-  field: string,
-  schema: JsonFieldSchema,
-  value: unknown,
-) {
-  return yield* decodeNamedJsonFieldValue(schema, value, {
-    field,
-    invalid: (message) => invalidRow(topic, message),
-    invalidPrefix: "Invalid field",
-  });
-});
 
 export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.encode")(function* <
   const Topics extends TopicDefinitions,
@@ -71,7 +49,13 @@ export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.enco
       );
     }
     const fieldSchema = topicSchema.fields[field]!;
-    output[field] = yield* encodeEventJsonFieldValue(topic, field, fieldSchema, value);
+    output[field] = yield* encodeTopicNamedJsonFieldValue(
+      topic,
+      field,
+      fieldSchema,
+      value,
+      rowJsonFieldContext,
+    );
   }
   return output;
 });
@@ -100,7 +84,13 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
       );
     }
     const fieldSchema = config.topics[topic]!.schema.fields[field]!;
-    output[field] = yield* decodeEventJsonFieldValue(topic, field, fieldSchema, value);
+    output[field] = yield* decodeTopicNamedJsonFieldValue(
+      topic,
+      field,
+      fieldSchema,
+      value,
+      rowJsonFieldContext,
+    );
   }
   return output;
 });
@@ -134,7 +124,13 @@ export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode
   for (const [field, value] of Object.entries(row)) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
-      output[field] = yield* encodeEventJsonFieldValue(topic, field, fieldSchema, value);
+      output[field] = yield* encodeTopicNamedJsonFieldValue(
+        topic,
+        field,
+        fieldSchema,
+        value,
+        rowJsonFieldContext,
+      );
     } else if (aggregateAliases.has(field)) {
       const aggregate = query.aggregates[field];
       if (aggregate === undefined) {
@@ -182,7 +178,13 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   for (const [field, value] of Object.entries(row)) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
-      output[field] = yield* decodeEventJsonFieldValue(topic, field, fieldSchema, value);
+      output[field] = yield* decodeTopicNamedJsonFieldValue(
+        topic,
+        field,
+        fieldSchema,
+        value,
+        rowJsonFieldContext,
+      );
     } else if (aggregateAliases.has(field)) {
       const aggregate = query.aggregates[field];
       if (aggregate === undefined) {


### PR DESCRIPTION
## Summary
- Add shared topic-named JSON field encode/decode helpers for protocol field values.
- Route filter and row codecs through the shared helpers while preserving InvalidQuery/InvalidRow error codes and message text.

## Validation
- pnpm --filter @view-server/protocol run test
- vp check --fix
- pnpm run check:package-exports
- pnpm run check:effect

## Review
- 3 local reviewer agents: no findings
- Note: I tested replacing detached server health reads with scoped fibers and rejected it because existing tests proved it can deadlock server shutdown with non-cancellable health reads. No server changes are included.