### PR TITLE
Stop release workflow from creating version PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,17 @@ on:
       - main
   workflow_dispatch:
     inputs:
+      action:
+        description: "Release action to run"
+        required: true
+        default: "stage"
+        type: choice
+        options:
+          - stage
+          - finalize
       version:
         description: "Published effect-view-server version to tag after npm stage approve"
-        required: true
+        required: false
         type: string
 
 permissions:
@@ -19,16 +27,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  version:
-    name: Ready and version PR
+  ready:
+    name: Ready
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
 
     steps:
       - name: Checkout
@@ -55,22 +58,11 @@ jobs:
       - name: Ready gate
         run: vp run -w ready
 
-      - name: Create version PR
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          title: "Version packages"
-          commit: "Version packages"
-          version: vp run -w release:version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    name: Publish
+  stage:
+    name: Stage npm package
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: version
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.version.outputs.hasChangesets == 'false'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.action == 'stage'
     permissions:
       contents: write
       id-token: write
@@ -92,6 +84,13 @@ jobs:
 
       - name: Install dependencies
         run: vp install --frozen-lockfile
+
+      - name: Install browser test dependencies
+        working-directory: packages/react
+        run: vp exec playwright install --with-deps chromium firefox webkit
+
+      - name: Ready gate
+        run: vp run -w ready
 
       - name: Install npm for trusted publishing
         run: npm install --global npm@11.17.0
@@ -115,7 +114,7 @@ jobs:
     name: Finalize approved npm stage
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.action == 'finalize'
     permissions:
       contents: write
 
@@ -138,6 +137,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate version input
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node -e "if (!process.env.RELEASE_VERSION) throw new Error('version input is required when action=finalize')"
 
       - name: Tag approved npm version
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,13 +147,14 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - Publish only the `effect-view-server` package. Internal `@effect-view-server/*` workspace packages stay private and must not be published separately.
 - The npm publish artifact must be staged and sanitized before publishing. Do not publish the workspace package directory directly. The staged artifact must exclude source maps, source-map references, scripts, dev dependencies, internal `@effect-view-server/*` package metadata, and internal workspace import specifiers.
 - Use Changesets for release intent. If a PR should publish a new npm version, add a changeset with `vp run -w changeset`. Do not add a changeset for private-only CI, docs, examples, benchmark, or internal-only changes that should not publish.
-- Merging an ordinary PR to `main` must not publish npm. The release workflow only publishes after a changeset has produced a version bump and the generated version PR is merged to `main`.
+- Merging an ordinary PR to `main` must not publish npm and must not make GitHub Actions create a PR. Version PRs are explicit human/agent branches: run `vp run -w release:version` on a branch, open the `Version packages` PR yourself, and merge it after review.
+- After a version PR is merged, manually run the `Release` workflow on `main` with `action=stage` to stage the npm package. Ordinary `main` pushes run readiness only.
 - npm publishing uses GitHub Actions trusted publishing/OIDC from `.github/workflows/release.yml`. Do not add `NPM_TOKEN`; keep `id-token: write` and `publishConfig.provenance: true`.
 - The npm trusted publisher must allow `npm stage publish` only. Do not enable direct `npm publish` unless explicitly changing the release process.
 - The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final stage publish so GitHub's OIDC environment reaches `npm stage publish`.
 - CI stages npm releases with `npm stage publish`; a maintainer approves the staged package later with `npm stage approve <stage-id>` or rejects it with `npm stage reject <stage-id>`.
 - The stage job may push an `effect-view-server@<version>-staged` marker tag as a best-effort pending-approval signal, but the release script must still ask npm on reruns so rejected stages can be restaged and approved stages can become public release tags.
-- After approving a staged package, manually run the `Release` workflow on `main` with the approved version input so CI observes the exact public npm version and creates the public `effect-view-server@<version>` git tag. Do not create the public tag before npm reports the version as published.
+- After approving a staged package, manually run the `Release` workflow on `main` with `action=finalize` and the approved version input so CI observes the exact public npm version and creates the public `effect-view-server@<version>` git tag. Do not create the public tag before npm reports the version as published.
 
 ## Common Blockers
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -53,32 +53,46 @@ when a validation step asks for explicit no-release intent.
 
 ## Main branch flow
 
