### PR TITLE
Deepen source ownership policy

### DIFF
--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -31,7 +31,10 @@ import { makeRuntimeCoreClient } from "./runtime-client";
 import type { ViewServerRuntimeCoreInternalClient } from "./runtime-client";
 import type { ViewServerRuntimeCoreInstance } from "./index";
 export { makeSourceOwnershipPolicy } from "./source-ownership-policy";
-export type { SourceOwnershipPolicy } from "./source-ownership-policy";
+export type {
+  SourceOwnershipAccessProfile,
+  SourceOwnershipPolicy,
+} from "./source-ownership-policy";
 
 export type { ViewServerRuntimeCoreInternalLiveClient } from "./live-client";
 export type { ViewServerRuntimeCoreInternalClient } from "./runtime-client";

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -33,7 +33,7 @@ import {
 } from "@effect-view-server/config";
 import { Cause, Clock, Effect, Exit, Queue, Scope, Semaphore, Stream } from "effect";
 import type { AtomRef } from "effect/unstable/reactivity";
-import { engineErrorToRuntimeError, leasedRuntimeAccessError } from "./runtime-error";
+import { engineErrorToRuntimeError } from "./runtime-error";
 import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
 
 const runtimeClosedError: ViewServerRuntimeError = {
@@ -190,24 +190,17 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError | ViewServerTransportError
       > {
-        return Effect.suspend(() => {
-          if (sourceOwnership.isGrpcLeasedTopic(topic)) {
-            return Effect.fail(leasedRuntimeAccessError(topic));
-          }
-          return subscribeInternal<Topic, Query>(topic, query);
-        });
+        return sourceOwnership
+          .requirePublicReadAllowed(topic, "runtimeCore")
+          .pipe(Effect.flatMap(() => subscribeInternal<Topic, Query>(topic, query)));
       }
       const subscribeRuntime: ViewServerRuntimeLiveClient<Topics>["subscribeRuntime"] = (
         topic,
         query,
-      ) => {
-        return Effect.suspend(() => {
-          if (sourceOwnership.isGrpcLeasedTopic(topic)) {
-            return Effect.fail(leasedRuntimeAccessError(topic));
-          }
-          return subscribeRuntimeInternal(topic, query);
-        });
-      };
+      ) =>
+        sourceOwnership
+          .requirePublicReadAllowed(topic, "runtimeCore")
+          .pipe(Effect.flatMap(() => subscribeRuntimeInternal(topic, query)));
       type ActiveHealthSubscription = {
         close: Effect.Effect<void>;
         claimClosed: () => boolean;

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -22,13 +22,7 @@ import {
   type RuntimeCoreHealthOverlay,
   type RuntimeCoreTransportHealth,
 } from "./health";
-import {
-  engineErrorToRuntimeError,
-  invalidRuntimeQueryError,
-  leasedRuntimeAccessError,
-  sourceOwnedRuntimeMutationError,
-  sourceOwnedRuntimeResetError,
-} from "./runtime-error";
+import { engineErrorToRuntimeError, invalidRuntimeQueryError } from "./runtime-error";
 import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
 
 export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> = {
@@ -190,37 +184,33 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
             engine.reset().pipe(Effect.tap(() => requestHealthRefresh())),
           ).pipe(Effect.mapError(engineErrorToRuntimeError)),
       };
