### PR TITLE
Add production capacity and operations guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - `pnpm run bench:baseline:websocket-firehose` is the small runtime WebSocket firehose smoke gate. It uses the production Effect RPC WebSocket + NDJSON path and bounded Vitest benchmark reads; update it only for accepted WebSocket transport or fanout performance changes.
 - `pnpm run pre-grpc:gate` is the serial pre-gRPC release gate. It runs `ready`, smoke, raw read/write, active-query-sharing, grouped admission, grouped order-neutral, WebSocket firehose, Kafka ingest, and Kafka sustained-firehose gates. Run it before starting gRPC work or declaring Kafka/performance readiness.
 - `pnpm run grpc:gate` is the gRPC runtime smoke gate. It runs `ready`, materialized gRPC baselines, and leased gRPC baselines. Keep it separate from `pre-grpc:gate`.
+- `pnpm run release-candidate:capacity` is the serial production-candidate gate. It runs example tests/builds, `pre-grpc:gate`, `grpc:gate`, and the broad no-compare release benchmark profile; use it before promoting a runtime image or claiming production-like capacity readiness.
 - Do not run competing benchmark suites in parallel when comparing results.
 
 ## Package And Architecture Rules

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Query Semantics](./docs/query-semantics.md)
 - [Benchmarks And Capacity](./docs/benchmarks-and-capacity.md)
 - [Deployment](./docs/deployment.md)
+- [Operations](./docs/operations.md)
 - [Examples](./examples/README.md)
 
 ## Remote React provider

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ design sketches.
 - [Query Semantics](./query-semantics.md)
 - [Benchmarks And Capacity](./benchmarks-and-capacity.md)
 - [Deployment](./deployment.md)
+- [Operations](./operations.md)
 
 The production browser transport is Effect RPC WebSocket with NDJSON
 serialization. Kafka, gRPC, TCP publish, and in-memory testing all feed the same

--- a/docs/benchmarks-and-capacity.md
+++ b/docs/benchmarks-and-capacity.md
@@ -24,6 +24,21 @@ pnpm run bench:baseline:grpc-leased-retained
 Use `pnpm run pre-grpc:gate` before gRPC-focused work and `pnpm run grpc:gate`
 for the gRPC profiles.
 
+For a release-candidate capacity pass, run:
+
+```sh
+pnpm run release-candidate:capacity
+```
+
+This runs example browser/type checks, example builds, `pre-grpc:gate`,
+`grpc:gate`, and the broad no-compare `bench:baseline:release` profile
+serially. Do not run competing benchmark suites in parallel when recording
+release-candidate numbers.
+
+The release profile runs 10M-row engine cases and sets
+`NODE_OPTIONS=--max-old-space-size=12288` so the benchmark process is not
+limited by Node's default old-space cap.
+
 ## What To Measure
 
 Read optimizations must measure write cost. For example, adding a column vector
@@ -48,3 +63,22 @@ Benchmark artifacts are written under package-local `.artifacts/` directories.
 Stable baseline comparisons are managed by `scripts/run-benchmark-baseline.mjs`.
 Noisy maximum latency should stay report-only unless repeated runs prove the
 threshold is stable enough to gate CI.
+
+## Release Candidate Notes
+
+Record the machine/container shape beside any release-candidate benchmark
+results:
+
+- CPU model and allocated cores
+- memory limit
+- Node version
+- Kafka broker location and topic partition counts
+- row counts per View Server topic
+- active browser/client count
+- active subscription count
+- Kafka input rate
+- gRPC leased route count
+- WebSocket fanout shape
+
+The baseline gates catch regressions against committed smoke profiles. They are
+not a substitute for one production-like capacity run before a real deployment.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,8 +25,12 @@ ownership.
 
 ## Kubernetes
 
