### PR TITLE
Add repeated gRPC leased retained benchmark report

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bench:baseline:grouped-order-neutral:update": "node scripts/run-benchmark-baseline.mjs --profile=grouped-order-neutral --update-baseline",
     "bench:baseline:grpc-leased": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased",
     "bench:baseline:grpc-leased-retained": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased-retained --no-compare",
+    "bench:baseline:grpc-leased-retained:repeat": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased-retained --repeat=3 --no-compare",
     "bench:baseline:grpc-leased:update": "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased --update-baseline",
     "bench:baseline:grpc-materialized": "node scripts/run-benchmark-baseline.mjs --profile=grpc-materialized",
     "bench:baseline:grpc-materialized:update": "node scripts/run-benchmark-baseline.mjs --profile=grpc-materialized --update-baseline",

--- a/packages/react/src/in-memory-live-query.bench.tsx
+++ b/packages/react/src/in-memory-live-query.bench.tsx
@@ -1,6 +1,6 @@
 // Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
-import { commands, server } from "vitest/browser";
+import { commands, server } from "@vitest/browser/context";
 import {
   defineViewServerConfig,
   type ViewServerHealth,

--- a/plans/grpc.md
+++ b/plans/grpc.md
@@ -779,6 +779,7 @@ Current leased-feed benchmark command:
 pnpm --filter @view-server/runtime run bench:grpc-leased
 pnpm run bench:baseline:grpc-leased
 pnpm run bench:baseline:grpc-leased-retained
+pnpm run bench:baseline:grpc-leased-retained:repeat
 ```
 
 This benchmark uses the production lease manager with Queue-backed in-process streams:
@@ -797,8 +798,10 @@ Current leased benchmark profiles:
 - retained local-filter snapshot report metadata over the configured retained rows. The direct
   `bench:grpc-leased` script defaults this retained case to 50k rows. The committed
   `grpc:gate` smoke baseline intentionally overrides it to 500 rows, while
-  `bench:baseline:grpc-leased-retained` runs the 50k retained-row profile in report-only mode
-  until repeated local runs are stable enough for a heavier gate.
+  `bench:baseline:grpc-leased-retained` runs the 50k retained-row profile in report-only mode.
+- repeated retained local-filter stability runs with isolated artifacts through
+  `bench:baseline:grpc-leased-retained:repeat`. This remains report-only until repeated local
+  runs are stable enough for a heavier gate.
 - leased delta fanout report metadata for multiple subscribers over one feed
 - leased last-subscriber cleanup report metadata as an explicit case
 - many routes with one subscriber each, including health overlay timing metadata
@@ -808,7 +811,7 @@ Future leased benchmark profiles:
 
 - promote the 50k retained local-filter snapshot report profile into a strict compare gate once
   repeated runs prove it is stable enough for CI
-- repeated-run stability before tightening inner-operation max-latency gates
+- repeated-run stability before tightening remaining inner-operation max-latency gates
 
 The smoke gRPC benchmark baselines are part of `pnpm run grpc:gate`, not the
 pre-gRPC gate. `pre-grpc:gate` remains the Kafka/performance readiness gate

--- a/scripts/benchmark-baseline-runner.mjs
+++ b/scripts/benchmark-baseline-runner.mjs
@@ -19,6 +19,18 @@ export const summaryPath = (outputJsonPath) =>
     ? `${outputJsonPath.slice(0, -".json".length)}.summary.json`
     : `${outputJsonPath}.summary.json`;
 
+export const repeatArtifactPath = (artifactPath, repeatIndex, repeatCount) => {
+  if (repeatCount === 1) {
+    return artifactPath;
+  }
+  const run = String(repeatIndex + 1).padStart(2, "0");
+  const total = String(repeatCount).padStart(2, "0");
+  const suffix = `.run-${run}-of-${total}`;
+  return artifactPath.endsWith(".json")
+    ? `${artifactPath.slice(0, -".json".length)}${suffix}.json`
+    : `${artifactPath}${suffix}`;
+};
+
 const packageArtifactPath = (packageDirectory, outputJsonPath) =>
   `${packageDirectory}/${outputJsonPath}`;
 
@@ -168,6 +180,56 @@ const task = ({
 });
 
 const minimumSampleCountFrom = (env, key) => Number.parseInt(env[key] ?? "5", 10);
+
+export const repeatCountFrom = (argv) => {
+  if (argv.includes("--repeat")) {
+    return undefined;
+  }
+  const repeatArguments = argv.filter((argument) => argument.startsWith("--repeat="));
+  if (repeatArguments.length > 1) {
+    return undefined;
+  }
+  const repeatArgument = repeatArguments[0];
+  if (repeatArgument === undefined) {
+    return 1;
+  }
+  const repeatValue = repeatArgument.slice("--repeat=".length);
+  if (!/^[1-9]\d*$/.test(repeatValue)) {
+    return undefined;
+  }
+  const repeatCount = Number.parseInt(repeatValue, 10);
+  return Number.isSafeInteger(repeatCount) && repeatCount <= 20 ? repeatCount : undefined;
+};
+
+export const taskForRepeat = (currentTask, repeatIndex, repeatCount) => {
+  if (repeatCount === 1) {
+    return currentTask;
+  }
+  const packageOutputJsonPath = repeatArtifactPath(
+    currentTask.packageOutputJsonPath,
+    repeatIndex,
+    repeatCount,
+  );
+  const env = Object.fromEntries(
+    Object.entries(currentTask.env).map(([key, value]) => [
+      key,
+      value === currentTask.packageOutputJsonPath ? packageOutputJsonPath : value,
+    ]),
+  );
+  const outputJsonPath = repeatArtifactPath(currentTask.outputJsonPath, repeatIndex, repeatCount);
+  return {
+    ...currentTask,
+    env: {
+      ...env,
+      VIEW_SERVER_BENCH_REPEAT_INDEX: String(repeatIndex + 1),
+      VIEW_SERVER_BENCH_REPEAT_TOTAL: String(repeatCount),
+    },
+    label: `${currentTask.label} run ${repeatIndex + 1}/${repeatCount}`,
+    outputJsonPath,
+    packageOutputJsonPath,
+    summaryPath: summaryPath(outputJsonPath),
+  };
+};
 
 const rawSnapshotTask = (rowCount, env = {}) => {
   const outputJsonPath = engineArtifactName(`raw-snapshot-${rowCount}rows.json`);
@@ -770,8 +832,12 @@ export const profiles = new Map([
   ],
 ]);
 
+export const repeatableReportOnlyProfiles = new Set(["grpc-leased-retained"]);
+
 export const isBenchmarkEnvironmentKey = (key) =>
   key === "VIEW_SERVER_BENCH_BASELINE_PROFILE" ||
+  key === "VIEW_SERVER_BENCH_REPEAT_INDEX" ||
+  key === "VIEW_SERVER_BENCH_REPEAT_TOTAL" ||
   key === "VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS" ||
   key.startsWith("VIEW_SERVER_ENGINE_BENCH_") ||
   key.startsWith("VIEW_SERVER_REACT_BENCH_") ||
@@ -817,13 +883,28 @@ export const runBenchmarkBaseline = async ({
   environment,
   logger,
   profileMap = profiles,
+  repeatableProfiles = repeatableReportOnlyProfiles,
   runTask,
 }) => {
   const compareBaseline = !argv.includes("--no-compare");
   const updateBaseline = argv.includes("--update-baseline");
+  const repeatCount = repeatCountFrom(argv);
   const requestedProfile = requestedProfileFrom(argv, environment);
   const tasks = profileMap.get(requestedProfile);
   const parentEnvironment = cleanBenchmarkEnvironment(environment);
+
+  if (repeatCount === undefined) {
+    logger.error("--repeat must be a positive integer.");
+    return 1;
+  }
+  if (repeatCount > 1 && compareBaseline) {
+    logger.error("--repeat requires --no-compare because repeated artifacts are report-only.");
+    return 1;
+  }
+  if (repeatCount > 1 && updateBaseline) {
+    logger.error("--repeat cannot be combined with --update-baseline.");
+    return 1;
+  }
 
   if (tasks === undefined) {
     logger.error(
@@ -834,30 +915,44 @@ export const runBenchmarkBaseline = async ({
     );
     return 1;
   }
-
-  logger.log(`Running ${requestedProfile} benchmark baseline serially (${tasks.length} tasks).`);
-
-  for (const [index, currentTask] of tasks.entries()) {
-    const taskNumber = index + 1;
-    const startedAt = process.hrtime.bigint();
-    logger.log(`\n[${taskNumber}/${tasks.length}] ${currentTask.label}`);
-    removeTaskArtifacts(currentTask);
-    const exitCode = await runTask({
-      ...currentTask,
-      env: {
-        ...parentEnvironment,
-        ...currentTask.env,
-      },
-    });
-    if (exitCode !== 0) {
-      return exitCode;
-    }
-    assertTaskArtifactsWritten(currentTask);
-    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
-    logger.log(`[${taskNumber}/${tasks.length}] completed in ${elapsedMs.toFixed(0)}ms`);
+  if (repeatCount > 1 && !repeatableProfiles.has(requestedProfile)) {
+    logger.error(`--repeat is not enabled for benchmark baseline profile: ${requestedProfile}`);
+    return 1;
   }
 
-  const observations = tasks.map(readBenchmarkObservation);
+  const runCountMessage =
+    repeatCount === 1
+      ? `${tasks.length} tasks`
+      : `${tasks.length} tasks x ${repeatCount} runs`;
+  logger.log(`Running ${requestedProfile} benchmark baseline serially (${runCountMessage}).`);
+
+  const completedTasks = [];
+  const totalTaskRuns = tasks.length * repeatCount;
+  for (let repeatIndex = 0; repeatIndex < repeatCount; repeatIndex += 1) {
+    for (const [index, baseTask] of tasks.entries()) {
+      const taskNumber = repeatIndex * tasks.length + index + 1;
+      const currentTask = taskForRepeat(baseTask, repeatIndex, repeatCount);
+      const startedAt = process.hrtime.bigint();
+      logger.log(`\n[${taskNumber}/${totalTaskRuns}] ${currentTask.label}`);
+      removeTaskArtifacts(currentTask);
+      const exitCode = await runTask({
+        ...currentTask,
+        env: {
+          ...parentEnvironment,
+          ...currentTask.env,
+        },
+      });
+      if (exitCode !== 0) {
+        return exitCode;
+      }
+      assertTaskArtifactsWritten(currentTask);
+      completedTasks.push(currentTask);
+      const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      logger.log(`[${taskNumber}/${totalTaskRuns}] completed in ${elapsedMs.toFixed(0)}ms`);
+    }
+  }
+
+  const observations = completedTasks.map(readBenchmarkObservation);
   const actualBaseline = buildBenchmarkBaseline(requestedProfile, observations);
   const profileBaselinePath = baselinePathForProfile(requestedProfile);
 

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -19,9 +19,12 @@ import {
   cleanBenchmarkEnvironment,
   exitCodeForSignal,
   profiles,
+  repeatArtifactPath,
+  repeatCountFrom,
   removeTaskArtifacts,
   runBenchmarkBaseline,
   summaryPath,
+  taskForRepeat,
 } from "./benchmark-baseline-runner.mjs";
 
 const vitestOutput = {
@@ -127,9 +130,16 @@ const writeArtifacts = (
   nextSummary = summary,
   nextVitestOutput = vitestOutput,
 ) => {
+  const summaryForTask = {
+    ...nextSummary,
+    latency: {
+      ...nextSummary.latency,
+      outputJsonPath: task.packageOutputJsonPath,
+    },
+  };
   mkdirSync(join(task.outputJsonPath, ".."), { recursive: true });
   writeFileSync(task.outputJsonPath, `${JSON.stringify(nextVitestOutput)}\n`);
-  writeFileSync(task.summaryPath, `${JSON.stringify(nextSummary)}\n`);
+  writeFileSync(task.summaryPath, `${JSON.stringify(summaryForTask)}\n`);
 };
 
 const silentLogger = () => {
@@ -166,6 +176,8 @@ describe("benchmark baseline runner", () => {
       cleanedEnvironment: cleanBenchmarkEnvironment({
         KEEP_ME: "yes",
         VIEW_SERVER_BENCH_BASELINE_PROFILE: "smoke",
+        VIEW_SERVER_BENCH_REPEAT_INDEX: "2",
+        VIEW_SERVER_BENCH_REPEAT_TOTAL: "3",
         VIEW_SERVER_ENGINE_BENCH_ROWS: "100",
         VIEW_SERVER_KAFKA_BOOTSTRAP_SERVERS: "localhost:19092",
         VIEW_SERVER_REACT_BENCH_ROWS: "100",
@@ -188,6 +200,72 @@ describe("benchmark baseline runner", () => {
     });
   });
 
+  it("computes repeat artifact paths and repeat task environments", () => {
+    const directory = makeDirectory();
+    const currentTask = makeTask(directory);
+    const repeatedTask = taskForRepeat(currentTask, 1, 3);
+    const repeatedTaskWithExtraEnv = taskForRepeat(
+      {
+        ...currentTask,
+        env: {
+          ...currentTask.env,
+          KEEP_ME: "yes",
+        },
+      },
+      0,
+      2,
+    );
+
+    expect({
+      invalidRepeat: repeatCountFrom(["node", "script", "--repeat=0"]),
+      invalidRepeatBare: repeatCountFrom(["node", "script", "--repeat", "3"]),
+      invalidRepeatDecimal: repeatCountFrom(["node", "script", "--repeat=1.5"]),
+      invalidRepeatDuplicate: repeatCountFrom(["node", "script", "--repeat=3", "--repeat=4"]),
+      invalidRepeatJunk: repeatCountFrom(["node", "script", "--repeat=3abc"]),
+      invalidRepeatTooLarge: repeatCountFrom(["node", "script", "--repeat=21"]),
+      invalidRepeatUnsafe: repeatCountFrom(["node", "script", "--repeat=9007199254740992"]),
+      missingRepeat: repeatCountFrom(["node", "script"]),
+      repeatedEnv: repeatedTask.env,
+      repeatedExtraEnv: repeatedTaskWithExtraEnv.env,
+      repeatedLabel: repeatedTask.label,
+      repeatedOutputJsonPath: repeatedTask.outputJsonPath,
+      repeatedPackageOutputJsonPath: repeatedTask.packageOutputJsonPath,
+      repeatedSummaryPath: repeatedTask.summaryPath,
+      repeatPathNoExtension: repeatArtifactPath(".artifacts/result", 1, 2),
+      repeatPath: repeatArtifactPath(".artifacts/result.json", 2, 12),
+      singlePath: repeatArtifactPath(".artifacts/result.json", 0, 1),
+      validRepeat: repeatCountFrom(["node", "script", "--repeat=3"]),
+    }).toStrictEqual({
+      invalidRepeat: undefined,
+      invalidRepeatBare: undefined,
+      invalidRepeatDecimal: undefined,
+      invalidRepeatDuplicate: undefined,
+      invalidRepeatJunk: undefined,
+      invalidRepeatTooLarge: undefined,
+      invalidRepeatUnsafe: undefined,
+      missingRepeat: 1,
+      repeatedEnv: {
+        VIEW_SERVER_BENCH_REPEAT_INDEX: "2",
+        VIEW_SERVER_BENCH_REPEAT_TOTAL: "3",
+        VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON: "actual.run-02-of-03.json",
+      },
+      repeatedExtraEnv: {
+        KEEP_ME: "yes",
+        VIEW_SERVER_BENCH_REPEAT_INDEX: "1",
+        VIEW_SERVER_BENCH_REPEAT_TOTAL: "2",
+        VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON: "actual.run-01-of-02.json",
+      },
+      repeatedLabel: "task a run 2/3",
+      repeatedOutputJsonPath: join(directory, "actual.run-02-of-03.json"),
+      repeatedPackageOutputJsonPath: "actual.run-02-of-03.json",
+      repeatedSummaryPath: join(directory, "actual.run-02-of-03.summary.json"),
+      repeatPathNoExtension: ".artifacts/result.run-02-of-02",
+      repeatPath: ".artifacts/result.run-03-of-12.json",
+      singlePath: ".artifacts/result.json",
+      validRepeat: 3,
+    });
+  });
+
   it("keeps targeted grouped baseline scripts in compare mode by default", () => {
     const scripts = JSON.parse(readFileSync("package.json", "utf8")).scripts;
 
@@ -201,6 +279,7 @@ describe("benchmark baseline runner", () => {
       grpcGate: scripts["grpc:gate"],
       grpcLeased: scripts["bench:baseline:grpc-leased"],
       grpcLeasedRetained: scripts["bench:baseline:grpc-leased-retained"],
+      grpcLeasedRetainedRepeat: scripts["bench:baseline:grpc-leased-retained:repeat"],
       grpcLeasedUpdate: scripts["bench:baseline:grpc-leased:update"],
       grpcMaterialized: scripts["bench:baseline:grpc-materialized"],
       grpcMaterializedUpdate: scripts["bench:baseline:grpc-materialized:update"],
@@ -230,6 +309,8 @@ describe("benchmark baseline runner", () => {
       grpcLeased: "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased",
       grpcLeasedRetained:
         "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased-retained --no-compare",
+      grpcLeasedRetainedRepeat:
+        "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased-retained --repeat=3 --no-compare",
       grpcLeasedUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=grpc-leased --update-baseline",
       grpcMaterialized: "node scripts/run-benchmark-baseline.mjs --profile=grpc-materialized",
@@ -1040,6 +1121,7 @@ describe("benchmark baseline runner", () => {
       environment: {},
       logger,
       profileMap,
+      repeatableProfiles: new Set(["tiny"]),
       runTask: async (currentTask: typeof task) => {
         writeArtifacts(currentTask);
         return 0;
@@ -1047,6 +1129,146 @@ describe("benchmark baseline runner", () => {
     });
 
     expect(exitCode).toBe(0);
+  });
+
+  it("runs repeated report-only profiles with isolated artifacts", async () => {
+    const directory = makeDirectory();
+    const task = makeTask(directory);
+    const profileMap = new Map([["tiny", [task]]]);
+    const capturedTasks: Array<{
+      env: Record<string, string>;
+      label: string;
+      outputJsonPath: string;
+      summaryPath: string;
+    }> = [];
+    const { logger, messages } = silentLogger();
+
+    const exitCode = await runBenchmarkBaseline({
+      argv: ["node", "script", "--profile=tiny", "--repeat=2", "--no-compare"],
+      baselinePathForProfile: () => join(directory, "missing-baseline.json"),
+      environment: {},
+      logger,
+      profileMap,
+      repeatableProfiles: new Set(["tiny"]),
+      runTask: async (currentTask: typeof task) => {
+        capturedTasks.push({
+          env: currentTask.env,
+          label: currentTask.label,
+          outputJsonPath: currentTask.outputJsonPath,
+          summaryPath: currentTask.summaryPath,
+        });
+        writeArtifacts(currentTask);
+        return 0;
+      },
+    });
+
+    expect({
+      capturedTasks,
+      exitCode,
+      startMessage: messages[0],
+    }).toStrictEqual({
+      capturedTasks: [
+        {
+          env: {
+            VIEW_SERVER_BENCH_REPEAT_INDEX: "1",
+            VIEW_SERVER_BENCH_REPEAT_TOTAL: "2",
+            VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON: "actual.run-01-of-02.json",
+          },
+          label: "task a run 1/2",
+          outputJsonPath: join(directory, "actual.run-01-of-02.json"),
+          summaryPath: join(directory, "actual.run-01-of-02.summary.json"),
+        },
+        {
+          env: {
+            VIEW_SERVER_BENCH_REPEAT_INDEX: "2",
+            VIEW_SERVER_BENCH_REPEAT_TOTAL: "2",
+            VIEW_SERVER_ENGINE_BENCH_OUTPUT_JSON: "actual.run-02-of-02.json",
+          },
+          label: "task a run 2/2",
+          outputJsonPath: join(directory, "actual.run-02-of-02.json"),
+          summaryPath: join(directory, "actual.run-02-of-02.summary.json"),
+        },
+      ],
+      exitCode: 0,
+      startMessage: "Running tiny benchmark baseline serially (1 tasks x 2 runs).",
+    });
+  });
+
+  it("rejects repeated baseline runs outside report-only mode", async () => {
+    const directory = makeDirectory();
+    const task = makeTask(directory);
+    const profileMap = new Map([["tiny", [task]]]);
+    const compareLogger = silentLogger();
+    const updateLogger = silentLogger();
+    const invalidLogger = silentLogger();
+    const unsupportedLogger = silentLogger();
+    const unknownProfileLogger = silentLogger();
+
+    const compareExitCode = await runBenchmarkBaseline({
+      argv: ["node", "script", "--profile=tiny", "--repeat=2"],
+      baselinePathForProfile: () => join(directory, "baseline.json"),
+      environment: {},
+      logger: compareLogger.logger,
+      profileMap,
+      runTask: async () => 0,
+    });
+    const updateExitCode = await runBenchmarkBaseline({
+      argv: ["node", "script", "--profile=tiny", "--repeat=2", "--update-baseline", "--no-compare"],
+      baselinePathForProfile: () => join(directory, "baseline.json"),
+      environment: {},
+      logger: updateLogger.logger,
+      profileMap,
+      repeatableProfiles: new Set(["tiny"]),
+      runTask: async () => 0,
+    });
+    const invalidExitCode = await runBenchmarkBaseline({
+      argv: ["node", "script", "--profile=tiny", "--repeat=nope", "--no-compare"],
+      baselinePathForProfile: () => join(directory, "baseline.json"),
+      environment: {},
+      logger: invalidLogger.logger,
+      profileMap,
+      runTask: async () => 0,
+    });
+    const unsupportedExitCode = await runBenchmarkBaseline({
+      argv: ["node", "script", "--profile=tiny", "--repeat=2", "--no-compare"],
+      baselinePathForProfile: () => join(directory, "baseline.json"),
+      environment: {},
+      logger: unsupportedLogger.logger,
+      profileMap,
+      runTask: async () => 0,
+    });
+    const unknownProfileExitCode = await runBenchmarkBaseline({
+      argv: ["node", "script", "--profile=missing", "--repeat=2", "--no-compare"],
+      baselinePathForProfile: () => join(directory, "baseline.json"),
+      environment: {},
+      logger: unknownProfileLogger.logger,
+      profileMap,
+      runTask: async () => 0,
+    });
+
+    expect({
+      compareError: compareLogger.messages[0],
+      compareExitCode,
+      invalidError: invalidLogger.messages[0],
+      invalidExitCode,
+      unknownProfileError: unknownProfileLogger.messages[0],
+      unknownProfileExitCode,
+      unsupportedError: unsupportedLogger.messages[0],
+      unsupportedExitCode,
+      updateError: updateLogger.messages[0],
+      updateExitCode,
+    }).toStrictEqual({
+      compareError: "--repeat requires --no-compare because repeated artifacts are report-only.",
+      compareExitCode: 1,
+      invalidError: "--repeat must be a positive integer.",
+      invalidExitCode: 1,
+      unknownProfileError: "Unknown benchmark baseline profile: missing\nAvailable profiles: tiny",
+      unknownProfileExitCode: 1,
+      unsupportedError: "--repeat is not enabled for benchmark baseline profile: tiny",
+      unsupportedExitCode: 1,
+      updateError: "--repeat cannot be combined with --update-baseline.",
+      updateExitCode: 1,
+    });
   });
 
   it("uses the profile from the benchmark environment when no profile argument is provided", async () => {


### PR DESCRIPTION
## Summary
- add report-only --repeat support to the benchmark baseline runner with isolated artifact paths and repeat env metadata
- add the gRPC leased retained 3-run script and document it in the gRPC plan
- fix the React in-memory bench Vitest browser context import

## Validation
- 3 reviewer agents: no findings after repeat-count guard
- pnpm run test:repository-scripts
- vp check --fix
- pnpm run bench:baseline:grpc-leased-retained:repeat
- pnpm run ready
- forbidden-pattern scan clean for toEqual, coverage ignores, Testing Library, flushSync, act
- cast scan only found import alias/prose, no TypeScript casts

## Notes
- --repeat is intentionally report-only and capped at 20 runs
- repeated retained artifacts are ignored under packages/runtime/.artifacts/