### PR TITLE
Add production guide set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # view-server-smart
 
+## Guides
+
+- [Public API](./docs/public-api.md)
+- [Runtime Config](./docs/runtime-config.md)
+- [Kafka Mapping](./docs/kafka-mapping.md)
+- [In-Memory Browser Testing](./docs/in-memory-browser-testing.md)
+- [Health And Metrics](./docs/health-and-metrics.md)
+- [Query Semantics](./docs/query-semantics.md)
+- [Benchmarks And Capacity](./docs/benchmarks-and-capacity.md)
+- [Deployment](./docs/deployment.md)
+
 ## Remote React provider
 
 Server code starts a runtime through Effect RPC WebSocket plus same-server

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# View Server Production Guides
+
+These guides document the current production contract for `view-server-smart`.
+They intentionally describe the shipped packages and runtime behavior, not old
+design sketches.
+
+- [Public API](./public-api.md)
+- [Runtime Config](./runtime-config.md)
+- [Kafka Mapping](./kafka-mapping.md)
+- [In-Memory Browser Testing](./in-memory-browser-testing.md)
+- [Health And Metrics](./health-and-metrics.md)
+- [Query Semantics](./query-semantics.md)
+- [Benchmarks And Capacity](./benchmarks-and-capacity.md)
+- [Deployment](./deployment.md)
+
+The production browser transport is Effect RPC WebSocket with NDJSON
+serialization. Kafka, gRPC, TCP publish, and in-memory testing all feed the same
+Runtime Core mutation path.

--- a/docs/benchmarks-and-capacity.md
+++ b/docs/benchmarks-and-capacity.md
@@ -1,0 +1,50 @@
+# Benchmarks And Capacity
+
+Benchmarks use Vitest benchmark mode through `vp test bench`. Do not add
+ad-hoc benchmark runners for engine/runtime performance work.
+
+## Gates
+
+Root scripts provide benchmark profiles and regression comparison:
+
+```sh
+pnpm run bench:baseline:smoke
+pnpm run bench:baseline:raw-read-write
+pnpm run bench:baseline:active-query-sharing
+pnpm run bench:baseline:grouped-admission
+pnpm run bench:baseline:grouped-order-neutral
+pnpm run bench:baseline:websocket-firehose
+pnpm run bench:baseline:kafka-ingest
+pnpm run bench:baseline:kafka-sustained-firehose
+pnpm run bench:baseline:grpc-materialized
+pnpm run bench:baseline:grpc-leased
+pnpm run bench:baseline:grpc-leased-retained
+```
+
+Use `pnpm run pre-grpc:gate` before gRPC-focused work and `pnpm run grpc:gate`
+for the gRPC profiles.
+
+## What To Measure
+
+Read optimizations must measure write cost. For example, adding a column vector
+or index can improve filtered reads while slowing publish/patch/delete. The
+benchmark suite tracks both read latency and write tax for relevant profiles.
+
+Core capacity profiles cover:
+
+- raw snapshots
+- filtered snapshots
+- sorted top-k windows
+- grouped aggregation
+- live delta generation
+- active query sharing
+- WebSocket fanout
+- Kafka ingest
+- gRPC materialized and leased feeds
+
+## Artifacts
+
+Benchmark artifacts are written under package-local `.artifacts/` directories.
+Stable baseline comparisons are managed by `scripts/run-benchmark-baseline.mjs`.
+Noisy maximum latency should stay report-only unless repeated runs prove the
+threshold is stable enough to gate CI.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,69 @@
+# Deployment
+
+## Runtime Process
+
+Run View Server as a Node process using `NodeRuntime.runMain`:
+
+```ts
+import { NodeRuntime } from "@effect/platform-node";
+import { runViewServerRuntime } from "@view-server/runtime";
+import { viewServer } from "./view-server-config";
+
+NodeRuntime.runMain(
+  runViewServerRuntime(viewServer, {
+    host: "0.0.0.0",
+    websocketPort: 8080,
+    healthPath: "/health",
+    metricsPath: "/metrics",
+  }),
+);
+```
+
+The runtime handles process signal interruption through Effect finalizers. Do
+not add separate process-level cleanup unless it is outside View Server
+ownership.
+
+## Kubernetes
+
+Use `GET /health` for readiness and liveness checks. The endpoint returns `200`
+only when the runtime is ready. If runtime auth is enabled, probes must be
+accepted by `auth.validateRequest` or auth must whitelist the health path;
+otherwise probes can receive auth failures instead of runtime health. Use
+`GET /metrics` for Prometheus scraping.
+
+Kafka and gRPC credentials, broker addresses, and base URLs should be loaded
+through Effect `Config`. Missing required values should fail startup.
+
+## Network Surface
+
+- Browser clients connect through Effect RPC WebSocket with NDJSON.
+- `GET /health` and `GET /metrics` share the runtime HTTP server.
+- TCP publish is optional and binds separately through `tcpPublishHost` and
+  `tcpPublishPort`.
+
+Keep TCP publish on a private interface unless protected by your own network
+controls. TCP publish is a mutation ingress, not a browser API.
+
+## Recovery
+
+Current Runtime Core state is in memory. There is no durable WAL/checkpoint.
+Deployments that need full rebuild after restart must replay source data from an
+authoritative source:
+
+- Kafka: use `startFrom: "earliest"` or a dedicated rebuild consumer group.
+- Materialized gRPC: reconnect and replay from the upstream stream contract.
+- Leased gRPC: rebuilt on demand from active subscriptions.
+- TCP publish: external publisher must be authoritative if replay is required.
+
+## Release Gate
+
+Before promoting a runtime build, run:
+
+```sh
+pnpm run ready
+pnpm run pre-grpc:gate
+pnpm run grpc:gate
+```
+
+The gates cover build, package seam checks, strict Effect diagnostics, tests,
+coverage, and benchmark baseline profiles.

