### PR TITLE
Stage npm releases before approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Published effect-view-server version to tag after npm stage approve"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,6 +21,7 @@ concurrency:
 jobs:
   version:
     name: Ready and version PR
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -51,7 +57,6 @@ jobs:
 
       - name: Create version PR
         id: changesets
-        if: github.event_name == 'push'
         uses: changesets/action@v1
         with:
           title: "Version packages"
@@ -65,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: version
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.version.outputs.hasChangesets == 'false')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.version.outputs.hasChangesets == 'false'
     permissions:
       contents: write
       id-token: write
@@ -105,3 +110,34 @@ jobs:
         run: |
           vp run effect-view-server#build
           node scripts/release-publish.mjs
+
+  finalize:
+    name: Finalize approved npm stage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "26"
+          version: "0.2.1"
+          cache: false
+          run-install: false
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag approved npm version
+        run: node scripts/release-publish.mjs --finalize-version "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           npm --version
           node -e "if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL || !process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) throw new Error('GitHub Actions OIDC token is unavailable. Check that the publish job has id-token: write.');"
 
-      - name: Publish to npm
+      - name: Stage npm publish
         run: |
           vp run effect-view-server#build
           node scripts/release-publish.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Create version PR
         id: changesets
+        if: github.event_name == 'push'
         uses: changesets/action@v1
         with:
           title: "Version packages"
@@ -64,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: version
-    if: github.ref == 'refs/heads/main' && needs.version.outputs.hasChangesets == 'false'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.version.outputs.hasChangesets == 'false')
     permissions:
       contents: write
       id-token: write
@@ -104,4 +105,3 @@ jobs:
         run: |
           vp run effect-view-server#build
           node scripts/release-publish.mjs
-          git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,4 +140,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Tag approved npm version
-        run: node scripts/release-publish.mjs --finalize-version "${{ inputs.version }}"
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node scripts/release-publish.mjs --finalize-version "$RELEASE_VERSION"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,10 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - Use Changesets for release intent. If a PR should publish a new npm version, add a changeset with `vp run -w changeset`. Do not add a changeset for private-only CI, docs, examples, benchmark, or internal-only changes that should not publish.
 - Merging an ordinary PR to `main` must not publish npm. The release workflow only publishes after a changeset has produced a version bump and the generated version PR is merged to `main`.
 - npm publishing uses GitHub Actions trusted publishing/OIDC from `.github/workflows/release.yml`. Do not add `NPM_TOKEN`; keep `id-token: write` and `publishConfig.provenance: true`.
-- The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final publish so GitHub's OIDC environment reaches `npm publish`.
+- The npm trusted publisher must allow `npm stage publish` only. Do not enable direct `npm publish` unless explicitly changing the release process.
+- The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final stage publish so GitHub's OIDC environment reaches `npm stage publish`.
+- CI stages npm releases with `npm stage publish`; a maintainer approves the staged package later with `npm stage approve <stage-id>` or rejects it with `npm stage reject <stage-id>`.
+- The stage job may push an `effect-view-server@<version>-staged` marker tag to make reruns idempotent while npm approval is pending. Do not create the public `effect-view-server@<version>` release tag until the package is actually published.
 
 ## Common Blockers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final stage publish so GitHub's OIDC environment reaches `npm stage publish`.
 - CI stages npm releases with `npm stage publish`; a maintainer approves the staged package later with `npm stage approve <stage-id>` or rejects it with `npm stage reject <stage-id>`.
 - The stage job may push an `effect-view-server@<version>-staged` marker tag as a best-effort pending-approval signal, but the release script must still ask npm on reruns so rejected stages can be restaged and approved stages can become public release tags.
-- After approving a staged package, manually run the `Release` workflow on `main` so CI observes the public npm version and creates the public `effect-view-server@<version>` git tag. Do not create the public tag before npm reports the version as published.
+- After approving a staged package, manually run the `Release` workflow on `main` with the approved version input so CI observes the exact public npm version and creates the public `effect-view-server@<version>` git tag. Do not create the public tag before npm reports the version as published.
 
 ## Common Blockers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,8 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - The npm trusted publisher must allow `npm stage publish` only. Do not enable direct `npm publish` unless explicitly changing the release process.
 - The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final stage publish so GitHub's OIDC environment reaches `npm stage publish`.
 - CI stages npm releases with `npm stage publish`; a maintainer approves the staged package later with `npm stage approve <stage-id>` or rejects it with `npm stage reject <stage-id>`.
-- The stage job may push an `effect-view-server@<version>-staged` marker tag to make reruns idempotent while npm approval is pending. Do not create the public `effect-view-server@<version>` release tag until the package is actually published.
+- The stage job may push an `effect-view-server@<version>-staged` marker tag as a best-effort pending-approval signal, but the release script must still ask npm on reruns so rejected stages can be restaged and approved stages can become public release tags.
+- After approving a staged package, manually run the `Release` workflow on `main` so CI observes the public npm version and creates the public `effect-view-server@<version>` git tag. Do not create the public tag before npm reports the version as published.
 
 ## Common Blockers
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -65,8 +65,9 @@ PR. When that PR is merged, the same workflow builds `effect-view-server` and
 stages a sanitized npm artifact through trusted publishing. A maintainer must
 then approve the staged package with `npm stage approve <stage-id>` to publish
 it publicly, or reject it with `npm stage reject <stage-id>`. After approval,
-manually run the `Release` workflow on `main`; the release script observes that
-the version is now public and creates the public
+manually run the `Release` workflow on `main` with the approved version as the
+workflow input; the release script observes that the exact version is now public
+and creates the public
 `effect-view-server@<version>` git tag. The staged artifact intentionally
 excludes source maps, source-map references, scripts, dev dependencies, internal
 `@effect-view-server/*` workspace metadata, and internal workspace import

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ Before the first publish, configure npm Trusted Publishing for the
 - Package name: `effect-view-server`
 - Repository: `bmvantunes/effect-view-server`
 - Workflow file: `release.yml`
-- Allowed action: `npm publish`
+- Allowed action: `npm stage publish`
 - Environment: leave unset unless the workflow is also changed to use a GitHub
   environment
 
@@ -27,8 +27,10 @@ publish job installs a known npm CLI version because trusted publishing requires
 modern npm OIDC support.
 
 The package already sets `publishConfig.provenance: true`, and the release
-workflow has `id-token: write`, so npm can attach provenance to published
-versions.
+workflow has `id-token: write`, so npm can attach provenance to staged
+versions. Staged publishing requires the package to already exist on npm; this
+repository was bootstrapped with a one-time manual `effect-view-server@0.0.1`
+publish before stage-only automation was enabled.
 
 ## Contributor flow
 
