### PR TITLE
Add retained gRPC leased benchmark profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bench:baseline:grouped-order-neutral": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral",
     "bench:baseline:grouped-order-neutral:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
     "bench:baseline:grpc-leased": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased",
+    "bench:baseline:grpc-leased-retained": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased-retained --no-compare",
     "bench:baseline:grpc-leased:update": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased --update-baseline",
     "bench:baseline:grpc-materialized": "node scripts/run-benchmark-baseline.mjs --profile=grpc-materialized",
     "bench:baseline:grpc-materialized:update": "node scripts/run-benchmark-baseline.mjs --profile=grpc-materialized --update-baseline",

--- a/plans/grpc.md
+++ b/plans/grpc.md
@@ -778,6 +778,7 @@ Current leased-feed benchmark command:
 ```sh
 pnpm --filter @view-server/runtime run bench:grpc-leased
 pnpm run bench:baseline:grpc-leased
+pnpm run bench:baseline:grpc-leased-retained
 ```
 
 This benchmark uses the production lease manager with Queue-backed in-process streams:
@@ -794,9 +795,10 @@ Current leased benchmark profiles:
 - leased partitioned write convergence over `routeCount` active routed feeds
 - leased health refresh overhead while `routeCount` routed feeds remain active
 - retained local-filter snapshot report metadata over the configured retained rows. The direct
-  `bench:grpc-leased` script defaults this retained case to 50k rows; the committed
-  `grpc:gate` smoke baseline intentionally overrides it to 500 rows until repeated
-  local runs are stable enough for a heavier gate.
+  `bench:grpc-leased` script defaults this retained case to 50k rows. The committed
+  `grpc:gate` smoke baseline intentionally overrides it to 500 rows, while
+  `bench:baseline:grpc-leased-retained` runs the 50k retained-row profile in report-only mode
+  until repeated local runs are stable enough for a heavier gate.
 - leased delta fanout report metadata for multiple subscribers over one feed
 - leased last-subscriber cleanup report metadata as an explicit case
 - many routes with one subscriber each, including health overlay timing metadata
@@ -804,8 +806,8 @@ Current leased benchmark profiles:
 
 Future leased benchmark profiles:
 
-- repeated-run stability for the direct 50k retained local-filter snapshot before
-  promoting that heavier case into the smoke gate
+- promote the 50k retained local-filter snapshot report profile into a strict compare gate once
+  repeated runs prove it is stable enough for CI
 - repeated-run stability before tightening inner-operation max-latency gates
 
 The smoke gRPC benchmark baselines are part of `pnpm run grpc:gate`, not the

