### PR TITLE
Move scheduler to optional peer dependency

### DIFF
--- a/.changeset/mean-crabs-wink.md
+++ b/.changeset/mean-crabs-wink.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Move React-only packages out of hard npm dependencies. The React subpath now declares @effect/atom-react and scheduler as optional peers, keeping non-React installs smaller while preserving an explicit React peer contract.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@
 - [Operations](./docs/operations.md)
 - [Examples](./examples/README.md)
 
+## Install
+
+Core/server-only consumers need only the main package:
+
+```sh
+npm install effect-view-server
+```
+
+React consumers should also install the React subpath peers:
+
+```sh
+npm install effect-view-server react react-dom @effect/atom-react scheduler
+```
+
 ## Remote React provider
 
 Server code starts a runtime through Effect RPC WebSocket plus same-server

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -108,12 +108,10 @@
     "@bufbuild/protobuf": "2.12.0",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2",
-    "@effect/atom-react": "4.0.0-beta.91",
     "@effect/platform-browser": "4.0.0-beta.91",
     "@effect/platform-node": "4.0.0-beta.91",
     "@platformatic/kafka": "2.2.3",
-    "effect": "4.0.0-beta.91",
-    "scheduler": "0.27.0"
+    "effect": "4.0.0-beta.91"
   },
   "devDependencies": {
     "@effect-view-server/client": "workspace:*",
@@ -123,6 +121,7 @@
     "@effect-view-server/react": "workspace:*",
     "@effect-view-server/runtime": "workspace:*",
     "@effect-view-server/server": "workspace:*",
+    "@effect/atom-react": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
@@ -132,14 +131,22 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@effect/atom-react": "4.0.0-beta.91",
     "react": "19.2.6",
-    "react-dom": "19.2.6"
+    "react-dom": "19.2.6",
+    "scheduler": "0.27.0"
   },
   "peerDependenciesMeta": {
+    "@effect/atom-react": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },
     "react-dom": {
+      "optional": true
+    },
+    "scheduler": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,9 +880,6 @@ importers:
       '@connectrpc/connect-node':
         specifier: 2.1.2
         version: 2.1.2(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0))
-      '@effect/atom-react':
-        specifier: 4.0.0-beta.91
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(react@19.2.6)(scheduler@0.27.0)
       '@effect/platform-browser':
         specifier: 4.0.0-beta.91
         version: 4.0.0-beta.91(effect@4.0.0-beta.91)
@@ -926,6 +923,9 @@ importers:
       '@effect-view-server/server':
         specifier: workspace:*
         version: link:../server
+      '@effect/atom-react':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(react@19.2.6)(scheduler@0.27.0)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -293,6 +293,28 @@ describe("release publish policy", () => {
     });
   });
 
+  it("keeps React-only packages out of the public package hard dependencies", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../packages/effect-view-server/package.json", import.meta.url), "utf8"),
+    );
+
+    expect({
+      atomReactDependency: packageJson.dependencies["@effect/atom-react"],
+      atomReactPeerDependency: packageJson.peerDependencies["@effect/atom-react"],
+      atomReactPeerOptional: packageJson.peerDependenciesMeta["@effect/atom-react"].optional,
+      dependency: packageJson.dependencies.scheduler,
+      peerDependency: packageJson.peerDependencies.scheduler,
+      peerOptional: packageJson.peerDependenciesMeta.scheduler.optional,
+    }).toStrictEqual({
+      atomReactDependency: undefined,
+      atomReactPeerDependency: "4.0.0-beta.91",
+      atomReactPeerOptional: true,
+      dependency: undefined,
+      peerDependency: "0.27.0",
+      peerOptional: true,
+    });
+  });
+
   it("omits undefined optional manifest fields from the staged npm artifact", () => {
     expect(
       sanitizePublicPackageJson({


### PR DESCRIPTION
## Summary
- remove scheduler from the public package hard dependencies
- keep scheduler as an optional peer for the React subpath / @effect/atom-react peer contract
- add a release policy regression test and patch changeset

## Validation
- git diff --check
- vp run -w test:repository-scripts

Note: @effect/atom-react remains a hard dependency so the single-package React subpath keeps working without forcing users to install it separately. This PR only removes scheduler from the direct npm Dependencies list.