--- a/docs/health-and-metrics.md
+++ b/docs/health-and-metrics.md
@@ -1,0 +1,61 @@
+# Health And Metrics
+
+## React Hooks
+
+React applications should use pushed health hooks, not UI polling.
+
+`useViewServerHealthSummary()` returns the small summary shape for page chrome
+and global status indicators:
+
+- merged `status`
+- runtime status
+- connection status
+- unhealthy topics
+- max Kafka lag
+- updated timestamp in nanoseconds
+
+`useViewServerHealth()` returns detailed live health rows for status pages and
+diagnostic UIs. Use the detailed hook only on pages that actually need detailed
+topic/source data.
+
+## Infrastructure Health
+
+The runtime exposes `GET /health` on the same server as the WebSocket endpoint.
+It serves the cached runtime health snapshot for infrastructure checks.
+
+- `200`: runtime is ready.
+- non-`200`: runtime is starting, degraded, or stopping.
+
+If runtime auth is configured, health requests are authenticated before the
+health snapshot is served. Kubernetes probes must either send accepted
+credentials or the auth implementation must explicitly allow the health path.
+The endpoint can also return `500` if reading or encoding the cached health
+snapshot fails.
+
+Internal `bigint` values, such as Kafka lag, are encoded as decimal strings in
+the JSON response.
+
+## Metrics
+
+The runtime exposes `GET /metrics` in Prometheus text exposition format. Metrics
+are derived from the same cached health snapshot as `GET /health`.
+
+Metrics intentionally keep labels low-cardinality. Raw error messages,
+route-specific leased feed keys, and detailed offsets remain available from
+`GET /health` instead of labels.
+
+If metrics cannot decode health, the endpoint returns `200` with
+`view_server_metrics_error 1` so scrape failure is visible to Prometheus.
+
+## Runtime Signals
+
+Health covers:
+
+- runtime status, version, uptime, and current time
+- transport active connections, subscriptions, queues, and backpressure
+- engine topic row counts, versions, queues, and backpressure
+- Kafka region status, assignments, lag, and failure rates
+- gRPC client/feed status, row counts, reconnects, and failure rates
+- TCP publish ingress status when configured
+
+Health is a status plane. It should not be used as a high-rate data stream.

