### PR TITLE
Remove npm release finalize workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,6 @@ on:
         type: choice
         options:
           - stage
-          - finalize
-      version:
-        description: "Published effect-view-server version to tag after npm stage approve"
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -109,41 +104,3 @@ jobs:
         run: |
           vp run effect-view-server#build
           node scripts/release-publish.mjs
-
-  finalize:
-    name: Finalize approved npm stage
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.action == 'finalize'
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version: "26"
-          version: "0.2.1"
-          cache: false
-          run-install: false
-
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Validate version input
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: node -e "if (!process.env.RELEASE_VERSION) throw new Error('version input is required when action=finalize')"
-
-      - name: Tag approved npm version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: node scripts/release-publish.mjs --finalize-version "$RELEASE_VERSION"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,9 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - npm publishing uses GitHub Actions trusted publishing/OIDC from `.github/workflows/release.yml`. Do not add `NPM_TOKEN`; keep `id-token: write` and `publishConfig.provenance: true`.
 - The npm trusted publisher must allow `npm stage publish` only. Do not enable direct `npm publish` unless explicitly changing the release process.
 - The release workflow may build with `vp`, but must invoke `node scripts/release-publish.mjs` directly for the final stage publish so GitHub's OIDC environment reaches `npm stage publish`.
-- CI stages npm releases with `npm stage publish`; a maintainer approves the staged package later with `npm stage approve <stage-id>` or rejects it with `npm stage reject <stage-id>`.
-- The stage job may push an `effect-view-server@<version>-staged` marker tag as a best-effort pending-approval signal, but the release script must still ask npm on reruns so rejected stages can be restaged and approved stages can become public release tags.
-- After approving a staged package, manually run the `Release` workflow on `main` with `action=finalize` and the approved version input so CI observes the exact public npm version and creates the public `effect-view-server@<version>` git tag. Do not create the public tag before npm reports the version as published.
+- CI stages npm releases with `npm stage publish`; a maintainer approves the staged package later with `npm stage approve <stage-id>` to publish it publicly, or rejects it with `npm stage reject <stage-id>`.
+- The stage job may push an `effect-view-server@<version>-staged` marker tag as a best-effort pending-approval signal, but the release script must still ask npm on reruns so rejected stages can be restaged safely.
+- Do not add a second GitHub "finalize" release action. `npm stage approve <stage-id>` is the publication step; GitHub should not require a follow-up workflow to make the npm version public.
 
 ## Common Blockers
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -78,11 +78,6 @@ and stages a sanitized npm artifact through trusted publishing. A maintainer
 must then approve the staged package with `npm stage approve <stage-id>` to
 publish it publicly, or reject it with `npm stage reject <stage-id>`.
 
-After approval, manually run the `Release` workflow on `main` with
-`action=finalize` and the approved version as the `version` input. The release
-script observes that the exact version is now public and creates the public
-`effect-view-server@<version>` git tag.
-
 The staged artifact intentionally excludes source maps, source-map references,
 scripts, dev dependencies, internal `@effect-view-server/*` workspace metadata,
 and internal workspace import specifiers. The publish script skips
@@ -90,9 +85,8 @@ and internal workspace import specifiers. The publish script skips
 publish the placeholder development version. The staging job may push an
 `effect-view-server@<version>-staged` marker tag as a best-effort signal that
 approval is pending. It is not authoritative: reruns still ask npm so rejected
-stages can be restaged and approved stages can be converted into public release
-tags. The public `effect-view-server@<version>` release tag is only created
-after npm reports that the version is actually published.
+stages can be restaged. No follow-up GitHub workflow is required after approval:
+`npm stage approve <stage-id>` is the step that makes the package public.
 
 ## Manual checks
 

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
   classifyStagePublishDuplicateOutput,
@@ -235,12 +236,23 @@ describe("release publish policy", () => {
     expect(policySource).not.toContain("GITHUB_RUN_ATTEMPT");
   });
 
