### PR TITLE
Deepen topic row storage lifecycle

### DIFF
--- a/packages/column-live-view-engine/src/topic-column-vector.test.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+import { fromStringUnsafe } from "effect/BigDecimal";
+import { rawQueryCompilerMetadata } from "./raw-query-compiler";
+import {
+  columnScalarEqualityKey,
+  columnValue,
+  createTopicColumnValues,
+} from "./topic-column-vector";
+
+const Row = Schema.Struct({
+  amount: Schema.BigInt,
+  payload: Schema.Unknown,
+  price: Schema.BigDecimal,
+});
+
+describe("column-live-view-engine topic column vector", () => {
+  it("supports lifecycle operations for generic, bigint, and BigDecimal columns", () => {
+    const metadata = rawQueryCompilerMetadata(Row);
+    const payload = createTopicColumnValues("payload", metadata);
+    const amount = createTopicColumnValues("amount", metadata);
+    const price = createTopicColumnValues("price", metadata);
+    const decimal = fromStringUnsafe("12.50");
+
+    payload.reserve(3);
+    payload.set(0, { id: "first" });
+    payload.set(1, { id: "second" });
+    payload.copySlot(0, 1);
+    payload.pop();
+
+    amount.reserve(3);
+    amount.set(0, 10n);
+    amount.set(1, "not-bigint");
+    amount.copySlot(1, 0);
+    amount.pop();
+
+    price.reserve(3);
+    price.set(0, decimal);
+    price.set(1, "not-decimal");
+    price.copySlot(1, 0);
+    price.pop();
+
+    expect({
+      amount: {
+        key: columnScalarEqualityKey(amount, 0),
+        length: amount.length,
+        value: columnValue(amount, 0),
+      },
+      payload: {
+        key: columnScalarEqualityKey(payload, 0),
+        length: payload.length,
+        value: columnValue(payload, 0),
+      },
+      price: {
+        key: columnScalarEqualityKey(price, 0),
+        length: price.length,
+        value: columnValue(price, 0),
+      },
+    }).toStrictEqual({
+      amount: {
+        key: "bigint:10",
+        length: 1,
+        value: 10n,
+      },
+      payload: {
+        key: undefined,
+        length: 1,
+        value: { id: "second" },
+      },
+      price: {
+        key: "bigDecimal:12.5",
+        length: 1,
+        value: decimal,
+      },
+    });
+  });
+});

