### PR TITLE
Deepen source ownership policy

### DIFF
--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -30,10 +30,20 @@ import type {
 import { makeRuntimeCoreClient } from "./runtime-client";
 import type { ViewServerRuntimeCoreInternalClient } from "./runtime-client";
 import type { ViewServerRuntimeCoreInstance } from "./index";
-export { makeSourceOwnershipPolicy } from "./source-ownership-policy";
+export {
+  collectSourceOwnershipConflicts,
+  makeSourceOwnershipPolicy,
+} from "./source-ownership-policy";
 export type {
   SourceOwnershipAccessProfile,
+  SourceOwnershipConflict,
+  SourceOwnershipDecision,
+  SourceOwnershipGrpcLifecycle,
+  SourceOwnershipGrpcOptions,
+  SourceOwnershipKafkaOptions,
+  SourceOwnershipOwner,
   SourceOwnershipPolicy,
+  SourceOwnershipTopic,
 } from "./source-ownership-policy";
 
 export type { ViewServerRuntimeCoreInternalLiveClient } from "./live-client";

--- a/packages/runtime-core/src/source-ownership-policy.test.ts
+++ b/packages/runtime-core/src/source-ownership-policy.test.ts
@@ -6,7 +6,10 @@ import {
 } from "@effect-view-server/config";
 import { grpcSourceMarkers } from "@effect-view-server/config/internal";
 import { Effect, Schema } from "effect";
-import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
+import {
+  collectSourceOwnershipConflicts,
+  makeSourceOwnershipPolicy,
+} from "./source-ownership-policy";
 
 const Row = Schema.Struct({
   id: Schema.String,
@@ -106,18 +109,56 @@ describe("SourceOwnershipPolicy", () => {
   it("classifies source-owned and leased topics behind one Interface", () => {
     const policy = makeSourceOwnershipPolicy(sourceOwnedViewServer);
 
+    expect([...policy.topics]).toStrictEqual([
+      [
+        "externalOrders",
+        {
+          grpcLeased: false,
+          owners: [],
+          sourceOwned: false,
+          topic: "externalOrders",
+        },
+      ],
+      [
+        "kafkaOrders",
+        {
+          grpcLeased: false,
+          owners: [{ _tag: "kafka" }],
+          sourceOwned: true,
+          topic: "kafkaOrders",
+        },
+      ],
+      [
+        "leasedOrders",
+        {
+          grpcLeased: true,
+          owners: [{ _tag: "grpc", lifecycle: "leased" }],
+          sourceOwned: true,
+          topic: "leasedOrders",
+        },
+      ],
+      [
+        "materializedOrders",
+        {
+          grpcLeased: false,
+          owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+          sourceOwned: true,
+          topic: "materializedOrders",
+        },
+      ],
+    ]);
     expect([...policy.sourceOwnedTopics]).toStrictEqual([
       "kafkaOrders",
       "leasedOrders",
       "materializedOrders",
     ]);
     expect([...policy.grpcLeasedTopics]).toStrictEqual(["leasedOrders"]);
-    expect(policy.hasSourceOwnedTopics).toBe(true);
-    expect(policy.isSourceOwnedTopic("externalOrders")).toBe(false);
-    expect(policy.isSourceOwnedTopic("kafkaOrders")).toBe(true);
-    expect(policy.isSourceOwnedTopic("materializedOrders")).toBe(true);
-    expect(policy.isGrpcLeasedTopic("leasedOrders")).toBe(true);
-    expect(policy.isGrpcLeasedTopic("kafkaOrders")).toBe(false);
+    expect(policy.hasSourceOwnedTopics).toStrictEqual(true);
+    expect(policy.isSourceOwnedTopic("externalOrders")).toStrictEqual(false);
+    expect(policy.isSourceOwnedTopic("kafkaOrders")).toStrictEqual(true);
+    expect(policy.isSourceOwnedTopic("materializedOrders")).toStrictEqual(true);
+    expect(policy.isGrpcLeasedTopic("leasedOrders")).toStrictEqual(true);
+    expect(policy.isGrpcLeasedTopic("kafkaOrders")).toStrictEqual(false);
   });
 
   it.effect("allows direct public mutations, reads, and reset for source-free topics", () =>
@@ -130,7 +171,7 @@ describe("SourceOwnershipPolicy", () => {
 
       expect([...policy.sourceOwnedTopics]).toStrictEqual([]);
       expect([...policy.grpcLeasedTopics]).toStrictEqual([]);
-      expect(policy.hasSourceOwnedTopics).toBe(false);
+      expect(policy.hasSourceOwnedTopics).toStrictEqual(false);
     }),
   );
 
@@ -160,6 +201,17 @@ describe("SourceOwnershipPolicy", () => {
         );
         expect(leasedMutationError).toStrictEqual(sourceOwnedMutationError("leasedOrders"));
         expect(resetError).toStrictEqual(sourceOwnedResetError);
+        expect(policy.publicMutationDecision("kafkaOrders", "runtimeCore")).toStrictEqual({
+          _tag: "rejected",
+          error: sourceOwnedMutationError("kafkaOrders"),
+        });
+        expect(policy.publicReadDecision("kafkaOrders", "runtimeCore")).toStrictEqual({
+          _tag: "allowed",
+        });
+        expect(policy.publicResetDecision("runtimeCore")).toStrictEqual({
+          _tag: "rejected",
+          error: sourceOwnedResetError,
+        });
       }),
   );
 
@@ -184,6 +236,134 @@ describe("SourceOwnershipPolicy", () => {
       expect(managedReadError).toStrictEqual(managedRuntimeLeasedAccessError("leasedOrders"));
       expect(managedMutationError).toStrictEqual(managedRuntimeLeasedAccessError("leasedOrders"));
       expect(managedResetError).toStrictEqual(managedRuntimeLeasedResetError);
+      expect(policy.publicReadDecision("leasedOrders", "managedRuntime")).toStrictEqual({
+        _tag: "rejected",
+        error: managedRuntimeLeasedAccessError("leasedOrders"),
+      });
+      expect(policy.publicMutationDecision("leasedOrders", "managedRuntime")).toStrictEqual({
+        _tag: "rejected",
+        error: managedRuntimeLeasedAccessError("leasedOrders"),
+      });
+      expect(policy.publicResetDecision("managedRuntime")).toStrictEqual({
+        _tag: "rejected",
+        error: managedRuntimeLeasedResetError,
+      });
     }),
   );
+
+  it("classifies malformed and conflicting source declarations without caller reflection", () => {
+    const malformedViewServer = defineViewServerConfig({
+      kafka: {
+        usa: "localhost:9092",
+      },
+      topics: {
+        malformedGrpcOrders: {
+          schema: Row,
+          key: "id",
+        },
+        primitiveGrpcOrders: {
+          schema: Row,
+          key: "id",
+        },
+        multiOwnedOrders: {
+          schema: Row,
+          key: "id",
+          kafkaSource: kafka.source({
+            topic: "multi-owned-orders-source",
+            regions: ["usa"],
+            value: kafka.json(Row),
+            key: kafka.stringKey(),
+            rowKey: ({ key }) => key,
+            map: ({ value }) => ({
+              price: value.price,
+              region: value.region,
+              status: value.status,
+            }),
+          }),
+        },
+      },
+    });
+    Object.defineProperty(malformedViewServer.topics.malformedGrpcOrders, "grpcSource", {
+      value: { kind: "grpc", lifecycle: "wat" },
+    });
+    Object.defineProperty(malformedViewServer.topics.primitiveGrpcOrders, "grpcSource", {
+      value: "not-a-grpc-source",
+    });
+    Object.defineProperty(malformedViewServer.topics.multiOwnedOrders, "grpcSource", {
+      value: grpcSourceMarkers.materialized(),
+    });
+
+    expect([...makeSourceOwnershipPolicy(malformedViewServer).topics]).toStrictEqual([
+      [
+        "malformedGrpcOrders",
+        {
+          grpcLeased: false,
+          owners: [{ _tag: "grpc", lifecycle: "unknown" }],
+          sourceOwned: true,
+          topic: "malformedGrpcOrders",
+        },
+      ],
+      [
+        "multiOwnedOrders",
+        {
+          grpcLeased: false,
+          owners: [{ _tag: "kafka" }, { _tag: "grpc", lifecycle: "materialized" }],
+          sourceOwned: true,
+          topic: "multiOwnedOrders",
+        },
+      ],
+      [
+        "primitiveGrpcOrders",
+        {
+          grpcLeased: false,
+          owners: [{ _tag: "grpc", lifecycle: "unknown" }],
+          sourceOwned: true,
+          topic: "primitiveGrpcOrders",
+        },
+      ],
+    ]);
+  });
+
+  it("collects resolved source owner conflicts without runtime-specific errors", () => {
+    expect(
+      collectSourceOwnershipConflicts(
+        {
+          topics: {
+            "orders-source": {
+              viewServerTopic: "orders",
+            },
+            "positions-source": {
+              viewServerTopic: "positions",
+            },
+            "trades-source": {
+              viewServerTopic: "trades",
+            },
+          },
+        },
+        {
+          feeds: {
+            ordersFeed: {
+              topic: "orders",
+            },
+            positionsFeed: {
+              topic: "positions",
+            },
+          },
+        },
+      ),
+    ).toStrictEqual([
+      {
+        grpcFeed: "ordersFeed",
+        kafkaSource: "orders-source",
+        topic: "orders",
+      },
+      {
+        grpcFeed: "positionsFeed",
+        kafkaSource: "positions-source",
+        topic: "positions",
+      },
+    ]);
+    expect(collectSourceOwnershipConflicts(undefined, { feeds: {} })).toStrictEqual([]);
+    expect(collectSourceOwnershipConflicts({ topics: {} }, undefined)).toStrictEqual([]);
+  });
 });