@@ -59,13 +61,19 @@ On every push to `main`, `.github/workflows/release.yml` runs:
 4. Changesets action
 
 If unreleased changesets exist, the action opens or updates a `Version packages`
-PR. When that PR is merged, the same workflow builds `effect-view-server`,
-stages a sanitized npm artifact, and publishes that staged artifact through
-trusted publishing. The staged artifact intentionally excludes source maps,
-source-map references, scripts, dev dependencies, internal
+PR. When that PR is merged, the same workflow builds `effect-view-server` and
+stages a sanitized npm artifact through trusted publishing. A maintainer must
+then approve the staged package with `npm stage approve <stage-id>` to publish
+it publicly, or reject it with `npm stage reject <stage-id>`. The staged
+artifact intentionally excludes source maps, source-map references, scripts,
+dev dependencies, internal
 `@effect-view-server/*` workspace metadata, and internal workspace import
 specifiers. The publish script skips `effect-view-server@0.0.0`, so enabling
 this workflow cannot accidentally publish the placeholder development version.
+The staging job may push an `effect-view-server@<version>-staged` marker tag so
+workflow reruns do not try to stage the same semver version again while approval
+is pending. The public `effect-view-server@<version>` release tag is only
+created after npm reports that the version is actually published.
 
 ## Manual checks
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -64,16 +64,20 @@ If unreleased changesets exist, the action opens or updates a `Version packages`
 PR. When that PR is merged, the same workflow builds `effect-view-server` and
 stages a sanitized npm artifact through trusted publishing. A maintainer must
 then approve the staged package with `npm stage approve <stage-id>` to publish
-it publicly, or reject it with `npm stage reject <stage-id>`. The staged
-artifact intentionally excludes source maps, source-map references, scripts,
-dev dependencies, internal
+it publicly, or reject it with `npm stage reject <stage-id>`. After approval,
+manually run the `Release` workflow on `main`; the release script observes that
+the version is now public and creates the public
+`effect-view-server@<version>` git tag. The staged artifact intentionally
+excludes source maps, source-map references, scripts, dev dependencies, internal
 `@effect-view-server/*` workspace metadata, and internal workspace import
 specifiers. The publish script skips `effect-view-server@0.0.0`, so enabling
 this workflow cannot accidentally publish the placeholder development version.
-The staging job may push an `effect-view-server@<version>-staged` marker tag so
-workflow reruns do not try to stage the same semver version again while approval
-is pending. The public `effect-view-server@<version>` release tag is only
-created after npm reports that the version is actually published.
+The staging job may push an `effect-view-server@<version>-staged` marker tag as
+a best-effort signal that approval is pending. It is not authoritative: reruns
+still ask npm so rejected stages can be restaged and approved stages can be
+converted into public release tags. The public
+`effect-view-server@<version>` release tag is only created after npm reports
+that the version is actually published.
 
 ## Manual checks
 

--- a/scripts/release-publish-policy.mjs
+++ b/scripts/release-publish-policy.mjs
@@ -127,6 +127,9 @@ export const oidcPublishEnvironmentViolations = (env) =>
     .filter((name) => env[name] === undefined || env[name] === "")
     .map((name) => `${name} is required for npm trusted publishing.`);
 
