### PR TITLE
Include README in npm artifact

### DIFF
--- a/.changeset/publish-readme.md
+++ b/.changeset/publish-readme.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Include the README in the published npm package artifact.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# view-server-smart
+# Effect View Server
 
 ## Guides
 

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -22,7 +22,8 @@
     "directory": "packages/effect-view-server"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "type": "module",
   "exports": {

--- a/scripts/release-publish-policy.mjs
+++ b/scripts/release-publish-policy.mjs
@@ -38,7 +38,7 @@ export const sanitizePublicPackageJson = (packageJson) =>
     ["repository", cloneJson(packageJson.repository)],
     ["type", packageJson.type],
     ["exports", cloneJson(packageJson.exports)],
-    ["files", ["dist"]],
+    ["files", ["dist", "README.md"]],
     [
       "publishConfig",
       {

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -53,7 +53,7 @@ const publicPackageJson = {
       import: "./dist/client.js",
     },
   },
-  files: ["dist"],
+  files: ["dist", "README.md"],
   publishConfig: {
     provenance: true,
   },
@@ -210,7 +210,7 @@ describe("release publish policy", () => {
           import: "./dist/client.js",
         },
       },
-      files: ["dist"],
+      files: ["dist", "README.md"],
       publishConfig: {
         access: "public",
         provenance: true,
@@ -252,7 +252,7 @@ describe("release publish policy", () => {
           import: "./dist/client.js",
         },
       },
-      files: ["dist"],
+      files: ["dist", "README.md"],
       publishConfig: {
         access: "public",
         provenance: true,
@@ -266,6 +266,17 @@ describe("release publish policy", () => {
         {
           relativePath: "dist/client.js",
           contents: 'const id = Symbol("@effect-view-server/config/KafkaCodecValue");',
+        },
+      ]),
+    ).toStrictEqual([]);
+  });
+
+  it("accepts the staged npm README", () => {
+    expect(
+      publishedFileViolations([
+        {
+          relativePath: "README.md",
+          contents: "# Effect View Server\n",
         },
       ]),
     ).toStrictEqual([]);

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -165,6 +165,7 @@ try {
     filter: (source) => !source.endsWith(".map"),
   });
   stripPublishedSourceMapReferences(distDirectory);
+  cpSync(new URL("../README.md", import.meta.url), join(stageDirectory, "README.md"));
   writeFileSync(
     join(stageDirectory, "package.json"),
     `${JSON.stringify(sanitizePublicPackageJson(packageJson), null, 2)}\n`,


### PR DESCRIPTION
## Summary
- copy the root README into the staged npm artifact before publishing
- include README.md in the sanitized public package manifest and package files whitelist
- add a patch changeset so the next release publishes the README to npm

## Validation
- vp check --fix
- vp run -w test:repository-scripts
- vp run -t effect-view-server#build