### PR TITLE
Add TCP publish ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ NodeRuntime.runMain(
   runViewServerRuntime(viewServer, {
     host: "127.0.0.1",
     websocketPort: 8080,
+    tcpPublishPort: 8081,
   }),
 );
 ```
@@ -24,6 +25,16 @@ NodeRuntime.runMain(
 The same-server `GET /health` endpoint serves the cached runtime health snapshot
 for deployment readiness checks. Internal `bigint` health fields, such as Kafka
 lag, are encoded as decimal strings in the JSON response.
+
+When `tcpPublishPort` is configured, the runtime also opens a non-browser TCP
+NDJSON publish endpoint and exposes its `tcpPublishUrl`. That endpoint supports
+`publish`, `publishMany`, `patch`, and `delete` commands and routes every
+mutation through the same Runtime Core path as Kafka, gRPC, and in-memory tests.
+TCP publish is for externally-published topics only; Kafka/gRPC-owned topics are
+rejected so one View Server topic has one source of truth. TCP publish has its
+own `tcpPublishHost` and defaults to `127.0.0.1`; it does not inherit the public
+WebSocket/HTTP host. The TCP endpoint is bounded by connection, line-size, and
+queued-command limits.
 
 The same-server `GET /metrics` endpoint serves Prometheus text exposition derived
 from the same cached health snapshot. It exposes scrape-safe runtime, transport,

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -12124,6 +12124,32 @@ describe("ColumnLiveViewEngine validation and health", () => {
     expect(rowsEqual(inheritedRow, { id: "1", status: "open" })).toBe(true);
   });
 
+  it("preserves own __proto__ data fields while cloning rows and records", () => {
+    const dangerousRecord = { id: "1" };
+    Object.defineProperty(dangerousRecord, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      value: "visible-record-data",
+      writable: true,
+    });
+
+    const dangerousRow = { id: "1" };
+    Object.defineProperty(dangerousRow, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      value: "visible-row-data",
+      writable: true,
+    });
+
+    const clonedRecord = cloneRecord(dangerousRecord);
+    const clonedRow = cloneRow(dangerousRow);
+
+    expect(clonedRecord).toStrictEqual(dangerousRecord);
+    expect(clonedRow).toStrictEqual(dangerousRow);
+    expect(Object.hasOwn(clonedRecord, "__proto__")).toBe(true);
+    expect(Object.hasOwn(clonedRow, "__proto__")).toBe(true);
+  });
+
   it.effect("fails invalid row publishes with a typed schema error", () =>
     Effect.gen(function* () {
       const engine = yield* makeEngine();

--- a/packages/column-live-view-engine/src/row-values.ts
+++ b/packages/column-live-view-engine/src/row-values.ts
@@ -21,6 +21,15 @@ export const isPlainRecord = (value: unknown): value is Record<string, unknown> 
   return prototype === Object.prototype;
 };
 
+const setClonedField = (record: Record<string, unknown>, field: string, value: unknown): void => {
+  Object.defineProperty(record, field, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
 export const cloneUnknown = (value: unknown): unknown => {
   if (isBigDecimal(value)) {
     return value;
@@ -41,7 +50,7 @@ export const cloneRecord = (value: Record<string, unknown>): Record<string, unkn
   const cloned: Record<string, unknown> = {};
   for (const key in value) {
     if (Object.hasOwn(value, key)) {
-      cloned[key] = cloneUnknown(value[key]);
+      setClonedField(cloned, key, cloneUnknown(value[key]));
     }
   }
   return cloned;
@@ -52,7 +61,7 @@ export function cloneRow(row: RowObject): RowObject {
   const cloned: Record<string, unknown> = {};
   for (const key in row) {
     if (Object.hasOwn(row, key)) {
-      cloned[key] = cloneUnknown(Reflect.get(row, key));
+      setClonedField(cloned, key, cloneUnknown(Reflect.get(row, key)));
     }
   }
   return cloned;

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -3,9 +3,9 @@
 Production runtime composition for View Server.
 
 This package wires Runtime Core, Effect RPC WebSocket transport, `GET /health`,
-`GET /metrics`, and optional Kafka ingestion. The in-memory engine remains the
-single mutation path; Kafka and future ingress adapters publish into the same
-runtime core used by tests.
+`GET /metrics`, optional Kafka/gRPC ingestion, and optional TCP publish ingress.
+The in-memory engine remains the single mutation path; Kafka, gRPC, TCP, and
+tests publish into the same runtime core.
 
 ## Entrypoint
 
@@ -21,12 +21,15 @@ NodeRuntime.runMain(
   runViewServerRuntime(viewServer, {
     host: "0.0.0.0",
     websocketPort: 8080,
+    tcpPublishHost: "127.0.0.1",
+    tcpPublishPort: 8081,
   }),
 );
 ```
 
-`runViewServerRuntime` logs the WebSocket, health, and metrics URLs when the
-runtime starts and keeps the server alive until the main fiber is interrupted.
+`runViewServerRuntime` logs the WebSocket, health, metrics, and TCP publish URLs
+when those endpoints are configured, then keeps the server alive until the main
+fiber is interrupted.
 
 ## Health
 
@@ -152,6 +155,46 @@ restart from committed offsets can skip rows that existed only in memory.
 Deployments that need rebuild-after-restart semantics must replay Kafka from an
 authoritative position, such as `startFrom: "earliest"` or a fresh/reset
 dedicated rebuild consumer group, until durable checkpoints are added.
+
+## TCP Publish Ingress
+
+`tcpPublishPort` enables a non-browser publisher ingress for systems that need a
+small push path without Kafka or gRPC. The runtime returns `tcpPublishUrl` when
+the endpoint is configured.
+
+TCP publish has its own `tcpPublishHost` and defaults to `127.0.0.1`. It does
+not inherit the public WebSocket/HTTP `host`, so binding the runtime server to
+`0.0.0.0` does not accidentally expose a mutation port. Bind TCP publish to a
+different interface only behind your own network controls.
+
+The protocol is NDJSON over TCP: one JSON command per line and one JSON response
+per line.
+
+Supported commands:
+
+```json
+{ "op": "publish", "topic": "orders", "row": { "id": "o1", "price": 10 } }
+{ "op": "publishMany", "topic": "orders", "rows": [{ "id": "o1", "price": 10 }] }
+{ "op": "patch", "topic": "orders", "key": "o1", "patch": { "price": 20 } }
+{ "op": "delete", "topic": "orders", "key": "o1" }
+```
+
+Responses:
+
+```json
+{ "ok": true }
+{ "ok": false, "error": { "_tag": "ViewServerTcpPublishIngressError", "phase": "decode", "message": "..." } }
+```
+
+Valid TCP publish mutations use the same runtime-core mutation methods as Kafka,
+gRPC, and in-memory tests. Invalid TCP row or patch payloads fail at the TCP
+decode boundary before mutation, so invalid batches do not partially publish.
+
+The endpoint is bounded: excessive connections, oversized lines, and excessive
+queued commands return typed `ViewServerTcpPublishIngressError` responses and
+close or reject the offending socket. TCP publish also refuses Kafka/gRPC-owned
+View Server topics; use it only for topics whose source of truth is the TCP
+publisher.
 
 ## Current Consumer Group Assumption
 

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -17,6 +17,7 @@ import {
   type ViewServerGrpcRuntimeOptions,
   type ViewServerGrpcIngressError,
   type ViewServerKafkaIngressError,
+  type ViewServerTcpPublishIngressError,
   type ViewServerRuntimeOptions,
 } from "./index";
 