-      const rejectSourceOwnedMutation = (
-        topic: string,
-      ): Effect.Effect<never, ViewServerRuntimeError> =>
-        Effect.fail(sourceOwnedRuntimeMutationError(topic));
       return {
         client: {
           publish: (topic, row) =>
-            sourceOwnership.isSourceOwnedTopic(topic)
-              ? rejectSourceOwnedMutation(topic)
-              : internalClient.publish(topic, row),
+            sourceOwnership
+              .requirePublicMutationAllowed(topic, "runtimeCore")
+              .pipe(Effect.flatMap(() => internalClient.publish(topic, row))),
           publishMany: (topic, rows) =>
-            sourceOwnership.isSourceOwnedTopic(topic)
-              ? rejectSourceOwnedMutation(topic)
-              : internalClient.publishMany(topic, rows),
+            sourceOwnership
+              .requirePublicMutationAllowed(topic, "runtimeCore")
+              .pipe(Effect.flatMap(() => internalClient.publishMany(topic, rows))),
           patch: (topic, key, patch) =>
-            sourceOwnership.isSourceOwnedTopic(topic)
-              ? rejectSourceOwnedMutation(topic)
-              : internalClient.patch(topic, key, patch),
+            sourceOwnership
+              .requirePublicMutationAllowed(topic, "runtimeCore")
+              .pipe(Effect.flatMap(() => internalClient.patch(topic, key, patch))),
           delete: (topic, key) =>
-            sourceOwnership.isSourceOwnedTopic(topic)
-              ? rejectSourceOwnedMutation(topic)
-              : internalClient.delete(topic, key),
+            sourceOwnership
+              .requirePublicMutationAllowed(topic, "runtimeCore")
+              .pipe(Effect.flatMap(() => internalClient.delete(topic, key))),
           snapshot: (topic, query) =>
-            sourceOwnership.isGrpcLeasedTopic(topic)
-              ? Effect.fail(leasedRuntimeAccessError(topic))
-              : internalClient.snapshot(topic, query),
+            sourceOwnership
+              .requirePublicReadAllowed(topic, "runtimeCore")
+              .pipe(Effect.flatMap(() => internalClient.snapshot(topic, query))),
           health: internalClient.health,
           reset: () =>
-            !sourceOwnership.hasSourceOwnedTopics
-              ? internalClient.reset()
-              : Effect.fail(sourceOwnedRuntimeResetError),
+            sourceOwnership
+              .requirePublicResetAllowed("runtimeCore")
+              .pipe(Effect.flatMap(() => internalClient.reset())),
         },
         internalClient,
         close: healthRefreshScheduler.close,

--- a/packages/runtime-core/src/runtime-error.ts
+++ b/packages/runtime-core/src/runtime-error.ts
@@ -66,6 +66,21 @@ export const leasedRuntimeAccessError = (topic: string): ViewServerRuntimeError 
     "Leased gRPC topics do not support direct runtime mutations, one-shot snapshots, or runtime-core subscriptions; use the runtime gRPC lease manager so it owns lease lifecycle.",
 });
 