--- a/packages/runtime-core/src/source-ownership-policy.ts
+++ b/packages/runtime-core/src/source-ownership-policy.ts
@@ -10,6 +10,45 @@ import {
 } from "./runtime-error";
 
 export type SourceOwnershipAccessProfile = "managedRuntime" | "runtimeCore";
+export type SourceOwnershipGrpcLifecycle = "leased" | "materialized" | "unknown";
+export type SourceOwnershipOwner =
+  | {
+      readonly _tag: "kafka";
+    }
+  | {
+      readonly _tag: "grpc";
+      readonly lifecycle: SourceOwnershipGrpcLifecycle;
+    };
+
+export type SourceOwnershipTopic = {
+  readonly grpcLeased: boolean;
+  readonly owners: ReadonlyArray<SourceOwnershipOwner>;
+  readonly sourceOwned: boolean;
+  readonly topic: string;
+};
+
+export type SourceOwnershipDecision =
+  | {
+      readonly _tag: "allowed";
+    }
+  | {
+      readonly _tag: "rejected";
+      readonly error: ViewServerRuntimeError;
+    };
+
+export type SourceOwnershipConflict = {
+  readonly grpcFeed: string;
+  readonly kafkaSource: string;
+  readonly topic: string;
+};
+
+export type SourceOwnershipKafkaOptions = {
+  readonly topics: Readonly<Record<string, { readonly viewServerTopic: string }>>;
+};
+
+export type SourceOwnershipGrpcOptions = {
+  readonly feeds: Readonly<Record<string, { readonly topic: string }>>;
+};
 
 const hasDefinedOwnProperty = (value: object, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key) && Reflect.get(value, key) !== undefined;
