### PR TITLE
Fix npm trusted publishing metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Verify npm trusted publishing OIDC
+        run: |
+          node -e "if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL || !process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) throw new Error('GitHub Actions OIDC token is unavailable. Check that the publish job has id-token: write.');"
+
       - name: Publish to npm
         run: |
           vp run -w release:publish

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,11 +13,16 @@ with `id-token: write`.
 Before the first publish, configure npm Trusted Publishing for the
 `effect-view-server` package:
 
+- Package name: `effect-view-server`
 - Repository: `bmvantunes/effect-view-server`
 - Workflow file: `release.yml`
 - Allowed action: `npm publish`
 - Environment: leave unset unless the workflow is also changed to use a GitHub
   environment
+
+The public package manifest uses the HTTPS repository URL
+`https://github.com/bmvantunes/effect-view-server.git`; keep that aligned with
+the npm trusted publisher repository instead of using an SSH URL.
 
 The package already sets `publishConfig.provenance: true`, and the release
 workflow has `id-token: write`, so npm can attach provenance to published

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/bmvantunes/effect-view-server.git",
+    "url": "https://github.com/bmvantunes/effect-view-server.git",
     "directory": "packages/effect-view-server"
   },
   "files": [

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -43,7 +43,7 @@ const publicPackageJson = {
   license: "MIT",
   repository: {
     type: "git",
-    url: "git+ssh://git@github.com/bmvantunes/effect-view-server.git",
+    url: "https://github.com/bmvantunes/effect-view-server.git",
     directory: "packages/effect-view-server",
   },
   type: "module",
@@ -200,7 +200,7 @@ describe("release publish policy", () => {
       license: "MIT",
       repository: {
         type: "git",
-        url: "git+ssh://git@github.com/bmvantunes/effect-view-server.git",
+        url: "https://github.com/bmvantunes/effect-view-server.git",
         directory: "packages/effect-view-server",
       },
       type: "module",


### PR DESCRIPTION
## Summary
- switch the publishable package repository URL from SSH to HTTPS so npm trusted publishing can match the GitHub repository identity
- add an OIDC preflight before npm publish so missing id-token permissions fail explicitly
- document the exact npm trusted publishing setup fields

## Validation
- vp check --fix
- vp run -w test:repository-scripts