### PR TITLE
Add runtime metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Remote React provider
 
-Server code starts a runtime through Effect RPC WebSocket and same-server
-`GET /health`:
+Server code starts a runtime through Effect RPC WebSocket plus same-server
+`GET /health` and `GET /metrics` endpoints:
 
 Node entrypoints should use `@effect/platform-node`'s `NodeRuntime.runMain` so
 `SIGINT` and `SIGTERM` interrupt the main fiber and run Effect finalizers.
@@ -24,6 +24,13 @@ NodeRuntime.runMain(
 The same-server `GET /health` endpoint serves the cached runtime health snapshot
 for deployment readiness checks. Internal `bigint` health fields, such as Kafka
 lag, are encoded as decimal strings in the JSON response.
+
+The same-server `GET /metrics` endpoint serves Prometheus text exposition derived
+from the same cached health snapshot. It exposes scrape-safe runtime, transport,
+engine, Kafka, and gRPC gauges/counters. It is not a full mirror of health:
+high-cardinality values such as raw error messages and route-specific leased
+feed keys remain in `GET /health`. Scrape failures that cannot decode health return `200` with
+`view_server_metrics_error 1` so the scrape itself remains observable.
 
 Browser React code keeps using the normal provider and hooks:
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -3,9 +3,9 @@
 Production runtime composition for View Server.
 
 This package wires Runtime Core, Effect RPC WebSocket transport, `GET /health`,
-and optional Kafka ingestion. The in-memory engine remains the single mutation
-path; Kafka and future ingress adapters publish into the same runtime core used
-by tests.
+`GET /metrics`, and optional Kafka ingestion. The in-memory engine remains the
+single mutation path; Kafka and future ingress adapters publish into the same
+runtime core used by tests.
 
 ## Entrypoint
 
@@ -25,8 +25,8 @@ NodeRuntime.runMain(
 );
 ```
 
-`runViewServerRuntime` logs the WebSocket and health URLs when the runtime starts
-and keeps the server alive until the main fiber is interrupted.
+`runViewServerRuntime` logs the WebSocket, health, and metrics URLs when the
+runtime starts and keeps the server alive until the main fiber is interrupted.
 
 ## Health
 
@@ -39,6 +39,32 @@ fields, such as Kafka lag, are encoded as decimal strings.
 
 React applications should use the pushed health hooks from `@view-server/react`;
 `GET /health` is for infrastructure and smoke checks, not UI polling.
+
+## Metrics
+
+The runtime exposes a same-server `GET /metrics` endpoint for Prometheus-style
+scrapes. The response uses `text/plain; version=0.0.4; charset=utf-8` and is
+derived from the same cached runtime health snapshot as `GET /health`.
+
+Metrics include runtime status/version/uptime, transport pressure, engine topic
+rows/versions/queues/backpressure, Kafka region lag and failure rates, and gRPC
+client/feed counters. It intentionally keeps labels low-cardinality: raw error
+messages, timestamps, committed offsets, and route-specific leased feed keys
+remain available from `GET /health` instead of Prometheus labels. If health
+cannot be read or decoded, the endpoint returns `200` with
+`view_server_metrics_error 1` so the scrape result is still visible to the
+metrics system.
+
+`metricsPath` can override the default `/metrics` path:
+
+```ts
+NodeRuntime.runMain(
+  runViewServerRuntime(viewServer, {
+    websocketPort: 8080,
+    metricsPath: "/view-server/metrics",
+  }),
+);
+```
 
 ## Kafka Ingestion
 

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -96,6 +96,9 @@ describe("runtime type contracts", () => {
     expectTypeOf(runtime.healthUrl).toEqualTypeOf<
       ViewServerRuntime<typeof viewServer.topics>["healthUrl"]
     >();
+    expectTypeOf(runtime.metricsUrl).toEqualTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>["metricsUrl"]
+    >();
     expectTypeOf(runtime.health).toEqualTypeOf<
       ViewServerRuntime<typeof viewServer.topics>["health"]
     >();
@@ -229,6 +232,10 @@ describe("runtime type contracts", () => {
     const invalidHealthPathOptions = makeViewServerRuntime(viewServer, {
       healthPath: "runtime-health",
     });
+    // @ts-expect-error runtime metrics paths must be absolute HTTP paths.
+    const invalidMetricsPathOptions = makeViewServerRuntime(viewServer, {
+      metricsPath: "runtime-metrics",
+    });
     // @ts-expect-error runtime RPC path must be a concrete slash-prefixed client URL path.
     const invalidWildcardRpcPathOptions = makeViewServerRuntime(viewServer, {
       rpcPath: "*",
@@ -236,6 +243,10 @@ describe("runtime type contracts", () => {
     // @ts-expect-error runtime health path must be a concrete slash-prefixed client URL path.
     const invalidWildcardHealthPathOptions = makeViewServerRuntime(viewServer, {
       healthPath: "*",
+    });
+    // @ts-expect-error runtime metrics path must be a concrete slash-prefixed client URL path.
+    const invalidWildcardMetricsPathOptions = makeViewServerRuntime(viewServer, {
+      metricsPath: "*",
     });
     const invalidGroupedAdmissionLimitKey = makeViewServerRuntime(viewServer, {
       groupedIncrementalAdmissionLimits: {
@@ -488,8 +499,10 @@ describe("runtime type contracts", () => {
     expectTypeOf(invalidTcpPublishPortOptions).not.toBeAny();
     expectTypeOf(invalidPathOptions).not.toBeAny();
     expectTypeOf(invalidHealthPathOptions).not.toBeAny();
+    expectTypeOf(invalidMetricsPathOptions).not.toBeAny();
     expectTypeOf(invalidWildcardRpcPathOptions).not.toBeAny();
     expectTypeOf(invalidWildcardHealthPathOptions).not.toBeAny();
+    expectTypeOf(invalidWildcardMetricsPathOptions).not.toBeAny();
     expectTypeOf(invalidGroupedAdmissionLimitKey).not.toBeAny();
     expectTypeOf(invalidGroupedAdmissionLimitValue).not.toBeAny();
     expectTypeOf<Effect.Success<typeof runtimeWithKafka>>().toMatchTypeOf<

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -581,6 +581,12 @@ const fetchHealth = Effect.fn("ViewServerRuntime.test.health.fetch")(function* (
   return { response, health };
 });
 
+const fetchText = Effect.fn("ViewServerRuntime.test.text.fetch")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  return { response, text };
+});
+
 const waitForTransportHealth = Effect.fn("ViewServerRuntime.test.transportHealth.wait")(function* (
   health: () => Effect.Effect<{ readonly transport: TransportHealth }, unknown>,
   expected: {
@@ -756,6 +762,7 @@ describe("@view-server/runtime", () => {
         host: "127.0.0.1",
         rpcPath: "/runtime-rpc",
         healthPath: "/runtime-health",
+        metricsPath: "/runtime-metrics",
       });
       const remoteClient = yield* makeViewServerClient(viewServer, { url: runtime.url });
       const subscription = yield* remoteClient.subscribe("orders", {
@@ -810,10 +817,16 @@ describe("@view-server/runtime", () => {
       });
 
       const health = yield* fetchHealth(runtime.healthUrl);
+      const metrics = yield* fetchText(runtime.metricsUrl);
       expect(runtime.url.endsWith("/runtime-rpc")).toBe(true);
       expect(runtime.healthUrl.endsWith("/runtime-health")).toBe(true);
+      expect(runtime.metricsUrl.endsWith("/runtime-metrics")).toBe(true);
       expect(health.response.status).toBe(200);
       expect(health.health.engine.topics.orders.rowCount).toBe(1);
+      expect(metrics.response.status).toBe(200);
+      expect(metrics.text).toContain(
+        'view_server_engine_topic_rows{topic="orders",state="total"} 1',
+      );
 
       yield* subscription.close().pipe(Effect.timeout("1 second"));
       yield* remoteClient.close;
@@ -843,6 +856,7 @@ describe("@view-server/runtime", () => {
       const defaultRuntime = yield* makeViewServerRuntime(viewServer);
       expect(defaultRuntime.url.endsWith("/rpc")).toBe(true);
       expect(defaultRuntime.healthUrl.endsWith("/health")).toBe(true);
+      expect(defaultRuntime.metricsUrl.endsWith("/metrics")).toBe(true);
       expect("subscribeRuntime" in defaultRuntime.liveClient).toBe(false);
       yield* defaultRuntime.close;
 
@@ -852,6 +866,7 @@ describe("@view-server/runtime", () => {
       });
       expect(configuredRuntime.url.endsWith("/rpc")).toBe(true);
       expect(configuredRuntime.healthUrl.endsWith("/health")).toBe(true);
+      expect(configuredRuntime.metricsUrl.endsWith("/metrics")).toBe(true);
       yield* configuredRuntime.close;
     }),
   );
@@ -940,6 +955,7 @@ describe("@view-server/runtime", () => {
           return Effect.succeed({
             url: "ws://127.0.0.1:0/custom-rpc",
             healthUrl: "http://127.0.0.1:0/custom-health",
+            metricsUrl: "http://127.0.0.1:0/custom-metrics",
             close: Effect.void,
           });
         },
@@ -953,6 +969,7 @@ describe("@view-server/runtime", () => {
         websocketPort: 1234,
         rpcPath: "/custom-rpc",
         healthPath: "/custom-health",
+        metricsPath: "/custom-metrics",
         subscriptionQueueCapacity: 7,
       });
 
@@ -988,6 +1005,7 @@ describe("@view-server/runtime", () => {
           port: 1234,
           path: "/custom-rpc",
           healthPath: "/custom-health",
+          metricsPath: "/custom-metrics",
         },
       });
       yield* runtime.close;
@@ -1025,6 +1043,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
         makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
@@ -1126,6 +1145,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
         makeGrpcHealthLedger: (config, options) => {
@@ -1520,6 +1540,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
       };
@@ -1569,6 +1590,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
       };
@@ -1737,6 +1759,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
       };
@@ -2195,6 +2218,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.sync(() => {
               serverClosed += 1;
             }),
@@ -2282,6 +2306,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.sync(() => {
               serverClosed += 1;
             }),
@@ -8880,6 +8905,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
         makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
@@ -8986,6 +9012,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.sync(() => {
               serverCloseCount += 1;
             }),
@@ -9013,6 +9040,7 @@ describe("@view-server/runtime", () => {
             Effect.as({
               url: "ws://127.0.0.1:0/rpc",
               healthUrl: "http://127.0.0.1:0/health",
+              metricsUrl: "http://127.0.0.1:0/metrics",
               close: Effect.sync(() => {
                 serverCloseCount += 1;
               }),
@@ -9063,6 +9091,7 @@ describe("@view-server/runtime", () => {
             Effect.as({
               url: "ws://127.0.0.1:0/rpc",
               healthUrl: "http://127.0.0.1:0/health",
+              metricsUrl: "http://127.0.0.1:0/metrics",
               close: Effect.sync(() => {
                 serverCloseCount += 1;
               }),
@@ -9204,6 +9233,7 @@ describe("@view-server/runtime", () => {
           Effect.succeed({
             url: "ws://127.0.0.1:0/rpc",
             healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.sync(() => {
               serverClosed = true;
             }),

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -234,9 +234,13 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
                 : Effect.void,
             ),
           );
-  const close = (grpcIngress?.close ?? Effect.void).pipe(
+  const closeGrpcIngress: Effect.Effect<void> =
+    grpcIngress === undefined ? Effect.void : grpcIngress.close;
+  const closeKafkaIngress: Effect.Effect<void> =
+    kafkaIngress === undefined ? Effect.void : kafkaIngress.close;
+  const close: Effect.Effect<void> = closeGrpcIngress.pipe(
     Effect.ensuring(closeGrpcLeaseManager),
-    Effect.ensuring(kafkaIngress?.close ?? Effect.void),
+    Effect.ensuring(closeKafkaIngress),
     Effect.ensuring(server.close),
     Effect.ensuring(runtimeCore.close),
   );
@@ -244,6 +248,7 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
   return {
     url: server.url,
     healthUrl: server.healthUrl,
+    metricsUrl: server.metricsUrl,
     client: runtimeClient,
     liveClient: publicLiveClient,
     health: runtimeClient.health,
@@ -256,6 +261,7 @@ const logRuntimeStarted = Effect.fn("ViewServerRuntime.logStarted")(function* <
 >(runtime: ViewServerRuntime<Topics>) {
   yield* Effect.logInfo(`View Server WebSocket listening at ${runtime.url}`);
   yield* Effect.logInfo(`View Server health endpoint listening at ${runtime.healthUrl}`);
+  yield* Effect.logInfo(`View Server metrics endpoint listening at ${runtime.metricsUrl}`);
 });
 
 const makeViewServerRuntimeLaunchLayer = <

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -392,6 +392,7 @@ export const resolveViewServerRuntimeOptions: <
     ...(options.websocketPort === undefined ? {} : { port: options.websocketPort }),
     ...(options.rpcPath === undefined ? {} : { path: options.rpcPath }),
     ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
+    ...(options.metricsPath === undefined ? {} : { metricsPath: options.metricsPath }),
   };
   const kafkaOptions =
     options.kafka === undefined ? undefined : yield* resolveKafkaOptions(options.kafka);

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -64,6 +64,7 @@ export type ViewServerRuntimeOptions<
   readonly websocketPort?: number;
   readonly rpcPath?: RuntimeHttpPath;
   readonly healthPath?: RuntimeHttpPath;
+  readonly metricsPath?: RuntimeHttpPath;
   readonly kafka?: ViewServerKafkaRuntimeOptions<Topics, Regions>;
   readonly grpc?: ViewServerGrpcRuntimeOptions<Topics, GrpcClients>;
   readonly groupedIncrementalAdmissionLimits?: Partial<GroupedIncrementalAdmissionLimits>;
@@ -279,6 +280,7 @@ type ViewServerPublicRuntimeClient<Topics extends object> = Omit<
 export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> = {
   readonly url: string;
   readonly healthUrl: string;
+  readonly metricsUrl: string;
   readonly client: ViewServerPublicRuntimeClient<Topics>;
   readonly liveClient: ViewServerLiveClient<Topics>;
   readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;

--- a/packages/server/src/index.test-d.ts
+++ b/packages/server/src/index.test-d.ts
@@ -64,10 +64,12 @@ describe("server type contracts", () => {
     const options = {
       path: "/rpc",
       healthPath: "/health",
+      metricsPath: "/metrics",
     } satisfies ViewServerWebSocketServerOptions;
     const prefixedOptions = {
       path: "/view-server/rpc",
       healthPath: "/view-server/health",
+      metricsPath: "/view-server/metrics",
     } satisfies ViewServerWebSocketServerOptions;
 
     const invalidWildcardRpcPath: ViewServerWebSocketServerOptions = {
@@ -86,14 +88,26 @@ describe("server type contracts", () => {
       // @ts-expect-error health path must be slash-prefixed.
       healthPath: "health",
     };
+    const invalidWildcardMetricsPath: ViewServerWebSocketServerOptions = {
+      // @ts-expect-error metrics path must produce a concrete fetch URL.
+      metricsPath: "*",
+    };
+    const invalidBareMetricsPath: ViewServerWebSocketServerOptions = {
+      // @ts-expect-error metrics path must be slash-prefixed.
+      metricsPath: "metrics",
+    };
 
     expectTypeOf(options.path).toEqualTypeOf<"/rpc">();
     expectTypeOf(options.healthPath).toEqualTypeOf<"/health">();
+    expectTypeOf(options.metricsPath).toEqualTypeOf<"/metrics">();
     expectTypeOf(prefixedOptions.path).toEqualTypeOf<"/view-server/rpc">();
     expectTypeOf(prefixedOptions.healthPath).toEqualTypeOf<"/view-server/health">();
+    expectTypeOf(prefixedOptions.metricsPath).toEqualTypeOf<"/view-server/metrics">();
     expectTypeOf(invalidWildcardRpcPath).not.toBeAny();
     expectTypeOf(invalidWildcardHealthPath).not.toBeAny();
     expectTypeOf(invalidBareRpcPath).not.toBeAny();
     expectTypeOf(invalidBareHealthPath).not.toBeAny();
+    expectTypeOf(invalidWildcardMetricsPath).not.toBeAny();
+    expectTypeOf(invalidBareMetricsPath).not.toBeAny();
   });
 });

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -229,6 +229,12 @@ const fetchJson = Effect.fn("ViewServerServer.test.fetchJson")(function* (url: s
   return { response, value };
 });
 
+const fetchText = Effect.fn("ViewServerServer.test.fetchText")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  return { response, text };
+});
+
 const reserveTcpPort = Effect.fn("ViewServerServer.test.tcp.reservePort")(function* () {
   const server = yield* Effect.acquireRelease(
     Effect.callback<Net.Server, ServerTestTcpError>((resume) => {
@@ -660,6 +666,40 @@ describe("@view-server/server", () => {
     }),
   );
 
+  it.live("serves GET /metrics beside the websocket RPC endpoint", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: inMemory.client,
+      });
+
+      yield* inMemory.client.publish("orders", order("a", 10));
+
+      const metrics = yield* fetchText(server.metricsUrl);
+
+      expect(metrics.response.status).toBe(200);
+      expect(metrics.response.headers.get("content-type")).toContain("text/plain");
+      expect(metrics.text).toContain("# TYPE view_server_runtime_status gauge");
+      expect(metrics.text).toContain("# TYPE view_server_runtime_version gauge");
+      expect(metrics.text).toContain("# TYPE view_server_transport_backpressure_events gauge");
+      expect(metrics.text).toContain("# TYPE view_server_engine_topic_grouped_evaluations gauge");
+      expect(metrics.text).toContain("# TYPE view_server_engine_topic_backpressure_events gauge");
+      expect(metrics.text).toContain("# TYPE view_server_grpc_feed_reconnects gauge");
+      expect(metrics.text).toContain('view_server_runtime_status{status="ready"} 1');
+      expect(metrics.text).toContain(
+        'view_server_engine_topic_rows{topic="orders",state="total"} 1',
+      );
+      expect(metrics.text).toContain(
+        'view_server_engine_topic_rows{topic="orders",state="live"} 1',
+      );
+      expect(metrics.text).toContain("view_server_transport_active_clients 0");
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
   it.live("composes with the public runtime-core live client", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
@@ -766,9 +806,12 @@ describe("@view-server/server", () => {
       });
 
       const health = yield* fetchJson(server.healthUrl);
+      const metrics = yield* fetchText(server.metricsUrl);
 
       expect(health.response.status).toBe(500);
       expect(health.value).toStrictEqual(healthError);
+      expect(metrics.response.status).toBe(200);
+      expect(metrics.text).toBe("view_server_metrics_error 1\n");
 
       yield* server.close;
       yield* inMemory.close;
@@ -851,6 +894,94 @@ describe("@view-server/server", () => {
                   committedOffset: null,
                   lastError: null,
                 },
+                london: {
+                  connected: false,
+                  assignedPartitions: 0,
+                  messagesPerSecond: 7,
+                  bytesPerSecond: 70,
+                  decodedMessagesPerSecond: 6,
+                  decodeFailuresPerSecond: 1,
+                  mappingFailuresPerSecond: 2,
+                  publishFailuresPerSecond: 3,
+                  commitFailuresPerSecond: 4,
+                  processingFailuresPerSecond: 5,
+                  lastMessageAt: null,
+                  lastCommitAt: null,
+                  consumerLagMessages: null,
+                  lagSampledAt: null,
+                  committedOffset: "11",
+                  lastError: "disconnected",
+                },
+              },
+            },
+          },
+        },
+        grpc: {
+          clients: {
+            ordersClient: {
+              status: "connected",
+              baseUrl: "http://127.0.0.1:8080",
+              activeFeeds: 3,
+              lastConnectedAt: null,
+              lastError: null,
+            },
+          },
+          feeds: {
+            orders: {
+              materialized: {
+                ordersFeed: {
+                  status: "ready",
+                  lifecycle: "materialized",
+                  feedName: "ordersFeed",
+                  feedKey: "ordersFeed",
+                  topic: "orders",
+                  subscriberCount: 2,
+                  rowCount: 5,
+                  messagesPerSecond: 9,
+                  rowsPerSecond: 8,
+                  decodeFailuresPerSecond: 0,
+                  mappingFailuresPerSecond: 0,
+                  publishFailuresPerSecond: 0,
+                  reconnects: 0,
+                  lastMessageAt: null,
+                  lastError: null,
+                },
+              },
+              leased: {
+                "ordersLease:strategy=strat-1": {
+                  status: "ready",
+                  lifecycle: "leased",
+                  feedName: "ordersLease",
+                  feedKey: "ordersLease:strategy=strat-1",
+                  topic: "orders",
+                  subscriberCount: 1,
+                  rowCount: 3,
+                  messagesPerSecond: 4,
+                  rowsPerSecond: 3,
+                  decodeFailuresPerSecond: 0,
+                  mappingFailuresPerSecond: 0,
+                  publishFailuresPerSecond: 0,
+                  reconnects: 0,
+                  lastMessageAt: null,
+                  lastError: null,
+                },
+                "ordersLease:strategy=strat-2": {
+                  status: "ready",
+                  lifecycle: "leased",
+                  feedName: "ordersLease",
+                  feedKey: "ordersLease:strategy=strat-2",
+                  topic: "orders",
+                  subscriberCount: 2,
+                  rowCount: 7,
+                  messagesPerSecond: 6,
+                  rowsPerSecond: 5,
+                  decodeFailuresPerSecond: 1,
+                  mappingFailuresPerSecond: 2,
+                  publishFailuresPerSecond: 3,
+                  reconnects: 4,
+                  lastMessageAt: null,
+                  lastError: null,
+                },
               },
             },
           },
@@ -866,9 +997,64 @@ describe("@view-server/server", () => {
       const expectedHealth =
         yield* Schema.encodeUnknownEffect(ViewServerHealthSchema)(degradedHealth);
       const health = yield* fetchJson(server.healthUrl);
+      const metrics = yield* fetchText(server.metricsUrl);
 
       expect(health.response.status).toBe(503);
       expect(health.value).toStrictEqual(expectedHealth);
+      expect(metrics.response.status).toBe(200);
+      expect(metrics.text).toContain(
+        'view_server_kafka_region_connected{region="usa",sourceTopic="source_orders",viewServerTopic="orders"} 1',
+      );
+      expect(metrics.text).toContain(
+        'view_server_kafka_bytes_per_second{region="london",sourceTopic="source_orders",viewServerTopic="orders"} 70',
+      );
+      expect(metrics.text).toContain(
+        'view_server_kafka_processing_failures_per_second{region="london",sourceTopic="source_orders",viewServerTopic="orders"} 5',
+      );
+      expect(metrics.text).toContain(
+        'view_server_kafka_consumer_lag_messages{region="usa",sourceTopic="source_orders",viewServerTopic="orders"} 42',
+      );
+      expect(metrics.text).toContain(
+        'view_server_kafka_region_connected{region="london",sourceTopic="source_orders",viewServerTopic="orders"} 0',
+      );
+      expect(metrics.text).not.toContain(
+        'view_server_kafka_consumer_lag_messages{region="london",sourceTopic="source_orders",viewServerTopic="orders"}',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_rows{lifecycle="materialized",topic="orders",feed="ordersFeed"} 5',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_client_active_feeds{client="ordersClient",baseUrl="http://127.0.0.1:8080"} 3',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_rows{lifecycle="leased",topic="orders",feed="ordersLease"} 10',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_subscribers{lifecycle="leased",topic="orders",feed="ordersLease"} 3',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_messages_per_second{lifecycle="leased",topic="orders",feed="ordersLease"} 10',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_rows_per_second{lifecycle="leased",topic="orders",feed="ordersLease"} 8',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_mapping_failures_per_second{lifecycle="leased",topic="orders",feed="ordersLease"} 2',
+      );
+      expect(metrics.text).toContain(
+        'view_server_grpc_feed_reconnects{lifecycle="leased",topic="orders",feed="ordersLease"} 4',
+      );
+      expect(
+        metrics.text
+          .split("\n")
+          .filter((line) =>
+            line.startsWith('view_server_grpc_feed_rows{lifecycle="leased",topic="orders"'),
+          ),
+      ).toStrictEqual([
+        'view_server_grpc_feed_rows{lifecycle="leased",topic="orders",feed="ordersLease"} 10',
+      ]);
+      expect(metrics.text).not.toContain("ordersLease:strategy=strat-1");
+      expect(metrics.text).not.toContain("ordersLease:strategy=strat-2");
 
       yield* server.close;
       yield* inMemory.close;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { HttpRouter, HttpServer, HttpServerError, HttpServerRequest } from "effe
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 import * as Http from "node:http";
 import { makeViewServerHealthRoute } from "./health-route";
+import { makeViewServerMetricsRoute } from "./metrics-route";
 import { makeViewServerRpcHandlers } from "./rpc-handlers";
 import type {
   Jsonify,
@@ -72,6 +73,7 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
 ) {
   const path = options.path ?? "/rpc";
   const healthPath = options.healthPath ?? "/health";
+  const metricsPath = options.metricsPath ?? "/metrics";
   const handlerScope = yield* Scope.make("parallel");
   const activeSocketClosers: ActiveSocketClosers = new Set();
   const protocol = makeTrackedWebSocketProtocolLayer(path, input, activeSocketClosers).pipe(
@@ -79,7 +81,8 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   );
   const handlers = ViewServerRpcs.toLayer(makeViewServerRpcHandlers(config, input, handlerScope));
   const healthRoute = makeViewServerHealthRoute(config, input, healthPath);
-  const httpApp = Layer.merge(protocol, healthRoute);
+  const metricsRoute = makeViewServerMetricsRoute(config, input, metricsPath);
+  const httpApp = Layer.mergeAll(protocol, healthRoute, metricsRoute);
   const rpcLayer = RpcServer.layer(ViewServerRpcs, {
     disableFatalDefects: true,
   }).pipe(
@@ -112,6 +115,7 @@ export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitio
   return {
     url: `${serverUrl}${path}`,
     healthUrl: `${publicHttpUrl}${healthPath}`,
+    metricsUrl: `${publicHttpUrl}${metricsPath}`,
     close: Scope.close(handlerScope, Exit.void).pipe(
       Effect.andThen(closeTrackedSockets(activeSocketClosers)),
       Effect.andThen(managedRuntime.disposeEffect),

--- a/packages/server/src/metrics-route.ts
+++ b/packages/server/src/metrics-route.ts
@@ -1,0 +1,420 @@
+import type { TopicDefinitions, ViewServerConfig, ViewServerHealth } from "@view-server/config";
+import { viewServerDecodeHealth } from "@view-server/protocol";
+import { Effect } from "effect";
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
+import type { ViewServerWebSocketServerInput } from "./server-types";
+
+const metricContentType = "text/plain; version=0.0.4; charset=utf-8";
+
+const escapeLabelValue = (value: string): string =>
+  value.replaceAll("\\", "\\\\").replaceAll("\n", "\\n").replaceAll('"', '\\"');
+
+const labelsText = (labels: Readonly<Record<string, string>>): string => {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries.map(([key, value]) => `${key}="${escapeLabelValue(value)}"`).join(",")}}`;
+};
+
+const metricLine = (
+  name: string,
+  value: number | bigint,
+  labels: Readonly<Record<string, string>> = {},
+): string => `${name}${labelsText(labels)} ${value.toString()}`;
+
+const nullableNumberMetricLine = (
+  name: string,
+  value: number | bigint | null,
+  labels: Readonly<Record<string, string>>,
+): string | undefined => (value === null ? undefined : metricLine(name, value, labels));
+
+const booleanMetric = (value: boolean): number => (value ? 1 : 0);
+
+const statusMetric = (status: string, expected: string): number =>
+  booleanMetric(status === expected);
+
+const compactLines = (lines: ReadonlyArray<string | undefined>): string =>
+  `${lines.filter((line) => line !== undefined).join("\n")}\n`;
+
+type GrpcFeedMetricTotals = {
+  readonly rowCount: number;
+  readonly subscriberCount: number;
+  readonly messagesPerSecond: number;
+  readonly rowsPerSecond: number;
+  readonly decodeFailuresPerSecond: number;
+  readonly mappingFailuresPerSecond: number;
+  readonly publishFailuresPerSecond: number;
+  readonly reconnects: number;
+};
+
+const emptyGrpcFeedMetricTotals = (): GrpcFeedMetricTotals => ({
+  rowCount: 0,
+  subscriberCount: 0,
+  messagesPerSecond: 0,
+  rowsPerSecond: 0,
+  decodeFailuresPerSecond: 0,
+  mappingFailuresPerSecond: 0,
+  publishFailuresPerSecond: 0,
+  reconnects: 0,
+});
+
+const addGrpcFeedMetricTotals = (
+  current: GrpcFeedMetricTotals,
+  feed: GrpcFeedMetricTotals,
+): GrpcFeedMetricTotals => ({
+  rowCount: current.rowCount + feed.rowCount,
+  subscriberCount: current.subscriberCount + feed.subscriberCount,
+  messagesPerSecond: current.messagesPerSecond + feed.messagesPerSecond,
+  rowsPerSecond: current.rowsPerSecond + feed.rowsPerSecond,
+  decodeFailuresPerSecond: current.decodeFailuresPerSecond + feed.decodeFailuresPerSecond,
+  mappingFailuresPerSecond: current.mappingFailuresPerSecond + feed.mappingFailuresPerSecond,
+  publishFailuresPerSecond: current.publishFailuresPerSecond + feed.publishFailuresPerSecond,
+  reconnects: current.reconnects + feed.reconnects,
+});
+
+const pushGrpcFeedMetrics = (
+  lines: Array<string | undefined>,
+  labels: Readonly<Record<string, string>>,
+  feed: GrpcFeedMetricTotals,
+): void => {
+  lines.push(
+    metricLine("view_server_grpc_feed_rows", feed.rowCount, labels),
+    metricLine("view_server_grpc_feed_subscribers", feed.subscriberCount, labels),
+    metricLine("view_server_grpc_feed_messages_per_second", feed.messagesPerSecond, labels),
+    metricLine("view_server_grpc_feed_rows_per_second", feed.rowsPerSecond, labels),
+    metricLine(
+      "view_server_grpc_feed_decode_failures_per_second",
+      feed.decodeFailuresPerSecond,
+      labels,
+    ),
+    metricLine(
+      "view_server_grpc_feed_mapping_failures_per_second",
+      feed.mappingFailuresPerSecond,
+      labels,
+    ),
+    metricLine(
+      "view_server_grpc_feed_publish_failures_per_second",
+      feed.publishFailuresPerSecond,
+      labels,
+    ),
+    metricLine("view_server_grpc_feed_reconnects", feed.reconnects, labels),
+  );
+};
+
+const viewServerHealthMetrics = <const Topics extends TopicDefinitions>(
+  health: ViewServerHealth<Topics>,
+): string => {
+  const lines: Array<string | undefined> = [
+    "# HELP view_server_runtime_status Runtime status as one-hot labels.",
+    "# TYPE view_server_runtime_status gauge",
+    metricLine("view_server_runtime_status", statusMetric(health.status, "ready"), {
+      status: "ready",
+    }),
+    metricLine("view_server_runtime_status", statusMetric(health.status, "starting"), {
+      status: "starting",
+    }),
+    metricLine("view_server_runtime_status", statusMetric(health.status, "degraded"), {
+      status: "degraded",
+    }),
+    metricLine("view_server_runtime_status", statusMetric(health.status, "stopping"), {
+      status: "stopping",
+    }),
+    "# HELP view_server_runtime_version Runtime health version.",
+    "# TYPE view_server_runtime_version gauge",
+    metricLine("view_server_runtime_version", health.version),
+    "# HELP view_server_runtime_uptime_millis Runtime uptime in milliseconds.",
+    "# TYPE view_server_runtime_uptime_millis gauge",
+    metricLine("view_server_runtime_uptime_millis", health.uptimeMs),
+    "# HELP view_server_transport_active_clients Active transport clients.",
+    "# TYPE view_server_transport_active_clients gauge",
+    metricLine("view_server_transport_active_clients", health.transport.activeClients),
+    "# HELP view_server_transport_active_streams Active transport streams.",
+    "# TYPE view_server_transport_active_streams gauge",
+    metricLine("view_server_transport_active_streams", health.transport.activeStreams),
+    "# HELP view_server_transport_active_subscriptions Active transport subscriptions.",
+    "# TYPE view_server_transport_active_subscriptions gauge",
+    metricLine("view_server_transport_active_subscriptions", health.transport.activeSubscriptions),
+    "# HELP view_server_transport_queued_messages Queued transport messages.",
+    "# TYPE view_server_transport_queued_messages gauge",
+    metricLine("view_server_transport_queued_messages", health.transport.queuedMessages),
+    "# HELP view_server_transport_queued_bytes Queued transport bytes.",
+    "# TYPE view_server_transport_queued_bytes gauge",
+    metricLine("view_server_transport_queued_bytes", health.transport.queuedBytes),
+    "# HELP view_server_transport_messages_per_second Transport messages per second.",
+    "# TYPE view_server_transport_messages_per_second gauge",
+    metricLine("view_server_transport_messages_per_second", health.transport.messagesPerSecond),
+    "# HELP view_server_transport_bytes_per_second Transport bytes per second.",
+    "# TYPE view_server_transport_bytes_per_second gauge",
+    metricLine("view_server_transport_bytes_per_second", health.transport.bytesPerSecond),
+    "# HELP view_server_transport_dropped_clients Dropped transport clients.",
+    "# TYPE view_server_transport_dropped_clients counter",
+    metricLine("view_server_transport_dropped_clients", health.transport.droppedClients),
+    "# HELP view_server_transport_backpressure_events Transport backpressure events.",
+    "# TYPE view_server_transport_backpressure_events gauge",
+    metricLine("view_server_transport_backpressure_events", health.transport.backpressureEvents),
+    "# HELP view_server_transport_reconnects Transport reconnects.",
+    "# TYPE view_server_transport_reconnects counter",
+    metricLine("view_server_transport_reconnects", health.transport.reconnects),
+    "# HELP view_server_engine_topic_rows Engine topic row counts.",
+    "# TYPE view_server_engine_topic_rows gauge",
+    "# HELP view_server_engine_topic_version Engine topic version.",
+    "# TYPE view_server_engine_topic_version gauge",
+    "# HELP view_server_engine_topic_pending_mutation_batches Pending mutation batches by topic.",
+    "# TYPE view_server_engine_topic_pending_mutation_batches gauge",
+    "# HELP view_server_engine_topic_active_views Active raw views by topic.",
+    "# TYPE view_server_engine_topic_active_views gauge",
+    "# HELP view_server_engine_topic_active_grouped_views Active grouped views by topic and mode.",
+    "# TYPE view_server_engine_topic_active_grouped_views gauge",
+    "# HELP view_server_engine_topic_grouped_evaluations Active grouped evaluation count by topic and mode.",
+    "# TYPE view_server_engine_topic_grouped_evaluations gauge",
+    "# HELP view_server_engine_topic_active_subscriptions Active subscriptions by topic.",
+    "# TYPE view_server_engine_topic_active_subscriptions gauge",
+    "# HELP view_server_engine_topic_queued_events Queued events by topic.",
+    "# TYPE view_server_engine_topic_queued_events gauge",
+    "# HELP view_server_engine_topic_max_queue_depth Maximum queue depth by topic.",
+    "# TYPE view_server_engine_topic_max_queue_depth gauge",
+    "# HELP view_server_engine_topic_backpressure_events Backpressure events by topic.",
+    "# TYPE view_server_engine_topic_backpressure_events gauge",
+    "# HELP view_server_engine_topic_memory_bytes Estimated memory bytes by topic.",
+    "# TYPE view_server_engine_topic_memory_bytes gauge",
+    "# HELP view_server_engine_topic_tombstones Tombstone count by topic.",
+    "# TYPE view_server_engine_topic_tombstones gauge",
+    "# HELP view_server_engine_topic_compaction_pending Topic compaction pending flag.",
+    "# TYPE view_server_engine_topic_compaction_pending gauge",
+    "# HELP view_server_engine_topic_mutations_per_second Mutations per second by topic.",
+    "# TYPE view_server_engine_topic_mutations_per_second gauge",
+    "# HELP view_server_engine_topic_rows_per_second Rows per second by topic.",
+    "# TYPE view_server_engine_topic_rows_per_second gauge",
+    "# HELP view_server_kafka_region_connected Kafka region connection state.",
+    "# TYPE view_server_kafka_region_connected gauge",
+    "# HELP view_server_kafka_messages_per_second Kafka messages per second.",
+    "# TYPE view_server_kafka_messages_per_second gauge",
+    "# HELP view_server_kafka_bytes_per_second Kafka bytes per second.",
+    "# TYPE view_server_kafka_bytes_per_second gauge",
+    "# HELP view_server_kafka_decoded_messages_per_second Kafka decoded messages per second.",
+    "# TYPE view_server_kafka_decoded_messages_per_second gauge",
+    "# HELP view_server_kafka_decode_failures_per_second Kafka decode failures per second.",
+    "# TYPE view_server_kafka_decode_failures_per_second gauge",
+    "# HELP view_server_kafka_mapping_failures_per_second Kafka mapping failures per second.",
+    "# TYPE view_server_kafka_mapping_failures_per_second gauge",
+    "# HELP view_server_kafka_publish_failures_per_second Kafka publish failures per second.",
+    "# TYPE view_server_kafka_publish_failures_per_second gauge",
+    "# HELP view_server_kafka_commit_failures_per_second Kafka commit failures per second.",
+    "# TYPE view_server_kafka_commit_failures_per_second gauge",
+    "# HELP view_server_kafka_processing_failures_per_second Kafka processing failures per second.",
+    "# TYPE view_server_kafka_processing_failures_per_second gauge",
+    "# HELP view_server_kafka_consumer_lag_messages Kafka consumer lag messages.",
+    "# TYPE view_server_kafka_consumer_lag_messages gauge",
+    "# HELP view_server_grpc_client_connected gRPC client connection state.",
+    "# TYPE view_server_grpc_client_connected gauge",
+    "# HELP view_server_grpc_client_active_feeds gRPC client active feed count.",
+    "# TYPE view_server_grpc_client_active_feeds gauge",
+    "# HELP view_server_grpc_feed_rows gRPC feed retained rows.",
+    "# TYPE view_server_grpc_feed_rows gauge",
+    "# HELP view_server_grpc_feed_subscribers gRPC feed subscribers.",
+    "# TYPE view_server_grpc_feed_subscribers gauge",
+    "# HELP view_server_grpc_feed_messages_per_second gRPC feed messages per second.",
+    "# TYPE view_server_grpc_feed_messages_per_second gauge",
+    "# HELP view_server_grpc_feed_rows_per_second gRPC feed rows per second.",
+    "# TYPE view_server_grpc_feed_rows_per_second gauge",
+    "# HELP view_server_grpc_feed_decode_failures_per_second gRPC feed decode failures per second.",
+    "# TYPE view_server_grpc_feed_decode_failures_per_second gauge",
+    "# HELP view_server_grpc_feed_mapping_failures_per_second gRPC feed mapping failures per second.",
+    "# TYPE view_server_grpc_feed_mapping_failures_per_second gauge",
+    "# HELP view_server_grpc_feed_publish_failures_per_second gRPC feed publish failures per second.",
+    "# TYPE view_server_grpc_feed_publish_failures_per_second gauge",
+    "# HELP view_server_grpc_feed_reconnects gRPC feed reconnects.",
+    "# TYPE view_server_grpc_feed_reconnects gauge",
+  ];
+
+  for (const [topicName, topic] of Object.entries(health.engine.topics)) {
+    const labels = { topic: topicName };
+    lines.push(
+      metricLine("view_server_engine_topic_rows", topic.rowCount, {
+        ...labels,
+        state: "total",
+      }),
+      metricLine("view_server_engine_topic_rows", topic.liveRowCount, {
+        ...labels,
+        state: "live",
+      }),
+      metricLine("view_server_engine_topic_rows", topic.deletedRowCount, {
+        ...labels,
+        state: "deleted",
+      }),
+      metricLine("view_server_engine_topic_version", topic.version, labels),
+      metricLine(
+        "view_server_engine_topic_pending_mutation_batches",
+        topic.pendingMutationBatches,
+        labels,
+      ),
+      metricLine("view_server_engine_topic_active_views", topic.activeViews, labels),
+      metricLine(
+        "view_server_engine_topic_active_grouped_views",
+        topic.activeFallbackGroupedViews,
+        {
+          ...labels,
+          mode: "fallback",
+        },
+      ),
+      metricLine(
+        "view_server_engine_topic_active_grouped_views",
+        topic.activeIncrementalGroupedViews,
+        {
+          ...labels,
+          mode: "incremental",
+        },
+      ),
+      metricLine("view_server_engine_topic_grouped_evaluations", topic.groupedFullEvaluationCount, {
+        ...labels,
+        mode: "full",
+      }),
+      metricLine(
+        "view_server_engine_topic_grouped_evaluations",
+        topic.groupedPatchedEvaluationCount,
+        {
+          ...labels,
+          mode: "patched",
+        },
+      ),
+      metricLine(
+        "view_server_engine_topic_active_subscriptions",
+        topic.activeSubscriptions,
+        labels,
+      ),
+      metricLine("view_server_engine_topic_queued_events", topic.queuedEvents, labels),
+      metricLine("view_server_engine_topic_max_queue_depth", topic.maxQueueDepth, labels),
+      metricLine("view_server_engine_topic_backpressure_events", topic.backpressureEvents, labels),
+      metricLine("view_server_engine_topic_memory_bytes", topic.memoryBytes, labels),
+      metricLine("view_server_engine_topic_tombstones", topic.tombstoneCount, labels),
+      metricLine(
+        "view_server_engine_topic_compaction_pending",
+        booleanMetric(topic.compactionPending),
+        labels,
+      ),
+      metricLine("view_server_engine_topic_mutations_per_second", topic.mutationsPerSecond, labels),
+      metricLine("view_server_engine_topic_rows_per_second", topic.rowsPerSecond, labels),
+    );
+  }
+
+  const kafka = health.kafka;
+  if (kafka !== undefined) {
+    for (const sourceTopic of Object.values(kafka.topics)) {
+      for (const [regionName, region] of Object.entries(sourceTopic.regions)) {
+        const labels = {
+          region: regionName,
+          sourceTopic: sourceTopic.sourceTopic,
+          viewServerTopic: sourceTopic.viewServerTopic,
+        };
+        lines.push(
+          metricLine("view_server_kafka_region_connected", booleanMetric(region.connected), labels),
+          metricLine("view_server_kafka_messages_per_second", region.messagesPerSecond, labels),
+          metricLine("view_server_kafka_bytes_per_second", region.bytesPerSecond, labels),
+          metricLine(
+            "view_server_kafka_decoded_messages_per_second",
+            region.decodedMessagesPerSecond,
+            labels,
+          ),
+          metricLine(
+            "view_server_kafka_decode_failures_per_second",
+            region.decodeFailuresPerSecond,
+            labels,
+          ),
+          metricLine(
+            "view_server_kafka_mapping_failures_per_second",
+            region.mappingFailuresPerSecond,
+            labels,
+          ),
+          metricLine(
+            "view_server_kafka_publish_failures_per_second",
+            region.publishFailuresPerSecond,
+            labels,
+          ),
+          metricLine(
+            "view_server_kafka_commit_failures_per_second",
+            region.commitFailuresPerSecond,
+            labels,
+          ),
+          metricLine(
+            "view_server_kafka_processing_failures_per_second",
+            region.processingFailuresPerSecond,
+            labels,
+          ),
+          nullableNumberMetricLine(
+            "view_server_kafka_consumer_lag_messages",
+            region.consumerLagMessages,
+            labels,
+          ),
+        );
+      }
+    }
+  }
+
+  const grpc = health.grpc;
+  if (grpc !== undefined) {
+    for (const [clientName, client] of Object.entries(grpc.clients)) {
+      const labels = {
+        client: clientName,
+        baseUrl: client.baseUrl,
+      };
+      lines.push(
+        metricLine(
+          "view_server_grpc_client_connected",
+          booleanMetric(client.status === "connected"),
+          labels,
+        ),
+        metricLine("view_server_grpc_client_active_feeds", client.activeFeeds, labels),
+      );
+    }
+    for (const [topicName, topicFeeds] of Object.entries(grpc.feeds)) {
+      for (const [feedName, feed] of Object.entries(topicFeeds.materialized)) {
+        const labels = {
+          lifecycle: "materialized",
+          topic: topicName,
+          feed: feedName,
+        };
+        pushGrpcFeedMetrics(lines, labels, feed);
+      }
+      const leasedFeedTotals = new Map<string, GrpcFeedMetricTotals>();
+      for (const feed of Object.values(topicFeeds.leased)) {
+        const current = leasedFeedTotals.get(feed.feedName) ?? emptyGrpcFeedMetricTotals();
+        leasedFeedTotals.set(feed.feedName, addGrpcFeedMetricTotals(current, feed));
+      }
+      for (const [feedName, feed] of leasedFeedTotals) {
+        const labels = {
+          lifecycle: "leased",
+          topic: topicName,
+          feed: feedName,
+        };
+        pushGrpcFeedMetrics(lines, labels, feed);
+      }
+    }
+  }
+
+  return compactLines(lines);
+};
+
+const metricsResponse = (status: number, body: string): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.text(body, {
+    status,
+    contentType: metricContentType,
+  });
+
+export const makeViewServerMetricsRoute = <const Topics extends TopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  input: ViewServerWebSocketServerInput<Topics>,
+  path: `/${string}`,
+) =>
+  HttpRouter.add(
+    "GET",
+    path,
+    input.runtime.health().pipe(
+      Effect.flatMap((health) => viewServerDecodeHealth(config, health)),
+      Effect.match({
+        onFailure: () =>
+          metricsResponse(200, compactLines([metricLine("view_server_metrics_error", 1)])),
+        onSuccess: (health) => metricsResponse(200, viewServerHealthMetrics(health)),
+      }),
+    ),
+  );