--- a/scripts/benchmark-baseline-runner.mjs
+++ b/scripts/benchmark-baseline-runner.mjs
@@ -605,6 +605,17 @@ export const profiles = new Map([
     ],
   ],
   [
+    "grpc-leased-retained",
+    [
+      runtimeGrpcLeasedTask(50, 25, 50_000, {
+        VIEW_SERVER_RUNTIME_BENCH_ITERATIONS: "3",
+        VIEW_SERVER_RUNTIME_BENCH_TIME_MS: "0",
+        VIEW_SERVER_RUNTIME_BENCH_WARMUP_ITERATIONS: "0",
+        VIEW_SERVER_RUNTIME_BENCH_WARMUP_TIME_MS: "0",
+      }),
+    ],
+  ],
+  [
     "websocket-firehose",
     [
       runtimeWebSocketFirehoseTask("same-window", 1_000, 10, {

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -200,6 +200,7 @@ describe("benchmark baseline runner", () => {
       groupedOrderNeutralUpdate: scripts["bench:baseline:grouped-order-neutral:update"],
       grpcGate: scripts["grpc:gate"],
       grpcLeased: scripts["bench:baseline:grpc-leased"],
+      grpcLeasedRetained: scripts["bench:baseline:grpc-leased-retained"],
       grpcLeasedUpdate: scripts["bench:baseline:grpc-leased:update"],
       grpcMaterialized: scripts["bench:baseline:grpc-materialized"],
       grpcMaterializedUpdate: scripts["bench:baseline:grpc-materialized:update"],
@@ -227,6 +228,8 @@ describe("benchmark baseline runner", () => {
       grpcGate:
         "pnpm run ready && pnpm run bench:baseline:grpc-materialized && pnpm run bench:baseline:grpc-leased",
       grpcLeased: "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased",
+      grpcLeasedRetained:
+        "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased-retained --no-compare",
       grpcLeasedUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased --update-baseline",
       grpcMaterialized: "node scripts/run-benchmark-baseline.mjs --profile=grpc-materialized",
@@ -263,6 +266,7 @@ describe("benchmark baseline runner", () => {
         !name.endsWith(":update") &&
         name !== "bench:baseline:grpc-materialized" &&
         name !== "bench:baseline:grpc-leased" &&
+        name !== "bench:baseline:grpc-leased-retained" &&
         command === command.replace(" --no-compare", ""),
       )
       .map(([name]) => name)
@@ -283,6 +287,7 @@ describe("benchmark baseline runner", () => {
     expect(preGrpcBenchmarkGates).not.toContain("bench:baseline:release");
     expect(preGrpcBenchmarkGates).not.toContain("bench:baseline:grpc-materialized");
     expect(preGrpcBenchmarkGates).not.toContain("bench:baseline:grpc-leased");
+    expect(preGrpcBenchmarkGates).not.toContain("bench:baseline:grpc-leased-retained");
   });
 
   it("keeps the gRPC gate scoped to gRPC runtime baselines", () => {
@@ -293,6 +298,9 @@ describe("benchmark baseline runner", () => {
       "pnpm run bench:baseline:grpc-materialized",
       "pnpm run bench:baseline:grpc-leased",
     ]);
+    expect(scripts["grpc:gate"].split(" && ")).not.toContain(
+      "pnpm run bench:baseline:grpc-leased-retained",
+    );
   });
 
   it("defines raw read and write performance gate tasks", () => {
@@ -543,9 +551,21 @@ describe("benchmark baseline runner", () => {
   it("defines the gRPC runtime benchmark tasks", () => {
     const materializedTasks = profiles.get("grpc-materialized") ?? [];
     const leasedTasks = profiles.get("grpc-leased") ?? [];
+    const retainedTasks = profiles.get("grpc-leased-retained") ?? [];
 
     expect({
       leased: leasedTasks.map((task) => ({
+        artifactKind: task.expectedArtifactKind,
+        benchmarkScope: task.expectedBenchmarkScope,
+        iterations: task.env["VIEW_SERVER_RUNTIME_BENCH_ITERATIONS"],
+        outputJsonPath: task.packageOutputJsonPath,
+        retainedRows: task.env["VIEW_SERVER_RUNTIME_BENCH_GRPC_LEASED_RETAINED_ROWS"],
+        routeCount: task.env["VIEW_SERVER_RUNTIME_BENCH_GRPC_LEASED_ROUTE_COUNT"],
+        rowCount: task.env["VIEW_SERVER_RUNTIME_BENCH_GRPC_LEASED_ROWS_PER_FEED"],
+          task: task.args,
+          timeMs: task.env["VIEW_SERVER_RUNTIME_BENCH_TIME_MS"],
+        })),
+      retained: retainedTasks.map((task) => ({
         artifactKind: task.expectedArtifactKind,
         benchmarkScope: task.expectedBenchmarkScope,
         iterations: task.env["VIEW_SERVER_RUNTIME_BENCH_ITERATIONS"],
@@ -574,6 +594,19 @@ describe("benchmark baseline runner", () => {
           iterations: "3",
           outputJsonPath: ".artifacts/grpc-leased-50rows-25routes-500retained.json",
           retainedRows: "500",
+          routeCount: "25",
+          rowCount: "50",
+          task: ["run", "--no-cache", "runtime#bench:grpc-leased"],
+          timeMs: "0",
+        },
+      ],
+      retained: [
+        {
+          artifactKind: "runtime-benchmark-summary",
+          benchmarkScope: "runtime-grpc-leased",
+          iterations: "3",
+          outputJsonPath: ".artifacts/grpc-leased-50rows-25routes-50000retained.json",
+          retainedRows: "50000",
           routeCount: "25",
           rowCount: "50",
           task: ["run", "--no-cache", "runtime#bench:grpc-leased"],
@@ -1421,7 +1454,7 @@ describe("benchmark baseline runner", () => {
     }).toStrictEqual({
       exitCode: 1,
       message:
-        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, kafka-sustained-firehose, grpc-materialized, grpc-leased, websocket-firehose, active-query-sharing, raw-read-write, grouped-admission, grouped-order-neutral, release",
+        "Unknown benchmark baseline profile: missing\nAvailable profiles: smoke, kafka-ingest, kafka-sustained-firehose, grpc-materialized, grpc-leased, grpc-leased-retained, websocket-firehose, active-query-sharing, raw-read-write, grouped-admission, grouped-order-neutral, release",
     });
   });
 

--- a/scripts/benchmark-baseline.mjs
+++ b/scripts/benchmark-baseline.mjs
@@ -150,7 +150,9 @@ export const benchmarkThresholdsForProfile = (profile) =>
       ? kafkaSustainedFirehoseBenchmarkThresholds
     : profile === "websocket-firehose"
       ? websocketFirehoseBenchmarkThresholds
-    : profile === "grpc-materialized" || profile === "grpc-leased"
+    : profile === "grpc-materialized" ||
+        profile === "grpc-leased" ||
+        profile === "grpc-leased-retained"
       ? grpcRuntimeBenchmarkThresholds
     : defaultBenchmarkThresholds;
 

--- a/scripts/benchmark-baseline.test.ts
+++ b/scripts/benchmark-baseline.test.ts
@@ -322,6 +322,7 @@ describe("benchmark baseline comparison", () => {
     expect({
       groupedOrderNeutral: benchmarkThresholdsForProfile("grouped-order-neutral"),
       grpcLeased: benchmarkThresholdsForProfile("grpc-leased"),
+      grpcLeasedRetained: benchmarkThresholdsForProfile("grpc-leased-retained"),
       grpcMaterialized: benchmarkThresholdsForProfile("grpc-materialized"),
       kafkaIngest: benchmarkThresholdsForProfile("kafka-ingest"),
       kafkaSustainedFirehose: benchmarkThresholdsForProfile("kafka-sustained-firehose"),
@@ -339,11 +340,14 @@ describe("benchmark baseline comparison", () => {
       orderNeutralBaseline: buildBenchmarkBaseline("grouped-order-neutral", [observation])
         .thresholds,
       grpcLeasedBaseline: buildBenchmarkBaseline("grpc-leased", [observation]).thresholds,
+      grpcLeasedRetainedBaseline: buildBenchmarkBaseline("grpc-leased-retained", [observation])
+        .thresholds,
       grpcMaterializedBaseline: buildBenchmarkBaseline("grpc-materialized", [observation])
         .thresholds,
     }).toStrictEqual({
       groupedOrderNeutral: groupedOrderNeutralBenchmarkThresholds,
       grpcLeased: grpcRuntimeBenchmarkThresholds,
+      grpcLeasedRetained: grpcRuntimeBenchmarkThresholds,
       grpcMaterialized: grpcRuntimeBenchmarkThresholds,
       kafkaIngest: kafkaIngestBenchmarkThresholds,
       kafkaSustainedFirehose: kafkaSustainedFirehoseBenchmarkThresholds,
@@ -357,6 +361,7 @@ describe("benchmark baseline comparison", () => {
       websocketFirehoseBaseline: websocketFirehoseBenchmarkThresholds,
       orderNeutralBaseline: groupedOrderNeutralBenchmarkThresholds,
       grpcLeasedBaseline: grpcRuntimeBenchmarkThresholds,
+      grpcLeasedRetainedBaseline: grpcRuntimeBenchmarkThresholds,
       grpcMaterializedBaseline: grpcRuntimeBenchmarkThresholds,
     });
   });


### PR DESCRIPTION
## Summary

- Add a report-only `grpc-leased-retained` baseline profile for the 50k retained-row leased gRPC benchmark.
- Keep the heavy retained profile out of `grpc:gate` and `pre-grpc:gate` while retaining threshold wiring for future promotion.
- Update runner tests and `plans/grpc.md` to document the smoke-vs-heavy retained-row split.

## Validation

- `pnpm run test:repository-scripts`
- `pnpm run bench:baseline:grpc-leased-retained`
- `vp check --fix`
- `pnpm run ready`
- 3 reviewer agents: no findings

## Benchmark Note

The new report profile ran with 50k retained rows. Retained local-filter snapshot p99 was about 3.60s; health refresh overhead p99 stayed about 2.77ms. The script is intentionally report-only until repeated runs prove it is stable enough for CI gating.
