### PR TITLE
Version effect-view-server 0.0.5

### DIFF
--- a/.changeset/topic-owned-sources.md
+++ b/.changeset/topic-owned-sources.md
@@ -1,5 +1,0 @@
----
-"effect-view-server": patch
----
-
-Add topic-owned Kafka and gRPC source declarations with derived Kafka runtime topics.

--- a/packages/effect-view-server/CHANGELOG.md
+++ b/packages/effect-view-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # effect-view-server
 
+## 0.0.5
+
+### Patch Changes
+
+- c915f73: Add topic-owned Kafka and gRPC source declarations with derived Kafka runtime topics.
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-view-server",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Typed Effect View Server for live query snapshots, deltas, React bindings, and runtime ingress adapters.",
   "keywords": [
     "effect",


### PR DESCRIPTION
## Summary
- version effect-view-server from 0.0.4 to 0.0.5
- consume the topic-owned source declarations changeset
- add the 0.0.5 changelog entry

## Validation
- vp run ready
- commit hook ran vp check --fix