--- a/docs/in-memory-browser-testing.md
+++ b/docs/in-memory-browser-testing.md
@@ -1,0 +1,57 @@
+# In-Memory Browser Testing
+
+Production React imports from `@view-server/react`. Browser tests import the
+testing helper from `@view-server/react/testing`.
+
+```tsx
+import { createInMemoryViewServerReact } from "@view-server/react/testing";
+import { viewServerReact } from "./view-server.config";
+
+export const createInMemoryExampleViewServer = () => createInMemoryViewServerReact(viewServerReact);
+```
+
+The testing helper returns a provider plus a typed client. The provider uses the
+same hook binding object as production, but transport is in-memory instead of
+Effect RPC WebSocket.
+
+```tsx
+import { Effect } from "effect";
+import { expect, it } from "@effect/vitest";
+import { render } from "vitest-browser-react";
+import { createInMemoryExampleViewServer } from "./testing";
+import { OrdersGrid } from "./orders-grid";
+
+it("renders pushed orders", async () => {
+  const { ViewServerInMemoryProvider, client } = createInMemoryExampleViewServer();
+  const screen = await render(
+    <ViewServerInMemoryProvider>
+      <OrdersGrid />
+    </ViewServerInMemoryProvider>,
+  );
+
+  await Effect.runPromise(
+    client.publish("orders", {
+      id: "order-1",
+      customerId: "customer-1",
+      status: "open",
+      price: 10,
+      region: "usa",
+      updatedAt: 1,
+    }),
+  );
+
+  await expect.element(screen.getByText("order-1")).toBeVisible();
+});
+```
+
+## Rules
+
+- Do not change application components for tests. Swap only the provider.
+- Do not seed providers. Publish through the returned client like any other
+  ingress path.
+- Do not use Testing Library, `act`, `flushSync`, or `data-testid`.
+- Use Vitest Browser Mode locators from `vitest-browser-react`.
+- Runtime-level tests should use Effect-based tests where possible.
+
+The in-memory provider exercises the same Runtime Core and engine code as the
+remote runtime. Only external ingress and transport are replaced.