-On every push to `main`, `.github/workflows/release.yml` runs:
+On every push to `main`, `.github/workflows/release.yml` runs readiness only:
 
 1. `vp install --frozen-lockfile`
 2. browser dependency installation
 3. `vp run -w ready`
-4. Changesets action
 
-If unreleased changesets exist, the action opens or updates a `Version packages`
-PR. When that PR is merged, the same workflow builds `effect-view-server` and
-stages a sanitized npm artifact through trusted publishing. A maintainer must
-then approve the staged package with `npm stage approve <stage-id>` to publish
-it publicly, or reject it with `npm stage reject <stage-id>`. After approval,
-manually run the `Release` workflow on `main` with the approved version as the
-workflow input; the release script observes that the exact version is now public
-and creates the public
-`effect-view-server@<version>` git tag. The staged artifact intentionally
-excludes source maps, source-map references, scripts, dev dependencies, internal
-`@effect-view-server/*` workspace metadata, and internal workspace import
-specifiers. The publish script skips `effect-view-server@0.0.0`, so enabling
-this workflow cannot accidentally publish the placeholder development version.
-The staging job may push an `effect-view-server@<version>-staged` marker tag as
-a best-effort signal that approval is pending. It is not authoritative: reruns
-still ask npm so rejected stages can be restaged and approved stages can be
-converted into public release tags. The public
-`effect-view-server@<version>` release tag is only created after npm reports
-that the version is actually published.
+The workflow must not create pull requests from `main`. When unreleased
+changesets are ready to publish, create the version PR explicitly from a normal
+branch:
+
+```sh
+git switch -c release/version-packages
+vp run -w release:version
+git add .
+git commit -m "Version packages"
+git push --set-upstream origin release/version-packages
+gh pr create --title "Version packages" --body "Version packages"
+```
+
+After the version PR is reviewed and merged, manually run the `Release` workflow
+on `main` with `action=stage`. The workflow rebuilds, reruns `vp run -w ready`,
+and stages a sanitized npm artifact through trusted publishing. A maintainer
+must then approve the staged package with `npm stage approve <stage-id>` to
+publish it publicly, or reject it with `npm stage reject <stage-id>`.
+
+After approval, manually run the `Release` workflow on `main` with
+`action=finalize` and the approved version as the `version` input. The release
+script observes that the exact version is now public and creates the public
+`effect-view-server@<version>` git tag.
+
+The staged artifact intentionally excludes source maps, source-map references,
+scripts, dev dependencies, internal `@effect-view-server/*` workspace metadata,
+and internal workspace import specifiers. The publish script skips
+`effect-view-server@0.0.0`, so enabling this workflow cannot accidentally
+publish the placeholder development version. The staging job may push an
+`effect-view-server@<version>-staged` marker tag as a best-effort signal that
+approval is pending. It is not authoritative: reruns still ask npm so rejected
+stages can be restaged and approved stages can be converted into public release
+tags. The public `effect-view-server@<version>` release tag is only created
+after npm reports that the version is actually published.
 
 ## Manual checks
 

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -243,6 +243,15 @@ describe("release publish policy", () => {
     expect(releaseWorkflow).not.toContain('node scripts/release-publish.mjs --finalize-version "${{ inputs.version }}"');
   });
 
+  it("does not create version pull requests from the main-branch release workflow", () => {
+    const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+
+    expect(releaseWorkflow).not.toContain("changesets/action");
+    expect(releaseWorkflow).not.toContain("pull-requests: write");
+    expect(releaseWorkflow).not.toContain("hasChangesets");
+    expect(releaseWorkflow).not.toContain("Create version PR");
+  });
+
   it("sanitizes the public package manifest before staging the npm artifact", () => {
     expect(sanitizePublicPackageJson(publicPackageJson)).toStrictEqual({
       name: "effect-view-server",


### PR DESCRIPTION
## Summary

- remove the Changesets action from the main-branch release workflow
- make ordinary main pushes run readiness only
- make npm stage/finalize explicit manual Release workflow actions
- document the explicit version-PR and stage/finalize flow
- add a regression test preventing auto-created version PRs from returning

## Validation

- vp install --frozen-lockfile
- vp run -r build
- vp check --fix
- vp run -w test:repository-scripts