+export const canRecoverMissingStagedMarker = (env) =>
+  env.GITHUB_ACTIONS === "true" && Number.parseInt(env.GITHUB_RUN_ATTEMPT ?? "1", 10) > 1;
+
 export const publishDecision = ({ env, version, workspacePackages }) => {
   if (version === "0.0.0") {
     return {

--- a/scripts/release-publish-policy.mjs
+++ b/scripts/release-publish-policy.mjs
@@ -16,6 +16,30 @@ const definedEntries = (entries) =>
 
 export const packageTagName = (version) => `${publicPackageName}@${version}`;
 
+export const stagedPackageTagName = (version) => `${packageTagName(version)}-staged`;
+
+export const stagePublishCommandArguments = (stageDirectory) => [
+  "stage",
+  "publish",
+  stageDirectory,
+  "--provenance",
+  "--access",
+  "public",
+];
+
+const escapedRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const isDuplicateStagePublishOutput = ({ stderr, stdout, version }) => {
+  const output = `${stdout}\n${stderr}`;
+  const versionPattern = escapedRegExp(version);
+  const duplicatePattern = "(already exists|already staged|cannot publish over|previously published)";
+
+  return new RegExp(
+    `(?:${duplicatePattern}).*${versionPattern}|${versionPattern}.*(?:${duplicatePattern})`,
+    "i",
+  ).test(output);
+};
+
 export const stripSourceMapReference = (contents) =>
   contents.replace(/(?:\n)?\/\/# sourceMappingURL=.*(?:\n|$)/g, "\n");
 

--- a/scripts/release-publish-policy.mjs
+++ b/scripts/release-publish-policy.mjs
@@ -29,15 +29,38 @@ export const stagePublishCommandArguments = (stageDirectory) => [
 
 const escapedRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-export const isDuplicateStagePublishOutput = ({ stderr, stdout, version }) => {
+export const classifyStagePublishDuplicateOutput = ({ stderr, stdout, version }) => {
   const output = `${stdout}\n${stderr}`;
   const versionPattern = escapedRegExp(version);
-  const duplicatePattern = "(already exists|already staged|cannot publish over|previously published)";
 
-  return new RegExp(
-    `(?:${duplicatePattern}).*${versionPattern}|${versionPattern}.*(?:${duplicatePattern})`,
-    "i",
-  ).test(output);
+  const hasVersion = new RegExp(versionPattern, "i").test(output);
+  if (!hasVersion) {
+    return {
+      _tag: "Unknown",
+    };
+  }
+
+  if (/previously published|cannot publish over|cannot modify pre-existing version/i.test(output)) {
+    return {
+      _tag: "AlreadyPublished",
+    };
+  }
+
+  if (/already exists|already staged|already pending|staged version/i.test(output)) {
+    if (/already exists/i.test(output) && !/already staged|already pending|staged version/i.test(output)) {
+      return {
+        _tag: "DuplicateVersion",
+      };
+    }
+
+    return {
+      _tag: "AlreadyStaged",
+    };
+  }
+
+  return {
+    _tag: "Unknown",
+  };
 };
 
 export const stripSourceMapReference = (contents) =>
@@ -95,7 +118,7 @@ export const internalPublishViolations = (workspacePackages) =>
 
 export const isTrustedPublishEnvironment = (env) =>
   env.GITHUB_ACTIONS === "true" &&
-  env.GITHUB_EVENT_NAME === "push" &&
+  (env.GITHUB_EVENT_NAME === "push" || env.GITHUB_EVENT_NAME === "workflow_dispatch") &&
   env.GITHUB_REF === "refs/heads/main" &&
   env.GITHUB_REPOSITORY === expectedPublishRepository;
 

--- a/scripts/release-publish-policy.mjs
+++ b/scripts/release-publish-policy.mjs
@@ -127,9 +127,6 @@ export const oidcPublishEnvironmentViolations = (env) =>
     .filter((name) => env[name] === undefined || env[name] === "")
     .map((name) => `${name} is required for npm trusted publishing.`);
 
-export const canRecoverMissingStagedMarker = (env) =>
-  env.GITHUB_ACTIONS === "true" && Number.parseInt(env.GITHUB_RUN_ATTEMPT ?? "1", 10) > 1;
-
 export const publishDecision = ({ env, version, workspacePackages }) => {
   if (version === "0.0.0") {
     return {

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import {
+  canRecoverMissingStagedMarker,
   classifyStagePublishDuplicateOutput,
   internalPublishViolations,
   oidcPublishEnvironmentViolations,
@@ -217,6 +218,27 @@ describe("release publish policy", () => {
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: "token",
       }),
     ).toStrictEqual([]);
+  });
+
+  it("recovers missing staged markers only on retried GitHub workflow attempts", () => {
+    expect(
+      canRecoverMissingStagedMarker({
+        GITHUB_ACTIONS: "true",
+        GITHUB_RUN_ATTEMPT: "2",
+      }),
+    ).toStrictEqual(true);
+    expect(
+      canRecoverMissingStagedMarker({
+        GITHUB_ACTIONS: "true",
+        GITHUB_RUN_ATTEMPT: "1",
+      }),
+    ).toStrictEqual(false);
+    expect(
+      canRecoverMissingStagedMarker({
+        GITHUB_ACTIONS: "true",
+      }),
+    ).toStrictEqual(false);
+    expect(canRecoverMissingStagedMarker({})).toStrictEqual(false);
   });
 
   it("sanitizes the public package manifest before staging the npm artifact", () => {

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import {
+  isDuplicateStagePublishOutput,
   internalPublishViolations,
   oidcPublishEnvironmentViolations,
   packageTagName,
@@ -7,6 +8,8 @@ import {
   publicPackageName,
   publishDecision,
   sanitizePublicPackageJson,
+  stagedPackageTagName,
+  stagePublishCommandArguments,
   stripSourceMapReference,
 } from "./release-publish-policy.mjs";
 
@@ -341,5 +344,44 @@ describe("release publish policy", () => {
 
   it("uses the public package name as the release git tag", () => {
     expect(packageTagName("1.2.3")).toStrictEqual("effect-view-server@1.2.3");
+  });
+
+  it("uses a distinct marker tag for staged packages awaiting approval", () => {
+    expect(stagedPackageTagName("1.2.3")).toStrictEqual("effect-view-server@1.2.3-staged");
+  });
+
+  it("stages npm packages instead of publishing directly", () => {
+    expect(stagePublishCommandArguments("/tmp/effect-view-server")).toStrictEqual([
+      "stage",
+      "publish",
+      "/tmp/effect-view-server",
+      "--provenance",
+      "--access",
+      "public",
+    ]);
+  });
+
+  it("detects duplicate staged package publish output for idempotent reruns", () => {
+    expect(
+      isDuplicateStagePublishOutput({
+        stderr: "npm error You cannot publish over the previously published versions: 1.2.3.",
+        stdout: "",
+        version: "1.2.3",
+      }),
+    ).toStrictEqual(true);
+    expect(
+      isDuplicateStagePublishOutput({
+        stderr: "",
+        stdout: "version 1.2.3 is already staged",
+        version: "1.2.3",
+      }),
+    ).toStrictEqual(true);
+    expect(
+      isDuplicateStagePublishOutput({
+        stderr: "npm error authentication failed",
+        stdout: "",
+        version: "1.2.3",
+      }),
+    ).toStrictEqual(false);
   });
 });

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import {
-  isDuplicateStagePublishOutput,
+  classifyStagePublishDuplicateOutput,
   internalPublishViolations,
   oidcPublishEnvironmentViolations,
   packageTagName,
@@ -191,6 +191,21 @@ describe("release publish policy", () => {
     });
   });
 
+  it("allows manual release workflow dispatch for post-approval release tags", () => {
+    expect(
+      publishDecision({
+        env: {
+          ...trustedEnvironment,
+          GITHUB_EVENT_NAME: "workflow_dispatch",
+        },
+        version: "1.2.3",
+        workspacePackages,
+      }),
+    ).toStrictEqual({
+      _tag: "Publish",
+    });
+  });
+
   it("requires GitHub Actions OIDC variables before trusted npm publishing", () => {
     expect(oidcPublishEnvironmentViolations({})).toStrictEqual([
       "ACTIONS_ID_TOKEN_REQUEST_URL is required for npm trusted publishing.",
@@ -361,27 +376,60 @@ describe("release publish policy", () => {
     ]);
   });
 
-  it("detects duplicate staged package publish output for idempotent reruns", () => {
+  it("classifies duplicate staged package output for idempotent reruns", () => {
     expect(
-      isDuplicateStagePublishOutput({
-        stderr: "npm error You cannot publish over the previously published versions: 1.2.3.",
-        stdout: "",
-        version: "1.2.3",
-      }),
-    ).toStrictEqual(true);
-    expect(
-      isDuplicateStagePublishOutput({
+      classifyStagePublishDuplicateOutput({
         stderr: "",
         stdout: "version 1.2.3 is already staged",
         version: "1.2.3",
       }),
-    ).toStrictEqual(true);
+    ).toStrictEqual({
+      _tag: "AlreadyStaged",
+    });
+  });
+
+  it("classifies duplicate published package output as public release completion", () => {
     expect(
-      isDuplicateStagePublishOutput({
+      classifyStagePublishDuplicateOutput({
+        stderr: "npm error You cannot publish over the previously published versions: 1.2.3.",
+        stdout: "",
+        version: "1.2.3",
+      }),
+    ).toStrictEqual({
+      _tag: "AlreadyPublished",
+    });
+  });
+
+  it("classifies generic duplicate package output as ambiguous", () => {
+    expect(
+      classifyStagePublishDuplicateOutput({
+        stderr: "npm error version 1.2.3 already exists",
+        stdout: "",
+        version: "1.2.3",
+      }),
+    ).toStrictEqual({
+      _tag: "DuplicateVersion",
+    });
+  });
+
+  it("ignores unrelated stage publish failures", () => {
+    expect(
+      classifyStagePublishDuplicateOutput({
         stderr: "npm error authentication failed",
         stdout: "",
         version: "1.2.3",
       }),
-    ).toStrictEqual(false);
+    ).toStrictEqual({
+      _tag: "Unknown",
+    });
+    expect(
+      classifyStagePublishDuplicateOutput({
+        stderr: "npm error timed out while preparing 1.2.3",
+        stdout: "",
+        version: "1.2.3",
+      }),
+    ).toStrictEqual({
+      _tag: "Unknown",
+    });
   });
 });

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
+import { readFileSync } from "node:fs";
 import {
-  canRecoverMissingStagedMarker,
   classifyStagePublishDuplicateOutput,
   internalPublishViolations,
   oidcPublishEnvironmentViolations,
@@ -220,25 +220,19 @@ describe("release publish policy", () => {
     ).toStrictEqual([]);
   });
 
-  it("recovers missing staged markers only on retried GitHub workflow attempts", () => {
-    expect(
-      canRecoverMissingStagedMarker({
-        GITHUB_ACTIONS: "true",
-        GITHUB_RUN_ATTEMPT: "2",
-      }),
-    ).toStrictEqual(true);
-    expect(
-      canRecoverMissingStagedMarker({
-        GITHUB_ACTIONS: "true",
-        GITHUB_RUN_ATTEMPT: "1",
-      }),
-    ).toStrictEqual(false);
-    expect(
-      canRecoverMissingStagedMarker({
-        GITHUB_ACTIONS: "true",
-      }),
-    ).toStrictEqual(false);
-    expect(canRecoverMissingStagedMarker({})).toStrictEqual(false);
+  it("does not expose a retry-count based staged marker recovery policy", () => {
+    const policySource = readFileSync(new URL("./release-publish-policy.mjs", import.meta.url), "utf8");
+
+    expect(policySource).not.toContain("canRecoverMissingStagedMarker");
+    expect(policySource).not.toContain("GITHUB_RUN_ATTEMPT");
+  });
+
+  it("passes manual release workflow version input through an environment variable", () => {
+    const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+
+    expect(releaseWorkflow).toContain("RELEASE_VERSION: ${{ inputs.version }}");
+    expect(releaseWorkflow).toContain('node scripts/release-publish.mjs --finalize-version "$RELEASE_VERSION"');
+    expect(releaseWorkflow).not.toContain('node scripts/release-publish.mjs --finalize-version "${{ inputs.version }}"');
   });
 
   it("sanitizes the public package manifest before staging the npm artifact", () => {

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -3,12 +3,15 @@ import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, wri
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import {
+  isDuplicateStagePublishOutput,
   packageTagName,
   oidcPublishEnvironmentViolations,
   publishedFileViolations,
   publicPackageName,
   publishDecision,
   sanitizePublicPackageJson,
+  stagedPackageTagName,
+  stagePublishCommandArguments,
   stripSourceMapReference,
 } from "./release-publish-policy.mjs";
 
@@ -73,7 +76,9 @@ const run = (command, args, options = {}) => {
   });
 
   if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+    throw Object.assign(new Error(`${command} ${args.join(" ")} failed.`), {
+      exitCode: result.status ?? 1,
+    });
   }
 };
 
@@ -118,15 +123,22 @@ const assertCleanPublishedFiles = (stageDirectory) => {
   const violations = publishedFileViolations(collectPublishedFiles(stageDirectory));
 
   if (violations.length > 0) {
-    process.stderr.write(
+    throw new Error(
       [
-        "Refusing npm publish because the staged package contains private workspace artifacts.",
+        "Refusing npm stage publish because the staged package contains private workspace artifacts.",
         ...violations.map((violation) => `- ${violation}`),
       ].join("\n"),
     );
-    process.stderr.write("\n");
-    process.exit(1);
   }
+};
+
+const isPackageAlreadyCreated = () => {
+  const result = commandResult("npm", ["view", publicPackageName, "name", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+
+  return result.status === 0 && JSON.parse(result.stdout) === publicPackageName;
 };
 
 const isVersionAlreadyPublished = () => {
@@ -142,19 +154,55 @@ const isVersionAlreadyPublished = () => {
   return result.status === 0 && JSON.parse(result.stdout) === version;
 };
 
-const ensureGitTag = () => {
-  const tagName = packageTagName(version);
+const runStagePublish = (stageDirectory) => {
+  const result = commandResult("npm", stagePublishCommandArguments(stageDirectory), {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+
+  if (result.status === 0) {
+    return {
+      _tag: "Staged",
+    };
+  }
+
+  if (
+    isDuplicateStagePublishOutput({
+      stderr: result.stderr,
+      stdout: result.stdout,
+      version,
+    })
+  ) {
+    return {
+      _tag: "AlreadyStaged",
+    };
+  }
+
+  throw Object.assign(new Error(`npm ${stagePublishCommandArguments(stageDirectory).join(" ")} failed.`), {
+    exitCode: result.status ?? 1,
+  });
+};
+
+const gitTagExists = (tagName) => {
   const existingTag = commandResult("git", ["rev-parse", "--quiet", "--verify", `refs/tags/${tagName}`], {
     stdio: "ignore",
   });
 
-  if (existingTag.status === 0) {
+  return existingTag.status === 0;
+};
+
+const ensureGitTag = (tagName) => {
+  if (gitTagExists(tagName)) {
     return;
   }
 
   run("git", ["tag", "-a", tagName, "-m", tagName]);
 };
 
+let exitCode = 0;
 const stageDirectory = mkdtempSync(join(tmpdir(), "effect-view-server-publish-"));
 
 try {
@@ -176,24 +224,49 @@ try {
 
   if (isVersionAlreadyPublished()) {
     process.stdout.write(`${publicPackageName}@${version} is already published; ensuring git tag.\n`);
-    ensureGitTag();
-    process.exit(0);
-  }
+    ensureGitTag(packageTagName(version));
+  } else {
+    if (!isPackageAlreadyCreated()) {
+      throw new Error(
+        `${publicPackageName} must exist on npm before staged publishing can be used. Publish the first version manually, then rerun this workflow.`,
+      );
+    }
 
-  const oidcViolations = oidcPublishEnvironmentViolations(process.env);
-  if (oidcViolations.length > 0) {
-    process.stderr.write(
-      [
-        "Refusing npm publish because GitHub Actions OIDC is unavailable.",
-        ...oidcViolations.map((violation) => `- ${violation}`),
-      ].join("\n"),
-    );
-    process.stderr.write("\n");
-    process.exit(1);
-  }
+    const stagedTagName = stagedPackageTagName(version);
 
-  run("npm", ["publish", stageDirectory, "--provenance", "--access", "public"]);
-  ensureGitTag();
+    if (gitTagExists(stagedTagName)) {
+      process.stdout.write(`${publicPackageName}@${version} is already staged; skipping npm stage publish.\n`);
+    } else {
+      const oidcViolations = oidcPublishEnvironmentViolations(process.env);
+      if (oidcViolations.length > 0) {
+        throw new Error(
+          [
+            "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
+            ...oidcViolations.map((violation) => `- ${violation}`),
+          ].join("\n"),
+        );
+      }
+
+      const stageResult = runStagePublish(stageDirectory);
+
+      if (stageResult._tag === "AlreadyStaged") {
+        process.stdout.write(
+          `${publicPackageName}@${version} is already staged in npm; repairing staged marker tag.\n`,
+        );
+      }
+
+      ensureGitTag(stagedTagName);
+    }
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  exitCode =
+    typeof error === "object" &&
+    error !== null &&
+    "exitCode" in error &&
+    typeof error.exitCode === "number"
+      ? error.exitCode
+      : 1;
 } finally {
   rmSync(stageDirectory, {
     force: true,
@@ -201,4 +274,4 @@ try {
   });
 }
 
-process.exit(0);
+process.exit(exitCode);

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -3,6 +3,7 @@ import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, wri
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import {
+  canRecoverMissingStagedMarker,
   classifyStagePublishDuplicateOutput,
   packageTagName,
   oidcPublishEnvironmentViolations,
@@ -156,6 +157,29 @@ const isVersionAlreadyPublished = () => {
   return result.status === 0 && JSON.parse(result.stdout) === version;
 };
 
+const publishedVersionGitHead = () => {
+  const result = commandResult(
+    "npm",
+    ["view", `${publicPackageName}@${version}`, "gitHead", "--json"],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  if (result.stdout.trim() === "") {
+    return undefined;
+  }
+
+  const gitHead = JSON.parse(result.stdout);
+
+  return typeof gitHead === "string" && gitHead.length > 0 ? gitHead : undefined;
+};
+
 const runStagePublish = (stageDirectory) => {
   const result = commandResult("npm", stagePublishCommandArguments(stageDirectory), {
     encoding: "utf8",
@@ -245,14 +269,15 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
 
 const ensurePublishedVersionTag = () => {
   const stagedTagName = stagedPackageTagName(version);
+  const targetRef = gitTagExists(stagedTagName) ? `refs/tags/${stagedTagName}` : publishedVersionGitHead();
 
-  if (!gitTagExists(stagedTagName)) {
+  if (targetRef === undefined) {
     throw new Error(
-      `Cannot create ${packageTagName(version)} because ${stagedTagName} does not exist. Stage the package before approving it.`,
+      `Cannot create ${packageTagName(version)} because ${stagedTagName} does not exist and npm did not report a gitHead for ${publicPackageName}@${version}.`,
     );
   }
 
-  ensureGitTag(packageTagName(version), `refs/tags/${stagedTagName}`);
+  ensureGitTag(packageTagName(version), targetRef);
 };
 
 let exitCode = 0;
@@ -321,8 +346,14 @@ try {
         });
       } else if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
         if (!gitTagExists(stagedTagName)) {
+          if (!canRecoverMissingStagedMarker(process.env)) {
+            throw new Error(
+              `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to recreate it from an unrelated workflow HEAD; rerun the failed staging workflow attempt or reject the npm stage and restage.`,
+            );
+          }
+
           process.stdout.write(
-            `npm reported ${publicPackageName}@${version} as already staged; recreating missing ${stagedTagName} marker.\n`,
+            `npm reported ${publicPackageName}@${version} as already staged on a retried workflow; recreating missing ${stagedTagName} marker.\n`,
           );
           ensureGitTag(stagedTagName, "HEAD", {
             allowMove: true,

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -17,7 +17,9 @@ import {
 
 const packageUrl = new URL("../packages/effect-view-server/package.json", import.meta.url);
 const packageJson = JSON.parse(readFileSync(packageUrl, "utf8"));
-const version = packageJson.version;
+const finalizeVersion =
+  process.argv[2] === "--finalize-version" && process.argv[3] !== undefined ? process.argv[3] : undefined;
+const version = finalizeVersion ?? packageJson.version;
 const workspacePackages = [];
 const workspacePackageDirectories = ["apps", "examples", "packages", "tools"];
 
@@ -154,28 +156,6 @@ const isVersionAlreadyPublished = () => {
   return result.status === 0 && JSON.parse(result.stdout) === version;
 };
 
-const hasPendingStageForVersion = () => {
-  const result = commandResult("npm", ["stage", "list", `${publicPackageName}@${version}`, "--json"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  if (result.status !== 0) {
-    throw Object.assign(
-      new Error(`npm stage list ${publicPackageName}@${version} --json failed.\n${result.stderr}`),
-      {
-        exitCode: result.status ?? 1,
-      },
-    );
-  }
-
-  const stages = JSON.parse(result.stdout);
-
-  return Array.isArray(stages)
-    ? stages.length > 0
-    : stages !== null && typeof stages === "object" && Object.keys(stages).length > 0;
-};
-
 const runStagePublish = (stageDirectory) => {
   const result = commandResult("npm", stagePublishCommandArguments(stageDirectory), {
     encoding: "utf8",
@@ -215,14 +195,23 @@ const gitRefTarget = (ref) => {
   return target.status === 0 ? target.stdout.trim() : undefined;
 };
 
+const gitRefObject = (ref) => {
+  const target = commandResult("git", ["rev-parse", "--quiet", "--verify", ref], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+
+  return target.status === 0 ? target.stdout.trim() : undefined;
+};
+
 const gitTagExists = (tagName) => gitRefTarget(`refs/tags/${tagName}`) !== undefined;
 
-const pushGitTag = (tagName, moved) => {
+const pushGitTag = (tagName, expectedRemoteObject) => {
   run(
     "git",
-    moved
-      ? ["push", `--force-with-lease=refs/tags/${tagName}`, "origin", `refs/tags/${tagName}`]
-      : ["push", "origin", `refs/tags/${tagName}`],
+    expectedRemoteObject === undefined
+      ? ["push", "origin", `refs/tags/${tagName}`]
+      : ["push", `--force-with-lease=refs/tags/${tagName}:${expectedRemoteObject}`, "origin", `refs/tags/${tagName}`],
   );
 };
 
@@ -234,6 +223,7 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
   }
 
   const existingTarget = gitRefTarget(`refs/tags/${tagName}`);
+  const existingObject = gitRefObject(`refs/tags/${tagName}`);
 
   if (existingTarget !== undefined) {
     if (existingTarget !== expectedTarget) {
@@ -242,7 +232,7 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
       }
 
       run("git", ["tag", "-f", "-a", tagName, targetRef, "-m", tagName]);
-      pushGitTag(tagName, true);
+      pushGitTag(tagName, existingObject);
       return;
     }
 
@@ -250,7 +240,7 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
   }
 
   run("git", ["tag", "-a", tagName, targetRef, "-m", tagName]);
-  pushGitTag(tagName, false);
+  pushGitTag(tagName, undefined);
 };
 
 const ensurePublishedVersionTag = () => {
@@ -266,50 +256,44 @@ const ensurePublishedVersionTag = () => {
 };
 
 let exitCode = 0;
-const stageDirectory = mkdtempSync(join(tmpdir(), "effect-view-server-publish-"));
+const stageDirectory =
+  finalizeVersion === undefined ? mkdtempSync(join(tmpdir(), "effect-view-server-publish-")) : undefined;
 
 try {
-  const distUrl = new URL("../packages/effect-view-server/dist/", import.meta.url);
-  const distDirectory = join(stageDirectory, "dist");
-
-  cpSync(distUrl, distDirectory, {
-    recursive: true,
-    filter: (source) => !source.endsWith(".map"),
-  });
-  stripPublishedSourceMapReferences(distDirectory);
-  cpSync(new URL("../README.md", import.meta.url), join(stageDirectory, "README.md"));
-  writeFileSync(
-    join(stageDirectory, "package.json"),
-    `${JSON.stringify(sanitizePublicPackageJson(packageJson), null, 2)}\n`,
-  );
-
-  assertCleanPublishedFiles(stageDirectory);
-
-  if (isVersionAlreadyPublished()) {
-    process.stdout.write(`${publicPackageName}@${version} is already published; ensuring git tag.\n`);
-    ensurePublishedVersionTag();
-  } else {
-    if (!isPackageAlreadyCreated()) {
-      throw new Error(
-        `${publicPackageName} must exist on npm before staged publishing can be used. Publish the first version manually, then rerun this workflow.`,
-      );
+  if (finalizeVersion !== undefined) {
+    if (!isVersionAlreadyPublished()) {
+      throw new Error(`${publicPackageName}@${version} is not published yet; approve the npm stage first.`);
     }
 
-    const stagedTagName = stagedPackageTagName(version);
+    process.stdout.write(`${publicPackageName}@${version} is published; ensuring git tag.\n`);
+    ensurePublishedVersionTag();
+  } else {
+    const distUrl = new URL("../packages/effect-view-server/dist/", import.meta.url);
+    const distDirectory = join(stageDirectory, "dist");
 
-    const pendingStageExists = hasPendingStageForVersion();
+    cpSync(distUrl, distDirectory, {
+      recursive: true,
+      filter: (source) => !source.endsWith(".map"),
+    });
+    stripPublishedSourceMapReferences(distDirectory);
+    cpSync(new URL("../README.md", import.meta.url), join(stageDirectory, "README.md"));
+    writeFileSync(
+      join(stageDirectory, "package.json"),
+      `${JSON.stringify(sanitizePublicPackageJson(packageJson), null, 2)}\n`,
+    );
 
-    if (pendingStageExists) {
-      if (!gitTagExists(stagedTagName)) {
+    assertCleanPublishedFiles(stageDirectory);
+
+    if (isVersionAlreadyPublished()) {
+      process.stdout.write(`${publicPackageName}@${version} is already published; ensuring git tag.\n`);
+      ensurePublishedVersionTag();
+    } else {
+      if (!isPackageAlreadyCreated()) {
         throw new Error(
-          `${publicPackageName}@${version} is pending npm approval, but ${stagedTagName} is missing. Refusing to create an untraceable staged marker.`,
+          `${publicPackageName} must exist on npm before staged publishing can be used. Publish the first version manually, then rerun this workflow.`,
         );
       }
 
-      process.stdout.write(
-        `${publicPackageName}@${version} is already pending npm approval; keeping ${stagedTagName}.\n`,
-      );
-    } else {
       const oidcViolations = oidcPublishEnvironmentViolations(process.env);
       if (oidcViolations.length > 0) {
         throw new Error(
@@ -320,12 +304,8 @@ try {
         );
       }
 
-      ensureGitTag(stagedTagName, "HEAD", {
-        allowMove: true,
-      });
-
+      const stagedTagName = stagedPackageTagName(version);
       const stageResult = runStagePublish(stageDirectory);
-
       const duplicateVersionIsPublished =
         (stageResult._tag === "AlreadyPublished" || stageResult._tag === "DuplicateVersion") &&
         isVersionAlreadyPublished();
@@ -335,32 +315,22 @@ try {
           `${publicPackageName}@${version} is already published; ensuring public git tag.\n`,
         );
         ensurePublishedVersionTag();
-      } else {
-        if (stageResult._tag === "DuplicateVersion") {
-          if (!hasPendingStageForVersion()) {
-            throw new Error(
-              `npm reported a duplicate ${publicPackageName}@${version}, but npm stage list does not show a pending stage and npm view does not report it as published.`,
-            );
-          }
-
-          process.stdout.write(
-            `${publicPackageName}@${version} has a pending npm stage after a duplicate response; keeping staged marker tag.\n`,
+      } else if (stageResult._tag === "Staged") {
+        ensureGitTag(stagedTagName, "HEAD", {
+          allowMove: true,
+        });
+      } else if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
+        if (!gitTagExists(stagedTagName)) {
+          throw new Error(
+            `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to create an untraceable staged marker.`,
           );
         }
 
-        if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
-          if (!hasPendingStageForVersion()) {
-            throw new Error(
-              `npm reported ${publicPackageName}@${version} as staged, but npm stage list does not show a pending stage.`,
-            );
-          }
-
-          process.stdout.write(
-            `${publicPackageName}@${version} is already staged in npm; ensuring staged marker tag.\n`,
-          );
-        }
-
-        ensureGitTag(stagedTagName);
+        process.stdout.write(`${publicPackageName}@${version} is already staged; keeping ${stagedTagName}.\n`);
+      } else if (stageResult._tag === "DuplicateVersion") {
+        throw new Error(
+          `npm reported a duplicate ${publicPackageName}@${version}, but npm view does not report it as published. Refusing to guess whether a stage exists.`,
+        );
       }
     }
   }
@@ -374,10 +344,12 @@ try {
       ? error.exitCode
       : 1;
 } finally {
-  rmSync(stageDirectory, {
-    force: true,
-    recursive: true,
-  });
+  if (stageDirectory !== undefined) {
+    rmSync(stageDirectory, {
+      force: true,
+      recursive: true,
+    });
+  }
 }
 
 process.exit(exitCode);

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -3,7 +3,6 @@ import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, wri
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import {
-  canRecoverMissingStagedMarker,
   classifyStagePublishDuplicateOutput,
   packageTagName,
   oidcPublishEnvironmentViolations,
@@ -346,18 +345,9 @@ try {
         });
       } else if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
         if (!gitTagExists(stagedTagName)) {
-          if (!canRecoverMissingStagedMarker(process.env)) {
-            throw new Error(
-              `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to recreate it from an unrelated workflow HEAD; rerun the failed staging workflow attempt or reject the npm stage and restage.`,
-            );
-          }
-
-          process.stdout.write(
-            `npm reported ${publicPackageName}@${version} as already staged on a retried workflow; recreating missing ${stagedTagName} marker.\n`,
+          throw new Error(
+            `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to recreate it from an unverified workflow HEAD; rerun the original failed staging workflow attempt or reject the npm stage and restage.`,
           );
-          ensureGitTag(stagedTagName, "HEAD", {
-            allowMove: true,
-          });
         } else {
           process.stdout.write(`${publicPackageName}@${version} is already staged; keeping ${stagedTagName}.\n`);
         }

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -231,7 +231,7 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
         throw new Error(`${tagName} already points at ${existingTarget}, expected ${expectedTarget}.`);
       }
 
-      run("git", ["tag", "-f", "-a", tagName, targetRef, "-m", tagName]);
+      run("git", ["tag", "-f", "-a", tagName, expectedTarget, "-m", tagName]);
       pushGitTag(tagName, existingObject);
       return;
     }
@@ -239,7 +239,7 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
     return;
   }
 
-  run("git", ["tag", "-a", tagName, targetRef, "-m", tagName]);
+  run("git", ["tag", "-a", tagName, expectedTarget, "-m", tagName]);
   pushGitTag(tagName, undefined);
 };
 
@@ -321,12 +321,15 @@ try {
         });
       } else if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
         if (!gitTagExists(stagedTagName)) {
-          throw new Error(
-            `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to create an untraceable staged marker.`,
+          process.stdout.write(
+            `npm reported ${publicPackageName}@${version} as already staged; recreating missing ${stagedTagName} marker.\n`,
           );
+          ensureGitTag(stagedTagName, "HEAD", {
+            allowMove: true,
+          });
+        } else {
+          process.stdout.write(`${publicPackageName}@${version} is already staged; keeping ${stagedTagName}.\n`);
         }
-
-        process.stdout.write(`${publicPackageName}@${version} is already staged; keeping ${stagedTagName}.\n`);
       } else if (stageResult._tag === "DuplicateVersion") {
         throw new Error(
           `npm reported a duplicate ${publicPackageName}@${version}, but npm view does not report it as published. Refusing to guess whether a stage exists.`,

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -3,7 +3,7 @@ import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, wri
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import {
-  isDuplicateStagePublishOutput,
+  classifyStagePublishDuplicateOutput,
   packageTagName,
   oidcPublishEnvironmentViolations,
   publishedFileViolations,
@@ -169,16 +169,14 @@ const runStagePublish = (stageDirectory) => {
     };
   }
 
-  if (
-    isDuplicateStagePublishOutput({
-      stderr: result.stderr,
-      stdout: result.stdout,
-      version,
-    })
-  ) {
-    return {
-      _tag: "AlreadyStaged",
-    };
+  const duplicate = classifyStagePublishDuplicateOutput({
+    stderr: result.stderr,
+    stdout: result.stdout,
+    version,
+  });
+
+  if (duplicate._tag !== "Unknown") {
+    return duplicate;
   }
 
   throw Object.assign(new Error(`npm ${stagePublishCommandArguments(stageDirectory).join(" ")} failed.`), {
@@ -235,23 +233,35 @@ try {
     const stagedTagName = stagedPackageTagName(version);
 
     if (gitTagExists(stagedTagName)) {
-      process.stdout.write(`${publicPackageName}@${version} is already staged; skipping npm stage publish.\n`);
+      process.stdout.write(
+        `${stagedTagName} marker exists; verifying npm staging state before skipping.\n`,
+      );
+    }
+
+    const oidcViolations = oidcPublishEnvironmentViolations(process.env);
+    if (oidcViolations.length > 0) {
+      throw new Error(
+        [
+          "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
+          ...oidcViolations.map((violation) => `- ${violation}`),
+        ].join("\n"),
+      );
+    }
+
+    const stageResult = runStagePublish(stageDirectory);
+
+    if (
+      stageResult._tag === "AlreadyPublished" ||
+      (stageResult._tag === "DuplicateVersion" && isVersionAlreadyPublished())
+    ) {
+      process.stdout.write(
+        `${publicPackageName}@${version} is already published; ensuring public git tag.\n`,
+      );
+      ensureGitTag(packageTagName(version));
     } else {
-      const oidcViolations = oidcPublishEnvironmentViolations(process.env);
-      if (oidcViolations.length > 0) {
-        throw new Error(
-          [
-            "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
-            ...oidcViolations.map((violation) => `- ${violation}`),
-          ].join("\n"),
-        );
-      }
-
-      const stageResult = runStagePublish(stageDirectory);
-
-      if (stageResult._tag === "AlreadyStaged") {
+      if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "DuplicateVersion") {
         process.stdout.write(
-          `${publicPackageName}@${version} is already staged in npm; repairing staged marker tag.\n`,
+          `${publicPackageName}@${version} is already staged in npm; ensuring staged marker tag.\n`,
         );
       }
 

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -154,6 +154,28 @@ const isVersionAlreadyPublished = () => {
   return result.status === 0 && JSON.parse(result.stdout) === version;
 };
 
+const hasPendingStageForVersion = () => {
+  const result = commandResult("npm", ["stage", "list", `${publicPackageName}@${version}`, "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    throw Object.assign(
+      new Error(`npm stage list ${publicPackageName}@${version} --json failed.\n${result.stderr}`),
+      {
+        exitCode: result.status ?? 1,
+      },
+    );
+  }
+
+  const stages = JSON.parse(result.stdout);
+
+  return Array.isArray(stages)
+    ? stages.length > 0
+    : stages !== null && typeof stages === "object" && Object.keys(stages).length > 0;
+};
+
 const runStagePublish = (stageDirectory) => {
   const result = commandResult("npm", stagePublishCommandArguments(stageDirectory), {
     encoding: "utf8",
@@ -184,20 +206,63 @@ const runStagePublish = (stageDirectory) => {
   });
 };
 
-const gitTagExists = (tagName) => {
-  const existingTag = commandResult("git", ["rev-parse", "--quiet", "--verify", `refs/tags/${tagName}`], {
-    stdio: "ignore",
+const gitRefTarget = (ref) => {
+  const target = commandResult("git", ["rev-parse", "--quiet", "--verify", `${ref}^{}`], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
   });
 
-  return existingTag.status === 0;
+  return target.status === 0 ? target.stdout.trim() : undefined;
 };
 
-const ensureGitTag = (tagName) => {
-  if (gitTagExists(tagName)) {
+const gitTagExists = (tagName) => gitRefTarget(`refs/tags/${tagName}`) !== undefined;
+
+const pushGitTag = (tagName, moved) => {
+  run(
+    "git",
+    moved
+      ? ["push", `--force-with-lease=refs/tags/${tagName}`, "origin", `refs/tags/${tagName}`]
+      : ["push", "origin", `refs/tags/${tagName}`],
+  );
+};
+
+const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
+  const expectedTarget = gitRefTarget(targetRef);
+
+  if (expectedTarget === undefined) {
+    throw new Error(`Cannot create ${tagName} because ${targetRef} does not resolve to a git object.`);
+  }
+
+  const existingTarget = gitRefTarget(`refs/tags/${tagName}`);
+
+  if (existingTarget !== undefined) {
+    if (existingTarget !== expectedTarget) {
+      if (options.allowMove !== true) {
+        throw new Error(`${tagName} already points at ${existingTarget}, expected ${expectedTarget}.`);
+      }
+
+      run("git", ["tag", "-f", "-a", tagName, targetRef, "-m", tagName]);
+      pushGitTag(tagName, true);
+      return;
+    }
+
     return;
   }
 
-  run("git", ["tag", "-a", tagName, "-m", tagName]);
+  run("git", ["tag", "-a", tagName, targetRef, "-m", tagName]);
+  pushGitTag(tagName, false);
+};
+
+const ensurePublishedVersionTag = () => {
+  const stagedTagName = stagedPackageTagName(version);
+
+  if (!gitTagExists(stagedTagName)) {
+    throw new Error(
+      `Cannot create ${packageTagName(version)} because ${stagedTagName} does not exist. Stage the package before approving it.`,
+    );
+  }
+
+  ensureGitTag(packageTagName(version), `refs/tags/${stagedTagName}`);
 };
 
 let exitCode = 0;
@@ -222,7 +287,7 @@ try {
 
   if (isVersionAlreadyPublished()) {
     process.stdout.write(`${publicPackageName}@${version} is already published; ensuring git tag.\n`);
-    ensureGitTag(packageTagName(version));
+    ensurePublishedVersionTag();
   } else {
     if (!isPackageAlreadyCreated()) {
       throw new Error(
@@ -232,40 +297,71 @@ try {
 
     const stagedTagName = stagedPackageTagName(version);
 
-    if (gitTagExists(stagedTagName)) {
-      process.stdout.write(
-        `${stagedTagName} marker exists; verifying npm staging state before skipping.\n`,
-      );
-    }
+    const pendingStageExists = hasPendingStageForVersion();
 
-    const oidcViolations = oidcPublishEnvironmentViolations(process.env);
-    if (oidcViolations.length > 0) {
-      throw new Error(
-        [
-          "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
-          ...oidcViolations.map((violation) => `- ${violation}`),
-        ].join("\n"),
-      );
-    }
-
-    const stageResult = runStagePublish(stageDirectory);
-
-    if (
-      stageResult._tag === "AlreadyPublished" ||
-      (stageResult._tag === "DuplicateVersion" && isVersionAlreadyPublished())
-    ) {
-      process.stdout.write(
-        `${publicPackageName}@${version} is already published; ensuring public git tag.\n`,
-      );
-      ensureGitTag(packageTagName(version));
-    } else {
-      if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "DuplicateVersion") {
-        process.stdout.write(
-          `${publicPackageName}@${version} is already staged in npm; ensuring staged marker tag.\n`,
+    if (pendingStageExists) {
+      if (!gitTagExists(stagedTagName)) {
+        throw new Error(
+          `${publicPackageName}@${version} is pending npm approval, but ${stagedTagName} is missing. Refusing to create an untraceable staged marker.`,
         );
       }
 
-      ensureGitTag(stagedTagName);
+      process.stdout.write(
+        `${publicPackageName}@${version} is already pending npm approval; keeping ${stagedTagName}.\n`,
+      );
+    } else {
+      const oidcViolations = oidcPublishEnvironmentViolations(process.env);
+      if (oidcViolations.length > 0) {
+        throw new Error(
+          [
+            "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
+            ...oidcViolations.map((violation) => `- ${violation}`),
+          ].join("\n"),
+        );
+      }
+
+      ensureGitTag(stagedTagName, "HEAD", {
+        allowMove: true,
+      });
+
+      const stageResult = runStagePublish(stageDirectory);
+
+      const duplicateVersionIsPublished =
+        (stageResult._tag === "AlreadyPublished" || stageResult._tag === "DuplicateVersion") &&
+        isVersionAlreadyPublished();
+
+      if (duplicateVersionIsPublished) {
+        process.stdout.write(
+          `${publicPackageName}@${version} is already published; ensuring public git tag.\n`,
+        );
+        ensurePublishedVersionTag();
+      } else {
+        if (stageResult._tag === "DuplicateVersion") {
+          if (!hasPendingStageForVersion()) {
+            throw new Error(
+              `npm reported a duplicate ${publicPackageName}@${version}, but npm stage list does not show a pending stage and npm view does not report it as published.`,
+            );
+          }
+
+          process.stdout.write(
+            `${publicPackageName}@${version} has a pending npm stage after a duplicate response; keeping staged marker tag.\n`,
+          );
+        }
+
+        if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
+          if (!hasPendingStageForVersion()) {
+            throw new Error(
+              `npm reported ${publicPackageName}@${version} as staged, but npm stage list does not show a pending stage.`,
+            );
+          }
+
+          process.stdout.write(
+            `${publicPackageName}@${version} is already staged in npm; ensuring staged marker tag.\n`,
+          );
+        }
+
+        ensureGitTag(stagedTagName);
+      }
     }
   }
 } catch (error) {


### PR DESCRIPTION
## Summary
- switch the release script from direct `npm publish` to `npm stage publish`
- pin the release workflow to `npm@11.18.0`, which includes staged publishing
- document that the npm Trusted Publisher should allow only `npm stage publish`
- add policy coverage for the exact staged publish command arguments

## Validation
- `vp check --fix`
- `vp run -w test:repository-scripts`
- `vp run effect-view-server#build`

## Release behavior
This PR intentionally has no changeset. After merge, the release workflow should retry the already-versioned `effect-view-server@0.0.2` package and create a staged npm publish for manual approval, instead of attempting direct publication.