+export const leasedManagedRuntimeAccessError = (topic: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  topic,
+  message:
+    "Leased gRPC topics do not support direct runtime mutations or one-shot snapshots; use a live subscription so the runtime can own lease lifecycle.",
+});
+
+export const leasedManagedRuntimeResetError: ViewServerRuntimeError = {
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  message:
+    "Leased gRPC topics do not support direct runtime reset; close the runtime or leased subscriptions so the lease manager owns cleanup.",
+};
+
 export const sourceOwnedRuntimeMutationError = (topic: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",
   code: "UnsupportedQuery",

--- a/packages/runtime-core/src/source-ownership-policy.test.ts
+++ b/packages/runtime-core/src/source-ownership-policy.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  defineViewServerConfig,
+  kafka,
+  type ViewServerRuntimeError,
+} from "@effect-view-server/config";
+import { grpcSourceMarkers } from "@effect-view-server/config/internal";
+import { Effect, Schema } from "effect";
+import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
+
+const Row = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+  region: Schema.String,
+  status: Schema.String,
+});
+
+const sourceOwnedMutationError = (topic: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  topic,
+  message:
+    "Source-owned topics do not support direct runtime mutations; publish through the configured Kafka/gRPC source or use an externally-published topic.",
+});
+
+const sourceOwnedResetError: ViewServerRuntimeError = {
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  message:
+    "Source-owned topics do not support direct runtime reset; close the runtime or reset source-free topics through their owner.",
+};
+
+const runtimeCoreLeasedAccessError = (topic: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  topic,
+  message:
+    "Leased gRPC topics do not support direct runtime mutations, one-shot snapshots, or runtime-core subscriptions; use the runtime gRPC lease manager so it owns lease lifecycle.",
+});
+
+const managedRuntimeLeasedAccessError = (topic: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  topic,
+  message:
+    "Leased gRPC topics do not support direct runtime mutations or one-shot snapshots; use a live subscription so the runtime can own lease lifecycle.",
+});
+
+const managedRuntimeLeasedResetError: ViewServerRuntimeError = {
+  _tag: "ViewServerRuntimeError",
+  code: "UnsupportedQuery",
+  message:
+    "Leased gRPC topics do not support direct runtime reset; close the runtime or leased subscriptions so the lease manager owns cleanup.",
+};
+
+const sourceFreeViewServer = defineViewServerConfig({
+  topics: {
+    externalOrders: {
+      schema: Row,
+      key: "id",
+    },
+  },
+});
+
+const sourceOwnedViewServer = defineViewServerConfig({
+  kafka: {
+    usa: "localhost:9092",
+  },
+  topics: {
+    externalOrders: {
+      schema: Row,
+      key: "id",
+    },
+    kafkaOrders: {
+      schema: Row,
+      key: "id",
+      kafkaSource: kafka.source({
+        topic: "orders-source",
+        regions: ["usa"],
+        value: kafka.json(Row),
+        key: kafka.stringKey(),
+        rowKey: ({ key }) => key,
+        map: ({ value }) => ({
+          price: value.price,
+          region: value.region,
+          status: value.status,
+        }),
+      }),
+    },
+    leasedOrders: {
+      schema: Row,
+      key: "id",
+      grpcSource: grpcSourceMarkers.leased({
+        routeBy: ["region"],
+      }),
+    },
+    materializedOrders: {
+      schema: Row,
+      key: "id",
+      grpcSource: grpcSourceMarkers.materialized(),
+    },
+  },
+});
+
+describe("SourceOwnershipPolicy", () => {
+  it("classifies source-owned and leased topics behind one Interface", () => {
+    const policy = makeSourceOwnershipPolicy(sourceOwnedViewServer);
+
+    expect([...policy.sourceOwnedTopics]).toStrictEqual([
+      "kafkaOrders",
+      "leasedOrders",
+      "materializedOrders",
+    ]);
+    expect([...policy.grpcLeasedTopics]).toStrictEqual(["leasedOrders"]);
+    expect(policy.hasSourceOwnedTopics).toBe(true);
+    expect(policy.isSourceOwnedTopic("externalOrders")).toBe(false);
+    expect(policy.isSourceOwnedTopic("kafkaOrders")).toBe(true);
+    expect(policy.isSourceOwnedTopic("materializedOrders")).toBe(true);
+    expect(policy.isGrpcLeasedTopic("leasedOrders")).toBe(true);
+    expect(policy.isGrpcLeasedTopic("kafkaOrders")).toBe(false);
+  });
+
+  it.effect("allows direct public mutations, reads, and reset for source-free topics", () =>
+    Effect.gen(function* () {
+      const policy = makeSourceOwnershipPolicy(sourceFreeViewServer);
+
+      yield* policy.requirePublicMutationAllowed("externalOrders", "runtimeCore");
+      yield* policy.requirePublicReadAllowed("externalOrders", "runtimeCore");
+      yield* policy.requirePublicResetAllowed("runtimeCore");
+
+      expect([...policy.sourceOwnedTopics]).toStrictEqual([]);
+      expect([...policy.grpcLeasedTopics]).toStrictEqual([]);
+      expect(policy.hasSourceOwnedTopics).toBe(false);
+    }),
+  );
+
+  it.effect(
+    "rejects source-owned runtime-core mutations and reset while keeping reads allowed",
+    () =>
+      Effect.gen(function* () {
+        const policy = makeSourceOwnershipPolicy(sourceOwnedViewServer);
+
+        yield* policy.requirePublicReadAllowed("kafkaOrders", "runtimeCore");
+        yield* policy.requirePublicReadAllowed("materializedOrders", "runtimeCore");
+
+        const kafkaMutationError = yield* policy
+          .requirePublicMutationAllowed("kafkaOrders", "runtimeCore")
+          .pipe(Effect.flip);
+        const materializedMutationError = yield* policy
+          .requirePublicMutationAllowed("materializedOrders", "runtimeCore")
+          .pipe(Effect.flip);
+        const leasedMutationError = yield* policy
+          .requirePublicMutationAllowed("leasedOrders", "runtimeCore")
+          .pipe(Effect.flip);
+        const resetError = yield* policy.requirePublicResetAllowed("runtimeCore").pipe(Effect.flip);
+
+        expect(kafkaMutationError).toStrictEqual(sourceOwnedMutationError("kafkaOrders"));
+        expect(materializedMutationError).toStrictEqual(
+          sourceOwnedMutationError("materializedOrders"),
+        );
+        expect(leasedMutationError).toStrictEqual(sourceOwnedMutationError("leasedOrders"));
+        expect(resetError).toStrictEqual(sourceOwnedResetError);
+      }),
+  );
+
+  it.effect("rejects leased reads and managed-runtime mutations with leased lifecycle errors", () =>
+    Effect.gen(function* () {
+      const policy = makeSourceOwnershipPolicy(sourceOwnedViewServer);
+
+      const runtimeCoreReadError = yield* policy
+        .requirePublicReadAllowed("leasedOrders", "runtimeCore")
+        .pipe(Effect.flip);
+      const managedReadError = yield* policy
+        .requirePublicReadAllowed("leasedOrders", "managedRuntime")
+        .pipe(Effect.flip);
+      const managedMutationError = yield* policy
+        .requirePublicMutationAllowed("leasedOrders", "managedRuntime")
+        .pipe(Effect.flip);
+      const managedResetError = yield* policy
+        .requirePublicResetAllowed("managedRuntime")
+        .pipe(Effect.flip);
+
+      expect(runtimeCoreReadError).toStrictEqual(runtimeCoreLeasedAccessError("leasedOrders"));
+      expect(managedReadError).toStrictEqual(managedRuntimeLeasedAccessError("leasedOrders"));
+      expect(managedMutationError).toStrictEqual(managedRuntimeLeasedAccessError("leasedOrders"));
+      expect(managedResetError).toStrictEqual(managedRuntimeLeasedResetError);
+    }),
+  );
+});