@@ -21,15 +60,55 @@ const topicGrpcSource = (definition: object): unknown => {
   return undefined;
 };
 
-const isGrpcLeasedSource = (source: unknown): boolean =>
-  typeof source === "object" &&
-  source !== null &&
-  Reflect.get(source, "kind") === "grpc" &&
-  Reflect.get(source, "lifecycle") === "leased";
+const grpcLifecycle = (source: unknown): SourceOwnershipGrpcLifecycle => {
+  if (typeof source !== "object" || source === null || Reflect.get(source, "kind") !== "grpc") {
+    return "unknown";
+  }
+  const lifecycle = Reflect.get(source, "lifecycle");
+  if (lifecycle === "leased" || lifecycle === "materialized") {
+    return lifecycle;
+  }
+  return "unknown";
+};
+
+const topicOwners = (definition: object): ReadonlyArray<SourceOwnershipOwner> => {
+  const owners: Array<SourceOwnershipOwner> = [];
+  if (hasDefinedOwnProperty(definition, "kafkaSource")) {
+    owners.push({ _tag: "kafka" });
+  }
+  const grpcSource = topicGrpcSource(definition);
+  if (grpcSource !== undefined) {
+    owners.push({
+      _tag: "grpc",
+      lifecycle: grpcLifecycle(grpcSource),
+    });
+  }
+  return owners;
+};
+
+const topicOwnership = (topic: string, definition: object): SourceOwnershipTopic => {
+  const owners = topicOwners(definition);
+  return {
+    grpcLeased: owners.some((owner) => owner._tag === "grpc" && owner.lifecycle === "leased"),
+    owners,
+    sourceOwned: owners.length > 0,
+    topic,
+  };
+};
 
 export type SourceOwnershipPolicy = {
   readonly grpcLeasedTopics: ReadonlySet<string>;
   readonly sourceOwnedTopics: ReadonlySet<string>;
+  readonly topics: ReadonlyMap<string, SourceOwnershipTopic>;
+  readonly publicMutationDecision: (
+    topic: string,
+    profile: SourceOwnershipAccessProfile,
+  ) => SourceOwnershipDecision;
+  readonly publicReadDecision: (
+    topic: string,
+    profile: SourceOwnershipAccessProfile,
+  ) => SourceOwnershipDecision;
+  readonly publicResetDecision: (profile: SourceOwnershipAccessProfile) => SourceOwnershipDecision;
   readonly requirePublicMutationAllowed: (
     topic: string,
     profile: SourceOwnershipAccessProfile,
@@ -54,51 +133,110 @@ const leasedRuntimeAccessErrorFor = (
     ? leasedManagedRuntimeAccessError(topic)
     : leasedRuntimeAccessError(topic);
 
+const allowedDecision: SourceOwnershipDecision = {
+  _tag: "allowed",
+};
+
+const rejectedDecision = (error: ViewServerRuntimeError): SourceOwnershipDecision => ({
+  _tag: "rejected",
+  error,
+});
+
+const decisionEffect = (
+  decision: SourceOwnershipDecision,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  decision._tag === "allowed" ? Effect.void : Effect.fail(decision.error);
+
 export const makeSourceOwnershipPolicy = <const Topics extends DecodableTopicDefinitions>(
   config: ViewServerTopicConfig<Topics>,
 ): SourceOwnershipPolicy => {
   const grpcLeasedTopics = new Set<string>();
   const sourceOwnedTopics = new Set<string>();
+  const topics = new Map<string, SourceOwnershipTopic>();
   for (const [topic, definition] of Object.entries(config.topics)) {
-    const grpcSource = topicGrpcSource(definition);
-    if (hasDefinedOwnProperty(definition, "kafkaSource") || grpcSource !== undefined) {
+    const ownership = topicOwnership(topic, definition);
+    topics.set(topic, ownership);
+    if (ownership.sourceOwned) {
       sourceOwnedTopics.add(topic);
     }
-    if (isGrpcLeasedSource(grpcSource)) {
+    if (ownership.grpcLeased) {
       grpcLeasedTopics.add(topic);
     }
   }
   const sortedGrpcLeasedTopics = new Set([...grpcLeasedTopics].sort());
   const sortedSourceOwnedTopics = new Set([...sourceOwnedTopics].sort());
+  const sortedTopics = new Map(
+    [...topics.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
+  const publicMutationDecision = (
+    topic: string,
+    profile: SourceOwnershipAccessProfile,
+  ): SourceOwnershipDecision => {
+    if (!sortedSourceOwnedTopics.has(topic)) {
+      return allowedDecision;
+    }
+    return rejectedDecision(
+      profile === "managedRuntime" && sortedGrpcLeasedTopics.has(topic)
+        ? leasedRuntimeAccessErrorFor(topic, profile)
+        : sourceOwnedRuntimeMutationError(topic),
+    );
+  };
+  const publicReadDecision = (
+    topic: string,
+    profile: SourceOwnershipAccessProfile,
+  ): SourceOwnershipDecision =>
+    sortedGrpcLeasedTopics.has(topic)
+      ? rejectedDecision(leasedRuntimeAccessErrorFor(topic, profile))
+      : allowedDecision;
+  const publicResetDecision = (profile: SourceOwnershipAccessProfile): SourceOwnershipDecision => {
+    if (sortedSourceOwnedTopics.size === 0) {
+      return allowedDecision;
+    }
+    return rejectedDecision(
+      profile === "managedRuntime" && sortedGrpcLeasedTopics.size > 0
+        ? leasedManagedRuntimeResetError
+        : sourceOwnedRuntimeResetError,
+    );
+  };
   return {
     grpcLeasedTopics: sortedGrpcLeasedTopics,
     sourceOwnedTopics: sortedSourceOwnedTopics,
-    requirePublicMutationAllowed: (topic, profile) => {
-      if (!sortedSourceOwnedTopics.has(topic)) {
-        return Effect.void;
-      }
-      return Effect.fail(
-        profile === "managedRuntime" && sortedGrpcLeasedTopics.has(topic)
-          ? leasedRuntimeAccessErrorFor(topic, profile)
-          : sourceOwnedRuntimeMutationError(topic),
-      );
-    },
+    topics: sortedTopics,
+    publicMutationDecision,
+    publicReadDecision,
+    publicResetDecision,
+    requirePublicMutationAllowed: (topic, profile) =>
+      decisionEffect(publicMutationDecision(topic, profile)),
     requirePublicReadAllowed: (topic, profile) =>
-      sortedGrpcLeasedTopics.has(topic)
-        ? Effect.fail(leasedRuntimeAccessErrorFor(topic, profile))
-        : Effect.void,
-    requirePublicResetAllowed: (profile) => {
-      if (sortedSourceOwnedTopics.size === 0) {
-        return Effect.void;
-      }
-      return Effect.fail(
-        profile === "managedRuntime" && sortedGrpcLeasedTopics.size > 0
-          ? leasedManagedRuntimeResetError
-          : sourceOwnedRuntimeResetError,
-      );
-    },
+      decisionEffect(publicReadDecision(topic, profile)),
+    requirePublicResetAllowed: (profile) => decisionEffect(publicResetDecision(profile)),
     isGrpcLeasedTopic: (topic) => sortedGrpcLeasedTopics.has(topic),
     isSourceOwnedTopic: (topic) => sortedSourceOwnedTopics.has(topic),
     hasSourceOwnedTopics: sortedSourceOwnedTopics.size > 0,
   };
+};
+
+export const collectSourceOwnershipConflicts = (
+  kafkaOptions: SourceOwnershipKafkaOptions | undefined,
+  grpcOptions: SourceOwnershipGrpcOptions | undefined,
+): ReadonlyArray<SourceOwnershipConflict> => {
+  if (kafkaOptions === undefined || grpcOptions === undefined) {
+    return [];
+  }
+  const grpcFeedByTopic = new Map<string, string>();
+  for (const [feedName, feed] of Object.entries(grpcOptions.feeds)) {
+    grpcFeedByTopic.set(feed.topic, feedName);
+  }
+  const conflicts: Array<SourceOwnershipConflict> = [];
+  for (const [sourceTopic, kafkaTopic] of Object.entries(kafkaOptions.topics)) {
+    const grpcFeedName = grpcFeedByTopic.get(kafkaTopic.viewServerTopic);
+    if (grpcFeedName !== undefined) {
+      conflicts.push({
+        grpcFeed: grpcFeedName,
+        kafkaSource: sourceTopic,
+        topic: kafkaTopic.viewServerTopic,
+      });
+    }
+  }
+  return conflicts;
 };

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -1,4 +1,9 @@
 import type { ViewServerRuntimeCoreOptionsFor } from "@effect-view-server/runtime-core";
+import {
+  collectSourceOwnershipConflicts,
+  type SourceOwnershipGrpcOptions,
+  type SourceOwnershipKafkaOptions,
+} from "@effect-view-server/runtime-core/internal";
 import type { ViewServerWebSocketServerOptions } from "@effect-view-server/server";
 import type {
   GrpcRuntimeClients,
@@ -649,14 +654,6 @@ const validatePublicGrpcRuntimeOptions = (
   return Effect.void;
 };
 
-type SourceOwnershipKafkaOptions = {
-  readonly topics: Readonly<Record<string, { readonly viewServerTopic: string }>>;
-};
-
-type SourceOwnershipGrpcOptions = {
-  readonly feeds: Readonly<Record<string, { readonly topic: string }>>;
-};
-
 export const validateSourceOwnership: (
   kafkaOptions: SourceOwnershipKafkaOptions | undefined,
   grpcOptions: SourceOwnershipGrpcOptions | undefined,
@@ -666,23 +663,14 @@ export const validateSourceOwnership: (
   kafkaOptions: SourceOwnershipKafkaOptions | undefined,
   grpcOptions: SourceOwnershipGrpcOptions | undefined,
 ) {
-  if (kafkaOptions === undefined || grpcOptions === undefined) {
-    return;
-  }
-  const grpcFeedByTopic = new Map<string, string>();
-  for (const [feedName, feed] of Object.entries(grpcOptions.feeds)) {
-    grpcFeedByTopic.set(feed.topic, feedName);
-  }
-  for (const [sourceTopic, kafkaTopic] of Object.entries(kafkaOptions.topics)) {
-    const grpcFeedName = grpcFeedByTopic.get(kafkaTopic.viewServerTopic);
-    if (grpcFeedName !== undefined) {
-      return yield* new ViewServerGrpcIngressError({
-        message: `View Server topic ${kafkaTopic.viewServerTopic} cannot be owned by both Kafka source ${sourceTopic} and gRPC feed ${grpcFeedName}.`,
-        cause: kafkaTopic.viewServerTopic,
-        feedName: grpcFeedName,
-        topic: kafkaTopic.viewServerTopic,
-      });
-    }
+  const conflict = collectSourceOwnershipConflicts(kafkaOptions, grpcOptions)[0];
+  if (conflict !== undefined) {
+    return yield* new ViewServerGrpcIngressError({
+      message: `View Server topic ${conflict.topic} cannot be owned by both Kafka source ${conflict.kafkaSource} and gRPC feed ${conflict.grpcFeed}.`,
+      cause: conflict.topic,
+      feedName: conflict.grpcFeed,
+      topic: conflict.topic,
+    });
   }
 });
 


### PR DESCRIPTION
Summary:
- Centralize source owner classification in SourceOwnershipPolicy, including Kafka/gRPC owners, gRPC lifecycle metadata, and immutable topic ownership snapshots.
- Add public mutation/read/reset decision helpers and keep the existing Effect-based require helpers as wrappers.
- Move resolved Kafka/gRPC source conflict collection into runtime-core while preserving runtime-specific ViewServerGrpcIngressError construction.
- Expand policy tests for ownership maps, decision objects, malformed sources, multi-owner topics, and multi-conflict ordering.

Validation:
- vp check --fix
- vp run runtime-core#test
- vp run runtime#test
- vp run -w ready

Review loop:
- 3 reviewer agents completed first pass with no blockers.
- Added toStrictEqual style cleanup and multi-conflict ordering coverage.
- 3 reviewer agents completed second pass with no findings.