### PR TITLE
Version packages

### DIFF
--- a/.changeset/mean-crabs-wink.md
+++ b/.changeset/mean-crabs-wink.md
@@ -1,5 +1,0 @@
----
-"effect-view-server": patch
----
-
-Move React-only packages out of hard npm dependencies. The React subpath now declares @effect/atom-react and scheduler as optional peers, keeping non-React installs smaller while preserving an explicit React peer contract.

--- a/packages/effect-view-server/CHANGELOG.md
+++ b/packages/effect-view-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # effect-view-server
 
+## 0.0.4
+
+### Patch Changes
+
+- 5ef7d69: Move React-only packages out of hard npm dependencies. The React subpath now declares @effect/atom-react and scheduler as optional peers, keeping non-React installs smaller while preserving an explicit React peer contract.
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-view-server",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Typed Effect View Server for live query snapshots, deltas, React bindings, and runtime ingress adapters.",
   "keywords": [
     "effect",


### PR DESCRIPTION
## Summary
- version effect-view-server after moving React-only packages out of hard dependencies
- removes the consumed changeset

## Notes
Created manually because GitHub Actions pushed changeset-release/main but is not permitted to create pull requests.