### PR TITLE
Pin npm for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
+      - name: Install npm for trusted publishing
+        run: npm install --global npm@11.17.0
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -93,6 +96,7 @@ jobs:
 
       - name: Verify npm trusted publishing OIDC
         run: |
+          npm --version
           node -e "if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL || !process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) throw new Error('GitHub Actions OIDC token is unavailable. Check that the publish job has id-token: write.');"
 
       - name: Publish to npm

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,9 +20,11 @@ Before the first publish, configure npm Trusted Publishing for the
 - Environment: leave unset unless the workflow is also changed to use a GitHub
   environment
 
-The public package manifest uses the HTTPS repository URL
-`https://github.com/bmvantunes/effect-view-server.git`; keep that aligned with
-the npm trusted publisher repository instead of using an SSH URL.
+The public package manifest uses npm's normalized repository URL
+`git+https://github.com/bmvantunes/effect-view-server.git`; keep that aligned
+with the npm trusted publisher repository instead of using an SSH URL. The
+publish job installs a known npm CLI version because trusted publishing requires
+modern npm OIDC support.
 
 The package already sets `publishConfig.provenance: true`, and the release
 workflow has `id-token: write`, so npm can attach provenance to published

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bmvantunes/effect-view-server.git",
+    "url": "git+https://github.com/bmvantunes/effect-view-server.git",
     "directory": "packages/effect-view-server"
   },
   "files": [

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -43,7 +43,7 @@ const publicPackageJson = {
   license: "MIT",
   repository: {
     type: "git",
-    url: "https://github.com/bmvantunes/effect-view-server.git",
+    url: "git+https://github.com/bmvantunes/effect-view-server.git",
     directory: "packages/effect-view-server",
   },
   type: "module",
@@ -200,7 +200,7 @@ describe("release publish policy", () => {
       license: "MIT",
       repository: {
         type: "git",
-        url: "https://github.com/bmvantunes/effect-view-server.git",
+        url: "git+https://github.com/bmvantunes/effect-view-server.git",
         directory: "packages/effect-view-server",
       },
       type: "module",


### PR DESCRIPTION
## Summary
- install npm 11.17.0 in the publish job so trusted publishing uses a modern npm CLI
- log npm --version during the OIDC preflight
- use npm's normalized git+https repository URL in the public package metadata

## Validation
- vp install --frozen-lockfile
- vp check --fix
- vp run -w test:repository-scripts