--- a/packages/runtime-core/src/source-ownership-policy.ts
+++ b/packages/runtime-core/src/source-ownership-policy.ts
@@ -1,5 +1,15 @@
 import type { DecodableTopicDefinitions } from "@effect-view-server/column-live-view-engine";
-import type { ViewServerTopicConfig } from "@effect-view-server/config";
+import type { ViewServerRuntimeError, ViewServerTopicConfig } from "@effect-view-server/config";
+import { Effect } from "effect";
+import {
+  leasedManagedRuntimeAccessError,
+  leasedManagedRuntimeResetError,
+  leasedRuntimeAccessError,
+  sourceOwnedRuntimeMutationError,
+  sourceOwnedRuntimeResetError,
+} from "./runtime-error";
+
+export type SourceOwnershipAccessProfile = "managedRuntime" | "runtimeCore";
 
 const hasDefinedOwnProperty = (value: object, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key) && Reflect.get(value, key) !== undefined;
@@ -20,10 +30,29 @@ const isGrpcLeasedSource = (source: unknown): boolean =>
 export type SourceOwnershipPolicy = {
   readonly grpcLeasedTopics: ReadonlySet<string>;
   readonly sourceOwnedTopics: ReadonlySet<string>;
+  readonly requirePublicMutationAllowed: (
+    topic: string,
+    profile: SourceOwnershipAccessProfile,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly requirePublicReadAllowed: (
+    topic: string,
+    profile: SourceOwnershipAccessProfile,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly requirePublicResetAllowed: (
+    profile: SourceOwnershipAccessProfile,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
   readonly isGrpcLeasedTopic: (topic: string) => boolean;
   readonly isSourceOwnedTopic: (topic: string) => boolean;
   readonly hasSourceOwnedTopics: boolean;
 };
+
+const leasedRuntimeAccessErrorFor = (
+  topic: string,
+  profile: SourceOwnershipAccessProfile,
+): ViewServerRuntimeError =>
+  profile === "managedRuntime"
+    ? leasedManagedRuntimeAccessError(topic)
+    : leasedRuntimeAccessError(topic);
 
 export const makeSourceOwnershipPolicy = <const Topics extends DecodableTopicDefinitions>(
   config: ViewServerTopicConfig<Topics>,
@@ -44,6 +73,30 @@ export const makeSourceOwnershipPolicy = <const Topics extends DecodableTopicDef
   return {
     grpcLeasedTopics: sortedGrpcLeasedTopics,
     sourceOwnedTopics: sortedSourceOwnedTopics,
+    requirePublicMutationAllowed: (topic, profile) => {
+      if (!sortedSourceOwnedTopics.has(topic)) {
+        return Effect.void;
+      }
+      return Effect.fail(
+        profile === "managedRuntime" && sortedGrpcLeasedTopics.has(topic)
+          ? leasedRuntimeAccessErrorFor(topic, profile)
+          : sourceOwnedRuntimeMutationError(topic),
+      );
+    },
+    requirePublicReadAllowed: (topic, profile) =>
+      sortedGrpcLeasedTopics.has(topic)
+        ? Effect.fail(leasedRuntimeAccessErrorFor(topic, profile))
+        : Effect.void,
+    requirePublicResetAllowed: (profile) => {
+      if (sortedSourceOwnedTopics.size === 0) {
+        return Effect.void;
+      }
+      return Effect.fail(
+        profile === "managedRuntime" && sortedGrpcLeasedTopics.size > 0
+          ? leasedManagedRuntimeResetError
+          : sourceOwnedRuntimeResetError,
+      );
+    },
     isGrpcLeasedTopic: (topic) => sortedGrpcLeasedTopics.has(topic),
     isSourceOwnedTopic: (topic) => sortedSourceOwnedTopics.has(topic),
     hasSourceOwnedTopics: sortedSourceOwnedTopics.size > 0,

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -166,23 +166,14 @@ const runtimeError = (input: {
     ViewServerRuntimeError,
     { readonly _tag: "ViewServerRuntimeError" }
   >["code"];
-  readonly topic?: string;
+  readonly topic: string;
   readonly message: string;
-}): ViewServerRuntimeError => {
-  if (input.topic === undefined) {
-    return {
-      _tag: "ViewServerRuntimeError",
-      code: input.code,
-      message: input.message,
-    };
-  }
-  return {
-    _tag: "ViewServerRuntimeError",
-    code: input.code,
-    topic: input.topic,
-    message: input.message,
-  };
-};
+}): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: input.code,
+  topic: input.topic,
+  message: input.message,
+});
 
 const grpcLeaseError = (input: {
   readonly message: string;
@@ -1054,28 +1045,6 @@ const leasedFeedsByTopic = <
   return feeds;
 };
 
-const leasedRuntimeAccessError = (topic: string): ViewServerRuntimeError =>
-  runtimeError({
-    code: "UnsupportedQuery",
-    topic,
-    message:
-      "Leased gRPC topics do not support direct runtime mutations or one-shot snapshots; use a live subscription so the runtime can own lease lifecycle.",
-  });
-
-const sourceOwnedRuntimeMutationError = (topic: string): ViewServerRuntimeError =>
-  runtimeError({
-    code: "UnsupportedQuery",
-    topic,
-    message:
-      "Source-owned topics do not support direct runtime mutations; publish through the configured Kafka/gRPC source or use an externally-published topic.",
-  });
-
-const sourceOwnedRuntimeResetError: ViewServerRuntimeError = runtimeError({
-  code: "UnsupportedQuery",
-  message:
-    "Source-owned topics do not support direct runtime reset; close the runtime or reset source-free topics through their owner.",
-});
-
 const normalizeAcquireLeaseError =
   (topic: string) =>
   (error: ViewServerRuntimeError | ViewServerGrpcIngressError): ViewServerRuntimeError => {
@@ -1532,47 +1501,31 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     });
 
   const snapshot: ViewServerRuntimeClient<Topics>["snapshot"] = (topic, query) =>
-    Effect.gen(function* () {
-      if (sourceOwnership.isGrpcLeasedTopic(topic)) {
-        return yield* Effect.fail(leasedRuntimeAccessError(topic));
-      }
-      return yield* runtimeClient.snapshot(topic, query);
-    });
-
-  const rejectSourceOwnedMutation = (topic: string): Effect.Effect<never, ViewServerRuntimeError> =>
-    sourceOwnership.isGrpcLeasedTopic(topic)
-      ? Effect.fail(leasedRuntimeAccessError(topic))
-      : Effect.fail(sourceOwnedRuntimeMutationError(topic));
+    sourceOwnership
+      .requirePublicReadAllowed(topic, "managedRuntime")
+      .pipe(Effect.flatMap(() => runtimeClient.snapshot(topic, query)));
 
   const publish: ViewServerRuntimeClient<Topics>["publish"] = (topic, row) =>
-    sourceOwnership.isSourceOwnedTopic(topic)
-      ? rejectSourceOwnedMutation(topic)
-      : runtimeClient.publish(topic, row);
+    sourceOwnership
+      .requirePublicMutationAllowed(topic, "managedRuntime")
+      .pipe(Effect.flatMap(() => runtimeClient.publish(topic, row)));
   const publishMany: ViewServerRuntimeClient<Topics>["publishMany"] = (topic, rows) =>
-    sourceOwnership.isSourceOwnedTopic(topic)
-      ? rejectSourceOwnedMutation(topic)
-      : runtimeClient.publishMany(topic, rows);
+    sourceOwnership
+      .requirePublicMutationAllowed(topic, "managedRuntime")
+      .pipe(Effect.flatMap(() => runtimeClient.publishMany(topic, rows)));
   const patch: ViewServerRuntimeClient<Topics>["patch"] = (topic, key, patchValue) =>
-    sourceOwnership.isSourceOwnedTopic(topic)
-      ? rejectSourceOwnedMutation(topic)
-      : runtimeClient.patch(topic, key, patchValue);
+    sourceOwnership
+      .requirePublicMutationAllowed(topic, "managedRuntime")
+      .pipe(Effect.flatMap(() => runtimeClient.patch(topic, key, patchValue)));
   const deleteRow: ViewServerRuntimeClient<Topics>["delete"] = (topic, key) =>
-    sourceOwnership.isSourceOwnedTopic(topic)
-      ? rejectSourceOwnedMutation(topic)
-      : runtimeClient.delete(topic, key);
+    sourceOwnership
+      .requirePublicMutationAllowed(topic, "managedRuntime")
+      .pipe(Effect.flatMap(() => runtimeClient.delete(topic, key)));
 
   const reset: ViewServerRuntimeClient<Topics>["reset"] = () =>
-    !sourceOwnership.hasSourceOwnedTopics
-      ? runtimeClient.reset()
-      : sourceOwnership.grpcLeasedTopics.size === 0
-        ? Effect.fail(sourceOwnedRuntimeResetError)
-        : Effect.fail(
-            runtimeError({
-              code: "UnsupportedQuery",
-              message:
-                "Leased gRPC topics do not support direct runtime reset; close the runtime or leased subscriptions so the lease manager owns cleanup.",
-            }),
-          );
+    sourceOwnership
+      .requirePublicResetAllowed("managedRuntime")
+      .pipe(Effect.flatMap(() => runtimeClient.reset()));
 
   const client: ViewServerRuntimeClient<Topics> = {
     publish,

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -2774,32 +2774,57 @@ describe("@effect-view-server/runtime", () => {
 
   it.live("rejects TCP publish commands for source-owned topics", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeViewServerRuntime(viewServer, {
-        host: "127.0.0.1",
-        websocketPort: 0,
+      const sourceOwnedViewServer = defineViewServerConfig({
+        kafka: {
+          local: "localhost:9092",
+        },
+        topics: {
+          orders: {
+            schema: Order,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "orders-source",
+              regions: ["local"],
+              value: kafka.json(Order),
+              key: kafka.stringKey(),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({
+                price: value.price,
+              }),
+            }),
+          },
+        },
       });
-      const ingress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
-        port: 0,
-        rejectedTopics: new Set(["orders"]),
-      });
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(sourceOwnedViewServer, {});
+      const ingress = yield* makeViewServerTcpPublishIngress(
+        sourceOwnedViewServer,
+        runtimeCore.client,
+        {
+          port: 0,
+        },
+      );
 
       const response = yield* sendTcpPublishCommand(ingress.url, {
         op: "publish",
         topic: "orders",
-        row: order("a", 10),
+        row: {
+          id: "a",
+          price: "not-a-number",
+        },
       });
 
       expect(response).toStrictEqual({
         ok: false,
         error: {
-          _tag: "ViewServerTcpPublishIngressError",
-          message: "TCP publish cannot mutate source-owned View Server topic orders.",
-          phase: "runtime",
+          _tag: "ViewServerRuntimeError",
+          code: "UnsupportedQuery",
+          message:
+            "Source-owned topics do not support direct runtime mutations; publish through the configured Kafka/gRPC source or use an externally-published topic.",
           topic: "orders",
         },
       });
       yield* ingress.close;
-      yield* runtime.close;
+      yield* runtimeCore.close;
     }),
   );
 