@@ -99,6 +100,9 @@ describe("runtime type contracts", () => {
     expectTypeOf(runtime.metricsUrl).toEqualTypeOf<
       ViewServerRuntime<typeof viewServer.topics>["metricsUrl"]
     >();
+    expectTypeOf(runtime.tcpPublishUrl).toEqualTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>["tcpPublishUrl"]
+    >();
     expectTypeOf(runtime.health).toEqualTypeOf<
       ViewServerRuntime<typeof viewServer.topics>["health"]
     >();
@@ -112,6 +116,7 @@ describe("runtime type contracts", () => {
       | ViewServerRuntimeError
       | ViewServerKafkaIngressError
       | ViewServerGrpcIngressError
+      | ViewServerTcpPublishIngressError
     >();
     expectTypeOf<Effect.Success<typeof runtimeWithGroupedAdmissionLimits>>().toMatchTypeOf<
       ViewServerRuntime<typeof viewServer.topics>
@@ -220,8 +225,20 @@ describe("runtime type contracts", () => {
     const invalidOptions = makeViewServerRuntime(viewServer, {
       websocketPort: "8080",
     });
+    const tcpPublishPortOptions = makeViewServerRuntime(viewServer, {
+      tcpPublishMaxConnections: 16,
+      tcpPublishPort: 8081,
+    });
+    expectTypeOf<Effect.Success<typeof tcpPublishPortOptions>>().toMatchTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>
+    >();
+    // @ts-expect-error runtime TCP publish port rejects string ports.
     const invalidTcpPublishPortOptions = makeViewServerRuntime(viewServer, {
-      // @ts-expect-error TCP publish ingress is not wired by the runtime package yet.
+      tcpPublishPort: "8081",
+    });
+    // @ts-expect-error runtime TCP publish connection cap rejects string values.
+    const invalidTcpPublishMaxConnectionsOptions = makeViewServerRuntime(viewServer, {
+      tcpPublishMaxConnections: "16",
       tcpPublishPort: 8081,
     });
     // @ts-expect-error runtime paths must be absolute HTTP paths.
@@ -496,7 +513,6 @@ describe("runtime type contracts", () => {
     expectTypeOf(invalidTopicPublish).not.toBeAny();
     expectTypeOf(invalidSnapshot).not.toBeAny();
     expectTypeOf(invalidOptions).not.toBeAny();
-    expectTypeOf(invalidTcpPublishPortOptions).not.toBeAny();
     expectTypeOf(invalidPathOptions).not.toBeAny();
     expectTypeOf(invalidHealthPathOptions).not.toBeAny();
     expectTypeOf(invalidMetricsPathOptions).not.toBeAny();
@@ -525,9 +541,13 @@ describe("runtime type contracts", () => {
     expectTypeOf(invalidGrpcReconnectMax).not.toBeAny();
     expectTypeOf(invalidGrpcReconnectDelay).not.toBeAny();
     expectTypeOf(invalidGrpcOptionKey).not.toBeAny();
+    expectTypeOf(invalidTcpPublishPortOptions).not.toBeAny();
+    expectTypeOf(invalidTcpPublishMaxConnectionsOptions).not.toBeAny();
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("port");
     expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("path");
-    expectTypeOf<ViewServerRuntimeOptions>().not.toHaveProperty("tcpPublishPort");
+    expectTypeOf<ViewServerRuntimeOptions>().toHaveProperty("tcpPublishMaxConnections");
+    expectTypeOf<ViewServerRuntimeOptions>().toHaveProperty("tcpPublishHost");
+    expectTypeOf<ViewServerRuntimeOptions>().toHaveProperty("tcpPublishPort");
     expectTypeOf<ViewServerRuntimeOptions>().toHaveProperty("grpc");
   });
 });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1344,6 +1344,11 @@ describe("@view-server/runtime", () => {
           topic: "orders",
           row: {
             allocations: {
+              ["__proto__"]: {
+                encodedQuantity: "2002",
+                runtimeAmount: "22.25",
+                runtimeQuantity: "21002",
+              },
               primary: {
                 encodedQuantity: "2001",
                 runtimeAmount: "21.25",
@@ -1431,6 +1436,11 @@ describe("@view-server/runtime", () => {
           key: "a",
           patch: {
             allocations: {
+              ["__proto__"]: {
+                encodedQuantity: "2004",
+                runtimeAmount: "24.25",
+                runtimeQuantity: "21004",
+              },
               primary: {
                 encodedQuantity: "2003",
                 runtimeAmount: "23.25",
@@ -1862,6 +1872,11 @@ describe("@view-server/runtime", () => {
         rows: [
           {
             allocations: {
+              ["__proto__"]: {
+                encodedQuantity: 2004n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("24.25"),
+                runtimeQuantity: 21004n,
+              },
               primary: {
                 encodedQuantity: 2003n,
                 runtimeAmount: BigDecimal.fromStringUnsafe("23.25"),

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -43,6 +43,13 @@ import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
 import { makeViewServerRuntime, runViewServerRuntime } from "./index";
 import { ViewServerKafkaIngressError } from "./kafka-ingress";
 import {
+  installTcpPublishAcceptedSocket,
+  makeViewServerTcpPublishIngress,
+  rejectTcpSocketWhenClosed,
+  ViewServerTcpPublishIngressError,
+  writeTcpJsonLineOrClose,
+} from "./tcp-publish-ingress";
+import {
   resolveViewServerRuntimeOptions,
   validateGrpcSourceFeeds,
   validateSourceOwnership,
@@ -50,6 +57,7 @@ import {
   type ResolvedViewServerKafkaRuntimeOptions,
 } from "./runtime-options";
 import { makeViewServerRuntimeTransportHealth } from "./transport-health";
+import * as Net from "node:net";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -81,10 +89,57 @@ class RuntimeTestFailure extends Schema.TaggedErrorClass<RuntimeTestFailure>()(
   },
 ) {}
 
+class RuntimeTcpTestFailure extends Schema.TaggedErrorClass<RuntimeTcpTestFailure>()(
+  "RuntimeTcpTestFailure",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  },
+) {}
+
+const TcpPublishResponse = Schema.Union([
+  Schema.Struct({
+    ok: Schema.Literal(true),
+  }),
+  Schema.Struct({
+    ok: Schema.Literal(false),
+    error: Schema.Struct({
+      _tag: Schema.String,
+      message: Schema.String,
+      phase: Schema.String,
+      topic: Schema.optional(Schema.String),
+    }),
+  }),
+]);
+
+type TcpPublishResponse = typeof TcpPublishResponse.Type;
+
+const TestTcpAddress = Schema.Struct({
+  address: Schema.String,
+  family: Schema.String,
+  port: Schema.Number,
+});
+
 const viewServer = defineViewServerConfig({
   topics: {
     orders: {
       schema: Order,
+      key: "id",
+    },
+  },
+});
+
+const NestedTcpOrder = Schema.Struct({
+  id: Schema.String,
+  meta: Schema.Struct({
+    desk: Schema.String,
+  }),
+});
+
+const nestedTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: NestedTcpOrder,
       key: "id",
     },
   },
@@ -587,6 +642,187 @@ const fetchText = Effect.fn("ViewServerRuntime.test.text.fetch")(function* (url:
   return { response, text };
 });
 
+const connectTcpPublishSocket = Effect.fn("ViewServerRuntime.test.tcp.connect")(function* (
+  url: string,
+) {
+  const parsedUrl = new URL(url);
+  const port = Number(parsedUrl.port);
+  if (!Number.isSafeInteger(port)) {
+    return yield* new RuntimeTcpTestFailure({
+      message: "TCP publish URL did not include a valid port.",
+      cause: url,
+    });
+  }
+  return yield* Effect.callback<Net.Socket, RuntimeTcpTestFailure>((resume) => {
+    const socket = Net.createConnection({
+      host: parsedUrl.hostname,
+      port,
+    });
+    socket.setEncoding("utf8");
+    socket.once("connect", () => {
+      resume(Effect.succeed(socket));
+    });
+    socket.once("error", (cause) => {
+      resume(
+        Effect.fail(
+          new RuntimeTcpTestFailure({
+            message: "TCP publish socket failed to connect.",
+            cause,
+          }),
+        ),
+      );
+    });
+  });
+});
+
+const readTcpPublishResponse = Effect.fn("ViewServerRuntime.test.tcp.response.read")(function* (
+  socket: Net.Socket,
+) {
+  const line = yield* Effect.callback<string, RuntimeTcpTestFailure>((resume) => {
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex >= 0) {
+        resume(Effect.succeed(buffer.slice(0, newlineIndex)));
+      }
+    });
+    socket.once("error", (cause) => {
+      resume(
+        Effect.fail(
+          new RuntimeTcpTestFailure({
+            message: "TCP publish socket failed while reading response.",
+            cause,
+          }),
+        ),
+      );
+    });
+  });
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(line),
+    catch: (cause) =>
+      new RuntimeTcpTestFailure({
+        message: "TCP publish response was not valid JSON.",
+        cause,
+      }),
+  });
+  return yield* Schema.decodeUnknownEffect(TcpPublishResponse)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new RuntimeTcpTestFailure({
+          message: "TCP publish response did not match the test schema.",
+          cause,
+        }),
+    ),
+  );
+});
+
+const readTcpPublishResponses = Effect.fn("ViewServerRuntime.test.tcp.responses.read")(function* (
+  socket: Net.Socket,
+  count: number,
+) {
+  const lines = yield* Effect.callback<ReadonlyArray<string>, RuntimeTcpTestFailure>((resume) => {
+    let buffer = "";
+    const responses: Array<string> = [];
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        responses.push(buffer.slice(0, newlineIndex));
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf("\n");
+      }
+      if (responses.length === count) {
+        resume(Effect.succeed(responses));
+      }
+    });
+    socket.once("error", (cause) => {
+      resume(
+        Effect.fail(
+          new RuntimeTcpTestFailure({
+            message: "TCP publish socket failed while reading responses.",
+            cause,
+          }),
+        ),
+      );
+    });
+  });
+  return yield* Effect.forEach(lines, (line) =>
+    Effect.try({
+      try: (): unknown => JSON.parse(line),
+      catch: (cause) =>
+        new RuntimeTcpTestFailure({
+          message: "TCP publish response was not valid JSON.",
+          cause,
+        }),
+    }).pipe(
+      Effect.flatMap((value) => Schema.decodeUnknownEffect(TcpPublishResponse)(value)),
+      Effect.mapError(
+        (cause) =>
+          new RuntimeTcpTestFailure({
+            message: "TCP publish response did not match the test schema.",
+            cause,
+          }),
+      ),
+    ),
+  );
+});
+
+const sendTcpPublishLine = Effect.fn("ViewServerRuntime.test.tcp.line.send")(function* (
+  url: string,
+  line: string,
+) {
+  const socket = yield* Effect.acquireRelease(connectTcpPublishSocket(url), (socket) =>
+    Effect.sync(() => socket.destroy()),
+  );
+  socket.write(`${line}\n`);
+  return yield* readTcpPublishResponse(socket).pipe(Effect.timeout("1 second"));
+});
+
+const sendTcpPublishCommand = Effect.fn("ViewServerRuntime.test.tcp.command.send")(function* (
+  url: string,
+  command: object,
+) {
+  return yield* sendTcpPublishLine(url, JSON.stringify(command));
+});
+
+const closeTestTcpServer = (server: Net.Server): Effect.Effect<void> =>
+  Effect.promise(
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  );
+
+const reserveTcpPort = Effect.fn("ViewServerRuntime.test.tcp.port.reserve")(function* () {
+  const server = yield* Effect.callback<Net.Server, RuntimeTcpTestFailure>((resume) => {
+    const nextServer = Net.createServer();
+    nextServer.once("error", (cause) => {
+      resume(
+        Effect.fail(
+          new RuntimeTcpTestFailure({
+            message: "Test TCP server failed to reserve a port.",
+            cause,
+          }),
+        ),
+      );
+    });
+    nextServer.listen({ host: "127.0.0.1", port: 0 }, () => {
+      resume(Effect.succeed(nextServer));
+    });
+  });
+  const address = yield* Schema.decodeUnknownEffect(TestTcpAddress)(server.address()).pipe(
+    Effect.mapError(
+      (cause) =>
+        new RuntimeTcpTestFailure({
+          message: "Test TCP server produced an invalid listen address.",
+          cause,
+        }),
+    ),
+  );
+  return { server, port: address.port };
+});
+
 const waitForTransportHealth = Effect.fn("ViewServerRuntime.test.transportHealth.wait")(function* (
   health: () => Effect.Effect<{ readonly transport: TransportHealth }, unknown>,
   expected: {
@@ -851,6 +1087,1114 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("accepts TCP publish commands through the runtime mutation path", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+      const subscription = yield* runtime.liveClient.subscribe("orders", {
+        select: ["id", "price"],
+        where: {
+          price: { gte: 10 },
+        },
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const responses = [
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: { price: 5 },
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publishMany",
+          topic: "orders",
+          rows: [order("b", 20), order("c", 30)],
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "delete",
+          topic: "orders",
+          key: "b",
+        }),
+      ];
+
+      expect(responses).toStrictEqual([{ ok: true }, { ok: true }, { ok: true }, { ok: true }]);
+
+      const events = yield* Fiber.join(eventsFiber);
+      expect(events).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 0,
+          toVersion: 1,
+          operations: [{ type: "insert", key: "a", row: { id: "a", price: 10 }, index: 0 }],
+          totalRows: 1,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "remove", key: "a" }],
+          totalRows: 0,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            { type: "insert", key: "b", row: { id: "b", price: 20 }, index: 0 },
+            { type: "insert", key: "c", row: { id: "c", price: 30 }, index: 1 },
+          ],
+          totalRows: 2,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 3,
+          toVersion: 4,
+          operations: [{ type: "remove", key: "b" }],
+          totalRows: 1,
+        },
+      ]);
+      yield* subscription.close();
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("rejects invalid TCP publish batches without partial mutation", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const response = yield* sendTcpPublishCommand(tcpPublishUrl, {
+        op: "publishMany",
+        topic: "orders",
+        rows: [order("valid", 10), { id: "invalid", price: "not-a-number" }],
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(response).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish row did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(snapshot).toStrictEqual({
+        rows: [],
+        totalRows: 0,
+        version: 0,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("returns typed TCP publish errors for malformed commands", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const responses = [
+        yield* sendTcpPublishLine(tcpPublishUrl, "{"),
+        yield* sendTcpPublishLine(tcpPublishUrl, JSON.stringify("not-object")),
+        yield* sendTcpPublishLine(tcpPublishUrl, "   \n{}"),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "orders",
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publishMany",
+          topic: "orders",
+          rows: {},
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "patch",
+          topic: "orders",
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "delete",
+          topic: "orders",
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "noop",
+          topic: "orders",
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+          rows: [order("b", 20)],
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+          unknown: true,
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "unknown",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "orders",
+          row: { ...order("a", 10), unknown: true },
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: { unknown: true },
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: { price: "expensive" },
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "delete",
+          topic: "unknown",
+          key: "a",
+        }),
+      ];
+
+      expect(responses).toStrictEqual([
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must be valid JSON.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command must match the publish command schema.",
+            phase: "decode",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish cannot find View Server topic unknown.",
+            phase: "decode",
+            topic: "unknown",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish row did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish patch did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish patch did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish cannot find View Server topic unknown.",
+            phase: "decode",
+            topic: "unknown",
+          },
+        },
+      ]);
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("rejects non-strict TCP publish patch field values at the decode boundary", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(nestedTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const response = yield* sendTcpPublishCommand(tcpPublishUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: { meta: { desk: "LDN", unknown: true } },
+      });
+
+      expect(response).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("rejects invalid TCP publish server options before listening", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        websocketPort: 0,
+      });
+      const invalidOptions = [
+        { port: -1 },
+        { port: 65536 },
+        { port: 1.5 },
+        { port: Number.NaN },
+        { port: Number.POSITIVE_INFINITY },
+        { maxLineBytes: 0, port: 0 },
+        { maxConnections: 0, port: 0 },
+        { maxQueuedCommands: 0, port: 0 },
+        { maxGlobalQueuedCommands: 0, port: 0 },
+      ];
+      const errors = yield* Effect.forEach(invalidOptions, (options) =>
+        makeViewServerTcpPublishIngress(viewServer, runtime.client, options).pipe(Effect.flip),
+      );
+
+      expect(
+        errors.map((error) => ({
+          message: error.message,
+          phase: error.phase,
+        })),
+      ).toStrictEqual([
+        {
+          message: "TCP publish port must be a safe integer between 0 and 65535.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish port must be a safe integer between 0 and 65535.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish port must be a safe integer between 0 and 65535.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish port must be a safe integer between 0 and 65535.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish port must be a safe integer between 0 and 65535.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish maxLineBytes must be a positive safe integer.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish maxConnections must be a positive safe integer.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish maxQueuedCommands must be a positive safe integer.",
+          phase: "configuration",
+        },
+        {
+          message: "TCP publish maxGlobalQueuedCommands must be a positive safe integer.",
+          phase: "configuration",
+        },
+      ]);
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("rejects TCP publish commands for source-owned topics", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        websocketPort: 0,
+      });
+      const ingress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
+        port: 0,
+        rejectedTopics: new Set(["orders"]),
+      });
+
+      const response = yield* sendTcpPublishCommand(ingress.url, {
+        op: "publish",
+        topic: "orders",
+        row: order("a", 10),
+      });
+
+      expect(response).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish cannot mutate source-owned View Server topic orders.",
+          phase: "runtime",
+          topic: "orders",
+        },
+      });
+      yield* ingress.close;
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("passes source-owned topics into TCP publish ingress rejection policy", () =>
+    Effect.gen(function* () {
+      type MixedTopics = typeof grpcAndKafkaViewServer.topics;
+      type RuntimeDependencies = ViewServerRuntimeDependencies<MixedTopics>;
+      const regions = {
+        local: "localhost:9092",
+      };
+      const localKafkaTopic = grpcAndKafkaViewServer.kafkaTopic<typeof regions>();
+      const feed = mixedGrpcFeed.materializedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        request: () => ({ orderId: "all" }),
+        acquire: () => Stream.never,
+        map: ({ value }) => ({
+          id: value.customerId,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: "usa",
+          updatedAt: value.updatedAt,
+        }),
+      });
+      let rejectedTopics: ReadonlyArray<string> = [];
+      const dependencies: RuntimeDependencies = {
+        ...makeDefaultRuntimeDependencies<MixedTopics>(),
+        makeServer: () =>
+          Effect.succeed({
+            url: "ws://127.0.0.1:0/rpc",
+            healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
+            close: Effect.void,
+          }),
+        makeKafkaIngress: () => Effect.succeed({ close: Effect.void }),
+        makeGrpcIngress: () => Effect.succeed({ close: Effect.void }),
+        makeTcpPublishIngress: (_config, _client, options) => {
+          rejectedTopics = Array.from(options.rejectedTopics ?? []);
+          return Effect.succeed({
+            url: "tcp://127.0.0.1:1235",
+            close: Effect.void,
+          });
+        },
+      };
+
+      const runtime = yield* makeViewServerRuntimeWithDependencies(
+        dependencies,
+        grpcAndKafkaViewServer,
+        {
+          host: "127.0.0.1",
+          tcpPublishPort: 1235,
+          kafka: {
+            consumerGroupId: "view-server-tcp-source-owned",
+            regions,
+            topics: {
+              "audit-source": localKafkaTopic({
+                regions: ["local"],
+                value: kafka.json(Order),
+                key: kafka.stringKey(),
+                viewServerTopic: "audit",
+                mapping: ({ key, value }) => ({
+                  id: key,
+                  price: value.price,
+                }),
+              }),
+            },
+          },
+          grpc: {
+            clients: grpcClients,
+            feeds: {
+              ordersFeed: feed,
+            },
+          },
+        },
+      );
+
+      expect({
+        rejectedTopics,
+        tcpPublishUrl: runtime.tcpPublishUrl,
+      }).toStrictEqual({
+        rejectedTopics: ["audit", "orders"],
+        tcpPublishUrl: "tcp://127.0.0.1:1235",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("bounds TCP publish line size and command queue", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        websocketPort: 0,
+      });
+      const rejectedAcceptedSocket = new Net.Socket();
+      installTcpPublishAcceptedSocket(
+        rejectedAcceptedSocket,
+        {
+          activeChains: new Set(),
+          activeFibers: new Set(),
+          closed: true,
+          queuedCommands: 0,
+          socketStates: new Map(),
+          sockets: new Set(),
+        },
+        viewServer,
+        runtime.client,
+        { port: 0 },
+      );
+      const slowPublishStarted = yield* Deferred.make<void>();
+      const slowPublishInterrupted = yield* Deferred.make<void>();
+      const globalPublishStarted = yield* Deferred.make<void>();
+      const globalPublishInterrupted = yield* Deferred.make<void>();
+      const disconnectedPublishStarted = yield* Deferred.make<void>();
+      const disconnectedPublishInterrupted = yield* Deferred.make<void>();
+      const closedQueuePublishStarted = yield* Deferred.make<void>();
+      const closedQueuePublishInterrupted = yield* Deferred.make<void>();
+      const slowPublishClient = Object.create(runtime.client);
+      Object.defineProperty(slowPublishClient, "publish", {
+        value: () =>
+          Deferred.succeed(slowPublishStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Deferred.succeed(slowPublishInterrupted, undefined)),
+          ),
+      });
+      const globalPublishClient = Object.create(runtime.client);
+      Object.defineProperty(globalPublishClient, "publish", {
+        value: () =>
+          Deferred.succeed(globalPublishStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Deferred.succeed(globalPublishInterrupted, undefined)),
+          ),
+      });
+      const disconnectedPublishClient = Object.create(runtime.client);
+      Object.defineProperty(disconnectedPublishClient, "publish", {
+        value: () =>
+          Deferred.succeed(disconnectedPublishStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Deferred.succeed(disconnectedPublishInterrupted, undefined)),
+          ),
+      });
+      const closedQueuePublishClient = Object.create(runtime.client);
+      Object.defineProperty(closedQueuePublishClient, "publish", {
+        value: () =>
+          Deferred.succeed(closedQueuePublishStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Deferred.succeed(closedQueuePublishInterrupted, undefined)),
+          ),
+      });
+      const compactCommandLine = `${JSON.stringify({
+        op: "publish",
+        topic: "orders",
+        row: order("a", 10),
+      })}\n`;
+      const oversizedIngress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
+        maxLineBytes: 8,
+        port: 0,
+      });
+      const oversizedCompleteLineIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        runtime.client,
+        {
+          maxLineBytes: 8,
+          port: 0,
+        },
+      );
+      const coalescedIngress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
+        maxLineBytes: Buffer.byteLength(compactCommandLine, "utf8"),
+        port: 0,
+      });
+      const queuedIngress = yield* makeViewServerTcpPublishIngress(viewServer, slowPublishClient, {
+        maxQueuedCommands: 2,
+        port: 0,
+      });
+      const globalQueuedIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        globalPublishClient,
+        {
+          maxGlobalQueuedCommands: 1,
+          maxQueuedCommands: 2,
+          port: 0,
+        },
+      );
+      const disconnectedIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        disconnectedPublishClient,
+        { port: 0 },
+      );
+      const connectionCappedIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        runtime.client,
+        {
+          maxConnections: 1,
+          port: 0,
+        },
+      );
+      const closedQueueIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        closedQueuePublishClient,
+        {
+          maxQueuedCommands: 1,
+          port: 0,
+        },
+      );
+      const oversizedSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(oversizedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      oversizedSocket.write("this-line-is-too-large");
+      const oversizedResponse = yield* readTcpPublishResponse(oversizedSocket).pipe(
+        Effect.timeout("1 second"),
+      );
+
+      const oversizedCompleteLineSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(oversizedCompleteLineIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      oversizedCompleteLineSocket.write("this-line-is-too-large\n");
+      const oversizedCompleteLineResponse = yield* readTcpPublishResponse(
+        oversizedCompleteLineSocket,
+      ).pipe(Effect.timeout("1 second"));
+
+      const coalescedSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(coalescedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      coalescedSocket.write(`${compactCommandLine}${compactCommandLine}`);
+      const coalescedResponses = yield* readTcpPublishResponses(coalescedSocket, 2).pipe(
+        Effect.timeout("1 second"),
+      );
+
+      const queuedSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(queuedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      const commandLine = `${JSON.stringify({
+        op: "publish",
+        topic: "orders",
+        row: order("a", 10),
+      })}\n`;
+      queuedSocket.write(commandLine);
+      yield* Deferred.await(slowPublishStarted);
+      queuedSocket.write(commandLine);
+      queuedSocket.write(commandLine);
+      const queuedResponse = yield* readTcpPublishResponse(queuedSocket).pipe(
+        Effect.timeout("1 second"),
+      );
+
+      const globalQueuedFirstSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(globalQueuedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      const globalQueuedSecondSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(globalQueuedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      globalQueuedFirstSocket.write(commandLine);
+      yield* Deferred.await(globalPublishStarted);
+      globalQueuedSecondSocket.write(commandLine);
+      const globalQueuedResponse = yield* readTcpPublishResponse(globalQueuedSecondSocket).pipe(
+        Effect.timeout("1 second"),
+      );
+
+      const disconnectedSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(disconnectedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      disconnectedSocket.write(commandLine);
+      yield* Deferred.await(disconnectedPublishStarted);
+      disconnectedSocket.destroy();
+      yield* Deferred.await(disconnectedPublishInterrupted).pipe(Effect.timeout("1 second"));
+
+      const closedQueueSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(closedQueueIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      closedQueueSocket.write(`${commandLine}${commandLine}${commandLine}`);
+      const closedQueueResponse = yield* readTcpPublishResponse(closedQueueSocket).pipe(
+        Effect.timeout("1 second"),
+      );
+
+      const heldConnectionCappedSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(connectionCappedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      const rejectedConnectionCappedSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(connectionCappedIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      const connectionCappedResponse = yield* readTcpPublishResponse(
+        rejectedConnectionCappedSocket,
+      ).pipe(Effect.timeout("1 second"));
+      yield* Effect.sleep("10 millis");
+
+      expect(oversizedResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish command exceeded 8 bytes without a newline.",
+          phase: "backpressure",
+        },
+      });
+      expect(oversizedCompleteLineResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish command exceeded 8 bytes.",
+          phase: "backpressure",
+        },
+      });
+      expect(coalescedResponses).toStrictEqual([{ ok: true }, { ok: true }]);
+      expect(queuedResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish command queue exceeded 2 commands.",
+          phase: "backpressure",
+        },
+      });
+      expect(globalQueuedResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish global command queue exceeded 1 commands.",
+          phase: "backpressure",
+        },
+      });
+      expect(closedQueueResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish command queue exceeded 1 commands.",
+          phase: "backpressure",
+        },
+      });
+      expect(connectionCappedResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish connection count exceeded 1 sockets.",
+          phase: "backpressure",
+        },
+      });
+      expect(rejectedConnectionCappedSocket.destroyed).toBe(true);
+      expect(rejectedAcceptedSocket.destroyed).toBe(true);
+
+      heldConnectionCappedSocket.destroy();
+      yield* connectionCappedIngress.close;
+      yield* closedQueueIngress.close.pipe(Effect.timeout("1 second"));
+      yield* disconnectedIngress.close;
+      yield* globalQueuedIngress.close.pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(globalPublishInterrupted);
+      yield* queuedIngress.close.pipe(Effect.timeout("1 second"));
+      yield* queuedIngress.close.pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(slowPublishInterrupted);
+      yield* coalescedIngress.close;
+      yield* oversizedCompleteLineIngress.close;
+      yield* oversizedIngress.close;
+      yield* oversizedIngress.close;
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("closes TCP writers and rejected accepted sockets through deterministic internals", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        websocketPort: 0,
+      });
+      const endedChunks: Array<string | undefined> = [];
+      const destroyed: Array<"socket"> = [];
+      const closedServerState = {
+        activeChains: new Set<Promise<void>>(),
+        activeFibers: new Set<Fiber.Fiber<void, never>>(),
+        closed: false,
+        queuedCommands: 0,
+        socketStates: new Map(),
+        sockets: new Set<Net.Socket>(),
+      };
+      const ignoredAfterCloseSocket = new Net.Socket();
+      const state = {
+        activeFibers: new Set<Fiber.Fiber<void, never>>(),
+        buffer: "",
+        chain: Promise.resolve(),
+        closed: false,
+        queuedCommands: 0,
+      };
+
+      writeTcpJsonLineOrClose(
+        () => false,
+        () => {
+          endedChunks.push(undefined);
+        },
+        state,
+        { ok: true },
+      );
+      const acceptedWhileClosed = rejectTcpSocketWhenClosed(true, {
+        destroy: () => {
+          destroyed.push("socket");
+        },
+      });
+      const acceptedWhileOpen = rejectTcpSocketWhenClosed(false, {
+        destroy: () => {
+          destroyed.push("socket");
+        },
+      });
+      installTcpPublishAcceptedSocket(
+        ignoredAfterCloseSocket,
+        closedServerState,
+        viewServer,
+        runtime.client,
+        { port: 0 },
+      );
+      closedServerState.closed = true;
+      ignoredAfterCloseSocket.emit("data", "ignored\n");
+      ignoredAfterCloseSocket.destroy();
+
+      expect({
+        acceptedWhileClosed,
+        acceptedWhileOpen,
+        destroyed,
+        endedChunks,
+        ignoredAfterCloseQueuedCommands: closedServerState.queuedCommands,
+        stateClosed: state.closed,
+      }).toStrictEqual({
+        acceptedWhileClosed: true,
+        acceptedWhileOpen: false,
+        destroyed: ["socket"],
+        endedChunks: [undefined],
+        ignoredAfterCloseQueuedCommands: 0,
+        stateClosed: true,
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("returns typed TCP publish errors for malformed runtime clients", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        websocketPort: 0,
+      });
+      const missingPublishClient = Object.create(runtime.client);
+      Object.defineProperty(missingPublishClient, "publish", {
+        value: undefined,
+      });
+      const nonEffectPublishClient = Object.create(runtime.client);
+      Object.defineProperty(nonEffectPublishClient, "publish", {
+        value: () => "not-an-effect",
+      });
+      const defectPublishClient = Object.create(runtime.client);
+      Object.defineProperty(defectPublishClient, "publish", {
+        value: () => Effect.die("tcp publish defect"),
+      });
+      const failingPublishClient = Object.create(runtime.client);
+      Object.defineProperty(failingPublishClient, "publish", {
+        value: () =>
+          Effect.fail(
+            new RuntimeTcpTestFailure({
+              cause: "typed runtime failure",
+              message: "typed runtime publish failure",
+            }),
+          ),
+      });
+      const missingPublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        missingPublishClient,
+        { port: 0 },
+      );
+      const nonEffectPublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        nonEffectPublishClient,
+        { port: 0 },
+      );
+      const defectPublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        defectPublishClient,
+        { port: 0 },
+      );
+      const failingPublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        failingPublishClient,
+        { port: 0 },
+      );
+
+      const responses = [
+        yield* sendTcpPublishCommand(missingPublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(nonEffectPublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(defectPublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(failingPublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+      ];
+
+      expect(responses).toStrictEqual([
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "Runtime publish did not return an Effect for TCP publish topic orders.",
+            phase: "runtime",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "Runtime publish did not return an Effect for TCP publish topic orders.",
+            phase: "runtime",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish command failed with an untyped cause.",
+            phase: "runtime",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish runtime publish failed for topic orders.",
+            phase: "runtime",
+            topic: "orders",
+          },
+        },
+      ]);
+
+      yield* failingPublishIngress.close;
+      yield* defectPublishIngress.close;
+      yield* nonEffectPublishIngress.close;
+      yield* missingPublishIngress.close;
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("fails startup when the TCP publish port is already bound", () =>
+    Effect.gen(function* () {
+      const reserved = yield* Effect.acquireRelease(reserveTcpPort(), ({ server }) =>
+        closeTestTcpServer(server),
+      );
+      const exit = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: reserved.port,
+        websocketPort: 0,
+      }).pipe(Effect.exit);
+
+      expect(
+        Exit.isFailure(exit)
+          ? Option.match(Cause.findErrorOption(exit.cause), {
+              onNone: () => null,
+              onSome: (error) => ({
+                message: error instanceof Error ? error.message : undefined,
+                phase: error instanceof ViewServerTcpPublishIngressError ? error.phase : undefined,
+                tag: error instanceof ViewServerTcpPublishIngressError ? error._tag : undefined,
+              }),
+            })
+          : null,
+      ).toStrictEqual({
+        message: "TCP publish server failed to listen.",
+        phase: "listen",
+        tag: "ViewServerTcpPublishIngressError",
+      });
+    }),
+  );
+
+  it.live("closes the TCP publish endpoint with runtime shutdown", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+      const response = yield* sendTcpPublishCommand(tcpPublishUrl, {
+        op: "publish",
+        topic: "orders",
+        row: order("a", 10),
+      });
+
+      expect(response).toStrictEqual({ ok: true });
+
+      const heldSocket = yield* connectTcpPublishSocket(tcpPublishUrl);
+      yield* runtime.close;
+      heldSocket.destroy();
+      const connectExit = yield* connectTcpPublishSocket(tcpPublishUrl).pipe(Effect.exit);
+      expect(Exit.isFailure(connectExit)).toBe(true);
+    }),
+  );
+
   it.live("supports default paths and queue capacity options", () =>
     Effect.gen(function* () {
       const defaultRuntime = yield* makeViewServerRuntime(viewServer);
@@ -862,11 +2206,14 @@ describe("@view-server/runtime", () => {
 
       const configuredRuntime = yield* makeViewServerRuntime(viewServer, {
         websocketPort: 0,
+        tcpPublishPort: 0,
         subscriptionQueueCapacity: 1,
       });
       expect(configuredRuntime.url.endsWith("/rpc")).toBe(true);
       expect(configuredRuntime.healthUrl.endsWith("/health")).toBe(true);
       expect(configuredRuntime.metricsUrl.endsWith("/metrics")).toBe(true);
+      const configuredTcpPublishUrl = yield* Effect.fromNullishOr(configuredRuntime.tcpPublishUrl);
+      expect(configuredTcpPublishUrl.startsWith("tcp://")).toBe(true);
       yield* configuredRuntime.close;
     }),
   );
@@ -943,6 +2290,9 @@ describe("@view-server/runtime", () => {
       let runtimeCoreOptions: Parameters<RuntimeDependencies["makeRuntimeCore"]>[1] | undefined;
       let serverInput: Parameters<RuntimeDependencies["makeServer"]>[1] | undefined;
       let serverOptions: Parameters<RuntimeDependencies["makeServer"]>[2] | undefined;
+      let tcpPublishOptions:
+        | Parameters<RuntimeDependencies["makeTcpPublishIngress"]>[2]
+        | undefined;
       const dependencies: RuntimeDependencies = {
         ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
         makeRuntimeCore: (config, options) => {
@@ -959,6 +2309,13 @@ describe("@view-server/runtime", () => {
             close: Effect.void,
           });
         },
+        makeTcpPublishIngress: (_config, _client, options) => {
+          tcpPublishOptions = options;
+          return Effect.succeed({
+            url: `tcp://${options.host ?? "127.0.0.1"}:${options.port}`,
+            close: Effect.void,
+          });
+        },
       };
 
       const runtime = yield* makeViewServerRuntimeWithDependencies(dependencies, viewServer, {
@@ -967,6 +2324,9 @@ describe("@view-server/runtime", () => {
         },
         host: "0.0.0.0",
         websocketPort: 1234,
+        tcpPublishHost: "127.0.0.1",
+        tcpPublishMaxConnections: 9,
+        tcpPublishPort: 1235,
         rpcPath: "/custom-rpc",
         healthPath: "/custom-health",
         metricsPath: "/custom-metrics",
@@ -986,6 +2346,8 @@ describe("@view-server/runtime", () => {
           streamClosedType: typeof serverInput?.transport?.streamClosed,
         },
         serverOptions,
+        tcpPublishOptions,
+        tcpPublishUrl: runtime.tcpPublishUrl,
       }).toStrictEqual({
         runtimeCoreOptions: {
           subscriptionQueueCapacity: 7,
@@ -1007,6 +2369,13 @@ describe("@view-server/runtime", () => {
           healthPath: "/custom-health",
           metricsPath: "/custom-metrics",
         },
+        tcpPublishOptions: {
+          host: "127.0.0.1",
+          maxConnections: 9,
+          port: 1235,
+          rejectedTopics: new Set(),
+        },
+        tcpPublishUrl: "tcp://127.0.0.1:1235",
       });
       yield* runtime.close;
     }),
@@ -9157,6 +10526,7 @@ describe("@view-server/runtime", () => {
     Effect.gen(function* () {
       const fiber = yield* runViewServerRuntime(viewServer, {
         host: "127.0.0.1",
+        tcpPublishPort: 0,
         websocketPort: 0,
       }).pipe(Effect.forkChild({ startImmediately: true }));
 

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -46,8 +46,9 @@ import {
   installTcpPublishAcceptedSocket,
   makeViewServerTcpPublishIngress,
   rejectTcpSocketWhenClosed,
+  tcpPublishUrl,
   ViewServerTcpPublishIngressError,
-  writeTcpJsonLineOrClose,
+  writeTcpJsonLine,
 } from "./tcp-publish-ingress";
 import {
   resolveViewServerRuntimeOptions,
@@ -105,8 +106,9 @@ const TcpPublishResponse = Schema.Union([
     ok: Schema.Literal(false),
     error: Schema.Struct({
       _tag: Schema.String,
+      code: Schema.optional(Schema.String),
       message: Schema.String,
-      phase: Schema.String,
+      phase: Schema.optional(Schema.String),
       topic: Schema.optional(Schema.String),
     }),
   }),
@@ -140,6 +142,20 @@ const nestedTcpViewServer = defineViewServerConfig({
   topics: {
     orders: {
       schema: NestedTcpOrder,
+      key: "id",
+    },
+  },
+});
+
+const TransformTcpOrder = Schema.Struct({
+  id: Schema.String,
+  quantity: Schema.BigIntFromString,
+});
+
+const transformTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: TransformTcpOrder,
       key: "id",
     },
   },
@@ -642,6 +658,9 @@ const fetchText = Effect.fn("ViewServerRuntime.test.text.fetch")(function* (url:
   return { response, text };
 });
 
+const tcpUrlConnectHost = (hostname: string): string =>
+  hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+
 const connectTcpPublishSocket = Effect.fn("ViewServerRuntime.test.tcp.connect")(function* (
   url: string,
 ) {
@@ -655,7 +674,7 @@ const connectTcpPublishSocket = Effect.fn("ViewServerRuntime.test.tcp.connect")(
   }
   return yield* Effect.callback<Net.Socket, RuntimeTcpTestFailure>((resume) => {
     const socket = Net.createConnection({
-      host: parsedUrl.hostname,
+      host: tcpUrlConnectHost(parsedUrl.hostname),
       port,
     });
     socket.setEncoding("utf8");
@@ -1191,6 +1210,86 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("passes TCP JSON rows to runtime core without double-decoding transform schemas", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(transformTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const responses = [
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publish",
+          topic: "orders",
+          row: { id: "a", quantity: "9007199254740993" },
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: { quantity: "9007199254740995" },
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publishMany",
+          topic: "orders",
+          rows: [{ id: "b", quantity: "9007199254740997" }],
+        }),
+      ];
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "quantity"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(responses).toStrictEqual([{ ok: true }, { ok: true }, { ok: true }]);
+      expect(snapshot).toStrictEqual({
+        rows: [
+          { id: "a", quantity: 9007199254740995n },
+          { id: "b", quantity: 9007199254740997n },
+        ],
+        totalRows: 2,
+        version: 3,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("returns a usable bracketed TCP publish URL for IPv6 hosts", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        tcpPublishHost: "::1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+      const response = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "publish",
+        topic: "orders",
+        row: order("ipv6", 42),
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price"],
+        limit: 10,
+      });
+
+      expect(tcpUrl.startsWith("tcp://[")).toBe(true);
+      expect(tcpUrl.includes("]:")).toBe(true);
+      expect(response).toStrictEqual({ ok: true });
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "ipv6", price: 42 }],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
   it.live("rejects invalid TCP publish batches without partial mutation", () =>
     Effect.gen(function* () {
       const runtime = yield* makeViewServerRuntime(viewServer, {
@@ -1226,6 +1325,35 @@ describe("@view-server/runtime", () => {
         version: 0,
         status: "ready",
         statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("preserves runtime error codes in TCP publish responses", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const response = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "missing",
+        patch: { price: 11 },
+      });
+
+      expect(response).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidRow",
+          message: "Cannot patch missing key: missing",
+          topic: "orders",
+        },
       });
       yield* runtime.close;
     }),
@@ -1930,6 +2058,8 @@ describe("@view-server/runtime", () => {
           phase: "backpressure",
         },
       });
+      expect(oversizedSocket.destroyed).toBe(true);
+      expect(oversizedCompleteLineSocket.destroyed).toBe(true);
       expect(rejectedConnectionCappedSocket.destroyed).toBe(true);
       expect(rejectedAcceptedSocket.destroyed).toBe(true);
 
@@ -1950,14 +2080,16 @@ describe("@view-server/runtime", () => {
     }),
   );
 
-  it.live("closes TCP writers and rejected accepted sockets through deterministic internals", () =>
+  it.live("keeps TCP response backpressure non-fatal through deterministic internals", () =>
     Effect.gen(function* () {
       const runtime = yield* makeViewServerRuntime(viewServer, {
         host: "127.0.0.1",
         websocketPort: 0,
       });
-      const endedChunks: Array<string | undefined> = [];
+      const writtenChunks: Array<string> = [];
       const destroyed: Array<"socket"> = [];
+      const listeners: Partial<Record<"close" | "error", () => void>> = {};
+      let writeCallback: () => void = () => undefined;
       const closedServerState = {
         activeChains: new Set<Promise<void>>(),
         activeFibers: new Set<Fiber.Fiber<void, never>>(),
@@ -1975,13 +2107,54 @@ describe("@view-server/runtime", () => {
         queuedCommands: 0,
       };
 
-      writeTcpJsonLineOrClose(
-        () => false,
-        () => {
-          endedChunks.push(undefined);
+      const pendingWrite = writeTcpJsonLine(
+        {
+          destroyed: false,
+          off: (event) => {
+            delete listeners[event];
+            return new Net.Socket();
+          },
+          once: (event, listener) => {
+            listeners[event] = () => listener();
+            return new Net.Socket();
+          },
+          write: (chunk, callback) => {
+            writtenChunks.push(chunk);
+            writeCallback = callback;
+            return false;
+          },
         },
         state,
         { ok: true },
+      );
+      yield* Effect.promise(() => Promise.resolve());
+      expect({
+        listenerNames: Object.keys(listeners),
+        stateClosed: state.closed,
+        writtenChunks,
+      }).toStrictEqual({
+        listenerNames: ["close", "error"],
+        stateClosed: false,
+        writtenChunks: ['{"ok":true}\n'],
+      });
+      writeCallback();
+      writeCallback();
+      yield* Effect.promise(() => pendingWrite);
+      yield* Effect.promise(() =>
+        writeTcpJsonLine(
+          {
+            destroyed: true,
+            off: () => new Net.Socket(),
+            once: () => new Net.Socket(),
+            write: (chunk, callback) => {
+              writtenChunks.push(chunk);
+              callback();
+              return true;
+            },
+          },
+          state,
+          { ok: false },
+        ),
       );
       const acceptedWhileClosed = rejectTcpSocketWhenClosed(true, {
         destroy: () => {
@@ -2008,16 +2181,18 @@ describe("@view-server/runtime", () => {
         acceptedWhileClosed,
         acceptedWhileOpen,
         destroyed,
-        endedChunks,
         ignoredAfterCloseQueuedCommands: closedServerState.queuedCommands,
+        listenerNames: Object.keys(listeners),
         stateClosed: state.closed,
+        writtenChunks,
       }).toStrictEqual({
         acceptedWhileClosed: true,
         acceptedWhileOpen: false,
         destroyed: ["socket"],
-        endedChunks: [undefined],
         ignoredAfterCloseQueuedCommands: 0,
-        stateClosed: true,
+        listenerNames: [],
+        stateClosed: false,
+        writtenChunks: ['{"ok":true}\n'],
       });
       yield* runtime.close;
     }),
@@ -2051,6 +2226,19 @@ describe("@view-server/runtime", () => {
             }),
           ),
       });
+      const stringFailingPublishClient = Object.create(runtime.client);
+      Object.defineProperty(stringFailingPublishClient, "publish", {
+        value: () => Effect.fail("string runtime failure"),
+      });
+      const unavailablePublishClient = Object.create(runtime.client);
+      Object.defineProperty(unavailablePublishClient, "publish", {
+        value: () =>
+          Effect.fail({
+            _tag: "ViewServerRuntimeError",
+            code: "RuntimeUnavailable",
+            message: "runtime unavailable for tcp test",
+          } satisfies ViewServerRuntimeError),
+      });
       const missingPublishIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
         missingPublishClient,
@@ -2071,6 +2259,16 @@ describe("@view-server/runtime", () => {
         failingPublishClient,
         { port: 0 },
       );
+      const stringFailingPublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        stringFailingPublishClient,
+        { port: 0 },
+      );
+      const unavailablePublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        unavailablePublishClient,
+        { port: 0 },
+      );
 
       const responses = [
         yield* sendTcpPublishCommand(missingPublishIngress.url, {
@@ -2089,6 +2287,16 @@ describe("@view-server/runtime", () => {
           row: order("a", 10),
         }),
         yield* sendTcpPublishCommand(failingPublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(stringFailingPublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(unavailablePublishIngress.url, {
           op: "publish",
           topic: "orders",
           row: order("a", 10),
@@ -2131,8 +2339,27 @@ describe("@view-server/runtime", () => {
             topic: "orders",
           },
         },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish runtime publish failed for topic orders.",
+            phase: "runtime",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerRuntimeError",
+            code: "RuntimeUnavailable",
+            message: "runtime unavailable for tcp test",
+          },
+        },
       ]);
 
+      yield* unavailablePublishIngress.close;
+      yield* stringFailingPublishIngress.close;
       yield* failingPublishIngress.close;
       yield* defectPublishIngress.close;
       yield* nonEffectPublishIngress.close;
@@ -2214,6 +2441,11 @@ describe("@view-server/runtime", () => {
       expect(configuredRuntime.metricsUrl.endsWith("/metrics")).toBe(true);
       const configuredTcpPublishUrl = yield* Effect.fromNullishOr(configuredRuntime.tcpPublishUrl);
       expect(configuredTcpPublishUrl.startsWith("tcp://")).toBe(true);
+      expect([
+        tcpPublishUrl({ address: "127.0.0.1", port: 1234 }),
+        tcpPublishUrl({ address: "::1", port: 1234 }),
+        tcpPublishUrl({ address: "::", port: 1234 }),
+      ]).toStrictEqual(["tcp://127.0.0.1:1234", "tcp://[::1]:1234", "tcp://[::]:1234"]);
       yield* configuredRuntime.close;
     }),
   );

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -44,6 +44,7 @@ import { makeViewServerRuntime, runViewServerRuntime } from "./index";
 import { ViewServerKafkaIngressError } from "./kafka-ingress";
 import {
   installTcpPublishAcceptedSocket,
+  installTcpServerSteadyStateErrorHandler,
   makeViewServerTcpPublishIngress,
   rejectTcpSocketWhenClosed,
   tcpPublishUrl,
@@ -1429,6 +1430,10 @@ describe("@view-server/runtime", () => {
           key: "a",
           patch: { unknown: true },
         }),
+        yield* sendTcpPublishLine(
+          tcpPublishUrl,
+          `{"op":"patch","topic":"orders","key":"a","patch":{"constructor":10}}\n`,
+        ),
         yield* sendTcpPublishCommand(tcpPublishUrl, {
           op: "patch",
           topic: "orders",
@@ -1553,6 +1558,15 @@ describe("@view-server/runtime", () => {
           error: {
             _tag: "ViewServerTcpPublishIngressError",
             message: "TCP publish row did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish patch did not match View Server topic orders.",
             phase: "decode",
             topic: "orders",
           },
@@ -2365,6 +2379,31 @@ describe("@view-server/runtime", () => {
       yield* nonEffectPublishIngress.close;
       yield* missingPublishIngress.close;
       yield* runtime.close;
+    }),
+  );
+
+  it.live("closes TCP publish servers on steady-state server errors", () =>
+    Effect.gen(function* () {
+      const closed = yield* Deferred.make<void>();
+      const server = new Net.Server();
+      const listenerCountBefore = server.listenerCount("error");
+      installTcpServerSteadyStateErrorHandler(
+        server,
+        Deferred.succeed(closed, undefined).pipe(Effect.asVoid),
+      );
+      const listenerCountAfter = server.listenerCount("error");
+
+      server.emit("error", new Error("tcp test steady-state failure"));
+      yield* Deferred.await(closed).pipe(Effect.timeout("1 second"));
+
+      expect({
+        listenerCountAfter,
+        listenerCountBefore,
+      }).toStrictEqual({
+        listenerCountAfter: 1,
+        listenerCountBefore: 0,
+      });
+      yield* Effect.sync(() => server.removeAllListeners());
     }),
   );
 

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -162,6 +162,76 @@ const transformTcpViewServer = defineViewServerConfig({
   },
 });
 
+const JsonCodecTcpNested = Schema.Struct({
+  encodedQuantity: Schema.BigIntFromString,
+  runtimeAmount: Schema.BigDecimal,
+  runtimeQuantity: Schema.optionalKey(Schema.BigInt),
+});
+
+const JsonCodecTcpOrder = Schema.Struct({
+  allocations: Schema.Record(Schema.String, JsonCodecTcpNested).check(Schema.isMinProperties(1)),
+  fills: Schema.Array(JsonCodecTcpNested).check(Schema.isMinLength(1)),
+  id: Schema.String,
+  amount: Schema.BigDecimal,
+  checkedOptionalMeta: Schema.optionalKey(JsonCodecTcpNested).check(Schema.isMaxProperties(0)),
+  checkedSuspendedMeta: Schema.optionalKey(
+    Schema.suspend(() => JsonCodecTcpNested).check(Schema.isMaxProperties(0)),
+  ),
+  meta: JsonCodecTcpNested,
+  nullableMeta: Schema.NullOr(JsonCodecTcpNested),
+  optionalMeta: Schema.optionalKey(JsonCodecTcpNested),
+  optionalValueMeta: Schema.optional(JsonCodecTcpNested),
+  quantity: Schema.BigInt,
+  suspendedMeta: Schema.suspend(() => JsonCodecTcpNested),
+  tuple: Schema.Tuple([JsonCodecTcpNested]),
+  tupleRest: Schema.TupleWithRest(Schema.Tuple([JsonCodecTcpNested]), [JsonCodecTcpNested]),
+  tupleRestTrailing: Schema.TupleWithRest(Schema.Tuple([JsonCodecTcpNested]), [
+    JsonCodecTcpNested,
+    JsonCodecTcpNested,
+  ]),
+  unionMeta: Schema.Union([JsonCodecTcpNested, Schema.Undefined]),
+});
+
+const jsonCodecTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: JsonCodecTcpOrder,
+      key: "id",
+    },
+  },
+});
+
+type JsonCodecTcpRecursiveNode = {
+  readonly id: bigint;
+  readonly amount: BigDecimal.BigDecimal;
+  readonly runtimeQuantity: bigint;
+  readonly child: JsonCodecTcpRecursiveNode | null;
+};
+
+const JsonCodecTcpRecursiveNode: Schema.Codec<JsonCodecTcpRecursiveNode, unknown, never, never> =
+  Schema.suspend(
+    (): Schema.Codec<JsonCodecTcpRecursiveNode, unknown, never, never> =>
+      Schema.Struct({
+        id: Schema.BigIntFromString,
+        amount: Schema.BigDecimal,
+        runtimeQuantity: Schema.BigInt,
+        child: Schema.NullOr(JsonCodecTcpRecursiveNode),
+      }),
+  );
+const JsonCodecTcpRecursiveOrder = Schema.Struct({
+  id: Schema.String,
+  node: JsonCodecTcpRecursiveNode,
+});
+
+const jsonCodecTcpRecursiveViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: JsonCodecTcpRecursiveOrder,
+      key: "id",
+    },
+  },
+});
+
 type OrderRow = typeof Order.Type;
 
 type GrpcOrderValueMessage = Message<"viewserver.runtime.OrderValue"> & {
@@ -1259,6 +1329,768 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("decodes TCP rows and patches through topic JSON codecs before publishing", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(jsonCodecTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const responses = [
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publish",
+          topic: "orders",
+          row: {
+            allocations: {
+              primary: {
+                encodedQuantity: "2001",
+                runtimeAmount: "21.25",
+                runtimeQuantity: "21001",
+              },
+            },
+            fills: [
+              {
+                encodedQuantity: "3001",
+                runtimeAmount: "31.25",
+                runtimeQuantity: "31001",
+              },
+            ],
+            id: "a",
+            amount: "123.45",
+            meta: {
+              encodedQuantity: "1001",
+              runtimeAmount: "11.25",
+              runtimeQuantity: "11001",
+            },
+            nullableMeta: {
+              encodedQuantity: "7001",
+              runtimeAmount: "71.25",
+            },
+            optionalMeta: {
+              encodedQuantity: "8001",
+              runtimeAmount: "81.25",
+            },
+            optionalValueMeta: {
+              encodedQuantity: "9001",
+              runtimeAmount: "91.25",
+            },
+            quantity: "9007199254740993",
+            suspendedMeta: {
+              encodedQuantity: "11001",
+              runtimeAmount: "111.25",
+              runtimeQuantity: "111001",
+            },
+            tuple: [
+              {
+                encodedQuantity: "4001",
+                runtimeAmount: "41.25",
+                runtimeQuantity: "41001",
+              },
+            ],
+            tupleRest: [
+              {
+                encodedQuantity: "5001",
+                runtimeAmount: "51.25",
+                runtimeQuantity: "51001",
+              },
+              {
+                encodedQuantity: "5002",
+                runtimeAmount: "52.25",
+                runtimeQuantity: "51002",
+              },
+            ],
+            tupleRestTrailing: [
+              {
+                encodedQuantity: "6001",
+                runtimeAmount: "61.25",
+                runtimeQuantity: "61001",
+              },
+              {
+                encodedQuantity: "6002",
+                runtimeAmount: "62.25",
+                runtimeQuantity: "61002",
+              },
+              {
+                encodedQuantity: "6003",
+                runtimeAmount: "63.25",
+                runtimeQuantity: "61003",
+              },
+            ],
+            unionMeta: {
+              encodedQuantity: "10001",
+              runtimeAmount: "101.25",
+              runtimeQuantity: "101001",
+            },
+          },
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: {
+            allocations: {
+              primary: {
+                encodedQuantity: "2003",
+                runtimeAmount: "23.25",
+                runtimeQuantity: "21003",
+              },
+            },
+            amount: "678.90",
+            fills: [
+              {
+                encodedQuantity: "3003",
+                runtimeAmount: "33.25",
+                runtimeQuantity: "31003",
+              },
+            ],
+            meta: {
+              encodedQuantity: "1003",
+              runtimeAmount: "33.75",
+              runtimeQuantity: "11003",
+            },
+            nullableMeta: {
+              encodedQuantity: "7003",
+              runtimeAmount: "73.25",
+            },
+            optionalMeta: {
+              encodedQuantity: "8003",
+              runtimeAmount: "83.25",
+            },
+            optionalValueMeta: {
+              encodedQuantity: "9003",
+              runtimeAmount: "93.25",
+            },
+            quantity: "9007199254740995",
+            suspendedMeta: {
+              encodedQuantity: "11003",
+              runtimeAmount: "113.25",
+              runtimeQuantity: "111003",
+            },
+            tuple: [
+              {
+                encodedQuantity: "4003",
+                runtimeAmount: "43.25",
+                runtimeQuantity: "41003",
+              },
+            ],
+            tupleRest: [
+              {
+                encodedQuantity: "5003",
+                runtimeAmount: "53.25",
+                runtimeQuantity: "51003",
+              },
+              {
+                encodedQuantity: "5004",
+                runtimeAmount: "54.25",
+                runtimeQuantity: "51004",
+              },
+            ],
+            tupleRestTrailing: [
+              {
+                encodedQuantity: "6003",
+                runtimeAmount: "63.25",
+                runtimeQuantity: "61003",
+              },
+              {
+                encodedQuantity: "6004",
+                runtimeAmount: "64.25",
+                runtimeQuantity: "61004",
+              },
+              {
+                encodedQuantity: "6005",
+                runtimeAmount: "65.25",
+                runtimeQuantity: "61005",
+              },
+            ],
+            unionMeta: {
+              encodedQuantity: "10003",
+              runtimeAmount: "103.25",
+              runtimeQuantity: "101003",
+            },
+          },
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publishMany",
+          topic: "orders",
+          rows: [
+            {
+              allocations: {
+                primary: {
+                  encodedQuantity: "2005",
+                  runtimeAmount: "25.25",
+                },
+              },
+              fills: [
+                {
+                  encodedQuantity: "3005",
+                  runtimeAmount: "35.25",
+                },
+              ],
+              id: "b",
+              amount: "42.25",
+              meta: {
+                encodedQuantity: "1005",
+                runtimeAmount: "55.50",
+                runtimeQuantity: "11005",
+              },
+              nullableMeta: null,
+              optionalMeta: {
+                encodedQuantity: "8005",
+                runtimeAmount: "85.25",
+              },
+              optionalValueMeta: {
+                encodedQuantity: "9005",
+                runtimeAmount: "95.25",
+              },
+              quantity: "9007199254740997",
+              suspendedMeta: {
+                encodedQuantity: "11005",
+                runtimeAmount: "115.25",
+              },
+              tuple: [
+                {
+                  encodedQuantity: "4005",
+                  runtimeAmount: "45.25",
+                },
+              ],
+              tupleRest: [
+                {
+                  encodedQuantity: "5005",
+                  runtimeAmount: "55.25",
+                },
+                {
+                  encodedQuantity: "5006",
+                  runtimeAmount: "56.25",
+                },
+              ],
+              tupleRestTrailing: [
+                {
+                  encodedQuantity: "6005",
+                  runtimeAmount: "65.25",
+                },
+                {
+                  encodedQuantity: "6006",
+                  runtimeAmount: "66.25",
+                },
+                {
+                  encodedQuantity: "6007",
+                  runtimeAmount: "67.25",
+                },
+              ],
+              unionMeta: {
+                encodedQuantity: "10005",
+                runtimeAmount: "105.25",
+              },
+            },
+          ],
+        }),
+      ];
+      const invalidNestedResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          meta: {
+            encodedQuantity: "1007",
+          },
+        },
+      });
+      const invalidNullNestedResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          meta: null,
+        },
+      });
+      const invalidArrayResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          fills: [],
+        },
+      });
+      const invalidRecordResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          allocations: {},
+        },
+      });
+      const invalidTupleResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          tuple: [],
+        },
+      });
+      const invalidTupleExtraResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          tuple: [
+            {
+              encodedQuantity: "4007",
+              runtimeAmount: "47.25",
+              runtimeQuantity: "41007",
+            },
+            {
+              encodedQuantity: "4008",
+              runtimeAmount: "48.25",
+              runtimeQuantity: "41008",
+            },
+          ],
+        },
+      });
+      const invalidTupleRestResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          tupleRest: [],
+        },
+      });
+      const invalidOptionalWrapperResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          optionalMeta: {
+            encodedQuantity: "8007",
+          },
+        },
+      });
+      const invalidNullableWrapperResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          nullableMeta: {
+            encodedQuantity: "7007",
+          },
+        },
+      });
+      const invalidUnionWrapperResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          unionMeta: {
+            encodedQuantity: "10007",
+          },
+        },
+      });
+      const invalidCheckedWrapperResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          checkedOptionalMeta: {
+            encodedQuantity: "11007",
+            runtimeAmount: "111.25",
+          },
+        },
+      });
+      const invalidSuspendedWrapperResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          suspendedMeta: {
+            encodedQuantity: "11009",
+          },
+        },
+      });
+      const invalidCheckedSuspendedWrapperResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: {
+          checkedSuspendedMeta: {
+            encodedQuantity: "12009",
+            runtimeAmount: "129.25",
+            runtimeQuantity: "121009",
+          },
+        },
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: [
+          "allocations",
+          "amount",
+          "fills",
+          "id",
+          "meta",
+          "nullableMeta",
+          "optionalMeta",
+          "optionalValueMeta",
+          "quantity",
+          "suspendedMeta",
+          "tuple",
+          "tupleRest",
+          "tupleRestTrailing",
+          "unionMeta",
+        ],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(responses).toStrictEqual([{ ok: true }, { ok: true }, { ok: true }]);
+      expect(invalidNestedResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidNullNestedResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidArrayResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidRecordResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidTupleResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidTupleExtraResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidTupleRestResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidOptionalWrapperResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidNullableWrapperResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidUnionWrapperResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidCheckedWrapperResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidSuspendedWrapperResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(invalidCheckedSuspendedWrapperResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerTcpPublishIngressError",
+          message: "TCP publish patch did not match View Server topic orders.",
+          phase: "decode",
+          topic: "orders",
+        },
+      });
+      expect(snapshot).toStrictEqual({
+        rows: [
+          {
+            allocations: {
+              primary: {
+                encodedQuantity: 2003n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("23.25"),
+                runtimeQuantity: 21003n,
+              },
+            },
+            id: "a",
+            amount: BigDecimal.fromStringUnsafe("678.90"),
+            fills: [
+              {
+                encodedQuantity: 3003n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("33.25"),
+                runtimeQuantity: 31003n,
+              },
+            ],
+            meta: {
+              encodedQuantity: 1003n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("33.75"),
+              runtimeQuantity: 11003n,
+            },
+            nullableMeta: {
+              encodedQuantity: 7003n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("73.25"),
+            },
+            optionalMeta: {
+              encodedQuantity: 8003n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("83.25"),
+            },
+            optionalValueMeta: {
+              encodedQuantity: 9003n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("93.25"),
+            },
+            quantity: 9007199254740995n,
+            suspendedMeta: {
+              encodedQuantity: 11003n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("113.25"),
+              runtimeQuantity: 111003n,
+            },
+            tuple: [
+              {
+                encodedQuantity: 4003n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("43.25"),
+                runtimeQuantity: 41003n,
+              },
+            ],
+            tupleRest: [
+              {
+                encodedQuantity: 5003n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("53.25"),
+                runtimeQuantity: 51003n,
+              },
+              {
+                encodedQuantity: 5004n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("54.25"),
+                runtimeQuantity: 51004n,
+              },
+            ],
+            tupleRestTrailing: [
+              {
+                encodedQuantity: 6003n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("63.25"),
+                runtimeQuantity: 61003n,
+              },
+              {
+                encodedQuantity: 6004n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("64.25"),
+                runtimeQuantity: 61004n,
+              },
+              {
+                encodedQuantity: 6005n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("65.25"),
+                runtimeQuantity: 61005n,
+              },
+            ],
+            unionMeta: {
+              encodedQuantity: 10003n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("103.25"),
+              runtimeQuantity: 101003n,
+            },
+          },
+          {
+            allocations: {
+              primary: {
+                encodedQuantity: 2005n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("25.25"),
+              },
+            },
+            id: "b",
+            amount: BigDecimal.fromStringUnsafe("42.25"),
+            fills: [
+              {
+                encodedQuantity: 3005n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("35.25"),
+              },
+            ],
+            meta: {
+              encodedQuantity: 1005n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("55.50"),
+              runtimeQuantity: 11005n,
+            },
+            nullableMeta: null,
+            optionalMeta: {
+              encodedQuantity: 8005n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("85.25"),
+            },
+            optionalValueMeta: {
+              encodedQuantity: 9005n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("95.25"),
+            },
+            quantity: 9007199254740997n,
+            suspendedMeta: {
+              encodedQuantity: 11005n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("115.25"),
+            },
+            tuple: [
+              {
+                encodedQuantity: 4005n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("45.25"),
+              },
+            ],
+            tupleRest: [
+              {
+                encodedQuantity: 5005n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("55.25"),
+              },
+              {
+                encodedQuantity: 5006n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("56.25"),
+              },
+            ],
+            tupleRestTrailing: [
+              {
+                encodedQuantity: 6005n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("65.25"),
+              },
+              {
+                encodedQuantity: 6006n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("66.25"),
+              },
+              {
+                encodedQuantity: 6007n,
+                runtimeAmount: BigDecimal.fromStringUnsafe("67.25"),
+              },
+            ],
+            unionMeta: {
+              encodedQuantity: 10005n,
+              runtimeAmount: BigDecimal.fromStringUnsafe("105.25"),
+            },
+          },
+        ],
+        totalRows: 2,
+        version: 3,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("decodes recursive suspended TCP rows through topic JSON codecs", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(jsonCodecTcpRecursiveViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const response = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "publish",
+        topic: "orders",
+        row: {
+          id: "recursive",
+          node: {
+            id: "1",
+            amount: "10.25",
+            runtimeQuantity: "9007199254740993",
+            child: {
+              id: "2",
+              amount: "20.25",
+              runtimeQuantity: "9007199254740995",
+              child: {
+                id: "3",
+                amount: "30.25",
+                runtimeQuantity: "9007199254740997",
+                child: null,
+              },
+            },
+          },
+        },
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "node"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(response).toStrictEqual({ ok: true });
+      expect(snapshot).toStrictEqual({
+        rows: [
+          {
+            id: "recursive",
+            node: {
+              id: 1n,
+              amount: BigDecimal.fromStringUnsafe("10.25"),
+              runtimeQuantity: 9007199254740993n,
+              child: {
+                id: 2n,
+                amount: BigDecimal.fromStringUnsafe("20.25"),
+                runtimeQuantity: 9007199254740995n,
+                child: {
+                  id: 3n,
+                  amount: BigDecimal.fromStringUnsafe("30.25"),
+                  runtimeQuantity: 9007199254740997n,
+                  child: null,
+                },
+              },
+            },
+          },
+        ],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
   it.live("returns a usable bracketed TCP publish URL for IPv6 hosts", () =>
     Effect.gen(function* () {
       const runtime = yield* makeViewServerRuntime(viewServer, {
@@ -1425,6 +2257,11 @@ describe("@view-server/runtime", () => {
           row: { ...order("a", 10), unknown: true },
         }),
         yield* sendTcpPublishCommand(tcpPublishUrl, {
+          op: "publish",
+          topic: "orders",
+          row: { id: "missing-price" },
+        }),
+        yield* sendTcpPublishCommand(tcpPublishUrl, {
           op: "patch",
           topic: "orders",
           key: "a",
@@ -1551,6 +2388,15 @@ describe("@view-server/runtime", () => {
             message: "TCP publish cannot find View Server topic unknown.",
             phase: "decode",
             topic: "unknown",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish row did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
           },
         },
         {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,6 +3,7 @@ import { Config, Effect } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
 import type { ViewServerGrpcIngressError } from "./grpc-ingress";
 import type { ViewServerKafkaIngressError } from "./kafka-ingress";
+import type { ViewServerTcpPublishIngressError } from "./tcp-publish-ingress";
 import {
   makeDefaultRuntimeDependencies,
   makeViewServerRuntimeWithDependencies,
@@ -22,6 +23,7 @@ export type {
 };
 export type { ViewServerKafkaIngressError };
 export type { ViewServerGrpcIngressError };
+export type { ViewServerTcpPublishIngressError } from "./tcp-publish-ingress";
 
 export const makeViewServerRuntime: <
   const Topics extends ViewServerRuntimeTopicDefinitions,
@@ -36,6 +38,7 @@ export const makeViewServerRuntime: <
   | ViewServerRuntimeError
   | ViewServerKafkaIngressError
   | ViewServerGrpcIngressError
+  | ViewServerTcpPublishIngressError
 > = Effect.fn("ViewServerRuntime.make")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
   const Options extends object,
@@ -64,6 +67,7 @@ export const runViewServerRuntime: <
   | ViewServerRuntimeError
   | ViewServerKafkaIngressError
   | ViewServerGrpcIngressError
+  | ViewServerTcpPublishIngressError
 > = Effect.fn("ViewServerRuntime.run")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
   const Options extends object,

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -16,6 +16,7 @@ import {
 } from "./runtime-dependencies";
 import type { ViewServerKafkaIngressError } from "./kafka-ingress";
 import type { ViewServerGrpcIngressError } from "./grpc-ingress";
+import type { ViewServerTcpPublishIngressError } from "./tcp-publish-ingress";
 import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
 import {
   resolveViewServerRuntimeOptions,
@@ -72,7 +73,8 @@ type ViewServerRuntimeFactoryError =
   | Config.ConfigError
   | ViewServerRuntimeError
   | ViewServerKafkaIngressError
-  | ViewServerGrpcIngressError;
+  | ViewServerGrpcIngressError
+  | ViewServerTcpPublishIngressError;
 
 type MakeViewServerRuntimeWithDependencies = {
   <const Topics extends ViewServerRuntimeTopicDefinitions>(
@@ -169,6 +171,28 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
   const runtimeClient = grpcLeaseManager?.client ?? runtimeCore.client;
   const closeGrpcLeaseManager =
     grpcLeaseManager === undefined ? Effect.void : grpcLeaseManager.close;
+  const sourceOwnedTopics = new Set<string>();
+  for (const kafkaTopic of Object.values(kafkaOptions?.topics ?? {})) {
+    sourceOwnedTopics.add(kafkaTopic.viewServerTopic);
+  }
+  for (const grpcFeed of Object.values(grpcOptions?.feeds ?? {})) {
+    sourceOwnedTopics.add(grpcFeed.topic);
+  }
+  const tcpPublishIngress =
+    resolvedOptions.tcpPublishOptions === undefined
+      ? undefined
+      : yield* dependencies
+          .makeTcpPublishIngress(config, runtimeClient, {
+            ...resolvedOptions.tcpPublishOptions,
+            rejectedTopics: sourceOwnedTopics,
+          })
+          .pipe(
+            Effect.onExit((exit) =>
+              Exit.isFailure(exit)
+                ? closeGrpcLeaseManager.pipe(Effect.ensuring(runtimeCore.close))
+                : Effect.void,
+            ),
+          );
   const server = yield* dependencies
     .makeServer(
       config,
@@ -187,7 +211,10 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
     .pipe(
       Effect.onExit((exit) =>
         Exit.isFailure(exit)
-          ? closeGrpcLeaseManager.pipe(Effect.ensuring(runtimeCore.close))
+          ? (tcpPublishIngress?.close ?? Effect.void).pipe(
+              Effect.ensuring(closeGrpcLeaseManager),
+              Effect.ensuring(runtimeCore.close),
+            )
           : Effect.void,
       ),
     );
@@ -205,7 +232,8 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
           .pipe(
             Effect.onExit((exit) =>
               Exit.isFailure(exit)
-                ? server.close.pipe(
+                ? (tcpPublishIngress?.close ?? Effect.void).pipe(
+                    Effect.ensuring(server.close),
                     Effect.ensuring(closeGrpcLeaseManager),
                     Effect.ensuring(runtimeCore.close),
                   )
@@ -226,7 +254,8 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
           .pipe(
             Effect.onExit((exit) =>
               Exit.isFailure(exit)
-                ? (kafkaIngress?.close ?? Effect.void).pipe(
+                ? (tcpPublishIngress?.close ?? Effect.void).pipe(
+                    Effect.ensuring(kafkaIngress?.close ?? Effect.void),
                     Effect.ensuring(closeGrpcLeaseManager),
                     Effect.ensuring(server.close),
                     Effect.ensuring(runtimeCore.close),
@@ -238,7 +267,10 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
     grpcIngress === undefined ? Effect.void : grpcIngress.close;
   const closeKafkaIngress: Effect.Effect<void> =
     kafkaIngress === undefined ? Effect.void : kafkaIngress.close;
-  const close: Effect.Effect<void> = closeGrpcIngress.pipe(
+  const closeTcpPublishIngress: Effect.Effect<void> =
+    tcpPublishIngress === undefined ? Effect.void : tcpPublishIngress.close;
+  const close: Effect.Effect<void> = closeTcpPublishIngress.pipe(
+    Effect.ensuring(closeGrpcIngress),
     Effect.ensuring(closeGrpcLeaseManager),
     Effect.ensuring(closeKafkaIngress),
     Effect.ensuring(server.close),
@@ -249,6 +281,7 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
     url: server.url,
     healthUrl: server.healthUrl,
     metricsUrl: server.metricsUrl,
+    ...(tcpPublishIngress === undefined ? {} : { tcpPublishUrl: tcpPublishIngress.url }),
     client: runtimeClient,
     liveClient: publicLiveClient,
     health: runtimeClient.health,
@@ -262,6 +295,9 @@ const logRuntimeStarted = Effect.fn("ViewServerRuntime.logStarted")(function* <
   yield* Effect.logInfo(`View Server WebSocket listening at ${runtime.url}`);
   yield* Effect.logInfo(`View Server health endpoint listening at ${runtime.healthUrl}`);
   yield* Effect.logInfo(`View Server metrics endpoint listening at ${runtime.metricsUrl}`);
+  if (runtime.tcpPublishUrl !== undefined) {
+    yield* Effect.logInfo(`View Server TCP publish endpoint listening at ${runtime.tcpPublishUrl}`);
+  }
 });
 
 const makeViewServerRuntimeLaunchLayer = <

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -30,6 +30,12 @@ import {
   type ViewServerKafkaIngress,
   type ViewServerKafkaIngressError,
 } from "./kafka-ingress";
+import {
+  makeViewServerTcpPublishIngress,
+  type ViewServerTcpPublishIngress,
+  type ViewServerTcpPublishIngressError,
+  type ViewServerTcpPublishIngressOptions,
+} from "./tcp-publish-ingress";
 import type {
   ResolvedViewServerGrpcRuntimeOptions,
   ResolvedViewServerKafkaRuntimeOptions,
@@ -61,6 +67,11 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
     options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
     health: ViewServerKafkaHealthLedger<Topics>,
   ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError>;
+  readonly makeTcpPublishIngress: (
+    config: ViewServerConfig<Topics>,
+    client: ViewServerRuntimeClient<Topics>,
+    options: ViewServerTcpPublishIngressOptions,
+  ) => Effect.Effect<ViewServerTcpPublishIngress, ViewServerTcpPublishIngressError>;
   readonly makeGrpcIngress: <const Clients extends GrpcRuntimeClients>(
     config: ViewServerConfig<Topics>,
     client: ViewServerRuntimeClient<Topics>,
@@ -106,5 +117,6 @@ export const makeDefaultRuntimeDependencies = <
       ),
     }),
   makeKafkaIngress: makeViewServerKafkaIngress,
+  makeTcpPublishIngress: makeViewServerTcpPublishIngress,
   makeGrpcIngress: makeViewServerGrpcIngress,
 });

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -25,6 +25,11 @@ export type ResolvedViewServerRuntimeOptions<
 > = {
   readonly runtimeCoreOptions: ViewServerRuntimeCoreOptionsFor<Topics>;
   readonly serverOptions: ViewServerWebSocketServerOptions;
+  readonly tcpPublishOptions?: {
+    readonly host?: string;
+    readonly maxConnections?: number;
+    readonly port: number;
+  };
   readonly kafkaOptions?: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>;
   readonly grpcOptions?: ResolvedViewServerGrpcRuntimeOptions<Topics, GrpcClients>;
 };
@@ -394,6 +399,16 @@ export const resolveViewServerRuntimeOptions: <
     ...(options.healthPath === undefined ? {} : { healthPath: options.healthPath }),
     ...(options.metricsPath === undefined ? {} : { metricsPath: options.metricsPath }),
   };
+  const tcpPublishOptions =
+    options.tcpPublishPort === undefined
+      ? undefined
+      : {
+          ...(options.tcpPublishHost === undefined ? {} : { host: options.tcpPublishHost }),
+          ...(options.tcpPublishMaxConnections === undefined
+            ? {}
+            : { maxConnections: options.tcpPublishMaxConnections }),
+          port: options.tcpPublishPort,
+        };
   const kafkaOptions =
     options.kafka === undefined ? undefined : yield* resolveKafkaOptions(options.kafka);
   const grpcOptions =
@@ -402,6 +417,7 @@ export const resolveViewServerRuntimeOptions: <
   return {
     runtimeCoreOptions,
     serverOptions,
+    ...(tcpPublishOptions === undefined ? {} : { tcpPublishOptions }),
     ...(kafkaOptions === undefined ? {} : { kafkaOptions }),
     ...(grpcOptions === undefined ? {} : { grpcOptions }),
   };

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -62,6 +62,9 @@ export type ViewServerRuntimeOptions<
 > = {
   readonly host?: string;
   readonly websocketPort?: number;
+  readonly tcpPublishHost?: string;
+  readonly tcpPublishMaxConnections?: number;
+  readonly tcpPublishPort?: number;
   readonly rpcPath?: RuntimeHttpPath;
   readonly healthPath?: RuntimeHttpPath;
   readonly metricsPath?: RuntimeHttpPath;
@@ -281,6 +284,7 @@ export type ViewServerRuntime<Topics extends ViewServerRuntimeTopicDefinitions> 
   readonly url: string;
   readonly healthUrl: string;
   readonly metricsUrl: string;
+  readonly tcpPublishUrl?: string;
   readonly client: ViewServerPublicRuntimeClient<Topics>;
   readonly liveClient: ViewServerLiveClient<Topics>;
   readonly health: () => Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>;

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -1,4 +1,9 @@
-import type { RowSchema, ViewServerConfig, ViewServerRuntimeClient } from "@view-server/config";
+import type {
+  RowSchema,
+  ViewServerConfig,
+  ViewServerRuntimeClient,
+  ViewServerRuntimeError,
+} from "@view-server/config";
 import { Cause, Effect, Exit, Fiber, Result, Schema } from "effect";
 import * as Net from "node:net";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
@@ -29,6 +34,7 @@ export type ViewServerTcpPublishIngress = {
 };
 
 type RuntimeMutationEffect = Effect.Effect<unknown, unknown, never>;
+type TcpPublishCommandError = ViewServerRuntimeError | ViewServerTcpPublishIngressError;
 
 const TcpAddress = Schema.Struct({
   address: Schema.String,
@@ -63,7 +69,7 @@ const TcpPublishCommandSchema = Schema.Union([
 ]);
 
 type TcpPublishSocketState = {
-  readonly activeFibers: Set<Fiber.Fiber<void, ViewServerTcpPublishIngressError>>;
+  readonly activeFibers: Set<Fiber.Fiber<void, TcpPublishCommandError>>;
   buffer: string;
   closed: boolean;
   queuedCommands: number;
@@ -73,7 +79,7 @@ type TcpPublishSocketState = {
 type TcpPublishServerState = {
   readonly activeChains: Set<Promise<void>>;
   closed: boolean;
-  readonly activeFibers: Set<Fiber.Fiber<void, ViewServerTcpPublishIngressError>>;
+  readonly activeFibers: Set<Fiber.Fiber<void, TcpPublishCommandError>>;
   queuedCommands: number;
   readonly socketStates: Map<Net.Socket, TcpPublishSocketState>;
   readonly sockets: Set<Net.Socket>;
@@ -81,6 +87,13 @@ type TcpPublishServerState = {
 
 type TcpDestroyableSocket = {
   readonly destroy: () => void;
+};
+
+type TcpResponseSocket = {
+  readonly destroyed: boolean;
+  readonly off: (event: "close" | "error", listener: () => void) => unknown;
+  readonly once: (event: "close" | "error", listener: () => void) => unknown;
+  readonly write: (chunk: string, callback: () => void) => boolean;
 };
 
 const defaultMaxLineBytes = 1024 * 1024;
@@ -97,6 +110,20 @@ const isTopicDefinitionWithSchema = (value: unknown): value is { readonly schema
 
 const isRuntimeMutationEffect = (value: unknown): value is RuntimeMutationEffect =>
   Effect.isEffect(value);
+
+const isViewServerRuntimeError = (value: unknown): value is ViewServerRuntimeError => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const tag = Reflect.get(value, "_tag");
+  const code = Reflect.get(value, "code");
+  const message = Reflect.get(value, "message");
+  return (
+    (tag === "ViewServerRuntimeError" || tag === "ViewServerBackpressureError") &&
+    typeof code === "string" &&
+    typeof message === "string"
+  );
+};
 
 const tcpDecodeError = (line: string, cause: unknown): ViewServerTcpPublishIngressError =>
   new ViewServerTcpPublishIngressError({
@@ -159,13 +186,15 @@ const runRuntimeMutation = Effect.fn("ViewServerRuntime.tcpPublish.runtime.mutat
   yield* effect.pipe(
     Effect.asVoid,
     Effect.mapError(
-      (cause) =>
-        new ViewServerTcpPublishIngressError({
-          message: `TCP publish runtime ${method} failed for topic ${topic}.`,
-          cause,
-          phase: "runtime",
-          topic,
-        }),
+      (cause): TcpPublishCommandError =>
+        isViewServerRuntimeError(cause)
+          ? cause
+          : new ViewServerTcpPublishIngressError({
+              message: `TCP publish runtime ${method} failed for topic ${topic}.`,
+              cause,
+              phase: "runtime",
+              topic,
+            }),
     ),
   );
 });
@@ -191,7 +220,8 @@ const validateTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.validate")(fu
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(config: ViewServerConfig<Topics>, topic: string, row: unknown) {
   const schema = yield* topicSchema(config, topic);
-  return yield* Schema.decodeUnknownEffect(schema)(row, strictParseOptions).pipe(
+  yield* Schema.decodeUnknownEffect(schema)(row, strictParseOptions).pipe(
+    Effect.asVoid,
     Effect.mapError(
       (cause) =>
         new ViewServerTcpPublishIngressError({
@@ -207,14 +237,13 @@ const validateTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.validate")(fu
 const validateTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.validate")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(config: ViewServerConfig<Topics>, topic: string, rows: ReadonlyArray<unknown>) {
-  return yield* Effect.forEach(rows, (row) => validateTcpRow(config, topic, row));
+  yield* Effect.forEach(rows, (row) => validateTcpRow(config, topic, row), { discard: true });
 });
 
 const validateTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.validate")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(config: ViewServerConfig<Topics>, topic: string, patch: Record<string, unknown>) {
   const schema = yield* topicSchema(config, topic);
-  const decodedPatch: Record<string, unknown> = {};
   for (const [field, value] of Object.entries(patch)) {
     const fieldSchema = schema.fields[field];
     if (fieldSchema === undefined) {
@@ -225,10 +254,8 @@ const validateTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.validate"
         topic,
       });
     }
-    decodedPatch[field] = yield* Schema.decodeUnknownEffect(fieldSchema)(
-      value,
-      strictParseOptions,
-    ).pipe(
+    yield* Schema.decodeUnknownEffect(fieldSchema)(value, strictParseOptions).pipe(
+      Effect.asVoid,
       Effect.mapError(
         (cause) =>
           new ViewServerTcpPublishIngressError({
@@ -240,7 +267,6 @@ const validateTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.validate"
       ),
     );
   }
-  return decodedPatch;
 });
 
 const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(function* <
@@ -254,18 +280,22 @@ const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(f
   const command = yield* parseCommand(line);
   yield* ensureTopicCanBeMutated(command.topic, options);
   if (command.op === "publish") {
-    const row = yield* validateTcpRow(config, command.topic, command.row);
-    yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, row]);
+    yield* validateTcpRow(config, command.topic, command.row);
+    yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, command.row]);
     return;
   }
   if (command.op === "publishMany") {
-    const rows = yield* validateTcpRows(config, command.topic, command.rows);
-    yield* runRuntimeMutation(client, "publishMany", command.topic, [command.topic, rows]);
+    yield* validateTcpRows(config, command.topic, command.rows);
+    yield* runRuntimeMutation(client, "publishMany", command.topic, [command.topic, command.rows]);
     return;
   }
   if (command.op === "patch") {
-    const patch = yield* validateTcpPatch(config, command.topic, command.patch);
-    yield* runRuntimeMutation(client, "patch", command.topic, [command.topic, command.key, patch]);
+    yield* validateTcpPatch(config, command.topic, command.patch);
+    yield* runRuntimeMutation(client, "patch", command.topic, [
+      command.topic,
+      command.key,
+      command.patch,
+    ]);
     return;
   }
   yield* topicSchema(config, command.topic);
@@ -287,9 +317,20 @@ const ensureTopicCanBeMutated = (
       )
     : Effect.void;
 
-const wireError = (cause: Cause.Cause<ViewServerTcpPublishIngressError>): object => {
+const wireError = (cause: Cause.Cause<TcpPublishCommandError>): object => {
   const failure = Cause.findErrorOption(cause);
   if (failure._tag === "Some") {
+    if (isViewServerRuntimeError(failure.value)) {
+      return {
+        ok: false,
+        error: {
+          _tag: failure.value._tag,
+          code: failure.value.code,
+          message: failure.value.message,
+          ...(failure.value.topic === undefined ? {} : { topic: failure.value.topic }),
+        },
+      };
+    }
     return {
       ok: false,
       error: {
@@ -321,21 +362,35 @@ const endTcpError = (
 ): void => {
   state.closed = true;
   interruptSocketFibers(state);
-  socket.end(jsonLine(tcpErrorPayload(error)));
+  socket.setTimeout(rejectedSocketDestroyTimeoutMs);
+  socket.once("timeout", socket.destroy.bind(socket));
+  socket.end(jsonLine(tcpErrorPayload(error)), socket.destroy.bind(socket));
 };
 
 /** @internal Package-local test hook; not exported from @view-server/runtime. */
-export const writeTcpJsonLineOrClose = (
-  write: (chunk: string) => boolean,
-  end: () => void,
+export const writeTcpJsonLine = (
+  socket: TcpResponseSocket,
   state: TcpPublishSocketState,
   value: object,
-): void => {
-  if (!write(jsonLine(value))) {
-    state.closed = true;
-    interruptSocketFibers(state);
-    end();
+): Promise<void> => {
+  if (state.closed || socket.destroyed) {
+    return Promise.resolve();
   }
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.off("close", settle);
+      socket.off("error", settle);
+      resolve();
+    };
+    socket.once("close", settle);
+    socket.once("error", settle);
+    socket.write(jsonLine(value), settle);
+  });
 };
 
 /** @internal Package-local test hook; not exported from @view-server/runtime. */
@@ -433,24 +488,23 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
       return;
     }
     if (Exit.isSuccess(exit)) {
-      writeTcpJsonLineOrClose(
-        socket.write.bind(socket),
-        socket.end.bind(socket),
-        state,
-        wireSuccess(),
-      );
+      await writeTcpJsonLine(socket, state, wireSuccess());
       return;
     }
-    writeTcpJsonLineOrClose(
-      socket.write.bind(socket),
-      socket.end.bind(socket),
-      state,
-      wireError(exit.cause),
-    );
+    await writeTcpJsonLine(socket, state, wireError(exit.cause));
   } finally {
     state.queuedCommands -= 1;
     serverState.queuedCommands -= 1;
   }
+};
+
+/** @internal Package-local test hook; not exported from @view-server/runtime. */
+export const tcpPublishUrl = (address: {
+  readonly address: string;
+  readonly port: number;
+}): string => {
+  const host = address.address.includes(":") ? `[${address.address}]` : address.address;
+  return `tcp://${host}:${address.port}`;
 };
 
 const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
@@ -693,7 +747,7 @@ export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpP
     });
     const address = Schema.decodeUnknownSync(TcpAddress)(server.address());
     return {
-      url: `tcp://${address.address}:${address.port}`,
+      url: tcpPublishUrl(address),
       close: closeTcpServer(server, state),
     };
   },

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -1,0 +1,700 @@
+import type { RowSchema, ViewServerConfig, ViewServerRuntimeClient } from "@view-server/config";
+import { Cause, Effect, Exit, Fiber, Result, Schema } from "effect";
+import * as Net from "node:net";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+export class ViewServerTcpPublishIngressError extends Schema.TaggedErrorClass<ViewServerTcpPublishIngressError>()(
+  "ViewServerTcpPublishIngressError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+    phase: Schema.Literals(["configuration", "listen", "decode", "runtime", "backpressure"]),
+    topic: Schema.optional(Schema.String),
+  },
+) {}
+
+export type ViewServerTcpPublishIngressOptions = {
+  readonly host?: string;
+  readonly maxConnections?: number;
+  readonly maxGlobalQueuedCommands?: number;
+  readonly maxLineBytes?: number;
+  readonly maxQueuedCommands?: number;
+  readonly port: number;
+  readonly rejectedTopics?: ReadonlySet<string>;
+};
+
+export type ViewServerTcpPublishIngress = {
+  readonly url: string;
+  readonly close: Effect.Effect<void>;
+};
+
+type RuntimeMutationEffect = Effect.Effect<unknown, unknown, never>;
+
+const TcpAddress = Schema.Struct({
+  address: Schema.String,
+  family: Schema.String,
+  port: Schema.Number,
+});
+
+const TcpJsonObject = Schema.Record(Schema.String, Schema.Json);
+
+const TcpPublishCommandSchema = Schema.Union([
+  Schema.Struct({
+    op: Schema.Literal("publish"),
+    topic: Schema.String,
+    row: TcpJsonObject,
+  }),
+  Schema.Struct({
+    op: Schema.Literal("publishMany"),
+    topic: Schema.String,
+    rows: Schema.Array(TcpJsonObject),
+  }),
+  Schema.Struct({
+    op: Schema.Literal("patch"),
+    topic: Schema.String,
+    key: Schema.String,
+    patch: TcpJsonObject,
+  }),
+  Schema.Struct({
+    op: Schema.Literal("delete"),
+    topic: Schema.String,
+    key: Schema.String,
+  }),
+]);
+
+type TcpPublishSocketState = {
+  readonly activeFibers: Set<Fiber.Fiber<void, ViewServerTcpPublishIngressError>>;
+  buffer: string;
+  closed: boolean;
+  queuedCommands: number;
+  chain: Promise<void>;
+};
+
+type TcpPublishServerState = {
+  readonly activeChains: Set<Promise<void>>;
+  closed: boolean;
+  readonly activeFibers: Set<Fiber.Fiber<void, ViewServerTcpPublishIngressError>>;
+  queuedCommands: number;
+  readonly socketStates: Map<Net.Socket, TcpPublishSocketState>;
+  readonly sockets: Set<Net.Socket>;
+};
+
+type TcpDestroyableSocket = {
+  readonly destroy: () => void;
+};
+
+const defaultMaxLineBytes = 1024 * 1024;
+const defaultMaxConnections = 1024;
+const defaultMaxGlobalQueuedCommands = 1024;
+const defaultMaxQueuedCommands = 1024;
+const rejectedSocketDestroyTimeoutMs = 1_000;
+const strictParseOptions = {
+  onExcessProperty: "error",
+} as const;
+
+const isTopicDefinitionWithSchema = (value: unknown): value is { readonly schema: RowSchema } =>
+  typeof value === "object" && value !== null && Schema.isSchema(Reflect.get(value, "schema"));
+
+const isRuntimeMutationEffect = (value: unknown): value is RuntimeMutationEffect =>
+  Effect.isEffect(value);
+
+const tcpDecodeError = (line: string, cause: unknown): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: "TCP publish command must be valid JSON.",
+    cause: { cause, line },
+    phase: "decode",
+  });
+
+const parseCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.parse")(function* (
+  line: string,
+) {
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(line),
+    catch: (cause) => tcpDecodeError(line, cause),
+  });
+  return yield* Result.match(
+    Schema.decodeUnknownResult(TcpPublishCommandSchema)(value, strictParseOptions),
+    {
+      onSuccess: Effect.succeed,
+      onFailure: (cause) =>
+        Effect.fail(
+          new ViewServerTcpPublishIngressError({
+            message: "TCP publish command must match the publish command schema.",
+            cause,
+            phase: "decode",
+          }),
+        ),
+    },
+  );
+});
+
+const runtimeCallFailed = (
+  method: string,
+  topic: string,
+  cause: unknown,
+): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `Runtime ${method} did not return an Effect for TCP publish topic ${topic}.`,
+    cause,
+    phase: "runtime",
+    topic,
+  });
+
+const runRuntimeMutation = Effect.fn("ViewServerRuntime.tcpPublish.runtime.mutate")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  client: ViewServerRuntimeClient<Topics>,
+  method: "delete" | "patch" | "publish" | "publishMany",
+  topic: string,
+  args: ReadonlyArray<unknown>,
+) {
+  const fn = Reflect.get(client, method);
+  if (typeof fn !== "function") {
+    return yield* runtimeCallFailed(method, topic, fn);
+  }
+  const effect = Reflect.apply(fn, client, args);
+  if (!isRuntimeMutationEffect(effect)) {
+    return yield* runtimeCallFailed(method, topic, effect);
+  }
+  yield* effect.pipe(
+    Effect.asVoid,
+    Effect.mapError(
+      (cause) =>
+        new ViewServerTcpPublishIngressError({
+          message: `TCP publish runtime ${method} failed for topic ${topic}.`,
+          cause,
+          phase: "runtime",
+          topic,
+        }),
+    ),
+  );
+});
+
+const topicSchema = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: ViewServerConfig<Topics>,
+  topic: string,
+): Effect.Effect<RowSchema, ViewServerTcpPublishIngressError> => {
+  const topicDefinition = Reflect.get(config.topics, topic);
+  return isTopicDefinitionWithSchema(topicDefinition)
+    ? Effect.succeed(topicDefinition.schema)
+    : Effect.fail(
+        new ViewServerTcpPublishIngressError({
+          message: `TCP publish cannot find View Server topic ${topic}.`,
+          cause: topic,
+          phase: "decode",
+          topic,
+        }),
+      );
+};
+
+const validateTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.validate")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(config: ViewServerConfig<Topics>, topic: string, row: unknown) {
+  const schema = yield* topicSchema(config, topic);
+  return yield* Schema.decodeUnknownEffect(schema)(row, strictParseOptions).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ViewServerTcpPublishIngressError({
+          message: `TCP publish row did not match View Server topic ${topic}.`,
+          cause,
+          phase: "decode",
+          topic,
+        }),
+    ),
+  );
+});
+
+const validateTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.validate")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(config: ViewServerConfig<Topics>, topic: string, rows: ReadonlyArray<unknown>) {
+  return yield* Effect.forEach(rows, (row) => validateTcpRow(config, topic, row));
+});
+
+const validateTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.validate")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(config: ViewServerConfig<Topics>, topic: string, patch: Record<string, unknown>) {
+  const schema = yield* topicSchema(config, topic);
+  const decodedPatch: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(patch)) {
+    const fieldSchema = schema.fields[field];
+    if (fieldSchema === undefined) {
+      return yield* new ViewServerTcpPublishIngressError({
+        message: `TCP publish patch did not match View Server topic ${topic}.`,
+        cause: { field },
+        phase: "decode",
+        topic,
+      });
+    }
+    decodedPatch[field] = yield* Schema.decodeUnknownEffect(fieldSchema)(
+      value,
+      strictParseOptions,
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ViewServerTcpPublishIngressError({
+            message: `TCP publish patch did not match View Server topic ${topic}.`,
+            cause,
+            phase: "decode",
+            topic,
+          }),
+      ),
+    );
+  }
+  return decodedPatch;
+});
+
+const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  options: ViewServerTcpPublishIngressOptions,
+  line: string,
+) {
+  const command = yield* parseCommand(line);
+  yield* ensureTopicCanBeMutated(command.topic, options);
+  if (command.op === "publish") {
+    const row = yield* validateTcpRow(config, command.topic, command.row);
+    yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, row]);
+    return;
+  }
+  if (command.op === "publishMany") {
+    const rows = yield* validateTcpRows(config, command.topic, command.rows);
+    yield* runRuntimeMutation(client, "publishMany", command.topic, [command.topic, rows]);
+    return;
+  }
+  if (command.op === "patch") {
+    const patch = yield* validateTcpPatch(config, command.topic, command.patch);
+    yield* runRuntimeMutation(client, "patch", command.topic, [command.topic, command.key, patch]);
+    return;
+  }
+  yield* topicSchema(config, command.topic);
+  yield* runRuntimeMutation(client, "delete", command.topic, [command.topic, command.key]);
+});
+
+const ensureTopicCanBeMutated = (
+  topic: string,
+  options: ViewServerTcpPublishIngressOptions,
+): Effect.Effect<void, ViewServerTcpPublishIngressError> =>
+  options.rejectedTopics?.has(topic) === true
+    ? Effect.fail(
+        new ViewServerTcpPublishIngressError({
+          message: `TCP publish cannot mutate source-owned View Server topic ${topic}.`,
+          cause: topic,
+          phase: "runtime",
+          topic,
+        }),
+      )
+    : Effect.void;
+
+const wireError = (cause: Cause.Cause<ViewServerTcpPublishIngressError>): object => {
+  const failure = Cause.findErrorOption(cause);
+  if (failure._tag === "Some") {
+    return {
+      ok: false,
+      error: {
+        _tag: failure.value._tag,
+        message: failure.value.message,
+        phase: failure.value.phase,
+        ...(failure.value.topic === undefined ? {} : { topic: failure.value.topic }),
+      },
+    };
+  }
+  return {
+    ok: false,
+    error: {
+      _tag: "ViewServerTcpPublishIngressError",
+      message: "TCP publish command failed with an untyped cause.",
+      phase: "runtime",
+    },
+  };
+};
+
+const wireSuccess = (): object => ({ ok: true });
+
+const jsonLine = (value: object): string => `${JSON.stringify(value)}\n`;
+
+const endTcpError = (
+  socket: Net.Socket,
+  state: TcpPublishSocketState,
+  error: ViewServerTcpPublishIngressError,
+): void => {
+  state.closed = true;
+  interruptSocketFibers(state);
+  socket.end(jsonLine(tcpErrorPayload(error)));
+};
+
+/** @internal Package-local test hook; not exported from @view-server/runtime. */
+export const writeTcpJsonLineOrClose = (
+  write: (chunk: string) => boolean,
+  end: () => void,
+  state: TcpPublishSocketState,
+  value: object,
+): void => {
+  if (!write(jsonLine(value))) {
+    state.closed = true;
+    interruptSocketFibers(state);
+    end();
+  }
+};
+
+/** @internal Package-local test hook; not exported from @view-server/runtime. */
+export const rejectTcpSocketWhenClosed = (
+  closed: boolean,
+  socket: TcpDestroyableSocket,
+): boolean => {
+  if (closed) {
+    socket.destroy();
+    return true;
+  }
+  return false;
+};
+
+const tcpErrorPayload = (error: ViewServerTcpPublishIngressError): object => ({
+  ok: false,
+  error: {
+    _tag: error._tag,
+    message: error.message,
+    phase: error.phase,
+    topic: error.topic,
+  },
+});
+
+const tcpQueueExceededError = (maxQueuedCommands: number): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish command queue exceeded ${maxQueuedCommands} commands.`,
+    cause: { maxQueuedCommands },
+    phase: "backpressure",
+  });
+
+const tcpGlobalQueueExceededError = (
+  maxGlobalQueuedCommands: number,
+): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish global command queue exceeded ${maxGlobalQueuedCommands} commands.`,
+    cause: { maxGlobalQueuedCommands },
+    phase: "backpressure",
+  });
+
+const tcpLineExceededError = (maxLineBytes: number): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish command exceeded ${maxLineBytes} bytes.`,
+    cause: { maxLineBytes },
+    phase: "backpressure",
+  });
+
+const tcpPartialLineExceededError = (maxLineBytes: number): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish command exceeded ${maxLineBytes} bytes without a newline.`,
+    cause: { maxLineBytes },
+    phase: "backpressure",
+  });
+
+const tcpConnectionExceededError = (maxConnections: number): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish connection count exceeded ${maxConnections} sockets.`,
+    cause: { maxConnections },
+    phase: "backpressure",
+  });
+
+const endRejectedSocket = (
+  socket: Net.Socket,
+  state: TcpPublishServerState,
+  error: ViewServerTcpPublishIngressError,
+): void => {
+  state.sockets.add(socket);
+  socket.on("error", socket.destroy.bind(socket));
+  socket.on("close", () => state.sockets.delete(socket));
+  socket.setTimeout(rejectedSocketDestroyTimeoutMs);
+  socket.once("timeout", socket.destroy.bind(socket));
+  socket.end(jsonLine(tcpErrorPayload(error)), socket.destroy.bind(socket));
+};
+
+const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  socket: Net.Socket,
+  state: TcpPublishSocketState,
+  serverState: TcpPublishServerState,
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  options: ViewServerTcpPublishIngressOptions,
+  line: string,
+): Promise<void> => {
+  try {
+    if (state.closed || serverState.closed) {
+      return;
+    }
+    const fiber = Effect.runFork(handleCommand(config, client, options, line));
+    serverState.activeFibers.add(fiber);
+    state.activeFibers.add(fiber);
+    const exit = await Effect.runPromise(Fiber.await(fiber));
+    serverState.activeFibers.delete(fiber);
+    state.activeFibers.delete(fiber);
+    if (state.closed || serverState.closed) {
+      return;
+    }
+    if (Exit.isSuccess(exit)) {
+      writeTcpJsonLineOrClose(
+        socket.write.bind(socket),
+        socket.end.bind(socket),
+        state,
+        wireSuccess(),
+      );
+      return;
+    }
+    writeTcpJsonLineOrClose(
+      socket.write.bind(socket),
+      socket.end.bind(socket),
+      state,
+      wireError(exit.cause),
+    );
+  } finally {
+    state.queuedCommands -= 1;
+    serverState.queuedCommands -= 1;
+  }
+};
+
+const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  socket: Net.Socket,
+  state: TcpPublishSocketState,
+  serverState: TcpPublishServerState,
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  options: ViewServerTcpPublishIngressOptions,
+  line: string,
+): void => {
+  const maxQueuedCommands = options.maxQueuedCommands ?? defaultMaxQueuedCommands;
+  const maxGlobalQueuedCommands = options.maxGlobalQueuedCommands ?? defaultMaxGlobalQueuedCommands;
+  if (state.closed || serverState.closed) {
+    return;
+  }
+  if (state.queuedCommands >= maxQueuedCommands) {
+    endTcpError(socket, state, tcpQueueExceededError(maxQueuedCommands));
+    return;
+  }
+  if (serverState.queuedCommands >= maxGlobalQueuedCommands) {
+    endTcpError(socket, state, tcpGlobalQueueExceededError(maxGlobalQueuedCommands));
+    return;
+  }
+  state.queuedCommands += 1;
+  serverState.queuedCommands += 1;
+  const previousChain = state.chain;
+  const chain = (async () => {
+    await Promise.allSettled([previousChain]);
+    await Promise.allSettled([
+      executeLine(socket, state, serverState, config, client, options, line),
+    ]);
+  })();
+  state.chain = chain;
+  serverState.activeChains.add(chain);
+  const cleanup = () => {
+    serverState.activeChains.delete(chain);
+    if (state.closed) {
+      serverState.socketStates.delete(socket);
+    }
+  };
+  void chain.then(cleanup);
+};
+
+const interruptSocketFibers = (state: TcpPublishSocketState): void => {
+  if (state.activeFibers.size > 0) {
+    Effect.runFork(Effect.forEach(state.activeFibers, Fiber.interrupt, { discard: true }));
+  }
+};
+
+const installSocketHandler = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  socket: Net.Socket,
+  state: TcpPublishSocketState,
+  serverState: TcpPublishServerState,
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  options: ViewServerTcpPublishIngressOptions,
+): void => {
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk: string) => {
+    if (state.closed || serverState.closed) {
+      return;
+    }
+    const nextBuffer = state.buffer + chunk;
+    const maxLineBytes = options.maxLineBytes ?? defaultMaxLineBytes;
+    const lines = nextBuffer.split("\n");
+    const partialLine = String(lines.pop());
+    for (const line of lines) {
+      if (Buffer.byteLength(line, "utf8") > maxLineBytes) {
+        endTcpError(socket, state, tcpLineExceededError(maxLineBytes));
+        return;
+      }
+      const trimmed = line.trim();
+      if (trimmed.length > 0) {
+        enqueueLine(socket, state, serverState, config, client, options, trimmed);
+      }
+    }
+    state.buffer = partialLine;
+    if (Buffer.byteLength(state.buffer, "utf8") > maxLineBytes) {
+      endTcpError(socket, state, tcpPartialLineExceededError(maxLineBytes));
+    }
+  });
+};
+
+const closeTcpServer = (server: Net.Server, state: TcpPublishServerState): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    if (state.closed) {
+      return;
+    }
+    state.closed = true;
+    for (const socketState of state.socketStates.values()) {
+      socketState.closed = true;
+    }
+    const serverClosed = new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    for (const socket of state.sockets) {
+      socket.destroy();
+    }
+    yield* Effect.forEach(state.activeFibers, Fiber.interrupt, { discard: true });
+    yield* Effect.promise(() => Promise.allSettled(state.activeChains));
+    yield* Effect.promise(() => serverClosed);
+  });
+
+const validateTcpPublishOptions = (
+  options: ViewServerTcpPublishIngressOptions,
+): Effect.Effect<void, ViewServerTcpPublishIngressError> => {
+  if (!Number.isSafeInteger(options.port) || options.port < 0 || options.port > 65535) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: "TCP publish port must be a safe integer between 0 and 65535.",
+        cause: options.port,
+        phase: "configuration",
+      }),
+    );
+  }
+  if (
+    options.maxLineBytes !== undefined &&
+    (!Number.isSafeInteger(options.maxLineBytes) || options.maxLineBytes <= 0)
+  ) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: "TCP publish maxLineBytes must be a positive safe integer.",
+        cause: options.maxLineBytes,
+        phase: "configuration",
+      }),
+    );
+  }
+  if (
+    options.maxConnections !== undefined &&
+    (!Number.isSafeInteger(options.maxConnections) || options.maxConnections <= 0)
+  ) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: "TCP publish maxConnections must be a positive safe integer.",
+        cause: options.maxConnections,
+        phase: "configuration",
+      }),
+    );
+  }
+  if (
+    options.maxQueuedCommands !== undefined &&
+    (!Number.isSafeInteger(options.maxQueuedCommands) || options.maxQueuedCommands <= 0)
+  ) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: "TCP publish maxQueuedCommands must be a positive safe integer.",
+        cause: options.maxQueuedCommands,
+        phase: "configuration",
+      }),
+    );
+  }
+  if (
+    options.maxGlobalQueuedCommands !== undefined &&
+    (!Number.isSafeInteger(options.maxGlobalQueuedCommands) || options.maxGlobalQueuedCommands <= 0)
+  ) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: "TCP publish maxGlobalQueuedCommands must be a positive safe integer.",
+        cause: options.maxGlobalQueuedCommands,
+        phase: "configuration",
+      }),
+    );
+  }
+  return Effect.void;
+};
+
+/** @internal Package-local test hook; not exported from @view-server/runtime. */
+export const installTcpPublishAcceptedSocket = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  socket: Net.Socket,
+  state: TcpPublishServerState,
+  config: ViewServerConfig<Topics>,
+  client: ViewServerRuntimeClient<Topics>,
+  options: ViewServerTcpPublishIngressOptions,
+): void => {
+  if (rejectTcpSocketWhenClosed(state.closed, socket)) {
+    return;
+  }
+  const maxConnections = options.maxConnections ?? defaultMaxConnections;
+  if (state.sockets.size >= maxConnections) {
+    endRejectedSocket(socket, state, tcpConnectionExceededError(maxConnections));
+    return;
+  }
+  const socketState: TcpPublishSocketState = {
+    activeFibers: new Set(),
+    buffer: "",
+    chain: Promise.resolve(),
+    closed: false,
+    queuedCommands: 0,
+  };
+  state.sockets.add(socket);
+  state.socketStates.set(socket, socketState);
+  socket.on("error", socket.destroy.bind(socket));
+  socket.on("close", () => {
+    socketState.closed = true;
+    state.sockets.delete(socket);
+    interruptSocketFibers(socketState);
+    void socketState.chain.then(() => state.socketStates.delete(socket));
+  });
+  installSocketHandler(socket, socketState, state, config, client, options);
+};
+
+export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpPublish.make")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    config: ViewServerConfig<Topics>,
+    client: ViewServerRuntimeClient<Topics>,
+    options: ViewServerTcpPublishIngressOptions,
+  ) {
+    yield* validateTcpPublishOptions(options);
+    const host = options.host ?? "127.0.0.1";
+    const state: TcpPublishServerState = {
+      activeChains: new Set(),
+      activeFibers: new Set(),
+      closed: false,
+      queuedCommands: 0,
+      socketStates: new Map(),
+      sockets: new Set(),
+    };
+    const server = Net.createServer((socket) => {
+      installTcpPublishAcceptedSocket(socket, state, config, client, options);
+    });
+    yield* Effect.callback<void, ViewServerTcpPublishIngressError>((resume) => {
+      server.once("error", (cause) => {
+        resume(
+          Effect.fail(
+            new ViewServerTcpPublishIngressError({
+              message: "TCP publish server failed to listen.",
+              cause,
+              phase: "listen",
+            }),
+          ),
+        );
+      });
+      server.listen({ host, port: options.port }, () => {
+        resume(Effect.void);
+      });
+      return closeTcpServer(server, state);
+    });
+    const address = Schema.decodeUnknownSync(TcpAddress)(server.address());
+    return {
+      url: `tcp://${address.address}:${address.port}`,
+      close: closeTcpServer(server, state),
+    };
+  },
+);

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -89,6 +89,10 @@ type TcpDestroyableSocket = {
   readonly destroy: () => void;
 };
 
