### PR TITLE
Extract runtime contract test harnesses

### DIFF
--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -11,7 +11,6 @@ import {
   kafka,
   type GrpcRuntimeClients,
   type RowSchema,
-  type TransportHealth,
   type ViewServerHealth,
   type ViewServerRuntimeClient,
   type ViewServerRuntimeError,
@@ -71,6 +70,22 @@ import {
   type ResolvedViewServerGrpcRuntimeOptions,
   type ResolvedViewServerKafkaRuntimeOptions,
 } from "./runtime-options";
+import {
+  closeTestTcpServer,
+  connectTcpPublishSocket,
+  fetchHealth,
+  fetchJson,
+  fetchText,
+  nullRecord,
+  readTcpPublishResponse,
+  readTcpPublishResponses,
+  reserveTcpPort,
+  RuntimeTcpTestFailure,
+  RuntimeTestFailure,
+  sendTcpPublishCommand,
+  sendTcpPublishLine,
+  waitForTransportHealth,
+} from "../test-harness/runtime";
 import { makeViewServerRuntimeTransportHealth } from "./transport-health";
 import * as Net from "node:net";
 
@@ -84,77 +99,12 @@ const Trade = Schema.Struct({
   symbol: Schema.String,
 });
 
-const HealthJson = Schema.Struct({
-  status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
-  engine: Schema.Struct({
-    topics: Schema.Struct({
-      orders: Schema.Struct({
-        rowCount: Schema.Number,
-      }),
-    }),
-  }),
-});
-
-class RuntimeHealthJsonParseError extends Schema.TaggedErrorClass<RuntimeHealthJsonParseError>()(
-  "RuntimeHealthJsonParseError",
-  {
-    cause: Schema.Unknown,
-  },
-) {}
-
-class RuntimeJsonParseError extends Schema.TaggedErrorClass<RuntimeJsonParseError>()(
-  "RuntimeJsonParseError",
-  {
-    cause: Schema.Unknown,
-  },
-) {}
-
-class RuntimeTestFailure extends Schema.TaggedErrorClass<RuntimeTestFailure>()(
-  "RuntimeTestFailure",
-  {
-    message: Schema.String,
-  },
-) {}
-
-class RuntimeTcpTestFailure extends Schema.TaggedErrorClass<RuntimeTcpTestFailure>()(
-  "RuntimeTcpTestFailure",
-  {
-    cause: Schema.Unknown,
-    message: Schema.String,
-  },
-) {}
-
 const defineGrpcFeed =
   <const Config extends { readonly topics: Record<string, { readonly schema: RowSchema }> }>(
     _config: Config,
   ) =>
   <const Clients extends GrpcRuntimeClients>() =>
     defineGrpcFeedInternal<Config["topics"], Clients>();
-
-const TcpPublishResponse = Schema.Union([
-  Schema.Struct({
-    ok: Schema.Literal(true),
-  }),
-  Schema.Struct({
-    ok: Schema.Literal(false),
-    error: Schema.Struct({
-      _tag: Schema.String,
-      code: Schema.optional(Schema.String),
-      message: Schema.String,
-      phase: Schema.optional(Schema.String),
-      status: Schema.optional(Schema.Number),
-      topic: Schema.optional(Schema.String),
-    }),
-  }),
-]);
-
-type TcpPublishResponse = typeof TcpPublishResponse.Type;
-
-const TestTcpAddress = Schema.Struct({
-  address: Schema.String,
-  family: Schema.String,
-  port: Schema.Number,
-});
 
 const viewServer = defineViewServerConfig({
   topics: {
@@ -812,245 +762,6 @@ const bearerAuth = {
           }),
         ),
 };
-
-const nullRecord = <Value>(
-  entries: ReadonlyArray<readonly [string, Value]>,
-): Record<string, Value> => {
-  const record: Record<string, Value> = Object.create(null);
-  for (const [key, value] of entries) {
-    record[key] = value;
-  }
-  return record;
-};
-
-const fetchHealth = Effect.fn("ViewServerRuntime.test.health.fetch")(function* (url: string) {
-  const response = yield* Effect.promise(() => fetch(url));
-  const text = yield* Effect.promise(() => response.text());
-  const value = yield* Effect.try({
-    try: (): unknown => JSON.parse(text),
-    catch: (cause) => new RuntimeHealthJsonParseError({ cause }),
-  });
-  const health = yield* Schema.decodeUnknownEffect(HealthJson)(value);
-  return { response, health };
-});
-
-const fetchText = Effect.fn("ViewServerRuntime.test.text.fetch")(function* (url: string) {
-  const response = yield* Effect.promise(() => fetch(url));
-  const text = yield* Effect.promise(() => response.text());
-  return { response, text };
-});
-
-const fetchJson = Effect.fn("ViewServerRuntime.test.json.fetch")(function* (url: string) {
-  const response = yield* Effect.promise(() => fetch(url));
-  const text = yield* Effect.promise(() => response.text());
-  const value = yield* Effect.try({
-    try: (): unknown => JSON.parse(text),
-    catch: (cause) => new RuntimeJsonParseError({ cause }),
-  });
-  return { response, value };
-});
-
-const tcpUrlConnectHost = (hostname: string): string =>
-  hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-
-const connectTcpPublishSocket = Effect.fn("ViewServerRuntime.test.tcp.connect")(function* (
-  url: string,
-) {
-  const parsedUrl = new URL(url);
-  const port = Number(parsedUrl.port);
-  if (!Number.isSafeInteger(port)) {
-    return yield* new RuntimeTcpTestFailure({
-      message: "TCP publish URL did not include a valid port.",
-      cause: url,
-    });
-  }
-  return yield* Effect.callback<Net.Socket, RuntimeTcpTestFailure>((resume) => {
-    const socket = Net.createConnection({
-      host: tcpUrlConnectHost(parsedUrl.hostname),
-      port,
-    });
-    socket.setEncoding("utf8");
-    socket.once("connect", () => {
-      resume(Effect.succeed(socket));
-    });
-    socket.once("error", (cause) => {
-      resume(
-        Effect.fail(
-          new RuntimeTcpTestFailure({
-            message: "TCP publish socket failed to connect.",
-            cause,
-          }),
-        ),
-      );
-    });
-  });
-});
-
-const readTcpPublishResponse = Effect.fn("ViewServerRuntime.test.tcp.response.read")(function* (
-  socket: Net.Socket,
-) {
-  const line = yield* Effect.callback<string, RuntimeTcpTestFailure>((resume) => {
-    let buffer = "";
-    socket.on("data", (chunk: string) => {
-      buffer += chunk;
-      const newlineIndex = buffer.indexOf("\n");
-      if (newlineIndex >= 0) {
-        resume(Effect.succeed(buffer.slice(0, newlineIndex)));
-      }
-    });
-    socket.once("error", (cause) => {
-      resume(
-        Effect.fail(
-          new RuntimeTcpTestFailure({
-            message: "TCP publish socket failed while reading response.",
-            cause,
-          }),
-        ),
-      );
-    });
-  });
-  const value = yield* Effect.try({
-    try: (): unknown => JSON.parse(line),
-    catch: (cause) =>
-      new RuntimeTcpTestFailure({
-        message: "TCP publish response was not valid JSON.",
-        cause,
-      }),
-  });
-  return yield* Schema.decodeUnknownEffect(TcpPublishResponse)(value).pipe(
-    Effect.mapError(
-      (cause) =>
-        new RuntimeTcpTestFailure({
-          message: "TCP publish response did not match the test schema.",
-          cause,
-        }),
-    ),
-  );
-});
-
-const readTcpPublishResponses = Effect.fn("ViewServerRuntime.test.tcp.responses.read")(function* (
-  socket: Net.Socket,
-  count: number,
-) {
-  const lines = yield* Effect.callback<ReadonlyArray<string>, RuntimeTcpTestFailure>((resume) => {
-    let buffer = "";
-    const responses: Array<string> = [];
-    socket.on("data", (chunk: string) => {
-      buffer += chunk;
-      let newlineIndex = buffer.indexOf("\n");
-      while (newlineIndex >= 0) {
-        responses.push(buffer.slice(0, newlineIndex));
-        buffer = buffer.slice(newlineIndex + 1);
-        newlineIndex = buffer.indexOf("\n");
-      }
-      if (responses.length === count) {
-        resume(Effect.succeed(responses));
-      }
-    });
-    socket.once("error", (cause) => {
-      resume(
-        Effect.fail(
-          new RuntimeTcpTestFailure({
-            message: "TCP publish socket failed while reading responses.",
-            cause,
-          }),
-        ),
-      );
-    });
-  });
-  return yield* Effect.forEach(lines, (line) =>
-    Effect.try({
-      try: (): unknown => JSON.parse(line),
-      catch: (cause) =>
-        new RuntimeTcpTestFailure({
-          message: "TCP publish response was not valid JSON.",
-          cause,
-        }),
-    }).pipe(
-      Effect.flatMap((value) => Schema.decodeUnknownEffect(TcpPublishResponse)(value)),
-      Effect.mapError(
-        (cause) =>
-          new RuntimeTcpTestFailure({
-            message: "TCP publish response did not match the test schema.",
-            cause,
-          }),
-      ),
-    ),
-  );
-});
-
-const sendTcpPublishLine = Effect.fn("ViewServerRuntime.test.tcp.line.send")(function* (
-  url: string,
-  line: string,
-) {
-  const socket = yield* Effect.acquireRelease(connectTcpPublishSocket(url), (socket) =>
-    Effect.sync(() => socket.destroy()),
-  );
-  socket.write(`${line}\n`);
-  return yield* readTcpPublishResponse(socket).pipe(Effect.timeout("1 second"));
-});
-
-const sendTcpPublishCommand = Effect.fn("ViewServerRuntime.test.tcp.command.send")(function* (
-  url: string,
-  command: object,
-) {
-  return yield* sendTcpPublishLine(url, JSON.stringify(command));
-});
-
-const closeTestTcpServer = (server: Net.Server): Effect.Effect<void> =>
-  Effect.promise(
-    () =>
-      new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      }),
-  );
-
-const reserveTcpPort = Effect.fn("ViewServerRuntime.test.tcp.port.reserve")(function* () {
-  const server = yield* Effect.callback<Net.Server, RuntimeTcpTestFailure>((resume) => {
-    const nextServer = Net.createServer();
-    nextServer.once("error", (cause) => {
-      resume(
-        Effect.fail(
-          new RuntimeTcpTestFailure({
-            message: "Test TCP server failed to reserve a port.",
-            cause,
-          }),
-        ),
-      );
-    });
-    nextServer.listen({ host: "127.0.0.1", port: 0 }, () => {
-      resume(Effect.succeed(nextServer));
-    });
-  });
-  const address = yield* Schema.decodeUnknownEffect(TestTcpAddress)(server.address()).pipe(
-    Effect.mapError(
-      (cause) =>
-        new RuntimeTcpTestFailure({
-          message: "Test TCP server produced an invalid listen address.",
-          cause,
-        }),
-    ),
-  );
-  return { server, port: address.port };
-});
-
-const waitForTransportHealth = Effect.fn("ViewServerRuntime.test.transportHealth.wait")(function* (
-  health: () => Effect.Effect<{ readonly transport: TransportHealth }, unknown>,
-  expected: {
-    readonly activeClients: number;
-    readonly activeStreams: number;
-  },
-) {
-  return yield* health().pipe(
-    Effect.map((value) => value.transport),
-    Effect.repeat({
-      schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
-      until: (transport) =>
-        transport.activeClients === expected.activeClients &&
-        transport.activeStreams === expected.activeStreams,
-    }),
-  );
-});
 
 const waitForGrpcSnapshotRows = Effect.fn("ViewServerRuntime.test.grpc.snapshotRows.wait")(
   function* (client: ViewServerRuntimeClient<GrpcTopics>, expectedTotalRows: number) {

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -1,17 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Consumer } from "@platformatic/kafka";
-import type { Message } from "@platformatic/kafka";
-import {
-  defineViewServerConfig,
-  kafka,
-  type RuntimeRegions,
-  type ViewServerConfig,
-  type ViewServerRuntimeError,
-} from "@effect-view-server/config";
-import {
-  makeKafkaSourceTopicsForConfig,
-  type KafkaResolvedSourceTopicDefinition,
-} from "@effect-view-server/config/internal";
+import { defineViewServerConfig, kafka } from "@effect-view-server/config";
 import {
   makeViewServerRuntimeCoreInternal as makeViewServerRuntimeCore,
   type ViewServerRuntimeCoreInternalClient,
@@ -29,10 +18,8 @@ import {
   Option,
   Queue,
   References,
-  Schema,
   Scope,
 } from "effect";
-import { makeViewServerKafkaHealthLedger as makeViewServerKafkaHealthLedgerBase } from "./kafka-health";
 import type { ViewServerKafkaHealthLedger } from "./kafka-health";
 import {
   assignedPartitionsForSourceTopic,
@@ -48,7 +35,6 @@ import {
   kafkaHeadersFromMessage,
   kafkaConsumerCloseError,
   kafkaConsumerStartError,
-  kafkaIngressErrorSourceTopic,
   kafkaMessageCommitError,
   kafkaMessageDecodeError,
   kafkaMessageProcessingError,
@@ -80,318 +66,36 @@ import type {
 } from "./kafka-ingress";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
 import { resolveViewServerRuntimeOptions } from "./runtime-options";
-import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
-
-class KafkaIngressTestError extends Schema.TaggedErrorClass<KafkaIngressTestError>()(
-  "KafkaIngressTestError",
-  {
-    message: Schema.String,
-  },
-) {}
-
-const Order = Schema.Struct({
-  id: Schema.String,
-  customerId: Schema.String,
-  price: Schema.Number,
-});
-
-const IncomingOrder = Schema.Struct({
-  customerId: Schema.String,
-  price: Schema.Number,
-});
-
-const PrecisePosition = Schema.Struct({
-  id: Schema.String,
-  accountId: Schema.String,
-  quantity: Schema.BigInt,
-  price: Schema.BigDecimal,
-});
-
-const IncomingPrecisePosition = Schema.Struct({
-  accountId: Schema.String,
-  quantity: Schema.BigInt,
-  price: Schema.BigDecimal,
-});
-
-const regions = {
-  cold: "localhost:9093",
-  local: " localhost:9092, ,localhost:9094 ",
-};
-const ordersSourceTopic = "orders-source";
-const paymentsSourceTopic = "payments-source";
-const unknownSourceTopic = "unknown-source";
-
-const viewServer = defineViewServerConfig({
-  kafka: regions,
-  topics: {
-    orders: {
-      schema: Order,
-      key: "id",
-      kafkaSource: kafka.source({
-        topic: ordersSourceTopic,
-        regions: ["local"],
-        value: kafka.json(IncomingOrder),
-        key: kafka.stringKey(),
-        rowKey: ({ key }) => key,
-        map: ({ value }) => ({
-          customerId: value.customerId,
-          price: value.price,
-        }),
-      }),
-    },
-    precisePositions: {
-      schema: PrecisePosition,
-      key: "id",
-    },
-  },
-});
-
-type Topics = typeof viewServer.topics;
-type KafkaMessageBytes = Buffer | null | undefined;
-type KafkaMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
-type CapturedLog = {
-  readonly cause: Cause.Cause<unknown>;
-  readonly message: unknown;
-};
-
-const makeCapturedLogs = () => {
-  const logs: Array<CapturedLog> = [];
-  const logger = Logger.make<unknown, void>((options) => {
-    logs.push({
-      cause: options.cause,
-      message: options.message,
-    });
-  });
-  return { logger, logs };
-};
-
-const nonStringTagCodecError: { readonly _tag: 123; readonly message: "non-string tag" } = {
-  _tag: 123,
-  message: "non-string tag",
-};
-const forgedMappingTagCodecError: {
-  readonly _tag: "KafkaMappingError";
-  readonly [key: symbol]: symbol;
-  readonly message: "forged mapping tag";
-} = {
-  _tag: "KafkaMappingError",
-  [Symbol.for("@effect-view-server/config/KafkaMappingError")]: Symbol.for(
-    "@effect-view-server/config/KafkaMappingError",
-  ),
-  message: "forged mapping tag",
-};
-
-const makeCommittedKafkaStart = (consumerGroupId: string) => ({
-  consume: {
-    consumerGroupId,
-    fallbackMode: "earliest" as const,
-    mode: "committed" as const,
-  },
-  startFrom: {
-    committedConsumerGroup: consumerGroupId,
-  },
-});
-
-const committedKafkaStart = (
-  consumerGroupId: string,
-): Pick<ResolvedViewServerKafkaRuntimeOptions<Topics>, "consume" | "startFrom"> =>
-  makeCommittedKafkaStart(consumerGroupId);
-
-const makeRuntimeTopicRecord = <
-  const CurrentTopics extends ViewServerRuntimeTopicDefinitions,
-  const CurrentRegions extends RuntimeRegions,
->(
-  config: ViewServerConfig<CurrentTopics, CurrentRegions>,
-): Record<string, KafkaResolvedSourceTopicDefinition<CurrentTopics, CurrentRegions>> => {
-  const topics: Record<
-    string,
-    KafkaResolvedSourceTopicDefinition<CurrentTopics, CurrentRegions>
-  > = Object.create(null);
-  for (const topic of makeKafkaSourceTopicsForConfig<CurrentTopics, CurrentRegions>(config)) {
-    topics[topic.topic] = topic;
-  }
-  return topics;
-};
-
-const kafkaOptionsForConfig = <
-  const CurrentTopics extends ViewServerRuntimeTopicDefinitions,
-  const CurrentRegions extends RuntimeRegions,
->(
-  config: ViewServerConfig<CurrentTopics, CurrentRegions>,
-  consumerGroupId: string,
-  runtimeRegions: Record<string, string> = regions,
-): ResolvedViewServerKafkaRuntimeOptions<CurrentTopics, CurrentRegions> => ({
-  consumerGroupId,
-  ...makeCommittedKafkaStart(consumerGroupId),
-  regions: runtimeRegions,
-  topics: makeRuntimeTopicRecord(config),
-});
-
-const kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
-  consumerGroupId: "view-server-test",
-  ...committedKafkaStart("view-server-test"),
+import {
+  causeReasonSummary,
+  committedKafkaStart,
+  decodeFailureThenSuccessKafkaStream,
+  failingClient,
+  failingKafkaStream,
+  forgedMappingTagCodecError,
+  IncomingOrder,
+  IncomingPrecisePosition,
+  KafkaIngressTestError,
+  kafkaIngressErrorSourceTopicOrNull,
+  kafkaIngressErrorSummary,
+  kafkaMessage,
+  kafkaOptions,
+  kafkaOptionsForConfig,
+  makeCapturedLogs,
+  makeViewServerKafkaHealthLedger,
+  nonStringTagCodecError,
+  nullRecord,
+  Order,
+  ordersSourceTopic,
+  paymentsSourceTopic,
+  PrecisePosition,
   regions,
-  topics: makeRuntimeTopicRecord(viewServer),
-};
-
-type KafkaHealthLedgerInput<LedgerTopics extends ViewServerRuntimeTopicDefinitions> = Parameters<
-  typeof makeViewServerKafkaHealthLedgerBase<LedgerTopics>
->[0];
-
-const makeViewServerKafkaHealthLedger = <
-  const LedgerTopics extends ViewServerRuntimeTopicDefinitions,
->(
-  input: Omit<KafkaHealthLedgerInput<LedgerTopics>, "startFrom"> &
-    Partial<Pick<KafkaHealthLedgerInput<LedgerTopics>, "startFrom">>,
-): ViewServerKafkaHealthLedger<LedgerTopics> =>
-  makeViewServerKafkaHealthLedgerBase<LedgerTopics>({
-    startFrom: kafkaOptions.consume,
-    ...input,
-  });
-
-const nullRecord = <Value>(entries: Record<string, Value>): Record<string, Value> => {
-  const record: Record<string, Value> = Object.create(null);
-  return Object.assign(record, entries);
-};
-
-const causeReasonSummary = (
-  cause: unknown,
-): ReadonlyArray<{
-  readonly tag: string;
-  readonly message: string | null;
-}> =>
-  Cause.isCause(cause)
-    ? cause.reasons.map((reason) => ({
-        tag: reason._tag,
-        message:
-          reason._tag === "Fail"
-            ? messageFromUnknown(reason.error)
-            : reason._tag === "Die"
-              ? messageFromUnknown(reason.defect)
-              : null,
-      }))
-    : [];
-
-const failedKafkaStreamQueueEvent = (
-  event: KafkaStreamQueueEvent,
-): Effect.Effect<Extract<KafkaStreamQueueEvent, { readonly _tag: "Failed" }>, Error> =>
-  Effect.succeed(event).pipe(
-    Effect.filterOrFail(
-      (value): value is Extract<KafkaStreamQueueEvent, { readonly _tag: "Failed" }> =>
-        value._tag === "Failed",
-      () => new KafkaIngressTestError({ message: "Expected Kafka stream queue failure event." }),
-    ),
-  );
-
-const kafkaIngressErrorSummary = (error: unknown) =>
-  error instanceof ViewServerKafkaIngressError
-    ? {
-        cause: causeReasonSummary(error.cause),
-        message: error.message,
-        region: error.region,
-        sourceTopic: error.sourceTopic,
-      }
-    : null;
-
-const kafkaIngressErrorSourceTopicOrNull = (error: unknown): string | null =>
-  Option.getOrNull(kafkaIngressErrorSourceTopic(error));
-
-const kafkaMessage = (input: {
-  readonly topic: string;
-  readonly key?: string | null;
-  readonly value?: string | null;
-  readonly headers?: ReadonlyMap<Buffer, Buffer>;
-  readonly offset?: bigint;
-  readonly onCommit?: () => void;
-  readonly commitFailure?: Error;
-}): KafkaMessage => {
-  const headers = new Map(input.headers ?? []);
-  const key = input.key === undefined || input.key === null ? input.key : Buffer.from(input.key);
-  const value =
-    input.value === undefined || input.value === null ? input.value : Buffer.from(input.value);
-  const offset = input.offset ?? 0n;
-  return {
-    key,
-    value,
-    headers,
-    topic: input.topic,
-    partition: 0,
-    timestamp: 1_234n,
-    offset,
-    metadata: {},
-    commit: () => {
-      if (input.commitFailure !== undefined) {
-        return Promise.reject(input.commitFailure);
-      }
-      input.onCommit?.();
-      return undefined;
-    },
-    toJSON: () => ({
-      key,
-      value,
-      headers: Array.from(headers.entries()),
-      topic: input.topic,
-      partition: 0,
-      timestamp: "1234",
-      offset: String(offset),
-      metadata: {},
-    }),
-  };
-};
-
-const runtimeUnavailable: ViewServerRuntimeError = {
-  _tag: "ViewServerRuntimeError",
-  code: "RuntimeUnavailable",
-  message: "publish failed",
-};
-
-const failingClient: ViewServerRuntimeCoreInternalClient<Topics> = {
-  delete: () => Effect.fail(runtimeUnavailable),
-  health: () => Effect.fail(runtimeUnavailable),
-  patch: () => Effect.fail(runtimeUnavailable),
-  publish: () => Effect.fail(runtimeUnavailable),
-  publishMany: () => Effect.fail(runtimeUnavailable),
-  publishManyDecodedRows: () => Effect.fail(runtimeUnavailable),
-  publishManyDecodedRowsWithStorageKeys: () => Effect.fail(runtimeUnavailable),
-  publishManyWithStorageKeys: () => Effect.fail(runtimeUnavailable),
-  reset: () => Effect.fail(runtimeUnavailable),
-  snapshot: () => Effect.fail(runtimeUnavailable),
-};
-
-async function* failingKafkaStream(): AsyncIterable<KafkaMessage> {
-  yield kafkaMessage({
-    topic: ordersSourceTopic,
-    key: "order-stream-1",
-    value: JSON.stringify({
-      customerId: "customer-stream-1",
-      price: 30,
-    }),
-    offset: 4n,
-  });
-  throw new Error("stream-down");
-}
-
-async function* decodeFailureThenSuccessKafkaStream(
-  onCommit: () => void,
-): AsyncIterable<KafkaMessage> {
-  yield kafkaMessage({
-    topic: ordersSourceTopic,
-    key: "bad-json",
-    value: "{",
-    offset: 1n,
-    onCommit,
-  });
-  yield kafkaMessage({
-    topic: ordersSourceTopic,
-    key: "order-after-failure",
-    value: JSON.stringify({
-      customerId: "customer-after-failure",
-      price: 40,
-    }),
-    offset: 2n,
-    onCommit,
-  });
-}
+  runtimeUnavailable,
+  type KafkaMessage,
+  type Topics,
+  unknownSourceTopic,
+  viewServer,
+} from "../test-harness/kafka-ingress";
 
 describe("@effect-view-server/runtime Kafka ingress internals", () => {
   it("normalizes Kafka helper values", () => {
@@ -3883,7 +3587,16 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
         queue,
         Cause.fromReasons([Cause.makeFailReason(rawFailure), Cause.makeInterruptReason()]),
       );
-      const event = yield* Queue.take(queue).pipe(Effect.andThen(failedKafkaStreamQueueEvent));
+      const event = yield* Queue.take(queue).pipe(
+        Effect.filterOrFail(
+          (value): value is Extract<KafkaStreamQueueEvent, { readonly _tag: "Failed" }> =>
+            value._tag === "Failed",
+          () =>
+            new KafkaIngressTestError({
+              message: "Expected Kafka stream queue failure event.",
+            }),
+        ),
+      );
 
       expect({
         cause: causeReasonSummary(event.cause),
@@ -3929,7 +3642,16 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
       ];
 
       yield* offerKafkaStreamProducerFailure("local", queue, Cause.fromReasons(failureReasons));
-      const event = yield* Queue.take(queue).pipe(Effect.andThen(failedKafkaStreamQueueEvent));
+      const event = yield* Queue.take(queue).pipe(
+        Effect.filterOrFail(
+          (value): value is Extract<KafkaStreamQueueEvent, { readonly _tag: "Failed" }> =>
+            value._tag === "Failed",
+          () =>
+            new KafkaIngressTestError({
+              message: "Expected Kafka stream queue failure event.",
+            }),
+        ),
+      );
 
       expect({
         cause: causeReasonSummary(event.cause),

--- a/packages/runtime/test-harness/kafka-ingress.ts
+++ b/packages/runtime/test-harness/kafka-ingress.ts
@@ -1,0 +1,325 @@
+import type { Message } from "@platformatic/kafka";
+import {
+  defineViewServerConfig,
+  kafka,
+  type RuntimeRegions,
+  type ViewServerConfig,
+  type ViewServerRuntimeError,
+} from "@effect-view-server/config";
+import {
+  makeKafkaSourceTopicsForConfig,
+  type KafkaResolvedSourceTopicDefinition,
+} from "@effect-view-server/config/internal";
+import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
+import { Buffer } from "node:buffer";
+import { Cause, Effect, Logger, Option, Schema } from "effect";
+import type { ViewServerKafkaHealthLedger } from "../src/kafka-health";
+import { makeViewServerKafkaHealthLedger as makeViewServerKafkaHealthLedgerBase } from "../src/kafka-health";
+import {
+  kafkaIngressErrorSourceTopic,
+  messageFromUnknown,
+  ViewServerKafkaIngressError,
+} from "../src/kafka-ingress";
+import type { ResolvedViewServerKafkaRuntimeOptions } from "../src/runtime-options";
+import type { ViewServerRuntimeTopicDefinitions } from "../src/runtime-types";
+
+export class KafkaIngressTestError extends Schema.TaggedErrorClass<KafkaIngressTestError>()(
+  "KafkaIngressTestError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export const Order = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  price: Schema.Number,
+});
+
+export const IncomingOrder = Schema.Struct({
+  customerId: Schema.String,
+  price: Schema.Number,
+});
+
+export const PrecisePosition = Schema.Struct({
+  id: Schema.String,
+  accountId: Schema.String,
+  quantity: Schema.BigInt,
+  price: Schema.BigDecimal,
+});
+
+export const IncomingPrecisePosition = Schema.Struct({
+  accountId: Schema.String,
+  quantity: Schema.BigInt,
+  price: Schema.BigDecimal,
+});
+
+export const regions = {
+  cold: "localhost:9093",
+  local: " localhost:9092, ,localhost:9094 ",
+};
+export const ordersSourceTopic = "orders-source";
+export const paymentsSourceTopic = "payments-source";
+export const unknownSourceTopic = "unknown-source";
+
+export const viewServer = defineViewServerConfig({
+  kafka: regions,
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+      kafkaSource: kafka.source({
+        topic: ordersSourceTopic,
+        regions: ["local"],
+        value: kafka.json(IncomingOrder),
+        key: kafka.stringKey(),
+        rowKey: ({ key }) => key,
+        map: ({ value }) => ({
+          customerId: value.customerId,
+          price: value.price,
+        }),
+      }),
+    },
+    precisePositions: {
+      schema: PrecisePosition,
+      key: "id",
+    },
+  },
+});
+
+export type Topics = typeof viewServer.topics;
+export type KafkaMessageBytes = Buffer | null | undefined;
+export type KafkaMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
+type CapturedLog = {
+  readonly cause: Cause.Cause<unknown>;
+  readonly message: unknown;
+};
+
+export const makeCapturedLogs = () => {
+  const logs: Array<CapturedLog> = [];
+  const logger = Logger.make<unknown, void>((options) => {
+    logs.push({
+      cause: options.cause,
+      message: options.message,
+    });
+  });
+  return { logger, logs };
+};
+
+export const nonStringTagCodecError: { readonly _tag: 123; readonly message: "non-string tag" } = {
+  _tag: 123,
+  message: "non-string tag",
+};
+export const forgedMappingTagCodecError: {
+  readonly _tag: "KafkaMappingError";
+  readonly [key: symbol]: symbol;
+  readonly message: "forged mapping tag";
+} = {
+  _tag: "KafkaMappingError",
+  [Symbol.for("@effect-view-server/config/KafkaMappingError")]: Symbol.for(
+    "@effect-view-server/config/KafkaMappingError",
+  ),
+  message: "forged mapping tag",
+};
+
+const makeCommittedKafkaStart = (consumerGroupId: string) => ({
+  consume: {
+    consumerGroupId,
+    fallbackMode: "earliest" as const,
+    mode: "committed" as const,
+  },
+  startFrom: {
+    committedConsumerGroup: consumerGroupId,
+  },
+});
+
+export const committedKafkaStart = (
+  consumerGroupId: string,
+): Pick<ResolvedViewServerKafkaRuntimeOptions<Topics>, "consume" | "startFrom"> =>
+  makeCommittedKafkaStart(consumerGroupId);
+
+const makeRuntimeTopicRecord = <
+  const CurrentTopics extends ViewServerRuntimeTopicDefinitions,
+  const CurrentRegions extends RuntimeRegions,
+>(
+  config: ViewServerConfig<CurrentTopics, CurrentRegions>,
+): Record<string, KafkaResolvedSourceTopicDefinition<CurrentTopics, CurrentRegions>> => {
+  const topics: Record<
+    string,
+    KafkaResolvedSourceTopicDefinition<CurrentTopics, CurrentRegions>
+  > = Object.create(null);
+  for (const topic of makeKafkaSourceTopicsForConfig<CurrentTopics, CurrentRegions>(config)) {
+    topics[topic.topic] = topic;
+  }
+  return topics;
+};
+
+export const kafkaOptionsForConfig = <
+  const CurrentTopics extends ViewServerRuntimeTopicDefinitions,
+  const CurrentRegions extends RuntimeRegions,
+>(
+  config: ViewServerConfig<CurrentTopics, CurrentRegions>,
+  consumerGroupId: string,
+  runtimeRegions: Record<string, string> = regions,
+): ResolvedViewServerKafkaRuntimeOptions<CurrentTopics, CurrentRegions> => ({
+  consumerGroupId,
+  ...makeCommittedKafkaStart(consumerGroupId),
+  regions: runtimeRegions,
+  topics: makeRuntimeTopicRecord(config),
+});
+
+export const kafkaOptions: ResolvedViewServerKafkaRuntimeOptions<Topics> = {
+  consumerGroupId: "view-server-test",
+  ...committedKafkaStart("view-server-test"),
+  regions,
+  topics: makeRuntimeTopicRecord(viewServer),
+};
+
+type KafkaHealthLedgerInput<LedgerTopics extends ViewServerRuntimeTopicDefinitions> = Parameters<
+  typeof makeViewServerKafkaHealthLedgerBase<LedgerTopics>
+>[0];
+
+export const makeViewServerKafkaHealthLedger = <
+  const LedgerTopics extends ViewServerRuntimeTopicDefinitions,
+>(
+  input: Omit<KafkaHealthLedgerInput<LedgerTopics>, "startFrom"> &
+    Partial<Pick<KafkaHealthLedgerInput<LedgerTopics>, "startFrom">>,
+): ViewServerKafkaHealthLedger<LedgerTopics> =>
+  makeViewServerKafkaHealthLedgerBase<LedgerTopics>({
+    startFrom: kafkaOptions.consume,
+    ...input,
+  });
+
+export const nullRecord = <Value>(entries: Record<string, Value>): Record<string, Value> => {
+  const record: Record<string, Value> = Object.create(null);
+  return Object.assign(record, entries);
+};
+
+export const causeReasonSummary = (
+  cause: unknown,
+): ReadonlyArray<{
+  readonly tag: string;
+  readonly message: string | null;
+}> =>
+  Cause.isCause(cause)
+    ? cause.reasons.map((reason) => ({
+        tag: reason._tag,
+        message:
+          reason._tag === "Fail"
+            ? messageFromUnknown(reason.error)
+            : reason._tag === "Die"
+              ? messageFromUnknown(reason.defect)
+              : null,
+      }))
+    : [];
+
+export const kafkaIngressErrorSummary = (error: unknown) =>
+  error instanceof ViewServerKafkaIngressError
+    ? {
+        cause: causeReasonSummary(error.cause),
+        message: error.message,
+        region: error.region,
+        sourceTopic: error.sourceTopic,
+      }
+    : null;
+
+export const kafkaIngressErrorSourceTopicOrNull = (error: unknown): string | null =>
+  Option.getOrNull(kafkaIngressErrorSourceTopic(error));
+
+export const kafkaMessage = (input: {
+  readonly topic: string;
+  readonly key?: string | null;
+  readonly value?: string | null;
+  readonly headers?: ReadonlyMap<Buffer, Buffer>;
+  readonly offset?: bigint;
+  readonly onCommit?: () => void;
+  readonly commitFailure?: Error;
+}): KafkaMessage => {
+  const headers = new Map(input.headers ?? []);
+  const key =
+    input.key === undefined ? undefined : input.key === null ? null : Buffer.from(input.key);
+  const value =
+    input.value === undefined ? undefined : input.value === null ? null : Buffer.from(input.value);
+  const offset = input.offset ?? 0n;
+  return {
+    key,
+    value,
+    headers,
+    topic: input.topic,
+    partition: 0,
+    timestamp: 1_234n,
+    offset,
+    metadata: {},
+    commit: () => {
+      if (input.commitFailure !== undefined) {
+        return Promise.reject(input.commitFailure);
+      }
+      input.onCommit?.();
+      return undefined;
+    },
+    toJSON: () => ({
+      key,
+      value,
+      headers: Array.from(headers.entries()),
+      topic: input.topic,
+      partition: 0,
+      timestamp: "1234",
+      offset: String(offset),
+      metadata: {},
+    }),
+  };
+};
+
+export const runtimeUnavailable: ViewServerRuntimeError = {
+  _tag: "ViewServerRuntimeError",
+  code: "RuntimeUnavailable",
+  message: "publish failed",
+};
+
+export const failingClient: ViewServerRuntimeCoreInternalClient<Topics> = {
+  delete: () => Effect.fail(runtimeUnavailable),
+  health: () => Effect.fail(runtimeUnavailable),
+  patch: () => Effect.fail(runtimeUnavailable),
+  publish: () => Effect.fail(runtimeUnavailable),
+  publishMany: () => Effect.fail(runtimeUnavailable),
+  publishManyDecodedRows: () => Effect.fail(runtimeUnavailable),
+  publishManyDecodedRowsWithStorageKeys: () => Effect.fail(runtimeUnavailable),
+  publishManyWithStorageKeys: () => Effect.fail(runtimeUnavailable),
+  reset: () => Effect.fail(runtimeUnavailable),
+  snapshot: () => Effect.fail(runtimeUnavailable),
+};
+
+export async function* failingKafkaStream(): AsyncIterable<KafkaMessage> {
+  yield kafkaMessage({
+    topic: ordersSourceTopic,
+    key: "order-stream-1",
+    value: JSON.stringify({
+      customerId: "customer-stream-1",
+      price: 30,
+    }),
+    offset: 4n,
+  });
+  throw new Error("stream-down");
+}
+
+export async function* decodeFailureThenSuccessKafkaStream(
+  onCommit: () => void,
+): AsyncIterable<KafkaMessage> {
+  yield kafkaMessage({
+    topic: ordersSourceTopic,
+    key: "bad-json",
+    value: "{",
+    offset: 1n,
+    onCommit,
+  });
+  yield kafkaMessage({
+    topic: ordersSourceTopic,
+    key: "order-after-failure",
+    value: JSON.stringify({
+      customerId: "customer-after-failure",
+      price: 40,
+    }),
+    offset: 2n,
+    onCommit,
+  });
+}

--- a/packages/runtime/test-harness/runtime.ts
+++ b/packages/runtime/test-harness/runtime.ts
@@ -1,0 +1,307 @@
+import { type TransportHealth } from "@effect-view-server/config";
+import { Effect, Schedule, Schema } from "effect";
+import * as Net from "node:net";
+
+const HealthJson = Schema.Struct({
+  status: Schema.Literals(["ready", "degraded", "starting", "stopping"]),
+  engine: Schema.Struct({
+    topics: Schema.Struct({
+      orders: Schema.Struct({
+        rowCount: Schema.Number,
+      }),
+    }),
+  }),
+});
+
+class RuntimeHealthJsonParseError extends Schema.TaggedErrorClass<RuntimeHealthJsonParseError>()(
+  "RuntimeHealthJsonParseError",
+  {
+    cause: Schema.Unknown,
+  },
+) {}
+
+class RuntimeJsonParseError extends Schema.TaggedErrorClass<RuntimeJsonParseError>()(
+  "RuntimeJsonParseError",
+  {
+    cause: Schema.Unknown,
+  },
+) {}
+
+export class RuntimeTestFailure extends Schema.TaggedErrorClass<RuntimeTestFailure>()(
+  "RuntimeTestFailure",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export class RuntimeTcpTestFailure extends Schema.TaggedErrorClass<RuntimeTcpTestFailure>()(
+  "RuntimeTcpTestFailure",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+  },
+) {}
+
+const TcpPublishResponse = Schema.Union([
+  Schema.Struct({
+    ok: Schema.Literal(true),
+  }),
+  Schema.Struct({
+    ok: Schema.Literal(false),
+    error: Schema.Struct({
+      _tag: Schema.String,
+      code: Schema.optional(Schema.String),
+      message: Schema.String,
+      phase: Schema.optional(Schema.String),
+      status: Schema.optional(Schema.Number),
+      topic: Schema.optional(Schema.String),
+    }),
+  }),
+]);
+
+const TestTcpAddress = Schema.Struct({
+  address: Schema.String,
+  family: Schema.String,
+  port: Schema.Number,
+});
+
+export const nullRecord = <Value>(
+  entries: ReadonlyArray<readonly [string, Value]>,
+): Record<string, Value> => {
+  const record: Record<string, Value> = Object.create(null);
+  for (const [key, value] of entries) {
+    record[key] = value;
+  }
+  return record;
+};
+
+export const fetchHealth = Effect.fn("ViewServerRuntime.test.health.fetch")(function* (
+  url: string,
+) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(text),
+    catch: (cause) => new RuntimeHealthJsonParseError({ cause }),
+  });
+  const health = yield* Schema.decodeUnknownEffect(HealthJson)(value);
+  return { response, health };
+});
+
+export const fetchText = Effect.fn("ViewServerRuntime.test.text.fetch")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  return { response, text };
+});
+
+export const fetchJson = Effect.fn("ViewServerRuntime.test.json.fetch")(function* (url: string) {
+  const response = yield* Effect.promise(() => fetch(url));
+  const text = yield* Effect.promise(() => response.text());
+  const value = yield* Effect.try({
+    try: (): unknown => JSON.parse(text),
+    catch: (cause) => new RuntimeJsonParseError({ cause }),
+  });
+  return { response, value };
+});
+
+const tcpUrlConnectHost = (hostname: string): string =>
+  hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+
+export const connectTcpPublishSocket = Effect.fn("ViewServerRuntime.test.tcp.connect")(function* (
+  url: string,
+) {
+  const parsedUrl = new URL(url);
+  const port = Number(parsedUrl.port);
+  if (!Number.isSafeInteger(port)) {
+    return yield* new RuntimeTcpTestFailure({
+      message: "TCP publish URL did not include a valid port.",
+      cause: url,
+    });
+  }
+  return yield* Effect.callback<Net.Socket, RuntimeTcpTestFailure>((resume) => {
+    const socket = Net.createConnection({
+      host: tcpUrlConnectHost(parsedUrl.hostname),
+      port,
+    });
+    socket.setEncoding("utf8");
+    socket.once("connect", () => {
+      resume(Effect.succeed(socket));
+    });
+    socket.once("error", (cause) => {
+      resume(
+        Effect.fail(
+          new RuntimeTcpTestFailure({
+            message: "TCP publish socket failed to connect.",
+            cause,
+          }),
+        ),
+      );
+    });
+  });
+});
+
+export const readTcpPublishResponse = Effect.fn("ViewServerRuntime.test.tcp.response.read")(
+  function* (socket: Net.Socket) {
+    const line = yield* Effect.callback<string, RuntimeTcpTestFailure>((resume) => {
+      let buffer = "";
+      socket.on("data", (chunk: string) => {
+        buffer += chunk;
+        const newlineIndex = buffer.indexOf("\n");
+        if (newlineIndex >= 0) {
+          resume(Effect.succeed(buffer.slice(0, newlineIndex)));
+        }
+      });
+      socket.once("error", (cause) => {
+        resume(
+          Effect.fail(
+            new RuntimeTcpTestFailure({
+              message: "TCP publish socket failed while reading response.",
+              cause,
+            }),
+          ),
+        );
+      });
+    });
+    const value = yield* Effect.try({
+      try: (): unknown => JSON.parse(line),
+      catch: (cause) =>
+        new RuntimeTcpTestFailure({
+          message: "TCP publish response was not valid JSON.",
+          cause,
+        }),
+    });
+    return yield* Schema.decodeUnknownEffect(TcpPublishResponse)(value).pipe(
+      Effect.mapError(
+        (cause) =>
+          new RuntimeTcpTestFailure({
+            message: "TCP publish response did not match the test schema.",
+            cause,
+          }),
+      ),
+    );
+  },
+);
+
+export const readTcpPublishResponses = Effect.fn("ViewServerRuntime.test.tcp.responses.read")(
+  function* (socket: Net.Socket, count: number) {
+    const lines = yield* Effect.callback<ReadonlyArray<string>, RuntimeTcpTestFailure>((resume) => {
+      let buffer = "";
+      const responses: Array<string> = [];
+      socket.on("data", (chunk: string) => {
+        buffer += chunk;
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex >= 0) {
+          responses.push(buffer.slice(0, newlineIndex));
+          buffer = buffer.slice(newlineIndex + 1);
+          newlineIndex = buffer.indexOf("\n");
+        }
+        if (responses.length === count) {
+          resume(Effect.succeed(responses));
+        }
+      });
+      socket.once("error", (cause) => {
+        resume(
+          Effect.fail(
+            new RuntimeTcpTestFailure({
+              message: "TCP publish socket failed while reading responses.",
+              cause,
+            }),
+          ),
+        );
+      });
+    });
+    return yield* Effect.forEach(lines, (line) =>
+      Effect.try({
+        try: (): unknown => JSON.parse(line),
+        catch: (cause) =>
+          new RuntimeTcpTestFailure({
+            message: "TCP publish response was not valid JSON.",
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap((value) => Schema.decodeUnknownEffect(TcpPublishResponse)(value)),
+        Effect.mapError(
+          (cause) =>
+            new RuntimeTcpTestFailure({
+              message: "TCP publish response did not match the test schema.",
+              cause,
+            }),
+        ),
+      ),
+    );
+  },
+);
+
+export const sendTcpPublishLine = Effect.fn("ViewServerRuntime.test.tcp.line.send")(function* (
+  url: string,
+  line: string,
+) {
+  const socket = yield* Effect.acquireRelease(connectTcpPublishSocket(url), (socket) =>
+    Effect.sync(() => socket.destroy()),
+  );
+  socket.write(`${line}\n`);
+  return yield* readTcpPublishResponse(socket).pipe(Effect.timeout("1 second"));
+});
+
+export const sendTcpPublishCommand = Effect.fn("ViewServerRuntime.test.tcp.command.send")(
+  function* (url: string, command: object) {
+    return yield* sendTcpPublishLine(url, JSON.stringify(command));
+  },
+);
+
+export const closeTestTcpServer = (server: Net.Server): Effect.Effect<void> =>
+  Effect.promise(
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  );
+
+export const reserveTcpPort = Effect.fn("ViewServerRuntime.test.tcp.port.reserve")(function* () {
+  const server = yield* Effect.callback<Net.Server, RuntimeTcpTestFailure>((resume) => {
+    const nextServer = Net.createServer();
+    nextServer.once("error", (cause) => {
+      resume(
+        Effect.fail(
+          new RuntimeTcpTestFailure({
+            message: "Test TCP server failed to reserve a port.",
+            cause,
+          }),
+        ),
+      );
+    });
+    nextServer.listen({ host: "127.0.0.1", port: 0 }, () => {
+      resume(Effect.succeed(nextServer));
+    });
+  });
+  const address = yield* Schema.decodeUnknownEffect(TestTcpAddress)(server.address()).pipe(
+    Effect.mapError(
+      (cause) =>
+        new RuntimeTcpTestFailure({
+          message: "Test TCP server produced an invalid listen address.",
+          cause,
+        }),
+    ),
+  );
+  return { server, port: address.port };
+});
+
+export const waitForTransportHealth = Effect.fn("ViewServerRuntime.test.transportHealth.wait")(
+  function* (
+    health: () => Effect.Effect<{ readonly transport: TransportHealth }, unknown>,
+    expected: {
+      readonly activeClients: number;
+      readonly activeStreams: number;
+    },
+  ) {
+    return yield* health().pipe(
+      Effect.map((value) => value.transport),
+      Effect.repeat({
+        schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+        until: (transport) =>
+          transport.activeClients === expected.activeClients &&
+          transport.activeStreams === expected.activeStreams,
+      }),
+    );
+  },
+);

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "declaration": true,
@@ -17,5 +17,5 @@
     "verbatimModuleSyntax": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "src/**/*.test-d.ts"]
+  "include": ["src/**/*.ts", "src/**/*.test-d.ts", "test-harness/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Extracted runtime HTTP/TCP helper effects into a package-local test harness module.
- Extracted Kafka ingress fixture/source-topic/message helpers into a package-local test harness module.
- Kept behavior assertions in the existing contract tests while reducing fixture/setup noise.

## Validation
- vp check --fix packages/runtime/src/index.test.ts packages/runtime/src/kafka-ingress.internal.test.ts packages/runtime/test-harness/runtime.ts packages/runtime/test-harness/kafka-ingress.ts packages/runtime/tsconfig.json
- vp run runtime#test -- src/index.test.ts src/kafka-ingress.internal.test.ts
- vp run -w ready