--- a/docs/kafka-mapping.md
+++ b/docs/kafka-mapping.md
@@ -1,0 +1,78 @@
+# Kafka Mapping
+
+Kafka source topics are configured from the typed View Server config. The
+mapping function receives typed decoded Kafka key/value data and must return a
+row that matches the target View Server topic schema.
+
+```ts
+import { Config } from "effect";
+import { NodeRuntime } from "@effect/platform-node";
+import { kafka } from "@view-server/config";
+import { runViewServerRuntime } from "@view-server/runtime";
+import { viewServer } from "./view-server-config";
+import { OrderKeySchema, OrderValueSchema } from "./generated/orders";
+
+const kafkaRegions = {
+  usa: Config.string("KAFKA_USA_BOOTSTRAP"),
+  london: Config.string("KAFKA_LONDON_BOOTSTRAP"),
+};
+
+const kafkaTopic = viewServer.kafkaTopic<typeof kafkaRegions>();
+
+NodeRuntime.runMain(
+  runViewServerRuntime(viewServer, {
+    websocketPort: 8080,
+    kafka: {
+      consumerGroupId: "orders-view-server",
+      regions: kafkaRegions,
+      topics: {
+        sourceOrders: kafkaTopic({
+          regions: ["usa", "london"],
+          value: kafka.protobuf(OrderValueSchema),
+          key: kafka.protobuf(OrderKeySchema),
+          viewServerTopic: "orders",
+          mapping: ({ key, value, region }) => ({
+            id: key.orderId,
+            customerId: value.customerId,
+            status: value.status,
+            price: value.price,
+            region,
+            updatedAt: value.updatedAt,
+          }),
+        }),
+      },
+    },
+  }),
+);
+```
+
+`kafka.protobuf(...)` expects the Buf generated `DescMessage` descriptor symbol,
+not a TypeScript value type.
+
+## Contract
+
+- `regions` is type-checked against the configured Kafka region names.
+- `viewServerTopic` is type-checked against the configured View Server topics.
+- `key` is typed from the configured key codec. If no key codec is configured,
+  the key is a string.
+- `value` is typed from the configured value codec.
+- `mapping` output is validated against the target topic schema before publish.
+
+## Delivery
+
+Kafka messages are decoded, mapped, microbatched, and published through Runtime
+Core with `publishMany`. Offsets are committed only after the corresponding
+Runtime Core publish succeeds.
+
+If a message fails decode or mapping, health records a decode or mapping failure
+for the source topic and region. If publishing fails, the corresponding messages
+remain uncommitted so Kafka can replay them.
+
+## Restart Semantics
+
+Runtime Core rows live in memory. There is no durable WAL/checkpoint yet. For
+rebuild-after-restart semantics, configure Kafka replay from an authoritative
+position such as `startFrom: "earliest"` or a fresh rebuild consumer group.
+
+Committed consumer-group resume is useful for live at-least-once processing, but
+it is not durable View Server recovery by itself.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,104 @@
+# Public API
+
+## Define Topics
+
+Application code starts with `defineViewServerConfig`. Each topic has an Effect
+Schema and a string row key field. The topic schema is the source of truth for
+query typing, runtime validation, protocol encoding, and in-memory tests.
+
+```ts
+import { defineViewServerConfig } from "@view-server/config";
+import { createViewServerReact } from "@view-server/react";
+import { Schema } from "effect";
+
+export const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Number,
+  region: Schema.String,
+  updatedAt: Schema.Number,
+});
+
+export const Trade = Schema.Struct({
+  id: Schema.String,
+  symbol: Schema.String,
+  quantity: Schema.BigInt,
+  price: Schema.Number,
+  region: Schema.String,
+});
+
+export const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+    trades: {
+      schema: Trade,
+      key: "id",
+    },
+  },
+});
+
+export const viewServerReact = createViewServerReact(viewServer);
+export const { ViewServerProvider, useLiveQuery, useViewServerHealthSummary } = viewServerReact;
+```
+
+## React Provider
+
+Production React code passes a runtime URL to the provider. The provider owns
+the remote Effect RPC WebSocket client. Application components use hooks from
+the same `createViewServerReact(viewServer)` binding object.
+
+```tsx
+export function AppRoot() {
+  return (
+    <ViewServerProvider url={window.__APP_CONFIG__.VIEW_SERVER_URL}>
+      <App />
+    </ViewServerProvider>
+  );
+}
+```
+
+## Live Queries
+
+Raw queries must declare `select`. This prevents accidentally returning every
+column from wide topics.
+
+```tsx
+function Orders() {
+  const orders = useLiveQuery("orders", {
+    select: ["id", "price", "status"],
+    where: {
+      status: { eq: "open" },
+      customerId: { startsWith: "customer-" },
+      price: { gte: 10 },
+    },
+    orderBy: [{ field: "price", direction: "desc" }],
+    limit: 20,
+  });
+
+  return <pre>{JSON.stringify(orders.rows, null, 2)}</pre>;
+}
+```
+
+Grouped queries use `groupBy` plus an aggregate object keyed by output alias.
+Aggregate aliases become fields on the returned row type.
+
+```tsx
+const totals = useLiveQuery("orders", {
+  groupBy: ["status"],
+  aggregates: {
+    rowCount: { aggFunc: "count" },
+    totalPrice: { aggFunc: "sum", field: "price" },
+    maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
+  },
+  orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+  limit: 10,
+});
+```
+
+The public API is designed so consumers do not need `as const` to keep type
+safety for normal `select`, `where`, `orderBy`, `groupBy`, and aggregate
+queries.