-Use `GET /health` for readiness and liveness checks. The endpoint returns `200`
-only when the runtime is ready. If runtime auth is enabled, probes must be
+Use `GET /health` for readiness and startup checks. The endpoint returns `200`
+only when the runtime is ready, and returns a non-`200` status while the runtime
+is starting, degraded, or stopping. Do not use it as liveness unless degraded
+source/runtime health should restart the only active runtime and rebuild
+in-memory state. Prefer a process-level or TCP liveness check until a separate
+liveness endpoint exists. If runtime auth is enabled, readiness probes must be
 accepted by `auth.validateRequest` or auth must whitelist the health path;
 otherwise probes can receive auth failures instead of runtime health. Use
 `GET /metrics` for Prometheus scraping.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,11 @@ otherwise probes can receive auth failures instead of runtime health. Use
 Kafka and gRPC credentials, broker addresses, and base URLs should be loaded
 through Effect `Config`. Missing required values should fail startup.
 
+The current supported deployment model is one active View Server runtime per
+logical deployment. Give each deployment a unique Kafka consumer group id. Kafka
+multi-replica rebalance/revoke handoff is intentionally out of scope for the
+current milestone.
+
 ## Network Surface
 
 - Browser clients connect through Effect RPC WebSocket with NDJSON.
@@ -60,10 +65,9 @@ authoritative source:
 Before promoting a runtime build, run:
 
 ```sh
-pnpm run ready
-pnpm run pre-grpc:gate
-pnpm run grpc:gate
+pnpm run release-candidate:capacity
 ```
 
-The gates cover build, package seam checks, strict Effect diagnostics, tests,
-coverage, and benchmark baseline profiles.
+The gate covers examples, build, package seam checks, strict Effect diagnostics,
+tests, coverage, and benchmark baseline profiles. See
+[Operations](./operations.md) for Prometheus, probe, and resource guidance.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,7 +22,7 @@ view_server_runtime_status{status!="ready"} == 1
 ```
 
 ```promql
-max(view_server_kafka_region_lag)
+max(view_server_kafka_consumer_lag_messages)
 ```
 
 ```promql
@@ -38,7 +38,15 @@ max(view_server_transport_active_subscriptions)
 ```
 
 ```promql
-increase(view_server_grpc_feed_failures[5m]) > 0
+max_over_time(view_server_grpc_feed_decode_failures_per_second[5m]) > 0
+```
+
+```promql
+max_over_time(view_server_grpc_feed_mapping_failures_per_second[5m]) > 0
+```
+
+```promql
+max_over_time(view_server_grpc_feed_publish_failures_per_second[5m]) > 0
 ```
 
 Metric names can grow as the health contract grows. Treat these examples as
@@ -46,7 +54,9 @@ starting points and validate names against the current `/metrics` output.
 
 ## Kubernetes Probes
 
-Use `GET /health` for readiness and liveness.
+Use `GET /health` for readiness and startup checks. It returns `200` only when
+the runtime is ready, and returns a non-`200` status while the runtime is
+starting, degraded, or stopping.
 
 ```yaml
 readinessProbe:
@@ -56,15 +66,19 @@ readinessProbe:
   periodSeconds: 5
   failureThreshold: 3
 livenessProbe:
-  httpGet:
-    path: /health
+  tcpSocket:
     port: websocket
   periodSeconds: 10
   failureThreshold: 6
 ```
 
-If runtime auth is configured, either allow probe requests in
-`auth.validateRequest` or configure probes to send accepted credentials.
+Do not use `GET /health` as liveness unless degraded source/runtime health
+should restart the only active pod and rebuild in-memory state. Prefer a
+process-level or TCP liveness check until a separate liveness endpoint exists.
+
+If runtime auth is configured, either allow readiness probe requests in
+`auth.validateRequest` or configure readiness probes to send accepted
+credentials.
 
 ## Resource Sizing
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,111 @@
+# Operations
+
+## Runtime Topology
+
+The current supported production topology is one active View Server runtime per
+logical deployment. Configure a unique Kafka consumer group id for that runtime.
+Do not run multiple active replicas in the same logical consumer group unless a
+future rebalance/revoke handoff contract is added.
+
+Use Kubernetes rolling updates carefully: the replacement pod should become
+ready only after its sources are connected and runtime health is ready.
+
+## Prometheus Metrics
+
+Scrape `GET /metrics` on the same HTTP server as WebSocket RPC. Metrics use
+low-cardinality labels and are derived from cached runtime health.
+
+Useful alert/query examples:
+
+```promql
+view_server_runtime_status{status!="ready"} == 1
+```
+
+```promql
+max(view_server_kafka_region_lag)
+```
+
+```promql
+increase(view_server_transport_backpressure_events[5m]) > 0
+```
+
+```promql
+increase(view_server_engine_topic_backpressure_events[5m]) > 0
+```
+
+```promql
+max(view_server_transport_active_subscriptions)
+```
+
+```promql
+increase(view_server_grpc_feed_failures[5m]) > 0
+```
+
+Metric names can grow as the health contract grows. Treat these examples as
+starting points and validate names against the current `/metrics` output.
+
+## Kubernetes Probes
+
+Use `GET /health` for readiness and liveness.
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /health
+    port: websocket
+  periodSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  httpGet:
+    path: /health
+    port: websocket
+  periodSeconds: 10
+  failureThreshold: 6
+```
+
+If runtime auth is configured, either allow probe requests in
+`auth.validateRequest` or configure probes to send accepted credentials.
+
+## Resource Sizing
+
+Do not size View Server from row count alone. Capacity depends on:
+
+- total rows per topic
+- number of active topics
+- number of active raw and grouped queries
+- active browser clients
+- subscriptions per client
+- Kafka input rate
+- gRPC leased route count
+- WebSocket fanout shape
+- selected fields and grouped aggregate width
+
+Start with conservative memory limits and run:
+
+```sh
+pnpm run release-candidate:capacity
+```
+
+Then run a production-like soak using your real topic shapes. Watch RSS, heap,
+event loop delay, Kafka lag, gRPC reconnects, WebSocket queue depth, and
+backpressure metrics.
+
+## TCP Publish
+
+TCP publish is a private mutation ingress. Bind it to `127.0.0.1` or a private
+network interface unless external network controls protect it. TCP publish is
+schema-safe, but it is still a write path.
+
+Do not use TCP publish for Kafka-owned or gRPC-owned topics. One View Server
+topic must have one source of truth.
+
+## Failure Triage
+
+- Runtime not ready: inspect `/health` first.
+- Kafka lag increasing: inspect Kafka region health and broker/topic health.
+- Backpressure increasing: reduce subscription fanout, inspect slow clients, or
+  raise queue limits only after measuring memory.
+- gRPC leased routes retained longer than expected: inspect active
+  subscriptions and leased feed health.
+- Metrics scrape returns `view_server_metrics_error 1`: inspect `/health`
+  encoding/decoding errors.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ code.
 | [`combined-sources-react`](./combined-sources-react)   | Kafka + gRPC                 | server runtime       | Production-shaped app with Kafka, leased gRPC, and materialized gRPC together. |
 | [`tcp-publisher-react`](./tcp-publisher-react)         | external TCP                 | server runtime       | Non-browser publisher pushing rows into schema-safe TCP ingress.               |
 | [`ssr-react`](./ssr-react)                             | optional WebSocket live data | TanStack Start SSR   | Server-rendered shell with browser-only live query hydration.                  |
+| [`production-deployment`](./production-deployment)     | deployment recipe            | server runtime       | K8s, Prometheus, runtime config, and browser URL injection guidance.           |
 
 ## Commands
 