-  it("passes manual release workflow version input through an environment variable", () => {
+  it("exposes only the manual stage action in the release workflow", () => {
     const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
 
-    expect(releaseWorkflow).toContain("RELEASE_VERSION: ${{ inputs.version }}");
-    expect(releaseWorkflow).toContain('node scripts/release-publish.mjs --finalize-version "$RELEASE_VERSION"');
-    expect(releaseWorkflow).not.toContain('node scripts/release-publish.mjs --finalize-version "${{ inputs.version }}"');
+    expect(releaseWorkflow).toContain("- stage");
+    expect(releaseWorkflow).not.toContain("- finalize");
+    expect(releaseWorkflow).not.toContain("inputs.version");
+    expect(releaseWorkflow).not.toContain("--finalize-version");
+  });
+
+  it("rejects removed release publish script arguments before staging", () => {
+    const result = spawnSync("node", ["scripts/release-publish.mjs", "--finalize-version", "1.2.3"], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("release-publish.mjs does not accept arguments");
+    expect(result.stdout).toBe("");
   });
 
   it("does not create version pull requests from the main-branch release workflow", () => {

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import {
   classifyStagePublishDuplicateOutput,
-  packageTagName,
   oidcPublishEnvironmentViolations,
   publishedFileViolations,
   publicPackageName,
@@ -17,9 +16,13 @@ import {
 
 const packageUrl = new URL("../packages/effect-view-server/package.json", import.meta.url);
 const packageJson = JSON.parse(readFileSync(packageUrl, "utf8"));
-const finalizeVersion =
-  process.argv[2] === "--finalize-version" && process.argv[3] !== undefined ? process.argv[3] : undefined;
-const version = finalizeVersion ?? packageJson.version;
+const version = packageJson.version;
+
+if (process.argv.length > 2) {
+  process.stderr.write("release-publish.mjs does not accept arguments; approve staged versions with npm stage approve.\n");
+  process.exit(1);
+}
+
 const workspacePackages = [];
 const workspacePackageDirectories = ["apps", "examples", "packages", "tools"];
 
@@ -156,29 +159,6 @@ const isVersionAlreadyPublished = () => {
   return result.status === 0 && JSON.parse(result.stdout) === version;
 };
 
-const publishedVersionGitHead = () => {
-  const result = commandResult(
-    "npm",
-    ["view", `${publicPackageName}@${version}`, "gitHead", "--json"],
-    {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    },
-  );
-
-  if (result.status !== 0) {
-    return undefined;
-  }
-
-  if (result.stdout.trim() === "") {
-    return undefined;
-  }
-
-  const gitHead = JSON.parse(result.stdout);
-
-  return typeof gitHead === "string" && gitHead.length > 0 ? gitHead : undefined;
-};
-
 const runStagePublish = (stageDirectory) => {
   const result = commandResult("npm", stagePublishCommandArguments(stageDirectory), {
     encoding: "utf8",
@@ -266,96 +246,70 @@ const ensureGitTag = (tagName, targetRef = "HEAD", options = {}) => {
   pushGitTag(tagName, undefined);
 };
 
-const ensurePublishedVersionTag = () => {
-  const stagedTagName = stagedPackageTagName(version);
-  const targetRef = gitTagExists(stagedTagName) ? `refs/tags/${stagedTagName}` : publishedVersionGitHead();
-
-  if (targetRef === undefined) {
-    throw new Error(
-      `Cannot create ${packageTagName(version)} because ${stagedTagName} does not exist and npm did not report a gitHead for ${publicPackageName}@${version}.`,
-    );
-  }
-
-  ensureGitTag(packageTagName(version), targetRef);
-};
-
 let exitCode = 0;
-const stageDirectory =
-  finalizeVersion === undefined ? mkdtempSync(join(tmpdir(), "effect-view-server-publish-")) : undefined;
+const stageDirectory = mkdtempSync(join(tmpdir(), "effect-view-server-publish-"));
 
 try {
-  if (finalizeVersion !== undefined) {
-    if (!isVersionAlreadyPublished()) {
-      throw new Error(`${publicPackageName}@${version} is not published yet; approve the npm stage first.`);
+  const distUrl = new URL("../packages/effect-view-server/dist/", import.meta.url);
+  const distDirectory = join(stageDirectory, "dist");
+
+  cpSync(distUrl, distDirectory, {
+    recursive: true,
+    filter: (source) => !source.endsWith(".map"),
+  });
+  stripPublishedSourceMapReferences(distDirectory);
+  cpSync(new URL("../README.md", import.meta.url), join(stageDirectory, "README.md"));
+  writeFileSync(
+    join(stageDirectory, "package.json"),
+    `${JSON.stringify(sanitizePublicPackageJson(packageJson), null, 2)}\n`,
+  );
+
+  assertCleanPublishedFiles(stageDirectory);
+
+  if (isVersionAlreadyPublished()) {
+    process.stdout.write(`${publicPackageName}@${version} is already published.\n`);
+  } else {
+    if (!isPackageAlreadyCreated()) {
+      throw new Error(
+        `${publicPackageName} must exist on npm before staged publishing can be used. Publish the first version manually, then rerun this workflow.`,
+      );
     }
 
-    process.stdout.write(`${publicPackageName}@${version} is published; ensuring git tag.\n`);
-    ensurePublishedVersionTag();
-  } else {
-    const distUrl = new URL("../packages/effect-view-server/dist/", import.meta.url);
-    const distDirectory = join(stageDirectory, "dist");
+    const oidcViolations = oidcPublishEnvironmentViolations(process.env);
+    if (oidcViolations.length > 0) {
+      throw new Error(
+        [
+          "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
+          ...oidcViolations.map((violation) => `- ${violation}`),
+        ].join("\n"),
+      );
+    }
 
-    cpSync(distUrl, distDirectory, {
-      recursive: true,
-      filter: (source) => !source.endsWith(".map"),
-    });
-    stripPublishedSourceMapReferences(distDirectory);
-    cpSync(new URL("../README.md", import.meta.url), join(stageDirectory, "README.md"));
-    writeFileSync(
-      join(stageDirectory, "package.json"),
-      `${JSON.stringify(sanitizePublicPackageJson(packageJson), null, 2)}\n`,
-    );
+    const stagedTagName = stagedPackageTagName(version);
+    const stageResult = runStagePublish(stageDirectory);
 
-    assertCleanPublishedFiles(stageDirectory);
-
-    if (isVersionAlreadyPublished()) {
-      process.stdout.write(`${publicPackageName}@${version} is already published; ensuring git tag.\n`);
-      ensurePublishedVersionTag();
-    } else {
-      if (!isPackageAlreadyCreated()) {
+    if (stageResult._tag === "Staged") {
+      ensureGitTag(stagedTagName, "HEAD", {
+        allowMove: true,
+      });
+    } else if (stageResult._tag === "AlreadyPublished" && isVersionAlreadyPublished()) {
+      process.stdout.write(`${publicPackageName}@${version} is already published.\n`);
+    } else if (stageResult._tag === "AlreadyPublished") {
+      throw new Error(
+        `npm reported ${publicPackageName}@${version} as already published, but npm view does not confirm it. Refusing to treat the release as complete.`,
+      );
+    } else if (stageResult._tag === "AlreadyStaged") {
+      if (!gitTagExists(stagedTagName)) {
         throw new Error(
-          `${publicPackageName} must exist on npm before staged publishing can be used. Publish the first version manually, then rerun this workflow.`,
+          `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to recreate it from an unverified workflow HEAD; rerun the original failed staging workflow attempt or reject the npm stage and restage.`,
         );
+      } else {
+        process.stdout.write(`${publicPackageName}@${version} is already staged; keeping ${stagedTagName}.\n`);
       }
-
-      const oidcViolations = oidcPublishEnvironmentViolations(process.env);
-      if (oidcViolations.length > 0) {
-        throw new Error(
-          [
-            "Refusing npm stage publish because GitHub Actions OIDC is unavailable.",
-            ...oidcViolations.map((violation) => `- ${violation}`),
-          ].join("\n"),
-        );
-      }
-
-      const stagedTagName = stagedPackageTagName(version);
-      const stageResult = runStagePublish(stageDirectory);
-      const duplicateVersionIsPublished =
-        (stageResult._tag === "AlreadyPublished" || stageResult._tag === "DuplicateVersion") &&
-        isVersionAlreadyPublished();
-
-      if (duplicateVersionIsPublished) {
-        process.stdout.write(
-          `${publicPackageName}@${version} is already published; ensuring public git tag.\n`,
-        );
-        ensurePublishedVersionTag();
-      } else if (stageResult._tag === "Staged") {
-        ensureGitTag(stagedTagName, "HEAD", {
-          allowMove: true,
-        });
-      } else if (stageResult._tag === "AlreadyStaged" || stageResult._tag === "AlreadyPublished") {
-        if (!gitTagExists(stagedTagName)) {
-          throw new Error(
-            `npm reported ${publicPackageName}@${version} as already staged, but ${stagedTagName} is missing. Refusing to recreate it from an unverified workflow HEAD; rerun the original failed staging workflow attempt or reject the npm stage and restage.`,
-          );
-        } else {
-          process.stdout.write(`${publicPackageName}@${version} is already staged; keeping ${stagedTagName}.\n`);
-        }
-      } else if (stageResult._tag === "DuplicateVersion") {
-        throw new Error(
-          `npm reported a duplicate ${publicPackageName}@${version}, but npm view does not report it as published. Refusing to guess whether a stage exists.`,
-        );
-      }
+    } else if (stageResult._tag === "DuplicateVersion") {
+      throw new Error(
+        `npm reported a duplicate ${publicPackageName}@${version}, but npm view does not report it as published. Refusing to guess whether a stage exists.`,
+      );
     }
   }
 } catch (error) {
@@ -368,12 +322,10 @@ try {
       ? error.exitCode
       : 1;
 } finally {
-  if (stageDirectory !== undefined) {
-    rmSync(stageDirectory, {
-      force: true,
-      recursive: true,
-    });
-  }
+  rmSync(stageDirectory, {
+    force: true,
+    recursive: true,
+  });
 }
 
 process.exit(exitCode);


### PR DESCRIPTION
## Summary
- remove the manual Release workflow finalize action and version input
- make npm stage approval the documented final publication step
- remove finalize/tagging behavior from the release publish script
- add a regression test that rejects removed release script arguments

## Validation
- vp run -w test:repository-scripts
- vp check
- vp run -w ready