--- a/packages/column-live-view-engine/src/topic-row-storage-lifecycle.test.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage-lifecycle.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "@effect/vitest";
+import type { TopicRowEntry } from "./row-scan";
+import { deleteCompactingTopicRowSlot } from "./topic-row-storage-lifecycle";
+
+type Row = {
+  readonly id: string;
+};
+
+type TestColumn = {
+  readonly values: Array<string>;
+  copySlot(targetSlot: number, sourceSlot: number): void;
+  pop(): void;
+};
+
+const row = (id: string): Row => ({ id });
+
+const entries = (...ids: ReadonlyArray<string>): Array<TopicRowEntry<Row>> =>
+  ids.map((id) => ({
+    key: id,
+    row: row(id),
+  }));
+
+const keySlots = (...ids: ReadonlyArray<string>): Map<string, number> =>
+  new Map(ids.map((id, slot) => [id, slot]));
+
+const testColumn = (
+  values: ReadonlyArray<string>,
+  events: Array<string>,
+  name: string,
+): TestColumn => ({
+  values: [...values],
+  copySlot(targetSlot, sourceSlot) {
+    events.push(`${name}:copy:${targetSlot}:${sourceSlot}`);
+    this.values[targetSlot] = this.values[sourceSlot]!;
+  },
+  pop() {
+    events.push(`${name}:pop`);
+    this.values.pop();
+  },
+});
+
+const testColumnMap = (...columns: ReadonlyArray<TestColumn>): Map<string, TestColumn> =>
+  new Map(columns.map((column, index) => [`column-${index}`, column]));
+
+describe("column-live-view-engine topic row storage lifecycle", () => {
+  it("keeps storage unchanged for unknown delete keys", () => {
+    const events: Array<string> = [];
+    const slots = entries("a", "b");
+    const keyToSlot = keySlots("a", "b");
+    const column = testColumn(["A", "B"], events, "column");
+
+    expect(
+      deleteCompactingTopicRowSlot(
+        {
+          addSlotToScalarIndexes: (slot) => events.push(`addScalar:${slot}`),
+          columns: () => testColumnMap(column).values(),
+          insertSlotIntoOrderedIndexes: (slot) => events.push(`insertOrdered:${slot}`),
+          keyToSlot,
+          removeSlotFromOrderedIndexes: (slot) => events.push(`removeOrdered:${slot}`),
+          removeSlotFromScalarIndexes: (slot) => events.push(`removeScalar:${slot}`),
+          slots,
+        },
+        "missing",
+      ),
+    ).toBeUndefined();
+
+    expect({
+      columnValues: column.values,
+      events,
+      keyToSlot,
+      slots,
+    }).toStrictEqual({
+      columnValues: ["A", "B"],
+      events: [],
+      keyToSlot: keySlots("a", "b"),
+      slots: entries("a", "b"),
+    });
+  });
+
+  it("deletes the last row without moving another slot", () => {
+    const events: Array<string> = [];
+    const slots = entries("a", "b");
+    const keyToSlot = keySlots("a", "b");
+    const column = testColumn(["A", "B"], events, "column");
+
+    expect(
+      deleteCompactingTopicRowSlot(
+        {
+          addSlotToScalarIndexes: (slot) => events.push(`addScalar:${slot}`),
+          columns: () => testColumnMap(column).values(),
+          insertSlotIntoOrderedIndexes: (slot) => events.push(`insertOrdered:${slot}`),
+          keyToSlot,
+          removeSlotFromOrderedIndexes: (slot) => events.push(`removeOrdered:${slot}`),
+          removeSlotFromScalarIndexes: (slot) => events.push(`removeScalar:${slot}`),
+          slots,
+        },
+        "b",
+      ),
+    ).toStrictEqual({
+      moved: undefined,
+      previous: row("b"),
+    });
+
+    expect({
+      columnValues: column.values,
+      events,
+      keyToSlot,
+      slots,
+    }).toStrictEqual({
+      columnValues: ["A"],
+      events: ["removeScalar:1", "removeOrdered:1", "column:pop"],
+      keyToSlot: keySlots("a"),
+      slots: entries("a"),
+    });
+  });
+
+  it("deletes a middle row by compacting the final slot and repairing indexes", () => {
+    const events: Array<string> = [];
+    const slots = entries("a", "b", "c");
+    const keyToSlot = keySlots("a", "b", "c");
+    const column = testColumn(["A", "B", "C"], events, "column");
+
+    expect(
+      deleteCompactingTopicRowSlot(
+        {
+          addSlotToScalarIndexes: (slot) => events.push(`addScalar:${slot}`),
+          columns: () => testColumnMap(column).values(),
+          insertSlotIntoOrderedIndexes: (slot) => events.push(`insertOrdered:${slot}`),
+          keyToSlot,
+          removeSlotFromOrderedIndexes: (slot) => events.push(`removeOrdered:${slot}`),
+          removeSlotFromScalarIndexes: (slot) => events.push(`removeScalar:${slot}`),
+          slots,
+        },
+        "b",
+      ),
+    ).toStrictEqual({
+      moved: {
+        fromSlot: 2,
+        key: "c",
+        toSlot: 1,
+      },
+      previous: row("b"),
+    });
+
+    expect({
+      columnValues: column.values,
+      events,
+      keyToSlot,
+      slots,
+    }).toStrictEqual({
+      columnValues: ["A", "C"],
+      events: [
+        "removeScalar:1",
+        "removeOrdered:1",
+        "removeScalar:2",
+        "removeOrdered:2",
+        "column:copy:1:2",
+        "addScalar:1",
+        "insertOrdered:1",
+        "column:pop",
+      ],
+      keyToSlot: keySlots("a", "c"),
+      slots: entries("a", "c"),
+    });
+  });
+});