--- a/packages/server/src/server-types.ts
+++ b/packages/server/src/server-types.ts
@@ -27,11 +27,13 @@ export type ViewServerWebSocketServerOptions = {
   readonly port?: number;
   readonly path?: `/${string}`;
   readonly healthPath?: `/${string}`;
+  readonly metricsPath?: `/${string}`;
 };
 
 export type ViewServerWebSocketServer = {
   readonly url: string;
   readonly healthUrl: string;
+  readonly metricsUrl: string;
   readonly close: Effect.Effect<void>;
 };
 

--- a/plans/remaining-roadmap-audit.md
+++ b/plans/remaining-roadmap-audit.md
@@ -1,0 +1,99 @@
+# Remaining Roadmap Audit
+
+This audit maps the still-relevant `plans/*.md` requirements to current implementation
+status. It is intentionally evidence-based: code and validation gates are the source of
+truth, not plan text that predates later implementation work.
+
+## Status Legend
+
+- `Implemented`: covered by current code, tests, gates, and documentation.
+- `Production-ready next`: should be implemented before calling the roadmap closed.
+- `Deferred intentionally`: known future/optional work, not required for the current
+  production milestone.
+- `Remove or rewrite`: plan text is stale or no longer describes desired behavior.
+
+## gRPC Plan
+
+`plans/grpc.md` is implemented for the accepted gRPC scope.
+
+| Area                                            | Status                 | Evidence                                                                                                              |
+| ----------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Source contracts and type gates                 | Implemented            | `packages/config/src/grpc-contract.ts`, `packages/config/src/index.test.ts`, `packages/runtime/src/index.test-d.ts`   |
+| Runtime ownership validation                    | Implemented            | Runtime validation tests reject Kafka/gRPC and multi-feed ownership conflicts.                                        |
+| Materialized gRPC runtime                       | Implemented            | `packages/runtime/src/grpc-ingress.ts`, materialized runtime tests, ConnectRPC tests.                                 |
+| Leased gRPC runtime                             | Implemented            | `packages/runtime/src/grpc-lease-manager.ts`, leased runtime tests, ConnectRPC tests.                                 |
+| gRPC health/lifecycle                           | Implemented            | `packages/runtime/src/grpc-health.ts`, runtime health tests, `pnpm run grpc:gate`.                                    |
+| gRPC benchmark gates                            | Implemented            | `benchmarks/baselines/grpc-materialized.json`, `grpc-leased.json`, `grpc-leased-retained.json`, `pnpm run grpc:gate`. |
+| Public config migration to source constructors  | Deferred intentionally | Listed under `Deferred Decisions`; current source markers are accepted.                                               |
+| Session-scoped leased feeds and auth forwarding | Deferred intentionally | Current slice uses system-scoped shared feeds.                                                                        |
+| Generic non-gRPC stream-source API              | Deferred intentionally | Plan explicitly keeps ConnectRPC-specific public API.                                                                 |
+| Multi-source topics                             | Deferred intentionally | Requires a separate ordering/dedupe/restart contract.                                                                 |
+| Custom live-event transport                     | Deferred intentionally | Browser transport remains Effect RPC WebSocket + NDJSON.                                                              |
+| WAL/checkpointing for gRPC materialized feeds   | Deferred intentionally | Same recovery policy as the in-memory runtime.                                                                        |
+
+## Column Live View Engine Plan
+
+`plans/v2-column-live-view-engine-plan.md` is the umbrella product roadmap. The
+current production slice is largely implemented, but the whole file is not complete
+because it includes explicit future scope.
+
+### Implemented Current Slice
+
+| Area                                                          | Status      | Evidence                                                                                                                                                                                          |
+| ------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Own in-memory live engine, no external analytical DB hot path | Implemented | `packages/column-live-view-engine`, `packages/runtime-core`; no chDB/Perspective runtime dependency.                                                                                              |
+| Explicit package seams                                        | Implemented | `packages/config`, `column-live-view-engine`, `runtime-core`, `client`, `protocol`, `in-memory`, `server`, `runtime`, `react`; `pnpm run check:package-exports`; `pnpm run check:internal-seams`. |
+| Typed public config/query API                                 | Implemented | Config type tests cover topic schemas, query select/where/order/group/aggregates, Kafka, and gRPC.                                                                                                |
+| Runtime URL in provider, not config                           | Implemented | React provider accepts runtime URL/client at provider boundary; browser bundles do not import runtime config.                                                                                     |
+| In-memory browser/test provider                               | Implemented | `@view-server/react/testing` and `@view-server/in-memory`; browser tests and in-memory benchmarks use real runtime-core/engine.                                                                   |
+| Effect RPC WebSocket production transport                     | Implemented | `packages/server`, `packages/client/remote.ts`, protocol package, WebSocket/runtime tests.                                                                                                        |
+| Health hook, `/health`, and `/metrics` endpoints              | Implemented | `useViewServerHealth`, runtime/server health tests, health codecs, metrics route/runtime tests, root/runtime README docs.                                                                         |
+| Kafka runtime ingress                                         | Implemented | `@platformatic/kafka`, JSON/protobuf/custom codecs, source mapping, Docker Apache Kafka e2e, restart/startFrom policy.                                                                            |
+| gRPC runtime ingress                                          | Implemented | Covered by `plans/grpc.md` implementation.                                                                                                                                                        |
+| Snapshot/delta convergence                                    | Implemented | Engine/runtime/client tests cover raw, grouped, retained deltas, cleanup, and convergence.                                                                                                        |
+| Grouped queries and aggregates                                | Implemented | Grouped query tests, grouped aggregate/write benchmarks and gates.                                                                                                                                |
+| Backpressure at subscription/transport boundary               | Implemented | `BackpressureExceeded` typed status, queue-capacity tests, remote/client/protocol tests.                                                                                                          |
+| Benchmark baseline automation                                 | Implemented | Smoke, raw read/write, active sharing, grouped, WebSocket, Kafka, and gRPC baseline scripts.                                                                                                      |
+| Pre-gRPC readiness gate                                       | Implemented | `pnpm run pre-grpc:gate`.                                                                                                                                                                         |
+
+### Production-Ready Next Items
+
+These are concrete gaps where the plan describes behavior that is still missing or
+currently only documented as a future seam.
+
+| Item                                 | Status                | Why it remains                                                                                   | Suggested first PR                                                                                                                      |
+| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| TCP publish API/runtime ingress      | Production-ready next | `ViewServerRuntimeOptions` explicitly rejects `tcpPublishPort`; no TCP publish adapter exists.   | Add typed TCP publish ingress that uses runtime-core publish/patch/delete/publishMany, with tests for live deltas and invalid payloads. |
+| Runtime auth/session validation seam | Production-ready next | gRPC has system/shared session context; server/runtime do not expose `auth.validateRequest` yet. | Add optional server/runtime auth validation at WebSocket and health/admin boundaries, initially anonymous by default.                   |
+| Span/observability assertions        | Production-ready next | Code uses named `Effect.fn`, but tests do not prove key ingest -> engine -> fanout spans exist.  | Add one focused tracing test that captures span names for publish -> engine mutation -> subscription fanout.                            |
+| Example app                          | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist.                                     | Add a minimal example using real provider URL injection and in-memory provider test/demo path.                                          |
+
+### Intentionally Deferred
+
+These are in the plan, but should remain future work unless explicitly promoted.
+
+| Item                                                     | Status                 | Reason                                                                                                                |
+| -------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| WAL/checkpoints                                          | Deferred intentionally | Current recovery contract is Kafka replay/startFrom based; WAL is allowed later but not required for first milestone. |
+| Multi-consumer Kafka rebalance/revoke/checkpoint handoff | Deferred intentionally | Runtime documents single-consumer-per-group assumption.                                                               |
+| Custom live-event WebSocket protocol                     | Deferred intentionally | Effect RPC WebSocket + NDJSON remains current production transport.                                                   |
+| Rust/native/SIMD engine                                  | Deferred intentionally | TypeScript engine remains primary; native acceleration only if future benchmarks justify it.                          |
+| User-defined indexes                                     | Deferred intentionally | Product principle remains automatic optimization from schemas and controlled query DSL.                               |
+| Session-scoped gRPC leased feeds                         | Deferred intentionally | Needs real authenticated sessions first.                                                                              |
+
+### Stale Or Needs Rewrite
+
+| Plan text                                                              | Status            | Action                                                                 |
+| ---------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------- |
+| `createRuntime` examples still show `tcpPublishPort` as if implemented | Remove or rewrite | Keep as future TCP publish section until implemented.                  |
+| Some early examples show raw queries without `select`                  | Remove or rewrite | Public query API now requires explicit `select` or grouped aggregates. |
+
+## Recommended Implementation Order
+
+1. TCP publish API/runtime ingress.
+2. Runtime auth/session validation seam.
+3. Span/observability assertions.
+4. Minimal example app.
+
+Do not reopen completed gRPC materialized/leased scope unless new tests reveal a real
+correctness gap.


### PR DESCRIPTION
## Summary
- add same-server GET /metrics Prometheus exposition beside /health and WebSocket RPC
- plumb metricsUrl/metricsPath through server and runtime APIs
- document low-cardinality metrics vs detailed health and add remaining roadmap audit

## Validation
- pnpm run ready
- vp run @view-server/server#test
- vp check --fix
- strict Effect LSP for @view-server/server and @view-server/runtime
- forbidden-pattern scan over touched server/runtime/docs files

## Review note
Please wait for Codex/GitHub comments before merge.