--- a/examples/production-deployment/README.md
+++ b/examples/production-deployment/README.md
@@ -16,7 +16,7 @@ service with:
 ```ts
 import { NodeRuntime } from "@effect/platform-node";
 import { runViewServerRuntime } from "@view-server/runtime";
-import { Config } from "effect";
+import { Config, Effect } from "effect";
 import {
   viewServer,
   kafkaRegions,
@@ -25,11 +25,11 @@ import {
   grpcFeeds,
 } from "./view-server.config";
 
-const websocketPort = Config.number("VIEW_SERVER_WEBSOCKET_PORT");
-const kafkaConsumerGroupId = Config.string("VIEW_SERVER_KAFKA_GROUP_ID");
+const program = Effect.gen(function* () {
+  const websocketPort = yield* Config.number("VIEW_SERVER_WEBSOCKET_PORT");
+  const kafkaConsumerGroupId = yield* Config.string("VIEW_SERVER_KAFKA_GROUP_ID");
 
-NodeRuntime.runMain(
-  runViewServerRuntime(viewServer, {
+  return yield* runViewServerRuntime(viewServer, {
     host: "0.0.0.0",
     websocketPort,
     healthPath: "/health",
@@ -44,8 +44,10 @@ NodeRuntime.runMain(
       clients: grpcClients,
       feeds: grpcFeeds,
     },
-  }),
-);
+  });
+});
+
+NodeRuntime.runMain(program);
 ```
 
 Use a deployment-unique `VIEW_SERVER_KAFKA_GROUP_ID`. The current supported
@@ -134,8 +136,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
           livenessProbe:
-            httpGet:
-              path: /health
+            tcpSocket:
               port: websocket
             periodSeconds: 10
             failureThreshold: 6
@@ -152,6 +153,11 @@ Size CPU and memory from `pnpm run release-candidate:capacity` on a
 production-like machine. Do not copy the resource values above without testing
 your topic count, row count, grouped queries, Kafka rate, gRPC routes, and
 WebSocket fanout.
+
+`GET /health` is a readiness/startup probe: it returns a non-`200` status while
+the runtime is starting, degraded, or stopping. Use a process-level or TCP
+liveness check unless you intentionally want recoverable source degradation to
+restart the pod and rebuild in-memory state.
 
 ## Release Candidate Gate
 