--- a/docs/query-semantics.md
+++ b/docs/query-semantics.md
@@ -1,0 +1,77 @@
+# Query Semantics
+
+## Raw Queries
+
+Raw queries return selected rows from one topic. `select` is required.
+
+```ts
+useLiveQuery("orders", {
+  select: ["id", "price", "status"],
+  where: {
+    status: { eq: "open" },
+    customerId: { startsWith: "customer-" },
+    price: { gte: 10, lt: 100 },
+  },
+  orderBy: [{ field: "price", direction: "desc" }],
+  offset: 0,
+  limit: 20,
+});
+```
+
+Supported filter operators:
+
+- strings: `eq`, `neq`, `in`, `startsWith`
+- numbers, bigint, BigDecimal: `eq`, `neq`, `in`, `gt`, `gte`, `lt`, `lte`
+- booleans and other equality-only fields: `eq`, `neq`, `in`
+
+Raw `orderBy` entries reference topic row fields only.
+
+## Grouped Queries
+
+Grouped queries require non-empty `groupBy` and an aggregate object. `select` is
+not allowed.
+
+```ts
+useLiveQuery("orders", {
+  groupBy: ["status"],
+  aggregates: {
+    rowCount: { aggFunc: "count" },
+    totalPrice: { aggFunc: "sum", field: "price" },
+    distinctCustomers: { aggFunc: "countDistinct", field: "customerId" },
+    maxUpdatedAt: { aggFunc: "max", field: "updatedAt" },
+  },
+  orderBy: [
+    { aggregate: "totalPrice", direction: "desc" },
+    { field: "status", direction: "asc" },
+  ],
+  limit: 10,
+});
+```
+
+Supported aggregates:
+
+- `count`
+- `countDistinct`
+- `sum`
+- `min`
+- `max`
+- `avg`
+
+Aggregate result precision:
+
+- `count` and `countDistinct` return `bigint`.
+- `sum` over `bigint` returns `bigint`.
+- `sum` over number/BigDecimal-compatible values returns Effect `BigDecimal`.
+- `avg` returns Effect `BigDecimal`.
+- `min` and `max` return the source field type.
+
+Grouped `orderBy` entries may reference group fields through `field` or
+aggregate aliases through `aggregate`. An order entry must not use both.
+
+## Live Results
+
+Snapshots and deltas always include `totalRows`. Empty result sets report
+`totalRows: 0`.
+
+Rows are ordered deterministically. When user-provided sort fields tie, the
+configured topic key is used as the final stable tie-breaker.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -1,0 +1,70 @@
+# Runtime Config
+
+## Entrypoint
+
+Node entrypoints should use `NodeRuntime.runMain` from `@effect/platform-node`.
+That lets process signals interrupt the main Effect fiber and run finalizers.
+
+```ts
+import { NodeRuntime } from "@effect/platform-node";
+import { runViewServerRuntime } from "@view-server/runtime";
+import { viewServer } from "./view-server-config";
+
+NodeRuntime.runMain(
+  runViewServerRuntime(viewServer, {
+    host: "0.0.0.0",
+    websocketPort: 8080,
+    tcpPublishHost: "127.0.0.1",
+    tcpPublishPort: 8081,
+  }),
+);
+```
+
+`runViewServerRuntime` logs configured WebSocket, health, metrics, and TCP
+publish URLs and keeps the runtime alive until interrupted.
+
+## Options
+
+- `host`: host for the WebSocket, health, and metrics HTTP server.
+- `websocketPort`: runtime server port. Set this explicitly in production;
+  omitting it uses an ephemeral port.
+- `healthPath`: health endpoint path. The default is `/health`.
+- `metricsPath`: metrics endpoint path. The default is `/metrics`.
+- `tcpPublishHost`: host for optional TCP publish ingress. Defaults to
+  `127.0.0.1`.
+- `tcpPublishPort`: enables optional TCP publish ingress.
+- `tcpPublishMaxConnections`: bounds TCP publisher connections.
+- `kafka`: optional Kafka source configuration.
+- `grpc`: optional gRPC source configuration.
+
+Environment-backed values should use Effect `Config`. Missing required brokers,
+URLs, or secrets should fail startup rather than silently defaulting.
+
+```ts
+import { Config } from "effect";
+
+const kafkaRegions = {
+  usa: Config.string("KAFKA_USA_BOOTSTRAP"),
+  london: Config.string("KAFKA_LONDON_BOOTSTRAP"),
+};
+```
+
+## Source Ownership
+
+Each View Server topic has one source of truth. Kafka-owned and gRPC-owned topics
+cannot also be mutated through TCP publish. This prevents two independent
+ingress paths from racing into the same in-memory topic.
+
+## Runtime Ownership
+
+The production runtime owns:
+
+- Runtime Core and the in-memory engine.
+- Effect RPC WebSocket server.
+- Same-server `GET /health` and `GET /metrics`.
+- Optional Kafka consumers.
+- Optional materialized and leased gRPC feeds.
+- Optional TCP publish ingress.
+
+React production code owns only the provider URL. In-memory browser tests use
+the testing provider described in [In-Memory Browser Testing](./in-memory-browser-testing.md).

