### PR TITLE
Add materialized gRPC reconnect policy

### DIFF
--- a/packages/runtime/src/grpc-health.ts
+++ b/packages/runtime/src/grpc-health.ts
@@ -59,6 +59,7 @@ export type ViewServerGrpcHealthLedger<Topics extends ViewServerRuntimeTopicDefi
   readonly clientConnected: (clientName: string, nowMillis: number) => Effect.Effect<void>;
   readonly clientDegraded: (clientName: string, message: string) => Effect.Effect<void>;
   readonly feedReady: (feedName: string) => Effect.Effect<void>;
+  readonly feedReconnecting: (feedName: string, message: string) => Effect.Effect<void>;
   readonly feedStopping: (feedName: string) => Effect.Effect<void>;
   readonly feedDegraded: (feedName: string, message: string) => Effect.Effect<void>;
   readonly leasedFeedStarting: (input: {
@@ -398,6 +399,16 @@ export const makeViewServerGrpcHealthLedger = <
         if (feed !== undefined) {
           feed.status = "ready";
           feed.lastError = null;
+          refreshClientFromFeeds(feed.clientName);
+        }
+      }),
+    feedReconnecting: (feedName, message) =>
+      Effect.sync(() => {
+        const feed = feeds.get(feedName);
+        if (feed !== undefined) {
+          feed.status = "starting";
+          feed.reconnects += 1;
+          feed.lastError = message;
           refreshClientFromFeeds(feed.clientName);
         }
       }),

--- a/packages/runtime/src/grpc-ingress.ts
+++ b/packages/runtime/src/grpc-ingress.ts
@@ -15,7 +15,7 @@ import {
   type ViewServerRuntimeClient,
 } from "@view-server/config";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@view-server/effect-utils";