--- a/examples/production-deployment/README.md
+++ b/examples/production-deployment/README.md
@@ -1,0 +1,165 @@
+# Production Deployment Example
+
+This example is a deployment recipe, not a runnable TanStack app. The runnable
+source-specific examples live beside it. Use this when wiring a real production
+service with:
+
+- one View Server runtime instance
+- one unique Kafka consumer group per deployment
+- runtime configuration from Effect `Config`
+- browser URL injection at deploy time
+- Kubernetes health probes
+- Prometheus metrics scraping
+
+## Runtime Entrypoint
+
+```ts
+import { NodeRuntime } from "@effect/platform-node";
+import { runViewServerRuntime } from "@view-server/runtime";
+import { Config } from "effect";
+import {
+  viewServer,
+  kafkaRegions,
+  kafkaTopics,
+  grpcClients,
+  grpcFeeds,
+} from "./view-server.config";
+
+const websocketPort = Config.number("VIEW_SERVER_WEBSOCKET_PORT");
+const kafkaConsumerGroupId = Config.string("VIEW_SERVER_KAFKA_GROUP_ID");
+
+NodeRuntime.runMain(
+  runViewServerRuntime(viewServer, {
+    host: "0.0.0.0",
+    websocketPort,
+    healthPath: "/health",
+    metricsPath: "/metrics",
+    kafka: {
+      consumerGroupId: kafkaConsumerGroupId,
+      startFrom: "latest",
+      regions: kafkaRegions,
+      topics: kafkaTopics,
+    },
+    grpc: {
+      clients: grpcClients,
+      feeds: grpcFeeds,
+    },
+  }),
+);
+```
+
+Use a deployment-unique `VIEW_SERVER_KAFKA_GROUP_ID`. The current supported
+deployment model is one active View Server runtime for a logical deployment.
+Multi-replica Kafka rebalance/revoke handoff is intentionally out of scope.
+
+## React Entrypoint
+
+React code should receive the runtime URL from deploy-time configuration, not
+from build-time environment variables.
+
+```tsx
+import { ViewServerProvider } from "./view-server.config";
+
+declare global {
+  interface Window {
+    readonly __APP_CONFIG__: {
+      readonly VIEW_SERVER_URL: string;
+    };
+  }
+}
+
+export function AppRoot() {
+  return (
+    <ViewServerProvider url={window.__APP_CONFIG__.VIEW_SERVER_URL}>
+      <App />
+    </ViewServerProvider>
+  );
+}
+```
+
+Serve a small config script before the app bundle:
+
+```html
+<script>
+  window.__APP_CONFIG__ = {
+    VIEW_SERVER_URL: "wss://view-server.example.com/rpc",
+  };
+</script>
+```
+
+The same app components can be tested in Vitest browser mode by wrapping them in
+`createInMemoryViewServerReact(...).ViewServerInMemoryProvider`.
+
+## Kubernetes Sketch
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: view-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: view-server
+  template:
+    metadata:
+      labels:
+        app: view-server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: view-server
+          image: registry.example.com/view-server:VERSION
+          ports:
+            - name: websocket
+              containerPort: 8080
+          env:
+            - name: VIEW_SERVER_WEBSOCKET_PORT
+              value: "8080"
+            - name: VIEW_SERVER_KAFKA_GROUP_ID
+              value: "view-server-prod-orders-v1"
+            - name: KAFKA_USA_BOOTSTRAP
+              valueFrom:
+                secretKeyRef:
+                  name: view-server-kafka
+                  key: usa-bootstrap
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: websocket
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: websocket
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              cpu: "4"
+              memory: 4Gi
+```
+
+Size CPU and memory from `pnpm run release-candidate:capacity` on a
+production-like machine. Do not copy the resource values above without testing
+your topic count, row count, grouped queries, Kafka rate, gRPC routes, and
+WebSocket fanout.
+
+## Release Candidate Gate
+
+Before promoting a runtime image:
+
+```sh
+pnpm run release-candidate:capacity
+```
+
+This runs examples, builds, readiness checks, pre-gRPC benchmark gates, gRPC
+benchmark gates, and the broad no-compare release benchmark profile serially.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bench:baseline:kafka-ingest:update": "node scripts/run-benchmark-baseline.mjs --profile=kafka-ingest --update-baseline",
     "bench:baseline:kafka-sustained-firehose": "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose",
     "bench:baseline:kafka-sustained-firehose:update": "node scripts/run-benchmark-baseline.mjs --profile=kafka-sustained-firehose --update-baseline",
-    "bench:baseline:release": "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
+    "bench:baseline:release": "NODE_OPTIONS=--max-old-space-size=12288 node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
     "bench:baseline:release:update": "node scripts/run-benchmark-baseline.mjs --profile=release --update-baseline",
     "bench:baseline:smoke": "node scripts/run-benchmark-baseline.mjs --profile=smoke",
     "bench:baseline:smoke:update": "node scripts/run-benchmark-baseline.mjs --profile=smoke --update-baseline",
@@ -39,6 +39,7 @@
     "examples:test": "vp run @view-server/example-in-memory-react#test && vp run @view-server/example-kafka-react#test && vp run @view-server/example-grpc-leased-react#test && vp run @view-server/example-grpc-materialized-react#test && vp run @view-server/example-combined-sources-react#test && vp run @view-server/example-ssr-react#test && vp run @view-server/example-tcp-publisher-react#test && pnpm run examples:check:effect",
     "ready": "vp run -r build && pnpm run check:package-exports && pnpm run check:internal-seams && pnpm run test:repository-scripts && vp check && pnpm run check:effect && vp run --filter '@view-server/*' --filter '!@view-server/runtime' test && vp run @view-server/runtime#test",
     "pre-grpc:gate": "pnpm run ready && pnpm run bench:baseline:smoke && pnpm run bench:baseline:raw-read-write && pnpm run bench:baseline:active-query-sharing && pnpm run bench:baseline:grouped-admission && pnpm run bench:baseline:grouped-order-neutral && pnpm run bench:baseline:websocket-firehose && pnpm run bench:baseline:kafka-ingest && pnpm run bench:baseline:kafka-sustained-firehose",
+    "release-candidate:capacity": "pnpm run examples:test && pnpm run examples:build && pnpm run pre-grpc:gate && pnpm run grpc:gate && pnpm run bench:baseline:release",
     "test:benchmark-baseline": "pnpm run test:repository-scripts",
     "test:repository-scripts": "vp test run scripts/benchmark-baseline.test.ts scripts/benchmark-baseline-runner.test.ts scripts/bench-runtime-kafka-ingest.test.ts scripts/check-internal-seams.test.ts --coverage",
     "prepare": "vp config && effect-language-service patch"

--- a/packages/react/src/in-memory-live-query.bench.tsx
+++ b/packages/react/src/in-memory-live-query.bench.tsx
@@ -1,6 +1,6 @@
 // Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
-import { commands, server } from "@vitest/browser/context";
+import { commands, server } from "vitest/browser";
 import {
   defineViewServerConfig,
   type ViewServerHealth,

--- a/scripts/benchmark-baseline-runner.test.ts
+++ b/scripts/benchmark-baseline-runner.test.ts
@@ -330,7 +330,8 @@ describe("benchmark baseline runner", () => {
       rawReadWrite: "node scripts/run-benchmark-baseline.mjs --profile=raw-read-write",
       rawReadWriteUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=raw-read-write --update-baseline",
-      release: "node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
+      release:
+        "NODE_OPTIONS=--max-old-space-size=12288 node scripts/run-benchmark-baseline.mjs --profile=release --no-compare",
       webSocketFirehose: "node scripts/run-benchmark-baseline.mjs --profile=websocket-firehose",
       webSocketFirehoseUpdate:
         "node scripts/run-benchmark-baseline.mjs --profile=websocket-firehose --update-baseline",
@@ -381,6 +382,18 @@ describe("benchmark baseline runner", () => {
       "pnpm run bench:baseline:grpc-materialized",
       "pnpm run bench:baseline:grpc-leased",
       "pnpm run bench:baseline:grpc-leased-retained",
+    ]);
+  });
+
+  it("keeps the release-candidate capacity gate serial and complete", () => {
+    const scripts = JSON.parse(readFileSync("package.json", "utf8")).scripts;
+
+    expect(scripts["release-candidate:capacity"].split(" && ")).toStrictEqual([
+      "pnpm run examples:test",
+      "pnpm run examples:build",
+      "pnpm run pre-grpc:gate",
+      "pnpm run grpc:gate",
+      "pnpm run bench:baseline:release",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- add production deployment recipe and operations docs for single-runtime View Server deployments
- add release-candidate capacity gate covering examples, pre-gRPC, gRPC, and broad release benchmarks
- document release benchmark heap budget and machine-shape recording requirements
- remove deprecated Vitest browser context import from the React benchmark

## Validation
- vp check
- pnpm run test:repository-scripts
- pnpm run pre-grpc:gate
- pnpm run grpc:gate
- pnpm run bench:baseline:release
- focused React benchmark after import change: VIEW_SERVER_REACT_BENCH_ROWS=20 VIEW_SERVER_REACT_BENCH_ITERATIONS=1 VIEW_SERVER_REACT_BENCH_TIME_MS=1 VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS=0 VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS=0 vp run @view-server/react#bench:in-memory-live-query

## Notes
- The first release benchmark attempt hit Node default old-space OOM at the 10M raw snapshot task. The release script now sets NODE_OPTIONS=--max-old-space-size=12288 and the release baseline passes.
- examples:test, examples:build, pre-grpc:gate, grpc:gate, and bench:baseline:release were run serially in chunks to avoid benchmark pollution.