+type TcpErrorHandlingServer = {
+  readonly on: (event: "error", listener: (cause: Error) => void) => unknown;
+};
+
 type TcpResponseSocket = {
   readonly destroyed: boolean;
   readonly off: (event: "close" | "error", listener: () => void) => unknown;
@@ -245,7 +249,9 @@ const validateTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.validate"
 >(config: ViewServerConfig<Topics>, topic: string, patch: Record<string, unknown>) {
   const schema = yield* topicSchema(config, topic);
   for (const [field, value] of Object.entries(patch)) {
-    const fieldSchema = schema.fields[field];
+    const fieldSchema = Object.entries(schema.fields).find(
+      ([fieldName]) => fieldName === field,
+    )?.[1];
     if (fieldSchema === undefined) {
       return yield* new ViewServerTcpPublishIngressError({
         message: `TCP publish patch did not match View Server topic ${topic}.`,
@@ -609,6 +615,21 @@ const closeTcpServer = (server: Net.Server, state: TcpPublishServerState): Effec
     yield* Effect.promise(() => serverClosed);
   });
 
+/** @internal Package-local test hook; not exported from @view-server/runtime. */
+export const installTcpServerSteadyStateErrorHandler = (
+  server: TcpErrorHandlingServer,
+  close: Effect.Effect<void>,
+): void => {
+  server.on("error", (cause) => {
+    Effect.runFork(
+      Effect.logWarning("TCP publish server emitted an error after listen; closing ingress.").pipe(
+        Effect.annotateLogs({ cause }),
+        Effect.andThen(close),
+      ),
+    );
+  });
+};
+
 const validateTcpPublishOptions = (
   options: ViewServerTcpPublishIngressOptions,
 ): Effect.Effect<void, ViewServerTcpPublishIngressError> => {
@@ -728,27 +749,37 @@ export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpP
     const server = Net.createServer((socket) => {
       installTcpPublishAcceptedSocket(socket, state, config, client, options);
     });
-    yield* Effect.callback<void, ViewServerTcpPublishIngressError>((resume) => {
-      server.once("error", (cause) => {
-        resume(
-          Effect.fail(
-            new ViewServerTcpPublishIngressError({
-              message: "TCP publish server failed to listen.",
-              cause,
-              phase: "listen",
-            }),
-          ),
+    return yield* Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const close = closeTcpServer(server, state);
+        yield* restore(
+          Effect.callback<void, ViewServerTcpPublishIngressError>((resume) => {
+            const onStartupError = (cause: Error) => {
+              resume(
+                Effect.fail(
+                  new ViewServerTcpPublishIngressError({
+                    message: "TCP publish server failed to listen.",
+                    cause,
+                    phase: "listen",
+                  }),
+                ),
+              );
+            };
+            server.once("error", onStartupError);
+            server.listen({ host, port: options.port }, () => {
+              server.off("error", onStartupError);
+              installTcpServerSteadyStateErrorHandler(server, close);
+              resume(Effect.void);
+            });
+            return close;
+          }),
         );
-      });
-      server.listen({ host, port: options.port }, () => {
-        resume(Effect.void);
-      });
-      return closeTcpServer(server, state);
-    });
-    const address = Schema.decodeUnknownSync(TcpAddress)(server.address());
-    return {
-      url: tcpPublishUrl(address),
-      close: closeTcpServer(server, state),
-    };
+        const address = Schema.decodeUnknownSync(TcpAddress)(server.address());
+        return {
+          url: tcpPublishUrl(address),
+          close,
+        };
+      }),
+    );
   },
 );

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -245,6 +245,15 @@ const tcpDecodeSchemaError = (
 
 const tcpFieldSchemaFromAst = (ast: SchemaAST.AST): TcpFieldSchema => Schema.make(ast);
 
+const setDecodedField = (record: Record<string, unknown>, field: string, value: unknown): void => {
+  Object.defineProperty(record, field, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
 const nestedTcpFieldAst = (ast: SchemaAST.Objects, field: string): SchemaAST.AST | undefined =>
   ast.propertySignatures.find((property) => property.name === field)?.type;
 
@@ -307,11 +316,15 @@ const decodeTcpFieldForRuntimeInternal: (
       if (fieldAst === undefined) {
         return yield* tcpDecodeSchemaError(topic, phase, { field });
       }
-      decodedValue[field] = yield* decodeTcpFieldForRuntimeInternal(
-        tcpFieldSchemaFromAst(fieldAst),
-        topic,
-        phase,
-        fieldValue,
+      setDecodedField(
+        decodedValue,
+        field,
+        yield* decodeTcpFieldForRuntimeInternal(
+          tcpFieldSchemaFromAst(fieldAst),
+          topic,
+          phase,
+          fieldValue,
+        ),
       );
     }
     yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
@@ -382,7 +395,11 @@ const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(functi
     if (fieldSchema === undefined) {
       return yield* tcpDecodeSchemaError(topic, "row", { field });
     }
-    decodedRow[field] = yield* decodeTcpFieldForRuntime(fieldSchema, topic, "row", value);
+    setDecodedField(
+      decodedRow,
+      field,
+      yield* decodeTcpFieldForRuntime(fieldSchema, topic, "row", value),
+    );
   }
   yield* Schema.decodeUnknownEffect(schema)(decodedRow, strictParseOptions).pipe(
     Effect.asVoid,
@@ -409,7 +426,11 @@ const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(fu
     if (fieldSchema === undefined) {
       return yield* tcpDecodeSchemaError(topic, "patch", { field });
     }
-    decodedPatch[field] = yield* decodeTcpFieldForRuntime(fieldSchema, topic, "patch", value);
+    setDecodedField(
+      decodedPatch,
+      field,
+      yield* decodeTcpFieldForRuntime(fieldSchema, topic, "patch", value),
+    );
   }
   return decodedPatch;
 });

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -4,7 +4,7 @@ import type {
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@view-server/config";
-import { Cause, Effect, Exit, Fiber, Result, Schema } from "effect";
+import { Cause, Effect, Exit, Fiber, Result, Schema, SchemaAST } from "effect";
 import * as Net from "node:net";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
@@ -100,6 +100,11 @@ type TcpResponseSocket = {
   readonly write: (chunk: string, callback: () => void) => boolean;
 };
 
+type TcpFieldSchema = NonNullable<RowSchema["fields"][string]>;
+type TcpSuspendedSchema = {
+  readonly ast: SchemaAST.Suspend;
+};
+
 const defaultMaxLineBytes = 1024 * 1024;
 const defaultMaxConnections = 1024;
 const defaultMaxGlobalQueuedCommands = 1024;
@@ -114,6 +119,12 @@ const isTopicDefinitionWithSchema = (value: unknown): value is { readonly schema
 
 const isRuntimeMutationEffect = (value: unknown): value is RuntimeMutationEffect =>
   Effect.isEffect(value);
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+
+const isSuspendSchema = (schema: TcpFieldSchema): schema is TcpFieldSchema & TcpSuspendedSchema =>
+  SchemaAST.isSuspend(schema.ast);
 
 const isViewServerRuntimeError = (value: unknown): value is ViewServerRuntimeError => {
   if (typeof value !== "object" || value === null) {
@@ -220,59 +231,187 @@ const topicSchema = <const Topics extends ViewServerRuntimeTopicDefinitions>(
       );
 };
 
-const validateTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.validate")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(config: ViewServerConfig<Topics>, topic: string, row: unknown) {
-  const schema = yield* topicSchema(config, topic);
-  yield* Schema.decodeUnknownEffect(schema)(row, strictParseOptions).pipe(
-    Effect.asVoid,
-    Effect.mapError(
-      (cause) =>
-        new ViewServerTcpPublishIngressError({
-          message: `TCP publish row did not match View Server topic ${topic}.`,
-          cause,
-          phase: "decode",
-          topic,
-        }),
-    ),
+const tcpDecodeSchemaError = (
+  topic: string,
+  phase: "patch" | "row",
+  cause: unknown,
+): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish ${phase} did not match View Server topic ${topic}.`,
+    cause,
+    phase: "decode",
+    topic,
+  });
+
+const tcpFieldSchemaFromAst = (ast: SchemaAST.AST): TcpFieldSchema => Schema.make(ast);
+
+const nestedTcpFieldAst = (ast: SchemaAST.Objects, field: string): SchemaAST.AST | undefined =>
+  ast.propertySignatures.find((property) => property.name === field)?.type;
+
+const arrayElementAst = (
+  ast: SchemaAST.Arrays,
+  index: number,
+  length: number,
+): SchemaAST.AST | undefined => {
+  if (index < ast.elements.length) {
+    return ast.elements[index];
+  }
+  if (ast.rest.length === 0) {
+    return undefined;
+  }
+  if (ast.rest.length === 1) {
+    return ast.rest[0];
+  }
+  const trailingCount = ast.rest.length - 1;
+  const firstTrailingIndex = length - trailingCount;
+  if (index >= firstTrailingIndex) {
+    const trailingIndex = index - firstTrailingIndex + 1;
+    return ast.rest[trailingIndex];
+  }
+  return ast.rest[0];
+};
+
+const decodeTcpFieldForRuntimeInternal: (
+  schema: TcpFieldSchema,
+  topic: string,
+  phase: "patch" | "row",
+  value: unknown,
+) => Effect.Effect<unknown, ViewServerTcpPublishIngressError> = Effect.fn(
+  "ViewServerRuntime.tcpPublish.field.decode.internal",
+)(function* (schema, topic, phase, value) {
+  const rawDecode = yield* Effect.exit(
+    Schema.decodeUnknownEffect(schema)(value, strictParseOptions),
   );
+  if (Exit.isSuccess(rawDecode)) {
+    // Transform schemas such as BigIntFromString must keep the JSON input shape for the engine path.
+    return value;
+  }
+  if (isSuspendSchema(schema)) {
+    const decodedValue = yield* decodeTcpFieldForRuntimeInternal(
+      Schema.make(schema.ast.thunk()),
+      topic,
+      phase,
+      value,
+    );
+    yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
+      Effect.asVoid,
+      Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)),
+    );
+    return decodedValue;
+  }
+  if (SchemaAST.isObjects(schema.ast) && isPlainRecord(value)) {
+    const decodedValue: Record<string, unknown> = {};
+    const indexSignature = schema.ast.indexSignatures[0];
+    for (const [field, fieldValue] of Object.entries(value)) {
+      const fieldAst = nestedTcpFieldAst(schema.ast, field) ?? indexSignature?.type;
+      if (fieldAst === undefined) {
+        return yield* tcpDecodeSchemaError(topic, phase, { field });
+      }
+      decodedValue[field] = yield* decodeTcpFieldForRuntimeInternal(
+        tcpFieldSchemaFromAst(fieldAst),
+        topic,
+        phase,
+        fieldValue,
+      );
+    }
+    yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
+      Effect.asVoid,
+      Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)),
+    );
+    return decodedValue;
+  }
+  if (SchemaAST.isArrays(schema.ast) && Array.isArray(value)) {
+    const decodedValue: Array<unknown> = Array.from(value);
+    for (const [index, item] of value.entries()) {
+      const elementAst = arrayElementAst(schema.ast, index, value.length);
+      if (elementAst !== undefined) {
+        decodedValue[index] = yield* decodeTcpFieldForRuntimeInternal(
+          tcpFieldSchemaFromAst(elementAst),
+          topic,
+          phase,
+          item,
+        );
+      }
+    }
+    yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
+      Effect.asVoid,
+      Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)),
+    );
+    return decodedValue;
+  }
+  if (SchemaAST.isUnion(schema.ast)) {
+    for (const member of schema.ast.types) {
+      const memberDecode = yield* Effect.exit(
+        decodeTcpFieldForRuntimeInternal(tcpFieldSchemaFromAst(member), topic, phase, value).pipe(
+          Effect.flatMap((decodedValue) =>
+            Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
+              Effect.as(decodedValue),
+            ),
+          ),
+        ),
+      );
+      if (Exit.isSuccess(memberDecode)) {
+        return memberDecode.value;
+      }
+    }
+  }
+  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(
+    value,
+    strictParseOptions,
+  ).pipe(Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)));
 });
 
-const validateTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.validate")(function* <
+const decodeTcpFieldForRuntime = Effect.fn("ViewServerRuntime.tcpPublish.field.decode")(function* (
+  schema: TcpFieldSchema,
+  topic: string,
+  phase: "patch" | "row",
+  value: unknown,
+) {
+  return yield* decodeTcpFieldForRuntimeInternal(schema, topic, phase, value);
+});
+
+const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
->(config: ViewServerConfig<Topics>, topic: string, rows: ReadonlyArray<unknown>) {
-  yield* Effect.forEach(rows, (row) => validateTcpRow(config, topic, row), { discard: true });
+>(config: ViewServerConfig<Topics>, topic: string, row: Record<string, unknown>) {
+  const schema = yield* topicSchema(config, topic);
+  const decodedRow: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(row)) {
+    const fieldSchema = Object.entries(schema.fields).find(
+      ([fieldName]) => fieldName === field,
+    )?.[1];
+    if (fieldSchema === undefined) {
+      return yield* tcpDecodeSchemaError(topic, "row", { field });
+    }
+    decodedRow[field] = yield* decodeTcpFieldForRuntime(fieldSchema, topic, "row", value);
+  }
+  yield* Schema.decodeUnknownEffect(schema)(decodedRow, strictParseOptions).pipe(
+    Effect.asVoid,
+    Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)),
+  );
+  return decodedRow;
 });
 
-const validateTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.validate")(function* <
+const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(config: ViewServerConfig<Topics>, topic: string, rows: ReadonlyArray<Record<string, unknown>>) {
+  return yield* Effect.forEach(rows, (row) => decodeTcpRow(config, topic, row));
+});
+
+const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(config: ViewServerConfig<Topics>, topic: string, patch: Record<string, unknown>) {
   const schema = yield* topicSchema(config, topic);
+  const decodedPatch: Record<string, unknown> = {};
   for (const [field, value] of Object.entries(patch)) {
     const fieldSchema = Object.entries(schema.fields).find(
       ([fieldName]) => fieldName === field,
     )?.[1];
     if (fieldSchema === undefined) {
-      return yield* new ViewServerTcpPublishIngressError({
-        message: `TCP publish patch did not match View Server topic ${topic}.`,
-        cause: { field },
-        phase: "decode",
-        topic,
-      });
+      return yield* tcpDecodeSchemaError(topic, "patch", { field });
     }
-    yield* Schema.decodeUnknownEffect(fieldSchema)(value, strictParseOptions).pipe(
-      Effect.asVoid,
-      Effect.mapError(
-        (cause) =>
-          new ViewServerTcpPublishIngressError({
-            message: `TCP publish patch did not match View Server topic ${topic}.`,
-            cause,
-            phase: "decode",
-            topic,
-          }),
-      ),
-    );
+    decodedPatch[field] = yield* decodeTcpFieldForRuntime(fieldSchema, topic, "patch", value);
   }
+  return decodedPatch;
 });
 
 const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(function* <
@@ -286,22 +425,18 @@ const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(f
   const command = yield* parseCommand(line);
   yield* ensureTopicCanBeMutated(command.topic, options);
   if (command.op === "publish") {
-    yield* validateTcpRow(config, command.topic, command.row);
-    yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, command.row]);
+    const row = yield* decodeTcpRow(config, command.topic, command.row);
+    yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, row]);
     return;
   }
   if (command.op === "publishMany") {
-    yield* validateTcpRows(config, command.topic, command.rows);
-    yield* runRuntimeMutation(client, "publishMany", command.topic, [command.topic, command.rows]);
+    const rows = yield* decodeTcpRows(config, command.topic, command.rows);
+    yield* runRuntimeMutation(client, "publishMany", command.topic, [command.topic, rows]);
     return;
   }
   if (command.op === "patch") {
-    yield* validateTcpPatch(config, command.topic, command.patch);
-    yield* runRuntimeMutation(client, "patch", command.topic, [
-      command.topic,
-      command.key,
-      command.patch,
-    ]);
+    const patch = yield* decodeTcpPatch(config, command.topic, command.patch);
+    yield* runRuntimeMutation(client, "patch", command.topic, [command.topic, command.key, patch]);
     return;
   }
   yield* topicSchema(config, command.topic);

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -150,10 +150,10 @@ const tcpDecodeError = (line: string, cause: unknown): ViewServerTcpPublishIngre
 const parseCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.parse")(function* (
   line: string,
 ) {
-  const value = yield* Effect.try({
-    try: (): unknown => JSON.parse(line),
-    catch: (cause) => tcpDecodeError(line, cause),
-  });
+  const value = yield* Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)(
+    line,
+    strictParseOptions,
+  ).pipe(Effect.mapError((cause) => tcpDecodeError(line, cause)));
   return yield* Result.match(
     Schema.decodeUnknownResult(TcpPublishCommandSchema)(value, strictParseOptions),
     {

--- a/plans/remaining-roadmap-audit.md
+++ b/plans/remaining-roadmap-audit.md
@@ -39,34 +39,34 @@ because it includes explicit future scope.
 
 ### Implemented Current Slice
 
-| Area                                                          | Status      | Evidence                                                                                                                                                                                          |
-| ------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Own in-memory live engine, no external analytical DB hot path | Implemented | `packages/column-live-view-engine`, `packages/runtime-core`; no chDB/Perspective runtime dependency.                                                                                              |
-| Explicit package seams                                        | Implemented | `packages/config`, `column-live-view-engine`, `runtime-core`, `client`, `protocol`, `in-memory`, `server`, `runtime`, `react`; `pnpm run check:package-exports`; `pnpm run check:internal-seams`. |
-| Typed public config/query API                                 | Implemented | Config type tests cover topic schemas, query select/where/order/group/aggregates, Kafka, and gRPC.                                                                                                |
-| Runtime URL in provider, not config                           | Implemented | React provider accepts runtime URL/client at provider boundary; browser bundles do not import runtime config.                                                                                     |
-| In-memory browser/test provider                               | Implemented | `@view-server/react/testing` and `@view-server/in-memory`; browser tests and in-memory benchmarks use real runtime-core/engine.                                                                   |
-| Effect RPC WebSocket production transport                     | Implemented | `packages/server`, `packages/client/remote.ts`, protocol package, WebSocket/runtime tests.                                                                                                        |
-| Health hook, `/health`, and `/metrics` endpoints              | Implemented | `useViewServerHealth`, runtime/server health tests, health codecs, metrics route/runtime tests, root/runtime README docs.                                                                         |
-| Kafka runtime ingress                                         | Implemented | `@platformatic/kafka`, JSON/protobuf/custom codecs, source mapping, Docker Apache Kafka e2e, restart/startFrom policy.                                                                            |
-| gRPC runtime ingress                                          | Implemented | Covered by `plans/grpc.md` implementation.                                                                                                                                                        |
-| Snapshot/delta convergence                                    | Implemented | Engine/runtime/client tests cover raw, grouped, retained deltas, cleanup, and convergence.                                                                                                        |
-| Grouped queries and aggregates                                | Implemented | Grouped query tests, grouped aggregate/write benchmarks and gates.                                                                                                                                |
-| Backpressure at subscription/transport boundary               | Implemented | `BackpressureExceeded` typed status, queue-capacity tests, remote/client/protocol tests.                                                                                                          |
-| Benchmark baseline automation                                 | Implemented | Smoke, raw read/write, active sharing, grouped, WebSocket, Kafka, and gRPC baseline scripts.                                                                                                      |
-| Pre-gRPC readiness gate                                       | Implemented | `pnpm run pre-grpc:gate`.                                                                                                                                                                         |
+| Area                                                          | Status      | Evidence                                                                                                                                                                                                                           |
+| ------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Own in-memory live engine, no external analytical DB hot path | Implemented | `packages/column-live-view-engine`, `packages/runtime-core`; no chDB/Perspective runtime dependency.                                                                                                                               |
+| Explicit package seams                                        | Implemented | `packages/config`, `column-live-view-engine`, `runtime-core`, `client`, `protocol`, `in-memory`, `server`, `runtime`, `react`; `pnpm run check:package-exports`; `pnpm run check:internal-seams`.                                  |
+| Typed public config/query API                                 | Implemented | Config type tests cover topic schemas, query select/where/order/group/aggregates, Kafka, and gRPC.                                                                                                                                 |
+| Runtime URL in provider, not config                           | Implemented | React provider accepts runtime URL/client at provider boundary; browser bundles do not import runtime config.                                                                                                                      |
+| In-memory browser/test provider                               | Implemented | `@view-server/react/testing` and `@view-server/in-memory`; browser tests and in-memory benchmarks use real runtime-core/engine.                                                                                                    |
+| Effect RPC WebSocket production transport                     | Implemented | `packages/server`, `packages/client/remote.ts`, protocol package, WebSocket/runtime tests.                                                                                                                                         |
+| Health hook, `/health`, and `/metrics` endpoints              | Implemented | `useViewServerHealth`, runtime/server health tests, health codecs, metrics route/runtime tests, root/runtime README docs.                                                                                                          |
+| Kafka runtime ingress                                         | Implemented | `@platformatic/kafka`, JSON/protobuf/custom codecs, source mapping, Docker Apache Kafka e2e, restart/startFrom policy.                                                                                                             |
+| gRPC runtime ingress                                          | Implemented | Covered by `plans/grpc.md` implementation.                                                                                                                                                                                         |
+| Snapshot/delta convergence                                    | Implemented | Engine/runtime/client tests cover raw, grouped, retained deltas, cleanup, and convergence.                                                                                                                                         |
+| Grouped queries and aggregates                                | Implemented | Grouped query tests, grouped aggregate/write benchmarks and gates.                                                                                                                                                                 |
+| Backpressure at subscription/transport boundary               | Implemented | `BackpressureExceeded` typed status, queue-capacity tests, remote/client/protocol tests.                                                                                                                                           |
+| Benchmark baseline automation                                 | Implemented | Smoke, raw read/write, active sharing, grouped, WebSocket, Kafka, and gRPC baseline scripts.                                                                                                                                       |
+| Pre-gRPC readiness gate                                       | Implemented | `pnpm run pre-grpc:gate`.                                                                                                                                                                                                          |
+| TCP publish API/runtime ingress                               | Implemented | `packages/runtime/src/tcp-publish-ingress.ts`, runtime TCP tests for publish/patch/delete/publishMany, schema decode errors, bounded line/queue backpressure, source-owned topic rejection, startup failure, and shutdown cleanup. |
 
 ### Production-Ready Next Items
 
 These are concrete gaps where the plan describes behavior that is still missing or
 currently only documented as a future seam.
 
-| Item                                 | Status                | Why it remains                                                                                   | Suggested first PR                                                                                                                      |
-| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| TCP publish API/runtime ingress      | Production-ready next | `ViewServerRuntimeOptions` explicitly rejects `tcpPublishPort`; no TCP publish adapter exists.   | Add typed TCP publish ingress that uses runtime-core publish/patch/delete/publishMany, with tests for live deltas and invalid payloads. |
-| Runtime auth/session validation seam | Production-ready next | gRPC has system/shared session context; server/runtime do not expose `auth.validateRequest` yet. | Add optional server/runtime auth validation at WebSocket and health/admin boundaries, initially anonymous by default.                   |
-| Span/observability assertions        | Production-ready next | Code uses named `Effect.fn`, but tests do not prove key ingest -> engine -> fanout spans exist.  | Add one focused tracing test that captures span names for publish -> engine mutation -> subscription fanout.                            |
-| Example app                          | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist.                                     | Add a minimal example using real provider URL injection and in-memory provider test/demo path.                                          |
+| Item                                 | Status                | Why it remains                                                                                   | Suggested first PR                                                                                                    |
+| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Runtime auth/session validation seam | Production-ready next | gRPC has system/shared session context; server/runtime do not expose `auth.validateRequest` yet. | Add optional server/runtime auth validation at WebSocket and health/admin boundaries, initially anonymous by default. |
+| Span/observability assertions        | Production-ready next | Code uses named `Effect.fn`, but tests do not prove key ingest -> engine -> fanout spans exist.  | Add one focused tracing test that captures span names for publish -> engine mutation -> subscription fanout.          |
+| Example app                          | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist.                                     | Add a minimal example using real provider URL injection and in-memory provider test/demo path.                        |
 
 ### Intentionally Deferred
 
@@ -83,17 +83,15 @@ These are in the plan, but should remain future work unless explicitly promoted.
 
 ### Stale Or Needs Rewrite
 
-| Plan text                                                              | Status            | Action                                                                 |
-| ---------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------- |
-| `createRuntime` examples still show `tcpPublishPort` as if implemented | Remove or rewrite | Keep as future TCP publish section until implemented.                  |
-| Some early examples show raw queries without `select`                  | Remove or rewrite | Public query API now requires explicit `select` or grouped aggregates. |
+| Plan text                                             | Status            | Action                                                                 |
+| ----------------------------------------------------- | ----------------- | ---------------------------------------------------------------------- |
+| Some early examples show raw queries without `select` | Remove or rewrite | Public query API now requires explicit `select` or grouped aggregates. |
 
 ## Recommended Implementation Order
 
-1. TCP publish API/runtime ingress.
-2. Runtime auth/session validation seam.
-3. Span/observability assertions.
-4. Minimal example app.
+1. Runtime auth/session validation seam.
+2. Span/observability assertions.
+3. Minimal example app.
 
 Do not reopen completed gRPC materialized/leased scope unless new tests reveal a real
 correctness gap.

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -1202,16 +1202,34 @@ Default local/dev mode can allow anonymous access, but production docs must make
 
 ### TCP Publish API
 
-`tcpPublishPort` exists for non-browser publishers.
+`tcpPublishPort` exists for non-browser publishers. When configured, the runtime
+opens a plain TCP NDJSON endpoint and returns `tcpPublishUrl`.
 
-The first implementation should support a simple typed publish path:
+TCP publish has a separate `tcpPublishHost` and defaults to `127.0.0.1`. It must
+not inherit the public WebSocket/HTTP host because it is a mutation ingress, not
+a browser endpoint.
 
-- publish row
-- patch row
-- delete row
-- publish batch
+The TCP endpoint accepts one JSON command per line:
 
-It must use the same engine mutation path as Kafka. No second mutation implementation.
+```json
+{ "op": "publish", "topic": "orders", "row": { "id": "o1" } }
+{ "op": "publishMany", "topic": "orders", "rows": [{ "id": "o1" }] }
+{ "op": "patch", "topic": "orders", "key": "o1", "patch": { "status": "done" } }
+{ "op": "delete", "topic": "orders", "key": "o1" }
+```
+
+Each response is also one JSON line:
+
+```json
+{ "ok": true }
+{ "ok": false, "error": { "_tag": "ViewServerTcpPublishIngressError", "phase": "decode", "message": "..." } }
+```
+
+It uses the same runtime-core mutation path as Kafka, gRPC materialized ingress,
+and in-memory tests. No second mutation implementation exists.
+
+TCP publish is only for topics whose source of truth is the TCP publisher. The
+runtime must reject TCP mutations for Kafka-owned or gRPC-owned topics.
 
 TCP publish tests should cover:
 
@@ -1220,6 +1238,9 @@ TCP publish tests should cover:
 - delete -> remove
 - batch -> one coherent version range
 - invalid payload -> typed failure, no partial mutation unless explicitly documented
+- startup failure when the configured TCP port is unavailable
+- runtime shutdown closes the TCP endpoint
+- connection/line/queue bounds and source-owned topic rejection
 
 ### React Provider Contract
 


### PR DESCRIPTION
## Summary
- add optional TCP NDJSON publish ingress for plain runtime-owned topics
- support publish, publishMany, patch, and delete through the same runtime mutation path as other ingress adapters
- reject Kafka/gRPC-owned topics, bound line size, per-socket queues, global queues, and connection count
- document TCP publish behavior and update the roadmap audit

## Validation
- pnpm run ready
- runtime package: 234 tests, 100% coverage
- strict Effect LSP: 0 errors, 0 warnings, 0 messages
- 3 reviewer agents: no remaining P1/P2 findings after the rejected-socket cleanup fix

## Reviewer loop notes
- Fixed over-limit accepted socket retention by tracking rejected sockets, destroying after error flush, and adding a 1s timeout fallback.
- Verified patch field decoding uses strict schema parse options.
- Verified unknown topic and delete topic validation stay at the decode boundary before runtime mutation.
