### PR TITLE
Add materialized gRPC ingress

### DIFF
--- a/packages/config/src/grpc-contract.ts
+++ b/packages/config/src/grpc-contract.ts
@@ -55,7 +55,7 @@ type ExactGrpcLeasedTopicSourceInput<Input> = Input &
     }
   >;
 
-type GrpcMaterializedTopic<Topics> = Extract<
+export type GrpcMaterializedTopic<Topics> = Extract<
   {
     readonly [Topic in keyof Topics]: Topics[Topic] extends {
       readonly source: GrpcMaterializedTopicSource;
@@ -66,7 +66,7 @@ type GrpcMaterializedTopic<Topics> = Extract<
   string
 >;
 
-type GrpcLeasedTopic<Topics> = Extract<
+export type GrpcLeasedTopic<Topics> = Extract<
   {
     readonly [Topic in keyof Topics]: [TopicRouteByTuple<Topics, Topic>] extends [never]
       ? never
@@ -125,20 +125,26 @@ export type GrpcConnectClientDefinition<Service extends DescService = DescServic
 
 export type GrpcRuntimeClients = Record<string, GrpcConnectClientDefinition>;
 
-export type GrpcClientValue<ClientDefinition> =
-  ClientDefinition extends GrpcConnectClientDefinition<infer Service> ? Client<Service> : never;
+export type GrpcClientDefinitionService<ClientDefinition extends GrpcConnectClientDefinition> =
+  ClientDefinition extends GrpcConnectClientDefinition<infer Service> ? Service : never;
+
+export type GrpcClientValue<ClientDefinition extends GrpcConnectClientDefinition> = Client<
+  GrpcClientDefinitionService<ClientDefinition>
+>;
 
 export type GrpcServerStreamingMethodName<ClientDefinition> =
   ClientDefinition extends GrpcConnectClientDefinition<infer Service>
-    ? {
-        readonly [MethodName in keyof Service["method"]]: Service["method"][MethodName] extends DescMethodServerStreaming<
-          infer _Input extends DescMessage,
-          infer _Output extends DescMessage
-        >
-          ? MethodName
-          : never;
-      }[keyof Service["method"]] &
-        string
+    ? DescService extends Service
+      ? string
+      : {
+          readonly [MethodName in keyof Service["method"]]: Service["method"][MethodName] extends DescMethodServerStreaming<
+            infer _Input extends DescMessage,
+            infer _Output extends DescMessage
+          >
+            ? MethodName
+            : never;
+        }[keyof Service["method"]] &
+          string
     : never;
 
 export type GrpcMethodRequest<
@@ -146,12 +152,14 @@ export type GrpcMethodRequest<
   MethodName extends GrpcServerStreamingMethodName<ClientDefinition>,
 > =
   ClientDefinition extends GrpcConnectClientDefinition<infer Service>
-    ? Service["method"][MethodName] extends DescMethodServerStreaming<
-        infer Input extends DescMessage,
-        infer _Output extends DescMessage
-      >
-      ? MessageInitShape<Input>
-      : never
+    ? DescService extends Service
+      ? unknown
+      : Service["method"][MethodName] extends DescMethodServerStreaming<
+            infer Input extends DescMessage,
+            infer _Output extends DescMessage
+          >
+        ? MessageInitShape<Input>
+        : never
     : never;
 
 export type GrpcMethodValue<
@@ -159,12 +167,14 @@ export type GrpcMethodValue<
   MethodName extends GrpcServerStreamingMethodName<ClientDefinition>,
 > =
   ClientDefinition extends GrpcConnectClientDefinition<infer Service>
-    ? Service["method"][MethodName] extends DescMethodServerStreaming<
-        infer _Input extends DescMessage,
-        infer Output extends DescMessage
-      >
-      ? MessageShape<Output>
-      : never
+    ? DescService extends Service
+      ? unknown
+      : Service["method"][MethodName] extends DescMethodServerStreaming<
+            infer _Input extends DescMessage,
+            infer Output extends DescMessage
+          >
+        ? MessageShape<Output>
+        : never
     : never;
 
 export type GrpcFeedSession = {
@@ -192,7 +202,7 @@ export type GrpcFeedMapInput<Value, Route, SchemaValue extends RowSchema> = {
   readonly schema: SchemaValue;
 };
 
-type GrpcLeasedFeedDefinition<
+export type GrpcLeasedFeedDefinition<
   Topics extends Record<string, { readonly schema: RowSchema }>,
   Clients extends GrpcRuntimeClients,
   Topic extends Extract<keyof Topics, string>,
@@ -248,7 +258,7 @@ type GrpcLeasedFeedDefinition<
   >;
 };
 
-type GrpcMaterializedFeedDefinition<
+export type GrpcMaterializedFeedDefinition<
   Topics extends Record<string, { readonly schema: RowSchema }>,
   Clients extends GrpcRuntimeClients,
   Topic extends GrpcMaterializedTopic<Topics>,
@@ -441,6 +451,40 @@ export type GrpcFeedHelper<
     input: ExactGrpcMaterializedFeedInput<Topics, Clients, Topic, ClientName, MethodName, Mapping>,
   ) => GrpcMaterializedFeedDefinition<Topics, Clients, Topic, ClientName, MethodName, Mapping>;
 };
+
+export type AnyGrpcMaterializedFeedDefinition<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+> = GrpcMaterializedFeedDefinition<
+  Topics,
+  Clients,
+  GrpcMaterializedTopic<Topics>,
+  Extract<keyof Clients, string>,
+  GrpcServerStreamingMethodName<Clients[Extract<keyof Clients, string>]>
+>;
+
+export type AnyGrpcLeasedFeedDefinition<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+> = {
+  readonly [Topic in GrpcLeasedTopic<Topics>]: {
+    readonly [ClientName in Extract<keyof Clients, string>]: GrpcLeasedFeedDefinition<
+      Topics,
+      Clients,
+      Topic,
+      ClientName,
+      GrpcLeasedRouteBy<Topics, Topic>,
+      GrpcServerStreamingMethodName<Clients[ClientName]>
+    >;
+  }[Extract<keyof Clients, string>];
+}[GrpcLeasedTopic<Topics>];
+
+export type GrpcFeedDefinition<
+  Topics extends Record<string, { readonly schema: RowSchema }>,
+  Clients extends GrpcRuntimeClients,
+> =
+  | AnyGrpcMaterializedFeedDefinition<Topics, Clients>
+  | AnyGrpcLeasedFeedDefinition<Topics, Clients>;
 
 export const grpc: GrpcHelper = {
   materialized: () => ({

--- a/packages/config/src/health-contract.ts
+++ b/packages/config/src/health-contract.ts
@@ -4,6 +4,9 @@ export type RuntimeStatus = "ready" | "degraded" | "starting" | "stopping";
 export type TopicHealthStatus = "ready" | "degraded" | "starting";
 export type KafkaRegionStatus = "connected" | "disconnected" | "degraded" | "starting";
 export type KafkaTopicStatus = "ready" | "degraded" | "starting" | "stalled";
+export type GrpcClientStatus = "connected" | "disconnected" | "degraded" | "starting";
+export type GrpcFeedStatus = "starting" | "ready" | "degraded" | "stopping";
+export type GrpcFeedLifecycle = "materialized" | "leased";
 export type ViewServerHealthConnectionStatus = "connecting" | "connected" | "disconnected";
 export type ViewServerHealthStatus =
   | RuntimeStatus
@@ -98,6 +101,44 @@ export type KafkaStartFromHealth =
       readonly fallbackMode: "earliest" | "latest" | "fail";
     };
 
+export type GrpcClientHealth = {
+  readonly status: GrpcClientStatus;
+  readonly baseUrl: string;
+  readonly activeFeeds: number;
+  readonly lastConnectedAt: number | null;
+  readonly lastError: string | null;
+};
+
+export type GrpcFeedHealth<Topic extends string = string> = {
+  readonly status: GrpcFeedStatus;
+  readonly lifecycle: GrpcFeedLifecycle;
+  readonly feedName: string;
+  readonly feedKey: string;
+  readonly topic: Topic;
+  readonly subscriberCount: number;
+  readonly rowCount: number;
+  readonly messagesPerSecond: number;
+  readonly rowsPerSecond: number;
+  readonly decodeFailuresPerSecond: number;
+  readonly mappingFailuresPerSecond: number;
+  readonly publishFailuresPerSecond: number;
+  readonly reconnects: number;
+  readonly lastMessageAt: number | null;
+  readonly lastError: string | null;
+};
+
+export type GrpcTopicFeedsHealth<Topic extends string = string> = {
+  readonly materialized: Record<string, GrpcFeedHealth<Topic>>;
+  readonly leased: Record<string, GrpcFeedHealth<Topic>>;
+};
+
+export type GrpcRuntimeHealth<Topics extends object = Record<string, object>> = {
+  readonly clients: Record<string, GrpcClientHealth>;
+  readonly feeds: {
+    readonly [Topic in Extract<keyof Topics, string>]?: GrpcTopicFeedsHealth<Topic>;
+  } & Record<string, GrpcTopicFeedsHealth<string>>;
+};
+
 export type TransportHealth = {
   readonly activeClients: number;
   readonly activeStreams: number;
@@ -126,6 +167,7 @@ export type ViewServerHealth<Topics extends object = Record<string, object>> = {
     readonly regions: Record<string, KafkaRegionHealth>;
     readonly topics: Record<string, KafkaTopicHealth>;
   };
+  readonly grpc?: GrpcRuntimeHealth<Topics>;
   readonly transport: TransportHealth;
 };
 
@@ -236,6 +278,42 @@ const kafkaTopicStatusForViewTopic = (
   return status;
 };
 
+const grpcFeedStatusToTopicStatus = (status: GrpcFeedStatus): TopicHealthStatus => {
+  if (status === "ready") {
+    return "ready";
+  }
+  if (status === "starting") {
+    return "starting";
+  }
+  return "degraded";
+};
+
+const grpcTopicStatusForViewTopic = <Topics extends object>(
+  health: Pick<ViewServerHealth<Topics>, "grpc">,
+  viewServerTopic: string,
+): TopicHealthStatus | undefined => {
+  const feeds = health.grpc?.feeds[viewServerTopic];
+  if (feeds === undefined) {
+    return undefined;
+  }
+  let status: TopicHealthStatus = "ready";
+  for (const feed of Object.values(feeds.materialized)) {
+    status = mergeTopicHealthStatus(status, grpcFeedStatusToTopicStatus(feed.status));
+  }
+  for (const feed of Object.values(feeds.leased)) {
+    status = mergeTopicHealthStatus(status, grpcFeedStatusToTopicStatus(feed.status));
+  }
+  return status;
+};
+
+const grpcTopicIsUnhealthy = <Topics extends object>(
+  health: Pick<ViewServerHealth<Topics>, "grpc">,
+  viewServerTopic: string,
+): boolean => {
+  const status = grpcTopicStatusForViewTopic(health, viewServerTopic);
+  return status !== undefined && status !== "ready";
+};
+
 const kafkaTopicIsUnhealthy = (
   health: Pick<ViewServerHealth, "kafka">,
   viewServerTopic: string,
@@ -330,7 +408,10 @@ export const viewServerHealthSummaryFromHealth = <Topics extends object>(
   const topicHealthByName: Readonly<Record<string, TopicRuntimeHealth>> = health.engine.topics;
   const unhealthyTopics = Object.entries(topicHealthByName)
     .filter(
-      ([topicName, topic]) => topicIsUnhealthy(topic) || kafkaTopicIsUnhealthy(health, topicName),
+      ([topicName, topic]) =>
+        topicIsUnhealthy(topic) ||
+        kafkaTopicIsUnhealthy(health, topicName) ||
+        grpcTopicIsUnhealthy(health, topicName),
     )
     .map(([topic]) => topic);
   return {
@@ -359,8 +440,8 @@ export const viewServerHealthTopicRowsFromHealth = <Topics extends object>(
   const rows: Array<ViewServerHealthTopicRow<string>> = [];
   for (const [id, topic] of Object.entries(topicHealthByName)) {
     const effectiveStatus = mergeTopicHealthStatus(
-      topic.status,
-      kafkaTopicStatusForViewTopic(health, id),
+      mergeTopicHealthStatus(topic.status, kafkaTopicStatusForViewTopic(health, id)),
+      grpcTopicStatusForViewTopic(health, id),
     );
     const status: TopicHealthStatus | "stopping" =
       health.status === "stopping" ? "stopping" : effectiveStatus;

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -31,6 +31,7 @@ import {
   viewServerHealthTopicRowsFromHealth,
   validateLiveQuerySourceRoute,
   type GrpcClientValue,
+  type GrpcTopicFeedsHealth,
   type KafkaCodec,
   type KafkaMappingInput,
   type KafkaMessageMetadata,
@@ -2444,6 +2445,67 @@ describe("defineViewServerConfig", () => {
           price: 10,
           updatedAt: 1,
         }),
+      map: ({ value }) => ({
+        id: value.customerId,
+        customerId: value.customerId,
+        status: value.status,
+        price: value.price,
+        region: "usa",
+        updatedAt: value.updatedAt,
+      }),
+    });
+
+    feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => ({ orderId: `${region}:${status}` }),
+      // @ts-expect-error leased feed acquire callbacks must accept every configured route value.
+      acquire: (input: {
+        readonly route: {
+          readonly region: "usa";
+          readonly status: "open";
+        };
+      }) =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: input.route.region,
+          status: input.route.status,
+          price: 10,
+          updatedAt: 1,
+        }),
+      map: ({ value }) => ({
+        id: value.customerId,
+        customerId: value.customerId,
+        status: value.status,
+        price: value.price,
+        region: "usa",
+        updatedAt: value.updatedAt,
+      }),
+    });
+
+    feed.leasedFeed({
+      topic: "orders",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region", "status"],
+      request: ({ region, status }) => ({ orderId: `${region}:${status}` }),
+      acquire: () =>
+        Stream.make({
+          $typeName: "viewserver.test.OrderValue",
+          customerId: "customer-1",
+          status: "open",
+          price: 10,
+          updatedAt: 1,
+        }),
+      // @ts-expect-error leased feed release callbacks must accept every configured route value.
+      release: (input: {
+        readonly route: {
+          readonly region: "usa";
+          readonly status: "open";
+        };
+      }) => Effect.logDebug(input.route.region),
       map: ({ value }) => ({
         id: value.customerId,
         customerId: value.customerId,
@@ -5512,6 +5574,98 @@ describe("public type surface", () => {
       engine: health.engine,
       transport: health.transport,
     };
+    const grpcOnlyHealth: ViewServerHealth<typeof viewServer.topics> = {
+      status: "degraded",
+      version: 9,
+      uptimeMs: 300,
+      engine: {
+        topics: {
+          orders: runtimeTopicHealth("ready", 10),
+          trades: runtimeTopicHealth("ready", 20),
+          positions: runtimeTopicHealth("ready", 30),
+        },
+      },
+      grpc: {
+        clients: {
+          ordersClient: {
+            status: "connected",
+            baseUrl: "http://localhost:8080",
+            activeFeeds: 3,
+            lastConnectedAt: null,
+            lastError: null,
+          },
+        },
+        feeds: {
+          orders: {
+            materialized: {
+              ordersFeed: {
+                status: "ready",
+                lifecycle: "materialized",
+                feedName: "ordersFeed",
+                feedKey: "ordersFeed",
+                topic: "orders",
+                subscriberCount: 0,
+                rowCount: 10,
+                messagesPerSecond: 1,
+                rowsPerSecond: 1,
+                decodeFailuresPerSecond: 0,
+                mappingFailuresPerSecond: 0,
+                publishFailuresPerSecond: 0,
+                reconnects: 0,
+                lastMessageAt: null,
+                lastError: null,
+              },
+            },
+            leased: {},
+          },
+          trades: {
+            materialized: {},
+            leased: {
+              tradesFeed: {
+                status: "starting",
+                lifecycle: "leased",
+                feedName: "tradesFeed",
+                feedKey: "tradesFeed:region=usa",
+                topic: "trades",
+                subscriberCount: 1,
+                rowCount: 0,
+                messagesPerSecond: 0,
+                rowsPerSecond: 0,
+                decodeFailuresPerSecond: 0,
+                mappingFailuresPerSecond: 0,
+                publishFailuresPerSecond: 0,
+                reconnects: 0,
+                lastMessageAt: null,
+                lastError: null,
+              },
+            },
+          },
+          positions: {
+            materialized: {
+              positionsFeed: {
+                status: "degraded",
+                lifecycle: "materialized",
+                feedName: "positionsFeed",
+                feedKey: "positionsFeed",
+                topic: "positions",
+                subscriberCount: 0,
+                rowCount: 0,
+                messagesPerSecond: 0,
+                rowsPerSecond: 0,
+                decodeFailuresPerSecond: 0,
+                mappingFailuresPerSecond: 1,
+                publishFailuresPerSecond: 0,
+                reconnects: 1,
+                lastMessageAt: null,
+                lastError: "mapping failed",
+              },
+            },
+            leased: {},
+          },
+        },
+      },
+      transport: health.transport,
+    };
     const kafkaStartingHealth: ViewServerHealth<typeof viewServer.topics> = {
       status: "starting",
       version: 8,
@@ -5767,6 +5921,21 @@ describe("public type surface", () => {
       updatedAtNanos: 123n,
       maxKafkaLag: null,
     });
+    expect(viewServerHealthSummaryFromHealth(grpcOnlyHealth, 123n)).toStrictEqual({
+      status: "degraded",
+      runtimeStatus: "degraded",
+      connectionStatus: "connected",
+      unhealthyTopics: ["trades", "positions"],
+      updatedAtNanos: 123n,
+      maxKafkaLag: null,
+    });
+    expect(
+      viewServerHealthTopicRowsFromHealth(grpcOnlyHealth, 123n).map((row) => [row.id, row.status]),
+    ).toStrictEqual([
+      ["orders", "ready"],
+      ["trades", "starting"],
+      ["positions", "degraded"],
+    ]);
     expect(stoppingRows.map((row) => row.status)).toStrictEqual([
       "stopping",
       "stopping",
@@ -5793,6 +5962,15 @@ describe("public type surface", () => {
       ViewServerHealthTopicRow<"orders" | "trades" | "positions"> | undefined
     >();
     expectTypeOf(rows[0]?.kafkaLag).toEqualTypeOf<bigint | null | undefined>();
+    expectTypeOf(grpcOnlyHealth.grpc?.feeds.orders).toEqualTypeOf<
+      GrpcTopicFeedsHealth<"orders"> | undefined
+    >();
+    expectTypeOf(grpcOnlyHealth.grpc?.feeds.trades).toEqualTypeOf<
+      GrpcTopicFeedsHealth<"trades"> | undefined
+    >();
+    expectTypeOf(grpcOnlyHealth.grpc?.feeds.positions).toEqualTypeOf<
+      GrpcTopicFeedsHealth<"positions"> | undefined
+    >();
     expectTypeOf<ViewServerHealthDetails<"orders">["status"]>().toEqualTypeOf<
       "ready" | "degraded" | "starting" | "stopping" | "connecting" | "disconnected"
     >();

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -69,6 +69,13 @@ export type {
   Where,
 } from "./topic-contract";
 export type {
+  GrpcClientHealth,
+  GrpcClientStatus,
+  GrpcFeedHealth,
+  GrpcFeedLifecycle,
+  GrpcFeedStatus,
+  GrpcRuntimeHealth,
+  GrpcTopicFeedsHealth,
   KafkaRegionHealth,
   KafkaRegionStatus,
   KafkaStartFromHealth,
@@ -127,15 +134,23 @@ export {
 } from "./kafka-contract";
 export { grpc } from "./grpc-contract";
 export type {
+  AnyGrpcLeasedFeedDefinition,
+  AnyGrpcMaterializedFeedDefinition,
   GrpcConnectClientDefinition,
+  GrpcClientDefinitionService,
   GrpcClientValue,
   GrpcFeedAcquireInput,
+  GrpcFeedDefinition,
   GrpcFeedHelper,
   GrpcFeedMapInput,
   GrpcFeedReleaseInput,
   GrpcFeedSession,
   GrpcHelper,
+  GrpcLeasedTopic,
+  GrpcLeasedFeedDefinition,
   GrpcLeasedTopicSource,
+  GrpcMaterializedFeedDefinition,
+  GrpcMaterializedTopic,
   GrpcMaterializedTopicSource,
   GrpcMethodRequest,
   GrpcMethodValue,

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -137,6 +137,24 @@ const wireHealth = {
   },
 } as const;
 
+const grpcFeedHealth = {
+  status: "ready",
+  lifecycle: "materialized",
+  feedName: "ordersFeed",
+  feedKey: "orders/ordersFeed/materialized",
+  topic: "orders",
+  subscriberCount: 0,
+  rowCount: 10,
+  messagesPerSecond: 2,
+  rowsPerSecond: 2,
+  decodeFailuresPerSecond: 0,
+  mappingFailuresPerSecond: 0,
+  publishFailuresPerSecond: 0,
+  reconnects: 0,
+  lastMessageAt: 123,
+  lastError: null,
+} as const;
+
 describe("@view-server/protocol", () => {
   it.effect("decodes the public wire schemas", () =>
     Effect.gen(function* () {
@@ -2734,6 +2752,188 @@ describe("@view-server/protocol", () => {
       );
       expect(unknownKafkaViewServerTopic.message).toBe(
         "Health payload references unknown topic: missing",
+      );
+
+      const validGrpcHealth = yield* viewServerDecodeHealth(viewServer, {
+        ...wireHealth,
+        grpc: {
+          clients: {
+            orders: {
+              status: "connected",
+              baseUrl: "https://orders.example.test",
+              activeFeeds: 1,
+              lastConnectedAt: 100,
+              lastError: null,
+            },
+          },
+          feeds: {
+            orders: {
+              materialized: {
+                ordersFeed: grpcFeedHealth,
+              },
+              leased: {},
+            },
+          },
+        },
+      });
+      expect(validGrpcHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]).toStrictEqual(
+        grpcFeedHealth,
+      );
+
+      const leasedFeedInMaterializedBucket = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          grpc: {
+            clients: {},
+            feeds: {
+              orders: {
+                materialized: {
+                  ordersFeed: { ...grpcFeedHealth, lifecycle: "leased" },
+                },
+                leased: {},
+              },
+            },
+          },
+        }),
+      );
+      expect(leasedFeedInMaterializedBucket.message).toBe(
+        "Health payload materialized feed has leased lifecycle: ordersFeed",
+      );
+
+      const unknownGrpcFeedGroupTopic = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          grpc: {
+            clients: {},
+            feeds: {
+              missing: {
+                materialized: {
+                  ordersFeed: { ...grpcFeedHealth, topic: "missing" },
+                },
+                leased: {},
+              },
+            },
+          },
+        }),
+      );
+      expect(unknownGrpcFeedGroupTopic.message).toBe(
+        "Health payload references unknown topic: missing",
+      );
+
+      const unknownGrpcFeedTopic = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          grpc: {
+            clients: {},
+            feeds: {
+              orders: {
+                materialized: {
+                  ordersFeed: { ...grpcFeedHealth, topic: "missing" },
+                },
+                leased: {},
+              },
+            },
+          },
+        }),
+      );
+      expect(unknownGrpcFeedTopic.message).toBe(
+        "Health payload feed topic does not match feed group: missing != orders",
+      );
+
+      const mismatchedGrpcFeedTopic = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          grpc: {
+            clients: {},
+            feeds: {
+              orders: {
+                materialized: {
+                  ordersFeed: { ...grpcFeedHealth, topic: "badjson" },
+                },
+                leased: {},
+              },
+            },
+          },
+        }),
+      );
+      expect(mismatchedGrpcFeedTopic.message).toBe(
+        "Health payload feed topic does not match feed group: badjson != orders",
+      );
+
+      const validLeasedGrpcHealth = yield* viewServerDecodeHealth(viewServer, {
+        ...wireHealth,
+        grpc: {
+          clients: {},
+          feeds: {
+            orders: {
+              materialized: {},
+              leased: {
+                ordersLease: {
+                  ...grpcFeedHealth,
+                  lifecycle: "leased",
+                  feedName: "ordersLease",
+                  feedKey: "orders/ordersLease/region=usa",
+                  subscriberCount: 2,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(validLeasedGrpcHealth.grpc?.feeds["orders"]?.leased["ordersLease"]).toStrictEqual({
+        ...grpcFeedHealth,
+        lifecycle: "leased",
+        feedName: "ordersLease",
+        feedKey: "orders/ordersLease/region=usa",
+        subscriberCount: 2,
+      });
+
+      const materializedFeedInLeasedBucket = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          grpc: {
+            clients: {},
+            feeds: {
+              orders: {
+                materialized: {},
+                leased: {
+                  ordersLease: {
+                    ...grpcFeedHealth,
+                    feedName: "ordersLease",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+      expect(materializedFeedInLeasedBucket.message).toBe(
+        "Health payload leased feed has materialized lifecycle: ordersLease",
+      );
+
+      const mismatchedLeasedGrpcFeedTopic = yield* Effect.flip(
+        viewServerDecodeHealth(viewServer, {
+          ...wireHealth,
+          grpc: {
+            clients: {},
+            feeds: {
+              orders: {
+                materialized: {},
+                leased: {
+                  ordersLease: {
+                    ...grpcFeedHealth,
+                    lifecycle: "leased",
+                    feedName: "ordersLease",
+                    topic: "badjson",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+      expect(mismatchedLeasedGrpcFeedTopic.message).toBe(
+        "Health payload feed topic does not match feed group: badjson != orders",
       );
 
       const wrongSummaryEncodeTopic = yield* Effect.flip(

--- a/packages/protocol/src/protocol-health-codec.ts
+++ b/packages/protocol/src/protocol-health-codec.ts
@@ -1,4 +1,5 @@
 import type {
+  GrpcFeedHealth,
   TopicDefinitions,
   ViewServerConfig,
   ViewServerHealth,
@@ -37,6 +38,29 @@ function typedHealth(health: ViewServerWireHealth): ViewServerWireHealth {
   return health;
 }
 
+const validateGrpcFeedHealth = Effect.fn("ViewServerProtocol.health.grpcFeed.validate")(function* (
+  topicName: string,
+  expectedLifecycle: GrpcFeedHealth["lifecycle"],
+  feed: GrpcFeedHealth,
+) {
+  if (feed.topic !== topicName) {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        topicName,
+        `Health payload feed topic does not match feed group: ${feed.topic} != ${topicName}`,
+      ),
+    );
+  }
+  if (feed.lifecycle !== expectedLifecycle) {
+    return yield* Effect.fail(
+      invalidHealthRow(
+        topicName,
+        `Health payload ${expectedLifecycle} feed has ${feed.lifecycle} lifecycle: ${feed.feedName}`,
+      ),
+    );
+  }
+});
+
 export const viewServerDecodeHealth = Effect.fn("ViewServerProtocol.health.decode")(function* <
   const Topics extends TopicDefinitions,
 >(config: ViewServerConfig<Topics>, health: ViewServerWireHealth) {
@@ -70,6 +94,19 @@ export const viewServerDecodeHealth = Effect.fn("ViewServerProtocol.health.decod
           `Health payload references unknown topic: ${kafkaTopic.viewServerTopic}`,
         ),
       );
+    }
+  }
+  for (const [topicName, feeds] of Object.entries(normalizedHealth.grpc?.feeds ?? {})) {
+    if (!hasConfiguredTopic(config, topicName)) {
+      return yield* Effect.fail(
+        invalidHealthRow(topicName, `Health payload references unknown topic: ${topicName}`),
+      );
+    }
+    for (const feed of Object.values(feeds.materialized)) {
+      yield* validateGrpcFeedHealth(topicName, "materialized", feed);
+    }
+    for (const feed of Object.values(feeds.leased)) {
+      yield* validateGrpcFeedHealth(topicName, "leased", feed);
     }
   }
   return typedHealth<Topics>(normalizedHealth);

--- a/packages/protocol/src/protocol-health-schema.ts
+++ b/packages/protocol/src/protocol-health-schema.ts
@@ -1,4 +1,7 @@
 import type {
+  GrpcClientHealth,
+  GrpcFeedHealth,
+  GrpcRuntimeHealth,
   KafkaStartFromHealth,
   TopicRuntimeHealth,
   TransportHealth,
@@ -67,6 +70,43 @@ const KafkaStartFromHealthSchema: Schema.Codec<KafkaStartFromHealth> = Schema.Un
   }),
 ]);
 
+const GrpcClientHealthSchema: Schema.Codec<GrpcClientHealth> = Schema.Struct({
+  status: Schema.Literals(["connected", "disconnected", "degraded", "starting"]),
+  baseUrl: Schema.String,
+  activeFeeds: Schema.Number,
+  lastConnectedAt: NumberOrNull,
+  lastError: StringOrNull,
+});
+
+const GrpcFeedHealthSchema: Schema.Codec<GrpcFeedHealth> = Schema.Struct({
+  status: Schema.Literals(["starting", "ready", "degraded", "stopping"]),
+  lifecycle: Schema.Literals(["materialized", "leased"]),
+  feedName: Schema.String,
+  feedKey: Schema.String,
+  topic: Schema.String,
+  subscriberCount: Schema.Number,
+  rowCount: Schema.Number,
+  messagesPerSecond: Schema.Number,
+  rowsPerSecond: Schema.Number,
+  decodeFailuresPerSecond: Schema.Number,
+  mappingFailuresPerSecond: Schema.Number,
+  publishFailuresPerSecond: Schema.Number,
+  reconnects: Schema.Number,
+  lastMessageAt: NumberOrNull,
+  lastError: StringOrNull,
+});
+
+const GrpcRuntimeHealthSchema: Schema.Codec<GrpcRuntimeHealth> = Schema.Struct({
+  clients: Schema.Record(Schema.String, GrpcClientHealthSchema),
+  feeds: Schema.Record(
+    Schema.String,
+    Schema.Struct({
+      materialized: Schema.Record(Schema.String, GrpcFeedHealthSchema),
+      leased: Schema.Record(Schema.String, GrpcFeedHealthSchema),
+    }),
+  ),
+});
+
 export const ViewServerHealthSchema = Schema.Struct({
   status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
   version: Schema.Number,
@@ -117,6 +157,7 @@ export const ViewServerHealthSchema = Schema.Struct({
       ),
     }),
   ),
+  grpc: Schema.optionalKey(GrpcRuntimeHealthSchema),
   transport: TransportHealthSchema,
 });
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,12 +13,15 @@
     }
   },
   "scripts": {
+    "bench:grpc-materialized": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && output=${VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON:-.artifacts/grpc-materialized-${VIEW_SERVER_RUNTIME_BENCH_GRPC_SEED_ROWS:-1000}seed-${VIEW_SERVER_RUNTIME_BENCH_GRPC_BATCH_SIZE:-256}batch.json} && mkdir -p .artifacts && VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON=$output vp test bench src/grpc-materialized.bench.ts --run --testTimeout 0 --outputJson $output",
     "bench:kafka-ingest": "node ../../scripts/run-runtime-kafka-ingest-bench.mjs",
     "bench:websocket-firehose": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && output=${VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON:-.artifacts/websocket-firehose-${VIEW_SERVER_RUNTIME_BENCH_WEBSOCKET_CASE:-same-window}-${VIEW_SERVER_RUNTIME_BENCH_WEBSOCKET_ROWS:-1000}rows-${VIEW_SERVER_RUNTIME_BENCH_WEBSOCKET_SUBSCRIBERS:-10}subs.json} && mkdir -p .artifacts && VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON=$output vp test bench src/websocket-firehose.bench.ts --run --testTimeout 0 --outputJson $output",
     "build": "vp run -t @view-server/effect-utils#build && vp run -t @view-server/runtime-core#build && vp run -t @view-server/server#build && vp pack",
     "test": "node ../../scripts/test-runtime.mjs"
   },
   "dependencies": {
+    "@connectrpc/connect": "catalog:",
+    "@connectrpc/connect-node": "catalog:",
     "@platformatic/kafka": "catalog:",
     "@view-server/client": "workspace:*",
     "@view-server/config": "workspace:*",

--- a/packages/runtime/src/grpc-health.ts
+++ b/packages/runtime/src/grpc-health.ts
@@ -1,0 +1,418 @@
+import type {
+  GrpcClientHealth,
+  GrpcFeedHealth,
+  GrpcTopicFeedsHealth,
+  ViewServerHealth,
+} from "@view-server/config";
+import { Effect } from "effect";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+type GrpcHealthSnapshot<Topics extends ViewServerRuntimeTopicDefinitions> = NonNullable<
+  ViewServerHealth<Topics>["grpc"]
+>;
+
+type GrpcClientLedger = {
+  status: GrpcClientHealth["status"];
+  baseUrl: string;
+  activeFeeds: number;
+  lastConnectedAt: number | null;
+  lastError: string | null;
+};
+
+type GrpcFeedLedger<Topic extends string> = {
+  status: GrpcFeedHealth["status"];
+  lifecycle: GrpcFeedHealth["lifecycle"];
+  feedName: string;
+  feedKey: string;
+  topic: Topic;
+  clientName: string;
+  subscriberCount: number;
+  rowCount: number;
+  messagesPerSecond: number;
+  rowsPerSecond: number;
+  decodeFailuresPerSecond: number;
+  mappingFailuresPerSecond: number;
+  publishFailuresPerSecond: number;
+  reconnects: number;
+  lastMessageAt: number | null;
+  lastError: string | null;
+  rateBuckets: Array<GrpcRateBucket | undefined>;
+};
+
+type GrpcRateBucket = {
+  occurredAt: number;
+  messages: number;
+  rows: number;
+  decodeFailed: number;
+  mappingFailed: number;
+  publishFailed: number;
+};
+
+const grpcRateWindowMillis = 1_000;
+const maxGrpcRateBuckets = grpcRateWindowMillis + 1;
+
+export type ViewServerGrpcHealthLedger<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly healthOverlay: (
+    health: ViewServerHealth<Topics>,
+    nowMillis: number,
+  ) => ViewServerHealth<Topics>;
+  readonly clientConnected: (clientName: string, nowMillis: number) => Effect.Effect<void>;
+  readonly clientDegraded: (clientName: string, message: string) => Effect.Effect<void>;
+  readonly feedReady: (feedName: string) => Effect.Effect<void>;
+  readonly feedStopping: (feedName: string) => Effect.Effect<void>;
+  readonly feedDegraded: (feedName: string, message: string) => Effect.Effect<void>;
+  readonly rowsPublished: (
+    feedName: string,
+    input: {
+      readonly messages: number;
+      readonly rows: number;
+      readonly nowMillis: number;
+    },
+  ) => Effect.Effect<void>;
+  readonly mappingFailed: (
+    feedName: string,
+    input: {
+      readonly message: string;
+      readonly nowMillis: number;
+    },
+  ) => Effect.Effect<void>;
+  readonly publishFailed: (
+    feedName: string,
+    input: {
+      readonly message: string;
+      readonly nowMillis: number;
+    },
+  ) => Effect.Effect<void>;
+};
+
+const initialRateBuckets = (): Array<GrpcRateBucket | undefined> =>
+  Array.from({ length: maxGrpcRateBuckets }, () => undefined);
+
+const copyClientHealth = (client: GrpcClientLedger): GrpcClientHealth => ({
+  status: client.status,
+  baseUrl: client.baseUrl,
+  activeFeeds: client.activeFeeds,
+  lastConnectedAt: client.lastConnectedAt,
+  lastError: client.lastError,
+});
+
+const copyFeedHealth = <Topic extends string>(
+  feed: GrpcFeedLedger<Topic>,
+): GrpcFeedHealth<Topic> => ({
+  status: feed.status,
+  lifecycle: feed.lifecycle,
+  feedName: feed.feedName,
+  feedKey: feed.feedKey,
+  topic: feed.topic,
+  subscriberCount: feed.subscriberCount,
+  rowCount: feed.rowCount,
+  messagesPerSecond: feed.messagesPerSecond,
+  rowsPerSecond: feed.rowsPerSecond,
+  decodeFailuresPerSecond: feed.decodeFailuresPerSecond,
+  mappingFailuresPerSecond: feed.mappingFailuresPerSecond,
+  publishFailuresPerSecond: feed.publishFailuresPerSecond,
+  reconnects: feed.reconnects,
+  lastMessageAt: feed.lastMessageAt,
+  lastError: feed.lastError,
+});
+
+const incrementWindow = (
+  feed: GrpcFeedLedger<string>,
+  nowMillis: number,
+  counters: {
+    readonly messages: number;
+    readonly rows: number;
+    readonly decodeFailed: number;
+    readonly mappingFailed: number;
+    readonly publishFailed: number;
+  },
+) => {
+  const occurredAt = Math.trunc(nowMillis);
+  const bucketIndex = Math.abs(occurredAt % maxGrpcRateBuckets);
+  const existingBucket = feed.rateBuckets[bucketIndex];
+  if (existingBucket !== undefined && existingBucket.occurredAt === occurredAt) {
+    existingBucket.messages += counters.messages;
+    existingBucket.rows += counters.rows;
+    existingBucket.decodeFailed += counters.decodeFailed;
+    existingBucket.mappingFailed += counters.mappingFailed;
+    existingBucket.publishFailed += counters.publishFailed;
+    return;
+  }
+  feed.rateBuckets[bucketIndex] = {
+    occurredAt,
+    messages: counters.messages,
+    rows: counters.rows,
+    decodeFailed: counters.decodeFailed,
+    mappingFailed: counters.mappingFailed,
+    publishFailed: counters.publishFailed,
+  };
+};
+
+const resetIdleWindow = (feed: GrpcFeedLedger<string>, nowMillis: number) => {
+  const occurredBefore = Math.trunc(nowMillis) - grpcRateWindowMillis;
+  const occurredAfter = Math.trunc(nowMillis);
+  let messagesPerSecond = 0;
+  let rowsPerSecond = 0;
+  let decodeFailuresPerSecond = 0;
+  let mappingFailuresPerSecond = 0;
+  let publishFailuresPerSecond = 0;
+  for (const bucket of feed.rateBuckets) {
+    if (
+      bucket === undefined ||
+      bucket.occurredAt < occurredBefore ||
+      bucket.occurredAt > occurredAfter
+    ) {
+      continue;
+    }
+    messagesPerSecond += bucket.messages;
+    rowsPerSecond += bucket.rows;
+    decodeFailuresPerSecond += bucket.decodeFailed;
+    mappingFailuresPerSecond += bucket.mappingFailed;
+    publishFailuresPerSecond += bucket.publishFailed;
+  }
+  feed.messagesPerSecond = messagesPerSecond;
+  feed.rowsPerSecond = rowsPerSecond;
+  feed.decodeFailuresPerSecond = decodeFailuresPerSecond;
+  feed.mappingFailuresPerSecond = mappingFailuresPerSecond;
+  feed.publishFailuresPerSecond = publishFailuresPerSecond;
+};
+
+const grpcRuntimeStatus = <Topics extends ViewServerRuntimeTopicDefinitions>(
+  snapshot: GrpcHealthSnapshot<Topics>,
+): ViewServerHealth<Topics>["status"] => {
+  const clientStatuses = Object.values(snapshot.clients).map((client) => client.status);
+  const feedStatuses = Object.values(snapshot.feeds).flatMap((feeds) => [
+    ...Object.values(feeds.materialized).map((feed) => feed.status),
+    ...Object.values(feeds.leased).map((feed) => feed.status),
+  ]);
+  if (
+    clientStatuses.some((status) => status === "disconnected" || status === "degraded") ||
+    feedStatuses.some((status) => status === "degraded")
+  ) {
+    return "degraded";
+  }
+  if (
+    clientStatuses.some((status) => status === "starting") ||
+    feedStatuses.some((status) => status === "starting" || status === "stopping")
+  ) {
+    return "starting";
+  }
+  return "ready";
+};
+
+const mergeRuntimeStatus = <Topics extends ViewServerRuntimeTopicDefinitions>(
+  health: ViewServerHealth<Topics>,
+  grpc: GrpcHealthSnapshot<Topics>,
+): ViewServerHealth<Topics>["status"] => {
+  if (health.status === "stopping" || health.status === "degraded") {
+    return health.status;
+  }
+  const grpcStatus = grpcRuntimeStatus(grpc);
+  if (grpcStatus === "degraded") {
+    return "degraded";
+  }
+  if (health.status === "starting" || grpcStatus === "starting") {
+    return "starting";
+  }
+  return "ready";
+};
+
+const createTopicFeedsHealth = <Topic extends string>(): GrpcTopicFeedsHealth<Topic> => ({
+  materialized: Object.create(null),
+  leased: Object.create(null),
+});
+
+export const makeViewServerGrpcHealthLedger = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(input: {
+  readonly clients: Readonly<Record<string, string>>;
+  readonly feeds: Readonly<
+    Record<
+      string,
+      {
+        readonly lifecycle: GrpcFeedHealth["lifecycle"];
+        readonly topic: Extract<keyof Topics, string>;
+        readonly client: string;
+      }
+    >
+  >;
+}): ViewServerGrpcHealthLedger<Topics> => {
+  const clients = new Map<string, GrpcClientLedger>();
+  const feeds = new Map<string, GrpcFeedLedger<Extract<keyof Topics, string>>>();
+
+  for (const [clientName, client] of Object.entries(input.clients)) {
+    clients.set(clientName, {
+      status: "starting",
+      baseUrl: client,
+      activeFeeds: 0,
+      lastConnectedAt: null,
+      lastError: null,
+    });
+  }
+
+  for (const [feedName, feed] of Object.entries(input.feeds)) {
+    feeds.set(feedName, {
+      status: "starting",
+      lifecycle: feed.lifecycle,
+      feedName,
+      feedKey: `${feed.topic}/${feedName}/${feed.lifecycle}`,
+      topic: feed.topic,
+      clientName: feed.client,
+      subscriberCount: 0,
+      rowCount: 0,
+      messagesPerSecond: 0,
+      rowsPerSecond: 0,
+      decodeFailuresPerSecond: 0,
+      mappingFailuresPerSecond: 0,
+      publishFailuresPerSecond: 0,
+      reconnects: 0,
+      lastMessageAt: null,
+      lastError: null,
+      rateBuckets: initialRateBuckets(),
+    });
+  }
+
+  const refreshClientActiveFeeds = () => {
+    for (const client of clients.values()) {
+      client.activeFeeds = 0;
+    }
+    for (const feed of feeds.values()) {
+      const client = clients.get(feed.clientName);
+      if (client !== undefined && feed.status === "ready") {
+        client.activeFeeds += 1;
+      }
+    }
+  };
+
+  const syncFeedRowCounts = (health: ViewServerHealth<Topics>) => {
+    for (const feed of feeds.values()) {
+      const topicHealth = health.engine.topics[feed.topic];
+      feed.rowCount = topicHealth.rowCount;
+    }
+  };
+
+  const snapshot = (
+    health: ViewServerHealth<Topics>,
+    nowMillis: number,
+  ): GrpcHealthSnapshot<Topics> => {
+    syncFeedRowCounts(health);
+    refreshClientActiveFeeds();
+    const clientHealth: Record<string, GrpcClientHealth> = Object.create(null);
+    const feedHealth: GrpcHealthSnapshot<Topics>["feeds"] = Object.create(null);
+    for (const [clientName, client] of clients) {
+      clientHealth[clientName] = copyClientHealth(client);
+    }
+    for (const [feedName, feed] of feeds) {
+      resetIdleWindow(feed, nowMillis);
+      const topicFeeds = feedHealth[feed.topic] ?? createTopicFeedsHealth();
+      feedHealth[feed.topic] = topicFeeds;
+      if (feed.lifecycle === "materialized") {
+        topicFeeds.materialized[feedName] = copyFeedHealth(feed);
+        continue;
+      }
+      topicFeeds.leased[feedName] = copyFeedHealth(feed);
+    }
+    return {
+      clients: clientHealth,
+      feeds: feedHealth,
+    };
+  };
+
+  return {
+    healthOverlay: (health, nowMillis) => {
+      const grpc = snapshot(health, nowMillis);
+      return {
+        ...health,
+        status: mergeRuntimeStatus(health, grpc),
+        grpc,
+      };
+    },
+    clientConnected: (clientName, nowMillis) =>
+      Effect.sync(() => {
+        const client = clients.get(clientName);
+        if (client !== undefined) {
+          client.status = "connected";
+          client.lastConnectedAt = client.lastConnectedAt ?? nowMillis;
+          client.lastError = null;
+        }
+      }),
+    clientDegraded: (clientName, message) =>
+      Effect.sync(() => {
+        const client = clients.get(clientName);
+        if (client !== undefined) {
+          client.status = "degraded";
+          client.lastError = message;
+        }
+      }),
+    feedReady: (feedName) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          feed.status = "ready";
+          feed.lastError = null;
+        }
+      }),
+    feedStopping: (feedName) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          feed.status = "stopping";
+        }
+      }),
+    feedDegraded: (feedName, message) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          feed.status = "degraded";
+          feed.lastError = message;
+        }
+      }),
+    rowsPublished: (feedName, input) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          incrementWindow(feed, input.nowMillis, {
+            messages: input.messages,
+            rows: input.rows,
+            decodeFailed: 0,
+            mappingFailed: 0,
+            publishFailed: 0,
+          });
+          feed.lastMessageAt = input.nowMillis;
+          feed.lastError = null;
+        }
+      }),
+    mappingFailed: (feedName, input) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          feed.status = "degraded";
+          incrementWindow(feed, input.nowMillis, {
+            messages: 1,
+            rows: 0,
+            decodeFailed: 0,
+            mappingFailed: 1,
+            publishFailed: 0,
+          });
+          feed.lastMessageAt = input.nowMillis;
+          feed.lastError = input.message;
+        }
+      }),
+    publishFailed: (feedName, input) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          feed.status = "degraded";
+          incrementWindow(feed, input.nowMillis, {
+            messages: 1,
+            rows: 0,
+            decodeFailed: 0,
+            mappingFailed: 0,
+            publishFailed: 1,
+          });
+          feed.lastMessageAt = input.nowMillis;
+          feed.lastError = input.message;
+        }
+      }),
+  };
+};

--- a/packages/runtime/src/grpc-ingress.ts
+++ b/packages/runtime/src/grpc-ingress.ts
@@ -1,0 +1,448 @@
+import { createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import {
+  type GrpcClientValue,
+  type GrpcConnectClientDefinition,
+  type GrpcFeedAcquireInput,
+  type GrpcMaterializedFeedDefinition,
+  type GrpcMaterializedTopic,
+  type GrpcMethodRequest,
+  type GrpcMethodValue,
+  type GrpcRuntimeClients,
+  type GrpcServerStreamingMethodName,
+  type TopicRow,
+  type ViewServerConfig,
+  type ViewServerRuntimeClient,
+} from "@view-server/config";
+import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
+import { Cause, Clock, Effect, Exit, Option, Schema, Scope, Stream } from "effect";
+import type { ViewServerGrpcHealthLedger } from "./grpc-health";
+import type { ResolvedViewServerGrpcRuntimeOptions } from "./runtime-options";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+export class ViewServerGrpcIngressError extends Schema.TaggedErrorClass<ViewServerGrpcIngressError>()(
+  "ViewServerGrpcIngressError",
+  {
+    message: Schema.String,
+    cause: Schema.Unknown,
+    feedName: Schema.optionalKey(Schema.String),
+    topic: Schema.optionalKey(Schema.String),
+  },
+) {}
+
+export type ViewServerGrpcIngress = {
+  readonly close: Effect.Effect<void>;
+};
+
+export type ViewServerGrpcClientFactory = <
+  const ClientDefinition extends GrpcConnectClientDefinition,
+>(
+  definition: ClientDefinition,
+  baseUrl: string,
+) => GrpcClientValue<ClientDefinition>;
+
+type ViewServerGrpcHealthRefreshRequest = Effect.Effect<void>;
+
+const grpcMessageBatchSize = 256;
+const grpcMessageBatchFlushInterval = "2 millis";
+
+const materializedFeedSession = {
+  id: null,
+  forwardedHeaders: {},
+  systemHeaders: {},
+};
+
+const ignoreGrpcFeedReleaseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring gRPC feed release failure.",
+);
+const ignoreGrpcHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring gRPC health refresh failure.",
+);
+
+export function makeDefaultGrpcClient<const ClientDefinition extends GrpcConnectClientDefinition>(
+  definition: ClientDefinition,
+  baseUrl: string,
+): GrpcClientValue<ClientDefinition>;
+export function makeDefaultGrpcClient(definition: GrpcConnectClientDefinition, baseUrl: string) {
+  return createClient(definition.service, createGrpcTransport({ baseUrl }));
+}
+
+const grpcIngressError = (input: {
+  readonly message: string;
+  readonly cause: unknown;
+  readonly feedName: string;
+  readonly topic: string;
+}) =>
+  new ViewServerGrpcIngressError({
+    message: input.message,
+    cause: input.cause,
+    feedName: input.feedName,
+    topic: input.topic,
+  });
+
+const hasMessage = (value: unknown): value is { readonly message: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "message" in value &&
+  typeof value.message === "string";
+
+const messageFromUnknown = (value: unknown): string => {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (hasMessage(value)) {
+    return value.message;
+  }
+  return String(value);
+};
+
+const grpcIngressErrorMessage = (error: ViewServerGrpcIngressError): string =>
+  `${error.message}: ${messageFromUnknown(error.cause)}`;
+
+const feedFailureMessage = (feedName: string, cause: Cause.Cause<unknown>): string => {
+  const error = Cause.findErrorOption(cause);
+  if (Option.isSome(error) && error.value instanceof ViewServerGrpcIngressError) {
+    return `gRPC feed ${feedName} failed: ${grpcIngressErrorMessage(error.value)}`;
+  }
+  return `gRPC feed ${feedName} failed: ${Cause.pretty(cause)}`;
+};
+
+const unexpectedFeedCompletionMessage = (feedName: string): string =>
+  `gRPC feed ${feedName} completed unexpectedly.`;
+
+const markMaterializedFeedDegraded = Effect.fn("ViewServerRuntime.grpc.materialized.degraded")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
+    health: ViewServerGrpcHealthLedger<Topics>,
+    feedName: string,
+    clientName: string,
+    message: string,
+  ) {
+    yield* health.feedDegraded(feedName, message);
+    yield* health.clientDegraded(clientName, message);
+    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+  },
+);
+
+const handleMaterializedFeedExit = Effect.fn("ViewServerRuntime.grpc.materialized.exit")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
+  health: ViewServerGrpcHealthLedger<Topics>,
+  feedName: string,
+  clientName: string,
+  exit: Exit.Exit<void, ViewServerGrpcIngressError>,
+) {
+  if (Exit.isSuccess(exit)) {
+    yield* markMaterializedFeedDegraded(
+      requestHealthRefresh,
+      health,
+      feedName,
+      clientName,
+      unexpectedFeedCompletionMessage(feedName),
+    );
+    return;
+  }
+  if (Cause.hasInterruptsOnly(exit.cause)) {
+    yield* health.feedStopping(feedName);
+    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+    return;
+  }
+  yield* markMaterializedFeedDegraded(
+    requestHealthRefresh,
+    health,
+    feedName,
+    clientName,
+    feedFailureMessage(feedName, exit.cause),
+  );
+});
+
+const mapMaterializedValue = Effect.fn("ViewServerRuntime.grpc.materialized.map")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Clients extends GrpcRuntimeClients,
+  const Topic extends GrpcMaterializedTopic<Topics>,
+  const ClientName extends Extract<keyof Clients, string>,
+  const MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+>(
+  config: ViewServerConfig<Topics>,
+  feed: GrpcMaterializedFeedDefinition<Topics, Clients, Topic, ClientName, MethodName>,
+  feedName: string,
+  value: GrpcMethodValue<Clients[ClientName], MethodName>,
+) {
+  const topicDefinition = config.topics[feed.topic];
+  return yield* Effect.try({
+    try: (): TopicRow<Topics, Topic> =>
+      feed.map({
+        value,
+        route: undefined,
+        schema: topicDefinition.schema,
+      }),
+    catch: (cause) =>
+      grpcIngressError({
+        message: `gRPC feed mapping failed for ${feedName}`,
+        cause,
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+});
+
+const publishMaterializedBatch = Effect.fn("ViewServerRuntime.grpc.materialized.publishBatch")(
+  function* <
+    const Topics extends ViewServerRuntimeTopicDefinitions,
+    const Clients extends GrpcRuntimeClients,
+    const Topic extends GrpcMaterializedTopic<Topics>,
+    const ClientName extends Extract<keyof Clients, string>,
+    const MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+  >(
+    config: ViewServerConfig<Topics>,
+    client: ViewServerRuntimeClient<Topics>,
+    requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
+    health: ViewServerGrpcHealthLedger<Topics>,
+    feed: GrpcMaterializedFeedDefinition<Topics, Clients, Topic, ClientName, MethodName>,
+    feedName: string,
+    values: ReadonlyArray<GrpcMethodValue<Clients[ClientName], MethodName>>,
+  ) {
+    const rows = yield* Effect.forEach(values, (value) =>
+      mapMaterializedValue(config, feed, feedName, value).pipe(
+        Effect.tapError((error) =>
+          Clock.currentTimeMillis.pipe(
+            Effect.flatMap((nowMillis) =>
+              health.mappingFailed(feedName, {
+                message: error.message,
+                nowMillis,
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    yield* client.publishMany(feed.topic, rows).pipe(
+      Effect.tapError((error) =>
+        Clock.currentTimeMillis.pipe(
+          Effect.flatMap((nowMillis) =>
+            health.publishFailed(feedName, {
+              message: error.message,
+              nowMillis,
+            }),
+          ),
+        ),
+      ),
+      Effect.mapError((cause) =>
+        grpcIngressError({
+          message: `gRPC feed publish failed for ${feedName}`,
+          cause,
+          feedName,
+          topic: feed.topic,
+        }),
+      ),
+    );
+    const nowMillis = yield* Clock.currentTimeMillis;
+    yield* health.rowsPublished(feedName, {
+      messages: values.length,
+      rows: rows.length,
+      nowMillis,
+    });
+    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+  },
+);
+
+const materializedAcquireInput = <
+  const Clients extends GrpcRuntimeClients,
+  const ClientName extends Extract<keyof Clients, string>,
+  const MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+>(
+  grpcClient: GrpcClientValue<Clients[ClientName]>,
+  request: GrpcMethodRequest<Clients[ClientName], MethodName>,
+): GrpcFeedAcquireInput<
+  GrpcClientValue<Clients[ClientName]>,
+  GrpcMethodRequest<Clients[ClientName], MethodName>,
+  undefined
+> => ({
+  client: grpcClient,
+  request,
+  route: undefined,
+  session: materializedFeedSession,
+});
+
+const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.start")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Clients extends GrpcRuntimeClients,
+  const Topic extends GrpcMaterializedTopic<Topics>,
+  const ClientName extends Extract<keyof Clients, string>,
+  const MethodName extends GrpcServerStreamingMethodName<Clients[ClientName]>,
+>(
+  scope: Scope.Scope,
+  config: ViewServerConfig<Topics>,
+  runtimeClient: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
+  options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
+  health: ViewServerGrpcHealthLedger<Topics>,
+  makeClient: ViewServerGrpcClientFactory,
+  feedName: string,
+  feed: GrpcMaterializedFeedDefinition<Topics, Clients, Topic, ClientName, MethodName>,
+) {
+  const clientDefinition = options.clients[feed.client];
+  if (clientDefinition === undefined) {
+    return yield* grpcIngressError({
+      message: `gRPC feed ${feedName} references missing client: ${feed.client}`,
+      cause: feed.client,
+      feedName,
+      topic: feed.topic,
+    });
+  }
+  const baseUrl = options.clientBaseUrls[feed.client];
+  if (baseUrl === undefined) {
+    return yield* grpcIngressError({
+      message: `gRPC feed ${feedName} references unresolved client URL: ${feed.client}`,
+      cause: feed.client,
+      feedName,
+      topic: feed.topic,
+    });
+  }
+  const grpcClient = yield* Effect.try({
+    try: () => makeClient(clientDefinition, baseUrl),
+    catch: (cause) =>
+      grpcIngressError({
+        message: `gRPC client creation failed for ${feedName}`,
+        cause,
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+  const request = yield* Effect.try({
+    try: () => feed.request(),
+    catch: (cause) =>
+      grpcIngressError({
+        message: `gRPC feed request creation failed for ${feedName}`,
+        cause,
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+  const input = materializedAcquireInput(grpcClient, request);
+  const releaseFeed = feed.release;
+  const startedAt = yield* Clock.currentTimeMillis;
+  yield* health.clientConnected(feed.client, startedAt);
+  yield* health.feedReady(feedName);
+  yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+  const runFeed = Effect.scoped(
+    Effect.gen(function* () {
+      const stream = yield* Effect.acquireRelease(
+        Effect.try({
+          try: () => feed.acquire(input),
+          catch: (cause) =>
+            grpcIngressError({
+              message: `gRPC feed acquire failed for ${feedName}`,
+              cause,
+              feedName,
+              topic: feed.topic,
+            }),
+        }),
+        () =>
+          releaseFeed === undefined
+            ? Effect.void
+            : ignoreGrpcFeedReleaseFailure(
+                Effect.try({
+                  try: () => releaseFeed(input),
+                  catch: (cause) =>
+                    grpcIngressError({
+                      message: `gRPC feed release failed for ${feedName}`,
+                      cause,
+                      feedName,
+                      topic: feed.topic,
+                    }),
+                }).pipe(Effect.flatMap((release) => release)),
+              ),
+      );
+      yield* stream.pipe(
+        Stream.mapError((cause) =>
+          grpcIngressError({
+            message: `gRPC feed stream failed for ${feedName}`,
+            cause,
+            feedName,
+            topic: feed.topic,
+          }),
+        ),
+        Stream.groupedWithin(grpcMessageBatchSize, grpcMessageBatchFlushInterval),
+        Stream.runForEach((values) =>
+          publishMaterializedBatch(
+            config,
+            runtimeClient,
+            requestHealthRefresh,
+            health,
+            feed,
+            feedName,
+            values,
+          ),
+        ),
+      );
+    }),
+  ).pipe(
+    Effect.exit,
+    Effect.flatMap((exit) =>
+      handleMaterializedFeedExit(requestHealthRefresh, health, feedName, feed.client, exit),
+    ),
+  );
+  yield* runFeed.pipe(Effect.forkIn(scope, { startImmediately: true }));
+});
+
+export const makeViewServerGrpcIngress: <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Clients extends GrpcRuntimeClients,
+>(
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
+  options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
+  health: ViewServerGrpcHealthLedger<Topics>,
+  makeClient?: ViewServerGrpcClientFactory,
+) => Effect.Effect<ViewServerGrpcIngress, ViewServerGrpcIngressError> = Effect.fn(
+  "ViewServerRuntime.grpc.makeIngress",
+)(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Clients extends GrpcRuntimeClients,
+>(
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
+  options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
+  health: ViewServerGrpcHealthLedger<Topics>,
+  makeClient: ViewServerGrpcClientFactory = makeDefaultGrpcClient,
+) {
+  const scope = yield* Scope.make("parallel");
+  const feedNames = Object.keys(options.feeds);
+  return yield* Effect.gen(function* () {
+    for (const [feedName, feed] of Object.entries(options.feeds)) {
+      if (feed.lifecycle === "materialized") {
+        yield* startMaterializedFeed(
+          scope,
+          config,
+          client,
+          requestHealthRefresh,
+          options,
+          health,
+          makeClient,
+          feedName,
+          feed,
+        );
+      } else {
+        return yield* grpcIngressError({
+          message: `gRPC leased feed ${feedName} is not supported by materialized ingress startup`,
+          cause: feed.lifecycle,
+          feedName,
+          topic: feed.topic,
+        });
+      }
+    }
+    return {
+      close: Effect.gen(function* () {
+        yield* Effect.forEach(feedNames, (feedName) => health.feedStopping(feedName), {
+          discard: true,
+        });
+        yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+        yield* Scope.close(scope, Exit.void);
+      }),
+    };
+  }).pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)));
+});

--- a/packages/runtime/src/grpc-materialized.bench.ts
+++ b/packages/runtime/src/grpc-materialized.bench.ts
@@ -1,0 +1,590 @@
+// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+import { afterAll, beforeAll, bench, describe } from "vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
+import type { Message } from "@bufbuild/protobuf";
+import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
+import { defineViewServerConfig, grpc, type ViewServerHealth } from "@view-server/config";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { FieldDescriptorProto_Type, FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";
+import { Clock, Config, Effect, Queue, Schedule, Schema, Stream } from "effect";
+import {
+  makeViewServerRuntimeCore,
+  type ViewServerRuntimeCoreInstance,
+} from "@view-server/runtime-core";
+import { makeViewServerGrpcHealthLedger } from "./grpc-health";
+import { makeViewServerGrpcIngress, type ViewServerGrpcIngress } from "./grpc-ingress";
+
+declare const process: {
+  readonly env: Record<string, string | undefined>;
+  readonly memoryUsage: () => {
+    readonly arrayBuffers: number;
+    readonly external: number;
+    readonly heapTotal: number;
+    readonly heapUsed: number;
+    readonly rss: number;
+  };
+};
+
+type BenchmarkMemorySnapshot = {
+  readonly arrayBuffersBytes: number;
+  readonly externalBytes: number;
+  readonly heapTotalBytes: number;
+  readonly heapUsedBytes: number;
+  readonly rssBytes: number;
+};
+
+type GrpcOrderValueMessage = Message<"viewserver.runtime.bench.OrderValue"> & {
+  readonly customerId: string;
+  readonly status: "open" | "closed" | "cancelled";
+  readonly price: number;
+  readonly updatedAt: number;
+};
+
+type GrpcOrderKeyMessage = Message<"viewserver.runtime.bench.OrderKey"> & {
+  readonly orderId: string;
+};
+
+type BenchmarkProfile = {
+  readonly health: ReturnType<typeof makeViewServerGrpcHealthLedger<Topics>>;
+  readonly ingress: ViewServerGrpcIngress;
+  readonly memoryAfterSetup: BenchmarkMemorySnapshot;
+  readonly queue: Queue.Queue<GrpcOrderValueMessage>;
+  readonly runtimeCore: ViewServerRuntimeCoreInstance<Topics>;
+};
+
+type BenchmarkCase = {
+  readonly name: string;
+  readonly run: () => Promise<void>;
+};
+
+type GrpcMaterializedSample = {
+  readonly healthOverlayMs: number;
+  readonly name: string;
+  readonly rows: number;
+  readonly rowsPerSecond: number;
+  readonly snapshotMs: number;
+  readonly streamConvergenceMs: number;
+  readonly totalRows: number;
+};
+
+const GrpcOrder = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Number,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: GrpcOrder,
+      key: "id",
+      source: grpc.materialized(),
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+type OrderRow = typeof GrpcOrder.Type;
+type OrderStatus = OrderRow["status"];
+
+const defaultBatchSize = 256;
+const defaultBenchmarkTimeMs = 0;
+const defaultIterations = 5;
+const defaultSeedRows = 1_000;
+const defaultWarmupIterations = 0;
+const defaultWarmupTimeMs = 0;
+const memoryBefore = memorySnapshot();
+
+const positiveIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/u.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a positive integer.`);
+};
+
+const nonNegativeIntegerFromEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!/^(0|[1-9]\d*)$/u.test(trimmed)) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isSafeInteger(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  throw new Error(`${name} must be a non-negative integer.`);
+};
+
+const batchSize = positiveIntegerFromEnv(
+  "VIEW_SERVER_RUNTIME_BENCH_GRPC_BATCH_SIZE",
+  defaultBatchSize,
+);
+const seedRows = positiveIntegerFromEnv(
+  "VIEW_SERVER_RUNTIME_BENCH_GRPC_SEED_ROWS",
+  defaultSeedRows,
+);
+const outputJsonPath = benchmarkOutputJsonPath(
+  `grpc-materialized-${seedRows}seed-${batchSize}batch.json`,
+);
+const benchOptions = {
+  iterations: positiveIntegerFromEnv("VIEW_SERVER_RUNTIME_BENCH_ITERATIONS", defaultIterations),
+  time: nonNegativeIntegerFromEnv("VIEW_SERVER_RUNTIME_BENCH_TIME_MS", defaultBenchmarkTimeMs),
+  warmupIterations: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_RUNTIME_BENCH_WARMUP_ITERATIONS",
+    defaultWarmupIterations,
+  ),
+  warmupTime: nonNegativeIntegerFromEnv(
+    "VIEW_SERVER_RUNTIME_BENCH_WARMUP_TIME_MS",
+    defaultWarmupTimeMs,
+  ),
+};
+if (benchOptions.time > 0 || benchOptions.warmupIterations > 0 || benchOptions.warmupTime > 0) {
+  throw new Error(
+    "gRPC materialized benchmark mutates shared runtime state; time and warmup must stay disabled.",
+  );
+}
+
+let profile: BenchmarkProfile | undefined;
+const samples: Array<GrpcMaterializedSample> = [];
+let nextRowIndex = 0;
+
+const base64FromBytes = (bytes: Uint8Array) =>
+  globalThis.btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+
+const runtimeGrpcProtoFile = fileDesc(
+  base64FromBytes(
+    toBinary(
+      FileDescriptorProtoSchema,
+      create(FileDescriptorProtoSchema, {
+        name: "viewserver/runtime-bench.proto",
+        package: "viewserver.runtime.bench",
+        syntax: "proto3",
+        messageType: [
+          {
+            name: "OrderValue",
+            field: [
+              { name: "customer_id", number: 1, type: FieldDescriptorProto_Type.STRING },
+              { name: "status", number: 2, type: FieldDescriptorProto_Type.STRING },
+              { name: "price", number: 3, type: FieldDescriptorProto_Type.DOUBLE },
+              { name: "updated_at", number: 4, type: FieldDescriptorProto_Type.DOUBLE },
+            ],
+          },
+          {
+            name: "OrderKey",
+            field: [{ name: "order_id", number: 1, type: FieldDescriptorProto_Type.STRING }],
+          },
+        ],
+        service: [
+          {
+            name: "OrdersService",
+            method: [
+              {
+                name: "StreamOrders",
+                inputType: ".viewserver.runtime.bench.OrderKey",
+                outputType: ".viewserver.runtime.bench.OrderValue",
+                serverStreaming: true,
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+  ),
+);
+
+const grpcOrderValueSchema = messageDesc<GrpcOrderValueMessage>(runtimeGrpcProtoFile, 0);
+const grpcOrderKeySchema = messageDesc<GrpcOrderKeyMessage>(runtimeGrpcProtoFile, 1);
+const grpcOrdersService = serviceDesc<{
+  readonly streamOrders: {
+    readonly input: typeof grpcOrderKeySchema;
+    readonly output: typeof grpcOrderValueSchema;
+    readonly methodKind: "server_streaming";
+  };
+}>(runtimeGrpcProtoFile, 0);
+
+const grpcClients = {
+  orders: grpc.connectClient({
+    service: grpcOrdersService,
+    baseUrl: Config.succeed("https://orders.example.test"),
+  }),
+};
+
+const grpcFeed = viewServer.grpcFeed<typeof grpcClients>();
+const grpcHealthClientBaseUrls = {
+  orders: "https://orders.example.test",
+};
+
+const orderStatus = (index: number): OrderStatus => {
+  if (index % 5 === 0) {
+    return "cancelled";
+  }
+  if (index % 3 === 0) {
+    return "closed";
+  }
+  return "open";
+};
+
+const grpcOrderValue = (index: number): GrpcOrderValueMessage => ({
+  $typeName: "viewserver.runtime.bench.OrderValue",
+  customerId: `order-${index}`,
+  status: orderStatus(index),
+  price: index % 10_000,
+  updatedAt: index,
+});
+
+const grpcMaterializedFeed = (stream: Stream.Stream<GrpcOrderValueMessage, never, never>) =>
+  grpcFeed.materializedFeed({
+    topic: "orders",
+    client: "orders",
+    method: "streamOrders",
+    request: () => ({ orderId: "all" }),
+    acquire: () => stream,
+    map: ({ value }) => ({
+      id: value.customerId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region: "usa",
+      updatedAt: value.updatedAt,
+    }),
+  });
+
+const createRuntimeCoreForBenchmark = Effect.fn("ViewServerRuntime.grpc.bench.core.make")(
+  function* () {
+    return yield* makeViewServerRuntimeCore(viewServer, {});
+  },
+);
+
+function memorySnapshot(): BenchmarkMemorySnapshot {
+  const memory = process.memoryUsage();
+  return {
+    arrayBuffersBytes: memory.arrayBuffers,
+    externalBytes: memory.external,
+    heapTotalBytes: memory.heapTotal,
+    heapUsedBytes: memory.heapUsed,
+    rssBytes: memory.rss,
+  };
+}
+
+function memoryDelta(
+  before: BenchmarkMemorySnapshot,
+  after: BenchmarkMemorySnapshot,
+): BenchmarkMemorySnapshot {
+  return {
+    arrayBuffersBytes: after.arrayBuffersBytes - before.arrayBuffersBytes,
+    externalBytes: after.externalBytes - before.externalBytes,
+    heapTotalBytes: after.heapTotalBytes - before.heapTotalBytes,
+    heapUsedBytes: after.heapUsedBytes - before.heapUsedBytes,
+    rssBytes: after.rssBytes - before.rssBytes,
+  };
+}
+
+function benchmarkOutputJsonPath(fallbackName: string): string {
+  const configured = process.env["VIEW_SERVER_RUNTIME_BENCH_OUTPUT_JSON"];
+  if (configured !== undefined && configured.trim() !== "") {
+    return configured.trim();
+  }
+  return join(".artifacts", fallbackName);
+}
+
+function benchmarkSummaryPath(path: string): string {
+  if (path.endsWith(".json")) {
+    return `${path.slice(0, -".json".length)}.summary.json`;
+  }
+  return `${path}.summary.json`;
+}
+
+function writeJsonFile(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, undefined, 2)}\n`);
+}
+
+const nextRows = (count: number): ReadonlyArray<GrpcOrderValueMessage> => {
+  const start = nextRowIndex;
+  nextRowIndex += count;
+  return Array.from({ length: count }, (_value, offset) => grpcOrderValue(start + offset));
+};
+
+const offerRows = Effect.fn("ViewServerRuntime.grpc.bench.rows.offer")(function* (
+  queue: Queue.Queue<GrpcOrderValueMessage>,
+  rows: ReadonlyArray<GrpcOrderValueMessage>,
+) {
+  yield* Effect.forEach(rows, (row) => Queue.offer(queue, row), {
+    discard: true,
+  });
+});
+
+const waitForTotalRows = Effect.fn("ViewServerRuntime.grpc.bench.totalRows.wait")(function* (
+  runtimeCore: ViewServerRuntimeCoreInstance<Topics>,
+  expectedTotalRows: number,
+) {
+  return yield* runtimeCore.client
+    .snapshot("orders", {
+      select: ["id", "price"],
+      orderBy: [{ field: "price", direction: "asc" }],
+      limit: 50,
+    })
+    .pipe(
+      Effect.repeat({
+        schedule: Schedule.addDelay(Schedule.recurs(200), () => Effect.succeed("1 millis")),
+        until: (snapshot) => snapshot.totalRows === expectedTotalRows,
+      }),
+    );
+});
+
+const readHealthOverlay = Effect.fn("ViewServerRuntime.grpc.bench.healthOverlay.read")(function* (
+  runtimeCore: ViewServerRuntimeCoreInstance<Topics>,
+  health: ReturnType<typeof makeViewServerGrpcHealthLedger<Topics>>,
+) {
+  const nowMillis = yield* Clock.currentTimeMillis;
+  return health.healthOverlay(yield* runtimeCore.client.health(), nowMillis);
+});
+
+const runGrpcBatch = Effect.fn("ViewServerRuntime.grpc.bench.batch.run")(function* (
+  name: string,
+  currentProfile: BenchmarkProfile,
+  rows: ReadonlyArray<GrpcOrderValueMessage>,
+) {
+  const before = performance.now();
+  yield* offerRows(currentProfile.queue, rows);
+  const snapshot = yield* waitForTotalRows(currentProfile.runtimeCore, nextRowIndex);
+  const afterConvergence = performance.now();
+  const healthBefore = performance.now();
+  const health = yield* readHealthOverlay(currentProfile.runtimeCore, currentProfile.health);
+  const healthAfter = performance.now();
+  const readBefore = performance.now();
+  yield* currentProfile.runtimeCore.client.snapshot("orders", {
+    select: ["id", "price", "status"],
+    where: {
+      status: { eq: "open" },
+      price: { gte: 10 },
+    },
+    orderBy: [{ field: "updatedAt", direction: "desc" }],
+    limit: 100,
+  });
+  const readAfter = performance.now();
+  const streamConvergenceMs = afterConvergence - before;
+  samples.push({
+    healthOverlayMs: healthAfter - healthBefore,
+    name,
+    rows: rows.length,
+    rowsPerSecond: (rows.length / streamConvergenceMs) * 1_000,
+    snapshotMs: readAfter - readBefore,
+    streamConvergenceMs,
+    totalRows: snapshot.totalRows,
+  });
+  if (health.status === "degraded") {
+    throw new Error("gRPC materialized benchmark health became degraded.");
+  }
+});
+
+const runHealthOverlayCase = Effect.fn("ViewServerRuntime.grpc.bench.healthOverlay.run")(function* (
+  name: string,
+  currentProfile: BenchmarkProfile,
+) {
+  const before = performance.now();
+  const health = yield* readHealthOverlay(currentProfile.runtimeCore, currentProfile.health);
+  const after = performance.now();
+  samples.push({
+    healthOverlayMs: after - before,
+    name,
+    rows: 0,
+    rowsPerSecond: 0,
+    snapshotMs: 0,
+    streamConvergenceMs: 0,
+    totalRows: health.engine.topics.orders.rowCount,
+  });
+  if (health.status === "degraded") {
+    throw new Error("gRPC materialized benchmark health became degraded.");
+  }
+});
+
+const currentBenchmarkProfile = (): BenchmarkProfile => {
+  const currentProfile = profile;
+  if (currentProfile === undefined) {
+    throw new Error("gRPC materialized benchmark setup did not create a profile.");
+  }
+  return currentProfile;
+};
+
+const benchmarkCases: ReadonlyArray<BenchmarkCase> = [
+  {
+    name: "gRPC materialized stream batch",
+    run: () =>
+      Effect.runPromise(
+        runGrpcBatch(
+          "gRPC materialized stream batch",
+          currentBenchmarkProfile(),
+          nextRows(batchSize),
+        ),
+      ),
+  },
+  {
+    name: "gRPC materialized burst",
+    run: () =>
+      Effect.runPromise(
+        runGrpcBatch("gRPC materialized burst", currentBenchmarkProfile(), nextRows(batchSize * 4)),
+      ),
+  },
+  {
+    name: "gRPC materialized health overlay",
+    run: () =>
+      Effect.runPromise(
+        runHealthOverlayCase("gRPC materialized health overlay", currentBenchmarkProfile()),
+      ),
+  },
+];
+
+const summarizeSamples = (
+  name: string,
+): {
+  readonly maxHealthOverlayMs: number;
+  readonly maxSnapshotMs: number;
+  readonly maxStreamConvergenceMs: number;
+  readonly meanHealthOverlayMs: number;
+  readonly meanRowsPerSecond: number;
+  readonly meanSnapshotMs: number;
+  readonly meanStreamConvergenceMs: number;
+  readonly name: string;
+  readonly sampleCount: number;
+  readonly totalRows: number;
+} => {
+  const matching = samples.filter((sample) => sample.name === name);
+  const totals = matching.reduce(
+    (accumulator, sample) => ({
+      healthOverlayMs: accumulator.healthOverlayMs + sample.healthOverlayMs,
+      rowsPerSecond: accumulator.rowsPerSecond + sample.rowsPerSecond,
+      snapshotMs: accumulator.snapshotMs + sample.snapshotMs,
+      streamConvergenceMs: accumulator.streamConvergenceMs + sample.streamConvergenceMs,
+    }),
+    {
+      healthOverlayMs: 0,
+      rowsPerSecond: 0,
+      snapshotMs: 0,
+      streamConvergenceMs: 0,
+    },
+  );
+  const sampleCount = matching.length;
+  return {
+    maxHealthOverlayMs: Math.max(...matching.map((sample) => sample.healthOverlayMs)),
+    maxSnapshotMs: Math.max(...matching.map((sample) => sample.snapshotMs)),
+    maxStreamConvergenceMs: Math.max(...matching.map((sample) => sample.streamConvergenceMs)),
+    meanHealthOverlayMs: totals.healthOverlayMs / sampleCount,
+    meanRowsPerSecond: totals.rowsPerSecond / sampleCount,
+    meanSnapshotMs: totals.snapshotMs / sampleCount,
+    meanStreamConvergenceMs: totals.streamConvergenceMs / sampleCount,
+    name,
+    sampleCount,
+    totalRows: matching[matching.length - 1]?.totalRows ?? 0,
+  };
+};
+
+beforeAll(async () => {
+  profile = await Effect.runPromise(
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<GrpcOrderValueMessage>();
+      const runtimeCore = yield* createRuntimeCoreForBenchmark();
+      const health = makeViewServerGrpcHealthLedger<Topics>({
+        clients: grpcHealthClientBaseUrls,
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+      const ingress = yield* makeViewServerGrpcIngress(
+        viewServer,
+        runtimeCore.client,
+        Effect.void,
+        {
+          clientBaseUrls: grpcHealthClientBaseUrls,
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: grpcMaterializedFeed(Stream.fromQueue(queue)),
+          },
+        },
+        health,
+      );
+      yield* runGrpcBatch(
+        "setup seed",
+        {
+          health,
+          ingress,
+          memoryAfterSetup: memorySnapshot(),
+          queue,
+          runtimeCore,
+        },
+        nextRows(seedRows),
+      );
+      samples.length = 0;
+      return {
+        health,
+        ingress,
+        memoryAfterSetup: memorySnapshot(),
+        queue,
+        runtimeCore,
+      };
+    }),
+  );
+});
+
+afterAll(async () => {
+  const currentProfile = profile;
+  const health: ViewServerHealth<Topics> | undefined =
+    currentProfile === undefined
+      ? undefined
+      : await Effect.runPromise(
+          readHealthOverlay(currentProfile.runtimeCore, currentProfile.health),
+        );
+  if (currentProfile !== undefined) {
+    await Effect.runPromise(currentProfile.ingress.close);
+    await Effect.runPromise(currentProfile.runtimeCore.close);
+  }
+  writeJsonFile(benchmarkSummaryPath(outputJsonPath), {
+    artifactKind: "runtime-benchmark-summary",
+    batchSize,
+    benchmarkCases: benchmarkCases.map((benchmarkCase) => benchmarkCase.name),
+    benchmarkName: "gRPC materialized runtime benchmark",
+    benchmarkScope: "runtime-grpc-materialized",
+    cases: benchmarkCases.map((benchmarkCase) => summarizeSamples(benchmarkCase.name)),
+    finalHealth: health,
+    latency: {
+      outputJsonPath,
+      source: "vitest-output-json",
+    },
+    memory: {
+      afterSetup: currentProfile?.memoryAfterSetup,
+      afterTeardown: memorySnapshot(),
+      deltaAfterSetup:
+        currentProfile?.memoryAfterSetup === undefined
+          ? undefined
+          : memoryDelta(memoryBefore, currentProfile.memoryAfterSetup),
+      deltaAfterTeardown: memoryDelta(memoryBefore, memorySnapshot()),
+    },
+    seedRows,
+  });
+});
+
+describe("runtime gRPC materialized benchmark", () => {
+  for (const benchmarkCase of benchmarkCases) {
+    bench(benchmarkCase.name, benchmarkCase.run, benchOptions);
+  }
+});

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -3,6 +3,8 @@ import {
   defineViewServerConfig,
   grpc,
   kafka,
+  type GrpcFeedDefinition,
+  type GrpcRuntimeClients,
   type ViewServerRuntimeError,
 } from "@view-server/config";
 import type { Config, Effect } from "effect";
@@ -12,6 +14,7 @@ import {
   makeViewServerRuntime,
   runViewServerRuntime,
   type ViewServerRuntime,
+  type ViewServerGrpcIngressError,
   type ViewServerKafkaIngressError,
   type ViewServerRuntimeOptions,
 } from "./index";
@@ -42,6 +45,16 @@ const leasedViewServer = defineViewServerConfig({
   },
 });
 
+const materializedGrpcViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      source: grpc.materialized(),
+    },
+  },
+});
+
 const runtimeEffect = makeViewServerRuntime(viewServer);
 const leasedRuntimeEffect = makeViewServerRuntime(leasedViewServer);
 const runtimeWithGroupedAdmissionLimits = makeViewServerRuntime(viewServer, {
@@ -52,6 +65,11 @@ const runtimeWithGroupedAdmissionLimits = makeViewServerRuntime(viewServer, {
 const runEffect = runViewServerRuntime(viewServer);
 declare const runtime: Effect.Success<typeof runtimeEffect>;
 declare const leasedRuntime: Effect.Success<typeof leasedRuntimeEffect>;
+declare const grpcRuntimeClients: GrpcRuntimeClients;
+declare const grpcOrdersFeed: GrpcFeedDefinition<
+  typeof materializedGrpcViewServer.topics,
+  typeof grpcRuntimeClients
+>;
 
 const usaKafkaRegions = {
   usa: "localhost:9092",
@@ -85,7 +103,10 @@ describe("runtime type contracts", () => {
     >();
     expectTypeOf<Effect.Success<typeof runEffect>>().toEqualTypeOf<never>();
     expectTypeOf<Effect.Error<typeof runEffect>>().toEqualTypeOf<
-      HttpServerError.ServeError | Config.ConfigError | ViewServerKafkaIngressError
+      | HttpServerError.ServeError
+      | Config.ConfigError
+      | ViewServerKafkaIngressError
+      | ViewServerGrpcIngressError
     >();
     expectTypeOf<Effect.Success<typeof runtimeWithGroupedAdmissionLimits>>().toMatchTypeOf<
       ViewServerRuntime<typeof viewServer.topics>
@@ -172,33 +193,33 @@ describe("runtime type contracts", () => {
         prcie: { gte: 10 },
       },
     });
+    // @ts-expect-error runtime options reject string ports.
     const invalidOptions = makeViewServerRuntime(viewServer, {
-      // @ts-expect-error runtime options reject string ports.
       websocketPort: "8080",
     });
     const invalidTcpPublishPortOptions = makeViewServerRuntime(viewServer, {
       // @ts-expect-error TCP publish ingress is not wired by the runtime package yet.
       tcpPublishPort: 8081,
     });
+    // @ts-expect-error runtime paths must be absolute HTTP paths.
     const invalidPathOptions = makeViewServerRuntime(viewServer, {
-      // @ts-expect-error runtime paths must be absolute HTTP paths.
       rpcPath: "runtime-rpc",
     });
+    // @ts-expect-error runtime health paths must be absolute HTTP paths.
     const invalidHealthPathOptions = makeViewServerRuntime(viewServer, {
-      // @ts-expect-error runtime health paths must be absolute HTTP paths.
       healthPath: "runtime-health",
     });
+    // @ts-expect-error runtime RPC path must be a concrete slash-prefixed client URL path.
     const invalidWildcardRpcPathOptions = makeViewServerRuntime(viewServer, {
-      // @ts-expect-error runtime RPC path must be a concrete slash-prefixed client URL path.
       rpcPath: "*",
     });
+    // @ts-expect-error runtime health path must be a concrete slash-prefixed client URL path.
     const invalidWildcardHealthPathOptions = makeViewServerRuntime(viewServer, {
-      // @ts-expect-error runtime health path must be a concrete slash-prefixed client URL path.
       healthPath: "*",
     });
     const invalidGroupedAdmissionLimitKey = makeViewServerRuntime(viewServer, {
       groupedIncrementalAdmissionLimits: {
-        // @ts-expect-error grouped admission limit keys are exact.
+        // @ts-expect-error grouped admission limits reject unknown keys.
         maxGroupz: 1,
       },
     });
@@ -273,9 +294,9 @@ describe("runtime type contracts", () => {
       kafka: {
         consumerGroupId: "view-server-type-test",
         regions: usaKafkaRegions,
+        // @ts-expect-error committed Kafka start fallback must be earliest, latest, or fail.
         startFrom: {
           committedConsumerGroup: "view-server-existing-group",
-          // @ts-expect-error committed Kafka start fallback must be earliest, latest, or fail.
           fallback: "middle",
         },
         topics: {
@@ -385,6 +406,24 @@ describe("runtime type contracts", () => {
         },
       },
     });
+    const runtimeWithGrpc = makeViewServerRuntime(materializedGrpcViewServer, {
+      grpc: {
+        clients: grpcRuntimeClients,
+        feeds: {
+          ordersFeed: grpcOrdersFeed,
+        },
+      },
+    });
+    const invalidGrpcOptionKey = makeViewServerRuntime(materializedGrpcViewServer, {
+      grpc: {
+        clients: grpcRuntimeClients,
+        feeds: {
+          ordersFeed: grpcOrdersFeed,
+        },
+        // @ts-expect-error runtime gRPC options reject unknown fields.
+        feedz: {},
+      },
+    });
     expectTypeOf(invalidPublish).not.toBeAny();
     expectTypeOf(invalidSubscribe).not.toBeAny();
     expectTypeOf(invalidTopicPublish).not.toBeAny();
@@ -410,8 +449,13 @@ describe("runtime type contracts", () => {
     expectTypeOf(invalidKafkaOptionKey).not.toBeAny();
     expectTypeOf(invalidMissingKafkaConsumerGroup).not.toBeAny();
     expectTypeOf(invalidKafkaRegionRuntime).not.toBeAny();
+    expectTypeOf<Effect.Success<typeof runtimeWithGrpc>>().toMatchTypeOf<
+      ViewServerRuntime<typeof materializedGrpcViewServer.topics>
+    >();
+    expectTypeOf(invalidGrpcOptionKey).not.toBeAny();
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("port");
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("path");
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("tcpPublishPort");
+    expectTypeOf<ViewServerRuntimeOptions>().toHaveProperty("grpc");
   });
 });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,19 +1,46 @@
 import { describe, expect, it } from "@effect/vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
+import type { Message } from "@bufbuild/protobuf";
+import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
 import type { ColumnLiveViewEngineHealth } from "@view-server/column-live-view-engine";
 import { makeViewServerClient } from "@view-server/client/remote";
-import { defineViewServerConfig, kafka, type TransportHealth } from "@view-server/config";
+import {
+  defineViewServerConfig,
+  grpc,
+  kafka,
+  type TransportHealth,
+  type ViewServerHealth,
+  type ViewServerRuntimeError,
+  type ViewServerRuntimeClient,
+} from "@view-server/config";
 import { makeViewServerRuntimeCore } from "@view-server/runtime-core";
-import { Config, Deferred, Effect, Exit, Fiber, Schedule, Schema, Stream } from "effect";
+import { FieldDescriptorProto_Type, FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";
+import {
+  Cause,
+  Clock,
+  Config,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Schedule,
+  Schema,
+  Stream,
+} from "effect";
 import type { ViewServerRuntimeDependencies } from "./internal";
 import {
   makeDefaultRuntimeDependencies,
   makeViewServerRuntimeWithDependencies,
   runViewServerRuntimeWithDependencies,
 } from "./internal";
+import { makeViewServerGrpcHealthLedger } from "./grpc-health";
+import { makeViewServerGrpcIngress, ViewServerGrpcIngressError } from "./grpc-ingress";
 import { makeViewServerRuntime, runViewServerRuntime } from "./index";
 import { ViewServerKafkaIngressError } from "./kafka-ingress";
 import {
   resolveViewServerRuntimeOptions,
+  validateSourceOwnership,
+  type ResolvedViewServerGrpcRuntimeOptions,
   type ResolvedViewServerKafkaRuntimeOptions,
 } from "./runtime-options";
 import { makeViewServerRuntimeTransportHealth } from "./transport-health";
@@ -51,6 +78,262 @@ const viewServer = defineViewServerConfig({
 });
 
 type OrderRow = typeof Order.Type;
+
+type GrpcOrderValueMessage = Message<"viewserver.runtime.OrderValue"> & {
+  readonly customerId: string;
+  readonly status: "open" | "closed" | "cancelled";
+  readonly price: number;
+  readonly updatedAt: number;
+};
+
+type GrpcOrderKeyMessage = Message<"viewserver.runtime.OrderKey"> & {
+  readonly orderId: string;
+};
+
+const base64FromBytes = (bytes: Uint8Array) =>
+  globalThis.btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+
+const runtimeGrpcProtoFile = fileDesc(
+  base64FromBytes(
+    toBinary(
+      FileDescriptorProtoSchema,
+      create(FileDescriptorProtoSchema, {
+        name: "viewserver/runtime.proto",
+        package: "viewserver.runtime",
+        syntax: "proto3",
+        messageType: [
+          {
+            name: "OrderValue",
+            field: [
+              { name: "customer_id", number: 1, type: FieldDescriptorProto_Type.STRING },
+              { name: "status", number: 2, type: FieldDescriptorProto_Type.STRING },
+              { name: "price", number: 3, type: FieldDescriptorProto_Type.DOUBLE },
+              { name: "updated_at", number: 4, type: FieldDescriptorProto_Type.DOUBLE },
+            ],
+          },
+          {
+            name: "OrderKey",
+            field: [{ name: "order_id", number: 1, type: FieldDescriptorProto_Type.STRING }],
+          },
+        ],
+        service: [
+          {
+            name: "OrdersService",
+            method: [
+              {
+                name: "StreamOrders",
+                inputType: ".viewserver.runtime.OrderKey",
+                outputType: ".viewserver.runtime.OrderValue",
+                serverStreaming: true,
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+  ),
+);
+
+const grpcOrderValueSchema = messageDesc<GrpcOrderValueMessage>(runtimeGrpcProtoFile, 0);
+const grpcOrderKeySchema = messageDesc<GrpcOrderKeyMessage>(runtimeGrpcProtoFile, 1);
+const grpcOrdersService = serviceDesc<{
+  readonly streamOrders: {
+    readonly input: typeof grpcOrderKeySchema;
+    readonly output: typeof grpcOrderValueSchema;
+    readonly methodKind: "server_streaming";
+  };
+}>(runtimeGrpcProtoFile, 0);
+
+const GrpcOrder = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Number,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+const grpcViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: GrpcOrder,
+      key: "id",
+      source: grpc.materialized(),
+    },
+  },
+});
+
+type GrpcTopics = typeof grpcViewServer.topics;
+
+const grpcAndKafkaViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: GrpcOrder,
+      key: "id",
+      source: grpc.materialized(),
+    },
+    audit: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+const leasedGrpcViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: GrpcOrder,
+      key: "id",
+      source: grpc.leased({
+        routeBy: ["region"],
+      }),
+    },
+  },
+});
+
+const grpcClients = {
+  orders: grpc.connectClient({
+    service: grpcOrdersService,
+    baseUrl: Config.succeed("https://orders.example.test"),
+  }),
+};
+
+const grpcClientsWithOrphan = {
+  ...grpcClients,
+  orphan: grpc.connectClient({
+    service: grpcOrdersService,
+    baseUrl: Config.succeed("https://orphan.example.test"),
+  }),
+};
+
+const grpcFeed = grpcViewServer.grpcFeed<typeof grpcClients>();
+const grpcFeedWithOrphan = grpcViewServer.grpcFeed<typeof grpcClientsWithOrphan>();
+const mixedGrpcFeed = grpcAndKafkaViewServer.grpcFeed<typeof grpcClients>();
+const leasedGrpcFeed = leasedGrpcViewServer.grpcFeed<typeof grpcClients>();
+
+const grpcOrderValue = (
+  customerId: string,
+  price: number,
+  status: GrpcOrderValueMessage["status"] = "open",
+): GrpcOrderValueMessage => ({
+  $typeName: "viewserver.runtime.OrderValue",
+  customerId,
+  status,
+  price,
+  updatedAt: price,
+});
+
+const grpcMaterializedFeed = (stream: Stream.Stream<GrpcOrderValueMessage, unknown, never>) =>
+  grpcFeed.materializedFeed({
+    topic: "orders",
+    client: "orders",
+    method: "streamOrders",
+    request: () => ({ orderId: "all" }),
+    acquire: () => stream,
+    map: ({ value }) => ({
+      id: value.customerId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region: "usa",
+      updatedAt: value.updatedAt,
+    }),
+  });
+
+const grpcMaterializedFeedWithRelease = (
+  stream: Stream.Stream<GrpcOrderValueMessage, unknown, never>,
+  release: Effect.Effect<void>,
+) =>
+  grpcFeed.materializedFeed({
+    topic: "orders",
+    client: "orders",
+    method: "streamOrders",
+    request: () => ({ orderId: "all" }),
+    acquire: () => stream,
+    release: () => release,
+    map: ({ value }) => ({
+      id: value.customerId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region: "usa",
+      updatedAt: value.updatedAt,
+    }),
+  });
+
+const grpcMaterializedFeedWithRequestFailure = () =>
+  grpcFeed.materializedFeed({
+    topic: "orders",
+    client: "orders",
+    method: "streamOrders",
+    request: () => {
+      throw new Error("request exploded");
+    },
+    acquire: () => Stream.never,
+    map: ({ value }) => ({
+      id: value.customerId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region: "usa",
+      updatedAt: value.updatedAt,
+    }),
+  });
+
+const grpcMaterializedFeedWithAcquireFailure = () =>
+  grpcFeed.materializedFeed({
+    topic: "orders",
+    client: "orders",
+    method: "streamOrders",
+    request: () => ({ orderId: "all" }),
+    acquire: () => {
+      throw new Error("acquire exploded");
+    },
+    map: ({ value }) => ({
+      id: value.customerId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region: "usa",
+      updatedAt: value.updatedAt,
+    }),
+  });
+
+const grpcMaterializedFeedWithMappingFailure = (
+  stream: Stream.Stream<GrpcOrderValueMessage, unknown, never>,
+) =>
+  grpcFeed.materializedFeed({
+    topic: "orders",
+    client: "orders",
+    method: "streamOrders",
+    request: () => ({ orderId: "all" }),
+    acquire: () => stream,
+    map: () => {
+      throw new Error("mapping exploded");
+    },
+  });
+
+const grpcMaterializedFeedWithOrphanClient = () =>
+  grpcFeedWithOrphan.materializedFeed({
+    topic: "orders",
+    client: "orphan",
+    method: "streamOrders",
+    request: () => ({ orderId: "all" }),
+    acquire: () => Stream.never,
+    map: ({ value }) => ({
+      id: value.customerId,
+      customerId: value.customerId,
+      status: value.status,
+      price: value.price,
+      region: "usa",
+      updatedAt: value.updatedAt,
+    }),
+  });
+
+const longRunningGrpcStream = (
+  values: ReadonlyArray<GrpcOrderValueMessage>,
+): Stream.Stream<GrpcOrderValueMessage, never, never> =>
+  Stream.make(...values).pipe(Stream.concat(Stream.never));
 
 const order = (id: string, price: number): OrderRow => ({
   id,
@@ -95,6 +378,80 @@ const waitForTransportHealth = Effect.fn("ViewServerRuntime.test.transportHealth
     }),
   );
 });
+
+const waitForGrpcSnapshotRows = Effect.fn("ViewServerRuntime.test.grpc.snapshotRows.wait")(
+  function* (client: ViewServerRuntimeClient<GrpcTopics>, expectedTotalRows: number) {
+    return yield* client
+      .snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      })
+      .pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (snapshot) => snapshot.totalRows === expectedTotalRows,
+        }),
+      );
+  },
+);
+
+const readGrpcHealthOverlay = Effect.fn("ViewServerRuntime.test.grpc.healthOverlay.read")(
+  function* (
+    client: ViewServerRuntimeClient<GrpcTopics>,
+    health: ReturnType<typeof makeViewServerGrpcHealthLedger<GrpcTopics>>,
+    nowMillis: number,
+  ) {
+    return health.healthOverlay(yield* client.health(), nowMillis);
+  },
+);
+
+const readGrpcHealthOverlayNow = Effect.fn("ViewServerRuntime.test.grpc.healthOverlay.readNow")(
+  function* (
+    client: ViewServerRuntimeClient<GrpcTopics>,
+    health: ReturnType<typeof makeViewServerGrpcHealthLedger<GrpcTopics>>,
+  ) {
+    const nowMillis = yield* Clock.currentTimeMillis;
+    return health.healthOverlay(yield* client.health(), nowMillis);
+  },
+);
+
+const makeGrpcHealth = (
+  grpcOptions: ResolvedViewServerGrpcRuntimeOptions<GrpcTopics, typeof grpcClients>,
+) =>
+  makeViewServerGrpcHealthLedger<GrpcTopics>({
+    clients: grpcOptions.clientBaseUrls,
+    feeds: {
+      ordersFeed: {
+        client: "orders",
+        lifecycle: "materialized",
+        topic: "orders",
+      },
+    },
+  });
+
+const grpcHealthFeed = (health: ViewServerHealth<GrpcTopics>) =>
+  health.grpc?.feeds["orders"]?.materialized["ordersFeed"];
+
+const grpcHealthClient = (health: ViewServerHealth<GrpcTopics>) => health.grpc?.clients["orders"];
+
+const resolveGrpcRuntimeOptions = Effect.fn("ViewServerRuntime.test.grpc.options.resolve")(
+  function* (feed: ReturnType<typeof grpcMaterializedFeed>) {
+    const options = yield* resolveViewServerRuntimeOptions<
+      GrpcTopics,
+      Record<string, string>,
+      typeof grpcClients
+    >({
+      grpc: {
+        clients: grpcClients,
+        feeds: {
+          ordersFeed: feed,
+        },
+      },
+    });
+    return yield* Effect.fromNullishOr(options.grpcOptions);
+  },
+);
 
 describe("@view-server/runtime", () => {
   it.live("starts a websocket runtime with health endpoint and runtime-core mutation client", () =>
@@ -344,10 +701,27 @@ describe("@view-server/runtime", () => {
   it.live("resolves Kafka runtime options and starts configured ingress", () =>
     Effect.gen(function* () {
       type RuntimeDependencies = ViewServerRuntimeDependencies<typeof viewServer.topics>;
-      let kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<typeof viewServer.topics> | undefined;
       const regions = {
         local: Config.succeed("localhost:9092"),
       };
+      let kafkaOptionsSummary:
+        | {
+            readonly consume: ResolvedViewServerKafkaRuntimeOptions<
+              typeof viewServer.topics
+            >["consume"];
+            readonly consumerGroupId: string;
+            readonly regions: Readonly<Record<string, string>>;
+            readonly startFrom: ResolvedViewServerKafkaRuntimeOptions<
+              typeof viewServer.topics
+            >["startFrom"];
+            readonly topics: Readonly<
+              Record<
+                string,
+                { readonly regions: ReadonlyArray<string>; readonly viewServerTopic: string }
+              >
+            >;
+          }
+        | undefined;
       const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
       const dependencies: RuntimeDependencies = {
         ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
@@ -358,7 +732,21 @@ describe("@view-server/runtime", () => {
             close: Effect.void,
           }),
         makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
-          kafkaOptions = options;
+          kafkaOptionsSummary = {
+            consume: options.consume,
+            consumerGroupId: options.consumerGroupId,
+            regions: options.regions,
+            startFrom: options.startFrom,
+            topics: Object.fromEntries(
+              Object.entries(options.topics).map(([sourceTopic, topic]) => [
+                sourceTopic,
+                {
+                  regions: topic.regions,
+                  viewServerTopic: topic.viewServerTopic,
+                },
+              ]),
+            ),
+          };
           return Effect.succeed({
             close: Effect.void,
           });
@@ -385,19 +773,11 @@ describe("@view-server/runtime", () => {
       });
 
       expect({
-        consume: kafkaOptions?.consume,
-        consumerGroupId: kafkaOptions?.consumerGroupId,
-        regions: kafkaOptions?.regions,
-        startFrom: kafkaOptions?.startFrom,
-        topics: Object.fromEntries(
-          Object.entries(kafkaOptions?.topics ?? {}).map(([sourceTopic, topic]) => [
-            sourceTopic,
-            {
-              regions: topic.regions,
-              viewServerTopic: topic.viewServerTopic,
-            },
-          ]),
-        ),
+        consume: kafkaOptionsSummary?.consume,
+        consumerGroupId: kafkaOptionsSummary?.consumerGroupId,
+        regions: kafkaOptionsSummary?.regions,
+        startFrom: kafkaOptionsSummary?.startFrom,
+        topics: kafkaOptionsSummary?.topics,
       }).toStrictEqual({
         consume: {
           consumerGroupId: "view-server-test-runtime",
@@ -418,6 +798,1213 @@ describe("@view-server/runtime", () => {
       });
 
       yield* runtime.close;
+    }),
+  );
+
+  it.live("resolves gRPC runtime options and starts configured materialized ingress", () =>
+    Effect.gen(function* () {
+      type RuntimeDependencies = ViewServerRuntimeDependencies<GrpcTopics>;
+      const feed = grpcMaterializedFeed(Stream.never);
+      let grpcOptionsSummary:
+        | {
+            readonly clientBaseUrls: Readonly<Record<string, string>>;
+            readonly clientNames: ReadonlyArray<string>;
+            readonly feeds: Readonly<
+              Record<
+                string,
+                {
+                  readonly client: string;
+                  readonly lifecycle: string;
+                  readonly method: string;
+                  readonly topic: string;
+                }
+              >
+            >;
+          }
+        | undefined;
+      let grpcHealthLedgerCreated = false;
+      const dependencies: RuntimeDependencies = {
+        ...makeDefaultRuntimeDependencies<GrpcTopics>(),
+        makeServer: () =>
+          Effect.succeed({
+            url: "ws://127.0.0.1:0/rpc",
+            healthUrl: "http://127.0.0.1:0/health",
+            close: Effect.void,
+          }),
+        makeGrpcHealthLedger: (config, options) => {
+          grpcHealthLedgerCreated =
+            config === grpcViewServer &&
+            options.clientBaseUrls["orders"] === "https://orders.example.test";
+          return makeDefaultRuntimeDependencies<GrpcTopics>().makeGrpcHealthLedger(config, options);
+        },
+        makeGrpcIngress: (_config, _client, _requestHealthRefresh, options) => {
+          grpcOptionsSummary = {
+            clientBaseUrls: options.clientBaseUrls,
+            clientNames: Object.keys(options.clients),
+            feeds: Object.fromEntries(
+              Object.entries(options.feeds).map(([feedName, resolvedFeed]) => [
+                feedName,
+                {
+                  client: resolvedFeed.client,
+                  lifecycle: resolvedFeed.lifecycle,
+                  method: resolvedFeed.method,
+                  topic: resolvedFeed.topic,
+                },
+              ]),
+            ),
+          };
+          return Effect.succeed({
+            close: Effect.void,
+          });
+        },
+      };
+
+      const grpcRuntimeOptions = {
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: feed,
+          },
+        },
+      };
+      const runtime = yield* makeViewServerRuntimeWithDependencies(
+        dependencies,
+        grpcViewServer,
+        grpcRuntimeOptions,
+      );
+
+      expect(grpcHealthLedgerCreated).toBe(true);
+      expect({
+        clientBaseUrls: grpcOptionsSummary?.clientBaseUrls,
+        clientNames: grpcOptionsSummary?.clientNames,
+        feeds: grpcOptionsSummary?.feeds,
+      }).toStrictEqual({
+        clientBaseUrls: nullRecord([["orders", "https://orders.example.test"]]),
+        clientNames: ["orders"],
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            method: "streamOrders",
+            topic: "orders",
+          },
+        },
+      });
+
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("rejects multiple gRPC feeds targeting the same View Server topic", () =>
+    Effect.gen(function* () {
+      const firstFeed = grpcMaterializedFeed(Stream.never);
+      const secondFeed = grpcFeedWithOrphan.materializedFeed({
+        topic: "orders",
+        client: "orphan",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.never,
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+
+      const error = yield* makeViewServerRuntime(grpcViewServer, {
+        grpc: {
+          clients: grpcClientsWithOrphan,
+          feeds: {
+            ordersFeed: firstFeed,
+            secondOrdersFeed: secondFeed,
+          },
+        },
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ViewServerGrpcIngressError);
+      expect(error.message).toBe(
+        "gRPC feed secondOrdersFeed conflicts with ordersFeed; View Server topic orders already has a gRPC feed owner.",
+      );
+    }),
+  );
+
+  it.live("rejects leased gRPC feeds until the runtime lease manager exists", () =>
+    Effect.gen(function* () {
+      const feed = leasedGrpcFeed.leasedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        routeBy: ["region"],
+        request: ({ region }) => ({ orderId: region }),
+        acquire: () => Stream.never,
+        map: ({ value, route }) => ({
+          id: `${route.region}:${value.customerId}`,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: route.region,
+          updatedAt: value.updatedAt,
+        }),
+      });
+
+      const error = yield* makeViewServerRuntime(leasedGrpcViewServer, {
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersLease: feed,
+          },
+        },
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ViewServerGrpcIngressError);
+      expect(error.message).toBe(
+        "gRPC leased feed ordersLease is not supported by runtime startup yet.",
+      );
+    }),
+  );
+
+  it.effect("rejects resolved Kafka and gRPC ownership of the same View Server topic", () =>
+    Effect.gen(function* () {
+      const error = yield* validateSourceOwnership(
+        {
+          topics: {
+            "orders-source": {
+              viewServerTopic: "orders",
+            },
+          },
+        },
+        {
+          feeds: {
+            ordersFeed: {
+              topic: "orders",
+            },
+          },
+        },
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ViewServerGrpcIngressError);
+      expect(error.message).toBe(
+        "View Server topic orders cannot be owned by both Kafka source orders-source and gRPC feed ordersFeed.",
+      );
+    }),
+  );
+
+  it.live("closes started resources when gRPC ingress startup fails", () =>
+    Effect.gen(function* () {
+      type MixedTopics = typeof grpcAndKafkaViewServer.topics;
+      type RuntimeDependencies = ViewServerRuntimeDependencies<MixedTopics>;
+      const feed = mixedGrpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.never,
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const regions = {
+        local: "localhost:9092",
+      };
+      const localKafkaTopic = grpcAndKafkaViewServer.kafkaTopic<typeof regions>();
+      let serverClosed = 0;
+      let kafkaClosed = 0;
+      let runtimeCoreClosed = 0;
+      const dependencies: RuntimeDependencies = {
+        ...makeDefaultRuntimeDependencies<MixedTopics>(),
+        makeRuntimeCore: (config, options) =>
+          makeDefaultRuntimeDependencies<MixedTopics>()
+            .makeRuntimeCore(config, options)
+            .pipe(
+              Effect.map((runtimeCore) => ({
+                ...runtimeCore,
+                close: runtimeCore.close.pipe(
+                  Effect.andThen(
+                    Effect.sync(() => {
+                      runtimeCoreClosed += 1;
+                    }),
+                  ),
+                ),
+              })),
+            ),
+        makeServer: () =>
+          Effect.succeed({
+            url: "ws://127.0.0.1:0/rpc",
+            healthUrl: "http://127.0.0.1:0/health",
+            close: Effect.sync(() => {
+              serverClosed += 1;
+            }),
+          }),
+        makeKafkaIngress: () =>
+          Effect.succeed({
+            close: Effect.sync(() => {
+              kafkaClosed += 1;
+            }),
+          }),
+        makeGrpcIngress: () =>
+          Effect.fail(
+            new ViewServerGrpcIngressError({
+              message: "gRPC failed during startup",
+              cause: "startup",
+            }),
+          ),
+      };
+
+      const exit = yield* Effect.exit(
+        makeViewServerRuntimeWithDependencies(dependencies, grpcAndKafkaViewServer, {
+          kafka: {
+            consumerGroupId: "view-server-grpc-startup-failure",
+            regions,
+            topics: {
+              "orders-source": localKafkaTopic({
+                regions: ["local"],
+                value: kafka.json(Order),
+                key: kafka.stringKey(),
+                viewServerTopic: "audit",
+                mapping: ({ key, value }) => ({
+                  id: key,
+                  price: value.price,
+                }),
+              }),
+            },
+          },
+          grpc: {
+            clients: grpcClients,
+            feeds: {
+              ordersFeed: feed,
+            },
+          },
+        }),
+      );
+
+      expect({
+        failed: Exit.isFailure(exit),
+        kafkaClosed,
+        runtimeCoreClosed,
+        serverClosed,
+      }).toStrictEqual({
+        failed: true,
+        kafkaClosed: 1,
+        runtimeCoreClosed: 1,
+        serverClosed: 1,
+      });
+    }),
+  );
+
+  it.live("closes server and runtime core when gRPC ingress startup fails without Kafka", () =>
+    Effect.gen(function* () {
+      type RuntimeDependencies = ViewServerRuntimeDependencies<GrpcTopics>;
+      const feed = grpcMaterializedFeed(Stream.never);
+      let serverClosed = 0;
+      let runtimeCoreClosed = 0;
+      const dependencies: RuntimeDependencies = {
+        ...makeDefaultRuntimeDependencies<GrpcTopics>(),
+        makeRuntimeCore: (config, options) =>
+          makeDefaultRuntimeDependencies<GrpcTopics>()
+            .makeRuntimeCore(config, options)
+            .pipe(
+              Effect.map((runtimeCore) => ({
+                ...runtimeCore,
+                close: runtimeCore.close.pipe(
+                  Effect.andThen(
+                    Effect.sync(() => {
+                      runtimeCoreClosed += 1;
+                    }),
+                  ),
+                ),
+              })),
+            ),
+        makeServer: () =>
+          Effect.succeed({
+            url: "ws://127.0.0.1:0/rpc",
+            healthUrl: "http://127.0.0.1:0/health",
+            close: Effect.sync(() => {
+              serverClosed += 1;
+            }),
+          }),
+        makeGrpcIngress: () =>
+          Effect.fail(
+            new ViewServerGrpcIngressError({
+              message: "gRPC failed before Kafka existed",
+              cause: "startup",
+            }),
+          ),
+      };
+
+      const exit = yield* Effect.exit(
+        makeViewServerRuntimeWithDependencies(dependencies, grpcViewServer, {
+          grpc: {
+            clients: grpcClients,
+            feeds: {
+              ordersFeed: feed,
+            },
+          },
+        }),
+      );
+
+      expect({
+        failed: Exit.isFailure(exit),
+        runtimeCoreClosed,
+        serverClosed,
+      }).toStrictEqual({
+        failed: true,
+        runtimeCoreClosed: 1,
+        serverClosed: 1,
+      });
+    }),
+  );
+
+  it.live("tracks gRPC materialized feed health and same-window rate increments", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
+        clients: {
+          orders: "https://orders.example.test",
+        },
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+
+      const startingHealth = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+      yield* health.clientConnected("missing", 1_000);
+      yield* health.clientDegraded("missing", "ignored");
+      yield* health.feedReady("missing");
+      yield* health.feedStopping("missing");
+      yield* health.feedDegraded("missing", "ignored");
+      yield* health.rowsPublished("missing", {
+        messages: 1,
+        rows: 1,
+        nowMillis: 2_000,
+      });
+      yield* health.mappingFailed("missing", {
+        message: "ignored",
+        nowMillis: 2_000,
+      });
+      yield* health.publishFailed("missing", {
+        message: "ignored",
+        nowMillis: 2_000,
+      });
+      yield* health.clientConnected("orders", 1_000);
+      yield* health.feedReady("ordersFeed");
+      yield* health.rowsPublished("ordersFeed", {
+        messages: 1,
+        rows: 2,
+        nowMillis: 2_000,
+      });
+      yield* health.rowsPublished("ordersFeed", {
+        messages: 3,
+        rows: 4,
+        nowMillis: 2_000,
+      });
+      const readyHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        startingStatus: startingHealth.status,
+        startingActiveFeeds: startingHealth.grpc?.clients["orders"]?.activeFeeds,
+        readyStatus: readyHealth.status,
+        readyActiveFeeds: readyHealth.grpc?.clients["orders"]?.activeFeeds,
+        materialized: readyHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"],
+      }).toStrictEqual({
+        startingStatus: "starting",
+        startingActiveFeeds: 0,
+        readyStatus: "ready",
+        readyActiveFeeds: 1,
+        materialized: {
+          status: "ready",
+          lifecycle: "materialized",
+          feedName: "ordersFeed",
+          feedKey: "orders/ordersFeed/materialized",
+          topic: "orders",
+          subscriberCount: 0,
+          rowCount: 0,
+          messagesPerSecond: 4,
+          rowsPerSecond: 6,
+          decodeFailuresPerSecond: 0,
+          mappingFailuresPerSecond: 0,
+          publishFailuresPerSecond: 0,
+          reconnects: 0,
+          lastMessageAt: 2_000,
+          lastError: null,
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("tracks leased gRPC feed health in the ledger without starting runtime leases", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(leasedGrpcViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof leasedGrpcViewServer.topics>({
+        clients: {
+          orders: "https://orders.example.test",
+        },
+        feeds: {
+          ordersLease: {
+            client: "orders",
+            lifecycle: "leased",
+            topic: "orders",
+          },
+        },
+      });
+
+      const startingHealth = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+      yield* health.clientConnected("orders", 1_000);
+      yield* health.feedReady("ordersLease");
+      const readyHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        startingActiveFeeds: startingHealth.grpc?.clients["orders"]?.activeFeeds,
+        startingStatus: startingHealth.grpc?.feeds["orders"]?.leased["ordersLease"]?.status,
+        readyActiveFeeds: readyHealth.grpc?.clients["orders"]?.activeFeeds,
+        readyFeed: readyHealth.grpc?.feeds["orders"]?.leased["ordersLease"],
+      }).toStrictEqual({
+        startingActiveFeeds: 0,
+        startingStatus: "starting",
+        readyActiveFeeds: 1,
+        readyFeed: {
+          status: "ready",
+          lifecycle: "leased",
+          feedName: "ordersLease",
+          feedKey: "orders/ordersLease/leased",
+          topic: "orders",
+          subscriberCount: 0,
+          rowCount: 0,
+          messagesPerSecond: 0,
+          rowsPerSecond: 0,
+          decodeFailuresPerSecond: 0,
+          mappingFailuresPerSecond: 0,
+          publishFailuresPerSecond: 0,
+          reconnects: 0,
+          lastMessageAt: null,
+          lastError: null,
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed degraded when the stream completes", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.make(grpcOrderValue("order-1", 10)));
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+        "gRPC feed ordersFeed completed unexpectedly.",
+      );
+      expect(grpcHealthClient(degradedHealth)?.activeFeeds).toBe(0);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed stopping when the stream is interrupted", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.failCause(Cause.interrupt()));
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const stoppingHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+        }),
+      );
+
+      expect(grpcHealthFeed(stoppingHealth)?.lastError).toBe(null);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("publishes materialized gRPC stream rows into runtime core and health", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(
+        longRunningGrpcStream([grpcOrderValue("order-1", 10), grpcOrderValue("order-2", 5)]),
+      );
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      let healthRefreshCount = 0;
+      const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.sync(() => {
+          healthRefreshCount += 1;
+        }),
+        grpcOptions,
+        health,
+      );
+
+      const snapshot = yield* waitForGrpcSnapshotRows(runtimeCore.client, 2);
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      const clientHealth = currentHealth.grpc?.clients["orders"];
+      const feedHealth = currentHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"];
+
+      expect(snapshot).toStrictEqual({
+        rows: [
+          { id: "order-2", price: 5 },
+          { id: "order-1", price: 10 },
+        ],
+        totalRows: 2,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      expect(clientHealth).toStrictEqual({
+        status: "connected",
+        baseUrl: "https://orders.example.test",
+        activeFeeds: 1,
+        lastConnectedAt: clientHealth?.lastConnectedAt,
+        lastError: null,
+      });
+      expect(feedHealth).toStrictEqual({
+        status: "ready",
+        lifecycle: "materialized",
+        feedName: "ordersFeed",
+        feedKey: "orders/ordersFeed/materialized",
+        topic: "orders",
+        subscriberCount: 0,
+        rowCount: 2,
+        messagesPerSecond: 0,
+        rowsPerSecond: 0,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        reconnects: 0,
+        lastMessageAt: feedHealth?.lastMessageAt,
+        lastError: null,
+      });
+      expect(typeof clientHealth?.lastConnectedAt).toBe("number");
+      expect(typeof feedHealth?.lastMessageAt).toBe("number");
+      expect(healthRefreshCount).toBe(2);
+
+      yield* ingress.close;
+      const stoppedHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      expect(stoppedHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.status).toBe(
+        "stopping",
+      );
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "reports materialized gRPC row count from engine health instead of cumulative publishes",
+    () =>
+      Effect.gen(function* () {
+        const feed = grpcMaterializedFeed(
+          longRunningGrpcStream([
+            grpcOrderValue("order-1", 10),
+            grpcOrderValue("order-1", 20),
+            grpcOrderValue("order-1", 30),
+          ]),
+        );
+        const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+        const health = makeGrpcHealth(grpcOptions);
+        const ingress = yield* makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const snapshot = yield* waitForGrpcSnapshotRows(runtimeCore.client, 1);
+        const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+        expect(snapshot).toStrictEqual({
+          rows: [{ id: "order-1", price: 30 }],
+          totalRows: 1,
+          version: 1,
+          status: "ready",
+          statusCode: "Ready",
+        });
+        expect(currentHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.rowCount).toBe(1);
+
+        yield* ingress.close;
+        yield* runtimeCore.close;
+      }),
+  );
+
+  it.live("marks materialized gRPC feed degraded when the stream defects", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.fromEffect(Effect.die("defect down")));
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toContain("gRPC feed ordersFeed failed:");
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toContain("defect down");
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed health degraded when the stream fails", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.fail("upstream down"));
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      let healthRefreshCount = 0;
+      const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.sync(() => {
+          healthRefreshCount += 1;
+        }),
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlay(runtimeCore.client, health, 2_000).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.status === "degraded",
+        }),
+      );
+
+      expect(degradedHealth.status).toBe("degraded");
+      expect(degradedHealth.grpc?.clients["orders"]?.status).toBe("degraded");
+      expect(degradedHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.status).toBe(
+        "degraded",
+      );
+      expect(degradedHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.lastError).toBe(
+        "gRPC feed ordersFeed failed: gRPC feed stream failed for ordersFeed: upstream down",
+      );
+      expect(healthRefreshCount).toBe(2);
+
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("releases materialized gRPC feed resources when ingress closes", () =>
+    Effect.gen(function* () {
+      const released = yield* Deferred.make<void>();
+      const feed = grpcMaterializedFeedWithRelease(
+        Stream.never,
+        Deferred.succeed(released, undefined),
+      );
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      yield* ingress.close;
+      yield* Deferred.await(released);
+      expect(
+        grpcHealthFeed(health.healthOverlay(yield* runtimeCore.client.health(), 2_000)),
+      ).toStrictEqual({
+        status: "stopping",
+        lifecycle: "materialized",
+        feedName: "ordersFeed",
+        feedKey: "orders/ordersFeed/materialized",
+        topic: "orders",
+        subscriberCount: 0,
+        rowCount: 0,
+        messagesPerSecond: 0,
+        rowsPerSecond: 0,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        reconnects: 0,
+        lastMessageAt: null,
+        lastError: null,
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("ignores materialized gRPC release construction failures during ingress close", () =>
+    Effect.gen(function* () {
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all-orders" }),
+        acquire: () => Stream.never,
+        release: () => {
+          throw new Error("release exploded");
+        },
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      yield* ingress.close;
+      expect(
+        grpcHealthFeed(health.healthOverlay(yield* runtimeCore.client.health(), 2_000))?.status,
+      ).toBe("stopping");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("refreshes materialized gRPC health after an idle feed becomes ready", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.never);
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      let healthRefreshCount = 0;
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.sync(() => {
+          healthRefreshCount += 1;
+        }),
+        grpcOptions,
+        health,
+      );
+
+      const readyHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      expect(grpcHealthFeed(readyHealth)?.status).toBe("ready");
+      expect(grpcHealthClient(readyHealth)?.activeFeeds).toBe(1);
+      expect(healthRefreshCount).toBe(1);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("fails materialized gRPC ingress startup when request creation fails", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeedWithRequestFailure();
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const error = yield* Effect.flip(
+        makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        ),
+      );
+
+      expect(error._tag).toBe("ViewServerGrpcIngressError");
+      expect(error.message).toBe("gRPC feed request creation failed for ordersFeed");
+      expect(error.feedName).toBe("ordersFeed");
+      expect(error.topic).toBe("orders");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("fails materialized gRPC ingress startup when client creation throws", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.never);
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const error = yield* Effect.flip(
+        makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+          () => {
+            throw new Error("client factory exploded");
+          },
+        ),
+      );
+
+      expect(error._tag).toBe("ViewServerGrpcIngressError");
+      expect(error.message).toBe("gRPC client creation failed for ordersFeed");
+      expect(error.feedName).toBe("ordersFeed");
+      expect(error.topic).toBe("orders");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("fails lower-level gRPC ingress startup for leased feeds", () =>
+    Effect.gen(function* () {
+      const feed = leasedGrpcFeed.leasedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        routeBy: ["region"],
+        request: ({ region }) => ({ orderId: region }),
+        acquire: () => Stream.never,
+        map: ({ value, route }) => ({
+          id: `${route.region}:${value.customerId}`,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: route.region,
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions: ResolvedViewServerGrpcRuntimeOptions<
+        typeof leasedGrpcViewServer.topics,
+        typeof grpcClients
+      > = {
+        clients: grpcClients,
+        clientBaseUrls: nullRecord([["orders", "https://orders.example.test"]]),
+        feeds: {
+          ordersLease: feed,
+        },
+      };
+      const runtimeCore = yield* makeViewServerRuntimeCore(leasedGrpcViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof leasedGrpcViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {
+          ordersLease: {
+            client: "orders",
+            lifecycle: "leased",
+            topic: "orders",
+          },
+        },
+      });
+
+      const error = yield* Effect.flip(
+        makeViewServerGrpcIngress(
+          leasedGrpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        ),
+      );
+
+      expect(error.message).toBe(
+        "gRPC leased feed ordersLease is not supported by materialized ingress startup",
+      );
+      expect(error.feedName).toBe("ordersLease");
+      expect(error.topic).toBe("orders");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("closes already-started gRPC feed resources when another feed fails startup", () =>
+    Effect.gen(function* () {
+      const released = yield* Deferred.make<void>();
+      const runningFeed = grpcMaterializedFeedWithRelease(
+        Stream.never,
+        Deferred.succeed(released, undefined),
+      );
+      const failingFeed = grpcMaterializedFeedWithRequestFailure();
+      const grpcOptions: ResolvedViewServerGrpcRuntimeOptions<GrpcTopics, typeof grpcClients> = {
+        clients: grpcClients,
+        clientBaseUrls: nullRecord([["orders", "https://orders.example.test"]]),
+        feeds: {
+          runningFeed,
+          failingFeed,
+        },
+      };
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {
+          runningFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+          failingFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+
+      const error = yield* Effect.flip(
+        makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        ),
+      );
+
+      yield* Deferred.await(released);
+      expect(error.message).toBe("gRPC feed request creation failed for failingFeed");
+      expect(error.feedName).toBe("failingFeed");
+      expect(error.topic).toBe("orders");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("fails materialized gRPC ingress startup when feed client is missing", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeedWithOrphanClient();
+      const grpcOptions: ResolvedViewServerGrpcRuntimeOptions<
+        GrpcTopics,
+        typeof grpcClientsWithOrphan
+      > = {
+        // @ts-expect-error defensive runtime-boundary test intentionally omits the orphan client.
+        clients: {},
+        clientBaseUrls: {},
+        feeds: {
+          ordersFeed: feed,
+        },
+      };
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+      const error = yield* Effect.flip(
+        makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        ),
+      );
+
+      expect(error.message).toBe("gRPC feed ordersFeed references missing client: orphan");
+      expect(error.feedName).toBe("ordersFeed");
+      expect(error.topic).toBe("orders");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("fails materialized gRPC ingress startup when feed client URL is unresolved", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(Stream.never);
+      const grpcOptions: ResolvedViewServerGrpcRuntimeOptions<GrpcTopics, typeof grpcClients> = {
+        clients: grpcClients,
+        clientBaseUrls: {},
+        feeds: {
+          ordersFeed: feed,
+        },
+      };
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {
+          ordersFeed: {
+            client: "orders",
+            lifecycle: "materialized",
+            topic: "orders",
+          },
+        },
+      });
+      const error = yield* Effect.flip(
+        makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        ),
+      );
+
+      expect(error.message).toBe("gRPC feed ordersFeed references unresolved client URL: orders");
+      expect(error.feedName).toBe("ordersFeed");
+      expect(error.topic).toBe("orders");
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed degraded when acquire throws", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeedWithAcquireFailure();
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(degradedHealth.status).toBe("degraded");
+      expect(grpcHealthClient(degradedHealth)?.status).toBe("degraded");
+      expect(grpcHealthFeed(degradedHealth)?.status).toBe("degraded");
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+        "gRPC feed ordersFeed failed: gRPC feed acquire failed for ordersFeed: acquire exploded",
+      );
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("records materialized gRPC mapping failures in health", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeedWithMappingFailure(
+        longRunningGrpcStream([grpcOrderValue("order-1", 10)]),
+      );
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(degradedHealth.status).toBe("degraded");
+      expect(grpcHealthFeed(degradedHealth)?.mappingFailuresPerSecond).toBe(1);
+      expect(grpcHealthFeed(degradedHealth)?.publishFailuresPerSecond).toBe(0);
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+        "gRPC feed ordersFeed failed: gRPC feed mapping failed for ordersFeed: mapping exploded",
+      );
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("records materialized gRPC publish failures in health", () =>
+    Effect.gen(function* () {
+      const feed = grpcMaterializedFeed(longRunningGrpcStream([grpcOrderValue("order-1", 10)]));
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCore(grpcViewServer, {});
+      const publishFailure: ViewServerRuntimeError = {
+        _tag: "ViewServerRuntimeError",
+        code: "RuntimeUnavailable",
+        message: "publish unavailable",
+        topic: "orders",
+      };
+      const failingRuntimeClient: ViewServerRuntimeClient<GrpcTopics> = {
+        ...runtimeCore.client,
+        publishMany: () => Effect.fail(publishFailure),
+      };
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        failingRuntimeClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(degradedHealth.status).toBe("degraded");
+      expect(grpcHealthFeed(degradedHealth)?.mappingFailuresPerSecond).toBe(0);
+      expect(grpcHealthFeed(degradedHealth)?.publishFailuresPerSecond).toBe(1);
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+        "gRPC feed ordersFeed failed: gRPC feed publish failed for ordersFeed: publish unavailable",
+      );
+      yield* ingress.close;
+      yield* runtimeCore.close;
     }),
   );
 
@@ -511,8 +2098,19 @@ describe("@view-server/runtime", () => {
   it.live("preserves dangerous Kafka runtime option keys", () =>
     Effect.gen(function* () {
       type RuntimeDependencies = ViewServerRuntimeDependencies<typeof viewServer.topics>;
-      let kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<typeof viewServer.topics> | undefined;
       const regions = nullRecord([["__proto__", Config.succeed("localhost:9092")]]);
+      let kafkaOptionsSummary:
+        | {
+            readonly consumerGroupId: string;
+            readonly regions: Readonly<Record<string, string>>;
+            readonly topics: Readonly<
+              Record<
+                string,
+                { readonly regions: ReadonlyArray<string>; readonly viewServerTopic: string }
+              >
+            >;
+          }
+        | undefined;
       const localKafkaTopic = viewServer.kafkaTopic<typeof regions>();
       const dangerousTopic = localKafkaTopic({
         regions: ["__proto__"],
@@ -534,7 +2132,19 @@ describe("@view-server/runtime", () => {
             close: Effect.void,
           }),
         makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
-          kafkaOptions = options;
+          kafkaOptionsSummary = {
+            consumerGroupId: options.consumerGroupId,
+            regions: options.regions,
+            topics: Object.fromEntries(
+              Object.entries(options.topics).map(([sourceTopic, topic]) => [
+                sourceTopic,
+                {
+                  regions: topic.regions,
+                  viewServerTopic: topic.viewServerTopic,
+                },
+              ]),
+            ),
+          };
           return Effect.succeed({
             close: Effect.void,
           });
@@ -549,13 +2159,13 @@ describe("@view-server/runtime", () => {
         },
       });
 
-      expect(Object.hasOwn(kafkaOptions?.regions ?? {}, "__proto__")).toBe(true);
-      expect(Object.hasOwn(kafkaOptions?.topics ?? {}, "__proto__")).toBe(true);
+      expect(Object.hasOwn(kafkaOptionsSummary?.regions ?? {}, "__proto__")).toBe(true);
+      expect(Object.hasOwn(kafkaOptionsSummary?.topics ?? {}, "__proto__")).toBe(true);
       expect({
-        consumerGroupId: kafkaOptions?.consumerGroupId,
-        region: kafkaOptions?.regions["__proto__"],
-        topicRegions: kafkaOptions?.topics["__proto__"]?.regions,
-        viewServerTopic: kafkaOptions?.topics["__proto__"]?.viewServerTopic,
+        consumerGroupId: kafkaOptionsSummary?.consumerGroupId,
+        region: kafkaOptionsSummary?.regions["__proto__"],
+        topicRegions: kafkaOptionsSummary?.topics["__proto__"]?.regions,
+        viewServerTopic: kafkaOptionsSummary?.topics["__proto__"]?.viewServerTopic,
       }).toStrictEqual({
         consumerGroupId: "view-server-dangerous-key-test-runtime",
         region: "localhost:9092",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 import type { ViewServerConfig } from "@view-server/config";
 import { Config, Effect } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
+import type { ViewServerGrpcIngressError } from "./grpc-ingress";
 import type { ViewServerKafkaIngressError } from "./kafka-ingress";
 import {
   makeDefaultRuntimeDependencies,
@@ -14,19 +15,23 @@ import {
 
 export type { ViewServerRuntime, ViewServerRuntimeOptions, ViewServerRuntimeOptionsInput };
 export type { ViewServerKafkaIngressError };
+export type { ViewServerGrpcIngressError };
 
 export const makeViewServerRuntime: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics> = ViewServerRuntimeOptions<Topics>,
+  const Options extends object = ViewServerRuntimeOptions<Topics>,
 >(
   config: ViewServerConfig<Topics>,
   options?: ViewServerRuntimeOptionsInput<Topics, Options>,
 ) => Effect.Effect<
   ViewServerRuntime<Topics>,
-  HttpServerError.ServeError | Config.ConfigError | ViewServerKafkaIngressError
+  | HttpServerError.ServeError
+  | Config.ConfigError
+  | ViewServerKafkaIngressError
+  | ViewServerGrpcIngressError
 > = Effect.fn("ViewServerRuntime.make")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics>,
+  const Options extends object,
 >(config: ViewServerConfig<Topics>, options?: ViewServerRuntimeOptionsInput<Topics, Options>) {
   return yield* options === undefined
     ? makeViewServerRuntimeWithDependencies(makeDefaultRuntimeDependencies<Topics>(), config)
@@ -41,16 +46,19 @@ export const createViewServerRuntime = makeViewServerRuntime;
 
 export const runViewServerRuntime: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics> = ViewServerRuntimeOptions<Topics>,
+  const Options extends object = ViewServerRuntimeOptions<Topics>,
 >(
   config: ViewServerConfig<Topics>,
   options?: ViewServerRuntimeOptionsInput<Topics, Options>,
 ) => Effect.Effect<
   never,
-  HttpServerError.ServeError | Config.ConfigError | ViewServerKafkaIngressError
+  | HttpServerError.ServeError
+  | Config.ConfigError
+  | ViewServerKafkaIngressError
+  | ViewServerGrpcIngressError
 > = Effect.fn("ViewServerRuntime.run")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics>,
+  const Options extends object,
 >(config: ViewServerConfig<Topics>, options?: ViewServerRuntimeOptionsInput<Topics, Options>) {
   return yield* options === undefined
     ? runViewServerRuntimeWithDependencies(makeDefaultRuntimeDependencies<Topics>(), config)

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -1,5 +1,10 @@
 import type { ViewServerLiveClient, ViewServerRuntimeLiveClient } from "@view-server/client";
-import type { RuntimeRegions, ViewServerConfig, ViewServerHealth } from "@view-server/config";
+import type {
+  GrpcRuntimeClients,
+  RuntimeRegions,
+  ViewServerConfig,
+  ViewServerHealth,
+} from "@view-server/config";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
 import type { ViewServerRuntimeCoreOptionsFor } from "@view-server/runtime-core";
 import { Config, Effect, Exit, Layer } from "effect";
@@ -9,7 +14,11 @@ import {
   type ViewServerRuntimeDependencies,
 } from "./runtime-dependencies";
 import type { ViewServerKafkaIngressError } from "./kafka-ingress";
-import { resolveViewServerRuntimeOptions } from "./runtime-options";
+import type { ViewServerGrpcIngressError } from "./grpc-ingress";
+import {
+  resolveViewServerRuntimeOptions,
+  type ResolvedViewServerRuntimeOptions,
+} from "./runtime-options";
 import type {
   ViewServerRuntime,
   ViewServerRuntimeOptionsInput,
@@ -53,48 +62,87 @@ type RuntimeCoreOptionsBuilder<Topics extends ViewServerRuntimeTopicDefinitions>
   healthOverlay?: NonNullable<ViewServerRuntimeCoreOptionsFor<Topics>["healthOverlay"]>;
 };
 
-export const makeViewServerRuntimeWithDependencies: <
+type ViewServerRuntimeFactoryError =
+  | HttpServerError.ServeError
+  | Config.ConfigError
+  | ViewServerKafkaIngressError
+  | ViewServerGrpcIngressError;
+
+type MakeViewServerRuntimeWithDependencies = {
+  <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    dependencies: ViewServerRuntimeDependencies<Topics>,
+    config: ViewServerConfig<Topics>,
+  ): Effect.Effect<ViewServerRuntime<Topics>, ViewServerRuntimeFactoryError>;
+  <const Topics extends ViewServerRuntimeTopicDefinitions, const Options extends object>(
+    dependencies: ViewServerRuntimeDependencies<Topics>,
+    config: ViewServerConfig<Topics>,
+    options: Options & ViewServerRuntimeOptionsInput<Topics, Options>,
+  ): Effect.Effect<ViewServerRuntime<Topics>, ViewServerRuntimeFactoryError>;
+};
+
+export const makeViewServerRuntimeWithDependencies: MakeViewServerRuntimeWithDependencies =
+  Effect.fn("ViewServerRuntime.makeWithDependencies")(function* <
+    const Topics extends ViewServerRuntimeTopicDefinitions,
+    const Options extends object,
+  >(
+    dependencies: ViewServerRuntimeDependencies<Topics>,
+    config: ViewServerConfig<Topics>,
+    options?: ViewServerRuntimeOptionsInput<Topics, Options>,
+  ) {
+    if (options === undefined) {
+      const resolvedOptions = yield* resolveViewServerRuntimeOptions<
+        Topics,
+        RuntimeRegions,
+        GrpcRuntimeClients
+      >({});
+      return yield* makeViewServerRuntimeFromResolvedOptions(dependencies, config, resolvedOptions);
+    }
+    const resolvedOptions = yield* resolveViewServerRuntimeOptions(options);
+    return yield* makeViewServerRuntimeFromResolvedOptions(dependencies, config, resolvedOptions);
+  });
+
+const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
+  "ViewServerRuntime.makeFromResolvedOptions",
+)(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics> = ViewServerRuntimeOptions<Topics>,
+  const Regions extends RuntimeRegions,
+  const GrpcClients extends GrpcRuntimeClients,
 >(
   dependencies: ViewServerRuntimeDependencies<Topics>,
   config: ViewServerConfig<Topics>,
-  options?: ViewServerRuntimeOptionsInput<Topics, Options>,
-) => Effect.Effect<
-  ViewServerRuntime<Topics>,
-  HttpServerError.ServeError | Config.ConfigError | ViewServerKafkaIngressError
-> = Effect.fn("ViewServerRuntime.makeWithDependencies")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics>,
->(
-  dependencies: ViewServerRuntimeDependencies<Topics>,
-  config: ViewServerConfig<Topics>,
-  options?: ViewServerRuntimeOptionsInput<Topics, Options>,
+  resolvedOptions: ResolvedViewServerRuntimeOptions<Topics, Regions, GrpcClients>,
 ) {
-  const { runtimeCoreOptions, serverOptions, kafkaOptions } =
-    options === undefined
-      ? yield* resolveViewServerRuntimeOptions<Topics, RuntimeRegions>({})
-      : yield* resolveViewServerRuntimeOptions(options);
+  const kafkaOptions = resolvedOptions.kafkaOptions;
+  const grpcOptions = resolvedOptions.grpcOptions;
   const transportHealth = makeViewServerRuntimeTransportHealth<Topics>();
   const kafkaHealth =
     kafkaOptions === undefined
       ? undefined
       : dependencies.makeKafkaHealthLedger(config, kafkaOptions);
+  const grpcHealth =
+    grpcOptions === undefined ? undefined : dependencies.makeGrpcHealthLedger(config, grpcOptions);
   const runtimeCoreInput: RuntimeCoreOptionsBuilder<Topics> = {
     transportHealth: transportHealth.transportHealth,
   };
-  if (runtimeCoreOptions.groupedIncrementalAdmissionLimits !== undefined) {
+  if (resolvedOptions.runtimeCoreOptions.groupedIncrementalAdmissionLimits !== undefined) {
     runtimeCoreInput.groupedIncrementalAdmissionLimits =
-      runtimeCoreOptions.groupedIncrementalAdmissionLimits;
+      resolvedOptions.runtimeCoreOptions.groupedIncrementalAdmissionLimits;
   }
-  if (runtimeCoreOptions.subscriptionQueueCapacity !== undefined) {
-    runtimeCoreInput.subscriptionQueueCapacity = runtimeCoreOptions.subscriptionQueueCapacity;
+  if (resolvedOptions.runtimeCoreOptions.subscriptionQueueCapacity !== undefined) {
+    runtimeCoreInput.subscriptionQueueCapacity =
+      resolvedOptions.runtimeCoreOptions.subscriptionQueueCapacity;
   }
-  if (kafkaHealth !== undefined) {
+  if (kafkaHealth !== undefined || grpcHealth !== undefined) {
     runtimeCoreInput.healthOverlay = (
       health: ViewServerHealth<Topics>,
       nowMillis: number,
-    ): ViewServerHealth<Topics> => kafkaHealth.healthOverlay(health, nowMillis);
+    ): ViewServerHealth<Topics> => {
+      const kafkaOverlayed =
+        kafkaHealth === undefined ? health : kafkaHealth.healthOverlay(health, nowMillis);
+      return grpcHealth === undefined
+        ? kafkaOverlayed
+        : grpcHealth.healthOverlay(kafkaOverlayed, nowMillis);
+    };
   }
   const runtimeCore = yield* dependencies.makeRuntimeCore(config, runtimeCoreInput);
   const refreshTransportHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
@@ -111,7 +159,7 @@ export const makeViewServerRuntimeWithDependencies: <
           streamClosed: transportHealth.streamClosed.pipe(Effect.andThen(refreshTransportHealth)),
         },
       },
-      serverOptions,
+      resolvedOptions.serverOptions,
     )
     .pipe(Effect.onExit((exit) => (Exit.isFailure(exit) ? runtimeCore.close : Effect.void)));
   const kafkaIngress =
@@ -132,7 +180,29 @@ export const makeViewServerRuntimeWithDependencies: <
                 : Effect.void,
             ),
           );
-  const close = (kafkaIngress?.close ?? Effect.void).pipe(
+  const grpcIngress =
+    grpcOptions === undefined || grpcHealth === undefined
+      ? undefined
+      : yield* dependencies
+          .makeGrpcIngress(
+            config,
+            runtimeCore.client,
+            runtimeCore.requestHealthRefresh,
+            grpcOptions,
+            grpcHealth,
+          )
+          .pipe(
+            Effect.onExit((exit) =>
+              Exit.isFailure(exit)
+                ? (kafkaIngress?.close ?? Effect.void).pipe(
+                    Effect.ensuring(server.close),
+                    Effect.ensuring(runtimeCore.close),
+                  )
+                : Effect.void,
+            ),
+          );
+  const close = (grpcIngress?.close ?? Effect.void).pipe(
+    Effect.ensuring(kafkaIngress?.close ?? Effect.void),
     Effect.ensuring(server.close),
     Effect.ensuring(runtimeCore.close),
   );
@@ -156,7 +226,7 @@ const logRuntimeStarted = Effect.fn("ViewServerRuntime.logStarted")(function* <
 
 const makeViewServerRuntimeLaunchLayer = <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics>,
+  const Options extends object,
 >(
   dependencies: ViewServerRuntimeDependencies<Topics>,
   config: ViewServerConfig<Topics>,
@@ -174,17 +244,20 @@ const makeViewServerRuntimeLaunchLayer = <
 
 export const runViewServerRuntimeWithDependencies: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics> = ViewServerRuntimeOptions<Topics>,
+  const Options extends object = ViewServerRuntimeOptions<Topics>,
 >(
   dependencies: ViewServerRuntimeDependencies<Topics>,
   config: ViewServerConfig<Topics>,
   options?: ViewServerRuntimeOptionsInput<Topics, Options>,
 ) => Effect.Effect<
   never,
-  HttpServerError.ServeError | Config.ConfigError | ViewServerKafkaIngressError
+  | HttpServerError.ServeError
+  | Config.ConfigError
+  | ViewServerKafkaIngressError
+  | ViewServerGrpcIngressError
 > = Effect.fn("ViewServerRuntime.runWithDependencies")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Options extends ViewServerRuntimeOptions<Topics>,
+  const Options extends object,
 >(
   dependencies: ViewServerRuntimeDependencies<Topics>,
   config: ViewServerConfig<Topics>,

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -6150,6 +6150,26 @@ describe("@view-server/runtime Kafka ingress internals", () => {
         runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
+        "cold",
+        kafkaMessage({
+          topic: ordersSourceTopic,
+          key: "wrong-region",
+          value: JSON.stringify({
+            customerId: "wrong-region",
+            price: 999,
+          }),
+          offset: 9n,
+          onCommit: () => {
+            committedMessages += 1;
+          },
+        }),
+      );
+      yield* processKafkaMessage(
+        viewServer,
+        runtimeCore.client,
+        runtimeCore.requestHealthRefresh,
+        kafkaOptions,
+        ledger,
         "local",
         kafkaMessage({
           topic: ordersSourceTopic,

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -9,6 +9,7 @@ import { Buffer } from "node:buffer";
 import {
   decodeKafkaTopicMessage,
   kafkaErrorIsMapping,
+  type RuntimeRegions,
   type KafkaMessageMetadata,
   type KafkaDecodedTopicMessage,
   type TopicRow,
@@ -189,8 +190,11 @@ export const kafkaHeadersFromMessage = (
   return output;
 };
 
-export const sourceTopicsForRegion = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+export const sourceTopicsForRegion = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
+>(
+  options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   region: string,
 ): ReadonlyArray<string> => {
   const topics: Array<string> = [];
@@ -624,10 +628,13 @@ export const acquireStartedKafkaConsumerResources = Effect.fn(
 });
 
 const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.decodeForBatch")(
-  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  function* <
+    const Topics extends ViewServerRuntimeTopicDefinitions,
+    const Regions extends RuntimeRegions,
+  >(
     config: ViewServerConfig<Topics>,
     requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+    options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
     health: ViewServerKafkaHealthLedger<Topics>,
     region: string,
     message: KafkaConsumerMessage,
@@ -637,13 +644,17 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
     if (topic === undefined) {
       return Option.none<DecodedKafkaBatchMessage<Topics>>();
     }
+    const topicRegion = topic.regions.find((candidate) => candidate === region);
+    if (topicRegion === undefined) {
+      return Option.none<DecodedKafkaBatchMessage<Topics>>();
+    }
     const nowMillis = yield* Clock.currentTimeMillis;
     const keyBytes = message.key ?? emptyMessageBytes;
     const valueBytes = message.value ?? emptyMessageBytes;
     const messageBytes = valueBytes.byteLength + keyBytes.byteLength;
-    const metadata: KafkaMessageMetadata = {
+    const metadata: KafkaMessageMetadata<typeof topicRegion> = {
       sourceTopic,
-      sourceRegion: region,
+      sourceRegion: topicRegion,
       partition: message.partition,
       offset: String(message.offset),
       timestamp: Number(message.timestamp),
@@ -653,7 +664,7 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
     const decoded = yield* decodeKafkaTopicMessage(topic, {
       keyBytes,
       valueBytes,
-      region,
+      region: topicRegion,
       metadata,
     }).pipe(
       Effect.matchCauseEffect({
@@ -857,11 +868,14 @@ const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit"
 });
 
 export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messageBatch.process")(
-  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  function* <
+    const Topics extends ViewServerRuntimeTopicDefinitions,
+    const Regions extends RuntimeRegions,
+  >(
     config: ViewServerConfig<Topics>,
     client: ViewServerRuntimeClient<Topics>,
     requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+    options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
     health: ViewServerKafkaHealthLedger<Topics>,
     region: string,
     batch: ReadonlyArray<KafkaConsumerMessage>,
@@ -917,11 +931,12 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
 
 export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.process")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
 >(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+  options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
   message: KafkaConsumerMessage,
@@ -1055,11 +1070,12 @@ const takeKafkaMessageBatch: (
 
 export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.run")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
 >(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+  options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
   stream: AsyncIterable<KafkaConsumerMessage>,
@@ -1308,11 +1324,12 @@ const startKafkaLagMonitoring = Effect.fn("ViewServerRuntime.kafka.consumer.star
 
 const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
 >(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+  options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   health: ViewServerKafkaHealthLedger<Topics>,
   region: string,
   brokers: string,
@@ -1439,19 +1456,25 @@ export const makeScopedKafkaIngress = Effect.fn("ViewServerRuntime.kafka.ingress
   },
 );
 
-export const makeViewServerKafkaIngress: <const Topics extends ViewServerRuntimeTopicDefinitions>(
+export const makeViewServerKafkaIngress: <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
+>(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+  options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   health: ViewServerKafkaHealthLedger<Topics>,
 ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError> = Effect.fn(
   "ViewServerRuntime.kafka.ingress.make",
-)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+)(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
+>(
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+  options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   health: ViewServerKafkaHealthLedger<Topics>,
 ) {
   return yield* makeScopedKafkaIngress((scope) =>

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -1,4 +1,9 @@
-import type { ViewServerConfig, ViewServerRuntimeClient } from "@view-server/config";
+import type {
+  GrpcRuntimeClients,
+  RuntimeRegions,
+  ViewServerConfig,
+  ViewServerRuntimeClient,
+} from "@view-server/config";
 import {
   makeViewServerRuntimeCore,
   type ViewServerRuntimeCoreInstance,
@@ -13,12 +18,21 @@ import {
 import type { Effect } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
 import { makeViewServerKafkaHealthLedger, type ViewServerKafkaHealthLedger } from "./kafka-health";
+import { makeViewServerGrpcHealthLedger, type ViewServerGrpcHealthLedger } from "./grpc-health";
+import {
+  makeViewServerGrpcIngress,
+  type ViewServerGrpcIngress,
+  type ViewServerGrpcIngressError,
+} from "./grpc-ingress";
 import {
   makeViewServerKafkaIngress,
   type ViewServerKafkaIngress,
   type ViewServerKafkaIngressError,
 } from "./kafka-ingress";
-import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
+import type {
+  ResolvedViewServerGrpcRuntimeOptions,
+  ResolvedViewServerKafkaRuntimeOptions,
+} from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
 export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicDefinitions> = {
@@ -31,17 +45,28 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
     input: ViewServerWebSocketServerInput<Topics>,
     options: ViewServerWebSocketServerOptions,
   ) => Effect.Effect<ViewServerWebSocketServer, HttpServerError.ServeError>;
-  readonly makeKafkaHealthLedger: (
+  readonly makeKafkaHealthLedger: <const Regions extends RuntimeRegions>(
     config: ViewServerConfig<Topics>,
-    options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+    options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   ) => ViewServerKafkaHealthLedger<Topics>;
-  readonly makeKafkaIngress: (
+  readonly makeGrpcHealthLedger: <const Clients extends GrpcRuntimeClients>(
+    config: ViewServerConfig<Topics>,
+    options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
+  ) => ViewServerGrpcHealthLedger<Topics>;
+  readonly makeKafkaIngress: <const Regions extends RuntimeRegions>(
     config: ViewServerConfig<Topics>,
     client: ViewServerRuntimeClient<Topics>,
     requestHealthRefresh: Effect.Effect<void>,
-    options: ResolvedViewServerKafkaRuntimeOptions<Topics>,
+    options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
     health: ViewServerKafkaHealthLedger<Topics>,
   ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError>;
+  readonly makeGrpcIngress: <const Clients extends GrpcRuntimeClients>(
+    config: ViewServerConfig<Topics>,
+    client: ViewServerRuntimeClient<Topics>,
+    requestHealthRefresh: Effect.Effect<void>,
+    options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
+    health: ViewServerGrpcHealthLedger<Topics>,
+  ) => Effect.Effect<ViewServerGrpcIngress, ViewServerGrpcIngressError>;
 };
 
 export const makeDefaultRuntimeDependencies = <
@@ -63,5 +88,20 @@ export const makeDefaultRuntimeDependencies = <
         ]),
       ),
     }),
+  makeGrpcHealthLedger: (_config, options) =>
+    makeViewServerGrpcHealthLedger({
+      clients: options.clientBaseUrls,
+      feeds: Object.fromEntries(
+        Object.entries(options.feeds).map(([feedName, feed]) => [
+          feedName,
+          {
+            client: feed.client,
+            lifecycle: feed.lifecycle,
+            topic: feed.topic,
+          },
+        ]),
+      ),
+    }),
   makeKafkaIngress: makeViewServerKafkaIngress,
+  makeGrpcIngress: makeViewServerGrpcIngress,
 });

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -1,6 +1,7 @@
 import type { ViewServerRuntimeCoreOptionsFor } from "@view-server/runtime-core";
 import type { ViewServerWebSocketServerOptions } from "@view-server/server";
 import type {
+  GrpcRuntimeClients,
   KafkaStartFromHealth,
   RuntimeRegions,
   RuntimeValue,
@@ -9,17 +10,21 @@ import type {
 import { Config, Effect } from "effect";
 import type {
   ViewServerKafkaRuntimeOptions,
+  ViewServerGrpcRuntimeOptions,
   ViewServerRuntimeOptions,
   ViewServerRuntimeTopicDefinitions,
 } from "./runtime-types";
+import { ViewServerGrpcIngressError } from "./grpc-ingress";
 
 export type ResolvedViewServerRuntimeOptions<
   Topics extends ViewServerRuntimeTopicDefinitions = ViewServerRuntimeTopicDefinitions,
   Regions extends RuntimeRegions = RuntimeRegions,
+  GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
 > = {
   readonly runtimeCoreOptions: ViewServerRuntimeCoreOptionsFor<Topics>;
   readonly serverOptions: ViewServerWebSocketServerOptions;
   readonly kafkaOptions?: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>;
+  readonly grpcOptions?: ResolvedViewServerGrpcRuntimeOptions<Topics, GrpcClients>;
 };
 
 export type ResolvedViewServerKafkaRuntimeOptions<
@@ -31,6 +36,15 @@ export type ResolvedViewServerKafkaRuntimeOptions<
   readonly consume: KafkaStartFromHealth;
   readonly regions: Record<string, string>;
   readonly topics: ViewServerKafkaRuntimeOptions<Topics, Regions>["topics"];
+};
+
+export type ResolvedViewServerGrpcRuntimeOptions<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Clients extends GrpcRuntimeClients = GrpcRuntimeClients,
+> = {
+  readonly clients: Clients;
+  readonly clientBaseUrls: Record<string, string>;
+  readonly feeds: ViewServerGrpcRuntimeOptions<Topics, Clients>["feeds"];
 };
 
 const resolveRuntimeValue = <A>(value: RuntimeValue<A>): Effect.Effect<A, Config.ConfigError> =>
@@ -92,35 +106,140 @@ const resolveKafkaOptions: <
     };
   });
 
+const resolveGrpcOptions: <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Clients extends GrpcRuntimeClients,
+>(
+  options: ViewServerGrpcRuntimeOptions<Topics, Clients>,
+) => Effect.Effect<
+  ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
+  Config.ConfigError | ViewServerGrpcIngressError
+> = Effect.fn("ViewServerRuntime.options.grpc.resolve")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Clients extends GrpcRuntimeClients,
+>(options: ViewServerGrpcRuntimeOptions<Topics, Clients>) {
+  const entries = yield* Effect.forEach(Object.entries(options.clients), ([clientName, client]) =>
+    resolveRuntimeValue(client.baseUrl).pipe(
+      Effect.map(
+        (baseUrl) =>
+          [
+            clientName,
+            {
+              _tag: client._tag,
+              baseUrl,
+              protocol: client.protocol,
+              service: client.service,
+            },
+          ] as const,
+      ),
+    ),
+  );
+  const clientBaseUrls: Record<string, string> = Object.create(null);
+  for (const [clientName, client] of entries) {
+    clientBaseUrls[clientName] = client.baseUrl;
+  }
+  const feedTopics = new Map<string, string>();
+  for (const [feedName, feed] of Object.entries(options.feeds)) {
+    if (feed.lifecycle === "leased") {
+      return yield* new ViewServerGrpcIngressError({
+        message: `gRPC leased feed ${feedName} is not supported by runtime startup yet.`,
+        cause: feed.lifecycle,
+        feedName,
+        topic: feed.topic,
+      });
+    }
+    const previousFeedName = feedTopics.get(feed.topic);
+    if (previousFeedName !== undefined) {
+      return yield* new ViewServerGrpcIngressError({
+        message: `gRPC feed ${feedName} conflicts with ${previousFeedName}; View Server topic ${feed.topic} already has a gRPC feed owner.`,
+        cause: feed.topic,
+        feedName,
+        topic: feed.topic,
+      });
+    }
+    feedTopics.set(feed.topic, feedName);
+  }
+  return {
+    clients: options.clients,
+    clientBaseUrls,
+    feeds: options.feeds,
+  };
+});
+
+type SourceOwnershipKafkaOptions = {
+  readonly topics: Readonly<Record<string, { readonly viewServerTopic: string }>>;
+};
+
+type SourceOwnershipGrpcOptions = {
+  readonly feeds: Readonly<Record<string, { readonly topic: string }>>;
+};
+
+export const validateSourceOwnership: (
+  kafkaOptions: SourceOwnershipKafkaOptions | undefined,
+  grpcOptions: SourceOwnershipGrpcOptions | undefined,
+) => Effect.Effect<void, ViewServerGrpcIngressError> = Effect.fn(
+  "ViewServerRuntime.options.sourceOwnership.validate",
+)(function* (
+  kafkaOptions: SourceOwnershipKafkaOptions | undefined,
+  grpcOptions: SourceOwnershipGrpcOptions | undefined,
+) {
+  if (kafkaOptions === undefined || grpcOptions === undefined) {
+    return;
+  }
+  const grpcFeedByTopic = new Map<string, string>();
+  for (const [feedName, feed] of Object.entries(grpcOptions.feeds)) {
+    grpcFeedByTopic.set(feed.topic, feedName);
+  }
+  for (const [sourceTopic, kafkaTopic] of Object.entries(kafkaOptions.topics)) {
+    const grpcFeedName = grpcFeedByTopic.get(kafkaTopic.viewServerTopic);
+    if (grpcFeedName !== undefined) {
+      return yield* new ViewServerGrpcIngressError({
+        message: `View Server topic ${kafkaTopic.viewServerTopic} cannot be owned by both Kafka source ${sourceTopic} and gRPC feed ${grpcFeedName}.`,
+        cause: kafkaTopic.viewServerTopic,
+        feedName: grpcFeedName,
+        topic: kafkaTopic.viewServerTopic,
+      });
+    }
+  }
+});
+
 export const resolveViewServerRuntimeOptions: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
   const Regions extends RuntimeRegions,
+  const GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
 >(
-  options: ViewServerRuntimeOptions<Topics, Regions>,
-) => Effect.Effect<ResolvedViewServerRuntimeOptions<Topics, Regions>, Config.ConfigError> =
-  Effect.fn("ViewServerRuntime.options.resolve")(function* <
-    const Topics extends ViewServerRuntimeTopicDefinitions,
-    const Regions extends RuntimeRegions,
-  >(options: ViewServerRuntimeOptions<Topics, Regions>) {
-    const runtimeCoreOptions = {
-      ...(options.groupedIncrementalAdmissionLimits === undefined
-        ? {}
-        : { groupedIncrementalAdmissionLimits: options.groupedIncrementalAdmissionLimits }),
-      ...(options.subscriptionQueueCapacity === undefined
-        ? {}
-        : { subscriptionQueueCapacity: options.subscriptionQueueCapacity }),
-    };
-    const serverOptions = {
-      ...(options.host === undefined ? {} : { host: options.host }),
-      ...(options.websocketPort === undefined ? {} : { port: options.websocketPort }),
-      ...(options.rpcPath === undefined ? {} : { path: options.rpcPath }),
-      ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
-    };
-    const kafkaOptions =
-      options.kafka === undefined ? undefined : yield* resolveKafkaOptions(options.kafka);
-    return {
-      runtimeCoreOptions,
-      serverOptions,
-      ...(kafkaOptions === undefined ? {} : { kafkaOptions }),
-    };
-  });
+  options: ViewServerRuntimeOptions<Topics, Regions, GrpcClients>,
+) => Effect.Effect<
+  ResolvedViewServerRuntimeOptions<Topics, Regions, GrpcClients>,
+  Config.ConfigError | ViewServerGrpcIngressError
+> = Effect.fn("ViewServerRuntime.options.resolve")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Regions extends RuntimeRegions,
+  const GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
+>(options: ViewServerRuntimeOptions<Topics, Regions, GrpcClients>) {
+  const runtimeCoreOptions = {
+    ...(options.groupedIncrementalAdmissionLimits === undefined
+      ? {}
+      : { groupedIncrementalAdmissionLimits: options.groupedIncrementalAdmissionLimits }),
+    ...(options.subscriptionQueueCapacity === undefined
+      ? {}
+      : { subscriptionQueueCapacity: options.subscriptionQueueCapacity }),
+  };
+  const serverOptions = {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.websocketPort === undefined ? {} : { port: options.websocketPort }),
+    ...(options.rpcPath === undefined ? {} : { path: options.rpcPath }),
+    ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
+  };
+  const kafkaOptions =
+    options.kafka === undefined ? undefined : yield* resolveKafkaOptions(options.kafka);
+  const grpcOptions =
+    options.grpc === undefined ? undefined : yield* resolveGrpcOptions(options.grpc);
+  yield* validateSourceOwnership(kafkaOptions, grpcOptions);
+  return {
+    runtimeCoreOptions,
+    serverOptions,
+    ...(kafkaOptions === undefined ? {} : { kafkaOptions }),
+    ...(grpcOptions === undefined ? {} : { grpcOptions }),
+  };
+});

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -9,6 +9,8 @@ import type {
   ViewServerKafkaStartFrom,
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
+  GrpcFeedDefinition,
+  GrpcRuntimeClients,
 } from "@view-server/config";
 import type { Effect, Schema } from "effect";
 
@@ -33,15 +35,25 @@ export type ViewServerKafkaRuntimeOptions<
   readonly topics: Record<string, KafkaRuntimeTopicDefinition<Topics, Regions>>;
 };
 
+export type ViewServerGrpcRuntimeOptions<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Clients extends GrpcRuntimeClients = GrpcRuntimeClients,
+> = {
+  readonly clients: Clients;
+  readonly feeds: Record<string, GrpcFeedDefinition<Topics, Clients>>;
+};
+
 export type ViewServerRuntimeOptions<
   Topics extends ViewServerRuntimeTopicDefinitions = ViewServerRuntimeTopicDefinitions,
   Regions extends RuntimeRegions = RuntimeRegions,
+  GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
 > = {
   readonly host?: string;
   readonly websocketPort?: number;
   readonly rpcPath?: RuntimeHttpPath;
   readonly healthPath?: RuntimeHttpPath;
   readonly kafka?: ViewServerKafkaRuntimeOptions<Topics, Regions>;
+  readonly grpc?: ViewServerGrpcRuntimeOptions<Topics, GrpcClients>;
   readonly groupedIncrementalAdmissionLimits?: Partial<GroupedIncrementalAdmissionLimits>;
   readonly subscriptionQueueCapacity?: number;
 };
@@ -100,14 +112,81 @@ type RuntimeKafkaStartFromExactKeysConstraint<Options> = Options extends {
     : unknown
   : unknown;
 
+type RuntimeGrpcExactKeysConstraint<Options> = Options extends {
+  readonly grpc: infer CandidateGrpc;
+}
+  ? {
+      readonly grpc: CandidateGrpc &
+        RejectExtraKeys<
+          CandidateGrpc,
+          ViewServerGrpcRuntimeOptions<ViewServerRuntimeTopicDefinitions>
+        >;
+    }
+  : unknown;
+
+type RuntimeGrpcFeedConstraint<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Options,
+> = Options extends {
+  readonly grpc: {
+    readonly clients: infer Clients extends GrpcRuntimeClients;
+    readonly feeds: infer Feeds extends Record<string, object>;
+  };
+}
+  ? {
+      readonly grpc: {
+        readonly feeds: {
+          readonly [FeedName in keyof Feeds]: Feeds[FeedName] extends GrpcFeedDefinition<
+            Topics,
+            Clients
+          >
+            ? Feeds[FeedName]
+            : never;
+        };
+      };
+    }
+  : unknown;
+
+type RuntimeGroupedIncrementalAdmissionLimitsExactKeysConstraint<Options> = Options extends {
+  readonly groupedIncrementalAdmissionLimits: infer CandidateLimits;
+}
+  ? {
+      readonly groupedIncrementalAdmissionLimits: CandidateLimits &
+        RejectExtraKeys<CandidateLimits, Partial<GroupedIncrementalAdmissionLimits>>;
+    }
+  : unknown;
+
+type RuntimeRegionsOf<Options> = Options extends {
+  readonly kafka: {
+    readonly regions: infer Regions extends RuntimeRegions;
+  };
+}
+  ? Regions
+  : RuntimeRegions;
+
+type RuntimeGrpcClientsOf<Options> = Options extends {
+  readonly grpc: {
+    readonly clients: infer Clients extends GrpcRuntimeClients;
+  };
+}
+  ? Clients
+  : GrpcRuntimeClients;
+
 export type ViewServerRuntimeOptionsInput<
   Topics extends ViewServerRuntimeTopicDefinitions,
-  Options extends ViewServerRuntimeOptions<Topics> = ViewServerRuntimeOptions<Topics>,
+  Options extends object = ViewServerRuntimeOptions<Topics>,
 > = Options &
-  RejectExtraKeys<Options, ViewServerRuntimeOptions<Topics>> &
+  ViewServerRuntimeOptions<Topics, RuntimeRegionsOf<Options>, RuntimeGrpcClientsOf<Options>> &
+  RejectExtraKeys<
+    Options,
+    ViewServerRuntimeOptions<Topics, RuntimeRegionsOf<Options>, RuntimeGrpcClientsOf<Options>>
+  > &
   RuntimeKafkaExactKeysConstraint<Options> &
   RuntimeKafkaRegionConstraint<Topics, Options> &
-  RuntimeKafkaStartFromExactKeysConstraint<Options>;
+  RuntimeKafkaStartFromExactKeysConstraint<Options> &
+  RuntimeGrpcExactKeysConstraint<Options> &
+  RuntimeGrpcFeedConstraint<Topics, Options> &
+  RuntimeGroupedIncrementalAdmissionLimitsExactKeysConstraint<Options>;
 
 export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> = {
   readonly url: string;

--- a/plans/grpc.md
+++ b/plans/grpc.md
@@ -11,6 +11,14 @@ It intentionally keeps the existing architecture intact:
 - React hooks continue to use the same provider/client seam
 - Effect RPC WebSocket with NDJSON remains the production browser transport
 
+Non-goals:
+
+- do not add a gRPC-specific query API
+- do not add a gRPC-specific React hook
+- do not expose leased feed instances as public topics
+- do not let one user query merge multiple upstream gRPC streams
+- do not make gRPC a second query engine or second storage API
+
 ## Compatibility With The Column Live View Engine Plan
 
 This plan does not conflict with `plans/v2-column-live-view-engine-plan.md`.
@@ -24,6 +32,15 @@ The existing plan says:
 - only transport/ingress Adapters differ between production and in-memory/test paths
 
 The gRPC design follows those rules by making gRPC an ingress Adapter that publishes rows into the existing runtime-core and engine. It must not create a second query engine, a second subscription system, or a gRPC-specific React hook.
+
+Validation result:
+
+- Compatible with the v2 plan's core rule that the `ColumnLiveViewEngine` is the only query/snapshot/delta engine.
+- Compatible with the one-topic-one-logical-table model because leased feed instances are internal runtime partitions for one public View Server topic, not public topics and not a second storage API.
+- Compatible with the runtime boundary because gRPC clients, upstream requests, session headers, reconnect policy, and source lifecycle are server-only runtime concerns.
+- Compatible with the React/provider model because `useLiveQuery` does not learn about gRPC. The server resolves leased feeds behind the same Live Query contract.
+- Compatible with the health cadence rule because gRPC health is a ledger/cached snapshot, not a full per-message health rebuild.
+- Compatible with the transport policy because browser live data continues over Effect RPC WebSocket with NDJSON. gRPC is ingress only.
 
 ## Core Vocabulary
 
@@ -41,7 +58,15 @@ Use these names consistently:
 - `view`: one user query over a materialized topic or leased feed.
 - `lease`: the refcount/lifecycle handle that keeps a leased feed alive while subscriptions use it.
 
+Avoid the names `hot`, `cold`, `eager`, and `lazy` in code. They are useful conversational shortcuts, but they blur the real contract:
+
+- `materializedFeed` means runtime-owned, startup-acquired, retained state.
+- `leasedFeed` means subscription-owned, route-keyed, retained only while there is demand.
+
 Do not call leased feed instances "topics" in public APIs. Health can expose feed instances under a topic, but the public topic remains stable.
+
+A leased feed instance is temporary retained state for one upstream route. It is not a View Server Topic, it is not visible to `useLiveQuery`, and it must
+not change the external topic name or result typing.
 
 ## Source Lifecycle Modes
 
@@ -52,10 +77,20 @@ A materialized feed is always-on.
 Behavior:
 
 - starts when the runtime starts
-- reconnects according to runtime policy
+- is scoped to runtime lifetime
+- marks health degraded if the upstream stream completes or fails
 - retains state even with zero subscribers
 - serves snapshots immediately when a user subscribes
 - behaves similarly to Kafka materialized topics
+
+Automatic reconnect policy is a later runtime policy slice. The first materialized runtime slice
+must be honest: one scoped upstream stream per feed, deterministic cleanup, and explicit degraded
+health on completion/failure.
+
+Generated gRPC clients own protobuf decode at the ConnectRPC boundary. For this slice, decode
+failures surface as upstream stream failures and degrade the feed. The `decodeFailuresPerSecond`
+field remains zero unless a future Adapter introduces a raw payload decode boundary that can
+attribute decode failures separately from stream failures.
 
 Use for bounded or globally useful sources, for example all strategies.
 
@@ -92,6 +127,10 @@ grpcFeed.materializedFeed({
 
 A leased feed is on-demand and route-keyed.
 
+The first runtime slice keeps the type contract and rejects leased feeds at startup until the lease
+manager exists. Do not silently accept leased feeds and leave them in health as permanently
+starting.
+
 Behavior:
 
 - does not connect on runtime startup
@@ -100,8 +139,13 @@ Behavior:
 - shares that upstream stream across all users with the same route
 - applies remaining user filters/order/grouping locally inside View Server
 - closes the upstream stream and drops retained rows for that feed when the last subscription releases it
+- rejects queries that cannot be routed to exactly one upstream stream
 
 Use for huge upstream sources where an unfiltered stream is impossible or dangerous.
+
+Do not model each possible user filter combination as a separate configured topic. A leased feed has a small explicit `routeBy` contract that maps to
+the upstream gRPC service's real access path, such as `strategyId` and `region`. The View Server then runs the full user query locally on the retained
+rows for that route.
 
 ```ts
 const grpcFeed = viewServer.grpcFeed<typeof grpcClients>();
@@ -191,6 +235,9 @@ Route predicates must be exact equality predicates. Do not allow `in`, `startsWi
 
 The runtime must reject invalid leased-feed queries with `InvalidQueryError`. Never fall back to an unfiltered upstream stream.
 
+The type system should reject the same invalid leased-feed query shapes whenever the query object is statically visible. Runtime validation still remains
+mandatory because remote clients and decoded wire payloads can bypass TypeScript.
+
 ## Local Query Semantics
 
 The full user query still runs locally in the View Server engine.
@@ -203,6 +250,12 @@ For a leased `orders` feed routed by `strategyId` and `region`:
 - order, projection, grouped aggregation, pagination/windowing, counts, and deltas are local engine work
 
 This avoids creating one upstream stream per full UI query and avoids merging multiple upstream streams.
+
+If the upstream gRPC API only supports `strategyId` and `region`, those two fields are the route contract. A user may add more local filters, but the runtime
+must not attempt to satisfy a broader query by opening every possible route or by stitching together multiple routes.
+
+The route contract is not derived from all possible filters in the UI. It is declared by the feed author from the upstream API contract. This avoids the
+factorial/permutation problem where ten possible UI filters would imply many fake source topics or access paths.
 
 Example:
 
@@ -312,23 +365,41 @@ Exact package/function names can change during implementation, but the semantics
 
 For this slice, a View Server topic has one ingress owner.
 
-Allowed:
+This rule protects the one-topic-one-logical-table invariant from the v2 plan. A topic can be owned by Kafka, a materialized gRPC feed, or one leased gRPC
+feed definition, but not by more than one ingress path at the same time.
+
+Allowed examples, each in a separate runtime config:
 
 ```txt
 orders -> Kafka materialized source
 strategies -> gRPC materialized feed
-ordersByStrategy -> gRPC leased feed
+orders -> gRPC leased feed definition ordersByStrategyRegion
 ```
+
+The repeated `orders` name above is only showing alternative valid ownership modes. A single
+configured View Server Topic must choose one ingress owner.
 
 Rejected:
 
 ```txt
-orders <- Kafka source
-orders <- gRPC materialized feed
-orders <- gRPC leased feed
+orders <- Kafka source and gRPC materialized feed
+orders <- Kafka source and gRPC leased feed
+orders <- gRPC materialized feed and gRPC leased feed
 ```
 
-The current public config shape can remain for now, but runtime/config validation must reject multiple ingress owners targeting the same View Server topic unless a future explicit multi-source design exists.
+`ordersByStrategyRegion` is a feed definition name, not a public View Server topic name. A leased
+feed definition may create many internal feed instances such as `orders/ordersByStrategyRegion/...`,
+but `useLiveQuery` still queries the public `orders` topic and the runtime must route that query to
+exactly one internal feed instance before executing local filters/sorts/groups.
+
+The current public config shape can remain for now, but runtime/config validation must reject:
+
+- Kafka and gRPC both targeting the same View Server topic
+- multiple materialized gRPC feeds targeting the same View Server topic
+- multiple leased gRPC feed definitions targeting the same View Server topic
+- a materialized and leased gRPC feed both targeting the same View Server topic
+
+If a future design needs multi-source topics, it must be explicit and must define ordering, deduplication, health, and restart semantics first.
 
 A later API cleanup can reshape the config toward:
 
@@ -341,6 +412,10 @@ topics: {
 ```
 
 Do not block the first gRPC implementation on that larger public API migration.
+
+The important invariant is ownership, not the exact config nesting. The current config can keep `grpc.clients` and `grpc.feeds`, but validation must make
+it impossible for two ingress sources to publish independently into the same View Server topic. That includes accidental combinations such as Kafka +
+gRPC, materialized gRPC + leased gRPC, or two leased definitions for the same topic.
 
 ## Feed Key
 
@@ -419,10 +494,16 @@ type GrpcFeedHealth = {
   mappingFailuresPerSecond: number;
   publishFailuresPerSecond: number;
   reconnects: number;
-  lastMessageAt: bigint | null;
+  lastMessageAt: number | null;
   lastError: string | null;
 };
 ```
+
+`lastMessageAt` follows the runtime health convention from
+`plans/v2-column-live-view-engine-plan.md`: health timestamps are numeric
+runtime timestamps or `null`. Domain rows may still use `bigint` nanoseconds as
+topic data, but health should not introduce a second timestamp encoding unless a
+future health contract explicitly changes all runtime health timestamps together.
 
 Health cadence rules from the v2 plan still apply:
 
@@ -522,10 +603,21 @@ Required type tests:
 - `useLiveQuery` accepts route fields plus additional local filters
 - `useLiveQuery` return type remains based on select/aggregates, not route internals
 
-Required runtime/e2e tests:
+Current materialized runtime/e2e tests:
 
 - materialized feed starts on runtime startup with zero subscribers
 - materialized feed serves snapshot to first subscriber without opening a new upstream stream
+- materialized feed startup rejects leased feed definitions explicitly until the lease manager exists
+- materialized feed startup rejects duplicate topic ownership across Kafka and gRPC
+- materialized feed startup rejects multiple gRPC owners for one View Server topic
+- stream completion marks feed/client degraded and releases resources
+- stream failure marks feed/client degraded and releases resources
+- runtime shutdown releases all materialized gRPC streams
+- health reports materialized feed keys, row counts, rates, and failures
+- materialized benchmark exercises the production ingress path into runtime-core and the engine
+
+Future leased manager runtime/e2e tests:
+
 - leased feed does not open before first subscriber
 - first leased subscriber opens one upstream stream
 - second subscriber with same route reuses the same upstream stream
@@ -533,10 +625,9 @@ Required runtime/e2e tests:
 - extra local filters produce different views over the same leased feed
 - last subscriber for a feed closes upstream and drops feed rows
 - session-scoped feed does not share across users
-- stream failure marks feed/client degraded and releases resources
-- runtime shutdown releases all gRPC streams
 - invalid leased query returns `InvalidQueryError`
-- health reports active feed keys, subscriber counts, row counts, and failures
+- health reports leased feed keys, subscriber counts, row counts, and failures
+- runtime shutdown releases all leased gRPC streams
 
 Tests should use a fake/in-process generated-compatible gRPC stream where possible first, then add a real ConnectRPC integration test if the tooling cost is acceptable.
 
@@ -547,6 +638,31 @@ Use Vitest benchmark mode only.
 Initial benchmark profiles:
 
 - materialized startup seed latency
+- materialized write throughput
+- materialized filtered/sorted snapshot latency
+- materialized grouped snapshot latency once grouped gRPC scenarios exist
+- mapping/schema validation throughput
+- health refresh overhead with many materialized feeds
+
+Current materialized-feed benchmark command:
+
+```sh
+pnpm --filter @view-server/runtime run bench:grpc-materialized
+```
+
+This benchmark uses a Queue-backed in-process gRPC stream but still exercises the
+production materialized ingress path:
+
+```txt
+Stream -> groupedWithin -> map -> runtime-core publishMany -> snapshot/readback -> health overlay
+```
+
+It records stream convergence, filtered/sorted snapshot latency, health overlay
+latency, rows/sec, final health, and memory deltas. Keep it as the materialized
+baseline while leased-feed benchmarks are still deferred.
+
+Future leased benchmark profiles:
+
 - leased first-subscriber acquisition latency
 - leased same-route reuse latency
 - leased last-subscriber cleanup latency
@@ -554,15 +670,14 @@ Initial benchmark profiles:
 - leased delta fanout latency for multiple subscribers over one feed
 - many routes with one subscriber each
 - one route with many subscribers
-- mapping/schema validation throughput
 - write tax from feed partitioning
-- health refresh overhead with many active feeds
+- health refresh overhead with many active leased feeds
 
 Add baseline automation only after repeated local runs are stable. Noisy max latency can remain report-only until stable.
 
 ## Acceptance Criteria
 
-The gRPC slice is not complete until:
+The current materialized gRPC slice is not complete until:
 
 - public API has type tests for all new inference and rejection behavior
 - package seam checks reject unapproved gRPC internals
@@ -571,11 +686,24 @@ The gRPC slice is not complete until:
 - `vp check` passes
 - focused runtime/config/protocol/client/server tests pass
 - pre-existing `pnpm run pre-grpc:gate` still passes or is intentionally extended
-- new gRPC e2e tests prove materialized and leased behavior
-- health shows materialized and leased feed instances without rebuilding per message
+- new gRPC e2e tests prove materialized behavior and explicit leased-feed rejection
+- health shows materialized feed instances without rebuilding per message
 - no long-lived stream uses detached/hand-rolled lifecycle
 - no public API requires consumer `as const`
 - no casts hide topic/route/request/value/map type erasure
+
+The future leased gRPC slice is not complete until:
+
+- `useLiveQuery` type tests reject missing/non-eq route fields for leased topics
+- decoded remote queries get the same route validation at runtime
+- first subscription opens exactly one upstream stream for one feed key
+- same-route subscribers share the upstream stream and retained feed state
+- different-route subscribers open different upstream streams
+- last subscriber closes the upstream stream and drops feed-owned rows
+- session-scoped feed keys do not share across users
+- health shows leased feed instances, subscriber counts, route/feed keys, row counts, and failures
+- invalid leased queries never fall back to an unfiltered upstream stream
+- all leased stream lifecycles are scoped and released on runtime shutdown
 
 ## Deferred Decisions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@connectrpc/connect':
       specifier: 2.1.2
       version: 2.1.2
+    '@connectrpc/connect-node':
+      specifier: 2.1.2
+      version: 2.1.2
     '@effect/atom-react':
       specifier: 4.0.0-beta.70
       version: 4.0.0-beta.70
@@ -107,7 +110,7 @@ importers:
         version: 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/client:
     dependencies:
@@ -144,7 +147,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/column-live-view-engine:
     dependencies:
@@ -169,7 +172,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/config:
     dependencies:
@@ -197,7 +200,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/effect-utils:
     dependencies:
@@ -219,7 +222,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/in-memory:
     dependencies:
@@ -250,7 +253,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/protocol:
     dependencies:
@@ -275,7 +278,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/react:
     dependencies:
@@ -339,13 +342,19 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(@voidzero-dev/vite-plus-test@0.1.23)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   packages/runtime:
     dependencies:
+      '@connectrpc/connect':
+        specifier: 'catalog:'
+        version: 2.1.2(@bufbuild/protobuf@2.12.0)
+      '@connectrpc/connect-node':
+        specifier: 'catalog:'
+        version: 2.1.2(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0))
       '@platformatic/kafka':
         specifier: 'catalog:'
         version: 2.2.3
@@ -391,7 +400,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/runtime-core:
     dependencies:
@@ -425,7 +434,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   packages/server:
     dependencies:
@@ -468,7 +477,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.23
-        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
 packages:
 
@@ -544,6 +553,13 @@ packages:
 
   '@bufbuild/protobuf@2.12.0':
     resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+
+  '@connectrpc/connect-node@2.1.2':
+    resolution: {integrity: sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
 
   '@connectrpc/connect@2.1.2':
     resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
@@ -2020,6 +2036,11 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.0': {}
 
+  '@connectrpc/connect-node@2.1.2(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.0)
+
   '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0)':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
@@ -2060,7 +2081,7 @@ snapshots:
   '@effect/vitest@4.0.0-beta.70(@voidzero-dev/vite-plus-test@0.1.23)(effect@4.0.0-beta.70)':
     dependencies:
       effect: 4.0.0-beta.70
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2451,7 +2472,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -2471,7 +2492,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
     transitivePeerDependencies:
       - supports-color
 
@@ -2530,7 +2551,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -3013,7 +3034,7 @@ snapshots:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@25.9.1)(typescript@6.0.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)
       oxfmt: 0.52.0(vite-plus@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
@@ -3074,7 +3095,7 @@ snapshots:
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.23))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.23(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(yaml@2.9.0))(yaml@2.9.0)'
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ catalog:
   vitest-browser-react: 2.2.0
   "@platformatic/kafka": 2.2.3
   "@connectrpc/connect": 2.1.2
+  "@connectrpc/connect-node": 2.1.2
 overrides:
   vite: "catalog:"
   vitest: "catalog:"


### PR DESCRIPTION
## Summary
- Add type-safe gRPC source/feed contracts, including materialized feeds now and leased feed contracts for the next slice.
- Add runtime materialized gRPC ingress with scoped feed fibers, ConnectRPC client creation, mapping/publish failure health counters, source-ownership checks, and gRPC health overlay.
- Add protocol health wire schemas/codecs for gRPC clients/feeds, including lifecycle-bucket validation.
- Add Vitest benchmark coverage for materialized gRPC ingress with separate Vitest JSON and custom .summary.json artifacts.
- Update plans/grpc.md to align names, ownership invariants, current materialized acceptance, and future leased-feed work.

## Validation
- pnpm run ready
- git diff --check
- forbidden-pattern scan clean except policy text/test names
- benchmark smoke: VIEW_SERVER_RUNTIME_BENCH_GRPC_SEED_ROWS=10 VIEW_SERVER_RUNTIME_BENCH_GRPC_BATCH_SIZE=4 VIEW_SERVER_RUNTIME_BENCH_ITERATIONS=1 pnpm --filter @view-server/runtime run bench:grpc-materialized

## Review loop
- 3 local reviewers checked the final diff.
- Two reviewers clean on first final pass.
- One P2 found for groupedIncrementalAdmissionLimits nested exactness; fixed with a type-level regression test and re-reviewed clean.