--- a/packages/column-live-view-engine/src/topic-row-storage-lifecycle.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage-lifecycle.ts
@@ -1,0 +1,79 @@
+import type { TopicRowEntry } from "./row-scan";
+
+type RowObject = object;
+
+export type TopicRowStorageLifecycleColumn = {
+  copySlot(targetSlot: number, sourceSlot: number): void;
+  pop(): void;
+};
+
+export type TopicRowStorageLifecycle<Row extends RowObject> = {
+  readonly addSlotToScalarIndexes: (slot: number) => void;
+  readonly columns: () => Iterable<TopicRowStorageLifecycleColumn>;
+  readonly insertSlotIntoOrderedIndexes: (slot: number) => void;
+  readonly keyToSlot: Map<string, number>;
+  readonly removeSlotFromOrderedIndexes: (slot: number) => void;
+  readonly removeSlotFromScalarIndexes: (slot: number) => void;
+  readonly slots: Array<TopicRowEntry<Row>>;
+};
+
+export type CompactingTopicRowDelete<Row extends RowObject> = {
+  readonly moved:
+    | {
+        readonly fromSlot: number;
+        readonly key: string;
+        readonly toSlot: number;
+      }
+    | undefined;
+  readonly previous: Row;
+};
+
+export const deleteCompactingTopicRowSlot = <Row extends RowObject>(
+  lifecycle: TopicRowStorageLifecycle<Row>,
+  key: string,
+): CompactingTopicRowDelete<Row> | undefined => {
+  const slot = lifecycle.keyToSlot.get(key);
+  if (slot === undefined) {
+    return undefined;
+  }
+
+  const lastSlot = lifecycle.slots.length - 1;
+  const lastEntry = lifecycle.slots[lastSlot]!;
+  const previous = lifecycle.slots[slot]!.row;
+  lifecycle.removeSlotFromScalarIndexes(slot);
+  lifecycle.removeSlotFromOrderedIndexes(slot);
+  lifecycle.keyToSlot.delete(key);
+
+  if (slot === lastSlot) {
+    lifecycle.slots.pop();
+    for (const column of lifecycle.columns()) {
+      column.pop();
+    }
+    return {
+      moved: undefined,
+      previous,
+    };
+  }
+
+  lifecycle.removeSlotFromScalarIndexes(lastSlot);
+  lifecycle.removeSlotFromOrderedIndexes(lastSlot);
+  lifecycle.slots[slot] = lastEntry;
+  lifecycle.keyToSlot.set(lastEntry.key, slot);
+  for (const column of lifecycle.columns()) {
+    column.copySlot(slot, lastSlot);
+  }
+  lifecycle.addSlotToScalarIndexes(slot);
+  lifecycle.insertSlotIntoOrderedIndexes(slot);
+  lifecycle.slots.pop();
+  for (const column of lifecycle.columns()) {
+    column.pop();
+  }
+  return {
+    moved: {
+      fromSlot: lastSlot,
+      key: lastEntry.key,
+      toSlot: slot,
+    },
+    previous,
+  };
+};

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -31,6 +31,7 @@ import {
   TopicRowChangeJournal,
   type TopicRowChangeJournalLimits,
 } from "./topic-row-change-journal";
+import { deleteCompactingTopicRowSlot } from "./topic-row-storage-lifecycle";
 import {
   prepareDecodedTopicRow,
   prepareDecodedTopicRowWithStorageKey,
@@ -233,35 +234,25 @@ export class TopicRowStorage {
   }
 
   delete(key: string): number {
-    const slot = this.keyToSlot.get(key);
-    if (slot === undefined) {
+    const deletion = deleteCompactingTopicRowSlot(
+      {
+        addSlotToScalarIndexes: (slot) => this.addSlotToScalarIndexes(slot),
+        columns: () => this.columns.values(),
+        insertSlotIntoOrderedIndexes: (slot) => this.insertSlotIntoOrderedIndexes(slot),
+        keyToSlot: this.keyToSlot,
+        removeSlotFromOrderedIndexes: (slot) => this.removeSlotFromOrderedIndexes(slot),
+        removeSlotFromScalarIndexes: (slot) => this.removeSlotFromScalarIndexes(slot),
+        slots: this.slots,
+      },
+      key,
+    );
+    if (deletion === undefined) {
       return 0;
     }
 
-    const lastSlot = this.slots.length - 1;
-    const lastEntry = this.slots[lastSlot]!;
-    const previous = this.slots[slot]!.row;
-    this.removeSlotFromScalarIndexes(slot);
-    this.removeSlotFromOrderedIndexes(slot);
-    this.keyToSlot.delete(key);
-    if (slot !== lastSlot) {
-      this.removeSlotFromScalarIndexes(lastSlot);
-      this.removeSlotFromOrderedIndexes(lastSlot);
-      this.slots[slot] = lastEntry;
-      this.keyToSlot.set(lastEntry.key, slot);
-      for (const column of this.columns.values()) {
-        column.copySlot(slot, lastSlot);
-      }
-      this.addSlotToScalarIndexes(slot);
-      this.insertSlotIntoOrderedIndexes(slot);
-    }
-    this.slots.pop();
-    for (const column of this.columns.values()) {
-      column.pop();
-    }
     this.recordRowChange({
       key,
-      previous,
+      previous: deletion.previous,
       next: undefined,
     });
     return 1;


### PR DESCRIPTION
## Summary
- Extract compacting row-delete slot lifecycle into a focused topic row storage lifecycle module.
- Keep TopicRowStorage as the source of truth while delegating key/slot/column/index compaction policy.
- Add lifecycle regression tests, including production-like Map.values() iterator behavior, plus column vector lifecycle coverage.

## Review Loop
- Three local reviewer agents checked the scoped diff.
- They found a P1 one-shot iterator bug in the first version.
- Fixed by making lifecycle columns a supplier, reran reviewers, and all three reported no findings.

## Validation
- vp run column-live-view-engine#test
- vp check --fix
- vp run -w ready