--- a/plans/remaining-roadmap-audit.md
+++ b/plans/remaining-roadmap-audit.md
@@ -60,12 +60,13 @@ because it includes explicit future scope.
 | Runtime-core span/observability assertions                    | Implemented | Runtime-core tracing test captures client publish -> engine publish -> topic-store mutation/fanout -> live-subscription spans with real span-id parent links and topic/query attributes.                                                                                       |
 | Minimal example app                                           | Implemented | `apps/example` defines typed config, production provider URL boundary, in-memory testing provider path, browser e2e test, type tests, and workspace build/check.                                                                                                               |
 | Current public API examples in the roadmap                    | Implemented | `plans/v2-column-live-view-engine-plan.md` and `plans/grpc.md` now use `@view-server/config`, `createViewServerReact(viewServer)`, `createInMemoryViewServerReact(viewServerReact)`, `runViewServerRuntime(viewServer, options)`, and explicit `select` in raw query examples. |
+| Production guide set                                          | Implemented | `docs/README.md`, `docs/public-api.md`, `docs/runtime-config.md`, `docs/kafka-mapping.md`, `docs/in-memory-browser-testing.md`, `docs/health-and-metrics.md`, `docs/query-semantics.md`, `docs/benchmarks-and-capacity.md`, and `docs/deployment.md`.                          |
 
 ### Production-Ready Next Items
 
-| Item                 | Status                | Evidence / Required Action                                                                                                                                                                                                                                                                                               |
-| -------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Production guide set | Production-ready next | `plans/v2-column-live-view-engine-plan.md` requires public API, runtime config, Kafka mapping, in-memory browser testing, health/metrics, query semantics, benchmark/capacity, and deployment guides before calling the slice done. Current docs are partial and distributed across root/package READMEs and plan files. |
+No production-ready plan items remain after the production guide set. The next
+step is validation of the documented scope with the readiness and benchmark
+gates.
 
 ### Intentionally Deferred
 
@@ -88,8 +89,7 @@ These are in the plan, but should remain future work unless explicitly promoted.
 
 ## Recommended Implementation Order
 
-1. Add the production guide set listed above and link it from the root README.
-2. Run `pnpm run ready`, `pnpm run pre-grpc:gate`, and `pnpm run grpc:gate` to prove the documented current scope still passes.
-3. Do not reopen completed gRPC materialized/leased scope unless new tests reveal a real correctness gap.
+1. Run `pnpm run ready`, `pnpm run pre-grpc:gate`, and `pnpm run grpc:gate` to prove the documented current scope still passes.
+2. Do not reopen completed gRPC materialized/leased scope unless new tests reveal a real correctness gap.
 
 After that, next work should come from a new explicit product decision or from promoting one intentionally deferred item.


### PR DESCRIPTION
## Summary
- add the production guide index and eight roadmap-required guides
- link the guides from the root README
- update the remaining roadmap audit to mark the production guide set implemented and make the next step the final gate validation

## Validation
- vp check --fix
- pnpm run test:repository-scripts
- pnpm run ready
- 3 reviewer agents re-reviewed the guide set after fixes: no findings

## Notes
- docs reflect current production APIs only: Effect RPC WebSocket + NDJSON, URL-based React provider, required raw select, aggregate object syntax, Effect Config-backed runtime setup, Kafka/gRPC/TCP source ownership, and in-memory browser testing provider