### PR TITLE
Add auth validation seam

### DIFF
--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -7,8 +7,9 @@ import {
   type GrpcRuntimeClients,
   type ViewServerRuntimeError,
 } from "@view-server/config";
-import type { Config, Effect } from "effect";
-import { Schema } from "effect";
+import type { ViewServerAuth } from "@view-server/server";
+import type { Config } from "effect";
+import { Effect, Schema } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
 import {
   makeViewServerRuntime,
@@ -63,6 +64,16 @@ const runtimeWithGroupedAdmissionLimits = makeViewServerRuntime(viewServer, {
   groupedIncrementalAdmissionLimits: {
     maxGroups: 1,
   },
+});
+const runtimeWithAuth = makeViewServerRuntime(viewServer, {
+  auth: {
+    validateRequest: () =>
+      Effect.succeed({
+        forwardedHeaders: {},
+        id: null,
+        systemHeaders: {},
+      }),
+  } satisfies ViewServerAuth,
 });
 const runEffect = runViewServerRuntime(viewServer);
 declare const runtime: Effect.Success<typeof runtimeEffect>;
@@ -119,6 +130,9 @@ describe("runtime type contracts", () => {
       | ViewServerTcpPublishIngressError
     >();
     expectTypeOf<Effect.Success<typeof runtimeWithGroupedAdmissionLimits>>().toMatchTypeOf<
+      ViewServerRuntime<typeof viewServer.topics>
+    >();
+    expectTypeOf<Effect.Success<typeof runtimeWithAuth>>().toMatchTypeOf<
       ViewServerRuntime<typeof viewServer.topics>
     >();
 
@@ -245,6 +259,13 @@ describe("runtime type contracts", () => {
     const invalidPathOptions = makeViewServerRuntime(viewServer, {
       rpcPath: "runtime-rpc",
     });
+    const invalidAuthOptions = {
+      auth: {
+        validateRequest: () => "not an effect",
+      },
+    };
+    // @ts-expect-error runtime auth validator must return an Effect.
+    invalidAuthOptions satisfies ViewServerRuntimeOptions<typeof viewServer.topics>;
     // @ts-expect-error runtime health paths must be absolute HTTP paths.
     const invalidHealthPathOptions = makeViewServerRuntime(viewServer, {
       healthPath: "runtime-health",

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -4,6 +4,7 @@ import type { Message } from "@bufbuild/protobuf";
 import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
 import type { ColumnLiveViewEngineHealth } from "@view-server/column-live-view-engine";
 import { makeViewServerClient } from "@view-server/client/remote";
+import { ViewServerAuthError } from "@view-server/server";
 import {
   defineViewServerConfig,
   grpc,
@@ -84,6 +85,13 @@ class RuntimeHealthJsonParseError extends Schema.TaggedErrorClass<RuntimeHealthJ
   },
 ) {}
 
+class RuntimeJsonParseError extends Schema.TaggedErrorClass<RuntimeJsonParseError>()(
+  "RuntimeJsonParseError",
+  {
+    cause: Schema.Unknown,
+  },
+) {}
+
 class RuntimeTestFailure extends Schema.TaggedErrorClass<RuntimeTestFailure>()(
   "RuntimeTestFailure",
   {
@@ -110,6 +118,7 @@ const TcpPublishResponse = Schema.Union([
       code: Schema.optional(Schema.String),
       message: Schema.String,
       phase: Schema.optional(Schema.String),
+      status: Schema.optional(Schema.Number),
       topic: Schema.optional(Schema.String),
     }),
   }),
@@ -702,6 +711,24 @@ const order = (id: string, price: number): OrderRow => ({
   price,
 });
 
+const bearerAuth = {
+  validateRequest: (request: { readonly headers: Readonly<Record<string, string>> }) =>
+    request.headers["authorization"] === "Bearer view-server-test"
+      ? Effect.succeed({
+          forwardedHeaders: {
+            authorization: request.headers["authorization"],
+          },
+          id: "session-1",
+          systemHeaders: {},
+        })
+      : Effect.fail(
+          new ViewServerAuthError({
+            message: "Missing or invalid authorization header.",
+            status: 401,
+          }),
+        ),
+};
+
 const nullRecord = <Value>(
   entries: ReadonlyArray<readonly [string, Value]>,
 ): Record<string, Value> => {
@@ -727,6 +754,16 @@ const fetchText = Effect.fn("ViewServerRuntime.test.text.fetch")(function* (url:
   const response = yield* Effect.promise(() => fetch(url));
   const text = yield* Effect.promise(() => response.text());
   return { response, text };
+});
+
+const fetchJson = Effect.fn("ViewServerRuntime.test.json.fetch")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(text),
+    catch: (cause) => new RuntimeJsonParseError({ cause }),
+  });
+  return { response, value };
 });
 
 const tcpUrlConnectHost = (hostname: string): string =>
@@ -2592,6 +2629,98 @@ describe("@view-server/runtime", () => {
     }),
   );
 
+  it.live("requires auth for TCP publish mutations when runtime auth is configured", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        auth: bearerAuth,
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const rejected = yield* sendTcpPublishCommand(tcpPublishUrl, {
+        op: "publish",
+        topic: "orders",
+        row: order("rejected", 10),
+      });
+      const accepted = yield* sendTcpPublishCommand(tcpPublishUrl, {
+        headers: {
+          authorization: "Bearer view-server-test",
+        },
+        op: "publish",
+        topic: "orders",
+        row: order("accepted", 20),
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price"],
+        orderBy: [{ field: "price", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(rejected).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerAuthError",
+          message: "Missing or invalid authorization header.",
+          status: 401,
+        },
+      });
+      expect(accepted).toStrictEqual({ ok: true });
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "accepted", price: 20 }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("passes TCP publish peer address into auth validation", () =>
+    Effect.gen(function* () {
+      const remoteAddress = yield* Deferred.make<string>();
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        auth: {
+          validateRequest: (request) =>
+            Option.match(request.remoteAddress, {
+              onNone: () =>
+                Effect.fail(
+                  new ViewServerAuthError({
+                    message: "TCP auth did not receive a peer address.",
+                    status: 403,
+                  }),
+                ),
+              onSome: (address) =>
+                Deferred.succeed(remoteAddress, address).pipe(
+                  Effect.as({
+                    forwardedHeaders: {},
+                    id: "tcp-session",
+                    systemHeaders: {},
+                  }),
+                ),
+            }),
+        },
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const accepted = yield* sendTcpPublishCommand(tcpPublishUrl, {
+        op: "publish",
+        topic: "orders",
+        row: order("accepted", 20),
+      });
+      const observedRemoteAddress = yield* Deferred.await(remoteAddress);
+
+      expect(accepted).toStrictEqual({ ok: true });
+      expect(observedRemoteAddress).toBe("127.0.0.1");
+      yield* runtime.close;
+    }),
+  );
+
   it.live("passes source-owned topics into TCP publish ingress rejection policy", () =>
     Effect.gen(function* () {
       type MixedTopics = typeof grpcAndKafkaViewServer.topics;
@@ -2685,12 +2814,19 @@ describe("@view-server/runtime", () => {
         websocketPort: 0,
       });
       const rejectedAcceptedSocket = new Net.Socket();
+      const partialAcceptedSocket = new Net.Socket();
+      const partialAcceptedSocketDestroyed: Array<"socket"> = [];
+      partialAcceptedSocket.destroy = () => {
+        partialAcceptedSocketDestroyed.push("socket");
+        return partialAcceptedSocket;
+      };
       installTcpPublishAcceptedSocket(
         rejectedAcceptedSocket,
         {
           activeChains: new Set(),
           activeFibers: new Set(),
           closed: true,
+          preCommandDeadlineMs: undefined,
           queuedCommands: 0,
           socketStates: new Map(),
           sockets: new Set(),
@@ -2699,8 +2835,67 @@ describe("@view-server/runtime", () => {
         runtime.client,
         { port: 0 },
       );
+      const partialAcceptedSocketState = {
+        activeChains: new Set<Promise<void>>(),
+        activeFibers: new Set<Fiber.Fiber<void, never>>(),
+        closed: false,
+        preCommandDeadlineMs: 1,
+        queuedCommands: 0,
+        socketStates: new Map(),
+        sockets: new Set<Net.Socket>(),
+      };
+      installTcpPublishAcceptedSocket(
+        partialAcceptedSocket,
+        partialAcceptedSocketState,
+        viewServer,
+        runtime.client,
+        { port: 0 },
+      );
+      partialAcceptedSocket.emit("data", "  ");
+      yield* Effect.sleep("20 millis");
+      const unauthorizedSocket = new Net.Socket();
+      const unauthorizedSocketResponses: Array<string> = [];
+      const unauthorizedSocketState = {
+        activeChains: new Set<Promise<void>>(),
+        activeFibers: new Set<Fiber.Fiber<void, never>>(),
+        closed: false,
+        preCommandDeadlineMs: 1_000,
+        queuedCommands: 0,
+        socketStates: new Map(),
+        sockets: new Set<Net.Socket>(),
+      };
+      Object.defineProperty(unauthorizedSocket, "write", {
+        value: (chunk: string, callback: () => void) => {
+          unauthorizedSocketResponses.push(chunk);
+          callback();
+          return true;
+        },
+      });
+      installTcpPublishAcceptedSocket(
+        unauthorizedSocket,
+        unauthorizedSocketState,
+        viewServer,
+        runtime.client,
+        {
+          auth: bearerAuth,
+          port: 0,
+        },
+      );
+      const initialUnauthorizedDeadline =
+        unauthorizedSocketState.socketStates.get(unauthorizedSocket)?.preCommandDeadline;
+      unauthorizedSocket.emit(
+        "data",
+        `${JSON.stringify({
+          op: "publish",
+          topic: "orders",
+          row: order("unauthorized", 10),
+        })}\n`,
+      );
+      yield* Effect.promise(() => Promise.allSettled(unauthorizedSocketState.activeChains));
       const slowPublishStarted = yield* Deferred.make<void>();
       const slowPublishInterrupted = yield* Deferred.make<void>();
+      const deadlineClearedPublishStarted = yield* Deferred.make<void>();
+      const deadlineClearedPublishInterrupted = yield* Deferred.make<void>();
       const globalPublishStarted = yield* Deferred.make<void>();
       const globalPublishInterrupted = yield* Deferred.make<void>();
       const disconnectedPublishStarted = yield* Deferred.make<void>();
@@ -2713,6 +2908,14 @@ describe("@view-server/runtime", () => {
           Deferred.succeed(slowPublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
             Effect.ensuring(Deferred.succeed(slowPublishInterrupted, undefined)),
+          ),
+      });
+      const deadlineClearedPublishClient = Object.create(runtime.client);
+      Object.defineProperty(deadlineClearedPublishClient, "publish", {
+        value: () =>
+          Deferred.succeed(deadlineClearedPublishStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Deferred.succeed(deadlineClearedPublishInterrupted, undefined)),
           ),
       });
       const globalPublishClient = Object.create(runtime.client);
@@ -2744,6 +2947,72 @@ describe("@view-server/runtime", () => {
         topic: "orders",
         row: order("a", 10),
       })}\n`;
+      const deadlineClearedSocket = new Net.Socket();
+      const deadlineClearedSocketDestroyed: Array<"socket"> = [];
+      const deadlineClearedSocketState = {
+        activeChains: new Set<Promise<void>>(),
+        activeFibers: new Set<Fiber.Fiber<void, never>>(),
+        closed: false,
+        preCommandDeadlineMs: 1,
+        queuedCommands: 0,
+        socketStates: new Map(),
+        sockets: new Set<Net.Socket>(),
+      };
+      deadlineClearedSocket.destroy = () => {
+        deadlineClearedSocketDestroyed.push("socket");
+        deadlineClearedSocket.emit("close");
+        return deadlineClearedSocket;
+      };
+      installTcpPublishAcceptedSocket(
+        deadlineClearedSocket,
+        deadlineClearedSocketState,
+        viewServer,
+        deadlineClearedPublishClient,
+        { port: 0 },
+      );
+      deadlineClearedSocket.emit("data", compactCommandLine);
+      yield* Deferred.await(deadlineClearedPublishStarted).pipe(Effect.timeout("1 second"));
+      yield* Effect.sleep("20 millis");
+      const rearmedSocket = new Net.Socket();
+      const rearmedSocketDestroyed: Array<"socket"> = [];
+      const rearmedSocketResponses: Array<string> = [];
+      const rearmedSocketState = {
+        activeChains: new Set<Promise<void>>(),
+        activeFibers: new Set<Fiber.Fiber<void, never>>(),
+        closed: false,
+        preCommandDeadlineMs: 1,
+        queuedCommands: 0,
+        socketStates: new Map(),
+        sockets: new Set<Net.Socket>(),
+      };
+      rearmedSocket.destroy = () => {
+        rearmedSocketDestroyed.push("socket");
+        rearmedSocket.emit("close");
+        return rearmedSocket;
+      };
+      Object.defineProperty(rearmedSocket, "write", {
+        value: (chunk: string, callback: () => void) => {
+          rearmedSocketResponses.push(chunk);
+          callback();
+          return true;
+        },
+      });
+      installTcpPublishAcceptedSocket(
+        rearmedSocket,
+        rearmedSocketState,
+        viewServer,
+        runtime.client,
+        { port: 0 },
+      );
+      rearmedSocket.emit(
+        "data",
+        `${JSON.stringify({
+          op: "publish",
+          topic: "orders",
+          row: order("rearmed", 10),
+        })}\n`,
+      );
+      yield* Effect.sleep("20 millis");
       const oversizedIngress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
         maxLineBytes: 8,
         port: 0,
@@ -2937,7 +3206,20 @@ describe("@view-server/runtime", () => {
       expect(oversizedCompleteLineSocket.destroyed).toBe(true);
       expect(rejectedConnectionCappedSocket.destroyed).toBe(true);
       expect(rejectedAcceptedSocket.destroyed).toBe(true);
+      expect(partialAcceptedSocketDestroyed).toStrictEqual(["socket"]);
+      expect(unauthorizedSocketResponses).toStrictEqual([
+        '{"ok":false,"error":{"_tag":"ViewServerAuthError","message":"Missing or invalid authorization header.","status":401}}\n',
+      ]);
+      expect(unauthorizedSocketState.socketStates.get(unauthorizedSocket)?.preCommandDeadline).toBe(
+        initialUnauthorizedDeadline,
+      );
+      expect(deadlineClearedSocketDestroyed).toStrictEqual([]);
+      expect(rearmedSocketResponses).toStrictEqual(['{"ok":true}\n']);
+      expect(rearmedSocketDestroyed).toStrictEqual(["socket"]);
 
+      deadlineClearedSocket.destroy();
+      unauthorizedSocket.destroy();
+      yield* Deferred.await(deadlineClearedPublishInterrupted).pipe(Effect.timeout("1 second"));
       heldConnectionCappedSocket.destroy();
       yield* connectionCappedIngress.close;
       yield* closedQueueIngress.close.pipe(Effect.timeout("1 second"));
@@ -2969,6 +3251,7 @@ describe("@view-server/runtime", () => {
         activeChains: new Set<Promise<void>>(),
         activeFibers: new Set<Fiber.Fiber<void, never>>(),
         closed: false,
+        preCommandDeadlineMs: undefined,
         queuedCommands: 0,
         socketStates: new Map(),
         sockets: new Set<Net.Socket>(),
@@ -2979,6 +3262,7 @@ describe("@view-server/runtime", () => {
         buffer: "",
         chain: Promise.resolve(),
         closed: false,
+        preCommandDeadline: undefined,
         queuedCommands: 0,
       };
 
@@ -3451,6 +3735,7 @@ describe("@view-server/runtime", () => {
       };
 
       const runtime = yield* makeViewServerRuntimeWithDependencies(dependencies, viewServer, {
+        auth: bearerAuth,
         groupedIncrementalAdmissionLimits: {
           maxGroups: 1,
         },
@@ -3477,7 +3762,9 @@ describe("@view-server/runtime", () => {
           streamOpenedType: typeof serverInput?.transport?.streamOpened,
           streamClosedType: typeof serverInput?.transport?.streamClosed,
         },
+        serverAuthType: typeof serverInput?.auth?.validateRequest,
         serverOptions,
+        tcpPublishAuthType: typeof tcpPublishOptions?.auth?.validateRequest,
         tcpPublishOptions,
         tcpPublishUrl: runtime.tcpPublishUrl,
       }).toStrictEqual({
@@ -3494,6 +3781,7 @@ describe("@view-server/runtime", () => {
           streamOpenedType: "object",
           streamClosedType: "object",
         },
+        serverAuthType: "function",
         serverOptions: {
           host: "0.0.0.0",
           port: 1234,
@@ -3501,7 +3789,9 @@ describe("@view-server/runtime", () => {
           healthPath: "/custom-health",
           metricsPath: "/custom-metrics",
         },
+        tcpPublishAuthType: "function",
         tcpPublishOptions: {
+          auth: bearerAuth,
           host: "127.0.0.1",
           maxConnections: 9,
           port: 1235,
@@ -3509,6 +3799,30 @@ describe("@view-server/runtime", () => {
         },
         tcpPublishUrl: "tcp://127.0.0.1:1235",
       });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("forwards runtime auth validation to operational HTTP endpoints", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(viewServer, {
+        auth: bearerAuth,
+      });
+
+      const health = yield* fetchJson(runtime.healthUrl);
+      const metrics = yield* fetchJson(runtime.metricsUrl);
+
+      expect(health.response.status).toBe(401);
+      expect(health.value).toStrictEqual({
+        _tag: "ViewServerAuthError",
+        message: "Missing or invalid authorization header.",
+      });
+      expect(metrics.response.status).toBe(401);
+      expect(metrics.value).toStrictEqual({
+        _tag: "ViewServerAuthError",
+        message: "Missing or invalid authorization header.",
+      });
+
       yield* runtime.close;
     }),
   );

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -184,6 +184,7 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
       : yield* dependencies
           .makeTcpPublishIngress(config, runtimeClient, {
             ...resolvedOptions.tcpPublishOptions,
+            ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
             rejectedTopics: sourceOwnedTopics,
           })
           .pipe(
@@ -197,6 +198,7 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
     .makeServer(
       config,
       {
+        ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
         liveClient: runtimeLiveClient,
         runtime: runtimeClient,
         transport: {

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -23,6 +23,7 @@ export type ResolvedViewServerRuntimeOptions<
   Regions extends RuntimeRegions = RuntimeRegions,
   GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
 > = {
+  readonly auth?: ViewServerRuntimeOptions<Topics, Regions, GrpcClients>["auth"];
   readonly runtimeCoreOptions: ViewServerRuntimeCoreOptionsFor<Topics>;
   readonly serverOptions: ViewServerWebSocketServerOptions;
   readonly tcpPublishOptions?: {
@@ -415,6 +416,7 @@ export const resolveViewServerRuntimeOptions: <
     options.grpc === undefined ? undefined : yield* resolveGrpcOptions(options.grpc);
   yield* validateSourceOwnership(kafkaOptions, grpcOptions);
   return {
+    ...(options.auth === undefined ? {} : { auth: options.auth }),
     runtimeCoreOptions,
     serverOptions,
     ...(tcpPublishOptions === undefined ? {} : { tcpPublishOptions }),

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -1,5 +1,6 @@
 import type { ViewServerLiveClient } from "@view-server/client";
 import type { GroupedIncrementalAdmissionLimits } from "@view-server/runtime-core";
+import type { ViewServerAuth } from "@view-server/server";
 import type {
   KafkaRuntimeTopicDefinition,
   LiveQueryRow,
@@ -68,6 +69,7 @@ export type ViewServerRuntimeOptions<
   readonly rpcPath?: RuntimeHttpPath;
   readonly healthPath?: RuntimeHttpPath;
   readonly metricsPath?: RuntimeHttpPath;
+  readonly auth?: ViewServerAuth;
   readonly kafka?: ViewServerKafkaRuntimeOptions<Topics, Regions>;
   readonly grpc?: ViewServerGrpcRuntimeOptions<Topics, GrpcClients>;
   readonly groupedIncrementalAdmissionLimits?: Partial<GroupedIncrementalAdmissionLimits>;

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -4,7 +4,9 @@ import type {
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@view-server/config";
-import { Cause, Effect, Exit, Fiber, Result, Schema, SchemaAST } from "effect";
+import type { ViewServerAuth, ViewServerAuthRequest } from "@view-server/server";
+import { validateViewServerAuthRequest, ViewServerAuthError } from "@view-server/server";
+import { Cause, Effect, Exit, Fiber, Option, Result, Schema, SchemaAST } from "effect";
 import * as Net from "node:net";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
@@ -26,6 +28,7 @@ export type ViewServerTcpPublishIngressOptions = {
   readonly maxQueuedCommands?: number;
   readonly port: number;
   readonly rejectedTopics?: ReadonlySet<string>;
+  readonly auth?: ViewServerAuth;
 };
 
 export type ViewServerTcpPublishIngress = {
@@ -34,7 +37,10 @@ export type ViewServerTcpPublishIngress = {
 };
 
 type RuntimeMutationEffect = Effect.Effect<unknown, unknown, never>;
-type TcpPublishCommandError = ViewServerRuntimeError | ViewServerTcpPublishIngressError;
+type TcpPublishCommandError =
+  | ViewServerAuthError
+  | ViewServerRuntimeError
+  | ViewServerTcpPublishIngressError;
 
 const TcpAddress = Schema.Struct({
   address: Schema.String,
@@ -43,35 +49,43 @@ const TcpAddress = Schema.Struct({
 });
 
 const TcpJsonObject = Schema.Record(Schema.String, Schema.Json);
+const TcpHeaders = Schema.Record(Schema.String, Schema.String);
 
 const TcpPublishCommandSchema = Schema.Union([
   Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
     op: Schema.Literal("publish"),
     topic: Schema.String,
     row: TcpJsonObject,
   }),
   Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
     op: Schema.Literal("publishMany"),
     topic: Schema.String,
     rows: Schema.Array(TcpJsonObject),
   }),
   Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
     op: Schema.Literal("patch"),
     topic: Schema.String,
     key: Schema.String,
     patch: TcpJsonObject,
   }),
   Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
     op: Schema.Literal("delete"),
     topic: Schema.String,
     key: Schema.String,
   }),
 ]);
 
+type TcpPublishCommand = typeof TcpPublishCommandSchema.Type;
+
 type TcpPublishSocketState = {
   readonly activeFibers: Set<Fiber.Fiber<void, TcpPublishCommandError>>;
   buffer: string;
   closed: boolean;
+  preCommandDeadline: ReturnType<typeof globalThis.setTimeout> | undefined;
   queuedCommands: number;
   chain: Promise<void>;
 };
@@ -80,6 +94,7 @@ type TcpPublishServerState = {
   readonly activeChains: Set<Promise<void>>;
   closed: boolean;
   readonly activeFibers: Set<Fiber.Fiber<void, TcpPublishCommandError>>;
+  readonly preCommandDeadlineMs: number | undefined;
   queuedCommands: number;
   readonly socketStates: Map<Net.Socket, TcpPublishSocketState>;
   readonly sockets: Set<Net.Socket>;
@@ -109,6 +124,7 @@ const defaultMaxLineBytes = 1024 * 1024;
 const defaultMaxConnections = 1024;
 const defaultMaxGlobalQueuedCommands = 1024;
 const defaultMaxQueuedCommands = 1024;
+const acceptedSocketPreCommandDeadlineMs = 30_000;
 const rejectedSocketDestroyTimeoutMs = 1_000;
 const strictParseOptions = {
   onExcessProperty: "error",
@@ -168,6 +184,13 @@ const parseCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.parse")(fun
         ),
     },
   );
+});
+
+const tcpAuthRequest = (command: TcpPublishCommand, socket: Net.Socket): ViewServerAuthRequest => ({
+  headers: command.headers ?? {},
+  method: "POST",
+  remoteAddress: Option.fromUndefinedOr(socket.remoteAddress),
+  url: "tcp://view-server/tcp-publish",
 });
 
 const runtimeCallFailed = (
@@ -438,12 +461,16 @@ const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(fu
 const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(
+  socket: Net.Socket,
+  state: TcpPublishSocketState,
   config: ViewServerConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
   line: string,
 ) {
   const command = yield* parseCommand(line);
+  yield* validateViewServerAuthRequest(options.auth, tcpAuthRequest(command, socket));
+  clearTcpPreCommandDeadline(state);
   yield* ensureTopicCanBeMutated(command.topic, options);
   if (command.op === "publish") {
     const row = yield* decodeTcpRow(config, command.topic, command.row);
@@ -490,6 +517,16 @@ const wireError = (cause: Cause.Cause<TcpPublishCommandError>): object => {
           code: failure.value.code,
           message: failure.value.message,
           ...(failure.value.topic === undefined ? {} : { topic: failure.value.topic }),
+        },
+      };
+    }
+    if (failure.value instanceof ViewServerAuthError) {
+      return {
+        ok: false,
+        error: {
+          _tag: failure.value._tag,
+          message: failure.value.message,
+          status: failure.value.status,
         },
       };
     }
@@ -640,7 +677,7 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
     if (state.closed || serverState.closed) {
       return;
     }
-    const fiber = Effect.runFork(handleCommand(config, client, options, line));
+    const fiber = Effect.runFork(handleCommand(socket, state, config, client, options, line));
     serverState.activeFibers.add(fiber);
     state.activeFibers.add(fiber);
     const exit = await Effect.runPromise(Fiber.await(fiber));
@@ -657,6 +694,19 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
   } finally {
     state.queuedCommands -= 1;
     serverState.queuedCommands -= 1;
+    if (
+      state.closed === false &&
+      serverState.closed === false &&
+      socket.destroyed === false &&
+      state.queuedCommands === 0 &&
+      state.preCommandDeadline === undefined
+    ) {
+      armTcpPreCommandDeadline(
+        socket,
+        state,
+        serverState.preCommandDeadlineMs ?? acceptedSocketPreCommandDeadlineMs,
+      );
+    }
   }
 };
 
@@ -709,6 +759,22 @@ const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
     }
   };
   void chain.then(cleanup);
+};
+
+const clearTcpPreCommandDeadline = (state: TcpPublishSocketState): void => {
+  if (state.preCommandDeadline !== undefined) {
+    globalThis.clearTimeout(state.preCommandDeadline);
+    state.preCommandDeadline = undefined;
+  }
+};
+
+const armTcpPreCommandDeadline = (
+  socket: Net.Socket,
+  state: TcpPublishSocketState,
+  deadlineMs: number,
+): void => {
+  clearTcpPreCommandDeadline(state);
+  state.preCommandDeadline = globalThis.setTimeout(socket.destroy.bind(socket), deadlineMs);
 };
 
 const interruptSocketFibers = (state: TcpPublishSocketState): void => {
@@ -872,13 +938,20 @@ export const installTcpPublishAcceptedSocket = <
     buffer: "",
     chain: Promise.resolve(),
     closed: false,
+    preCommandDeadline: undefined,
     queuedCommands: 0,
   };
   state.sockets.add(socket);
   state.socketStates.set(socket, socketState);
   socket.on("error", socket.destroy.bind(socket));
+  armTcpPreCommandDeadline(
+    socket,
+    socketState,
+    state.preCommandDeadlineMs ?? acceptedSocketPreCommandDeadlineMs,
+  );
   socket.on("close", () => {
     socketState.closed = true;
+    clearTcpPreCommandDeadline(socketState);
     state.sockets.delete(socket);
     interruptSocketFibers(socketState);
     void socketState.chain.then(() => state.socketStates.delete(socket));
@@ -898,6 +971,7 @@ export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpP
       activeChains: new Set(),
       activeFibers: new Set(),
       closed: false,
+      preCommandDeadlineMs: undefined,
       queuedCommands: 0,
       socketStates: new Map(),
       sockets: new Set(),

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,0 +1,77 @@
+import { Effect, Schema } from "effect";
+import type { HttpServerRequest } from "effect/unstable/http";
+import { HttpServerResponse } from "effect/unstable/http";
+
+export class ViewServerAuthError extends Schema.TaggedErrorClass<ViewServerAuthError>()(
+  "ViewServerAuthError",
+  {
+    message: Schema.String,
+    status: Schema.Union([Schema.Literal(401), Schema.Literal(403)]),
+  },
+) {}
+
+export type ViewServerSession = {
+  readonly id: string | null;
+  readonly forwardedHeaders: Readonly<Record<string, string>>;
+  readonly systemHeaders: Readonly<Record<string, string>>;
+};
+
+export type ViewServerAuthRequest = {
+  readonly headers: Readonly<Record<string, string>>;
+  readonly method: HttpServerRequest.HttpServerRequest["method"];
+  readonly remoteAddress: HttpServerRequest.HttpServerRequest["remoteAddress"];
+  readonly url: string;
+};
+
+export type ViewServerAuthValidator = (
+  request: ViewServerAuthRequest,
+) => Effect.Effect<ViewServerSession, ViewServerAuthError>;
+
+export type ViewServerAuth = {
+  readonly validateRequest: ViewServerAuthValidator;
+};
+
+export const anonymousViewServerSession: ViewServerSession = {
+  forwardedHeaders: {},
+  id: null,
+  systemHeaders: {},
+};
+
+export const allowAnonymousViewServerAuth: ViewServerAuth = {
+  validateRequest: () => Effect.succeed(anonymousViewServerSession),
+};
+
+const requestInput = (request: HttpServerRequest.HttpServerRequest): ViewServerAuthRequest => ({
+  headers: request.headers,
+  method: request.method,
+  remoteAddress: request.remoteAddress,
+  url: request.url,
+});
+
+export const validateViewServerAuthRequest = Effect.fn("ViewServerServer.auth.validateRequest")(
+  function* (auth: ViewServerAuth | undefined, request: ViewServerAuthRequest) {
+    const validator = auth ?? allowAnonymousViewServerAuth;
+    return yield* validator.validateRequest(request);
+  },
+);
+
+export const validateViewServerHttpRequest = Effect.fn("ViewServerServer.auth.validate")(function* (
+  auth: ViewServerAuth | undefined,
+  request: HttpServerRequest.HttpServerRequest,
+) {
+  return yield* validateViewServerAuthRequest(auth, requestInput(request));
+});
+
+const authErrorBody = (error: ViewServerAuthError): string =>
+  JSON.stringify({
+    _tag: error._tag,
+    message: error.message,
+  });
+
+export const viewServerAuthErrorResponse = (
+  error: ViewServerAuthError,
+): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.text(authErrorBody(error), {
+    contentType: "application/json",
+    status: error.status,
+  });

--- a/packages/server/src/health-route.ts
+++ b/packages/server/src/health-route.ts
@@ -1,7 +1,8 @@
 import type { TopicDefinitions, ViewServerConfig } from "@view-server/config";
 import { viewServerDecodeHealth } from "@view-server/protocol";
-import { Effect } from "effect";
-import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
+import { Cause, Effect, Option } from "effect";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import { validateViewServerHttpRequest, viewServerAuthErrorResponse } from "./auth";
 import type { ViewServerWebSocketServerInput } from "./server-types";
 
 const jsonStringify = (value: unknown): string =>
@@ -15,6 +16,9 @@ const jsonResponse = (status: number, value: unknown): HttpServerResponse.HttpSe
     contentType: "application/json",
   });
 
+const failureJsonResponse = (cause: Cause.Cause<unknown>): HttpServerResponse.HttpServerResponse =>
+  jsonResponse(500, Cause.findErrorOption(cause).pipe(Option.getOrElse(() => Cause.pretty(cause))));
+
 export const makeViewServerHealthRoute = <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,
   input: ViewServerWebSocketServerInput<Topics>,
@@ -23,11 +27,20 @@ export const makeViewServerHealthRoute = <const Topics extends TopicDefinitions>
   HttpRouter.add(
     "GET",
     path,
-    input.runtime.health().pipe(
-      Effect.flatMap((health) => viewServerDecodeHealth(config, health)),
-      Effect.match({
-        onFailure: (error) => jsonResponse(500, error),
-        onSuccess: (health) => jsonResponse(health.status === "ready" ? 200 : 503, health),
-      }),
-    ),
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      return yield* validateViewServerHttpRequest(input.auth, request).pipe(
+        Effect.matchEffect({
+          onFailure: (error) => Effect.succeed(viewServerAuthErrorResponse(error)),
+          onSuccess: () =>
+            Effect.gen(function* () {
+              const health = yield* input.runtime.health();
+              return yield* viewServerDecodeHealth(config, health);
+            }).pipe(
+              Effect.map((health) => jsonResponse(health.status === "ready" ? 200 : 503, health)),
+              Effect.catchCause((cause) => Effect.succeed(failureJsonResponse(cause))),
+            ),
+        }),
+      );
+    }),
   );

--- a/packages/server/src/index.test-d.ts
+++ b/packages/server/src/index.test-d.ts
@@ -1,11 +1,25 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
 import { Effect } from "effect";
-import type { ViewServerWebSocketServerInput, ViewServerWebSocketServerOptions } from "./index";
+import type {
+  ViewServerAuth,
+  ViewServerAuthRequest,
+  ViewServerSession,
+  ViewServerWebSocketServerInput,
+  ViewServerWebSocketServerOptions,
+} from "./index";
 
 declare const serverInput: ViewServerWebSocketServerInput<never>;
 
 describe("server type contracts", () => {
   it("accepts omitted, empty, client-only, and stream-only transport hooks", () => {
+    const auth = {
+      validateRequest: (_request: ViewServerAuthRequest) =>
+        Effect.succeed({
+          forwardedHeaders: {},
+          id: "session-1",
+          systemHeaders: {},
+        }),
+    } satisfies ViewServerAuth;
     const noTransportInput = {
       liveClient: serverInput.liveClient,
       runtime: serverInput.runtime,
@@ -14,6 +28,11 @@ describe("server type contracts", () => {
       liveClient: serverInput.liveClient,
       runtime: serverInput.runtime,
       transport: {},
+    } satisfies ViewServerWebSocketServerInput<never>;
+    const authInput = {
+      auth,
+      liveClient: serverInput.liveClient,
+      runtime: serverInput.runtime,
     } satisfies ViewServerWebSocketServerInput<never>;
     const clientOnlyInput = {
       liveClient: serverInput.liveClient,
@@ -34,6 +53,8 @@ describe("server type contracts", () => {
 
     expectTypeOf(noTransportInput).not.toBeAny();
     expectTypeOf(emptyTransportInput).not.toBeAny();
+    expectTypeOf(authInput).toMatchTypeOf<ViewServerWebSocketServerInput<never>>();
+    expectTypeOf(authInput.auth.validateRequest).not.toBeAny();
     expectTypeOf(clientOnlyInput).not.toBeAny();
     expectTypeOf(streamOnlyInput).not.toBeAny();
   });
@@ -53,11 +74,37 @@ describe("server type contracts", () => {
         streamOpened: "not an effect",
       },
     };
+    const invalidAuthInput = {
+      auth: {
+        validateRequest: () => "not an effect",
+      },
+      liveClient: serverInput.liveClient,
+      runtime: serverInput.runtime,
+    };
 
     // @ts-expect-error clientOpened must be an Effect.
     invalidClientHookInput satisfies ViewServerWebSocketServerInput<never>;
     // @ts-expect-error streamOpened must be an Effect.
     invalidStreamHookInput satisfies ViewServerWebSocketServerInput<never>;
+    // @ts-expect-error auth validator must return an Effect.
+    invalidAuthInput satisfies ViewServerWebSocketServerInput<never>;
+  });
+
+  it("keeps session shape explicit", () => {
+    const session = {
+      forwardedHeaders: {
+        authorization: "Bearer forwarded",
+      },
+      id: "session-1",
+      systemHeaders: {
+        "x-system": "view-server",
+      },
+    } satisfies ViewServerSession;
+
+    expectTypeOf(session).toMatchTypeOf<ViewServerSession>();
+    expectTypeOf<ViewServerSession["id"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<ViewServerSession["forwardedHeaders"][string]>().toEqualTypeOf<string>();
+    expectTypeOf<ViewServerSession["systemHeaders"][string]>().toEqualTypeOf<string>();
   });
 
   it("only accepts concrete slash-prefixed connection paths", () => {

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -40,7 +40,8 @@ import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import type { RpcClientError } from "effect/unstable/rpc/RpcClientError";
 import * as Socket from "effect/unstable/socket/Socket";
 import * as Net from "node:net";
-import { makeViewServerWebSocketServer } from "./index";
+import { makeViewServerWebSocketServer, ViewServerAuthError } from "./index";
+import type { ViewServerAuth } from "./index";
 import { makeViewServerRpcHandlers } from "./rpc-handlers";
 import { closeTrackedSockets, makeTrackedSocket } from "./websocket-tracking";
 
@@ -161,6 +162,24 @@ const kafkaStartFromHealth = {
   mode: "latest",
 } as const;
 
+const bearerAuth: ViewServerAuth = {
+  validateRequest: (request) =>
+    request.headers["authorization"] === "Bearer view-server-test"
+      ? Effect.succeed({
+          forwardedHeaders: {
+            authorization: request.headers["authorization"],
+          },
+          id: "session-1",
+          systemHeaders: {},
+        })
+      : Effect.fail(
+          new ViewServerAuthError({
+            message: "Missing or invalid authorization header.",
+            status: 401,
+          }),
+        ),
+};
+
 type OrderRow = typeof Order.Type;
 type TradeRow = typeof Trade.Type;
 type QuoteRow = typeof Quote.Type;
@@ -234,6 +253,38 @@ const fetchText = Effect.fn("ViewServerServer.test.fetchText")(function* (url: s
   const text = yield* Effect.promise(() => response.text());
   return { response, text };
 });
+
+const fetchJsonWithAuthorization = Effect.fn("ViewServerServer.test.fetchJsonWithAuthorization")(
+  function* (url: string, authorization: string) {
+    const response = yield* Effect.promise(() =>
+      fetch(url, {
+        headers: {
+          authorization,
+        },
+      }),
+    );
+    const text = yield* Effect.promise(() => response.text());
+    const value = yield* Effect.try({
+      try: (): unknown => JSON.parse(text),
+      catch: (cause) => new ServerTestJsonParseError({ cause }),
+    });
+    return { response, value };
+  },
+);
+
+const fetchTextWithAuthorization = Effect.fn("ViewServerServer.test.fetchTextWithAuthorization")(
+  function* (url: string, authorization: string) {
+    const response = yield* Effect.promise(() =>
+      fetch(url, {
+        headers: {
+          authorization,
+        },
+      }),
+    );
+    const text = yield* Effect.promise(() => response.text());
+    return { response, text };
+  },
+);
 
 const reserveTcpPort = Effect.fn("ViewServerServer.test.tcp.reservePort")(function* () {
   const server = yield* Effect.acquireRelease(
@@ -700,6 +751,88 @@ describe("@view-server/server", () => {
     }),
   );
 
+  it.live("requires auth for GET /health when an auth validator is configured", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        auth: bearerAuth,
+        liveClient: inMemory.liveClient,
+        runtime: inMemory.client,
+      });
+
+      const deniedHealth = yield* fetchJson(server.healthUrl);
+      const acceptedHealth = yield* fetchJsonWithAuthorization(
+        server.healthUrl,
+        "Bearer view-server-test",
+      );
+      const acceptedBody = yield* Schema.decodeUnknownEffect(HealthJson)(acceptedHealth.value);
+
+      expect(deniedHealth.response.status).toBe(401);
+      expect(deniedHealth.value).toStrictEqual({
+        _tag: "ViewServerAuthError",
+        message: "Missing or invalid authorization header.",
+      });
+      expect(acceptedHealth.response.status).toBe(200);
+      expect(acceptedBody.status).toBe("ready");
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("requires auth for GET /metrics when an auth validator is configured", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        auth: bearerAuth,
+        liveClient: inMemory.liveClient,
+        runtime: inMemory.client,
+      });
+
+      const deniedMetrics = yield* fetchJson(server.metricsUrl);
+      const acceptedMetrics = yield* fetchTextWithAuthorization(
+        server.metricsUrl,
+        "Bearer view-server-test",
+      );
+
+      expect(deniedMetrics.response.status).toBe(401);
+      expect(deniedMetrics.value).toStrictEqual({
+        _tag: "ViewServerAuthError",
+        message: "Missing or invalid authorization header.",
+      });
+      expect(acceptedMetrics.response.status).toBe(200);
+      expect(acceptedMetrics.text).toContain("# TYPE view_server_runtime_status gauge");
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("rejects websocket upgrades when auth validation fails", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      let openedClients = 0;
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        auth: bearerAuth,
+        liveClient: inMemory.liveClient,
+        runtime: inMemory.client,
+        transport: {
+          clientOpened: Effect.sync(() => {
+            openedClients += 1;
+          }),
+        },
+      });
+
+      const socketExit = yield* Effect.exit(openRawWebSocket(server.url));
+
+      expect(Exit.isFailure(socketExit)).toBe(true);
+      expect(openedClients).toBe(0);
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
   it.live("composes with the public runtime-core live client", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
@@ -812,6 +945,26 @@ describe("@view-server/server", () => {
       expect(health.value).toStrictEqual(healthError);
       expect(metrics.response.status).toBe(200);
       expect(metrics.text).toBe("view_server_metrics_error 1\n");
+
+      yield* server.close;
+      yield* inMemory.close;
+    }),
+  );
+
+  it.live("returns 500 when runtime health defects", () =>
+    Effect.gen(function* () {
+      const inMemory = createServerTestRuntime(viewServer);
+      const server = yield* makeViewServerWebSocketServer(viewServer, {
+        liveClient: inMemory.liveClient,
+        runtime: {
+          health: () => Effect.die("health defect"),
+        },
+      });
+
+      const health = yield* fetchJson(server.healthUrl);
+
+      expect(health.response.status).toBe(500);
+      expect(health.value).toContain("Error: health defect");
 
       yield* server.close;
       yield* inMemory.close;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,13 @@ import { Context, Effect, Exit, Layer, ManagedRuntime, Scope } from "effect";
 import { HttpRouter, HttpServer, HttpServerError, HttpServerRequest } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 import * as Http from "node:http";
+import { validateViewServerHttpRequest, viewServerAuthErrorResponse } from "./auth";
+import type {
+  ViewServerAuth,
+  ViewServerAuthRequest,
+  ViewServerAuthValidator,
+  ViewServerSession,
+} from "./auth";
 import { makeViewServerHealthRoute } from "./health-route";
 import { makeViewServerMetricsRoute } from "./metrics-route";
 import { makeViewServerRpcHandlers } from "./rpc-handlers";
@@ -33,11 +40,17 @@ const makeTrackedWebSocketProtocol = Effect.fn("ViewServerServer.websocket.proto
     const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffectWebsocket;
     const trackedHttpEffect = Effect.gen(function* () {
       const request = yield* HttpServerRequest.HttpServerRequest;
-      return yield* httpEffect.pipe(
-        Effect.provideService(
-          HttpServerRequest.HttpServerRequest,
-          makeTrackedUpgradeRequest(request, clientOpened, clientClosed, activeSocketClosers),
-        ),
+      return yield* validateViewServerHttpRequest(input.auth, request).pipe(
+        Effect.matchEffect({
+          onFailure: (error) => Effect.succeed(viewServerAuthErrorResponse(error)),
+          onSuccess: () =>
+            httpEffect.pipe(
+              Effect.provideService(
+                HttpServerRequest.HttpServerRequest,
+                makeTrackedUpgradeRequest(request, clientOpened, clientClosed, activeSocketClosers),
+              ),
+            ),
+        }),
       );
     });
     yield* router.add("GET", path, trackedHttpEffect);
@@ -54,11 +67,20 @@ const makeTrackedWebSocketProtocolLayer = <const Topics extends TopicDefinitions
 
 export type {
   Jsonify,
+  ViewServerAuth,
+  ViewServerAuthRequest,
+  ViewServerAuthValidator,
   ViewServerHealthHttpJson,
+  ViewServerSession,
   ViewServerWebSocketServer,
   ViewServerWebSocketServerInput,
   ViewServerWebSocketServerOptions,
 };
+export {
+  ViewServerAuthError,
+  anonymousViewServerSession,
+  validateViewServerAuthRequest,
+} from "./auth";
 
 export const makeViewServerWebSocketServer: <const Topics extends TopicDefinitions>(
   config: ViewServerConfig<Topics>,

--- a/packages/server/src/metrics-route.ts
+++ b/packages/server/src/metrics-route.ts
@@ -1,7 +1,8 @@
 import type { TopicDefinitions, ViewServerConfig, ViewServerHealth } from "@view-server/config";
 import { viewServerDecodeHealth } from "@view-server/protocol";
 import { Effect } from "effect";
-import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import { validateViewServerHttpRequest, viewServerAuthErrorResponse } from "./auth";
 import type { ViewServerWebSocketServerInput } from "./server-types";
 
 const metricContentType = "text/plain; version=0.0.4; charset=utf-8";
@@ -409,12 +410,24 @@ export const makeViewServerMetricsRoute = <const Topics extends TopicDefinitions
   HttpRouter.add(
     "GET",
     path,
-    input.runtime.health().pipe(
-      Effect.flatMap((health) => viewServerDecodeHealth(config, health)),
-      Effect.match({
-        onFailure: () =>
-          metricsResponse(200, compactLines([metricLine("view_server_metrics_error", 1)])),
-        onSuccess: (health) => metricsResponse(200, viewServerHealthMetrics(health)),
-      }),
-    ),
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      return yield* validateViewServerHttpRequest(input.auth, request).pipe(
+        Effect.matchEffect({
+          onFailure: (error) => Effect.succeed(viewServerAuthErrorResponse(error)),
+          onSuccess: () =>
+            Effect.gen(function* () {
+              const health = yield* input.runtime.health();
+              return yield* viewServerDecodeHealth(config, health);
+            }).pipe(
+              Effect.map((health) => metricsResponse(200, viewServerHealthMetrics(health))),
+              Effect.catchCause(() =>
+                Effect.succeed(
+                  metricsResponse(200, compactLines([metricLine("view_server_metrics_error", 1)])),
+                ),
+              ),
+            ),
+        }),
+      );
+    }),
   );

--- a/packages/server/src/server-types.ts
+++ b/packages/server/src/server-types.ts
@@ -5,6 +5,7 @@ import type {
   ViewServerRuntimeClient,
 } from "@view-server/config";
 import type { Effect } from "effect";
+import type { ViewServerAuth } from "./auth";
 
 export type ViewServerServerRuntime<Topics extends TopicDefinitions> = Pick<
   ViewServerRuntimeClient<Topics>,
@@ -12,6 +13,7 @@ export type ViewServerServerRuntime<Topics extends TopicDefinitions> = Pick<
 >;
 
 export type ViewServerWebSocketServerInput<Topics extends TopicDefinitions> = {
+  readonly auth?: ViewServerAuth;
   readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
   readonly runtime: ViewServerServerRuntime<Topics>;
   readonly transport?: {

--- a/plans/remaining-roadmap-audit.md
+++ b/plans/remaining-roadmap-audit.md
@@ -25,7 +25,7 @@ truth, not plan text that predates later implementation work.
 | gRPC health/lifecycle                           | Implemented            | `packages/runtime/src/grpc-health.ts`, runtime health tests, `pnpm run grpc:gate`.                                    |
 | gRPC benchmark gates                            | Implemented            | `benchmarks/baselines/grpc-materialized.json`, `grpc-leased.json`, `grpc-leased-retained.json`, `pnpm run grpc:gate`. |
 | Public config migration to source constructors  | Deferred intentionally | Listed under `Deferred Decisions`; current source markers are accepted.                                               |
-| Session-scoped leased feeds and auth forwarding | Deferred intentionally | Current slice uses system-scoped shared feeds.                                                                        |
+| Session-scoped leased feeds and auth forwarding | Deferred intentionally | Runtime auth validates edge requests; gRPC feeds still use system-scoped shared feed identity.                        |
 | Generic non-gRPC stream-source API              | Deferred intentionally | Plan explicitly keeps ConnectRPC-specific public API.                                                                 |
 | Multi-source topics                             | Deferred intentionally | Requires a separate ordering/dedupe/restart contract.                                                                 |
 | Custom live-event transport                     | Deferred intentionally | Browser transport remains Effect RPC WebSocket + NDJSON.                                                              |
@@ -50,6 +50,7 @@ because it includes explicit future scope.
 | Health hook, `/health`, and `/metrics` endpoints              | Implemented | `useViewServerHealth`, runtime/server health tests, health codecs, metrics route/runtime tests, root/runtime README docs.                                                                                                          |
 | Kafka runtime ingress                                         | Implemented | `@platformatic/kafka`, JSON/protobuf/custom codecs, source mapping, Docker Apache Kafka e2e, restart/startFrom policy.                                                                                                             |
 | gRPC runtime ingress                                          | Implemented | Covered by `plans/grpc.md` implementation.                                                                                                                                                                                         |
+| Runtime auth/session validation seam                          | Implemented | Optional `auth.validateRequest` on server/runtime validates WebSocket upgrades, `/health`, and `/metrics`; default remains anonymous.                                                                                              |
 | Snapshot/delta convergence                                    | Implemented | Engine/runtime/client tests cover raw, grouped, retained deltas, cleanup, and convergence.                                                                                                                                         |
 | Grouped queries and aggregates                                | Implemented | Grouped query tests, grouped aggregate/write benchmarks and gates.                                                                                                                                                                 |
 | Backpressure at subscription/transport boundary               | Implemented | `BackpressureExceeded` typed status, queue-capacity tests, remote/client/protocol tests.                                                                                                                                           |
@@ -62,11 +63,10 @@ because it includes explicit future scope.
 These are concrete gaps where the plan describes behavior that is still missing or
 currently only documented as a future seam.
 
-| Item                                 | Status                | Why it remains                                                                                   | Suggested first PR                                                                                                    |
-| ------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| Runtime auth/session validation seam | Production-ready next | gRPC has system/shared session context; server/runtime do not expose `auth.validateRequest` yet. | Add optional server/runtime auth validation at WebSocket and health/admin boundaries, initially anonymous by default. |
-| Span/observability assertions        | Production-ready next | Code uses named `Effect.fn`, but tests do not prove key ingest -> engine -> fanout spans exist.  | Add one focused tracing test that captures span names for publish -> engine mutation -> subscription fanout.          |
-| Example app                          | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist.                                     | Add a minimal example using real provider URL injection and in-memory provider test/demo path.                        |
+| Item                          | Status                | Why it remains                                                                                  | Suggested first PR                                                                                           |
+| ----------------------------- | --------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Span/observability assertions | Production-ready next | Code uses named `Effect.fn`, but tests do not prove key ingest -> engine -> fanout spans exist. | Add one focused tracing test that captures span names for publish -> engine mutation -> subscription fanout. |
+| Example app                   | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist.                                    | Add a minimal example using real provider URL injection and in-memory provider test/demo path.               |
 
 ### Intentionally Deferred
 
@@ -79,7 +79,7 @@ These are in the plan, but should remain future work unless explicitly promoted.
 | Custom live-event WebSocket protocol                     | Deferred intentionally | Effect RPC WebSocket + NDJSON remains current production transport.                                                   |
 | Rust/native/SIMD engine                                  | Deferred intentionally | TypeScript engine remains primary; native acceleration only if future benchmarks justify it.                          |
 | User-defined indexes                                     | Deferred intentionally | Product principle remains automatic optimization from schemas and controlled query DSL.                               |
-| Session-scoped gRPC leased feeds                         | Deferred intentionally | Needs real authenticated sessions first.                                                                              |
+| Session-scoped gRPC leased feeds                         | Deferred intentionally | Edge auth exists, but leased feeds still need a separate session partitioning/forwarding contract.                    |
 
 ### Stale Or Needs Rewrite
 
@@ -89,9 +89,8 @@ These are in the plan, but should remain future work unless explicitly promoted.
 
 ## Recommended Implementation Order
 
-1. Runtime auth/session validation seam.
-2. Span/observability assertions.
-3. Minimal example app.
+1. Span/observability assertions.
+2. Minimal example app.
 
 Do not reopen completed gRPC materialized/leased scope unless new tests reveal a real
 correctness gap.


### PR DESCRIPTION
## Summary
- add a shared View Server auth validator seam for WebSocket, health, metrics, and TCP publish ingress
- decode TCP publish command JSON and row/patch payloads with Effect Schema before runtime mutation
- cover authenticated TCP publish, peer address propagation, operational endpoint auth, invalid row/patch rejection, and TCP pre-command deadline behavior

## Validation
- pnpm run ready