### PR TITLE
Preserve OIDC for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,5 +101,6 @@ jobs:
 
       - name: Publish to npm
         run: |
-          vp run -w release:publish
+          vp run effect-view-server#build
+          node scripts/release-publish.mjs
           git push --follow-tags

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - Use Changesets for release intent. If a PR should publish a new npm version, add a changeset with `vp run -w changeset`. Do not add a changeset for private-only CI, docs, examples, benchmark, or internal-only changes that should not publish.
 - Merging an ordinary PR to `main` must not publish npm. The release workflow only publishes after a changeset has produced a version bump and the generated version PR is merged to `main`.
 - npm publishing uses GitHub Actions trusted publishing/OIDC from `.github/workflows/release.yml`. Do not add `NPM_TOKEN`; keep `id-token: write` and `publishConfig.provenance: true`.
+- The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final publish so GitHub's OIDC environment reaches `npm publish`.
 
 ## Common Blockers
 

--- a/scripts/release-publish-policy.mjs
+++ b/scripts/release-publish-policy.mjs
@@ -75,6 +75,11 @@ export const isTrustedPublishEnvironment = (env) =>
   env.GITHUB_REF === "refs/heads/main" &&
   env.GITHUB_REPOSITORY === expectedPublishRepository;
 
+export const oidcPublishEnvironmentViolations = (env) =>
+  ["ACTIONS_ID_TOKEN_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"]
+    .filter((name) => env[name] === undefined || env[name] === "")
+    .map((name) => `${name} is required for npm trusted publishing.`);
+
 export const publishDecision = ({ env, version, workspacePackages }) => {
   if (version === "0.0.0") {
     return {

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import {
   internalPublishViolations,
+  oidcPublishEnvironmentViolations,
   packageTagName,
   publishedFileViolations,
   publicPackageName,
@@ -185,6 +186,19 @@ describe("release publish policy", () => {
     ).toStrictEqual({
       _tag: "Publish",
     });
+  });
+
+  it("requires GitHub Actions OIDC variables before trusted npm publishing", () => {
+    expect(oidcPublishEnvironmentViolations({})).toStrictEqual([
+      "ACTIONS_ID_TOKEN_REQUEST_URL is required for npm trusted publishing.",
+      "ACTIONS_ID_TOKEN_REQUEST_TOKEN is required for npm trusted publishing.",
+    ]);
+    expect(
+      oidcPublishEnvironmentViolations({
+        ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.actions.githubusercontent.com",
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: "token",
+      }),
+    ).toStrictEqual([]);
   });
 
   it("sanitizes the public package manifest before staging the npm artifact", () => {

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import {
   packageTagName,
+  oidcPublishEnvironmentViolations,
   publishedFileViolations,
   publicPackageName,
   publishDecision,
@@ -177,6 +178,18 @@ try {
     process.stdout.write(`${publicPackageName}@${version} is already published; ensuring git tag.\n`);
     ensureGitTag();
     process.exit(0);
+  }
+
+  const oidcViolations = oidcPublishEnvironmentViolations(process.env);
+  if (oidcViolations.length > 0) {
+    process.stderr.write(
+      [
+        "Refusing npm publish because GitHub Actions OIDC is unavailable.",
+        ...oidcViolations.map((violation) => `- ${violation}`),
+      ].join("\n"),
+    );
+    process.stderr.write("\n");
+    process.exit(1);
   }
 
   run("npm", ["publish", stageDirectory, "--provenance", "--access", "public"]);


### PR DESCRIPTION
## Summary

- Run the final npm publish script directly from the release workflow so GitHub Actions OIDC env is preserved for npm.
- Keep package build on Vite+ before publishing.
- Add a publisher-side OIDC env guard and tests so missing trusted publishing env fails explicitly.
- Document the workflow constraint in AGENTS.md.

## Root Cause

The release workflow OIDC preflight passed before publish, but npm publish ran inside the Vite+ release task and still failed with ENEEDAUTH. The likely cause is the nested task environment not exposing the ACTIONS_ID_TOKEN_REQUEST variables npm needs for trusted publishing.

## Validation

- vp check --fix
- vp run -w test:repository-scripts
