### PR TITLE
Add runtime-core span observability assertions

### DIFF
--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -4,7 +4,7 @@ import {
   type ColumnLiveViewEngineHealth,
 } from "@view-server/column-live-view-engine";
 import { defineViewServerConfig, grpc, type ViewServerRuntimeError } from "@view-server/config";
-import { Deferred, Effect, Fiber, Queue, Schema, Stream } from "effect";
+import { Deferred, Effect, Fiber, Option, Queue, Schema, Stream, Tracer } from "effect";
 import { AtomRef } from "effect/unstable/reactivity";
 import {
   healthFromEngine,
@@ -49,6 +49,15 @@ const leasedViewServer = defineViewServerConfig({
 type OrderRow = typeof Order.Type;
 type Topics = typeof viewServer.topics;
 
+type RecordedSpan = {
+  readonly attributes: ReadonlyArray<readonly [string, unknown]>;
+  readonly name: string;
+  readonly parentName: string | null;
+  readonly parentSpanId: string | null;
+  readonly spanId: string;
+  readonly traceId: string;
+};
+
 const order = (id: string, price: number): OrderRow => ({
   id,
   customerId: `customer-${id}`,
@@ -71,6 +80,80 @@ const publicLeasedRuntimeAccessError = {
   message:
     "Leased gRPC topics do not support direct runtime mutations, one-shot snapshots, or runtime-core subscriptions; use the runtime gRPC lease manager so it owns lease lifecycle.",
 } satisfies ViewServerRuntimeError;
+
+const stableAttributes = (
+  attributes: ReadonlyMap<string, unknown>,
+): ReadonlyArray<readonly [string, unknown]> =>
+  Array.from(attributes.entries()).sort(([left], [right]) => left.localeCompare(right));
+
+const spanName = (span: Tracer.AnySpan): string => (span._tag === "Span" ? span.name : span.spanId);
+
+const makeRecordingTracer = (): {
+  readonly spans: Array<RecordedSpan>;
+  readonly tracer: Tracer.Tracer;
+} => {
+  const spans: Array<RecordedSpan> = [];
+  let nextSpanId = 0;
+  const nextId = (): string => {
+    nextSpanId += 1;
+    return String(nextSpanId);
+  };
+  const tracer = Tracer.make({
+    span: (options): Tracer.Span => {
+      const id = nextId();
+      const attributes = new Map<string, unknown>();
+      const links = Array.from(options.links);
+      let status: Tracer.SpanStatus = {
+        _tag: "Started",
+        startTime: options.startTime,
+      };
+      const span: Tracer.Span = {
+        _tag: "Span",
+        annotations: options.annotations,
+        attribute: (key, value) => {
+          attributes.set(key, value);
+        },
+        attributes,
+        end: (endTime, exit) => {
+          const parent = Option.getOrNull(options.parent);
+          status = {
+            _tag: "Ended",
+            endTime,
+            exit,
+            startTime: status.startTime,
+          };
+          spans.push({
+            attributes: stableAttributes(attributes),
+            name: options.name,
+            parentName: parent === null ? null : spanName(parent),
+            parentSpanId: parent === null ? null : parent.spanId,
+            spanId: span.spanId,
+            traceId: span.traceId,
+          });
+        },
+        event: () => {},
+        addLinks: (newLinks) => {
+          links.push(...newLinks);
+        },
+        get status() {
+          return status;
+        },
+        kind: options.kind,
+        links,
+        name: options.name,
+        parent: options.parent,
+        sampled: options.sampled,
+        spanId: `span-${id}`,
+        traceId: Option.match(options.parent, {
+          onNone: () => `trace-${id}`,
+          onSome: (parent) => parent.traceId,
+        }),
+      };
+      return span;
+    },
+  });
+  return { spans, tracer };
+};
 
 const engineHealth = (
   status: "ready" | "stopping",
@@ -110,6 +193,168 @@ const engineHealth = (
 });
 
 describe("@view-server/runtime-core", () => {
+  it.effect("records runtime core publish, engine mutation, and subscription fanout spans", () =>
+    Effect.gen(function* () {
+      const recording = makeRecordingTracer();
+      const observedSpans = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+          yield* Effect.addFinalizer(() => runtimeCore.close);
+          const subscription = yield* runtimeCore.liveClient.subscribe("orders", {
+            select: ["id", "price"],
+            orderBy: [{ field: "price", direction: "asc" }],
+            limit: 10,
+          });
+          yield* Effect.addFinalizer(() => subscription.close().pipe(Effect.orDie));
+
+          const eventsFiber = yield* subscription.events.pipe(
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          yield* runtimeCore.client.publish("orders", order("a", 10));
+          const events = yield* Fiber.join(eventsFiber);
+          expect(events).toStrictEqual([
+            {
+              type: "snapshot",
+              topic: "orders",
+              queryId: "query-0",
+              version: 0,
+              keys: [],
+              rows: [],
+              totalRows: 0,
+            },
+            {
+              type: "delta",
+              topic: "orders",
+              queryId: "query-0",
+              fromVersion: 0,
+              toVersion: 1,
+              operations: [
+                {
+                  type: "insert",
+                  key: "a",
+                  row: {
+                    id: "a",
+                    price: 10,
+                  },
+                  index: 0,
+                },
+              ],
+              totalRows: 1,
+            },
+          ]);
+
+          return recording.spans;
+        }),
+      ).pipe(Effect.provideService(Tracer.Tracer, recording.tracer));
+
+      const spansByName = new Map(observedSpans.map((span) => [span.name, span]));
+      const clientPublish = spansByName.get("ViewServerRuntimeCore.client.publish");
+      const publish = spansByName.get("ColumnLiveViewEngine.publish");
+      const topicStorePublish = spansByName.get("ColumnLiveViewEngine.topicStore.publish");
+      const mutationTransaction = spansByName.get(
+        "ColumnLiveViewEngine.topicStore.mutationTransaction",
+      );
+      const mutationBatch = spansByName.get("ColumnLiveViewEngine.topicStore.mutationBatch");
+      const notify = spansByName.get("ColumnLiveViewEngine.topicStore.notify");
+      const liveSubscriptionNotify = spansByName.get(
+        "ColumnLiveViewEngine.liveSubscription.notify",
+      );
+
+      expect({
+        clientPublish: {
+          name: clientPublish?.name,
+          parentSpanId: clientPublish?.parentSpanId,
+          traceId: clientPublish?.traceId,
+        },
+        liveSubscriptionNotify: {
+          attributes: liveSubscriptionNotify?.attributes,
+          name: liveSubscriptionNotify?.name,
+          parentName: liveSubscriptionNotify?.parentName,
+          parentSpanId: liveSubscriptionNotify?.parentSpanId,
+          traceId: liveSubscriptionNotify?.traceId,
+        },
+        mutationBatch: {
+          name: mutationBatch?.name,
+          parentName: mutationBatch?.parentName,
+          parentSpanId: mutationBatch?.parentSpanId,
+          traceId: mutationBatch?.traceId,
+        },
+        mutationTransaction: {
+          name: mutationTransaction?.name,
+          parentName: mutationTransaction?.parentName,
+          parentSpanId: mutationTransaction?.parentSpanId,
+          traceId: mutationTransaction?.traceId,
+        },
+        notify: {
+          name: notify?.name,
+          parentName: notify?.parentName,
+          parentSpanId: notify?.parentSpanId,
+          traceId: notify?.traceId,
+        },
+        publish: {
+          name: publish?.name,
+          parentName: publish?.parentName,
+          parentSpanId: publish?.parentSpanId,
+          traceId: publish?.traceId,
+        },
+        topicStorePublish: {
+          name: topicStorePublish?.name,
+          parentName: topicStorePublish?.parentName,
+          parentSpanId: topicStorePublish?.parentSpanId,
+          traceId: topicStorePublish?.traceId,
+        },
+      }).toStrictEqual({
+        clientPublish: {
+          name: "ViewServerRuntimeCore.client.publish",
+          parentSpanId: null,
+          traceId: clientPublish?.traceId,
+        },
+        liveSubscriptionNotify: {
+          attributes: [
+            ["queryId", "query-0"],
+            ["topic", "orders"],
+          ],
+          name: "ColumnLiveViewEngine.liveSubscription.notify",
+          parentName: "ColumnLiveViewEngine.topicStore.notify",
+          parentSpanId: notify?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+        mutationBatch: {
+          name: "ColumnLiveViewEngine.topicStore.mutationBatch",
+          parentName: "ColumnLiveViewEngine.topicStore.mutationTransaction",
+          parentSpanId: mutationTransaction?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+        mutationTransaction: {
+          name: "ColumnLiveViewEngine.topicStore.mutationTransaction",
+          parentName: "ColumnLiveViewEngine.topicStore.publish",
+          parentSpanId: topicStorePublish?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+        notify: {
+          name: "ColumnLiveViewEngine.topicStore.notify",
+          parentName: "ColumnLiveViewEngine.topicStore.mutationBatch",
+          parentSpanId: mutationBatch?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+        publish: {
+          name: "ColumnLiveViewEngine.publish",
+          parentName: "ViewServerRuntimeCore.client.publish",
+          parentSpanId: clientPublish?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+        topicStorePublish: {
+          name: "ColumnLiveViewEngine.topicStore.publish",
+          parentName: "ColumnLiveViewEngine.publish",
+          parentSpanId: publish?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+      });
+    }),
+  );
+
   it.effect("runs the shared runtime core and live client", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -131,11 +131,15 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
             .snapshot<Topic, Query>(topic, query)
             .pipe(Effect.mapError(engineErrorToRuntimeError));
         });
+      const publish = Effect.fn("ViewServerRuntimeCore.client.publish")(function* <
+        Topic extends Extract<keyof Topics, string>,
+      >(topic: Topic, row: TopicRow<Topics, Topic>) {
+        yield* Effect.uninterruptible(
+          engine.publish(topic, row).pipe(Effect.tap(() => requestHealthRefresh())),
+        ).pipe(Effect.mapError(engineErrorToRuntimeError));
+      });
       const internalClient: ViewServerRuntimeCoreInternalClient<Topics> = {
-        publish: (topic, row) =>
-          Effect.uninterruptible(
-            engine.publish(topic, row).pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+        publish,
         publishMany: (topic, rows) =>
           Effect.uninterruptible(
             engine.publishMany(topic, rows).pipe(Effect.tap(() => requestHealthRefresh())),

--- a/plans/remaining-roadmap-audit.md
+++ b/plans/remaining-roadmap-audit.md
@@ -57,16 +57,16 @@ because it includes explicit future scope.
 | Benchmark baseline automation                                 | Implemented | Smoke, raw read/write, active sharing, grouped, WebSocket, Kafka, and gRPC baseline scripts.                                                                                                                                       |
 | Pre-gRPC readiness gate                                       | Implemented | `pnpm run pre-grpc:gate`.                                                                                                                                                                                                          |
 | TCP publish API/runtime ingress                               | Implemented | `packages/runtime/src/tcp-publish-ingress.ts`, runtime TCP tests for publish/patch/delete/publishMany, schema decode errors, bounded line/queue backpressure, source-owned topic rejection, startup failure, and shutdown cleanup. |
+| Runtime-core span/observability assertions                    | Implemented | Runtime-core tracing test captures client publish -> engine publish -> topic-store mutation/fanout -> live-subscription spans with real span-id parent links and topic/query attributes.                                           |
 
 ### Production-Ready Next Items
 
 These are concrete gaps where the plan describes behavior that is still missing or
 currently only documented as a future seam.
 
-| Item                          | Status                | Why it remains                                                                                  | Suggested first PR                                                                                           |
-| ----------------------------- | --------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Span/observability assertions | Production-ready next | Code uses named `Effect.fn`, but tests do not prove key ingest -> engine -> fanout spans exist. | Add one focused tracing test that captures span names for publish -> engine mutation -> subscription fanout. |
-| Example app                   | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist.                                    | Add a minimal example using real provider URL injection and in-memory provider test/demo path.               |
+| Item        | Status                | Why it remains                                               | Suggested first PR                                                                             |
+| ----------- | --------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Example app | Production-ready next | Plan lists `apps/examples`; no `apps` files currently exist. | Add a minimal example using real provider URL injection and in-memory provider test/demo path. |
 
 ### Intentionally Deferred
 
@@ -89,8 +89,7 @@ These are in the plan, but should remain future work unless explicitly promoted.
 
 ## Recommended Implementation Order
 
-1. Span/observability assertions.
-2. Minimal example app.
+1. Minimal example app.
 
 Do not reopen completed gRPC materialized/leased scope unless new tests reveal a real
 correctness gap.


### PR DESCRIPTION
Adds a runtime-core publish span and a tracing regression that verifies the client publish -> engine publish -> topic-store mutation/fanout -> live-subscription notify span chain using real span ids, trace ids, and topic/query attributes. Updates the roadmap audit so the remaining production-ready next item is the minimal example app. Validation: pnpm run ready passed; strict Effect LSP passed; runtime-core coverage remains 100%; three reviewer agents reported no findings.