-import { Cause, Clock, Effect, Exit, Option, Schema, Scope, Stream } from "effect";
+import { Cause, Clock, Effect, Exit, Fiber, Option, Schema, Scope, Stream } from "effect";
 import type { ViewServerGrpcHealthLedger } from "./grpc-health";
 import type { ResolvedViewServerGrpcRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
@@ -25,6 +25,18 @@ export class ViewServerGrpcIngressError extends Schema.TaggedErrorClass<ViewServ
   {
     message: Schema.String,
     cause: Schema.Unknown,
+    phase: Schema.optionalKey(
+      Schema.Literals([
+        "configuration",
+        "client",
+        "request",
+        "acquire",
+        "stream",
+        "mapping",
+        "publish",
+        "release",
+      ]),
+    ),
     feedName: Schema.optionalKey(Schema.String),
     topic: Schema.optionalKey(Schema.String),
   },
@@ -70,12 +82,14 @@ export function makeDefaultGrpcClient(definition: GrpcConnectClientDefinition, b
 const grpcIngressError = (input: {
   readonly message: string;
   readonly cause: unknown;
+  readonly phase: NonNullable<ViewServerGrpcIngressError["phase"]>;
   readonly feedName: string;
   readonly topic: string;
 }) =>
   new ViewServerGrpcIngressError({
     message: input.message,
     cause: input.cause,
+    phase: input.phase,
     feedName: input.feedName,
     topic: input.topic,
   });
@@ -87,6 +101,13 @@ const hasMessage = (value: unknown): value is { readonly message: string } =>
   typeof value.message === "string";
 
 const messageFromUnknown = (value: unknown): string => {
+  if (Cause.isCause(value)) {
+    const failure = value.reasons.find(Cause.isFailReason);
+    if (failure !== undefined) {
+      return messageFromUnknown(failure.error);
+    }
+    return Cause.pretty(value);
+  }
   if (value instanceof Error) {
     return value.message;
   }
@@ -109,6 +130,54 @@ const feedFailureMessage = (feedName: string, cause: Cause.Cause<unknown>): stri
 
 const unexpectedFeedCompletionMessage = (feedName: string): string =>
   `gRPC feed ${feedName} completed unexpectedly.`;
+
+const isRestartableMaterializedFeedError = (error: ViewServerGrpcIngressError): boolean =>
+  (error.phase === "acquire" || error.phase === "stream") &&
+  (!Cause.isCause(error.cause) || !Cause.hasDies(error.cause));
+
+const materializedFeedErrorHasInterrupts = (error: ViewServerGrpcIngressError): boolean =>
+  Cause.isCause(error.cause) && Cause.hasInterrupts(error.cause);
+
+const materializedFeedCauseHasInterrupts = (
+  cause: Cause.Cause<ViewServerGrpcIngressError>,
+): boolean => {
+  if (Cause.hasInterrupts(cause)) {
+    return true;
+  }
+  const error = Cause.findErrorOption(cause);
+  return (
+    Option.isSome(error) &&
+    error.value instanceof ViewServerGrpcIngressError &&
+    materializedFeedErrorHasInterrupts(error.value)
+  );
+};
+
+const canReconnectMaterializedFeedCause = (
+  cause: Cause.Cause<ViewServerGrpcIngressError>,
+): boolean => {
+  if (materializedFeedCauseHasInterrupts(cause)) {
+    return false;
+  }
+  const error = Cause.findErrorOption(cause);
+  return (
+    Option.isSome(error) &&
+    error.value instanceof ViewServerGrpcIngressError &&
+    isRestartableMaterializedFeedError(error.value)
+  );
+};
+
+const materializedFeedReconnectMessage = (
+  feedName: string,
+  exit: Exit.Exit<void, ViewServerGrpcIngressError>,
+): string =>
+  Exit.isSuccess(exit)
+    ? unexpectedFeedCompletionMessage(feedName)
+    : feedFailureMessage(feedName, exit.cause);
+
+const materializedFeedExitEffect = (
+  exit: Exit.Exit<void, ViewServerGrpcIngressError>,
+): Effect.Effect<void, ViewServerGrpcIngressError> =>
+  Exit.isSuccess(exit) ? Effect.void : Effect.failCause(exit.cause);
 
 const markMaterializedFeedDegraded = Effect.fn("ViewServerRuntime.grpc.materialized.degraded")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
@@ -143,7 +212,7 @@ const handleMaterializedFeedExit = Effect.fn("ViewServerRuntime.grpc.materialize
     );
     return;
   }
-  if (Cause.hasInterruptsOnly(exit.cause)) {
+  if (materializedFeedCauseHasInterrupts(exit.cause)) {
     yield* health.feedStopping(feedName);
     yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
     return;
@@ -181,6 +250,7 @@ const mapMaterializedValue = Effect.fn("ViewServerRuntime.grpc.materialized.map"
       grpcIngressError({
         message: `gRPC feed mapping failed for ${feedName}`,
         cause,
+        phase: "mapping",
         feedName,
         topic: feed.topic,
       }),
@@ -190,6 +260,7 @@ const mapMaterializedValue = Effect.fn("ViewServerRuntime.grpc.materialized.map"
       grpcIngressError({
         message: `gRPC feed mapping produced an invalid row for ${feedName}`,
         cause,
+        phase: "mapping",
         feedName,
         topic: feed.topic,
       }),
@@ -243,6 +314,7 @@ const publishMaterializedBatch = Effect.fn("ViewServerRuntime.grpc.materialized.
         grpcIngressError({
           message: `gRPC feed publish failed for ${feedName}`,
           cause,
+          phase: "publish",
           feedName,
           topic: feed.topic,
         }),
@@ -290,6 +362,7 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
   options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
   health: ViewServerGrpcHealthLedger<Topics>,
   makeClient: ViewServerGrpcClientFactory,
+  registerCloseFeedState: (closeFeedState: () => void) => void,
   feedName: string,
   feed: GrpcMaterializedFeedDefinition<Topics, Clients, Topic, ClientName, MethodName>,
 ) {
@@ -298,6 +371,7 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
     return yield* grpcIngressError({
       message: `gRPC feed ${feedName} references missing client: ${feed.client}`,
       cause: feed.client,
+      phase: "configuration",
       feedName,
       topic: feed.topic,
     });
@@ -307,6 +381,7 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
     return yield* grpcIngressError({
       message: `gRPC feed ${feedName} references unresolved client URL: ${feed.client}`,
       cause: feed.client,
+      phase: "configuration",
       feedName,
       topic: feed.topic,
     });
@@ -317,6 +392,7 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
       grpcIngressError({
         message: `gRPC client creation failed for ${feedName}`,
         cause,
+        phase: "client",
         feedName,
         topic: feed.topic,
       }),
@@ -327,6 +403,7 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
       grpcIngressError({
         message: `gRPC feed request creation failed for ${feedName}`,
         cause,
+        phase: "request",
         feedName,
         topic: feed.topic,
       }),
@@ -335,67 +412,164 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
   const releaseFeed = feed.release;
   const startedAt = yield* Clock.currentTimeMillis;
   yield* health.clientConnected(feed.client, startedAt);
-  yield* health.feedReady(feedName);
   yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-  const runFeed = Effect.scoped(
-    Effect.gen(function* () {
-      const stream = yield* Effect.acquireRelease(
-        Effect.try({
-          try: () => feed.acquire(input),
-          catch: (cause) =>
-            grpcIngressError({
-              message: `gRPC feed acquire failed for ${feedName}`,
-              cause,
-              feedName,
-              topic: feed.topic,
-            }),
-        }),
-        () =>
-          releaseFeed === undefined
-            ? Effect.void
-            : ignoreGrpcFeedReleaseFailure(
-                Effect.try({
-                  try: () => releaseFeed(input),
-                  catch: (cause) =>
-                    grpcIngressError({
-                      message: `gRPC feed release failed for ${feedName}`,
-                      cause,
-                      feedName,
-                      topic: feed.topic,
-                    }),
-                }).pipe(Effect.flatMap((release) => release)),
-              ),
-      );
-      yield* stream.pipe(
-        Stream.mapError((cause) =>
+  const maxReconnects = options.materializedReconnect.maxReconnects;
+  const reconnectDelay = options.materializedReconnect.delay;
+  let unstableExits = 0;
+  let currentRunPublishedBatch = false;
+  let currentRunStayedOpen = false;
+  let closing = false;
+  registerCloseFeedState(() => {
+    closing = true;
+  });
+  const releaseFeedEffect = Effect.fn("ViewServerRuntime.grpc.materialized.feed.release")(
+    function* () {
+      if (releaseFeed === undefined) {
+        return;
+      }
+      const release = yield* Effect.try({
+        try: () => releaseFeed(input),
+        catch: (cause) =>
           grpcIngressError({
-            message: `gRPC feed stream failed for ${feedName}`,
+            message: `gRPC feed release failed for ${feedName}`,
             cause,
+            phase: "release",
+            feedName,
+            topic: feed.topic,
+          }),
+      });
+      yield* release.pipe(
+        Effect.mapError((cause) =>
+          grpcIngressError({
+            message: `gRPC feed release failed for ${feedName}`,
+            cause,
+            phase: "release",
             feedName,
             topic: feed.topic,
           }),
         ),
-        Stream.groupedWithin(grpcMessageBatchSize, grpcMessageBatchFlushInterval),
-        Stream.runForEach((values) =>
-          publishMaterializedBatch(
-            config,
-            runtimeClient,
-            requestHealthRefresh,
-            health,
-            feed,
+      );
+    },
+  );
+  const acquireFeedStream = Effect.try({
+    try: () => feed.acquire(input),
+    catch: (cause) =>
+      grpcIngressError({
+        message: `gRPC feed acquire failed for ${feedName}`,
+        cause,
+        phase: "acquire",
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+  const runFeedStream = Effect.fn("ViewServerRuntime.grpc.materialized.stream")(function* (
+    stream: Stream.Stream<GrpcMethodValue<Clients[ClientName], MethodName>, unknown>,
+  ) {
+    yield* health.feedReady(feedName);
+    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+    yield* Effect.sleep(reconnectDelay).pipe(
+      Effect.flatMap(() =>
+        Effect.sync(() => {
+          currentRunStayedOpen = true;
+        }),
+      ),
+      Effect.forkScoped({ startImmediately: true }),
+      Effect.asVoid,
+    );
+    yield* stream.pipe(
+      Stream.catchCause((cause) =>
+        Stream.fail(
+          new ViewServerGrpcIngressError({
+            message: `gRPC feed stream failed for ${feedName}`,
+            cause,
+            phase: "stream",
             feedName,
-            values,
+            topic: feed.topic,
+          }),
+        ),
+      ),
+      Stream.groupedWithin(grpcMessageBatchSize, grpcMessageBatchFlushInterval),
+      Stream.runForEach((values) =>
+        publishMaterializedBatch(
+          config,
+          runtimeClient,
+          requestHealthRefresh,
+          health,
+          feed,
+          feedName,
+          values,
+        ).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              currentRunPublishedBatch = true;
+            }),
           ),
         ),
-      );
-    }),
-  ).pipe(
-    Effect.exit,
-    Effect.flatMap((exit) =>
-      handleMaterializedFeedExit(requestHealthRefresh, health, feedName, feed.client, exit),
-    ),
-  );
-  yield* runFeed.pipe(Effect.forkIn(scope, { startImmediately: true }));
+      ),
+    );
+  });
+  const runFeedOnce = Effect.fn("ViewServerRuntime.grpc.materialized.runOnce")(function* () {
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const stream = yield* restore(acquireFeedStream);
+        const useExit = yield* restore(Effect.scoped(runFeedStream(stream))).pipe(Effect.exit);
+        const releaseExit = yield* (
+          closing ? ignoreGrpcFeedReleaseFailure(releaseFeedEffect()) : releaseFeedEffect()
+        ).pipe(Effect.exit);
+        if (Exit.isFailure(releaseExit)) {
+          if (closing) {
+            return yield* materializedFeedExitEffect(useExit);
+          }
+          if (Exit.isFailure(useExit) && materializedFeedCauseHasInterrupts(useExit.cause)) {
+            return yield* Effect.failCause(useExit.cause);
+          }
+          return yield* Effect.failCause(releaseExit.cause);
+        }
+        return yield* materializedFeedExitEffect(useExit);
+      }),
+    );
+  });
+  const runFeed = Effect.gen(function* () {
+    while (true) {
+      currentRunPublishedBatch = false;
+      currentRunStayedOpen = false;
+      const exit = yield* runFeedOnce().pipe(Effect.exit);
+      if (Exit.isSuccess(exit)) {
+        if (unstableExits < maxReconnects) {
+          unstableExits += 1;
+          yield* health.feedReconnecting(
+            feedName,
+            materializedFeedReconnectMessage(feedName, exit),
+          );
+          yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+          yield* Effect.sleep(reconnectDelay);
+          continue;
+        }
+        yield* handleMaterializedFeedExit(
+          requestHealthRefresh,
+          health,
+          feedName,
+          feed.client,
+          exit,
+        );
+        return;
+      }
+      if (Exit.isFailure(exit) && (currentRunPublishedBatch || currentRunStayedOpen)) {
+        unstableExits = 0;
+      }
+      if (unstableExits < maxReconnects && canReconnectMaterializedFeedCause(exit.cause)) {
+        unstableExits += 1;
+        yield* health.feedReconnecting(feedName, materializedFeedReconnectMessage(feedName, exit));
+        yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+        yield* Effect.sleep(reconnectDelay);
+        continue;
+      }
+      yield* handleMaterializedFeedExit(requestHealthRefresh, health, feedName, feed.client, exit);
+      return;
+    }
+  });
+  const fiber = yield* runFeed.pipe(Effect.forkIn(scope, { startImmediately: true }));
+  yield* Scope.addFinalizer(scope, Fiber.interrupt(fiber));
 });
 
 export const makeViewServerGrpcIngress: <
@@ -425,6 +599,7 @@ export const makeViewServerGrpcIngress: <
   const feedNames = Object.entries(options.feeds)
     .filter(([, feed]) => feed.lifecycle === "materialized")
     .map(([feedName]) => feedName);
+  const closeFeedStates: Array<() => void> = [];
   return yield* Effect.gen(function* () {
     for (const [feedName, feed] of Object.entries(options.feeds)) {
       if (feed.lifecycle === "materialized") {
@@ -436,6 +611,9 @@ export const makeViewServerGrpcIngress: <
           options,
           health,
           makeClient,
+          (closeFeedState) => {
+            closeFeedStates.push(closeFeedState);
+          },
           feedName,
           feed,
         );
@@ -443,6 +621,9 @@ export const makeViewServerGrpcIngress: <
     }
     return {
       close: Effect.gen(function* () {
+        for (const closeFeed of closeFeedStates) {
+          closeFeed();
+        }
         yield* Effect.forEach(feedNames, (feedName) => health.feedStopping(feedName), {
           discard: true,
         });

--- a/packages/runtime/src/grpc-leased.bench.ts
+++ b/packages/runtime/src/grpc-leased.bench.ts
@@ -1033,6 +1033,10 @@ beforeAll(async () => {
           feeds: {
             ordersLease: grpcLeasedFeed(queues),
           },
+          materializedReconnect: {
+            delay: "1 second",
+            maxReconnects: 60,
+          },
         },
         health,
       );

--- a/packages/runtime/src/grpc-materialized.bench.ts
+++ b/packages/runtime/src/grpc-materialized.bench.ts
@@ -569,6 +569,10 @@ beforeAll(async () => {
           feeds: {
             ordersFeed: grpcMaterializedFeed(Stream.fromQueue(queue)),
           },
+          materializedReconnect: {
+            delay: "1 second",
+            maxReconnects: 60,
+          },
         },
         health,
       );

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -14,6 +14,7 @@ import {
   makeViewServerRuntime,
   runViewServerRuntime,
   type ViewServerRuntime,
+  type ViewServerGrpcRuntimeOptions,
   type ViewServerGrpcIngressError,
   type ViewServerKafkaIngressError,
   type ViewServerRuntimeOptions,
@@ -431,8 +432,44 @@ describe("runtime type contracts", () => {
         feeds: {
           ordersFeed: grpcOrdersFeed,
         },
+        materializedReconnect: {
+          delay: "100 millis",
+          maxReconnects: 5,
+        },
       },
     });
+    const invalidGrpcReconnectKey = makeViewServerRuntime(materializedGrpcViewServer, {
+      grpc: {
+        clients: grpcRuntimeClients,
+        feeds: {
+          ordersFeed: grpcOrdersFeed,
+        },
+        materializedReconnect: {
+          delay: "100 millis",
+          maxReconnects: 5,
+          // @ts-expect-error runtime gRPC reconnect options reject unknown fields.
+          maxAttempts: 5,
+        },
+      },
+    });
+    const invalidGrpcReconnectMax = {
+      delay: "100 millis",
+      // @ts-expect-error runtime gRPC reconnect maxReconnects must be a number.
+      maxReconnects: "5",
+    } satisfies NonNullable<
+      ViewServerGrpcRuntimeOptions<
+        typeof materializedGrpcViewServer.topics
+      >["materializedReconnect"]
+    >;
+    const invalidGrpcReconnectDelay = {
+      // @ts-expect-error runtime gRPC reconnect delay must be a Duration.Input.
+      delay: false,
+      maxReconnects: 5,
+    } satisfies NonNullable<
+      ViewServerGrpcRuntimeOptions<
+        typeof materializedGrpcViewServer.topics
+      >["materializedReconnect"]
+    >;
     const invalidGrpcOptionKey = makeViewServerRuntime(materializedGrpcViewServer, {
       grpc: {
         clients: grpcRuntimeClients,
@@ -471,6 +508,9 @@ describe("runtime type contracts", () => {
     expectTypeOf<Effect.Success<typeof runtimeWithGrpc>>().toMatchTypeOf<
       ViewServerRuntime<typeof materializedGrpcViewServer.topics>
     >();
+    expectTypeOf(invalidGrpcReconnectKey).not.toBeAny();
+    expectTypeOf(invalidGrpcReconnectMax).not.toBeAny();
+    expectTypeOf(invalidGrpcReconnectDelay).not.toBeAny();
     expectTypeOf(invalidGrpcOptionKey).not.toBeAny();
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("port");
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("path");

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -655,6 +655,11 @@ const grpcHealthFeed = (health: ViewServerHealth<GrpcTopics>) =>
 
 const grpcHealthClient = (health: ViewServerHealth<GrpcTopics>) => health.grpc?.clients["orders"];
 
+const fastGrpcMaterializedReconnect = {
+  delay: "10 millis",
+  maxReconnects: 3,
+} satisfies ResolvedViewServerGrpcRuntimeOptions<GrpcTopics>["materializedReconnect"];
+
 const resolveGrpcRuntimeOptions = Effect.fn("ViewServerRuntime.test.grpc.options.resolve")(
   function* (feed: ReturnType<typeof grpcMaterializedFeed>) {
     const options = yield* resolveViewServerRuntimeOptions<
@@ -667,6 +672,7 @@ const resolveGrpcRuntimeOptions = Effect.fn("ViewServerRuntime.test.grpc.options
         feeds: {
           ordersFeed: feed,
         },
+        materializedReconnect: fastGrpcMaterializedReconnect,
       },
     });
     return yield* Effect.fromNullishOr(options.grpcOptions);
@@ -686,6 +692,7 @@ const resolveLeasedGrpcRuntimeOptions = Effect.fn(
       feeds: {
         ordersLease: feed,
       },
+      materializedReconnect: fastGrpcMaterializedReconnect,
     },
   });
   return yield* Effect.fromNullishOr(options.grpcOptions);
@@ -1109,6 +1116,7 @@ describe("@view-server/runtime", () => {
                 }
               >
             >;
+            readonly materializedReconnect: ResolvedViewServerGrpcRuntimeOptions<GrpcTopics>["materializedReconnect"];
           }
         | undefined;
       let grpcHealthLedgerCreated = false;
@@ -1141,6 +1149,7 @@ describe("@view-server/runtime", () => {
                 },
               ]),
             ),
+            materializedReconnect: options.materializedReconnect,
           };
           return Effect.succeed({
             close: Effect.void,
@@ -1153,6 +1162,10 @@ describe("@view-server/runtime", () => {
           clients: grpcClients,
           feeds: {
             ordersFeed: feed,
+          },
+          materializedReconnect: {
+            delay: "100 millis",
+            maxReconnects: 5,
           },
         },
       };
@@ -1167,6 +1180,7 @@ describe("@view-server/runtime", () => {
         clientBaseUrls: grpcOptionsSummary?.clientBaseUrls,
         clientNames: grpcOptionsSummary?.clientNames,
         feeds: grpcOptionsSummary?.feeds,
+        materializedReconnect: grpcOptionsSummary?.materializedReconnect,
       }).toStrictEqual({
         clientBaseUrls: nullRecord([["orders", "https://orders.example.test"]]),
         clientNames: ["orders"],
@@ -1177,6 +1191,10 @@ describe("@view-server/runtime", () => {
             method: "streamOrders",
             topic: "orders",
           },
+        },
+        materializedReconnect: {
+          delay: "100 millis",
+          maxReconnects: 5,
         },
       });
 
@@ -1240,6 +1258,85 @@ describe("@view-server/runtime", () => {
       });
 
       expect(options.grpcOptions?.feeds["ordersLease"]).toBe(feed);
+    }),
+  );
+
+  it.live("rejects invalid materialized gRPC reconnect maxReconnects", () =>
+    Effect.gen(function* () {
+      const error = yield* makeViewServerRuntime(grpcViewServer, {
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: grpcMaterializedFeed(Stream.never),
+          },
+          materializedReconnect: {
+            delay: "10 millis",
+            maxReconnects: Infinity,
+          },
+        },
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ViewServerGrpcIngressError);
+      expect(error).toStrictEqual(
+        new ViewServerGrpcIngressError({
+          message:
+            "gRPC materialized reconnect maxReconnects must be a finite non-negative integer.",
+          cause: Infinity,
+          phase: "configuration",
+        }),
+      );
+    }),
+  );
+
+  it.live("rejects invalid materialized gRPC reconnect delay", () =>
+    Effect.gen(function* () {
+      const error = yield* makeViewServerRuntime(grpcViewServer, {
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: grpcMaterializedFeed(Stream.never),
+          },
+          materializedReconnect: {
+            delay: "Infinity",
+            maxReconnects: 3,
+          },
+        },
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ViewServerGrpcIngressError);
+      expect(error).toStrictEqual(
+        new ViewServerGrpcIngressError({
+          message: "gRPC materialized reconnect delay must be finite and positive.",
+          cause: "Infinity",
+          phase: "configuration",
+        }),
+      );
+    }),
+  );
+
+  it.live("rejects zero materialized gRPC reconnect delay", () =>
+    Effect.gen(function* () {
+      const error = yield* makeViewServerRuntime(grpcViewServer, {
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: grpcMaterializedFeed(Stream.never),
+          },
+          materializedReconnect: {
+            delay: 0,
+            maxReconnects: 3,
+          },
+        },
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ViewServerGrpcIngressError);
+      expect(error).toStrictEqual(
+        new ViewServerGrpcIngressError({
+          message: "gRPC materialized reconnect delay must be finite and positive.",
+          cause: 0,
+          phase: "configuration",
+        }),
+      );
     }),
   );
 
@@ -1960,6 +2057,7 @@ describe("@view-server/runtime", () => {
         feeds: {
           ordersFeed: feed,
         },
+        materializedReconnect: fastGrpcMaterializedReconnect,
       };
       const nullTopicError = yield* validateGrpcSourceFeeds(nullTopicConfig, grpcOptions).pipe(
         Effect.flip,
@@ -2008,6 +2106,7 @@ describe("@view-server/runtime", () => {
           feeds: {
             ordersFeed: feed,
           },
+          materializedReconnect: fastGrpcMaterializedReconnect,
         };
 
         const error = yield* validateGrpcSourceFeeds(grpcViewServer, grpcOptions).pipe(Effect.flip);
@@ -5792,6 +5891,7 @@ describe("@view-server/runtime", () => {
           feeds: {
             ordersLease: feed,
           },
+          materializedReconnect: fastGrpcMaterializedReconnect,
         },
         health,
       );
@@ -6542,6 +6642,7 @@ describe("@view-server/runtime", () => {
           clients: grpcClients,
           clientBaseUrls: nullRecord([["orders", "https://orders.example.test"]]),
           feeds: {},
+          materializedReconnect: fastGrpcMaterializedReconnect,
         },
         health,
       );
@@ -6875,10 +6976,156 @@ describe("@view-server/runtime", () => {
       }),
   );
 
-  it.live("marks materialized gRPC feed degraded when the stream completes", () =>
+  it.live("marks materialized gRPC feed degraded when stream completion exhausts reconnects", () =>
     Effect.gen(function* () {
       const feed = grpcMaterializedFeed(Stream.make(grpcOrderValue("order-1", 10)));
       const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => {
+            const feedHealth = grpcHealthFeed(currentHealth);
+            return (
+              feedHealth?.status === "degraded" &&
+              feedHealth.reconnects === 3 &&
+              feedHealth.lastError === "gRPC feed ordersFeed completed unexpectedly."
+            );
+          },
+        }),
+      );
+
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+        "gRPC feed ordersFeed completed unexpectedly.",
+      );
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(3);
+      expect(grpcHealthClient(degradedHealth)?.activeFeeds).toBe(0);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "marks materialized gRPC feed degraded when delayed stream completion exhausts reconnects",
+    () =>
+      Effect.gen(function* () {
+        let acquireCount = 0;
+        const streams = [
+          Stream.fromEffect(Effect.sleep("20 millis")).pipe(Stream.drain),
+          Stream.fromEffect(Effect.sleep("20 millis")).pipe(Stream.drain),
+        ];
+        const feed = grpcFeed.materializedFeed({
+          topic: "orders",
+          client: "orders",
+          method: "streamOrders",
+          request: () => ({ orderId: "all" }),
+          acquire: () => {
+            const stream = streams[acquireCount] ?? Stream.never;
+            acquireCount += 1;
+            return stream;
+          },
+          map: ({ value }) => ({
+            id: value.customerId,
+            customerId: value.customerId,
+            status: value.status,
+            price: value.price,
+            region: "usa",
+            updatedAt: value.updatedAt,
+          }),
+        });
+        const options = yield* resolveViewServerRuntimeOptions<
+          GrpcTopics,
+          Record<string, string>,
+          typeof grpcClients
+        >({
+          grpc: {
+            clients: grpcClients,
+            feeds: {
+              ordersFeed: feed,
+            },
+            materializedReconnect: {
+              delay: "10 millis",
+              maxReconnects: 1,
+            },
+          },
+        });
+        const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+        const health = makeGrpcHealth(grpcOptions);
+        const ingress = yield* makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+          }),
+        );
+
+        expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+          "gRPC feed ordersFeed completed unexpectedly.",
+        );
+        expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(1);
+        expect(acquireCount).toBe(2);
+        yield* ingress.close;
+        yield* runtimeCore.close;
+      }),
+  );
+
+  it.live("uses one materialized gRPC reconnect budget across completion and failure", () =>
+    Effect.gen(function* () {
+      let acquireCount = 0;
+      const streams = [Stream.empty, Stream.fail("upstream down"), Stream.never];
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => {
+          const stream = streams[acquireCount] ?? Stream.never;
+          acquireCount += 1;
+          return stream;
+        },
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const options = yield* resolveViewServerRuntimeOptions<
+        GrpcTopics,
+        Record<string, string>,
+        typeof grpcClients
+      >({
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: feed,
+          },
+          materializedReconnect: {
+            delay: "10 millis",
+            maxReconnects: 1,
+          },
+        },
+      });
+      const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
       const health = makeGrpcHealth(grpcOptions);
       const ingress = yield* makeViewServerGrpcIngress(
@@ -6896,10 +7143,16 @@ describe("@view-server/runtime", () => {
         }),
       );
 
-      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
-        "gRPC feed ordersFeed completed unexpectedly.",
-      );
-      expect(grpcHealthClient(degradedHealth)?.activeFeeds).toBe(0);
+      expect({
+        acquireCount,
+        lastError: grpcHealthFeed(degradedHealth)?.lastError,
+        reconnects: grpcHealthFeed(degradedHealth)?.reconnects,
+      }).toStrictEqual({
+        acquireCount: 2,
+        lastError:
+          "gRPC feed ordersFeed failed: gRPC feed stream failed for ordersFeed: upstream down",
+        reconnects: 1,
+      });
       yield* ingress.close;
       yield* runtimeCore.close;
     }),
@@ -6932,6 +7185,113 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("keeps materialized gRPC stream interruption terminal when release fails", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.failCause(Cause.interrupt()),
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            return yield* Effect.fail("release down");
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const stoppingHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+        }),
+      );
+
+      expect({
+        lastError: grpcHealthFeed(stoppingHealth)?.lastError,
+        reconnects: grpcHealthFeed(stoppingHealth)?.reconnects,
+        releaseCount,
+      }).toStrictEqual({
+        lastError: null,
+        reconnects: 0,
+        releaseCount: 1,
+      });
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "does not reconnect materialized gRPC feed when failure cause includes interruption",
+    () =>
+      Effect.gen(function* () {
+        const feed = grpcMaterializedFeed(
+          Stream.failCause(
+            Cause.fromReasons([
+              Cause.makeFailReason("upstream down during shutdown"),
+              Cause.makeInterruptReason(),
+            ]),
+          ),
+        );
+        const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+        const health = makeGrpcHealth(grpcOptions);
+        const ingress = yield* makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const stoppingHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+          }),
+        );
+
+        expect(grpcHealthFeed(stoppingHealth)).toStrictEqual({
+          status: "stopping",
+          lifecycle: "materialized",
+          feedName: "ordersFeed",
+          feedKey: "orders/ordersFeed/materialized",
+          topic: "orders",
+          subscriberCount: 0,
+          rowCount: 0,
+          messagesPerSecond: 0,
+          rowsPerSecond: 0,
+          decodeFailuresPerSecond: 0,
+          mappingFailuresPerSecond: 0,
+          publishFailuresPerSecond: 0,
+          reconnects: 0,
+          lastMessageAt: null,
+          lastError: null,
+        });
+        yield* ingress.close;
+        yield* runtimeCore.close;
+      }),
+  );
+
   it.live("publishes materialized gRPC stream rows into runtime core and health", () =>
     Effect.gen(function* () {
       const feed = grpcMaterializedFeed(
@@ -6939,7 +7299,6 @@ describe("@view-server/runtime", () => {
       );
       const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
-      let healthRefreshCount = 0;
       const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
         clients: grpcOptions.clientBaseUrls,
         feeds: {
@@ -6953,9 +7312,7 @@ describe("@view-server/runtime", () => {
       const ingress = yield* makeViewServerGrpcIngress(
         grpcViewServer,
         runtimeCore.client,
-        Effect.sync(() => {
-          healthRefreshCount += 1;
-        }),
+        Effect.void,
         grpcOptions,
         health,
       );
@@ -7001,7 +7358,6 @@ describe("@view-server/runtime", () => {
       });
       expect(typeof clientHealth?.lastConnectedAt).toBe("number");
       expect(typeof feedHealth?.lastMessageAt).toBe("number");
-      expect(healthRefreshCount).toBe(2);
 
       yield* ingress.close;
       const stoppedHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
@@ -7074,6 +7430,523 @@ describe("@view-server/runtime", () => {
 
       expect(grpcHealthFeed(degradedHealth)?.lastError).toContain("gRPC feed ordersFeed failed:");
       expect(grpcHealthFeed(degradedHealth)?.lastError).toContain("defect down");
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(0);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("does not reset materialized gRPC reconnect budget during slow release", () =>
+    Effect.gen(function* () {
+      let acquireCount = 0;
+      let releaseCount = 0;
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => {
+          acquireCount += 1;
+          return Stream.fail("upstream down");
+        },
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            yield* Effect.sleep("25 millis");
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const options = yield* resolveViewServerRuntimeOptions<
+        GrpcTopics,
+        Record<string, string>,
+        typeof grpcClients
+      >({
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: feed,
+          },
+          materializedReconnect: {
+            delay: "10 millis",
+            maxReconnects: 1,
+          },
+        },
+      });
+      const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect({
+        acquireCount,
+        releaseCount,
+        reconnects: grpcHealthFeed(degradedHealth)?.reconnects,
+      }).toStrictEqual({
+        acquireCount: 2,
+        releaseCount: 2,
+        reconnects: 1,
+      });
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("resets materialized gRPC reconnect failure streak after publishing a batch", () =>
+    Effect.gen(function* () {
+      let acquireCount = 0;
+      const failAfterProgress = yield* Deferred.make<void>();
+      const streams = [
+        Stream.fail("first transient failure"),
+        Stream.make(grpcOrderValue("progress-row", 11)).pipe(
+          Stream.concat(
+            Stream.fromEffect(Deferred.await(failAfterProgress)).pipe(
+              Stream.drain,
+              Stream.concat(Stream.fail("second transient failure after progress")),
+            ),
+          ),
+        ),
+        longRunningGrpcStream([grpcOrderValue("final-row", 12)]),
+      ];
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => {
+          const stream = streams[acquireCount] ?? Stream.never;
+          acquireCount += 1;
+          return stream;
+        },
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const options = yield* resolveViewServerRuntimeOptions<
+        GrpcTopics,
+        Record<string, string>,
+        typeof grpcClients
+      >({
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: feed,
+          },
+          materializedReconnect: {
+            delay: "10 millis",
+            maxReconnects: 1,
+          },
+        },
+      });
+      const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const progressSnapshot = yield* waitForGrpcSnapshotRows(runtimeCore.client, 1);
+      yield* Deferred.succeed(failAfterProgress, undefined);
+      const finalSnapshot = yield* waitForGrpcSnapshotRows(runtimeCore.client, 2);
+      const finalHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.reconnects === 2,
+        }),
+      );
+
+      expect(progressSnapshot).toStrictEqual({
+        rows: [{ id: "progress-row", price: 11 }],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      expect(finalSnapshot).toStrictEqual({
+        rows: [
+          { id: "progress-row", price: 11 },
+          { id: "final-row", price: 12 },
+        ],
+        totalRows: 2,
+        version: 2,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      expect(grpcHealthFeed(finalHealth)?.reconnects).toBe(2);
+      expect(acquireCount).toBe(3);
+
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "resets materialized gRPC reconnect failure streak after staying open for one delay",
+    () =>
+      Effect.gen(function* () {
+        let acquireCount = 0;
+        const streams = [
+          Stream.fail("first transient failure"),
+          Stream.fromEffect(Effect.sleep("20 millis")).pipe(
+            Stream.drain,
+            Stream.concat(Stream.fail("second transient failure after stable open")),
+          ),
+          longRunningGrpcStream([grpcOrderValue("stable-reset-row", 13)]),
+        ];
+        const feed = grpcFeed.materializedFeed({
+          topic: "orders",
+          client: "orders",
+          method: "streamOrders",
+          request: () => ({ orderId: "all" }),
+          acquire: () => {
+            const stream = streams[acquireCount] ?? Stream.never;
+            acquireCount += 1;
+            return stream;
+          },
+          map: ({ value }) => ({
+            id: value.customerId,
+            customerId: value.customerId,
+            status: value.status,
+            price: value.price,
+            region: "usa",
+            updatedAt: value.updatedAt,
+          }),
+        });
+        const options = yield* resolveViewServerRuntimeOptions<
+          GrpcTopics,
+          Record<string, string>,
+          typeof grpcClients
+        >({
+          grpc: {
+            clients: grpcClients,
+            feeds: {
+              ordersFeed: feed,
+            },
+            materializedReconnect: {
+              delay: "10 millis",
+              maxReconnects: 1,
+            },
+          },
+        });
+        const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+        const health = makeGrpcHealth(grpcOptions);
+        const ingress = yield* makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const snapshot = yield* waitForGrpcSnapshotRows(runtimeCore.client, 1);
+        const finalHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (currentHealth) => grpcHealthFeed(currentHealth)?.reconnects === 2,
+          }),
+        );
+
+        expect(snapshot).toStrictEqual({
+          rows: [{ id: "stable-reset-row", price: 13 }],
+          totalRows: 1,
+          version: 1,
+          status: "ready",
+          statusCode: "Ready",
+        });
+        expect(grpcHealthFeed(finalHealth)?.reconnects).toBe(2);
+        expect(acquireCount).toBe(3);
+
+        yield* ingress.close;
+        yield* runtimeCore.close;
+      }),
+  );
+
+  it.live("reconnects materialized gRPC feed after a transient upstream failure", () =>
+    Effect.gen(function* () {
+      let acquireCount = 0;
+      let releaseCount = 0;
+      const streams = [
+        Stream.fail("upstream down"),
+        longRunningGrpcStream([grpcOrderValue("order-after-reconnect", 10)]),
+      ];
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => {
+          const stream = streams[acquireCount] ?? Stream.never;
+          acquireCount += 1;
+          return stream;
+        },
+        release: () =>
+          Effect.sync(() => {
+            releaseCount += 1;
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const readyHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => {
+            const currentFeed = grpcHealthFeed(currentHealth);
+            return (
+              currentFeed?.status === "ready" &&
+              currentFeed.reconnects === 1 &&
+              currentFeed.rowCount === 1
+            );
+          },
+        }),
+      );
+      const snapshot = yield* waitForGrpcSnapshotRows(runtimeCore.client, 1);
+      const feedHealth = grpcHealthFeed(readyHealth);
+
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "order-after-reconnect", price: 10 }],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      expect(feedHealth).toStrictEqual({
+        status: "ready",
+        lifecycle: "materialized",
+        feedName: "ordersFeed",
+        feedKey: "orders/ordersFeed/materialized",
+        topic: "orders",
+        subscriberCount: 0,
+        rowCount: 1,
+        messagesPerSecond: 1,
+        rowsPerSecond: 1,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        reconnects: 1,
+        lastMessageAt: feedHealth?.lastMessageAt,
+        lastError: null,
+      });
+      expect(acquireCount).toBe(2);
+      expect(releaseCount).toBe(1);
+
+      yield* ingress.close;
+      expect(releaseCount).toBe(2);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed degraded when release fails after stream failure", () =>
+    Effect.gen(function* () {
+      let acquireCount = 0;
+      let releaseCount = 0;
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => {
+          acquireCount += 1;
+          return Stream.fail("upstream down");
+        },
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            return yield* Effect.fail("release down");
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const options = yield* resolveViewServerRuntimeOptions<
+        GrpcTopics,
+        Record<string, string>,
+        typeof grpcClients
+      >({
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: feed,
+          },
+          materializedReconnect: {
+            delay: "10 millis",
+            maxReconnects: 3,
+          },
+        },
+      });
+      const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
+        "gRPC feed ordersFeed failed: gRPC feed release failed for ordersFeed: release down",
+      );
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(0);
+      expect(acquireCount).toBe(1);
+      expect(releaseCount).toBe(1);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed degraded when release defects after completion", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.empty,
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            return yield* Effect.die("release defect");
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const degradedHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "degraded",
+        }),
+      );
+
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toContain("gRPC feed ordersFeed failed:");
+      expect(grpcHealthFeed(degradedHealth)?.lastError).toContain("release defect");
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(0);
+      expect(releaseCount).toBe(1);
+      yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("marks materialized gRPC feed stopping when release is interrupted", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.fail("upstream down"),
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            return yield* Effect.interrupt;
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const stoppingHealth = yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+        }),
+      );
+
+      expect(grpcHealthFeed(stoppingHealth)?.lastError).toBe(null);
+      expect(grpcHealthFeed(stoppingHealth)?.reconnects).toBe(0);
+      expect(releaseCount).toBe(1);
       yield* ingress.close;
       yield* runtimeCore.close;
     }),
@@ -7082,9 +7955,24 @@ describe("@view-server/runtime", () => {
   it.live("marks materialized gRPC feed health degraded when the stream fails", () =>
     Effect.gen(function* () {
       const feed = grpcMaterializedFeed(Stream.fail("upstream down"));
-      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const options = yield* resolveViewServerRuntimeOptions<
+        GrpcTopics,
+        Record<string, string>,
+        typeof grpcClients
+      >({
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersFeed: feed,
+          },
+          materializedReconnect: {
+            delay: "10 millis",
+            maxReconnects: 0,
+          },
+        },
+      });
+      const grpcOptions = yield* Effect.fromNullishOr(options.grpcOptions);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
-      let healthRefreshCount = 0;
       const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
         clients: grpcOptions.clientBaseUrls,
         feeds: {
@@ -7098,9 +7986,7 @@ describe("@view-server/runtime", () => {
       const ingress = yield* makeViewServerGrpcIngress(
         grpcViewServer,
         runtimeCore.client,
-        Effect.sync(() => {
-          healthRefreshCount += 1;
-        }),
+        Effect.void,
         grpcOptions,
         health,
       );
@@ -7121,7 +8007,7 @@ describe("@view-server/runtime", () => {
       expect(degradedHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.lastError).toBe(
         "gRPC feed ordersFeed failed: gRPC feed stream failed for ordersFeed: upstream down",
       );
-      expect(healthRefreshCount).toBe(2);
+      expect(degradedHealth.grpc?.feeds["orders"]?.materialized["ordersFeed"]?.reconnects).toBe(0);
 
       yield* ingress.close;
       yield* runtimeCore.close;
@@ -7148,6 +8034,228 @@ describe("@view-server/runtime", () => {
 
       yield* ingress.close;
       yield* Deferred.await(released);
+      expect(
+        grpcHealthFeed(health.healthOverlay(yield* runtimeCore.client.health(), 2_000)),
+      ).toStrictEqual({
+        status: "stopping",
+        lifecycle: "materialized",
+        feedName: "ordersFeed",
+        feedKey: "orders/ordersFeed/materialized",
+        topic: "orders",
+        subscriberCount: 0,
+        rowCount: 0,
+        messagesPerSecond: 0,
+        rowsPerSecond: 0,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        reconnects: 0,
+        lastMessageAt: null,
+        lastError: null,
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "does not reconnect completed materialized gRPC feed when close starts during release",
+    () =>
+      Effect.gen(function* () {
+        let releaseCount = 0;
+        const releaseStarted = yield* Deferred.make<void>();
+        const releaseContinue = yield* Deferred.make<void>();
+        const feed = grpcFeed.materializedFeed({
+          topic: "orders",
+          client: "orders",
+          method: "streamOrders",
+          request: () => ({ orderId: "all" }),
+          acquire: () => Stream.empty,
+          release: () =>
+            Effect.gen(function* () {
+              releaseCount += 1;
+              yield* Deferred.succeed(releaseStarted, undefined);
+              yield* Deferred.await(releaseContinue);
+            }),
+          map: ({ value }) => ({
+            id: value.customerId,
+            customerId: value.customerId,
+            status: value.status,
+            price: value.price,
+            region: "usa",
+            updatedAt: value.updatedAt,
+          }),
+        });
+        const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+        const health = makeGrpcHealth(grpcOptions);
+        const ingress = yield* makeViewServerGrpcIngress(
+          grpcViewServer,
+          runtimeCore.client,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        yield* Deferred.await(releaseStarted);
+        const closeFiber = yield* ingress.close.pipe(Effect.forkChild);
+        yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+          }),
+        );
+        yield* Deferred.succeed(releaseContinue, undefined);
+        yield* Fiber.join(closeFiber);
+
+        expect(releaseCount).toBe(1);
+        expect(
+          grpcHealthFeed(health.healthOverlay(yield* runtimeCore.client.health(), 2_000)),
+        ).toStrictEqual({
+          status: "stopping",
+          lifecycle: "materialized",
+          feedName: "ordersFeed",
+          feedKey: "orders/ordersFeed/materialized",
+          topic: "orders",
+          subscriberCount: 0,
+          rowCount: 0,
+          messagesPerSecond: 0,
+          rowsPerSecond: 0,
+          decodeFailuresPerSecond: 0,
+          mappingFailuresPerSecond: 0,
+          publishFailuresPerSecond: 0,
+          reconnects: 0,
+          lastMessageAt: null,
+          lastError: null,
+        });
+        yield* runtimeCore.close;
+      }),
+  );
+
+  it.live("ignores materialized gRPC release failure when close starts during release", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const releaseStarted = yield* Deferred.make<void>();
+      const releaseContinue = yield* Deferred.make<void>();
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.empty,
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            yield* Deferred.succeed(releaseStarted, undefined);
+            yield* Deferred.await(releaseContinue);
+            return yield* Effect.fail("release down after close");
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      yield* Deferred.await(releaseStarted);
+      const closeFiber = yield* ingress.close.pipe(Effect.forkChild);
+      yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+        }),
+      );
+      yield* Deferred.succeed(releaseContinue, undefined);
+      yield* Fiber.join(closeFiber);
+
+      expect({
+        releaseCount,
+        feed: grpcHealthFeed(health.healthOverlay(yield* runtimeCore.client.health(), 2_000)),
+      }).toStrictEqual({
+        releaseCount: 1,
+        feed: {
+          status: "stopping",
+          lifecycle: "materialized",
+          feedName: "ordersFeed",
+          feedKey: "orders/ordersFeed/materialized",
+          topic: "orders",
+          subscriberCount: 0,
+          rowCount: 0,
+          messagesPerSecond: 0,
+          rowsPerSecond: 0,
+          decodeFailuresPerSecond: 0,
+          mappingFailuresPerSecond: 0,
+          publishFailuresPerSecond: 0,
+          reconnects: 0,
+          lastMessageAt: null,
+          lastError: null,
+        },
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("does not reconnect failed materialized gRPC feed when close starts during release", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const releaseStarted = yield* Deferred.make<void>();
+      const releaseContinue = yield* Deferred.make<void>();
+      const feed = grpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.fail("upstream down"),
+        release: () =>
+          Effect.gen(function* () {
+            releaseCount += 1;
+            yield* Deferred.succeed(releaseStarted, undefined);
+            yield* Deferred.await(releaseContinue);
+          }),
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+      const ingress = yield* makeViewServerGrpcIngress(
+        grpcViewServer,
+        runtimeCore.client,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      yield* Deferred.await(releaseStarted);
+      const closeFiber = yield* ingress.close.pipe(Effect.forkChild);
+      yield* readGrpcHealthOverlayNow(runtimeCore.client, health).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) => grpcHealthFeed(currentHealth)?.status === "stopping",
+        }),
+      );
+      yield* Deferred.succeed(releaseContinue, undefined);
+      yield* Fiber.join(closeFiber);
+
+      expect(releaseCount).toBe(1);
       expect(
         grpcHealthFeed(health.healthOverlay(yield* runtimeCore.client.health(), 2_000)),
       ).toStrictEqual({
@@ -7215,14 +8323,11 @@ describe("@view-server/runtime", () => {
       const feed = grpcMaterializedFeed(Stream.never);
       const grpcOptions = yield* resolveGrpcRuntimeOptions(feed);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
-      let healthRefreshCount = 0;
       const health = makeGrpcHealth(grpcOptions);
       const ingress = yield* makeViewServerGrpcIngress(
         grpcViewServer,
         runtimeCore.client,
-        Effect.sync(() => {
-          healthRefreshCount += 1;
-        }),
+        Effect.void,
         grpcOptions,
         health,
       );
@@ -7230,8 +8335,37 @@ describe("@view-server/runtime", () => {
       const readyHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
       expect(grpcHealthFeed(readyHealth)?.status).toBe("ready");
       expect(grpcHealthClient(readyHealth)?.activeFeeds).toBe(1);
-      expect(healthRefreshCount).toBe(1);
       yield* ingress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("ignores reconnect health updates for unknown gRPC feeds", () =>
+    Effect.gen(function* () {
+      const grpcOptions = yield* resolveGrpcRuntimeOptions(grpcMaterializedFeed(Stream.never));
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
+      const health = makeGrpcHealth(grpcOptions);
+
+      yield* health.feedReconnecting("missingFeed", "ignored reconnect");
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect(grpcHealthFeed(currentHealth)).toStrictEqual({
+        status: "starting",
+        lifecycle: "materialized",
+        feedName: "ordersFeed",
+        feedKey: "orders/ordersFeed/materialized",
+        topic: "orders",
+        subscriberCount: 0,
+        rowCount: 0,
+        messagesPerSecond: 0,
+        rowsPerSecond: 0,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        reconnects: 0,
+        lastMessageAt: null,
+        lastError: null,
+      });
       yield* runtimeCore.close;
     }),
   );
@@ -7305,6 +8439,7 @@ describe("@view-server/runtime", () => {
         feeds: {
           ordersLease: feed,
         },
+        materializedReconnect: fastGrpcMaterializedReconnect,
       };
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
       const health = makeViewServerGrpcHealthLedger<typeof leasedGrpcViewServer.topics>({
@@ -7343,6 +8478,7 @@ describe("@view-server/runtime", () => {
           runningFeed,
           failingFeed,
         },
+        materializedReconnect: fastGrpcMaterializedReconnect,
       };
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
       const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
@@ -7392,6 +8528,7 @@ describe("@view-server/runtime", () => {
         feeds: {
           ordersFeed: feed,
         },
+        materializedReconnect: fastGrpcMaterializedReconnect,
       };
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
       const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
@@ -7430,6 +8567,7 @@ describe("@view-server/runtime", () => {
         feeds: {
           ordersFeed: feed,
         },
+        materializedReconnect: fastGrpcMaterializedReconnect,
       };
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcViewServer, {});
       const health = makeViewServerGrpcHealthLedger<GrpcTopics>({
@@ -7486,6 +8624,7 @@ describe("@view-server/runtime", () => {
       expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
         "gRPC feed ordersFeed failed: gRPC feed acquire failed for ordersFeed: acquire exploded",
       );
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(3);
       yield* ingress.close;
       yield* runtimeCore.close;
     }),
@@ -7517,6 +8656,7 @@ describe("@view-server/runtime", () => {
       expect(degradedHealth.status).toBe("degraded");
       expect(grpcHealthFeed(degradedHealth)?.mappingFailuresPerSecond).toBe(1);
       expect(grpcHealthFeed(degradedHealth)?.publishFailuresPerSecond).toBe(0);
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(0);
       expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
         "gRPC feed ordersFeed failed: gRPC feed mapping failed for ordersFeed: mapping exploded",
       );
@@ -7567,6 +8707,7 @@ describe("@view-server/runtime", () => {
       expect(degradedHealth.status).toBe("degraded");
       expect(grpcHealthFeed(degradedHealth)?.mappingFailuresPerSecond).toBe(1);
       expect(grpcHealthFeed(degradedHealth)?.publishFailuresPerSecond).toBe(0);
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(0);
       expect(grpcHealthFeed(degradedHealth)?.lastError).toContain(
         "gRPC feed mapping produced an invalid row for ordersFeed",
       );
@@ -7609,6 +8750,7 @@ describe("@view-server/runtime", () => {
       expect(degradedHealth.status).toBe("degraded");
       expect(grpcHealthFeed(degradedHealth)?.mappingFailuresPerSecond).toBe(0);
       expect(grpcHealthFeed(degradedHealth)?.publishFailuresPerSecond).toBe(1);
+      expect(grpcHealthFeed(degradedHealth)?.reconnects).toBe(0);
       expect(grpcHealthFeed(degradedHealth)?.lastError).toBe(
         "gRPC feed ordersFeed failed: gRPC feed publish failed for ordersFeed: publish unavailable",
       );

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,10 +10,16 @@ import {
   type ViewServerRuntime,
   type ViewServerRuntimeOptionsInput,
   type ViewServerRuntimeOptions,
+  type ViewServerGrpcRuntimeOptions,
   type ViewServerRuntimeTopicDefinitions,
 } from "./internal";
 
-export type { ViewServerRuntime, ViewServerRuntimeOptions, ViewServerRuntimeOptionsInput };
+export type {
+  ViewServerRuntime,
+  ViewServerRuntimeOptions,
+  ViewServerRuntimeOptionsInput,
+  ViewServerGrpcRuntimeOptions,
+};
 export type { ViewServerKafkaIngressError };
 export type { ViewServerGrpcIngressError };
 

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -26,6 +26,7 @@ import type {
   ViewServerRuntime,
   ViewServerRuntimeOptionsInput,
   ViewServerRuntimeOptions,
+  ViewServerGrpcRuntimeOptions,
   ViewServerRuntimeTopicDefinitions,
 } from "./runtime-types";
 import { makeViewServerRuntimeTransportHealth } from "./transport-health";
@@ -36,6 +37,7 @@ export type {
   ViewServerRuntimeDependencies,
   ViewServerRuntimeOptionsInput,
   ViewServerRuntimeOptions,
+  ViewServerGrpcRuntimeOptions,
   ViewServerRuntimeTopicDefinitions,
 };
 

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -8,7 +8,8 @@ import type {
   ViewServerConfig,
   ViewServerKafkaStartFrom,
 } from "@view-server/config";
-import { Config, Effect } from "effect";
+import type { Duration } from "effect";
+import { Config, Duration as EffectDuration, Effect, Option } from "effect";
 import type {
   ViewServerKafkaRuntimeOptions,
   ViewServerGrpcRuntimeOptions,
@@ -46,6 +47,10 @@ export type ResolvedViewServerGrpcRuntimeOptions<
   readonly clients: Clients;
   readonly clientBaseUrls: Record<string, string>;
   readonly feeds: ViewServerGrpcRuntimeOptions<Topics, Clients>["feeds"];
+  readonly materializedReconnect: {
+    readonly maxReconnects: number;
+    readonly delay: Duration.Input;
+  };
 };
 
 const resolveRuntimeValue = <A>(value: RuntimeValue<A>): Effect.Effect<A, Config.ConfigError> =>
@@ -54,6 +59,45 @@ const resolveRuntimeValue = <A>(value: RuntimeValue<A>): Effect.Effect<A, Config
 const defaultKafkaStartFrom = (consumerGroupId: string): ViewServerKafkaStartFrom => ({
   committedConsumerGroup: consumerGroupId,
 });
+
+const defaultGrpcMaterializedReconnect = {
+  delay: "1 second",
+  maxReconnects: 60,
+} satisfies ResolvedViewServerGrpcRuntimeOptions<ViewServerRuntimeTopicDefinitions>["materializedReconnect"];
+
+const validateGrpcMaterializedMaxReconnects = (
+  maxReconnects: number,
+): Effect.Effect<number, ViewServerGrpcIngressError> => {
+  if (Number.isSafeInteger(maxReconnects) && maxReconnects >= 0) {
+    return Effect.succeed(maxReconnects);
+  }
+  return Effect.fail(
+    new ViewServerGrpcIngressError({
+      message: "gRPC materialized reconnect maxReconnects must be a finite non-negative integer.",
+      cause: maxReconnects,
+      phase: "configuration",
+    }),
+  );
+};
+
+const validateGrpcMaterializedReconnectDelay = (
+  delay: Duration.Input,
+): Effect.Effect<Duration.Input, ViewServerGrpcIngressError> => {
+  const duration = EffectDuration.fromInput(delay);
+  if (Option.isSome(duration) && EffectDuration.isFinite(duration.value)) {
+    const millis = EffectDuration.toMillis(duration.value);
+    if (Number.isFinite(millis) && millis > 0) {
+      return Effect.succeed(delay);
+    }
+  }
+  return Effect.fail(
+    new ViewServerGrpcIngressError({
+      message: "gRPC materialized reconnect delay must be finite and positive.",
+      cause: delay,
+      phase: "configuration",
+    }),
+  );
+};
 
 const normalizeKafkaConsumePolicy = (
   consumerGroupId: string,
@@ -139,6 +183,12 @@ const resolveGrpcOptions: <
   for (const [clientName, client] of entries) {
     clientBaseUrls[clientName] = client.baseUrl;
   }
+  const materializedReconnectDelay = yield* validateGrpcMaterializedReconnectDelay(
+    options.materializedReconnect?.delay ?? defaultGrpcMaterializedReconnect.delay,
+  );
+  const materializedReconnectMaxReconnects = yield* validateGrpcMaterializedMaxReconnects(
+    options.materializedReconnect?.maxReconnects ?? defaultGrpcMaterializedReconnect.maxReconnects,
+  );
   const feedTopics = new Map<string, string>();
   for (const [feedName, feed] of Object.entries(options.feeds)) {
     const previousFeedName = feedTopics.get(feed.topic);
@@ -156,6 +206,10 @@ const resolveGrpcOptions: <
     clients: options.clients,
     clientBaseUrls,
     feeds: options.feeds,
+    materializedReconnect: {
+      delay: materializedReconnectDelay,
+      maxReconnects: materializedReconnectMaxReconnects,
+    },
   };
 });
 

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -20,7 +20,7 @@ import type {
   GrpcFeedDefinition,
   GrpcRuntimeClients,
 } from "@view-server/config";
-import type { Effect, Schema } from "effect";
+import type { Duration, Effect, Schema } from "effect";
 
 export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
   Record<
@@ -49,6 +49,10 @@ export type ViewServerGrpcRuntimeOptions<
 > = {
   readonly clients: Clients;
   readonly feeds: Record<string, GrpcFeedDefinition<Topics, Clients>>;
+  readonly materializedReconnect?: {
+    readonly maxReconnects?: number;
+    readonly delay?: Duration.Input;
+  };
 };
 
 export type ViewServerRuntimeOptions<
@@ -155,6 +159,24 @@ type RuntimeGrpcFeedConstraint<
     }
   : unknown;
 
+type RuntimeGrpcMaterializedReconnectExactKeysConstraint<Options> = Options extends {
+  readonly grpc: {
+    readonly materializedReconnect: infer CandidateReconnect;
+  };
+}
+  ? {
+      readonly grpc: {
+        readonly materializedReconnect: CandidateReconnect &
+          RejectExtraKeys<
+            CandidateReconnect,
+            NonNullable<
+              ViewServerGrpcRuntimeOptions<ViewServerRuntimeTopicDefinitions>["materializedReconnect"]
+            >
+          >;
+      };
+    }
+  : unknown;
+
 type RuntimeGroupedIncrementalAdmissionLimitsExactKeysConstraint<Options> = Options extends {
   readonly groupedIncrementalAdmissionLimits: infer CandidateLimits;
 }
@@ -194,6 +216,7 @@ export type ViewServerRuntimeOptionsInput<
   RuntimeKafkaStartFromExactKeysConstraint<Options> &
   RuntimeGrpcExactKeysConstraint<Options> &
   RuntimeGrpcFeedConstraint<Topics, Options> &
+  RuntimeGrpcMaterializedReconnectExactKeysConstraint<Options> &
   RuntimeGroupedIncrementalAdmissionLimitsExactKeysConstraint<Options>;
 
 type RuntimePublicMutationTopic<Topics extends object> = Extract<

--- a/plans/grpc.md
+++ b/plans/grpc.md
@@ -88,14 +88,22 @@ Behavior:
 
 - starts when the runtime starts
 - is scoped to runtime lifetime
-- marks health degraded if the upstream stream completes or fails
+- retries configurable bounded reconnects when upstream acquire, stream failure, or stream
+  completion is restartable
+- marks health degraded when reconnects are exhausted or when mapper/publish failures occur
+- treats any interruption-containing failure cause as shutdown, not as reconnectable failure
 - retains state even with zero subscribers
 - serves snapshots immediately when a user subscribes
 - behaves similarly to Kafka materialized topics
 
-Automatic reconnect policy is a later runtime policy slice. The first materialized runtime slice
-must be honest: one scoped upstream stream per feed, deterministic cleanup, and explicit degraded
-health on completion/failure.
+Materialized reconnect is intentionally bounded in the runtime Adapter. It protects normal upstream
+disconnects without hiding permanent failures forever. Mapper validation failures and runtime publish
+failures are not reconnectable because retrying the same bad row or broken runtime path would only
+hide the real fault. The default reconnect policy is `maxReconnects: 60` with `delay: "1 second"`,
+and applications can override it with `grpc.materializedReconnect`. The reconnect budget counts
+consecutive unstable exits. It resets after the stream stays open for one reconnect delay, and after
+a stream failure that already published a batch in that run. Normal completion still consumes
+reconnect budget even if a batch was published, so an emit-then-complete loop cannot run forever.
 
 Generated gRPC clients own protobuf decode at the ConnectRPC boundary. For this slice, decode
 failures surface as upstream stream failures and degrade the feed. The `decodeFailuresPerSecond`
@@ -701,8 +709,13 @@ Current materialized runtime/e2e tests:
 - materialized feed startup ignores leased feed definitions because the lease manager owns them
 - materialized feed startup rejects duplicate topic ownership across Kafka and gRPC
 - materialized feed startup rejects multiple gRPC owners for one View Server topic
-- stream completion marks feed/client degraded and releases resources
-- stream failure marks feed/client degraded and releases resources
+- transient stream failure reconnects and resumes publishing
+- interruption-containing failures stop without reconnecting
+- stream defects degrade without reconnecting
+- repeated stream completion/failure exhausts reconnects, marks feed/client degraded, and releases
+  resources
+- reconnect failure streak resets after a published batch on a failing stream
+- reconnect failure streak resets after a stream stays open for one reconnect delay
 - runtime shutdown releases all materialized gRPC streams
 - health reports materialized feed keys, row counts, rates, and failures
 - materialized benchmark exercises the production ingress path into runtime-core and the engine
@@ -852,7 +865,8 @@ Implement in slices that keep `pnpm run ready`, strict Effect LSP, package seam 
 3. Materialized feed runtime
    - Acquire materialized streams at runtime startup.
    - Publish mapped rows through runtime-core.
-   - Mark health degraded on stream completion/failure.
+   - Use configurable bounded reconnects for restartable upstream completion/failure.
+   - Mark health degraded when reconnects are exhausted or when mapper/publish failures occur.
    - Release streams on runtime shutdown.
    - Add e2e tests and a Vitest benchmark.
 


### PR DESCRIPTION
## Summary
- add configurable materialized gRPC reconnect policy with defaults and type coverage
- reconnect only on restartable stream failures or unexpected completion, with one consecutive unstable-exit budget
- preserve terminal behavior for mapper/publish/request/config/client/release failures, defects, interruption, and explicit close
- report materialized feed reconnect attempts in gRPC health and benchmark metadata
- document materialized reconnect semantics in the gRPC plan

## Validation
- pnpm --filter @view-server/runtime run test -- src/index.test.ts
- vp run @view-server/runtime#test
- vp check --fix
- pnpm exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict
- vp run @view-server/runtime#build
- pnpm run ready
- forbidden-pattern scans for casts, Testing Library, act, flushSync, toEqual, coverage ignores, console.log, node:assert, and direct Vitest imports

## Review
- 3 local review agents completed after fixes and reported no blockers
