### PR TITLE
Add gRPC ingress plan and config contracts

### DIFF
--- a/packages/client/src/index.test-d.ts
+++ b/packages/client/src/index.test-d.ts
@@ -43,8 +43,26 @@ const leasedViewServer = defineViewServerConfig({
   },
 });
 
+const mixedSourceViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      source: grpc.leased({
+        routeBy: ["id"],
+      }),
+    },
+    positions: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
 declare const client: ViewServerLiveClient<typeof viewServer.topics>;
 declare const leasedClient: ViewServerLiveClient<typeof leasedViewServer.topics>;
+declare const mixedSourceClient: ViewServerLiveClient<typeof mixedSourceViewServer.topics>;
+declare const mixedSourceTopic: "orders" | "positions";
 
 describe("client type contracts", () => {
   it("preserves selected row types through live subscriptions", () => {
@@ -113,6 +131,36 @@ describe("client type contracts", () => {
     >();
     expectTypeOf(missingRouteSubscription).not.toBeAny();
     expectTypeOf(shorthandRouteSubscription).not.toBeAny();
+  });
+
+  it("keeps leased gRPC route predicates when the topic is a union", () => {
+    const routedUnionSubscription = mixedSourceClient.subscribe(mixedSourceTopic, {
+      where: {
+        id: { eq: "order-1" },
+      },
+      select: ["id"],
+    });
+    const missingRouteQuery = {
+      select: ["id"],
+    } satisfies {
+      readonly select: readonly ["id"];
+    };
+
+    const missingRouteSubscription = mixedSourceClient.subscribe(
+      mixedSourceTopic,
+      // @ts-expect-error dynamic topic unions that include a leased topic still require route filters.
+      missingRouteQuery,
+    );
+
+    expectTypeOf<Effect.Success<typeof routedUnionSubscription>>().toEqualTypeOf<
+      ViewServerLiveSubscription<{
+        readonly id: string;
+      }>
+    >();
+    expectTypeOf<Effect.Error<typeof routedUnionSubscription>>().toEqualTypeOf<
+      ViewServerRuntimeError | ViewServerTransportError
+    >();
+    expectTypeOf(missingRouteSubscription).not.toBeAny();
   });
 
   it("exposes health as a read-only ref", () => {

--- a/packages/client/src/index.test-d.ts
+++ b/packages/client/src/index.test-d.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
 import {
   defineViewServerConfig,
+  grpc,
   VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
   VIEW_SERVER_HEALTH_TOPIC,
 } from "@view-server/config";
@@ -30,7 +31,20 @@ const viewServer = defineViewServerConfig({
   },
 });
 
+const leasedViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      source: grpc.leased({
+        routeBy: ["id"],
+      }),
+    },
+  },
+});
+
 declare const client: ViewServerLiveClient<typeof viewServer.topics>;
+declare const leasedClient: ViewServerLiveClient<typeof leasedViewServer.topics>;
 
 describe("client type contracts", () => {
   it("preserves selected row types through live subscriptions", () => {
@@ -61,6 +75,44 @@ describe("client type contracts", () => {
 
     expectTypeOf(undefinedSelectedField).not.toBeAny();
     expectTypeOf(nullSelectedField).not.toBeAny();
+  });
+
+  it("requires leased gRPC route predicates in live subscriptions", () => {
+    const routedSubscription = leasedClient.subscribe("orders", {
+      where: {
+        id: { eq: "order-1" },
+      },
+      select: ["id", "price"],
+    });
+    const missingRouteQuery = {
+      select: ["id"],
+    } satisfies {
+      readonly select: readonly ["id"];
+    };
+    const shorthandRouteQuery = {
+      where: {
+        id: "order-1",
+      },
+      select: ["id"],
+    } satisfies {
+      readonly where: {
+        readonly id: "order-1";
+      };
+      readonly select: readonly ["id"];
+    };
+    // @ts-expect-error leased gRPC subscriptions require exact eq route filters.
+    const missingRouteSubscription = leasedClient.subscribe("orders", missingRouteQuery);
+    // @ts-expect-error leased gRPC route filters must not use shorthand equality.
+    const shorthandRouteSubscription = leasedClient.subscribe("orders", shorthandRouteQuery);
+
+    expectTypeOf<Effect.Success<typeof routedSubscription>>().toEqualTypeOf<
+      ViewServerLiveSubscription<{
+        readonly id: string;
+        readonly price: number;
+      }>
+    >();
+    expectTypeOf(missingRouteSubscription).not.toBeAny();
+    expectTypeOf(shorthandRouteSubscription).not.toBeAny();
   });
 
   it("exposes health as a read-only ref", () => {

--- a/packages/client/src/live-client.ts
+++ b/packages/client/src/live-client.ts
@@ -1,6 +1,6 @@
 import type {
   DeltaEvent,
-  ExactLiveQueryInput,
+  ExactLiveQueryInputForTopic,
   GroupedQuery,
   LiveQuery,
   LiveQueryRow,
@@ -120,7 +120,7 @@ export type ViewServerLiveClient<Topics extends TopicDefinitions> = {
       const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
     >(
       topic: Topic,
-      query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+      query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
     ): Effect.Effect<
       ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
       ViewServerRuntimeError | ViewServerTransportError

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -1,8 +1,6 @@
 import { BrowserSocket } from "@effect/platform-browser";
 import type {
-  ExactGroupedQuery,
-  ExactLiveQuery,
-  ExactRawQuery,
+  ExactLiveQueryInputForTopic,
   GroupedQuery,
   GroupedResult,
   LiveQueryRow,
@@ -10,7 +8,6 @@ import type {
   RawQuery,
   TopicDefinitions,
   TopicRow,
-  ValidateLiveQuery,
   ViewServerConfig,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
@@ -229,9 +226,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): Effect.Effect<
     ViewServerLiveSubscription<GroupedResult<TopicRow<Topics, Topic>, Query>>,
     ViewServerRemoteClientError
@@ -241,9 +236,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     const Query extends RawQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): Effect.Effect<
     ViewServerLiveSubscription<PickRawFields<TopicRow<Topics, Topic>, Query>>,
     ViewServerRemoteClientError
@@ -253,9 +246,7 @@ export const makeViewServerClient: <const Topics extends TopicDefinitions>(
     const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): Effect.Effect<
     ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
     ViewServerRemoteClientError

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,6 +30,10 @@
     "./kafka": {
       "types": "./dist/kafka-contract.d.ts",
       "import": "./dist/kafka-contract.js"
+    },
+    "./grpc": {
+      "types": "./dist/grpc-contract.d.ts",
+      "import": "./dist/grpc-contract.js"
     }
   },
   "scripts": {
@@ -38,6 +42,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "2.12.0",
+    "@connectrpc/connect": "catalog:",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/config/src/grpc-contract.ts
+++ b/packages/config/src/grpc-contract.ts
@@ -25,7 +25,7 @@ const brandGrpcFeedMap = <Mapping extends (...args: ReadonlyArray<never>) => unk
   mapping: Mapping,
 ) => Object.assign(mapping, grpcFeedMapBrand);
 
-export type GrpcTopicSourceKind = "materialized" | "leased";
+export type GrpcTopicSourceLifecycle = "materialized" | "leased";
 
 export type GrpcMaterializedTopicSource = TopicMaterializedSourceDefinition & {
   readonly _tag: "GrpcMaterializedTopicSource";

--- a/packages/config/src/grpc-contract.ts
+++ b/packages/config/src/grpc-contract.ts
@@ -1,0 +1,496 @@
+import type {
+  DescMessage,
+  DescMethodServerStreaming,
+  DescService,
+  MessageInitShape,
+  MessageShape,
+} from "@bufbuild/protobuf";
+import type { Client } from "@connectrpc/connect";
+import type { Config, Effect, Stream } from "effect";
+import type { FieldKey, RowSchema, TopicRow } from "./query-core";
+import type { RejectExtraKeys } from "./query-exact";
+import type { TopicRouteByTuple } from "./source-query-contract";
+import type {
+  NonEmptyRouteBy,
+  TopicLeasedSourceDefinition,
+  TopicMaterializedSourceDefinition,
+} from "./source-contract";
+
+const GrpcTopicSourceTypeId: unique symbol = Symbol("@view-server/config/GrpcTopicSource");
+const GrpcFeedDefinitionTypeId: unique symbol = Symbol("@view-server/config/GrpcFeedDefinition");
+const GrpcFeedMapTypeId: unique symbol = Symbol("@view-server/config/GrpcFeedMap");
+const grpcFeedMapBrand = { [GrpcFeedMapTypeId]: true } as const;
+
+const brandGrpcFeedMap = <Mapping extends (...args: ReadonlyArray<never>) => unknown>(
+  mapping: Mapping,
+) => Object.assign(mapping, grpcFeedMapBrand);
+
+export type GrpcTopicSourceKind = "materialized" | "leased";
+
+export type GrpcMaterializedTopicSource = TopicMaterializedSourceDefinition & {
+  readonly _tag: "GrpcMaterializedTopicSource";
+  readonly [GrpcTopicSourceTypeId]: true;
+  readonly kind: "grpc";
+  readonly lifecycle: "materialized";
+};
+
+export type GrpcLeasedTopicSource<RouteBy extends ReadonlyArray<string> = ReadonlyArray<string>> =
+  TopicLeasedSourceDefinition<RouteBy> & {
+    readonly _tag: "GrpcLeasedTopicSource";
+    readonly [GrpcTopicSourceTypeId]: true;
+    readonly kind: "grpc";
+    readonly lifecycle: "leased";
+    readonly routeBy: RouteBy;
+  };
+
+export type GrpcTopicSource = GrpcMaterializedTopicSource | GrpcLeasedTopicSource;
+
+type ExactObject<Candidate, Shape> = Candidate & RejectExtraKeys<Candidate, Shape>;
+
+type ExactGrpcLeasedTopicSourceInput<Input> = Input &
+  RejectExtraKeys<
+    Input,
+    {
+      readonly routeBy: NonEmptyRouteBy;
+    }
+  >;
+
+type GrpcMaterializedTopic<Topics> = Extract<
+  {
+    readonly [Topic in keyof Topics]: Topics[Topic] extends {
+      readonly source: GrpcMaterializedTopicSource;
+    }
+      ? Topic
+      : never;
+  }[keyof Topics],
+  string
+>;
+
+type GrpcLeasedTopic<Topics> = Extract<
+  {
+    readonly [Topic in keyof Topics]: [TopicRouteByTuple<Topics, Topic>] extends [never]
+      ? never
+      : TopicRouteByTuple<Topics, Topic> extends NonEmptyRouteBy
+        ? Topic
+        : never;
+  }[keyof Topics],
+  string
+>;
+
+type GrpcLeasedRouteBy<Topics, Topic extends GrpcLeasedTopic<Topics>> =
+  TopicRouteByTuple<Topics, Topic> extends NonEmptyRouteBy
+    ? TopicRouteByTuple<Topics, Topic>
+    : never;
+
+type RouteShape<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Topic extends Extract<keyof Topics, string>,
+  RouteBy extends ReadonlyArray<string>,
+> = Pick<TopicRow<Topics, Topic>, Extract<RouteBy[number], FieldKey<TopicRow<Topics, Topic>>>>;
+
+type ExactGrpcFeedMap<Input, Row, Mapping extends (input: Input) => Row> = Mapping &
+  ((input: Input) => ExactObject<ReturnType<Mapping>, Row>);
+
+type GrpcFeedMapDefinition<Input, Row, Mapping extends (input: Input) => Row> = ExactGrpcFeedMap<
+  Input,
+  Row,
+  Mapping
+> & {
+  readonly [GrpcFeedMapTypeId]: true;
+};
+
+export type GrpcHelper = {
+  readonly materialized: () => GrpcMaterializedTopicSource;
+  readonly leased: <const Input extends { readonly routeBy: NonEmptyRouteBy }>(
+    input: ExactGrpcLeasedTopicSourceInput<Input>,
+  ) => GrpcLeasedTopicSource<Input["routeBy"]>;
+  readonly connectClient: <
+    const Input extends {
+      readonly service: DescService;
+      readonly baseUrl: GrpcRuntimeValue<string>;
+    },
+  >(
+    input: ExactGrpcConnectClientInput<Input>,
+  ) => GrpcConnectClientDefinition<Input["service"]>;
+};
+
+export type GrpcRuntimeValue<A> = A | Config.Config<A>;
+
+export type GrpcConnectClientDefinition<Service extends DescService = DescService> = {
+  readonly _tag: "GrpcConnectClientDefinition";
+  readonly service: Service;
+  readonly baseUrl: GrpcRuntimeValue<string>;
+  readonly protocol: "grpc";
+};
+
+export type GrpcRuntimeClients = Record<string, GrpcConnectClientDefinition>;
+
+export type GrpcClientValue<ClientDefinition> =
+  ClientDefinition extends GrpcConnectClientDefinition<infer Service> ? Client<Service> : never;
+
+export type GrpcServerStreamingMethodName<ClientDefinition> =
+  ClientDefinition extends GrpcConnectClientDefinition<infer Service>
+    ? {
+        readonly [MethodName in keyof Service["method"]]: Service["method"][MethodName] extends DescMethodServerStreaming<
+          infer _Input extends DescMessage,
+          infer _Output extends DescMessage
+        >
+          ? MethodName
+          : never;
+      }[keyof Service["method"]] &
+        string
+    : never;
+
+export type GrpcMethodRequest<
+  ClientDefinition,
+  MethodName extends GrpcServerStreamingMethodName<ClientDefinition>,
+> =
+  ClientDefinition extends GrpcConnectClientDefinition<infer Service>
+    ? Service["method"][MethodName] extends DescMethodServerStreaming<
+        infer Input extends DescMessage,
+        infer _Output extends DescMessage
+      >
+      ? MessageInitShape<Input>
+      : never
+    : never;
+
+export type GrpcMethodValue<
+  ClientDefinition,
+  MethodName extends GrpcServerStreamingMethodName<ClientDefinition>,
+> =
+  ClientDefinition extends GrpcConnectClientDefinition<infer Service>
+    ? Service["method"][MethodName] extends DescMethodServerStreaming<
+        infer _Input extends DescMessage,
+        infer Output extends DescMessage
+      >
+      ? MessageShape<Output>
+      : never
+    : never;
+
+export type GrpcFeedSession = {
+  readonly id: string | null;
+  readonly forwardedHeaders: Readonly<Record<string, string>>;
+  readonly systemHeaders: Readonly<Record<string, string>>;
+};
+
+export type GrpcFeedAcquireInput<ClientValue, Request, Route> = {
+  readonly client: ClientValue;
+  readonly request: Request;
+  readonly route: Route;
+  readonly session: GrpcFeedSession;
+};
+
+export type GrpcFeedReleaseInput<ClientValue, Request, Route> = GrpcFeedAcquireInput<
+  ClientValue,
+  Request,
+  Route
+>;
+
+export type GrpcFeedMapInput<Value, Route, SchemaValue extends RowSchema> = {
+  readonly value: Value;
+  readonly route: Route;
+  readonly schema: SchemaValue;
+};
+
+type GrpcLeasedFeedDefinition<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+  Topic extends Extract<keyof Topics, string>,
+  ClientName extends Extract<keyof Clients, string>,
+  RouteBy extends NonEmptyRouteBy,
+  MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+  Mapping extends (
+    input: GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>,
+      Topics[Topic]["schema"]
+    >,
+  ) => TopicRow<Topics, Topic> = (
+    input: GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>,
+      Topics[Topic]["schema"]
+    >,
+  ) => TopicRow<Topics, Topic>,
+> = {
+  readonly _tag: "GrpcLeasedFeedDefinition";
+  readonly [GrpcFeedDefinitionTypeId]: true;
+  readonly lifecycle: "leased";
+  readonly topic: Topic;
+  readonly client: ClientName;
+  readonly method: MethodName;
+  readonly routeBy: RouteBy;
+  readonly request: (
+    route: RouteShape<Topics, Topic, RouteBy>,
+  ) => GrpcMethodRequest<Clients[ClientName], MethodName>;
+  readonly acquire: (
+    input: GrpcFeedAcquireInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>
+    >,
+  ) => Stream.Stream<GrpcMethodValue<Clients[ClientName], MethodName>, unknown, never>;
+  readonly release?: (
+    input: GrpcFeedReleaseInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>
+    >,
+  ) => Effect.Effect<void, unknown, never>;
+  readonly map: GrpcFeedMapDefinition<
+    GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>,
+      Topics[Topic]["schema"]
+    >,
+    TopicRow<Topics, Topic>,
+    Mapping
+  >;
+};
+
+type GrpcMaterializedFeedDefinition<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+  Topic extends GrpcMaterializedTopic<Topics>,
+  ClientName extends Extract<keyof Clients, string>,
+  MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+  Mapping extends (
+    input: GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      undefined,
+      Topics[Topic]["schema"]
+    >,
+  ) => TopicRow<Topics, Topic> = (
+    input: GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      undefined,
+      Topics[Topic]["schema"]
+    >,
+  ) => TopicRow<Topics, Topic>,
+> = {
+  readonly _tag: "GrpcMaterializedFeedDefinition";
+  readonly [GrpcFeedDefinitionTypeId]: true;
+  readonly lifecycle: "materialized";
+  readonly topic: Topic;
+  readonly client: ClientName;
+  readonly method: MethodName;
+  readonly request: () => GrpcMethodRequest<Clients[ClientName], MethodName>;
+  readonly acquire: (
+    input: GrpcFeedAcquireInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      undefined
+    >,
+  ) => Stream.Stream<GrpcMethodValue<Clients[ClientName], MethodName>, unknown, never>;
+  readonly release?: (
+    input: GrpcFeedReleaseInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      undefined
+    >,
+  ) => Effect.Effect<void, unknown, never>;
+  readonly map: GrpcFeedMapDefinition<
+    GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      undefined,
+      Topics[Topic]["schema"]
+    >,
+    TopicRow<Topics, Topic>,
+    Mapping
+  >;
+};
+
+type ExactGrpcConnectClientInput<Input> = Input &
+  RejectExtraKeys<
+    Input,
+    {
+      readonly service: DescService;
+      readonly baseUrl: GrpcRuntimeValue<string>;
+    }
+  >;
+
+type ExactGrpcLeasedFeedInput<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+  Topic extends Extract<keyof Topics, string>,
+  ClientName extends Extract<keyof Clients, string>,
+  RouteBy extends TopicRouteByTuple<Topics, Topic>,
+  MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+  Mapping extends (
+    input: GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>,
+      Topics[Topic]["schema"]
+    >,
+  ) => TopicRow<Topics, Topic>,
+> = {
+  readonly topic: Topic;
+  readonly client: ClientName;
+  readonly method: MethodName;
+  readonly routeBy: RouteBy;
+  readonly request: (
+    route: RouteShape<Topics, Topic, RouteBy>,
+  ) => GrpcMethodRequest<Clients[ClientName], MethodName>;
+  readonly acquire: (
+    input: GrpcFeedAcquireInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>
+    >,
+  ) => Stream.Stream<GrpcMethodValue<Clients[ClientName], MethodName>, unknown, never>;
+  readonly release?: (
+    input: GrpcFeedReleaseInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>
+    >,
+  ) => Effect.Effect<void, unknown, never>;
+  readonly map: ExactGrpcFeedMap<
+    GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      RouteShape<Topics, Topic, RouteBy>,
+      Topics[Topic]["schema"]
+    >,
+    TopicRow<Topics, Topic>,
+    Mapping
+  >;
+};
+
+type ExactGrpcMaterializedFeedInput<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+  Topic extends GrpcMaterializedTopic<Topics>,
+  ClientName extends Extract<keyof Clients, string>,
+  MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+  Mapping extends (
+    input: GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      undefined,
+      Topics[Topic]["schema"]
+    >,
+  ) => TopicRow<Topics, Topic>,
+> = {
+  readonly topic: Topic;
+  readonly client: ClientName;
+  readonly method: MethodName;
+  readonly request: () => GrpcMethodRequest<Clients[ClientName], MethodName>;
+  readonly acquire: (
+    input: GrpcFeedAcquireInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      undefined
+    >,
+  ) => Stream.Stream<GrpcMethodValue<Clients[ClientName], MethodName>, unknown, never>;
+  readonly release?: (
+    input: GrpcFeedReleaseInput<
+      GrpcClientValue<Clients[ClientName]>,
+      GrpcMethodRequest<Clients[ClientName], MethodName>,
+      undefined
+    >,
+  ) => Effect.Effect<void, unknown, never>;
+  readonly map: ExactGrpcFeedMap<
+    GrpcFeedMapInput<
+      GrpcMethodValue<Clients[ClientName], MethodName>,
+      undefined,
+      Topics[Topic]["schema"]
+    >,
+    TopicRow<Topics, Topic>,
+    Mapping
+  >;
+};
+
+export type GrpcFeedHelper<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+> = {
+  readonly leasedFeed: <
+    const Topic extends GrpcLeasedTopic<Topics>,
+    const ClientName extends Extract<keyof Clients, string>,
+    const RouteBy extends GrpcLeasedRouteBy<Topics, Topic>,
+    const MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+    const Mapping extends (
+      input: GrpcFeedMapInput<
+        GrpcMethodValue<Clients[ClientName], MethodName>,
+        RouteShape<Topics, Topic, RouteBy>,
+        Topics[Topic]["schema"]
+      >,
+    ) => TopicRow<Topics, Topic>,
+  >(
+    input: ExactGrpcLeasedFeedInput<
+      Topics,
+      Clients,
+      Topic,
+      ClientName,
+      RouteBy,
+      MethodName,
+      Mapping
+    >,
+  ) => GrpcLeasedFeedDefinition<Topics, Clients, Topic, ClientName, RouteBy, MethodName, Mapping>;
+  readonly materializedFeed: <
+    const Topic extends GrpcMaterializedTopic<Topics>,
+    const ClientName extends Extract<keyof Clients, string>,
+    const MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+    const Mapping extends (
+      input: GrpcFeedMapInput<
+        GrpcMethodValue<Clients[ClientName], MethodName>,
+        undefined,
+        Topics[Topic]["schema"]
+      >,
+    ) => TopicRow<Topics, Topic>,
+  >(
+    input: ExactGrpcMaterializedFeedInput<Topics, Clients, Topic, ClientName, MethodName, Mapping>,
+  ) => GrpcMaterializedFeedDefinition<Topics, Clients, Topic, ClientName, MethodName, Mapping>;
+};
+
+export const grpc: GrpcHelper = {
+  materialized: () => ({
+    _tag: "GrpcMaterializedTopicSource",
+    [GrpcTopicSourceTypeId]: true,
+    kind: "grpc",
+    lifecycle: "materialized",
+  }),
+  leased: (input) => ({
+    _tag: "GrpcLeasedTopicSource",
+    [GrpcTopicSourceTypeId]: true,
+    kind: "grpc",
+    lifecycle: "leased",
+    routeBy: input.routeBy,
+  }),
+  connectClient: (input) => ({
+    _tag: "GrpcConnectClientDefinition",
+    service: input.service,
+    baseUrl: input.baseUrl,
+    protocol: "grpc",
+  }),
+};
+
+export const defineGrpcFeed = <
+  const Topics extends Record<string, { readonly schema: RowSchema }>,
+  const Clients extends GrpcRuntimeClients,
+>(): GrpcFeedHelper<Topics, Clients> => ({
+  leasedFeed: (input) => ({
+    _tag: "GrpcLeasedFeedDefinition",
+    [GrpcFeedDefinitionTypeId]: true,
+    lifecycle: "leased",
+    topic: input.topic,
+    client: input.client,
+    method: input.method,
+    routeBy: input.routeBy,
+    request: input.request,
+    acquire: input.acquire,
+    map: brandGrpcFeedMap(input.map),
+    ...(input.release === undefined ? {} : { release: input.release }),
+  }),
+  materializedFeed: (input) => ({
+    _tag: "GrpcMaterializedFeedDefinition",
+    [GrpcFeedDefinitionTypeId]: true,
+    lifecycle: "materialized",
+    topic: input.topic,
+    client: input.client,
+    method: input.method,
+    request: input.request,
+    acquire: input.acquire,
+    map: brandGrpcFeedMap(input.map),
+    ...(input.release === undefined ? {} : { release: input.release }),
+  }),
+});

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { create, toBinary } from "@bufbuild/protobuf";
-import { fileDesc, messageDesc } from "@bufbuild/protobuf/codegenv2";
-import type { GenMessage } from "@bufbuild/protobuf/codegenv2";
+import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
+import type { GenMessage, GenService } from "@bufbuild/protobuf/codegenv2";
 import type { Message } from "@bufbuild/protobuf";
 import { FieldDescriptorProto_Type, FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";
 import * as BigDecimal from "effect/BigDecimal";
@@ -10,11 +10,14 @@ import * as HashMap from "effect/HashMap";
 import * as HashSet from "effect/HashSet";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
-import { Config, Effect, Exit, Schema, SchemaGetter, SchemaTransformation } from "effect";
+import { Config, Effect, Exit, Schema, SchemaGetter, SchemaTransformation, Stream } from "effect";
 import {
   decodeKafkaCodec,
   decodeKafkaTopicMessage,
+  defineKafkaTopic,
+  defineGrpcFeed,
   defineViewServerConfig,
+  grpc,
   kafka,
   kafkaErrorIsMapping,
   VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
@@ -26,6 +29,8 @@ import {
   viewServerHealthSummaryFromHealth,
   viewServerHealthSummaryRowFromHealth,
   viewServerHealthTopicRowsFromHealth,
+  validateLiveQuerySourceRoute,
+  type GrpcClientValue,
   type KafkaCodec,
   type KafkaMappingInput,
   type KafkaMessageMetadata,
@@ -37,6 +42,7 @@ import {
   type KafkaTopicRegionHealth,
   type KafkaTopicDefinition,
   type ExactGroupedQuery,
+  type ExactLiveQueryInputForTopic,
   type ExactRawQuery,
   type GroupedQuery,
   type LiveQueryResult,
@@ -47,6 +53,7 @@ import {
   type SnapshotEvent,
   type StatusEvent,
   type TopicRuntimeHealth,
+  type TopicRouteBy,
   type TopicRow,
   type ValidateLiveQuery,
   type ViewServerBackpressureError,
@@ -1712,6 +1719,30 @@ const testProtoFile = fileDesc(
             ],
           },
         ],
+        service: [
+          {
+            name: "OrdersService",
+            method: [
+              {
+                name: "StreamOrders",
+                inputType: ".viewserver.test.OrderKey",
+                outputType: ".viewserver.test.OrderValue",
+                serverStreaming: true,
+              },
+              {
+                name: "StreamTrades",
+                inputType: ".viewserver.test.OrderKey",
+                outputType: ".viewserver.test.TradeValue",
+                serverStreaming: true,
+              },
+              {
+                name: "GetOrder",
+                inputType: ".viewserver.test.OrderKey",
+                outputType: ".viewserver.test.OrderValue",
+              },
+            ],
+          },
+        ],
       }),
     ),
   ),
@@ -1720,6 +1751,30 @@ const testProtoFile = fileDesc(
 const ordersValueSchema = messageDesc<OrdersValueMessage>(testProtoFile, 0);
 const ordersKeySchema = messageDesc<OrdersKeyMessage>(testProtoFile, 1);
 const tradesValueSchema = messageDesc<TradesValueMessage>(testProtoFile, 2);
+const ordersService = serviceDesc<{
+  readonly streamOrders: {
+    readonly input: typeof ordersKeySchema;
+    readonly output: typeof ordersValueSchema;
+    readonly methodKind: "server_streaming";
+  };
+  readonly streamTrades: {
+    readonly input: typeof ordersKeySchema;
+    readonly output: typeof tradesValueSchema;
+    readonly methodKind: "server_streaming";
+  };
+  readonly getOrder: {
+    readonly input: typeof ordersKeySchema;
+    readonly output: typeof ordersValueSchema;
+    readonly methodKind: "unary";
+  };
+}>(testProtoFile, 0);
+const tradesOnlyService = serviceDesc<{
+  readonly streamTrades: {
+    readonly input: typeof ordersKeySchema;
+    readonly output: typeof tradesValueSchema;
+    readonly methodKind: "server_streaming";
+  };
+}>(testProtoFile, 0);
 
 declare const generatedOrdersValueSchema: GenMessage<
   Message<"viewserver.test.OrderValue"> & {
@@ -1834,18 +1889,14 @@ type LiveQueryCall<Topics extends object> = {
     const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;
   <
     Topic extends Extract<keyof Topics, string>,
     const Query extends RawQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;
 };
 
@@ -1860,6 +1911,704 @@ const ordersKeyKafkaCodec = kafka.protobuf(ordersKeySchema);
 const tradesValueKafkaCodec = kafka.protobuf(tradesValueSchema);
 
 describe("defineViewServerConfig", () => {
+  it("types gRPC leased topic route metadata", () => {
+    const grpcViewServer = defineViewServerConfig({
+      topics: {
+        orders: {
+          schema: Order,
+          key: "id",
+          source: grpc.leased({
+            routeBy: ["region", "status"],
+          }),
+        },
+        trades: {
+          schema: Trade,
+          key: "id",
+          source: grpc.materialized(),
+        },
+        positions: {
+          schema: Position,
+          key: "id",
+        },
+      },
+    });
+    expectTypeOf<TopicRouteBy<typeof grpcViewServer.topics, "orders">>().toEqualTypeOf<
+      "region" | "status"
+    >();
+    expectTypeOf<TopicRouteBy<typeof grpcViewServer.topics, "trades">>().toEqualTypeOf<never>();
+
+    defineViewServerConfig({
+      topics: {
+        orders: {
+          schema: Order,
+          key: "id",
+          // @ts-expect-error routeBy fields must exist on the target topic row.
+          source: grpc.leased({
+            routeBy: ["strategyId"],
+          }),
+        },
+      },
+    });
+  });
+
+  it("requires exact equality predicates for leased gRPC route fields", () => {
+    const grpcViewServer = defineViewServerConfig({
+      topics: {
+        orders: {
+          schema: Order,
+          key: "id",
+          source: grpc.leased({
+            routeBy: ["region", "status"],
+          }),
+        },
+      },
+    });
+    const grpcRouteValidationViewServer = defineViewServerConfig({
+      topics: {
+        orders: {
+          schema: Order,
+          key: "id",
+          source: grpc.leased({
+            routeBy: ["region", "status"],
+          }),
+        },
+        trades: {
+          schema: Trade,
+          key: "id",
+          source: grpc.materialized(),
+        },
+        positions: {
+          schema: Position,
+          key: "id",
+        },
+      },
+    });
+    const assertGrpcRouteQueryTypes = (
+      useLiveQuery: LiveQueryCall<typeof grpcViewServer.topics>,
+    ) => {
+      const validRouteQuery = useLiveQuery("orders", {
+        where: {
+          region: { eq: "usa" },
+          status: { eq: "open" },
+          price: { gte: 10 },
+        },
+        orderBy: [{ field: "updatedAt", direction: "desc" }],
+        select: ["id", "price", "updatedAt"],
+        limit: 50,
+      });
+
+      expectTypeOf(validRouteQuery).toEqualTypeOf<
+        LiveQueryResult<{
+          readonly id: string;
+          readonly price: number;
+          readonly updatedAt: number;
+        }>
+      >();
+
+      const missingRouteFieldQuery = {
+        where: {
+          region: { eq: "usa" },
+        },
+        select: ["id"],
+      } satisfies {
+        readonly where: {
+          readonly region: {
+            readonly eq: "usa";
+          };
+        };
+        readonly select: readonly ["id"];
+      };
+      // @ts-expect-error leased gRPC topics require every routeBy field.
+      useLiveQuery("orders", missingRouteFieldQuery);
+
+      const routeInOperatorQuery = {
+        where: {
+          region: { eq: "usa" },
+          status: { in: ["open", "closed"] },
+        },
+        select: ["id"],
+      } satisfies {
+        readonly where: {
+          readonly region: {
+            readonly eq: "usa";
+          };
+          readonly status: {
+            readonly in: readonly ["open", "closed"];
+          };
+        };
+        readonly select: readonly ["id"];
+      };
+      // @ts-expect-error leased gRPC route filters must be exact eq predicates.
+      useLiveQuery("orders", routeInOperatorQuery);
+
+      const routeShorthandQuery = {
+        where: {
+          region: "usa",
+          status: { eq: "open" },
+        },
+        select: ["id"],
+      } satisfies {
+        readonly where: {
+          readonly region: "usa";
+          readonly status: {
+            readonly eq: "open";
+          };
+        };
+        readonly select: readonly ["id"];
+      };
+      // @ts-expect-error leased gRPC route filters must not use shorthand equality.
+      useLiveQuery("orders", routeShorthandQuery);
+
+      const routeExtraOperatorQuery = {
+        where: {
+          region: {
+            eq: "usa",
+            neq: "london",
+          },
+          status: { eq: "open" },
+        },
+        select: ["id"],
+      } satisfies {
+        readonly where: {
+          readonly region: {
+            readonly eq: "usa";
+            readonly neq: "london";
+          };
+          readonly status: {
+            readonly eq: "open";
+          };
+        };
+        readonly select: readonly ["id"];
+      };
+      // @ts-expect-error leased gRPC route filters must not include extra operators.
+      useLiveQuery("orders", routeExtraOperatorQuery);
+    };
+    expectTypeOf(assertGrpcRouteQueryTypes).toBeFunction();
+    expect(validateLiveQuerySourceRoute(grpcViewServer.topics, "missing", {})).toBeUndefined();
+    expect(
+      validateLiveQuerySourceRoute(grpcRouteValidationViewServer.topics, "positions", {}),
+    ).toBeUndefined();
+    expect(
+      validateLiveQuerySourceRoute(grpcRouteValidationViewServer.topics, "trades", {}),
+    ).toBeUndefined();
+    expect(validateLiveQuerySourceRoute(grpcViewServer.topics, "orders", null)).toBe(
+      "Leased topic orders requires a query object.",
+    );
+    expect(validateLiveQuerySourceRoute(grpcViewServer.topics, "orders", {})).toBe(
+      "Leased topic orders requires exact equality filters for route fields: region, status.",
+    );
+    expect(
+      validateLiveQuerySourceRoute(grpcViewServer.topics, "orders", {
+        where: {
+          region: { eq: "usa" },
+        },
+      }),
+    ).toBe("Leased topic orders route field status must use an exact eq filter.");
+    expect(
+      validateLiveQuerySourceRoute(grpcViewServer.topics, "orders", {
+        where: {
+          region: { eq: "usa" },
+          status: { eq: "open", neq: "closed" },
+        },
+      }),
+    ).toBe("Leased topic orders route field status must use an exact eq filter.");
+    expect(
+      validateLiveQuerySourceRoute(grpcViewServer.topics, "orders", {
+        where: {
+          region: { eq: "usa" },
+          status: { neq: "closed" },
+        },
+      }),
+    ).toBe("Leased topic orders route field status must use an exact eq filter.");
+    expect(
+      validateLiveQuerySourceRoute(grpcViewServer.topics, "orders", {
+        where: {
+          region: { eq: "usa" },
+          status: { eq: "open" },
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      validateLiveQuerySourceRoute(
+        {
+          malformed: {
+            schema: Order,
+            key: "id",
+            source: { kind: "grpc", lifecycle: "leased", routeBy: [] },
+          },
+        },
+        "malformed",
+        {},
+      ),
+    ).toBe("Leased topic malformed has invalid route metadata.");
+    expect(
+      validateLiveQuerySourceRoute(
+        {
+          malformed: {
+            schema: Order,
+            key: "id",
+            source: { kind: "grpc", lifecycle: "leased", routeBy: ["region", 1] },
+          },
+        },
+        "malformed",
+        {},
+      ),
+    ).toBe("Leased topic malformed has invalid route metadata.");
+  });
+
+  it("types gRPC clients and feed mapping contracts", () => {
+    const grpcViewServer = defineViewServerConfig({
+      topics: {
+        orders: {
+          schema: Order,
+          key: "id",
+          source: grpc.leased({
+            routeBy: ["region", "status"],
+          }),
+        },
+        trades: {
+          schema: Trade,
+          key: "id",
+          source: grpc.materialized(),
+        },
+        positions: {
+          schema: Position,
+          key: "id",
+        },
+      },
+    });
+    const clients = {
+      orders: grpc.connectClient({
+        service: ordersService,
+        baseUrl: "https://orders.example.test",
+      }),
+      trades: grpc.connectClient({
+        service: tradesOnlyService,
+        baseUrl: "https://trades.example.test",
+      }),
+    };
+    const standaloneFeed = defineGrpcFeed<typeof grpcViewServer.topics, typeof clients>();
+    const feed = grpcViewServer.grpcFeed<typeof clients>();
+    expectTypeOf(standaloneFeed.leasedFeed).toBeFunction();
+    const leasedOrders = feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => {
+        expectTypeOf(region).toEqualTypeOf<string>();
+        expectTypeOf(status).toEqualTypeOf<"open" | "closed" | "cancelled">();
+        return { orderId: `${region}:${status}` };
+      },
+      acquire: ({ client, request, route, session }) => {
+        expectTypeOf(client).toEqualTypeOf<GrpcClientValue<(typeof clients)["orders"]>>();
+        expectTypeOf(client.streamOrders).toBeFunction();
+        expectTypeOf(request.orderId).toEqualTypeOf<string | undefined>();
+        expectTypeOf(route).toEqualTypeOf<{
+          readonly region: string;
+          readonly status: "open" | "closed" | "cancelled";
+        }>();
+        expectTypeOf(session.forwardedHeaders).toEqualTypeOf<Readonly<Record<string, string>>>();
+        return Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        });
+      },
+      release: ({ client, request, route, session }) => {
+        expectTypeOf(client).toEqualTypeOf<GrpcClientValue<(typeof clients)["orders"]>>();
+        expectTypeOf(request.orderId).toEqualTypeOf<string | undefined>();
+        expectTypeOf(route).toEqualTypeOf<{
+          readonly region: string;
+          readonly status: "open" | "closed" | "cancelled";
+        }>();
+        expectTypeOf(session.systemHeaders).toEqualTypeOf<Readonly<Record<string, string>>>();
+        return Effect.void;
+      },
+      map: ({ value, route, schema }) => {
+        expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
+        expectTypeOf(route.region).toEqualTypeOf<string>();
+        expectTypeOf(schema).toEqualTypeOf<typeof Order>();
+        return {
+          id: `${route.region}:${value.customerId}`,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: route.region,
+          updatedAt: value.updatedAt,
+        };
+      },
+    });
+    const materializedTrades = feed.materializedFeed({
+      topic: "trades",
+      client: "orders",
+      method: "streamTrades",
+      request: () => ({ orderId: "all-trades" }),
+      acquire: ({ client, route }) => {
+        expectTypeOf(client).toEqualTypeOf<GrpcClientValue<(typeof clients)["orders"]>>();
+        expectTypeOf(route).toEqualTypeOf<undefined>();
+        return Stream.make({
+          $typeName: "viewserver.test.TradeValue",
+          symbol: "AAPL",
+          quantity: 1,
+          price: 10,
+        });
+      },
+      release: ({ request, route }) => {
+        expectTypeOf(request.orderId).toEqualTypeOf<string | undefined>();
+        expectTypeOf(route).toEqualTypeOf<undefined>();
+        return Effect.void;
+      },
+      map: ({ value }) => ({
+        id: value.symbol,
+        symbol: value.symbol,
+        quantity: value.quantity,
+        price: value.price,
+        region: "usa",
+      }),
+    });
+
+    expect(leasedOrders.lifecycle).toBe("leased");
+    expect(materializedTrades.lifecycle).toBe("materialized");
+    expectTypeOf(ordersService).toEqualTypeOf<
+      GenService<{
+        readonly streamOrders: {
+          readonly input: typeof ordersKeySchema;
+          readonly output: typeof ordersValueSchema;
+          readonly methodKind: "server_streaming";
+        };
+        readonly streamTrades: {
+          readonly input: typeof ordersKeySchema;
+          readonly output: typeof tradesValueSchema;
+          readonly methodKind: "server_streaming";
+        };
+        readonly getOrder: {
+          readonly input: typeof ordersKeySchema;
+          readonly output: typeof ordersValueSchema;
+          readonly methodKind: "unary";
+        };
+      }>
+    >();
+
+    const openOrderStatus = "open" as const;
+
+    const invalidManualRuntimeFeedDefinition: typeof leasedOrders = {
+      _tag: "GrpcLeasedFeedDefinition",
+      lifecycle: "leased",
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => ({ orderId: `${region}:${status}` }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        }),
+      // @ts-expect-error runtime feed definitions require helper-branded maps, so manual objects cannot bypass map exactness.
+      map: () => ({
+        id: "order-1",
+        customerId: "customer-1",
+        status: openOrderStatus,
+        price: 10,
+        region: "usa",
+        updatedAt: 1,
+        ze: true,
+      }),
+    };
+    expectTypeOf(invalidManualRuntimeFeedDefinition).not.toBeNever();
+
+    const invalidSpreadRuntimeFeedDefinition: typeof leasedOrders = {
+      ...leasedOrders,
+      // @ts-expect-error spread feeds cannot replace helper-branded exact maps with a broader function.
+      map: () => ({
+        id: "order-1",
+        customerId: "customer-1",
+        status: openOrderStatus,
+        price: 10,
+        region: "usa",
+        updatedAt: 1,
+        ze: true,
+      }),
+    };
+    expectTypeOf(invalidSpreadRuntimeFeedDefinition).not.toBeNever();
+
+    feed.materializedFeed({
+      topic: "trades",
+      client: "trades",
+      // @ts-expect-error gRPC feed methods must belong to the selected client.
+      method: "streamOrders",
+      request: () => ({ orderId: "all-trades" }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.TradeValue",
+          symbol: "AAPL",
+          quantity: 1,
+          price: 10,
+        }),
+      map: ({ value }) => ({
+        id: value.symbol,
+        symbol: value.symbol,
+        quantity: value.quantity,
+        price: value.price,
+        region: "usa",
+      }),
+    });
+
+    feed.materializedFeed({
+      // @ts-expect-error materialized feeds can only target topics declared with grpc.materialized().
+      topic: "orders",
+      client: "orders",
+      method: "streamTrades",
+      request: () => ({ orderId: "all-trades" }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.TradeValue",
+          symbol: "AAPL",
+          quantity: 1,
+          price: 10,
+        }),
+      map: ({ value }) => ({
+        id: value.symbol,
+        symbol: value.symbol,
+        quantity: value.quantity,
+        price: value.price,
+        region: "usa",
+      }),
+    });
+
+    feed.materializedFeed({
+      // @ts-expect-error materialized feeds can only target topics explicitly marked as gRPC materialized.
+      topic: "positions",
+      client: "orders",
+      method: "streamTrades",
+      request: () => ({ orderId: "positions" }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.TradeValue",
+          symbol: "AAPL",
+          quantity: 1,
+          price: 10,
+        }),
+      map: ({ value }) => ({
+        id: value.symbol,
+        symbol: value.symbol,
+        quantity: value.quantity,
+        price: value.price,
+        region: "usa",
+      }),
+    });
+
+    feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      // @ts-expect-error gRPC feeds must use server-streaming methods.
+      method: "getOrder",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => ({ orderId: `${region}:${status}` }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        }),
+      map: () => ({
+        id: "order-1",
+        customerId: "customer-1",
+        status: openOrderStatus,
+        price: 10,
+        region: "usa",
+        updatedAt: 1,
+      }),
+    });
+
+    feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      // @ts-expect-error leased feed routeBy must match the configured topic route tuple.
+      routeBy: ["region"],
+      request: ({ region }) => ({ orderId: region }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        }),
+      map: ({ value }) => ({
+        id: value.customerId,
+        customerId: value.customerId,
+        status: value.status,
+        price: value.price,
+        region: "usa",
+        updatedAt: value.updatedAt,
+      }),
+    });
+
+    feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => ({ orderId: `${region}:${status}` }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        }),
+      // @ts-expect-error gRPC feed mappings must not return fields outside the topic schema.
+      map: ({ value }) => ({
+        id: value.customerId,
+        customerId: value.customerId,
+        status: value.status,
+        price: value.price,
+        region: "usa",
+        updatedAt: value.updatedAt,
+        ze: true,
+      }),
+    });
+
+    feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => ({ orderId: `${region}:${status}` }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        }),
+      // @ts-expect-error gRPC feed mappings must return every topic field.
+      map: ({ value }) => ({
+        id: value.customerId,
+        customerId: value.customerId,
+        status: value.status,
+        price: value.price,
+        region: "usa",
+      }),
+    });
+
+    const grpcOwnedKafkaTopic = grpcViewServer.kafkaTopic<typeof kafkaRegions>();
+    expect(() =>
+      grpcOwnedKafkaTopic({
+        regions: ["usa"],
+        value: tradesValueKafkaCodec,
+        key: kafka.stringKey(),
+        // @ts-expect-error Kafka runtime topics cannot publish into gRPC-owned leased topics.
+        viewServerTopic: "orders",
+        mapping: ({ key, value }) => ({
+          id: key,
+          accountId: "account-1",
+          symbol: value.symbol,
+          active: true,
+          quantity: BigInt(value.quantity),
+          optionalQuantity: undefined,
+          price: BigDecimal.fromStringUnsafe(String(value.price)),
+          notional: value.price * value.quantity,
+          optionalNotional: undefined,
+        }),
+      }),
+    ).toThrow("Kafka source cannot publish into gRPC-owned View Server topic: orders");
+    expect(() =>
+      grpcOwnedKafkaTopic({
+        regions: ["usa"],
+        value: tradesValueKafkaCodec,
+        key: kafka.stringKey(),
+        // @ts-expect-error Kafka runtime topics cannot publish into gRPC-owned materialized topics.
+        viewServerTopic: "trades",
+        mapping: ({ key, value }) => ({
+          id: key,
+          accountId: "account-1",
+          symbol: value.symbol,
+          active: true,
+          quantity: BigInt(value.quantity),
+          optionalQuantity: undefined,
+          price: BigDecimal.fromStringUnsafe(String(value.price)),
+          notional: value.price * value.quantity,
+          optionalNotional: undefined,
+        }),
+      }),
+    ).toThrow("Kafka source cannot publish into gRPC-owned View Server topic: trades");
+    expect(() =>
+      grpcOwnedKafkaTopic({
+        regions: ["usa"],
+        value: tradesValueKafkaCodec,
+        key: kafka.stringKey(),
+        // @ts-expect-error hostile JS callers can still target missing View Server topics.
+        viewServerTopic: "missing",
+        mapping: ({ key, value }) => ({
+          id: key,
+          accountId: "account-1",
+          symbol: value.symbol,
+          active: true,
+          quantity: BigInt(value.quantity),
+          optionalQuantity: undefined,
+          price: BigDecimal.fromStringUnsafe(String(value.price)),
+          notional: value.price * value.quantity,
+          optionalNotional: undefined,
+        }),
+      }),
+    ).toThrow();
+    const malformedSourceKafkaTopic = defineKafkaTopic({
+      malformed: {
+        schema: Position,
+        source: { kind: 1 },
+      },
+    })<typeof kafkaRegions>();
+    const malformedSourceTopic = malformedSourceKafkaTopic({
+      regions: ["usa"],
+      value: tradesValueKafkaCodec,
+      key: kafka.stringKey(),
+      viewServerTopic: "malformed",
+      mapping: ({ key, value }) => ({
+        id: key,
+        accountId: "account-1",
+        symbol: value.symbol,
+        active: true,
+        quantity: BigInt(value.quantity),
+        optionalQuantity: undefined,
+        price: BigDecimal.fromStringUnsafe(String(value.price)),
+        notional: value.price * value.quantity,
+        optionalNotional: undefined,
+      }),
+    });
+    expect(malformedSourceTopic.viewServerTopic).toBe("malformed");
+    const kafkaPositionTopic = grpcOwnedKafkaTopic({
+      regions: ["usa"],
+      value: tradesValueKafkaCodec,
+      key: kafka.stringKey(),
+      viewServerTopic: "positions",
+      mapping: ({ key, value }) => ({
+        id: key,
+        accountId: "account-1",
+        symbol: value.symbol,
+        active: true,
+        quantity: BigInt(value.quantity),
+        optionalQuantity: undefined,
+        price: BigDecimal.fromStringUnsafe(String(value.price)),
+        notional: value.price * value.quantity,
+        optionalNotional: undefined,
+      }),
+    });
+    expect(kafkaPositionTopic.viewServerTopic).toBe("positions");
+  });
+
   it("derives schema field metadata for query validation", () => {
     expect(viewServerSchemaFieldMetadata(Schema.Number)).toStrictEqual({
       isNumeric: true,
@@ -4509,7 +5258,12 @@ describe("defineViewServerConfig", () => {
   );
 
   it("does not expose executable React or runtime placeholders from config", () => {
-    expect(Object.keys(viewServer)).toStrictEqual(["topics", "defineRuntimeOptions", "kafkaTopic"]);
+    expect(Object.keys(viewServer)).toStrictEqual([
+      "topics",
+      "defineRuntimeOptions",
+      "kafkaTopic",
+      "grpcFeed",
+    ]);
   });
 });
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,7 +6,22 @@ import {
   type RuntimeOptionsCandidate,
   type RuntimeOptionsDefinition,
 } from "./kafka-contract";
-import type { RowFromSchema, RowSchema, StringFieldKey, TopicDefinition } from "./topic-contract";
+import type {
+  GrpcFeedHelper,
+  GrpcLeasedTopicSource,
+  GrpcRuntimeClients,
+  GrpcTopicSource,
+} from "./grpc-contract";
+import { defineGrpcFeed } from "./grpc-contract";
+import type { TopicSourceDefinition } from "./source-contract";
+import type {
+  FieldKey,
+  RowFromSchema,
+  RowSchema,
+  StringFieldKey,
+  TopicDefinition,
+  TopicDefinitions,
+} from "./topic-contract";
 import { viewServerUnsupportedRuntimeFieldDomain } from "./schema-field-metadata";
 
 export type {
@@ -110,6 +125,34 @@ export {
   kafka,
   kafkaErrorIsMapping,
 } from "./kafka-contract";
+export { grpc } from "./grpc-contract";
+export type {
+  GrpcConnectClientDefinition,
+  GrpcClientValue,
+  GrpcFeedAcquireInput,
+  GrpcFeedHelper,
+  GrpcFeedMapInput,
+  GrpcFeedReleaseInput,
+  GrpcFeedSession,
+  GrpcHelper,
+  GrpcLeasedTopicSource,
+  GrpcMaterializedTopicSource,
+  GrpcMethodRequest,
+  GrpcMethodValue,
+  GrpcRuntimeClients,
+  GrpcRuntimeValue,
+  GrpcServerStreamingMethodName,
+  GrpcTopicSource,
+  GrpcTopicSourceKind,
+} from "./grpc-contract";
+export { defineGrpcFeed } from "./grpc-contract";
+export type {
+  ExactLeasedRouteQuery,
+  ExactLiveQueryInputForTopic,
+  TopicRouteBy,
+} from "./source-query-contract";
+export { validateLiveQuerySourceRoute } from "./source-query-contract";
+export type { TopicSourceDefinition } from "./source-contract";
 export type {
   KafkaBytesCodec,
   KafkaDecodedTopicMessage,
@@ -147,27 +190,53 @@ type ViewServerConfigTopicShape = Record<
   {
     readonly schema: RowSchema;
     readonly key: string;
+    readonly source?: TopicSourceDefinition;
   }
 >;
 
-export type ViewServerConfig<Topics extends ViewServerConfigTopicShape> = {
+export type ViewServerConfig<Topics extends TopicDefinitions> = {
   readonly topics: Topics & ValidateTopicDefinitions<Topics>;
   readonly defineRuntimeOptions: <const Options extends RuntimeOptionsCandidate>(
     options: ExactRuntimeOptions<Topics, Options>,
   ) => RuntimeOptionsDefinition<Topics, Options>;
   readonly kafkaTopic: KafkaTopicHelper<Topics>;
+  readonly grpcFeed: <const Clients extends GrpcRuntimeClients>() => GrpcFeedHelper<
+    Topics,
+    Clients
+  >;
 };
 
-type ValidateTopicDefinitions<Topics extends ViewServerConfigTopicShape> = {
+type ValidateTopicDefinitions<Topics extends TopicDefinitions> = {
   readonly [Topic in keyof Topics]: Topic extends ViewServerSystemTopicName
     ? never
     : Topics[Topic] extends {
           readonly schema: infer S extends RowSchema;
           readonly key: infer Key extends string;
         }
-      ? TopicDefinition<S, Key & StringFieldKey<RowFromSchema<S>>>
+      ? Topics[Topic] extends { readonly source: infer Source }
+        ? TopicDefinition<
+            S,
+            Key & StringFieldKey<RowFromSchema<S>>,
+            ValidateTopicSource<RowFromSchema<S>, Source>
+          >
+        : TopicDefinition<S, Key & StringFieldKey<RowFromSchema<S>>>
       : never;
 };
+
+type ValidateGrpcLeasedRouteBy<Row, Source> =
+  Source extends GrpcLeasedTopicSource<infer RouteBy>
+    ? GrpcLeasedTopicSource<{
+        readonly [Index in keyof RouteBy]: RouteBy[Index] extends FieldKey<Row>
+          ? RouteBy[Index]
+          : never;
+      }>
+    : Source;
+
+type ValidateTopicSource<Row, Source> = Source extends GrpcTopicSource
+  ? ValidateGrpcLeasedRouteBy<Row, Source>
+  : Source extends undefined
+    ? undefined
+    : never;
 
 export type DefineViewServerConfigInput<Topics extends ViewServerConfigTopicShape> = {
   readonly topics: Topics & ValidateTopicDefinitions<Topics>;
@@ -179,6 +248,7 @@ export const defineViewServerConfig = <
     {
       readonly schema: RowSchema;
       readonly key: string;
+      readonly source?: TopicSourceDefinition;
     }
   >,
 >(
@@ -207,5 +277,6 @@ export const defineViewServerConfig = <
     topics: input.topics,
     defineRuntimeOptions: (options) => options,
     kafkaTopic: defineKafkaTopic<Topics>(input.topics),
+    grpcFeed: <const Clients extends GrpcRuntimeClients>() => defineGrpcFeed<Topics, Clients>(),
   };
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -143,7 +143,7 @@ export type {
   GrpcRuntimeValue,
   GrpcServerStreamingMethodName,
   GrpcTopicSource,
-  GrpcTopicSourceKind,
+  GrpcTopicSourceLifecycle,
 } from "./grpc-contract";
 export { defineGrpcFeed } from "./grpc-contract";
 export type {

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -172,6 +172,19 @@ type KafkaTopicSchemaRegistry = Record<
   }
 >;
 
+type KafkaWritableViewTopic<Topics extends KafkaTopicSchemaRegistry> = Extract<
+  {
+    readonly [Topic in keyof Topics]: "source" extends keyof Topics[Topic]
+      ? Topics[Topic] extends { readonly source: infer Source }
+        ? Source extends { readonly kind: "grpc" }
+          ? never
+          : Topic
+        : Topic
+      : Topic;
+  }[keyof Topics],
+  string
+>;
+
 const schemaForKafkaTopic = <
   const ViewTopic extends string,
   SchemaValue extends RowSchema,
@@ -184,6 +197,31 @@ const schemaForKafkaTopic = <
   topics: Topics,
   viewTopic: ViewTopic,
 ): SchemaValue => topics[viewTopic].schema;
+
+const viewTopicSourceKind = <Topics extends KafkaTopicSchemaRegistry>(
+  topics: Topics,
+  viewTopic: Extract<keyof Topics, string>,
+): string | undefined => {
+  const topicDefinition: unknown = topics[viewTopic];
+  if (!isInspectableObject(topicDefinition)) {
+    return undefined;
+  }
+  const source: unknown = Reflect.get(topicDefinition, "source");
+  if (!isInspectableObject(source)) {
+    return undefined;
+  }
+  const kind: unknown = Reflect.get(source, "kind");
+  return typeof kind === "string" ? kind : undefined;
+};
+
+const validateKafkaViewTopicOwnership = <Topics extends KafkaTopicSchemaRegistry>(
+  topics: Topics,
+  viewTopic: Extract<keyof Topics, string>,
+) => {
+  if (viewTopicSourceKind(topics, viewTopic) === "grpc") {
+    throw new Error(`Kafka source cannot publish into gRPC-owned View Server topic: ${viewTopic}`);
+  }
+};
 
 const utf8Decoder = new TextDecoder();
 
@@ -1018,7 +1056,7 @@ export type KafkaDecodedTopicMessage<
 type KafkaTopicWithoutKeyInput<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
   Mapping extends (
@@ -1040,7 +1078,7 @@ type KafkaTopicWithoutKeyInput<
 type KafkaTopicWithoutKey<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
   Mapping extends (
@@ -1061,7 +1099,7 @@ type KafkaTopicWithoutKey<
 type KafkaTopicWithKeyInput<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown>,
   KeyCodec extends KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
@@ -1085,7 +1123,7 @@ type KafkaTopicWithKeyInput<
 type KafkaTopicWithKey<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown>,
   KeyCodec extends KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
@@ -1115,7 +1153,7 @@ type KafkaTopicWithKey<
 export type KafkaTopicDefinition<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics> = KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown> = KafkaCodec<unknown, unknown>,
   KeyCodec = undefined,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
@@ -1172,10 +1210,10 @@ export type KafkaRuntimeTopicDefinition<
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
     NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
 > = KafkaTopicDefinitionMarker &
-  KafkaTopicSchemaMarker<Topics, Extract<keyof Topics, string>> &
-  KafkaTopicDecoder<Topics, Extract<keyof Topics, string>, TopicRegions[number], unknown> & {
+  KafkaTopicSchemaMarker<Topics, KafkaWritableViewTopic<Topics>> &
+  KafkaTopicDecoder<Topics, KafkaWritableViewTopic<Topics>, TopicRegions[number], unknown> & {
     readonly regions: TopicRegions;
-    readonly viewServerTopic: Extract<keyof Topics, string>;
+    readonly viewServerTopic: KafkaWritableViewTopic<Topics>;
   };
 
 const decodeKafkaStringKey = (input: KafkaCodecDecodeInput): string =>
@@ -1208,7 +1246,7 @@ export const decodeKafkaTopicMessage = Effect.fn("ViewServerConfig.kafka.topic.d
 type KafkaTopicDefinitionInput<
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics> = KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown> = KafkaCodec<unknown, unknown>,
   KeyCodec extends KafkaCodec<unknown, unknown> = KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>> =
@@ -1252,7 +1290,7 @@ type ValidateKafkaTopic<
   >;
   readonly value: infer ValueCodec extends KafkaCodec<unknown, unknown>;
   readonly key: infer KeyCodec extends KafkaCodec<unknown, unknown>;
-  readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
+  readonly viewServerTopic: infer ViewTopic extends KafkaWritableViewTopic<Topics>;
 }
   ? Candidate extends {
       readonly mapping: infer Mapping extends (
@@ -1282,7 +1320,7 @@ type ValidateKafkaTopic<
           Extract<keyof Regions, string>
         >;
         readonly value: infer ValueCodec extends KafkaCodec<unknown, unknown>;
-        readonly viewServerTopic: infer ViewTopic extends Extract<keyof Topics, string>;
+        readonly viewServerTopic: infer ViewTopic extends KafkaWritableViewTopic<Topics>;
       }
     ? Candidate extends {
         readonly mapping: infer Mapping extends (
@@ -1397,7 +1435,7 @@ export type KafkaTopicHelper<Topics extends KafkaTopicSchemaRegistry> = <
     const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
     ValueCodec extends KafkaCodec<unknown, unknown>,
     KeyCodec extends KafkaCodec<unknown, unknown>,
-    const ViewTopic extends Extract<keyof Topics, string>,
+    const ViewTopic extends KafkaWritableViewTopic<Topics>,
     Mapping extends (
       input: KafkaMappingInputWithKey<
         Topics,
@@ -1421,7 +1459,7 @@ export type KafkaTopicHelper<Topics extends KafkaTopicSchemaRegistry> = <
   <
     const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
     ValueCodec extends KafkaCodec<unknown, unknown>,
-    const ViewTopic extends Extract<keyof Topics, string>,
+    const ViewTopic extends KafkaWritableViewTopic<Topics>,
     Mapping extends (
       input: KafkaMappingInputWithoutKey<Topics, ViewTopic, TopicRegions[number], ValueCodec>,
     ) => TopicRow<Topics, ViewTopic>,
@@ -1433,7 +1471,7 @@ export type KafkaTopicHelper<Topics extends KafkaTopicSchemaRegistry> = <
 const makeKafkaTopicWithKey = <
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown>,
   KeyCodec extends KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
@@ -1484,7 +1522,7 @@ const makeKafkaTopicWithKey = <
 const makeKafkaTopicWithoutKey = <
   Topics extends KafkaTopicSchemaRegistry,
   Regions extends RuntimeRegions,
-  ViewTopic extends Extract<keyof Topics, string>,
+  ViewTopic extends KafkaWritableViewTopic<Topics>,
   ValueCodec extends KafkaCodec<unknown, unknown>,
   TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
   Mapping extends (
@@ -1531,7 +1569,7 @@ export const defineKafkaTopic = <Topics extends KafkaTopicSchemaRegistry>(
       const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
       ValueCodec extends KafkaCodec<unknown, unknown>,
       KeyCodec extends KafkaCodec<unknown, unknown>,
-      const ViewTopic extends Extract<keyof Topics, string>,
+      const ViewTopic extends KafkaWritableViewTopic<Topics>,
       Mapping extends (
         input: KafkaMappingInputWithKey<
           Topics,
@@ -1555,7 +1593,7 @@ export const defineKafkaTopic = <Topics extends KafkaTopicSchemaRegistry>(
     function topicHelper<
       const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
       ValueCodec extends KafkaCodec<unknown, unknown>,
-      const ViewTopic extends Extract<keyof Topics, string>,
+      const ViewTopic extends KafkaWritableViewTopic<Topics>,
       Mapping extends (
         input: KafkaMappingInputWithoutKey<Topics, ViewTopic, TopicRegions[number], ValueCodec>,
       ) => TopicRow<Topics, ViewTopic>,
@@ -1573,7 +1611,7 @@ export const defineKafkaTopic = <Topics extends KafkaTopicSchemaRegistry>(
       const TopicRegions extends NonEmptyReadonlyArray<Extract<keyof Regions, string>>,
       ValueCodec extends KafkaCodec<unknown, unknown>,
       KeyCodec extends KafkaCodec<unknown, unknown>,
-      const ViewTopic extends Extract<keyof Topics, string>,
+      const ViewTopic extends KafkaWritableViewTopic<Topics>,
     >(
       topic: KafkaTopicDefinitionInput<
         Topics,
@@ -1584,6 +1622,7 @@ export const defineKafkaTopic = <Topics extends KafkaTopicSchemaRegistry>(
         TopicRegions
       >,
     ) {
+      validateKafkaViewTopicOwnership(topics, topic.viewServerTopic);
       if ("key" in topic) {
         return makeKafkaTopicWithKey(
           topic,

--- a/packages/config/src/query-core.ts
+++ b/packages/config/src/query-core.ts
@@ -1,5 +1,6 @@
 import type { Schema } from "effect";
 import type * as BigDecimal from "effect/BigDecimal";
+import type { TopicSourceDefinition } from "./source-contract";
 
 export type TopicName = string;
 export type SortDirection = "asc" | "desc";
@@ -37,12 +38,21 @@ export type NumericFieldKey<Row> = Extract<
 
 export type FieldKey<Row> = Extract<keyof Row, string>;
 
-export type TopicDefinition<S extends RowSchema, Key extends string> = {
+export type TopicDefinition<
+  S extends RowSchema,
+  Key extends string,
+  Source extends TopicSourceDefinition | undefined = undefined,
+> = {
   readonly schema: S;
   readonly key: Key;
-};
+} & (Source extends TopicSourceDefinition
+  ? { readonly source: Source }
+  : { readonly source?: undefined });
 
-export type TopicDefinitions = Record<string, TopicDefinition<RowSchema, string>>;
+export type TopicDefinitions = Record<
+  string,
+  TopicDefinition<RowSchema, string, TopicSourceDefinition | undefined>
+>;
 
 export type TopicSchema<Topics, Topic extends keyof Topics> = Topics[Topic] extends {
   readonly schema: infer S extends RowSchema;

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -1,7 +1,7 @@
 import type { Config, Effect } from "effect";
 import type { ViewServerHealth } from "./health-contract";
+import type { ExactLiveQueryInputForTopic } from "./source-query-contract";
 import type {
-  ExactLiveQueryInput,
   ExactPatch,
   GroupedQuery,
   LiveQueryRow,
@@ -51,7 +51,7 @@ type RuntimeSnapshot<Topics extends object> = <
   const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
 >(
   topic: Topic,
-  query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
 ) => Effect.Effect<
   LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
   ViewServerRuntimeError

--- a/packages/config/src/source-contract.ts
+++ b/packages/config/src/source-contract.ts
@@ -1,0 +1,16 @@
+export type TopicSourceDefinition = {
+  readonly kind: string;
+};
+
+export type NonEmptyRouteBy = readonly [string, ...ReadonlyArray<string>];
+
+export type TopicMaterializedSourceDefinition = TopicSourceDefinition & {
+  readonly lifecycle: "materialized";
+};
+
+export type TopicLeasedSourceDefinition<
+  RouteBy extends ReadonlyArray<string> = ReadonlyArray<string>,
+> = TopicSourceDefinition & {
+  readonly lifecycle: "leased";
+  readonly routeBy: RouteBy;
+};

--- a/packages/config/src/source-query-contract.ts
+++ b/packages/config/src/source-query-contract.ts
@@ -1,0 +1,111 @@
+import type { FieldKey, TopicDefinitions, TopicRow } from "./query-core";
+import type { RejectExtraKeys } from "./query-exact";
+import type { ExactLiveQuery, ValidateLiveQuery } from "./query-result-contract";
+import type {
+  NonEmptyRouteBy,
+  TopicLeasedSourceDefinition,
+  TopicSourceDefinition,
+} from "./source-contract";
+
+type RouteFilterShape<Value> = {
+  readonly eq: Value;
+};
+
+type ExactRouteFilter<Value, Filter> =
+  Filter extends RouteFilterShape<infer Eq>
+    ? [Eq] extends [Value]
+      ? Filter & RejectExtraKeys<Filter, RouteFilterShape<Value>>
+      : never
+    : never;
+
+type ExactRouteWhere<Row, QueryWhere, RouteBy extends string> = QueryWhere & {
+  readonly [Field in Extract<RouteBy, FieldKey<Row>>]-?: Field extends keyof QueryWhere
+    ? ExactRouteFilter<Row[Field], QueryWhere[Field]>
+    : never;
+};
+
+export type TopicRouteBy<Topics, Topic extends keyof Topics> = Topics[Topic] extends {
+  readonly source: TopicLeasedSourceDefinition<infer RouteBy>;
+}
+  ? Extract<RouteBy[number], string>
+  : never;
+
+export type TopicRouteByTuple<Topics, Topic extends keyof Topics> = Topics[Topic] extends {
+  readonly source: TopicLeasedSourceDefinition<infer RouteBy>;
+}
+  ? RouteBy extends NonEmptyRouteBy
+    ? RouteBy
+    : never
+  : never;
+
+export type ExactLeasedRouteQuery<Row, RouteBy extends string, Query> = [RouteBy] extends [never]
+  ? unknown
+  : Query extends {
+        readonly where: infer QueryWhere;
+      }
+    ? {
+        readonly where: ExactRouteWhere<Row, QueryWhere, RouteBy>;
+      }
+    : {
+        readonly where: never;
+      };
+
+export type ExactLiveQueryInputForTopic<Topics, Topic extends keyof Topics, Query> = Query &
+  ExactLiveQuery<TopicRow<Topics, Topic>, Query> &
+  ValidateLiveQuery<Query> &
+  ExactLeasedRouteQuery<TopicRow<Topics, Topic>, TopicRouteBy<Topics, Topic>, Query>;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const sourceLeasedRouteBy = (
+  source: TopicSourceDefinition | undefined,
+): ReadonlyArray<string> | "invalid" | undefined => {
+  const candidate: unknown = source;
+  if (!isRecord(candidate) || candidate["lifecycle"] !== "leased") {
+    return undefined;
+  }
+  const routeBy = candidate["routeBy"];
+  if (
+    !Array.isArray(routeBy) ||
+    routeBy.length === 0 ||
+    !routeBy.every((field) => typeof field === "string")
+  ) {
+    return "invalid";
+  }
+  return routeBy;
+};
+
+const exactEqFilterIsPresent = (filter: unknown): boolean =>
+  isRecord(filter) && Object.keys(filter).length === 1 && Object.hasOwn(filter, "eq");
+
+export const validateLiveQuerySourceRoute = <Topics extends TopicDefinitions>(
+  topics: Topics,
+  topic: string,
+  query: unknown,
+): string | undefined => {
+  const topicDefinition = topics[topic];
+  if (topicDefinition === undefined) {
+    return undefined;
+  }
+  const routeBy = sourceLeasedRouteBy(topicDefinition.source);
+  if (routeBy === undefined) {
+    return undefined;
+  }
+  if (routeBy === "invalid") {
+    return `Leased topic ${topic} has invalid route metadata.`;
+  }
+  if (!isRecord(query)) {
+    return `Leased topic ${topic} requires a query object.`;
+  }
+  const where = query["where"];
+  if (!isRecord(where)) {
+    return `Leased topic ${topic} requires exact equality filters for route fields: ${routeBy.join(", ")}.`;
+  }
+  for (const field of routeBy) {
+    if (!exactEqFilterIsPresent(where[field])) {
+      return `Leased topic ${topic} route field ${field} must use an exact eq filter.`;
+    }
+  }
+  return undefined;
+};

--- a/packages/config/src/source-query-contract.ts
+++ b/packages/config/src/source-query-contract.ts
@@ -24,6 +24,12 @@ type ExactRouteWhere<Row, QueryWhere, RouteBy extends string> = QueryWhere & {
     : never;
 };
 
+type UnionToIntersection<Union> = (Union extends unknown ? (value: Union) => void : never) extends (
+  value: infer Intersection,
+) => void
+  ? Intersection
+  : never;
+
 export type TopicRouteBy<Topics, Topic extends keyof Topics> = Topics[Topic] extends {
   readonly source: TopicLeasedSourceDefinition<infer RouteBy>;
 }
@@ -38,8 +44,10 @@ export type TopicRouteByTuple<Topics, Topic extends keyof Topics> = Topics[Topic
     : never
   : never;
 
+type NoLeasedRouteRequirement = Readonly<Record<never, never>>;
+
 export type ExactLeasedRouteQuery<Row, RouteBy extends string, Query> = [RouteBy] extends [never]
-  ? unknown
+  ? NoLeasedRouteRequirement
   : Query extends {
         readonly where: infer QueryWhere;
       }
@@ -50,10 +58,18 @@ export type ExactLeasedRouteQuery<Row, RouteBy extends string, Query> = [RouteBy
         readonly where: never;
       };
 
+type ExactLeasedRouteQueryForTopic<
+  Topics,
+  Topic extends keyof Topics,
+  Query,
+> = Topic extends keyof Topics
+  ? ExactLeasedRouteQuery<TopicRow<Topics, Topic>, TopicRouteBy<Topics, Topic>, Query>
+  : never;
+
 export type ExactLiveQueryInputForTopic<Topics, Topic extends keyof Topics, Query> = Query &
   ExactLiveQuery<TopicRow<Topics, Topic>, Query> &
   ValidateLiveQuery<Query> &
-  ExactLeasedRouteQuery<TopicRow<Topics, Topic>, TopicRouteBy<Topics, Topic>, Query>;
+  UnionToIntersection<ExactLeasedRouteQueryForTopic<Topics, Topic, Query>>;
 
 const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/config/vite.config.ts
+++ b/packages/config/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "src/health-contract.ts",
     "src/live-protocol.ts",
     "src/kafka-contract.ts",
+    "src/grpc-contract.ts",
   ]),
   lint: {
     options: {

--- a/packages/react/src/index.test-d.ts
+++ b/packages/react/src/index.test-d.ts
@@ -2,6 +2,7 @@ import { describe, expectTypeOf, it } from "@effect/vitest";
 import type { ViewServerLiveClient } from "@view-server/client";
 import {
   defineViewServerConfig,
+  grpc,
   type LiveQueryResult,
   type ViewServerRuntimeError,
 } from "@view-server/config";
@@ -36,9 +37,22 @@ const viewServer = defineViewServerConfig({
   },
 });
 
+const leasedViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      source: grpc.leased({
+        routeBy: ["region", "status"],
+      }),
+    },
+  },
+});
+
 const react = createViewServerReact(viewServer);
 const { ViewServerProvider, useLiveQuery, useViewServerHealth, useViewServerHealthSummary } = react;
 const ViewServerClientProvider = react[ViewServerReactClientProvider];
+const leasedReact = createViewServerReact(leasedViewServer);
 
 type TestInMemoryOptions = ViewServerInMemoryOptions<typeof viewServer.topics>;
 
@@ -227,6 +241,64 @@ describe("React type contracts", () => {
     };
     // @ts-expect-error numeric fields do not support string filters.
     useLiveQuery("orders", numericStringFilterQuery);
+  });
+
+  it("requires leased gRPC route predicates in React hooks", () => {
+    const routedRows = leasedReact.useLiveQuery("orders", {
+      where: {
+        region: { eq: "usa" },
+        status: { eq: "open" },
+        customerId: { startsWith: "customer-" },
+      },
+      orderBy: [{ field: "updatedAt", direction: "desc" }],
+      select: ["id", "customerId", "price"],
+      limit: 25,
+    });
+
+    expectTypeOf(routedRows).toEqualTypeOf<
+      LiveQueryResult<{
+        readonly id: string;
+        readonly customerId: string;
+        readonly price: number;
+      }>
+    >();
+
+    const missingRouteQuery = {
+      where: {
+        region: { eq: "usa" },
+      },
+      select: ["id"],
+    } satisfies {
+      readonly where: {
+        readonly region: {
+          readonly eq: "usa";
+        };
+      };
+      readonly select: readonly ["id"];
+    };
+    const invalidRouteOperatorQuery = {
+      where: {
+        region: { eq: "usa" },
+        status: { in: ["open"] },
+      },
+      select: ["id"],
+    } satisfies {
+      readonly where: {
+        readonly region: {
+          readonly eq: "usa";
+        };
+        readonly status: {
+          readonly in: readonly ["open"];
+        };
+      };
+      readonly select: readonly ["id"];
+    };
+
+    // @ts-expect-error leased gRPC queries require every routeBy field.
+    leasedReact.useLiveQuery("orders", missingRouteQuery);
+
+    // @ts-expect-error leased gRPC route filters must be exact eq predicates.
+    leasedReact.useLiveQuery("orders", invalidRouteOperatorQuery);
   });
 
   it("keeps health and in-memory client keyed by configured topics", () => {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -10,9 +10,7 @@ import {
 } from "@view-server/client";
 import { makeViewServerClient, type ViewServerClientOptions } from "@view-server/client/remote";
 import type {
-  ExactGroupedQuery,
-  ExactLiveQuery,
-  ExactRawQuery,
+  ExactLiveQueryInputForTopic,
   GroupedQuery,
   GroupedResult,
   LiveQueryResult,
@@ -21,7 +19,6 @@ import type {
   RawQuery,
   TopicDefinitions,
   TopicRow,
-  ValidateLiveQuery,
   ViewServerConfig,
   ViewServerHealthConnectionStatus,
   ViewServerHealthDetails,
@@ -65,18 +62,14 @@ export type UseLiveQueryHook<Topics extends TopicDefinitions> = {
     const Query extends RawQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<PickRawFields<TopicRow<Topics, Topic>, Query>>;
   <
     Topic extends Extract<keyof Topics, string>,
     const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<GroupedResult<TopicRow<Topics, Topic>, Query>>;
 };
 
@@ -171,27 +164,21 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
     const Query extends RawQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<PickRawFields<TopicRow<Topics, Topic>, Query>>;
   function useLiveQuery<
     Topic extends Extract<keyof Topics, string>,
     const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<GroupedResult<TopicRow<Topics, Topic>, Query>>;
   function useLiveQuery<
     Topic extends Extract<keyof Topics, string>,
     const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
   >(
     topic: Topic,
-    query: Query &
-      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
-      ValidateLiveQuery<NoInfer<Query>>,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   ): LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>> {
     const client = useClient();
     type Row = LiveQueryRow<TopicRow<Topics, Topic>, Query>;

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -3,7 +3,7 @@ import {
   createColumnLiveViewEngine,
   type ColumnLiveViewEngineHealth,
 } from "@view-server/column-live-view-engine";
-import { defineViewServerConfig, type ViewServerRuntimeError } from "@view-server/config";
+import { defineViewServerConfig, grpc, type ViewServerRuntimeError } from "@view-server/config";
 import { Deferred, Effect, Fiber, Queue, Schema, Stream } from "effect";
 import { AtomRef } from "effect/unstable/reactivity";
 import {
@@ -29,6 +29,18 @@ const viewServer = defineViewServerConfig({
     orders: {
       schema: Order,
       key: "id",
+    },
+  },
+});
+
+const leasedViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      source: grpc.leased({
+        routeBy: ["region", "status"],
+      }),
     },
   },
 });
@@ -176,6 +188,92 @@ describe("@view-server/runtime-core", () => {
     }),
   );
 
+  it.effect("rejects leased topic queries without exact runtime route filters", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(leasedViewServer, {});
+      const missingRouteQuery = {
+        where: {
+          region: { eq: "usa" },
+        },
+        select: ["id"],
+        limit: 1,
+      } as const;
+
+      const missingRoute = yield* Effect.flip(
+        // @ts-expect-error hostile callers can bypass compile-time leased-route checks.
+        runtimeCore.client.snapshot("orders", missingRouteQuery),
+      );
+      expect(missingRoute).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message: "Leased topic orders route field status must use an exact eq filter.",
+      });
+
+      const missingSubscribeRoute = yield* Effect.flip(
+        // @ts-expect-error hostile callers can bypass compile-time leased-route subscribe checks.
+        runtimeCore.liveClient.subscribe("orders", missingRouteQuery),
+      );
+      expect(missingSubscribeRoute).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message: "Leased topic orders route field status must use an exact eq filter.",
+      });
+
+      const nonEqRoute = yield* Effect.flip(
+        runtimeCore.liveClient.subscribeRuntime("orders", {
+          where: {
+            region: { eq: "usa" },
+            status: { in: ["open"] },
+          },
+          select: ["id"],
+          limit: 1,
+        }),
+      );
+      expect(nonEqRoute).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message: "Leased topic orders route field status must use an exact eq filter.",
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("allows leased topic queries with exact runtime route filters", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(leasedViewServer, {});
+      yield* runtimeCore.client.publish("orders", order("a", 10));
+
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        where: {
+          region: { eq: "usa" },
+          status: { eq: "open" },
+        },
+        select: ["id", "region", "status"],
+        limit: 1,
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [
+          {
+            id: "a",
+            region: "usa",
+            status: "open",
+          },
+        ],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("forwards grouped admission limits to the engine", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {
@@ -234,6 +332,7 @@ describe("@view-server/runtime-core", () => {
       const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
+        viewServer,
         engine,
         health,
         Effect.fail(refreshFailed),
@@ -268,6 +367,7 @@ describe("@view-server/runtime-core", () => {
       const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
+        viewServer,
         engine,
         health,
         Effect.fail(refreshFailed),
@@ -589,6 +689,7 @@ describe("@view-server/runtime-core", () => {
       const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
+        viewServer,
         engine,
         health,
         Effect.sync(() => health.value),
@@ -630,6 +731,7 @@ describe("@view-server/runtime-core", () => {
         const refreshStarted = yield* Deferred.make<void>();
         const releaseRefresh = yield* Deferred.make<void>();
         const liveClient = yield* makeRuntimeCoreLiveClient(
+          viewServer,
           engine,
           health,
           Effect.gen(function* () {
@@ -744,6 +846,7 @@ describe("@view-server/runtime-core", () => {
         const refreshStarted = yield* Deferred.make<void>();
         const releaseRefresh = yield* Deferred.make<void>();
         const liveClient = yield* makeRuntimeCoreLiveClient(
+          viewServer,
           engine,
           health,
           Effect.gen(function* () {
@@ -811,6 +914,7 @@ describe("@view-server/runtime-core", () => {
       const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
+        viewServer,
         engine,
         health,
         Effect.sync(() => health.value),

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -274,6 +274,84 @@ describe("@view-server/runtime-core", () => {
     }),
   );
 
+  it.effect("validates leased route predicates when subscription effects execute", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(leasedViewServer, {});
+      const delayedSubscribeQuery = {
+        where: {
+          region: { eq: "usa" },
+          status: { eq: "open" },
+        },
+        select: ["id"],
+        limit: 1,
+      } satisfies {
+        readonly where: {
+          readonly region: {
+            readonly eq: "usa";
+          };
+          readonly status: {
+            readonly eq: "open";
+          };
+        };
+        readonly select: readonly ["id"];
+        readonly limit: 1;
+      };
+      const subscribeEffect = runtimeCore.liveClient.subscribe("orders", delayedSubscribeQuery);
+      expect(Reflect.deleteProperty(delayedSubscribeQuery.where.status, "eq")).toBe(true);
+      Object.defineProperty(delayedSubscribeQuery.where.status, "in", {
+        enumerable: true,
+        value: ["open"],
+      });
+
+      const subscribeRouteError = yield* Effect.flip(subscribeEffect);
+      expect(subscribeRouteError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message: "Leased topic orders route field status must use an exact eq filter.",
+      });
+
+      const delayedRuntimeQuery = {
+        where: {
+          region: { eq: "usa" },
+          status: { eq: "open" },
+        },
+        select: ["id"],
+        limit: 1,
+      } satisfies {
+        readonly where: {
+          readonly region: {
+            readonly eq: "usa";
+          };
+          readonly status: {
+            readonly eq: "open";
+          };
+        };
+        readonly select: readonly ["id"];
+        readonly limit: 1;
+      };
+      const subscribeRuntimeEffect = runtimeCore.liveClient.subscribeRuntime(
+        "orders",
+        delayedRuntimeQuery,
+      );
+      expect(Reflect.deleteProperty(delayedRuntimeQuery.where.status, "eq")).toBe(true);
+      Object.defineProperty(delayedRuntimeQuery.where.status, "in", {
+        enumerable: true,
+        value: ["open"],
+      });
+
+      const subscribeRuntimeRouteError = yield* Effect.flip(subscribeRuntimeEffect);
+      expect(subscribeRuntimeRouteError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message: "Leased topic orders route field status must use an exact eq filter.",
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("forwards grouped admission limits to the engine", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -78,6 +78,7 @@ export const makeViewServerRuntimeCore: <const Topics extends DecodableTopicDefi
       healthFromEngine(engineHealth, transportHealth, healthOverlay, nowMillis),
     );
     const runtimeClient = yield* makeRuntimeCoreClient<Topics>(
+      config,
       engine,
       health,
       transportHealth,
@@ -85,6 +86,7 @@ export const makeViewServerRuntimeCore: <const Topics extends DecodableTopicDefi
       input.healthRefreshCadence,
     );
     const liveClient = yield* makeRuntimeCoreLiveClient<Topics>(
+      config,
       engine,
       health,
       runtimeClient.refreshHealth,

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -12,11 +12,12 @@ import {
   runAllFinalizers,
 } from "@view-server/effect-utils";
 import type {
-  ExactLiveQueryInput,
+  ExactLiveQueryInputForTopic,
   GroupedQuery,
   LiveQueryRow,
   RawQuery,
   TopicRow,
+  ViewServerConfig,
   ViewServerHealth,
   ViewServerHealthSummaryRow,
   ViewServerHealthTopicRow,
@@ -26,12 +27,13 @@ import type {
 import {
   VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
   VIEW_SERVER_HEALTH_TOPIC,
+  validateLiveQuerySourceRoute,
   viewServerHealthSummaryRowFromHealth,
   viewServerHealthTopicRowsFromHealth,
 } from "@view-server/config";
 import { Cause, Clock, Effect, Exit, Queue, Scope, Semaphore, Stream } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
-import { engineErrorToRuntimeError } from "./runtime-error";
+import { engineErrorToRuntimeError, invalidRuntimeQueryError } from "./runtime-error";
 
 const runtimeClosedError: ViewServerRuntimeError = {
   _tag: "ViewServerRuntimeError",
@@ -67,6 +69,7 @@ const runtimeHealthBackpressureStatus = <Topic extends string>(
 
 export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveClient.make")(
   <const Topics extends DecodableTopicDefinitions>(
+    config: ViewServerConfig<Topics>,
     engine: ColumnLiveViewEngine<Topics>,
     health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
     refreshHealth: Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>,
@@ -79,7 +82,7 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
           | GroupedQuery<TopicRow<Topics, Topic>>,
       >(
         topic: Topic,
-        query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+        query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
       ): Effect.Effect<
         ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError | ViewServerTransportError
@@ -91,12 +94,16 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
           | GroupedQuery<TopicRow<Topics, Topic>>,
       >(
         topic: Topic,
-        query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+        query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
       ): Effect.Effect<
         ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError | ViewServerTransportError
       > {
         const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
+        const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
+        if (routeError !== undefined) {
+          return Effect.fail(invalidRuntimeQueryError(topic, routeError));
+        }
         return engine.subscribe<Topic, Query>(topic, query).pipe(
           Effect.mapError(engineErrorToRuntimeError),
           Effect.flatMap((subscription) =>
@@ -115,6 +122,10 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         query,
       ) => {
         const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
+        const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
+        if (routeError !== undefined) {
+          return Effect.fail(invalidRuntimeQueryError(topic, routeError));
+        }
         return engine.subscribeRuntime(topic, query).pipe(
           Effect.mapError(engineErrorToRuntimeError),
           Effect.flatMap((subscription) =>

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -99,45 +99,49 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError | ViewServerTransportError
       > {
-        const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
-        const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
-        if (routeError !== undefined) {
-          return Effect.fail(invalidRuntimeQueryError(topic, routeError));
-        }
-        return engine.subscribe<Topic, Query>(topic, query).pipe(
-          Effect.mapError(engineErrorToRuntimeError),
-          Effect.flatMap((subscription) =>
-            refreshHealth.pipe(
-              Effect.as({
-                events: subscription.events,
-                close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
-              }),
-              Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+        return Effect.suspend(() => {
+          const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
+          const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
+          if (routeError !== undefined) {
+            return Effect.fail(invalidRuntimeQueryError(topic, routeError));
+          }
+          return engine.subscribe<Topic, Query>(topic, query).pipe(
+            Effect.mapError(engineErrorToRuntimeError),
+            Effect.flatMap((subscription) =>
+              refreshHealth.pipe(
+                Effect.as({
+                  events: subscription.events,
+                  close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
+                }),
+                Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+              ),
             ),
-          ),
-        );
+          );
+        });
       }
       const subscribeRuntime: ViewServerRuntimeLiveClient<Topics>["subscribeRuntime"] = (
         topic,
         query,
       ) => {
-        const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
-        const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
-        if (routeError !== undefined) {
-          return Effect.fail(invalidRuntimeQueryError(topic, routeError));
-        }
-        return engine.subscribeRuntime(topic, query).pipe(
-          Effect.mapError(engineErrorToRuntimeError),
-          Effect.flatMap((subscription) =>
-            refreshHealth.pipe(
-              Effect.as({
-                events: subscription.events,
-                close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
-              }),
-              Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+        return Effect.suspend(() => {
+          const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
+          const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
+          if (routeError !== undefined) {
+            return Effect.fail(invalidRuntimeQueryError(topic, routeError));
+          }
+          return engine.subscribeRuntime(topic, query).pipe(
+            Effect.mapError(engineErrorToRuntimeError),
+            Effect.flatMap((subscription) =>
+              refreshHealth.pipe(
+                Effect.as({
+                  events: subscription.events,
+                  close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
+                }),
+                Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+              ),
             ),
-          ),
-        );
+          );
+        });
       };
       type ActiveHealthSubscription = {
         close: Effect.Effect<void>;

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -3,16 +3,18 @@ import type {
   DecodableTopicDefinitions,
 } from "@view-server/column-live-view-engine";
 import type {
-  ExactLiveQueryInput,
+  ExactLiveQueryInputForTopic,
   GroupedQuery,
   LiveQueryRow,
   LiveQueryResult,
   RawQuery,
   TopicRow,
+  ViewServerConfig,
   ViewServerHealth,
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@view-server/config";
+import { validateLiveQuerySourceRoute } from "@view-server/config";
 import { Effect } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
 import {
@@ -23,7 +25,7 @@ import {
   type RuntimeCoreTransportHealth,
 } from "./health";
 import type * as Duration from "effect/Duration";
-import { engineErrorToRuntimeError } from "./runtime-error";
+import { engineErrorToRuntimeError, invalidRuntimeQueryError } from "./runtime-error";
 
 export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> = {
   readonly client: ViewServerRuntimeClient<Topics>;
@@ -34,6 +36,7 @@ export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> 
 
 export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.make")(
   <const Topics extends DecodableTopicDefinitions>(
+    config: ViewServerConfig<Topics>,
     engine: ColumnLiveViewEngine<Topics>,
     health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
     transportHealth: RuntimeCoreTransportHealth<Topics>,
@@ -99,14 +102,20 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
           | GroupedQuery<TopicRow<Topics, Topic>>,
       >(
         topic: Topic,
-        query: ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>,
+        query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
       ): Effect.Effect<
         LiveQueryResult<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError
       > =>
-        engine
-          .snapshot<Topic, Query>(topic, query)
-          .pipe(Effect.mapError(engineErrorToRuntimeError));
+        Effect.suspend(() => {
+          const routeError = validateLiveQuerySourceRoute(config.topics, topic, query);
+          if (routeError !== undefined) {
+            return Effect.fail(invalidRuntimeQueryError(topic, routeError));
+          }
+          return engine
+            .snapshot<Topic, Query>(topic, query)
+            .pipe(Effect.mapError(engineErrorToRuntimeError));
+        });
       return {
         client: {
           publish: (topic, row) =>

--- a/packages/runtime-core/src/runtime-error.ts
+++ b/packages/runtime-core/src/runtime-error.ts
@@ -47,3 +47,13 @@ export const engineErrorToRuntimeError = (error: EngineRuntimeError): ViewServer
     }
   }
 };
+
+export const invalidRuntimeQueryError = (
+  topic: string,
+  message: string,
+): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidQuery",
+  topic,
+  message,
+});

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -1,5 +1,10 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
-import { defineViewServerConfig, kafka, type ViewServerRuntimeError } from "@view-server/config";
+import {
+  defineViewServerConfig,
+  grpc,
+  kafka,
+  type ViewServerRuntimeError,
+} from "@view-server/config";
 import type { Config, Effect } from "effect";
 import { Schema } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
@@ -25,7 +30,20 @@ const viewServer = defineViewServerConfig({
   },
 });
 
+const leasedViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      source: grpc.leased({
+        routeBy: ["id"],
+      }),
+    },
+  },
+});
+
 const runtimeEffect = makeViewServerRuntime(viewServer);
+const leasedRuntimeEffect = makeViewServerRuntime(leasedViewServer);
 const runtimeWithGroupedAdmissionLimits = makeViewServerRuntime(viewServer, {
   groupedIncrementalAdmissionLimits: {
     maxGroups: 1,
@@ -33,6 +51,7 @@ const runtimeWithGroupedAdmissionLimits = makeViewServerRuntime(viewServer, {
 });
 const runEffect = runViewServerRuntime(viewServer);
 declare const runtime: Effect.Success<typeof runtimeEffect>;
+declare const leasedRuntime: Effect.Success<typeof leasedRuntimeEffect>;
 
 const usaKafkaRegions = {
   usa: "localhost:9092",
@@ -82,9 +101,49 @@ describe("runtime type contracts", () => {
     const subscribe = runtime.liveClient.subscribe("orders", {
       select: ["id", "price"],
     });
+    const leasedSnapshot = leasedRuntime.client.snapshot("orders", {
+      where: {
+        id: { eq: "order-1" },
+      },
+      select: ["id", "price"],
+    });
+    const leasedSubscribe = leasedRuntime.liveClient.subscribe("orders", {
+      where: {
+        id: { eq: "order-1" },
+      },
+      select: ["id"],
+    });
 
     expectTypeOf<Effect.Error<typeof publish>>().toEqualTypeOf<ViewServerRuntimeError>();
     expectTypeOf(subscribe).not.toBeAny();
+    expectTypeOf(leasedSnapshot).not.toBeAny();
+    expectTypeOf(leasedSubscribe).not.toBeAny();
+
+    const missingRouteQuery = {
+      select: ["id"],
+    } satisfies {
+      readonly select: readonly ["id"];
+    };
+    const shorthandRouteQuery = {
+      where: {
+        id: "order-1",
+      },
+      select: ["id"],
+    } satisfies {
+      readonly where: {
+        readonly id: "order-1";
+      };
+      readonly select: readonly ["id"];
+    };
+    // @ts-expect-error leased gRPC snapshots require exact eq route filters.
+    const invalidLeasedSnapshot = leasedRuntime.client.snapshot("orders", missingRouteQuery);
+    const invalidLeasedSubscribe = leasedRuntime.liveClient.subscribe(
+      "orders",
+      // @ts-expect-error leased gRPC route filters must be exact eq predicates.
+      shorthandRouteQuery,
+    );
+    expectTypeOf(invalidLeasedSnapshot).not.toBeAny();
+    expectTypeOf(invalidLeasedSubscribe).not.toBeAny();
 
     const invalidPublish = runtime.client.publish("orders", {
       id: "order-1",

--- a/plans/grpc.md
+++ b/plans/grpc.md
@@ -1,0 +1,591 @@
+# View Server gRPC Ingress Plan
+
+This plan defines the gRPC ingress model for View Server.
+
+It intentionally keeps the existing architecture intact:
+
+- one View Server topic is one logical table
+- `ColumnLiveViewEngine` remains the only query/snapshot/delta engine
+- runtime-core and the engine stay transport/ingress-neutral
+- Kafka, gRPC, TCP, and future sources are ingress Adapters only
+- React hooks continue to use the same provider/client seam
+- Effect RPC WebSocket with NDJSON remains the production browser transport
+
+## Compatibility With The Column Live View Engine Plan
+
+This plan does not conflict with `plans/v2-column-live-view-engine-plan.md`.
+
+The existing plan says:
+
+- runtime config owns Kafka, TCP publishing, gRPC publishing, and deploy-time/server-only wiring
+- browser bundles must not import runtime config
+- the engine package must not depend on Kafka, WebSocket, React, TCP, gRPC, or server runtime code
+- the same authoritative in-memory Topic Store serves snapshots, deltas, counts, grouped views, and subscription change streams
+- only transport/ingress Adapters differ between production and in-memory/test paths
+
+The gRPC design follows those rules by making gRPC an ingress Adapter that publishes rows into the existing runtime-core and engine. It must not create a second query engine, a second subscription system, or a gRPC-specific React hook.
+
+## Core Vocabulary
+
+Use these names consistently:
+
+- `topic`: the public View Server logical table, for example `orders`.
+- `materializedFeed`: a gRPC source that starts on View Server startup and remains active until runtime shutdown.
+- `leasedFeed`: a gRPC source that starts only while at least one subscription needs a specific upstream route.
+- `routeBy`: topic row fields that must be present as exact equality predicates in user queries for a leased feed.
+- `route`: the extracted route values from a user query.
+- `feedKey`: the derived internal identity for one upstream stream instance.
+- `request`: the typed upstream gRPC request built from `route`.
+- `acquire`: the Effect operation that opens the upstream gRPC stream.
+- `release`: optional Effect cleanup beyond stream interruption.
+- `view`: one user query over a materialized topic or leased feed.
+- `lease`: the refcount/lifecycle handle that keeps a leased feed alive while subscriptions use it.
+
+Do not call leased feed instances "topics" in public APIs. Health can expose feed instances under a topic, but the public topic remains stable.
+
+## Source Lifecycle Modes
+
+### Materialized Feed
+
+A materialized feed is always-on.
+
+Behavior:
+
+- starts when the runtime starts
+- reconnects according to runtime policy
+- retains state even with zero subscribers
+- serves snapshots immediately when a user subscribes
+- behaves similarly to Kafka materialized topics
+
+Use for bounded or globally useful sources, for example all strategies.
+
+```ts
+const grpcFeed = viewServer.grpcFeed<typeof grpcClients>();
+
+grpcFeed.materializedFeed({
+  topic: "strategies",
+  client: "strategies",
+  method: "streamStrategies",
+  request: () => ({}),
+
+  acquire: ({ client, session }) =>
+    Stream.fromAsyncIterable(
+      client.streamStrategies(
+        {},
+        {
+          headers: session.systemHeaders,
+        },
+      ),
+      (cause) => new GrpcUpstreamError({ cause }),
+    ),
+
+  map: ({ value, schema }) => ({
+    id: value.strategyId,
+    name: value.name,
+    region: value.region,
+    updatedAt: value.updatedAt,
+  }),
+});
+```
+
+### Leased Feed
+
+A leased feed is on-demand and route-keyed.
+
+Behavior:
+
+- does not connect on runtime startup
+- requires all `routeBy` fields in the user query
+- opens one upstream gRPC stream per distinct `feedKey`
+- shares that upstream stream across all users with the same route
+- applies remaining user filters/order/grouping locally inside View Server
+- closes the upstream stream and drops retained rows for that feed when the last subscription releases it
+
+Use for huge upstream sources where an unfiltered stream is impossible or dangerous.
+
+```ts
+const grpcFeed = viewServer.grpcFeed<typeof grpcClients>();
+
+grpcFeed.leasedFeed({
+  topic: "orders",
+  client: "orders",
+  method: "streamOrders",
+  routeBy: ["strategyId", "region"],
+
+  request: ({ strategyId, region }) => ({
+    strategyId,
+    region,
+  }),
+
+  acquire: ({ client, request, session }) =>
+    Stream.fromAsyncIterable(
+      client.streamOrders(request, {
+        headers: session.forwardedHeaders,
+      }),
+      (cause) => new GrpcUpstreamError({ cause }),
+    ),
+
+  release: ({ client, request }) => client.closeOrdersStream?.(request) ?? Effect.void,
+
+  map: ({ value, route, schema }) => ({
+    id: value.orderId,
+    strategyId: route.strategyId,
+    region: route.region,
+    instrumentId: value.instrumentId,
+    status: value.status,
+    price: value.price,
+    updatedAt: value.updatedAt,
+  }),
+});
+```
+
+## Query Routing Invariant
+
+A leased-feed user query must resolve to exactly one feed key.
+
+If `orders` is configured with:
+
+```ts
+routeBy: ["strategyId", "region"];
+```
+
+then this is valid:
+
+```ts
+useLiveQuery("orders", {
+  where: {
+    strategyId: { eq: "strategy-1" },
+    region: { eq: "usa" },
+    status: { eq: "open" },
+  },
+  orderBy: [{ field: "updatedAt", direction: "desc" }],
+  select: ["id", "status", "price", "updatedAt"],
+  limit: 50,
+});
+```
+
+These must fail at compile time and runtime:
+
+```ts
+useLiveQuery("orders", {
+  where: {
+    strategyId: { eq: "strategy-1" },
+  },
+  select: ["id", "price"],
+  limit: 50,
+});
+```
+
+```ts
+useLiveQuery("orders", {
+  where: {
+    strategyId: { in: ["strategy-1", "strategy-2"] },
+    region: { eq: "usa" },
+  },
+  select: ["id", "price"],
+  limit: 50,
+});
+```
+
+Route predicates must be exact equality predicates. Do not allow `in`, `startsWith`, `gte`, `lte`, ranges, missing route fields, or ambiguous access paths for leased feeds.
+
+The runtime must reject invalid leased-feed queries with `InvalidQueryError`. Never fall back to an unfiltered upstream stream.
+
+## Local Query Semantics
+
+The full user query still runs locally in the View Server engine.
+
+For a leased `orders` feed routed by `strategyId` and `region`:
+
+- `strategyId` and `region` select the upstream feed
+- all rows from that upstream feed are retained in memory for that feed
+- extra predicates such as `status`, `instrumentId`, `price`, and text filters are local engine filters
+- order, projection, grouped aggregation, pagination/windowing, counts, and deltas are local engine work
+
+This avoids creating one upstream stream per full UI query and avoids merging multiple upstream streams.
+
+Example:
+
+```txt
+User A query:
+  strategyId = s1, region = usa, status = open
+
+User B query:
+  strategyId = s1, region = usa, price >= 100
+
+Shared leased feed:
+  orders route strategyId=s1 region=usa
+
+Separate local views:
+  A applies status = open
+  B applies price >= 100
+```
+
+## Type Guarantees
+
+The gRPC API must be as type-safe as the Kafka API.
+
+Compile-time guarantees:
+
+- `topic` only accepts keys from `defineViewServerConfig`.
+- `routeBy` only accepts keys from the target topic row schema.
+- leased-feed topics require exact equality filters for every `routeBy` field in `useLiveQuery`.
+- route fields in `request(route)` are inferred from the configured topic row schema.
+- `method` only accepts server-streaming methods from the configured ConnectRPC service.
+- `request` must return the generated ConnectRPC request type for `method`.
+- `acquire` receives a generated ConnectRPC client and request typed from `method`.
+- `acquire` must return an Effect `Stream` whose value type matches the generated ConnectRPC response type for `method`.
+- `map` is required for the first implementation slice, so schema conversion is explicit.
+- `map` receives `value` inferred from the stream value and the return value must exactly match the target topic row schema.
+- extra returned fields in `map` must fail.
+- missing returned fields in `map` must fail.
+- wrong route fields, wrong route operators, invalid topic names, invalid select/order/group/aggregate fields, and invalid mapping output must have type tests.
+
+Do not require users to write `as const` to preserve route, select, or query inference.
+
+## ConnectRPC-Specific Public API
+
+The public gRPC API should be specific to ConnectRPC/generated clients instead of pretending to be a generic stream adapter.
+
+Reasoning:
+
+- generated service/client types should drive inference
+- authentication and header forwarding are gRPC/Connect-specific
+- users should not hand-wire low-level stream protocols for the common path
+- a future generic stream-source seam can exist internally if it earns its keep
+
+Sketch:
+
+```ts
+const grpcClients = {
+  orders: grpc.connectClient({
+    service: OrderService,
+    baseUrl: Config.string("ORDERS_GRPC_URL"),
+  }),
+};
+const grpcFeed = viewServer.grpcFeed<typeof grpcClients>();
+
+export const runtime = viewServer.createRuntime({
+  websocketPort: 8080,
+
+  grpc: {
+    clients: grpcClients,
+
+    feeds: {
+      ordersByStrategyRegion: grpcFeed.leasedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        routeBy: ["strategyId", "region"],
+
+        request: ({ strategyId, region }) => ({
+          strategyId,
+          region,
+        }),
+
+        acquire: ({ client, request, session }) =>
+          Stream.fromAsyncIterable(
+            client.streamOrders(request, {
+              headers: session.forwardedHeaders,
+            }),
+            (cause) => new GrpcUpstreamError({ cause }),
+          ),
+
+        map: ({ value, route, schema }) => ({
+          id: value.orderId,
+          strategyId: route.strategyId,
+          region: route.region,
+          instrumentId: value.instrumentId,
+          status: value.status,
+          price: value.price,
+          updatedAt: value.updatedAt,
+        }),
+      }),
+    },
+  },
+});
+```
+
+Exact package/function names can change during implementation, but the semantics should not.
+
+## Topic Ownership Rule
+
+For this slice, a View Server topic has one ingress owner.
+
+Allowed:
+
+```txt
+orders -> Kafka materialized source
+strategies -> gRPC materialized feed
+ordersByStrategy -> gRPC leased feed
+```
+
+Rejected:
+
+```txt
+orders <- Kafka source
+orders <- gRPC materialized feed
+orders <- gRPC leased feed
+```
+
+The current public config shape can remain for now, but runtime/config validation must reject multiple ingress owners targeting the same View Server topic unless a future explicit multi-source design exists.
+
+A later API cleanup can reshape the config toward:
+
+```ts
+topics: {
+  orders: kafka.topic(...),
+  liveOrders: grpc.leasedTopic(...),
+  strategies: grpc.materializedTopic(...),
+}
+```
+
+Do not block the first gRPC implementation on that larger public API migration.
+
+## Feed Key
+
+Users should not manually return `feedKey` from `acquire`.
+
+The framework should derive it from:
+
+- View Server topic
+- feed definition name
+- routeBy field names
+- canonical route values
+
+Example:
+
+```txt
+topic: orders
+feed: ordersByStrategyRegion
+route: { strategyId: "s1", region: "usa" }
+
+feedKey:
+orders/ordersByStrategyRegion/region=usa/strategyId=s1
+```
+
+Canonicalization rules:
+
+- stable field ordering from configured `routeBy`
+- stable value encoding that preserves strings, numbers, bigint, and BigDecimal-like values
+- no `JSON.stringify` on arbitrary user query objects as the authoritative key
+- selected fields must not affect feed identity
+- local-only filters must not affect feed identity
+- order/group/aggregate/window must not affect feed identity
+
+The feed key is internal but should appear in health and benchmark artifacts.
+
+## Health
+
+Health should expose gRPC separately from engine topic health.
+
+Suggested shape:
+
+```ts
+grpc: {
+  clients: {
+    orders: {
+      status: "connected" | "disconnected" | "degraded" | "starting";
+      baseUrl: string;
+      activeFeeds: number;
+      lastConnectedAt: number | null;
+      lastError: string | null;
+    }
+  }
+
+  feeds: {
+    orders: {
+      materialized: Record<string, GrpcFeedHealth>;
+      leased: Record<string, GrpcFeedHealth>;
+    }
+  }
+}
+```
+
+Feed health should include:
+
+```ts
+type GrpcFeedHealth = {
+  status: "starting" | "ready" | "degraded" | "stopping";
+  lifecycle: "materialized" | "leased";
+  feedName: string;
+  feedKey: string;
+  topic: string;
+  subscriberCount: number;
+  rowCount: number;
+  messagesPerSecond: number;
+  rowsPerSecond: number;
+  decodeFailuresPerSecond: number;
+  mappingFailuresPerSecond: number;
+  publishFailuresPerSecond: number;
+  reconnects: number;
+  lastMessageAt: bigint | null;
+  lastError: string | null;
+};
+```
+
+Health cadence rules from the v2 plan still apply:
+
+- hot paths may update cheap counters
+- do not rebuild full health per message
+- `/health` returns a cached snapshot
+- health updates should be around once per second by default
+
+## Lifecycle And Resource Ownership
+
+All gRPC streams must be scoped Effect resources.
+
+Rules:
+
+- materialized feeds are acquired when runtime starts and released on runtime shutdown
+- leased feeds are acquired on first matching subscription
+- leased feeds increment a lease count per active subscription/view
+- leased feeds release when the last lease closes
+- release closes the upstream stream and drops feed-owned rows/state
+- parent runtime interruption must release all materialized and leased feeds
+- stream defects must mark feed/client health degraded and cleanly release resources
+- user-level subscription close must decrement the lease even if client disconnects mid-stream
+- do not use detached fibers for long-lived stream ownership
+
+Public callback shape:
+
+```ts
+acquire: ({ client, request, route, session }) => Stream.Stream<GrpcValue, GrpcError>;
+release?: ({ client, request, route, session }) => Effect.Effect<void, GrpcError>;
+```
+
+Implementation should wrap user callbacks in named `Effect.fn` spans.
+
+## Session And Auth
+
+Session context must be available to gRPC feeds.
+
+Use cases:
+
+- forward selected browser/user headers to upstream gRPC
+- attach service credentials for materialized feeds
+- apply per-user auth for leased feeds
+- support future session-owned feeds that must not be shared across users
+
+Initial sharing modes:
+
+- `shared`: route-keyed feed shared across all sessions
+- `session`: route-keyed feed scoped to one session/user
+
+Do not implement arbitrary auth policy in the engine. Auth belongs in runtime/server/gRPC Adapter code.
+
+For `shared` leased feeds, be careful with forwarded user headers. If upstream results depend on user identity, the feed must be `session` scoped or include an explicit auth partition in the feed key.
+
+## Runtime Integration
+
+The runtime should compose:
+
+```txt
+runtime package
+  -> runtime-core
+  -> server/WebSocket adapter
+  -> Kafka ingress adapter
+  -> gRPC ingress adapter
+```
+
+The gRPC Adapter publishes rows into runtime-core exactly like Kafka does:
+
+```txt
+upstream gRPC event
+  -> decode/generated type
+  -> map to topic row
+  -> schema validate
+  -> runtime-core publish/publishMany
+  -> engine mutation batch
+  -> active query fanout
+```
+
+Leased feed row storage must be isolated per feed instance, while still using the same engine/query code path. The implementation can model this as an internal feed partition under a topic, but public queries must see only the rows for their resolved feed.
+
+Do not merge multiple leased feed instances to satisfy one user query.
+
+## Testing Strategy
+
+Use Vitest and Effect tests according to repository rules.
+
+Required type tests:
+
+- materialized feed accepts valid topic and mapping output
+- leased feed `routeBy` accepts only topic row fields
+- leased feed `request` receives correctly typed route values
+- `acquire` receives correctly typed ConnectRPC client and request
+- `map` receives correctly typed stream value and route
+- `map` rejects missing fields
+- `map` rejects extra fields
+- `useLiveQuery` rejects leased topic queries missing route fields
+- `useLiveQuery` rejects non-eq route operators
+- `useLiveQuery` accepts route fields plus additional local filters
+- `useLiveQuery` return type remains based on select/aggregates, not route internals
+
+Required runtime/e2e tests:
+
+- materialized feed starts on runtime startup with zero subscribers
+- materialized feed serves snapshot to first subscriber without opening a new upstream stream
+- leased feed does not open before first subscriber
+- first leased subscriber opens one upstream stream
+- second subscriber with same route reuses the same upstream stream
+- subscriber with different route opens a second upstream stream
+- extra local filters produce different views over the same leased feed
+- last subscriber for a feed closes upstream and drops feed rows
+- session-scoped feed does not share across users
+- stream failure marks feed/client degraded and releases resources
+- runtime shutdown releases all gRPC streams
+- invalid leased query returns `InvalidQueryError`
+- health reports active feed keys, subscriber counts, row counts, and failures
+
+Tests should use a fake/in-process generated-compatible gRPC stream where possible first, then add a real ConnectRPC integration test if the tooling cost is acceptable.
+
+## Benchmarks And Gates
+
+Use Vitest benchmark mode only.
+
+Initial benchmark profiles:
+
+- materialized startup seed latency
+- leased first-subscriber acquisition latency
+- leased same-route reuse latency
+- leased last-subscriber cleanup latency
+- leased local-filter snapshot latency over 50k rows
+- leased delta fanout latency for multiple subscribers over one feed
+- many routes with one subscriber each
+- one route with many subscribers
+- mapping/schema validation throughput
+- write tax from feed partitioning
+- health refresh overhead with many active feeds
+
+Add baseline automation only after repeated local runs are stable. Noisy max latency can remain report-only until stable.
+
+## Acceptance Criteria
+
+The gRPC slice is not complete until:
+
+- public API has type tests for all new inference and rejection behavior
+- package seam checks reject unapproved gRPC internals
+- strict Effect LSP passes
+- changed package tests pass with 100% coverage
+- `vp check` passes
+- focused runtime/config/protocol/client/server tests pass
+- pre-existing `pnpm run pre-grpc:gate` still passes or is intentionally extended
+- new gRPC e2e tests prove materialized and leased behavior
+- health shows materialized and leased feed instances without rebuilding per message
+- no long-lived stream uses detached/hand-rolled lifecycle
+- no public API requires consumer `as const`
+- no casts hide topic/route/request/value/map type erasure
+
+## Deferred Decisions
+
+Do not implement these in the first gRPC slice unless needed:
+
+- full public config migration to `topics: { orders: kafka.topic(...), liveOrders: grpc.leasedTopic(...) }`
+- generic non-gRPC stream-source API
+- multi-source topics
+- merging multiple leased feed instances for one user query
+- arbitrary access-path priority selection
+- custom live-event transport replacing Effect RPC WebSocket
+- persistent leased feed cache after last subscriber disconnects
+- WAL/checkpointing for materialized gRPC feeds

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@connectrpc/connect':
+      specifier: 2.1.2
+      version: 2.1.2
     '@effect/atom-react':
       specifier: 4.0.0-beta.70
       version: 4.0.0-beta.70
@@ -104,7 +107,7 @@ importers:
         version: 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/client:
     dependencies:
@@ -141,7 +144,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/column-live-view-engine:
     dependencies:
@@ -166,13 +169,16 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/config:
     dependencies:
       '@bufbuild/protobuf':
         specifier: 2.12.0
         version: 2.12.0
+      '@connectrpc/connect':
+        specifier: 'catalog:'
+        version: 2.1.2(@bufbuild/protobuf@2.12.0)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.70
@@ -191,7 +197,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/effect-utils:
     dependencies:
@@ -213,7 +219,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/in-memory:
     dependencies:
@@ -244,7 +250,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/protocol:
     dependencies:
@@ -269,7 +275,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/react:
     dependencies:
@@ -333,7 +339,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(@voidzero-dev/vite-plus-test@0.1.23)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -385,7 +391,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/runtime-core:
     dependencies:
@@ -419,7 +425,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/server:
     dependencies:
@@ -462,7 +468,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
 packages:
 
@@ -538,6 +544,11 @@ packages:
 
   '@bufbuild/protobuf@2.12.0':
     resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@effect/atom-react@4.0.0-beta.70':
     resolution: {integrity: sha512-G8fZHLBclfD9mZZY+9ltvJMZOMy4cJPa0wGoQcpevcvlpJoXlrugAosQ0ggiQ//HtVUsJ7K1ri9i28WX+d/a1Q==}
@@ -2009,6 +2020,10 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.0': {}
 
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+
   '@effect/atom-react@4.0.0-beta.70(effect@4.0.0-beta.70)(react@19.2.6)(scheduler@0.27.0)':
     dependencies:
       effect: 4.0.0-beta.70
@@ -2045,7 +2060,7 @@ snapshots:
   '@effect/vitest@4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)':
     dependencies:
       effect: 4.0.0-beta.70
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2436,7 +2451,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -2456,7 +2471,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
     transitivePeerDependencies:
       - supports-color
 
@@ -2515,7 +2530,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -2998,7 +3013,7 @@ snapshots:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
       oxfmt: 0.52.0(vite-plus@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
@@ -3059,7 +3074,7 @@ snapshots:
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalog:
   scheduler: 0.27.0
   vitest-browser-react: 2.2.0
   "@platformatic/kafka": 2.2.3
+  "@connectrpc/connect": 2.1.2
 overrides:
   vite: "catalog:"
   vitest: "catalog:"

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1499,6 +1499,7 @@ const approvedPublicViewServerSpecifiers = new Set([
   "@view-server/client/remote",
   "@view-server/column-live-view-engine",
   "@view-server/config",
+  "@view-server/config/grpc",
   "@view-server/config/health",
   "@view-server/config/kafka",
   "@view-server/config/live-protocol",

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -26,6 +26,7 @@ import { createViewServerWebSocketServer } from "@view-server/server";
 import type { ViewServerHealthHttpJson, ViewServerWebSocketServer } from "@view-server/server";
 import * as configPackage from "@view-server/config";
 import * as healthPackage from "@view-server/config/health";
+import * as grpcPackage from "@view-server/config/grpc";
 import * as kafkaPackage from "@view-server/config/kafka";
 import * as liveProtocolPackage from "@view-server/config/live-protocol";
 import * as queryPackage from "@view-server/config/query";
@@ -90,6 +91,7 @@ const approvedPackageExports = [
   "@view-server/client/remote",
   "@view-server/column-live-view-engine",
   "@view-server/config",
+  "@view-server/config/grpc",
   "@view-server/config/health",
   "@view-server/config/kafka",
   "@view-server/config/live-protocol",
@@ -202,6 +204,12 @@ const forbiddenPackageDeepImports = [
   "@view-server/column-live-view-engine/topic-store-state",
   "@view-server/config/src/index",
   "@view-server/config/dist/index.js",
+  "@view-server/config/src/grpc-contract",
+  "@view-server/config/src/source-contract",
+  "@view-server/config/src/source-query-contract",
+  "@view-server/config/dist/grpc-contract.js",
+  "@view-server/config/dist/source-contract.js",
+  "@view-server/config/dist/source-query-contract.js",
   "@view-server/config/dist/topic-contract.js",
   "@view-server/config/src/topic-contract",
   "@view-server/config/query/raw-query-contract",
@@ -242,12 +250,21 @@ for (const specifier of forbiddenPackageDeepImports) {
 
 requireExport("@view-server/config", configPackage, "defineViewServerConfig");
 requireExport("@view-server/config", configPackage, "defineKafkaTopic");
+requireExport("@view-server/config", configPackage, "defineGrpcFeed");
+requireExport("@view-server/config", configPackage, "grpc");
 requireExport("@view-server/config", configPackage, "kafka");
 requireModule("@view-server/config/query", queryPackage);
+requireModule("@view-server/config/grpc", grpcPackage);
 requireModule("@view-server/config/health", healthPackage);
 requireModule("@view-server/config/live-protocol", liveProtocolPackage);
+rejectExport("@view-server/config/query", queryPackage, "grpc");
+rejectExport("@view-server/config/query", queryPackage, "defineGrpcFeed");
+rejectExport("@view-server/config/query", queryPackage, "GrpcTopicSource");
+rejectExport("@view-server/config/query", queryPackage, "GrpcLeasedTopicSource");
 requireExport("@view-server/config/kafka", kafkaPackage, "defineKafkaTopic");
 requireExport("@view-server/config/kafka", kafkaPackage, "kafka");
+requireExport("@view-server/config/grpc", grpcPackage, "grpc");
+requireExport("@view-server/config/grpc", grpcPackage, "defineGrpcFeed");
 requireExport("@view-server/config/runtime", runtimePackage, "runtimeConfig");
 requireExport("@view-server/config/runtime", runtimePackage, "runtimeEnvironmentConfig");
 requireExport("@view-server/client", clientPackage, "stableQueryKey");


### PR DESCRIPTION
## Summary
- add plans/grpc.md after validating alignment with the column live view engine plan
- add gRPC source/feed config contracts for materialized and leased ConnectRPC streams
- enforce leased routeBy exact-eq query requirements in client, React, and runtime-core paths
- reject Kafka mappings into gRPC-owned topics and extend package seam checks

## Review loop
- 3-agent review found and rechecked exact-map/runtime-feed type escape hatches
- fixed by removing the broad public runtime-feed structural type and keeping feeds helper-created/opaque
- final 3-agent review: no findings

## Validation
- pnpm run ready
- focused config tsc/test/vp check during iteration
- package export and internal seam checks pass
- strict Effect diagnostics pass for all packages