@@ -2895,7 +2920,7 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
-  it.live("passes source-owned topics into TCP publish ingress rejection policy", () =>
+  it.live("passes matching config into TCP publish ingress", () =>
     Effect.gen(function* () {
       const regions = {
         local: "localhost:9092",
@@ -2940,7 +2965,8 @@ describe("@effect-view-server/runtime", () => {
       });
       type MixedTopics = typeof mixedSourceViewServer.topics;
       type RuntimeDependencies = ViewServerRuntimeDependencies<MixedTopics>;
-      let rejectedTopics: ReadonlyArray<string> = [];
+      let tcpPublishTopics: ReadonlyArray<string> = [];
+      let tcpPublishOptionKeys: ReadonlyArray<string> = [];
       const dependencies: RuntimeDependencies = {
         ...makeDefaultRuntimeDependencies<MixedTopics>(),
         makeServer: () =>
@@ -2952,8 +2978,9 @@ describe("@effect-view-server/runtime", () => {
           }),
         makeKafkaIngress: () => Effect.succeed({ close: Effect.void }),
         makeGrpcIngress: () => Effect.succeed({ close: Effect.void }),
-        makeTcpPublishIngress: (_config, _client, options) => {
-          rejectedTopics = Array.from(options.rejectedTopics ?? []);
+        makeTcpPublishIngress: (tcpConfig, _client, options) => {
+          tcpPublishTopics = Object.keys(tcpConfig.topics);
+          tcpPublishOptionKeys = Object.keys(options).sort();
           return Effect.succeed({
             url: "tcp://127.0.0.1:1235",
             close: Effect.void,
@@ -2974,10 +3001,12 @@ describe("@effect-view-server/runtime", () => {
       );
 
       expect({
-        rejectedTopics,
+        tcpPublishOptionKeys,
+        tcpPublishTopics,
         tcpPublishUrl: runtime.tcpPublishUrl,
       }).toStrictEqual({
-        rejectedTopics: ["audit", "orders"],
+        tcpPublishOptionKeys: ["port"],
+        tcpPublishTopics: ["orders", "audit"],
         tcpPublishUrl: "tcp://127.0.0.1:1235",
       });
       yield* runtime.close;
@@ -3942,7 +3971,12 @@ describe("@effect-view-server/runtime", () => {
         serverAuthType: typeof serverInput?.auth?.validateRequest,
         serverOptions,
         tcpPublishAuthType: typeof tcpPublishOptions?.auth?.validateRequest,
-        tcpPublishOptions,
+        tcpPublishOptions: {
+          authType: typeof tcpPublishOptions?.auth?.validateRequest,
+          host: tcpPublishOptions?.host,
+          maxConnections: tcpPublishOptions?.maxConnections,
+          port: tcpPublishOptions?.port,
+        },
         tcpPublishUrl: runtime.tcpPublishUrl,
       }).toStrictEqual({
         runtimeCoreOptions: {
@@ -3968,11 +4002,10 @@ describe("@effect-view-server/runtime", () => {
         },
         tcpPublishAuthType: "function",
         tcpPublishOptions: {
-          auth: bearerAuth,
+          authType: "function",
           host: "127.0.0.1",
           maxConnections: 9,
           port: 1235,
-          rejectedTopics: new Set(),
         },
         tcpPublishUrl: "tcp://127.0.0.1:1235",
       });

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -8,7 +8,6 @@ import type {
 } from "@effect-view-server/config";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
 import type { ViewServerRuntimeCoreOptionsFor } from "@effect-view-server/runtime-core";
-import { makeSourceOwnershipPolicy } from "@effect-view-server/runtime-core/internal";
 import { Config, Effect, Exit, Layer } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
 import {
@@ -223,7 +222,6 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
           grpcOptions,
           grpcHealth,
         );
-  const sourceOwnership = makeSourceOwnershipPolicy(dependencyConfig);
   const runtimeLiveClient = grpcLeaseManager?.liveClient ?? runtimeCore.liveClient;
   const runtimeClient = grpcLeaseManager?.client ?? runtimeCore.client;
   const closeGrpcLeaseManager =
@@ -235,7 +233,6 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
           .makeTcpPublishIngress(dependencyConfig, runtimeClient, {
             ...resolvedOptions.tcpPublishOptions,
             ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
-            rejectedTopics: sourceOwnership.sourceOwnedTopics,
           })
           .pipe(
             Effect.onExit((exit) =>

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -6,6 +6,10 @@ import type {
 } from "@effect-view-server/config";
 import type { ViewServerAuth, ViewServerAuthRequest } from "@effect-view-server/server";
 import { validateViewServerAuthRequest, ViewServerAuthError } from "@effect-view-server/server";
+import {
+  makeSourceOwnershipPolicy,
+  type SourceOwnershipPolicy,
+} from "@effect-view-server/runtime-core/internal";
 import { Cause, Effect, Exit, Fiber, Option, Result, Schema, SchemaAST } from "effect";
 import * as Net from "node:net";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
@@ -27,7 +31,6 @@ export type ViewServerTcpPublishIngressOptions = {
   readonly maxLineBytes?: number;
   readonly maxQueuedCommands?: number;
   readonly port: number;
-  readonly rejectedTopics?: ReadonlySet<string>;
   readonly auth?: ViewServerAuth;
 };
 
@@ -471,12 +474,13 @@ const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(f
   config: ViewServerTopicConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
+  sourceOwnership: SourceOwnershipPolicy,
   line: string,
 ) {
   const command = yield* parseCommand(line);
   yield* validateViewServerAuthRequest(options.auth, tcpAuthRequest(command, socket));
   clearTcpPreCommandDeadline(state);
-  yield* ensureTopicCanBeMutated(command.topic, options);
+  yield* ensureTopicCanBeMutated(command.topic, sourceOwnership);
   if (command.op === "publish") {
     const row = yield* decodeTcpRow(config, command.topic, command.row);
     yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, row]);
@@ -498,18 +502,9 @@ const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(f
 
 const ensureTopicCanBeMutated = (
   topic: string,
-  options: ViewServerTcpPublishIngressOptions,
-): Effect.Effect<void, ViewServerTcpPublishIngressError> =>
-  options.rejectedTopics?.has(topic) === true
-    ? Effect.fail(
-        new ViewServerTcpPublishIngressError({
-          message: `TCP publish cannot mutate source-owned View Server topic ${topic}.`,
-          cause: topic,
-          phase: "runtime",
-          topic,
-        }),
-      )
-    : Effect.void;
+  sourceOwnership: SourceOwnershipPolicy,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  sourceOwnership.requirePublicMutationAllowed(topic, "runtimeCore");
 
 const wireError = (cause: Cause.Cause<TcpPublishCommandError>): object => {
   const failure = Cause.findErrorOption(cause);
@@ -676,13 +671,16 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
   config: ViewServerTopicConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
+  sourceOwnership: SourceOwnershipPolicy,
   line: string,
 ): Promise<void> => {
   try {
     if (state.closed || serverState.closed) {
       return;
     }
-    const fiber = Effect.runFork(handleCommand(socket, state, config, client, options, line));
+    const fiber = Effect.runFork(
+      handleCommand(socket, state, config, client, options, sourceOwnership, line),
+    );
     serverState.activeFibers.add(fiber);
     state.activeFibers.add(fiber);
     const exit = await Effect.runPromise(Fiber.await(fiber));
@@ -731,6 +729,7 @@ const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerTopicConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
+  sourceOwnership: SourceOwnershipPolicy,
   line: string,
 ): void => {
   const maxQueuedCommands = options.maxQueuedCommands ?? defaultMaxQueuedCommands;
@@ -752,7 +751,7 @@ const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   const chain = (async () => {
     await Promise.allSettled([previousChain]);
     await Promise.allSettled([
-      executeLine(socket, state, serverState, config, client, options, line),
+      executeLine(socket, state, serverState, config, client, options, sourceOwnership, line),
     ]);
   })();
   state.chain = chain;
@@ -795,6 +794,7 @@ const installSocketHandler = <const Topics extends ViewServerRuntimeTopicDefinit
   config: ViewServerTopicConfig<Topics>,
   client: ViewServerRuntimeClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
+  sourceOwnership: SourceOwnershipPolicy,
 ): void => {
   socket.setEncoding("utf8");
   socket.on("data", (chunk: string) => {
@@ -812,7 +812,7 @@ const installSocketHandler = <const Topics extends ViewServerRuntimeTopicDefinit
       }
       const trimmed = line.trim();
       if (trimmed.length > 0) {
-        enqueueLine(socket, state, serverState, config, client, options, trimmed);
+        enqueueLine(socket, state, serverState, config, client, options, sourceOwnership, trimmed);
       }
     }
     state.buffer = partialLine;
@@ -930,6 +930,7 @@ export const installTcpPublishAcceptedSocket = <
   client: ViewServerRuntimeClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
 ): void => {
+  const sourceOwnership = makeSourceOwnershipPolicy(config);
   if (rejectTcpSocketWhenClosed(state.closed, socket)) {
     return;
   }
@@ -961,7 +962,7 @@ export const installTcpPublishAcceptedSocket = <
     interruptSocketFibers(socketState);
     void socketState.chain.then(() => state.socketStates.delete(socket));
   });
-  installSocketHandler(socket, socketState, state, config, client, options);
+  installSocketHandler(socket, socketState, state, config, client, options, sourceOwnership);
 };
 
 export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpPublish.make")(


### PR DESCRIPTION
## Summary
- centralize source-owned and leased gRPC mutation/read/reset decisions in SourceOwnershipPolicy
- route runtime-core, managed runtime gRPC lease client, and TCP publish ingress through the policy
- remove the TCP rejectedTopics option so ingress derives ownership from the same topic config it decodes
- add policy and TCP regression coverage for source-free, source-owned, materialized, and leased topics

## Validation
- 3 reviewer agents: no findings
- vp run runtime-core#test -- src/source-ownership-policy.test.ts
- node ../../scripts/test-runtime.mjs -- src/index.test.ts -t "rejects TCP publish commands for source-owned topics" (from packages/runtime, escalated because VP IPC/shared-memory is sandbox-blocked)
- vp run react#test
- vp run ready (escalated because VP IPC/shared-memory is sandbox-blocked)