### PR TITLE
Deepen Kafka delivery contract

### DIFF
--- a/packages/runtime/src/kafka-delivery-contract.test.ts
+++ b/packages/runtime/src/kafka-delivery-contract.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@effect-view-server/config";
+import { Buffer } from "node:buffer";
+import { Schema } from "effect";
+import {
+  planKafkaDecodedPublishRuns,
+  planKafkaUpsertPublishRuns,
+  type DecodedKafkaBatchMessage,
+  type DecodedKafkaBatchTombstoneMessage,
+  type DecodedKafkaBatchUpsertMessage,
+  type KafkaConsumerMessage,
+} from "./kafka-delivery-contract";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+});
+
+const Trade = Schema.Struct({
+  id: Schema.String,
+  quantity: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      key: "id",
+      schema: Order,
+    },
+    trades: {
+      key: "id",
+      schema: Trade,
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+
+const kafkaMessage = (input: {
+  readonly offset: bigint;
+  readonly sourceTopic: string;
+}): KafkaConsumerMessage => ({
+  commit: () => undefined,
+  headers: new Map(),
+  key: Buffer.from(`key-${input.offset}`),
+  metadata: {},
+  offset: input.offset,
+  partition: 0,
+  timestamp: 0n,
+  toJSON: () => ({
+    headers: [],
+    key: Buffer.from(`key-${input.offset}`),
+    metadata: {},
+    offset: String(input.offset),
+    partition: 0,
+    timestamp: "0",
+    topic: input.sourceTopic,
+    value: Buffer.from(`value-${input.offset}`),
+  }),
+  topic: input.sourceTopic,
+  value: Buffer.from(`value-${input.offset}`),
+});
+
+const upsertMessage = (input: {
+  readonly offset: bigint;
+  readonly row: object;
+  readonly rowKey: string;
+  readonly sourceTopic: string;
+  readonly viewServerTopic: Extract<keyof Topics, string>;
+}): DecodedKafkaBatchUpsertMessage<Topics> => ({
+  decoded: {
+    row: input.row,
+    rowKey: input.rowKey,
+    viewServerTopic: input.viewServerTopic,
+  },
+  message: kafkaMessage({
+    offset: input.offset,
+    sourceTopic: input.sourceTopic,
+  }),
+  messageBytes: 10,
+  nowMillis: Number(input.offset),
+  sourceTopic: input.sourceTopic,
+});
+
+const tombstoneMessage = (input: {
+  readonly offset: bigint;
+  readonly rowKey: string;
+  readonly sourceTopic: string;
+  readonly viewServerTopic: Extract<keyof Topics, string>;
+}): DecodedKafkaBatchTombstoneMessage<Topics> => ({
+  decoded: {
+    rowKey: input.rowKey,
+    tombstone: true,
+    viewServerTopic: input.viewServerTopic,
+  },
+  message: kafkaMessage({
+    offset: input.offset,
+    sourceTopic: input.sourceTopic,
+  }),
+  messageBytes: 10,
+  nowMillis: Number(input.offset),
+  sourceTopic: input.sourceTopic,
+});
+
+describe("Kafka delivery contract", () => {
+  it("plans contiguous upsert runs and tombstone runs without reordering messages", () => {
+    const firstUpsert = upsertMessage({
+      offset: 1n,
+      row: { id: "a", price: 10 },
+      rowKey: "a",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const secondUpsert = upsertMessage({
+      offset: 2n,
+      row: { id: "b", price: 20 },
+      rowKey: "b",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const tombstone = tombstoneMessage({
+      offset: 3n,
+      rowKey: "a",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const finalUpsert = upsertMessage({
+      offset: 4n,
+      row: { id: "c", price: 30 },
+      rowKey: "c",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>> = [
+      firstUpsert,
+      secondUpsert,
+      tombstone,
+      finalUpsert,
+    ];
+
+    expect(planKafkaDecodedPublishRuns(messages)).toStrictEqual([
+      {
+        _tag: "Upserts",
+        messages: [firstUpsert, secondUpsert],
+      },
+      {
+        _tag: "Tombstone",
+        message: tombstone,
+      },
+      {
+        _tag: "Upserts",
+        messages: [finalUpsert],
+      },
+    ]);
+  });
+
+  it("plans upsert publish runs by contiguous source topic and View Server topic", () => {
+    const firstOrder = upsertMessage({
+      offset: 1n,
+      row: { id: "a", price: 10 },
+      rowKey: "a",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const secondOrder = upsertMessage({
+      offset: 2n,
+      row: { id: "b", price: 20 },
+      rowKey: "b",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const trade = upsertMessage({
+      offset: 3n,
+      row: { id: "t", quantity: 5 },
+      rowKey: "t",
+      sourceTopic: "trades-source",
+      viewServerTopic: "trades",
+    });
+    const londonOrder = upsertMessage({
+      offset: 4n,
+      row: { id: "c", price: 30 },
+      rowKey: "c",
+      sourceTopic: "orders-london-source",
+      viewServerTopic: "orders",
+    });
+
+    expect(planKafkaUpsertPublishRuns([firstOrder, secondOrder, trade, londonOrder])).toStrictEqual(
+      [
+        {
+          rows: [
+            {
+              message: firstOrder,
+              row: { id: "a", price: 10 },
+              storageKey: "a",
+            },
+            {
+              message: secondOrder,
+              row: { id: "b", price: 20 },
+              storageKey: "b",
+            },
+          ],
+          sourceTopic: "orders-source",
+          topic: "orders",
+        },
+        {
+          rows: [
+            {
+              message: trade,
+              row: { id: "t", quantity: 5 },
+              storageKey: "t",
+            },
+          ],
+          sourceTopic: "trades-source",
+          topic: "trades",
+        },
+        {
+          rows: [
+            {
+              message: londonOrder,
+              row: { id: "c", price: 30 },
+              storageKey: "c",
+            },
+          ],
+          sourceTopic: "orders-london-source",
+          topic: "orders",
+        },
+      ],
+    );
+  });
+});

--- a/packages/runtime/src/kafka-delivery-contract.ts
+++ b/packages/runtime/src/kafka-delivery-contract.ts
@@ -1,0 +1,133 @@
+import type { Message } from "@platformatic/kafka";
+import { Buffer } from "node:buffer";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+type KafkaMessageBytes = Buffer | null | undefined;
+
+export type KafkaConsumerMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
+
+export type KafkaBatchTopic<Topics extends ViewServerRuntimeTopicDefinitions> = Extract<
+  keyof Topics,
+  string
+>;
+
+export type DecodedKafkaBatchUpsertMessage<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly decoded: {
+    readonly viewServerTopic: KafkaBatchTopic<Topics>;
+    readonly row: object;
+    readonly rowKey: string;
+  };
+  readonly message: KafkaConsumerMessage;
+  readonly messageBytes: number;
+  readonly nowMillis: number;
+  readonly sourceTopic: string;
+};
+
+export type DecodedKafkaBatchTombstoneMessage<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly decoded: {
+    readonly rowKey: string;
+    readonly tombstone: true;
+    readonly viewServerTopic: KafkaBatchTopic<Topics>;
+  };
+  readonly message: KafkaConsumerMessage;
+  readonly messageBytes: number;
+  readonly nowMillis: number;
+  readonly sourceTopic: string;
+};
+
+export type DecodedKafkaBatchMessage<Topics extends ViewServerRuntimeTopicDefinitions> =
+  | DecodedKafkaBatchUpsertMessage<Topics>
+  | DecodedKafkaBatchTombstoneMessage<Topics>;
+
+export type KafkaDecodedPublishRun<Topics extends ViewServerRuntimeTopicDefinitions> =
+  | {
+      readonly _tag: "Upserts";
+      readonly messages: ReadonlyArray<DecodedKafkaBatchUpsertMessage<Topics>>;
+    }
+  | {
+      readonly _tag: "Tombstone";
+      readonly message: DecodedKafkaBatchTombstoneMessage<Topics>;
+    };
+
+export type KafkaStorageUpsertBatchRow<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly message: DecodedKafkaBatchUpsertMessage<Topics>;
+  readonly row: object;
+  readonly storageKey: string;
+};
+
+export type KafkaUpsertPublishRun<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly rows: ReadonlyArray<KafkaStorageUpsertBatchRow<Topics>>;
+  readonly sourceTopic: string;
+  readonly topic: KafkaBatchTopic<Topics>;
+};
+
+export const kafkaBatchMessageIsTombstone = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  message: DecodedKafkaBatchMessage<Topics>,
+): message is DecodedKafkaBatchTombstoneMessage<Topics> => "tombstone" in message.decoded;
+
+export const planKafkaDecodedPublishRuns = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
+): ReadonlyArray<KafkaDecodedPublishRun<Topics>> => {
+  const runs: Array<
+    | {
+        readonly _tag: "Upserts";
+        readonly messages: Array<DecodedKafkaBatchUpsertMessage<Topics>>;
+      }
+    | {
+        readonly _tag: "Tombstone";
+        readonly message: DecodedKafkaBatchTombstoneMessage<Topics>;
+      }
+  > = [];
+  for (const message of messages) {
+    if (kafkaBatchMessageIsTombstone(message)) {
+      runs.push({
+        _tag: "Tombstone",
+        message,
+      });
+    } else {
+      const previousRun = runs[runs.length - 1];
+      if (previousRun?._tag === "Upserts") {
+        previousRun.messages.push(message);
+      } else {
+        runs.push({
+          _tag: "Upserts",
+          messages: [message],
+        });
+      }
+    }
+  }
+  return runs;
+};
+
+export const planKafkaUpsertPublishRuns = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  messages: ReadonlyArray<DecodedKafkaBatchUpsertMessage<Topics>>,
+): ReadonlyArray<KafkaUpsertPublishRun<Topics>> => {
+  const runs: Array<{
+    readonly rows: Array<KafkaStorageUpsertBatchRow<Topics>>;
+    readonly sourceTopic: string;
+    readonly topic: KafkaBatchTopic<Topics>;
+  }> = [];
+  for (const message of messages) {
+    const previousRun = runs[runs.length - 1];
+    const row: KafkaStorageUpsertBatchRow<Topics> = {
+      message,
+      row: message.decoded.row,
+      storageKey: message.decoded.rowKey,
+    };
+    if (
+      previousRun?.topic === message.decoded.viewServerTopic &&
+      previousRun.sourceTopic === message.sourceTopic
+    ) {
+      previousRun.rows.push(row);
+    } else {
+      runs.push({
+        rows: [row],
+        sourceTopic: message.sourceTopic,
+        topic: message.decoded.viewServerTopic,
+      });
+    }
+  }
+  return runs;
+};

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -1,10 +1,5 @@
 import { Consumer } from "@platformatic/kafka";
-import type {
-  ConsumerGroupJoinPayload,
-  GroupAssignment,
-  Message,
-  Offsets,
-} from "@platformatic/kafka";
+import type { ConsumerGroupJoinPayload, GroupAssignment, Offsets } from "@platformatic/kafka";
 import { Buffer } from "node:buffer";
 import {
   kafkaErrorIsMapping,
@@ -35,6 +30,15 @@ import {
   Scope,
 } from "effect";
 import type { ViewServerKafkaHealthLedger } from "./kafka-health";
+import {
+  planKafkaDecodedPublishRuns,
+  planKafkaUpsertPublishRuns,
+  type DecodedKafkaBatchMessage,
+  type DecodedKafkaBatchTombstoneMessage,
+  type DecodedKafkaBatchUpsertMessage,
+  type KafkaBatchTopic,
+  type KafkaConsumerMessage,
+} from "./kafka-delivery-contract";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
@@ -73,8 +77,6 @@ export type StartedKafkaConsumerResources = {
   readonly stream: CloseableKafkaStream;
   readonly healthListeners: () => KafkaConsumerHealthListenerRegistration | null;
 };
-type KafkaMessageBytes = Buffer | null | undefined;
-type KafkaConsumerMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
 export type KafkaStreamQueueEvent =
   | {
       readonly _tag: "Message";
@@ -99,38 +101,6 @@ type KafkaMessageBatchTakeResult =
       readonly batch: ReadonlyArray<KafkaConsumerMessage>;
       readonly terminal: KafkaStreamTerminalEvent | null;
     };
-type KafkaBatchTopic<Topics extends ViewServerRuntimeTopicDefinitions> = Extract<
-  keyof Topics,
-  string
->;
-type DecodedKafkaBatchUpsertMessage<Topics extends ViewServerRuntimeTopicDefinitions> = {
-  readonly decoded: {
-    readonly viewServerTopic: KafkaBatchTopic<Topics>;
-    readonly row: object;
-    readonly rowKey: string;
-  };
-  readonly message: KafkaConsumerMessage;
-  readonly messageBytes: number;
-  readonly nowMillis: number;
-  readonly sourceTopic: string;
-};
-type DecodedKafkaBatchTombstoneMessage<Topics extends ViewServerRuntimeTopicDefinitions> = {
-  readonly decoded: {
-    readonly rowKey: string;
-    readonly tombstone: true;
-    readonly viewServerTopic: KafkaBatchTopic<Topics>;
-  };
-  readonly message: KafkaConsumerMessage;
-  readonly messageBytes: number;
-  readonly nowMillis: number;
-  readonly sourceTopic: string;
-};
-type DecodedKafkaBatchMessage<Topics extends ViewServerRuntimeTopicDefinitions> =
-  | DecodedKafkaBatchUpsertMessage<Topics>
-  | DecodedKafkaBatchTombstoneMessage<Topics>;
-const kafkaBatchMessageIsTombstone = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  message: DecodedKafkaBatchMessage<Topics>,
-): message is DecodedKafkaBatchTombstoneMessage<Topics> => "tombstone" in message.decoded;
 type KafkaIngressRuntimeClient<Topics extends ViewServerRuntimeTopicDefinitions> = Pick<
   ViewServerRuntimeCoreInternalClient<Topics>,
   "delete" | "publishManyDecodedRows" | "publishManyDecodedRowsWithStorageKeys"
@@ -943,37 +913,7 @@ const publishKafkaDecodedUpsertBatch = Effect.fn("ViewServerRuntime.kafka.batch.
     region: string,
     messages: ReadonlyArray<DecodedKafkaBatchUpsertMessage<Topics>>,
   ) {
-    type KafkaStorageUpsertBatchRow = {
-      readonly message: DecodedKafkaBatchMessage<Topics>;
-      readonly row: object;
-      readonly storageKey: string;
-    };
-    type KafkaUpsertPublishRun = {
-      readonly rows: Array<KafkaStorageUpsertBatchRow>;
-      readonly sourceTopic: string;
-      readonly topic: KafkaBatchTopic<Topics>;
-    };
-    const runs: Array<KafkaUpsertPublishRun> = [];
-    for (const message of messages) {
-      const previousRun = runs[runs.length - 1];
-      const row: KafkaStorageUpsertBatchRow = {
-        message,
-        row: message.decoded.row,
-        storageKey: message.decoded.rowKey,
-      };
-      if (
-        previousRun?.topic === message.decoded.viewServerTopic &&
-        previousRun.sourceTopic === message.sourceTopic
-      ) {
-        previousRun.rows.push(row);
-      } else {
-        runs.push({
-          rows: [row],
-          sourceTopic: message.sourceTopic,
-          topic: message.decoded.viewServerTopic,
-        });
-      }
-    }
+    const runs = planKafkaUpsertPublishRuns(messages);
     for (const run of runs) {
       yield* publishKafkaRowsForMessages(
         requestHealthRefresh,
@@ -1048,35 +988,7 @@ const publishAndCommitKafkaDecodedBatch = Effect.fn(
     readonly preserveLastErrorForSourceTopic: string | undefined;
   },
 ) {
-  type KafkaDecodedPublishRun =
-    | {
-        readonly _tag: "Upserts";
-        readonly messages: Array<DecodedKafkaBatchUpsertMessage<Topics>>;
-      }
-    | {
-        readonly _tag: "Tombstone";
-        readonly message: DecodedKafkaBatchTombstoneMessage<Topics>;
-      };
-  const runs: Array<KafkaDecodedPublishRun> = [];
-
-  for (const message of messages) {
-    if (kafkaBatchMessageIsTombstone(message)) {
-      runs.push({
-        _tag: "Tombstone",
-        message,
-      });
-    } else {
-      const previousRun = runs[runs.length - 1];
-      if (previousRun?._tag === "Upserts") {
-        previousRun.messages.push(message);
-      } else {
-        runs.push({
-          _tag: "Upserts",
-          messages: [message],
-        });
-      }
-    }
-  }
+  const runs = planKafkaDecodedPublishRuns(messages);
 
   for (const run of runs) {
     if (run._tag === "Upserts") {


### PR DESCRIPTION
## Summary
- Extract Kafka decoded batch delivery planning into a focused runtime module.
- Preserve ordered delivery by splitting contiguous upsert runs and tombstone runs without reordering.
- Add dedicated planner tests for upsert/tombstone run planning and contiguous source/topic grouping.

## Validation
- vp run runtime#test -- src/kafka-delivery-contract.test.ts src/kafka-ingress.internal.test.ts src/kafka-ingress.test.ts
- vp check --fix
- vp run -w ready

## Review
- 3 local review agents completed after fixes with no blockers or high-signal issues.