### PR TITLE
Harden Kafka source edge cases

### DIFF
--- a/docs/adr/0001-topic-owned-source-modules.md
+++ b/docs/adr/0001-topic-owned-source-modules.md
@@ -39,6 +39,7 @@ Runtime-owned Kafka helpers are deleted rather than treated as a compatibility p
 Source Ownership Policy is the focused Module for ownership decisions: given a View Server config, it can answer which topics are source-owned, which topics allow direct runtime/TCP mutation, and which topics require leased gRPC lifecycle.
 
 Kafka Delivery Contract stays local to Kafka source ingestion. Kafka tombstones can be interpreted using the topic-owned source declaration, decoded key, Region, metadata, configured Row Key, and target schema.
+Microbatch publishing groups only contiguous compatible messages. It must not globally regroup interleaved topics or source topics, because that would trade a small publish-count win for weaker Kafka-order semantics.
 
 gRPC Source Lifecycle stays local to gRPC source ingestion. Materialized and leased gRPC feeds can use the same topic-owned policy without a second source registry.
 

--- a/docs/kafka-mapping.md
+++ b/docs/kafka-mapping.md
@@ -102,6 +102,12 @@ Core. Topic-owned sources upsert with source-owned storage keys, and compacted
 topic tombstones delete by that same key. Offsets are committed only after the
 corresponding Runtime Core mutation succeeds.
 
+Kafka records without key bytes cannot derive a source-owned row key. The
+runtime records a mapping failure, commits the record, and skips it so one
+poison record cannot replay forever and stall the whole region. Tombstone
+deletes are idempotent: a tombstone for an already-missing row is a successful
+no-op after the delete mutation runs.
+
 If a message fails decode or mapping, health records a decode or mapping failure
 for the source topic and region. If publishing fails, the corresponding messages
 remain uncommitted so Kafka can replay them.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -77,6 +77,11 @@ Topics without `kafkaSource` or `grpcSource` are externally/manual published
 topics, for example through TCP publish or an in-memory test client. A topic can
 only have one source owner.
 
+Runtime reset is rejected while any source-owned topic exists. Resetting only
+manual topics while Kafka or gRPC topics continue running would make the public
+contract ambiguous, so source-backed rebuilds should be driven by source replay
+or by restarting a runtime with the intended Kafka start position.
+
 Kafka source topics must define `rowKey`. The runtime uses that value as the
 topic row key and forces the configured key field on the mapped row to match it,
 so source-owned rows cannot drift away from their Kafka identity.

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -8960,16 +8960,15 @@ const assertCompileTimeContracts = () => {
     websocketPort: 8080,
     // @ts-expect-error runtime options reject unknown top-level fields
     extraRuntimeField: true,
-    kafka: {
-      consumerGroupId: "view-server-type-test",
-      regions: {
-        usa: "broker-a:9092",
-      },
-    },
   });
 
   viewServer.defineRuntimeOptions({
     websocketPort: 8080,
+  });
+
+  viewServer.defineRuntimeOptions({
+    websocketPort: 8080,
+    // @ts-expect-error source-free runtime options reject Kafka settings.
     kafka: {
       consumerGroupId: "view-server-type-test",
       regions: {
@@ -8978,7 +8977,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     kafka: {
       consumerGroupId: "view-server-type-test",
@@ -8991,7 +8990,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     kafka: {
       consumerGroupId: "view-server-type-test",
@@ -9034,7 +9033,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     kafka: {
       consumerGroupId: "view-server-type-test",
@@ -9048,7 +9047,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     // @ts-expect-error committed Kafka start config requires committedConsumerGroup.
     kafka: {
@@ -9062,7 +9061,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     // @ts-expect-error runtime Kafka startFrom only accepts earliest, latest, or committed group config.
     kafka: {
@@ -9074,7 +9073,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     // @ts-expect-error committed Kafka start fallback must be earliest, latest, or fail.
     kafka: {
@@ -9089,7 +9088,7 @@ const assertCompileTimeContracts = () => {
     },
   });
 
-  viewServer.defineRuntimeOptions({
+  topicOwnedViewServer.defineRuntimeOptions({
     websocketPort: 8080,
     kafka: {
       consumerGroupId: "view-server-type-test",

--- a/packages/config/src/internal.ts
+++ b/packages/config/src/internal.ts
@@ -27,6 +27,12 @@ export const makeKafkaSourceTopicsForConfig = <
 
 export { decodeKafkaTopicMessage, isKafkaTopicSourceDefinition };
 export type { KafkaResolvedSourceTopicDefinition } from "./kafka-contract";
+export type {
+  RuntimeKafkaSourceOwnershipConstraint,
+  RuntimeKafkaSourceRegionConstraint,
+  TopicOwnedKafkaSourceRegion,
+  TopicOwnedKafkaSourceTopic,
+} from "./kafka-contract";
 
 export { defineGrpcFeed, grpcSourceMarkers } from "./grpc-contract";
 export type { GrpcFeedDefinition } from "./grpc-contract";

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -1781,7 +1781,7 @@ type RejectExtraRuntimeKafkaStartFromKeys<Options> = Options extends {
     : unknown
   : unknown;
 
-type TopicOwnedKafkaSourceTopic<Topics extends object> = Extract<
+export type TopicOwnedKafkaSourceTopic<Topics extends object> = Extract<
   {
     readonly [Topic in keyof Topics]: Topics[Topic] extends {
       readonly kafkaSource: object;
@@ -1792,7 +1792,7 @@ type TopicOwnedKafkaSourceTopic<Topics extends object> = Extract<
   string
 >;
 
-type TopicOwnedKafkaSourceRegion<Topics extends object> = Extract<
+export type TopicOwnedKafkaSourceRegion<Topics extends object> = Extract<
   {
     readonly [Topic in keyof Topics]: Topics[Topic] extends {
       readonly kafkaSource: {
@@ -1805,11 +1805,11 @@ type TopicOwnedKafkaSourceRegion<Topics extends object> = Extract<
   string
 >;
 
-type RuntimeRegionsAreBroad<Regions extends RuntimeRegions> = string extends keyof Regions
+export type RuntimeRegionsAreBroad<Regions extends RuntimeRegions> = string extends keyof Regions
   ? true
   : false;
 
-type RuntimeKafkaSourceRegionConstraint<
+export type RuntimeKafkaSourceRegionConstraint<
   Topics extends object,
   ConfigRegions extends RuntimeRegions,
   Options,
@@ -1841,10 +1841,16 @@ type RuntimeKafkaSourceRegionConstraint<
         }
       : unknown;
 
-type RuntimeKafkaSourceOwnershipConstraint<Topics extends object, Options> = [
+export type RuntimeKafkaSourceOwnershipConstraint<Topics extends object, Options> = [
   TopicOwnedKafkaSourceTopic<Topics>,
 ] extends [never]
-  ? unknown
+  ? Options extends {
+      readonly kafka: unknown;
+    }
+    ? {
+        readonly kafka: never;
+      }
+    : unknown
   : Options extends {
         readonly kafka: infer CandidateKafka;
       }

--- a/packages/effect-view-server/CHANGELOG.md
+++ b/packages/effect-view-server/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- c915f73: Add topic-owned Kafka and gRPC source declarations with derived Kafka runtime topics.
+- c915f73: Add topic-owned Kafka and gRPC source declarations with derived Kafka runtime topics. This removes the old runtime-owned Kafka source declaration path: declare `kafkaSource` / `grpcSource` on topics, and keep runtime options for operational settings such as consumer group, start position, broker overrides, and ports.
 
 ## 0.0.4
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -155,6 +155,10 @@ Offsets are committed only after the corresponding Runtime Core mutation
 succeeds. If publish/delete fails, the original Kafka messages remain
 uncommitted so Kafka can replay them.
 
+Kafka records without key bytes are not publishable because source-owned row
+identity is key-derived. They are recorded as mapping failures, committed, and
+skipped so one malformed record cannot poison the region indefinitely.
+
 If a later message in a batch fails decode or mapping after earlier messages
 were decoded, the decoded prefix is published and committed before the failing
 message is reported. If the Kafka stream fails after yielding messages, the

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -154,6 +154,13 @@ const kafkaOwnedViewServer = defineViewServerConfig({
 });
 
 const runtimeEffect = makeViewServerRuntime(viewServer);
+const _invalidSourceFreeRuntimeWithKafka = makeViewServerRuntime(viewServer, {
+  // @ts-expect-error source-free runtimes reject Kafka options.
+  kafka: {
+    consumerGroupId: "view-server-source-free-type-test",
+    regions: usaKafkaRegions,
+  },
+});
 const kafkaOwnedRuntimeEffect = makeViewServerRuntime(kafkaOwnedViewServer, {
   kafka: {
     consumerGroupId: "view-server-kafka-owned-type-test",
@@ -204,6 +211,13 @@ const runtimeWithAuth = makeViewServerRuntime(viewServer, {
   } satisfies ViewServerAuth,
 });
 const runEffect = runViewServerRuntime(viewServer);
+const _invalidSourceFreeRunRuntimeWithKafka = runViewServerRuntime(viewServer, {
+  // @ts-expect-error source-free runtimes reject Kafka options.
+  kafka: {
+    consumerGroupId: "view-server-source-free-run-type-test",
+    regions: usaKafkaRegions,
+  },
+});
 declare const runtime: Effect.Success<typeof runtimeEffect>;
 declare const kafkaOwnedRuntime: Effect.Success<typeof kafkaOwnedRuntimeEffect>;
 type MultiGrpcSourceVisible = typeof multiMaterializedGrpcViewServer.topics.orders extends {

--- a/packages/runtime/src/index.test-d.ts
+++ b/packages/runtime/src/index.test-d.ts
@@ -21,6 +21,7 @@ import {
   type ViewServerGrpcIngressError,
   type ViewServerKafkaIngressError,
   type ViewServerTcpPublishIngressError,
+  type ViewServerRuntimeOptionsInput,
   type ViewServerRuntimeOptions,
 } from "./index";
 
@@ -218,6 +219,17 @@ const _invalidSourceFreeRunRuntimeWithKafka = runViewServerRuntime(viewServer, {
     regions: usaKafkaRegions,
   },
 });
+type SourceFreeRuntimeOptionsInput = ViewServerRuntimeOptionsInput<typeof viewServer.topics>;
+const _validSourceFreeRuntimeOptionsInput: SourceFreeRuntimeOptionsInput = {
+  websocketPort: 3_800,
+};
+const _invalidSourceFreeRuntimeOptionsInput: SourceFreeRuntimeOptionsInput = {
+  // @ts-expect-error exported source-free runtime options reject Kafka options.
+  kafka: {
+    consumerGroupId: "view-server-source-free-exported-input-type-test",
+    regions: usaKafkaRegions,
+  },
+};
 declare const runtime: Effect.Success<typeof runtimeEffect>;
 declare const kafkaOwnedRuntime: Effect.Success<typeof kafkaOwnedRuntimeEffect>;
 type MultiGrpcSourceVisible = typeof multiMaterializedGrpcViewServer.topics.orders extends {

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -13674,6 +13674,39 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
+  it.effect("rejects source-free Kafka options before resolving Kafka region config", () =>
+    Effect.gen(function* () {
+      const sourceFreeConfigBackedViewServer = defineViewServerConfig({
+        kafka: {
+          local: Config.string("VIEW_SERVER_RUNTIME_TEST_UNSET_KAFKA_BOOTSTRAP"),
+        },
+        topics: {
+          orders: {
+            schema: Order,
+            key: "id",
+          },
+        },
+      });
+
+      const error = yield* Effect.flip(
+        resolveViewServerRuntimeOptions(sourceFreeConfigBackedViewServer, {
+          kafka: {
+            consumerGroupId: "view-server-no-kafka-topics-config-first",
+          },
+        }),
+      );
+
+      expect(error).toStrictEqual(
+        new ViewServerKafkaIngressError({
+          message:
+            "runtime options.kafka was provided, but no topic-owned Kafka sources were declared; remove options.kafka or add kafkaSource to a View Server topic.",
+          cause: "missing-kafka-source-topics",
+        }),
+      );
+      expect(error.cause).toBe("missing-kafka-source-topics");
+    }),
+  );
+
   it.effect("rejects duplicate topic-owned Kafka source topic names", () =>
     Effect.gen(function* () {
       const regions = {

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -13650,26 +13650,27 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
-  it.effect("resolves runtime Kafka regions without configured source topics", () =>
+  it.effect("rejects runtime Kafka options without configured source topics", () =>
     Effect.gen(function* () {
-      const options = yield* resolvePublicViewServerRuntimeOptions({
-        kafka: {
-          consumerGroupId: "view-server-no-kafka-topics",
-          regions: {
-            local: "localhost:9092",
+      const error = yield* Effect.flip(
+        resolvePublicViewServerRuntimeOptions({
+          kafka: {
+            consumerGroupId: "view-server-no-kafka-topics",
+            regions: {
+              local: "localhost:9092",
+            },
           },
-        },
-      });
+        }),
+      );
 
-      expect({
-        consumerGroupId: options.kafkaOptions?.consumerGroupId,
-        regions: options.kafkaOptions?.regions,
-        topics: options.kafkaOptions?.topics,
-      }).toStrictEqual({
-        consumerGroupId: "view-server-no-kafka-topics",
-        regions: nullRecord([["local", "localhost:9092"]]),
-        topics: nullRecord([]),
-      });
+      expect(error).toStrictEqual(
+        new ViewServerKafkaIngressError({
+          message:
+            "runtime options.kafka was provided, but no topic-owned Kafka sources were declared; remove options.kafka or add kafkaSource to a View Server topic.",
+          cause: "missing-kafka-source-topics",
+        }),
+      );
+      expect(error.cause).toBe("missing-kafka-source-topics");
     }),
   );
 

--- a/packages/runtime/src/kafka-delivery-contract.test.ts
+++ b/packages/runtime/src/kafka-delivery-contract.test.ts
@@ -227,4 +227,64 @@ describe("Kafka delivery contract", () => {
       ],
     );
   });
+
+  it("keeps interleaved upsert topics in separate contiguous publish runs", () => {
+    const firstOrder = upsertMessage({
+      offset: 1n,
+      row: { id: "a", price: 10 },
+      rowKey: "a",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+    const trade = upsertMessage({
+      offset: 2n,
+      row: { id: "t", quantity: 5 },
+      rowKey: "t",
+      sourceTopic: "trades-source",
+      viewServerTopic: "trades",
+    });
+    const secondOrder = upsertMessage({
+      offset: 3n,
+      row: { id: "b", price: 20 },
+      rowKey: "b",
+      sourceTopic: "orders-source",
+      viewServerTopic: "orders",
+    });
+
+    expect(planKafkaUpsertPublishRuns([firstOrder, trade, secondOrder])).toStrictEqual([
+      {
+        rows: [
+          {
+            message: firstOrder,
+            row: { id: "a", price: 10 },
+            storageKey: "a",
+          },
+        ],
+        sourceTopic: "orders-source",
+        topic: "orders",
+      },
+      {
+        rows: [
+          {
+            message: trade,
+            row: { id: "t", quantity: 5 },
+            storageKey: "t",
+          },
+        ],
+        sourceTopic: "trades-source",
+        topic: "trades",
+      },
+      {
+        rows: [
+          {
+            message: secondOrder,
+            row: { id: "b", price: 20 },
+            storageKey: "b",
+          },
+        ],
+        sourceTopic: "orders-source",
+        topic: "orders",
+      },
+    ]);
+  });
 });

--- a/packages/runtime/src/kafka-delivery-contract.ts
+++ b/packages/runtime/src/kafka-delivery-contract.ts
@@ -6,6 +6,14 @@ type KafkaMessageBytes = Buffer | null | undefined;
 
 export type KafkaConsumerMessage = Message<KafkaMessageBytes, KafkaMessageBytes, Buffer, Buffer>;
 
+export type KeyedKafkaConsumerMessage = KafkaConsumerMessage & {
+  readonly key: Buffer;
+};
+
+export const kafkaConsumerMessageHasKey = (
+  message: KafkaConsumerMessage,
+): message is KeyedKafkaConsumerMessage => message.key !== null && message.key !== undefined;
+
 export type KafkaBatchTopic<Topics extends ViewServerRuntimeTopicDefinitions> = Extract<
   keyof Topics,
   string

--- a/packages/runtime/src/kafka-health.ts
+++ b/packages/runtime/src/kafka-health.ts
@@ -101,6 +101,14 @@ export type ViewServerKafkaHealthLedger<Topics extends ViewServerRuntimeTopicDef
       readonly preserveLastError?: boolean;
     },
   ) => Effect.Effect<void>;
+  readonly messageSkippedCommitted: (
+    sourceTopic: string,
+    region: string,
+    input: {
+      readonly committedOffset: string;
+      readonly nowMillis: number;
+    },
+  ) => Effect.Effect<void>;
   readonly decodeFailed: (
     sourceTopic: string,
     region: string,
@@ -135,6 +143,7 @@ export type ViewServerKafkaHealthLedger<Topics extends ViewServerRuntimeTopicDef
       readonly bytes: number;
       readonly message: string;
       readonly nowMillis: number;
+      readonly recountMessage?: boolean;
     },
   ) => Effect.Effect<void>;
 };
@@ -511,6 +520,16 @@ export const makeViewServerKafkaHealthLedger = <
           refreshTopicStatus(topic);
         }
       }),
+    messageSkippedCommitted: (sourceTopic, region, input) =>
+      Effect.sync(() => {
+        const ledger = getTopicRegion(topics, sourceTopic, region);
+        const topic = topics.get(sourceTopic);
+        if (ledger !== undefined && topic !== undefined) {
+          ledger.lastCommitAt = input.nowMillis;
+          ledger.committedOffset = input.committedOffset;
+          refreshTopicStatus(topic);
+        }
+      }),
     decodeFailed: (sourceTopic, region, input) =>
       Effect.sync(() => {
         const ledger = getTopicRegion(topics, sourceTopic, region);
@@ -576,14 +595,15 @@ export const makeViewServerKafkaHealthLedger = <
         const ledger = getTopicRegion(topics, sourceTopic, region);
         const topic = topics.get(sourceTopic);
         if (ledger !== undefined && topic !== undefined) {
+          const recountMessage = input.recountMessage ?? true;
           incrementWindow(ledger, input.nowMillis, {
-            bytes: input.bytes,
+            bytes: recountMessage ? input.bytes : 0,
             decoded: 0,
             failed: 0,
             mappingFailed: 0,
             publishFailed: 0,
             commitFailed: 1,
-            messages: 1,
+            messages: recountMessage ? 1 : 0,
             processingFailed: 1,
           });
           ledger.lastMessageAt = input.nowMillis;

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -5347,6 +5347,160 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("preserves missing topic failures when decoded prefix flush fails", () =>
+    Effect.gen(function* () {
+      const multiSourceViewServer = defineViewServerConfig({
+        kafka: regions,
+        topics: {
+          orders: {
+            schema: Order,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: ordersSourceTopic,
+              regions: ["local"],
+              value: kafka.json(IncomingOrder),
+              key: kafka.stringKey(),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({
+                customerId: value.customerId,
+                price: value.price,
+              }),
+            }),
+          },
+          payments: {
+            schema: Order,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: paymentsSourceTopic,
+              regions: ["local"],
+              value: kafka.json(IncomingOrder),
+              key: kafka.stringKey(),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({
+                customerId: value.customerId,
+                price: value.price,
+              }),
+            }),
+          },
+        },
+      });
+      const runtimeCore = yield* makeViewServerRuntimeCore(multiSourceViewServer, {});
+      const multiSourceKafkaOptions = kafkaOptionsForConfig(
+        multiSourceViewServer,
+        "view-server-missing-topic-prefix-flush-failure-test",
+      );
+      const ledger = makeViewServerKafkaHealthLedger<typeof multiSourceViewServer.topics>({
+        regions: multiSourceKafkaOptions.regions,
+        startFrom: multiSourceKafkaOptions.consume,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+          [paymentsSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "payments",
+          },
+        },
+      });
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      yield* ledger.topicConnected(paymentsSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+      const publishManyFailingClient: ViewServerRuntimeCoreInternalClient<
+        typeof multiSourceViewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishManyDecodedRows: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(Effect.fail(runtimeUnavailable))),
+        publishManyDecodedRowsWithStorageKeys: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(Effect.fail(runtimeUnavailable))),
+      };
+      Reflect.deleteProperty(multiSourceViewServer.topics, "payments");
+
+      const exit = yield* Effect.exit(
+        processKafkaMessageBatch(
+          multiSourceViewServer,
+          publishManyFailingClient,
+          runtimeCore.requestHealthRefresh,
+          multiSourceKafkaOptions,
+          ledger,
+          "local",
+          [
+            kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "orders-prefix",
+              value: JSON.stringify({
+                customerId: "customer-orders-prefix",
+                price: 10,
+              }),
+              offset: 1n,
+              onCommit: () => {
+                operations.push("commit:orders-prefix");
+              },
+            }),
+            kafkaMessage({
+              topic: paymentsSourceTopic,
+              key: "payments-poison",
+              value: JSON.stringify({
+                customerId: "customer-payments-poison",
+                price: 20,
+              }),
+              offset: 2n,
+              onCommit: () => {
+                operations.push("commit:payments-poison");
+              },
+            }),
+          ],
+        ),
+      );
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id", "customerId", "price"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const exitSummary = Exit.match(exit, {
+        onFailure: causeReasonSummary,
+        onSuccess: () => [],
+      });
+
+      expect({
+        exit: exitSummary,
+        operations,
+        snapshot,
+      }).toStrictEqual({
+        exit: [
+          {
+            tag: "Fail",
+            message: "Kafka source references unknown View Server topic: payments",
+          },
+          {
+            tag: "Fail",
+            message: `Failed to process Kafka message for source topic ${ordersSourceTopic}`,
+          },
+          {
+            tag: "Fail",
+            message: "publish failed",
+          },
+        ],
+        operations: ["publishMany:orders:1"],
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [],
+          totalRows: 0,
+          version: 0,
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("flushes decoded Kafka microbatch messages before a later codec defect", () =>
     Effect.gen(function* () {
       const defectingViewServer = defineViewServerConfig({

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -1055,6 +1055,10 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
         message: "ignored",
         nowMillis: 2_000,
       });
+      yield* ledger.messageSkippedCommitted("missing", "local", {
+        committedOffset: "4",
+        nowMillis: 2_000,
+      });
 
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
 
@@ -5188,6 +5192,161 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("flushes decoded Kafka microbatch messages before a missing topic failure", () =>
+    Effect.gen(function* () {
+      const multiSourceViewServer = defineViewServerConfig({
+        kafka: regions,
+        topics: {
+          orders: {
+            schema: Order,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: ordersSourceTopic,
+              regions: ["local"],
+              value: kafka.json(IncomingOrder),
+              key: kafka.stringKey(),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({
+                customerId: value.customerId,
+                price: value.price,
+              }),
+            }),
+          },
+          payments: {
+            schema: Order,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: paymentsSourceTopic,
+              regions: ["local"],
+              value: kafka.json(IncomingOrder),
+              key: kafka.stringKey(),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({
+                customerId: value.customerId,
+                price: value.price,
+              }),
+            }),
+          },
+        },
+      });
+      const runtimeCore = yield* makeViewServerRuntimeCore(multiSourceViewServer, {});
+      const multiSourceKafkaOptions = kafkaOptionsForConfig(
+        multiSourceViewServer,
+        "view-server-missing-topic-prefix-test",
+      );
+      const ledger = makeViewServerKafkaHealthLedger<typeof multiSourceViewServer.topics>({
+        regions: multiSourceKafkaOptions.regions,
+        startFrom: multiSourceKafkaOptions.consume,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+          [paymentsSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "payments",
+          },
+        },
+      });
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      yield* ledger.topicConnected(paymentsSourceTopic, "local", 1, 1_000);
+      const operations: Array<string> = [];
+      const batchingClient: ViewServerRuntimeCoreInternalClient<
+        typeof multiSourceViewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+        publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
+        publishManyDecodedRows: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(Effect.andThen(runtimeCore.internalClient.publishManyDecodedRows(topic, rows))),
+        publishManyDecodedRowsWithStorageKeys: (topic, rows) =>
+          Effect.sync(() => {
+            operations.push(`publishMany:${topic}:${rows.length}`);
+          }).pipe(
+            Effect.andThen(
+              runtimeCore.internalClient.publishManyDecodedRowsWithStorageKeys(topic, rows),
+            ),
+          ),
+      };
+      Reflect.deleteProperty(multiSourceViewServer.topics, "payments");
+
+      const error = yield* Effect.flip(
+        processKafkaMessageBatch(
+          multiSourceViewServer,
+          batchingClient,
+          runtimeCore.requestHealthRefresh,
+          multiSourceKafkaOptions,
+          ledger,
+          "local",
+          [
+            kafkaMessage({
+              topic: ordersSourceTopic,
+              key: "orders-prefix",
+              value: JSON.stringify({
+                customerId: "customer-orders-prefix",
+                price: 10,
+              }),
+              offset: 1n,
+              onCommit: () => {
+                operations.push("commit:orders-prefix");
+              },
+            }),
+            kafkaMessage({
+              topic: paymentsSourceTopic,
+              key: "payments-poison",
+              value: JSON.stringify({
+                customerId: "customer-payments-poison",
+                price: 20,
+              }),
+              offset: 2n,
+              onCommit: () => {
+                operations.push("commit:payments-poison");
+              },
+            }),
+          ],
+        ),
+      );
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id", "customerId", "price"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect({
+        error: {
+          message: error.message,
+          region: error.region,
+          sourceTopic: error.sourceTopic,
+        },
+        operations,
+        snapshot,
+      }).toStrictEqual({
+        error: {
+          message: "Kafka source references unknown View Server topic: payments",
+          region: "local",
+          sourceTopic: paymentsSourceTopic,
+        },
+        operations: ["publishMany:orders:1", "commit:orders-prefix"],
+        snapshot: {
+          status: "ready",
+          statusCode: "Ready",
+          rows: [
+            {
+              id: "orders-prefix",
+              customerId: "customer-orders-prefix",
+              price: 10,
+            },
+          ],
+          totalRows: 1,
+          version: 1,
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("flushes decoded Kafka microbatch messages before a later codec defect", () =>
     Effect.gen(function* () {
       const defectingViewServer = defineViewServerConfig({
@@ -6611,6 +6770,94 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
     }),
   );
 
+  it.effect("ignores keyless Kafka messages for unknown source topics and wrong regions", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      let committedMessages = 0;
+
+      yield* processKafkaMessage(
+        viewServer,
+        runtimeCore.internalClient,
+        runtimeCore.requestHealthRefresh,
+        kafkaOptions,
+        ledger,
+        "local",
+        kafkaMessage({
+          topic: unknownSourceTopic,
+          key: null,
+          value: null,
+          offset: 1n,
+          onCommit: () => {
+            committedMessages += 1;
+          },
+        }),
+      );
+      yield* processKafkaMessage(
+        viewServer,
+        runtimeCore.internalClient,
+        runtimeCore.requestHealthRefresh,
+        kafkaOptions,
+        ledger,
+        "cold",
+        kafkaMessage({
+          topic: ordersSourceTopic,
+          key: null,
+          value: null,
+          offset: 2n,
+          onCommit: () => {
+            committedMessages += 1;
+          },
+        }),
+      );
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+
+      expect({
+        committedMessages,
+        topicHealth: health.kafka?.topics[ordersSourceTopic],
+      }).toStrictEqual({
+        committedMessages: 0,
+        topicHealth: {
+          status: "ready",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: true,
+              assignedPartitions: 1,
+              messagesPerSecond: 0,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 0,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 0,
+              processingFailuresPerSecond: 0,
+              lastMessageAt: null,
+              lastCommitAt: null,
+              consumerLagMessages: null,
+              lagSampledAt: null,
+              committedOffset: null,
+              lastError: null,
+            },
+          }),
+        },
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("preserves high-precision Kafka JSON values through runtime snapshots", () =>
     Effect.gen(function* () {
       const preciseSourceTopic = "precise-position-source";
@@ -7157,8 +7404,8 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
       );
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(healthRefreshRequestCount).toBe(1);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(healthRefreshRequestCount).toBe(2);
       expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
         status: "degraded",
         sourceTopic: ordersSourceTopic,
@@ -7176,13 +7423,100 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
             commitFailuresPerSecond: 0,
             processingFailuresPerSecond: 0,
             lastMessageAt: 0,
-            lastCommitAt: null,
+            lastCommitAt: 0,
             consumerLagMessages: null,
             lagSampledAt: null,
-            committedOffset: null,
+            committedOffset: "7",
             lastError: "Kafka source key bytes are required",
           },
         }),
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("fails processing when keyless Kafka skip commit fails", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+      const ledger = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      yield* ledger.regionConnected("local", 1_000);
+      yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
+      let healthRefreshRequestCount = 0;
+      const requestHealthRefresh = Effect.sync(() => {
+        healthRefreshRequestCount += 1;
+      });
+      const commitFailedMessage = kafkaMessage({
+        topic: ordersSourceTopic,
+        key: null,
+        value: null,
+        offset: 6n,
+        commitFailure: new Error("commit failed"),
+      });
+
+      const error = yield* Effect.flip(
+        processKafkaMessage(
+          viewServer,
+          runtimeCore.internalClient,
+          requestHealthRefresh,
+          kafkaOptions,
+          ledger,
+          "local",
+          commitFailedMessage,
+        ),
+      );
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+
+      expect({
+        error: {
+          causeMessage: messageFromUnknown(error.cause),
+          message: error.message,
+          region: error.region,
+          sourceTopic: error.sourceTopic,
+        },
+        healthRefreshRequestCount,
+        kafkaTopic: health.kafka?.topics[ordersSourceTopic],
+      }).toStrictEqual({
+        error: {
+          causeMessage: "commit failed",
+          message: `Failed to commit Kafka message for source topic ${ordersSourceTopic}`,
+          region: "local",
+          sourceTopic: ordersSourceTopic,
+        },
+        healthRefreshRequestCount: 2,
+        kafkaTopic: {
+          status: "degraded",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: true,
+              assignedPartitions: 1,
+              messagesPerSecond: 1,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 1,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 1,
+              processingFailuresPerSecond: 1,
+              lastMessageAt: 0,
+              lastCommitAt: null,
+              consumerLagMessages: null,
+              lagSampledAt: null,
+              committedOffset: null,
+              lastError: `Failed to commit Kafka message for source topic ${ordersSourceTopic}: commit failed`,
+            },
+          }),
+        },
       });
 
       yield* runtimeCore.close;

--- a/packages/runtime/src/kafka-ingress.test.ts
+++ b/packages/runtime/src/kafka-ingress.test.ts
@@ -737,7 +737,7 @@ describe("@effect-view-server/runtime Kafka ingress", () => {
     }),
   );
 
-  it.effect("rejects topic-owned tombstones without Kafka keys", () =>
+  it.effect("commits and skips topic-owned tombstones without Kafka keys", () =>
     Effect.gen(function* () {
       const regions = {
         local: kafkaBootstrapServers,
@@ -780,35 +780,47 @@ describe("@effect-view-server/runtime Kafka ingress", () => {
         },
       });
 
-      const error = yield* Effect.flip(
-        processKafkaMessage(
-          topicOwnedViewServer,
-          runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
-          kafkaOptions,
-          health,
-          "local",
-          kafkaProcessorMessage({
-            key: null,
-            topic: "orders-source",
-            value: null,
-          }),
-        ),
+      const committedOffsets: Array<bigint> = [];
+      const keylessTombstone = kafkaProcessorMessage({
+        key: null,
+        offset: 41n,
+        topic: "orders-source",
+        value: null,
+      });
+
+      yield* processKafkaMessage(
+        topicOwnedViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.requestHealthRefresh,
+        kafkaOptions,
+        health,
+        "local",
+        {
+          ...keylessTombstone,
+          commit: () => {
+            committedOffsets.push(keylessTombstone.offset);
+          },
+        },
       );
       const snapshot = yield* runtimeCore.client.snapshot("orders", {
         select: ["id", "customerId", "price"],
         limit: 10,
       });
+      const degradedHealth = health.healthOverlay(yield* runtimeCore.client.health(), 41);
       yield* runtimeCore.close;
 
-      expect(error).toStrictEqual(
-        new ViewServerKafkaIngressError({
-          message: "Failed to map Kafka message for source topic orders-source",
-          cause: "missing-kafka-key",
-          region: "local",
-          sourceTopic: "orders-source",
-        }),
-      );
+      expect(committedOffsets).toStrictEqual([41n]);
+      expect({
+        committedOffset:
+          degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.committedOffset,
+        lastError: degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.lastError,
+        mappingFailures:
+          degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.mappingFailuresPerSecond,
+      }).toStrictEqual({
+        committedOffset: "42",
+        lastError: "Kafka source key bytes are required",
+        mappingFailures: 1,
+      });
       expect(snapshot).toStrictEqual({
         version: 0,
         rows: [],
@@ -819,7 +831,7 @@ describe("@effect-view-server/runtime Kafka ingress", () => {
     }),
   );
 
-  it.effect("flushes valid topic-owned batch prefix before failing keyless tombstones", () =>
+  it.effect("flushes valid topic-owned batch prefix and commits keyless tombstones", () =>
     Effect.gen(function* () {
       const regions = {
         local: kafkaBootstrapServers,
@@ -878,45 +890,47 @@ describe("@effect-view-server/runtime Kafka ingress", () => {
         value: null,
       });
 
-      const error = yield* Effect.flip(
-        processKafkaMessageBatch(
-          topicOwnedViewServer,
-          runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
-          kafkaOptions,
-          health,
-          "local",
-          [
-            {
-              ...validMessage,
-              commit: () => {
-                committedOffsets.push(validMessage.offset);
-              },
+      yield* processKafkaMessageBatch(
+        topicOwnedViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.requestHealthRefresh,
+        kafkaOptions,
+        health,
+        "local",
+        [
+          {
+            ...validMessage,
+            commit: () => {
+              committedOffsets.push(validMessage.offset);
             },
-            {
-              ...keylessTombstone,
-              commit: () => {
-                committedOffsets.push(keylessTombstone.offset);
-              },
+          },
+          {
+            ...keylessTombstone,
+            commit: () => {
+              committedOffsets.push(keylessTombstone.offset);
             },
-          ],
-        ),
+          },
+        ],
       );
       const ordersSnapshot = yield* runtimeCore.client.snapshot("orders", {
         select: ["id", "customerId", "price"],
         limit: 10,
       });
+      const degradedHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2);
       yield* runtimeCore.close;
 
-      expect(error).toStrictEqual(
-        new ViewServerKafkaIngressError({
-          message: "Failed to map Kafka message for source topic orders-source",
-          cause: "missing-kafka-key",
-          region: "local",
-          sourceTopic: "orders-source",
-        }),
-      );
-      expect(committedOffsets).toStrictEqual([1n]);
+      expect(committedOffsets).toStrictEqual([1n, 2n]);
+      expect({
+        committedOffset:
+          degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.committedOffset,
+        lastError: degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.lastError,
+        mappingFailures:
+          degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.mappingFailuresPerSecond,
+      }).toStrictEqual({
+        committedOffset: "3",
+        lastError: "Kafka source key bytes are required",
+        mappingFailures: 1,
+      });
       expect(ordersSnapshot).toStrictEqual({
         version: 1,
         rows: [
@@ -1387,57 +1401,52 @@ describe("@effect-view-server/runtime Kafka ingress", () => {
     }),
   );
 
-  it.effect("rejects topic-owned Kafka source rows when Kafka key bytes are missing", () =>
-    Effect.gen(function* () {
-      const regions = {
-        local: kafkaBootstrapServers,
-      };
-      const kafkaBackedViewServer = defineViewServerConfig({
-        kafka: regions,
-        topics: {
-          orders: {
-            schema: Order,
-            key: "id",
-            kafkaSource: kafka.source({
-              topic: "orders-source",
-              regions: ["local"],
-              value: kafka.json(IncomingOrder),
-              key: kafka.stringKey(),
-              rowKey: ({ key }) => key,
-              map: ({ value }) => ({
-                customerId: value.customerId,
-                price: value.price,
+  it.effect(
+    "commits and skips topic-owned Kafka source rows when Kafka key bytes are missing",
+    () =>
+      Effect.gen(function* () {
+        const regions = {
+          local: kafkaBootstrapServers,
+        };
+        const kafkaBackedViewServer = defineViewServerConfig({
+          kafka: regions,
+          topics: {
+            orders: {
+              schema: Order,
+              key: "id",
+              kafkaSource: kafka.source({
+                topic: "orders-source",
+                regions: ["local"],
+                value: kafka.json(IncomingOrder),
+                key: kafka.stringKey(),
+                rowKey: ({ key }) => key,
+                map: ({ value }) => ({
+                  customerId: value.customerId,
+                  price: value.price,
+                }),
               }),
-            }),
+            },
           },
-        },
-      });
-      const resolved = yield* resolveViewServerRuntimeOptions(kafkaBackedViewServer, {
-        kafka: {
-          consumerGroupId: "view-server-direct-null-key-upsert",
-        },
-      });
-      const kafkaOptions = Option.getOrThrow(Option.fromNullishOr(resolved.kafkaOptions));
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(kafkaBackedViewServer, {});
-      const health = makeViewServerKafkaHealthLedger<typeof kafkaBackedViewServer.topics>({
-        regions: kafkaOptions.regions,
-        startFrom: kafkaOptions.consume,
-        topics: {
-          "orders-source": {
-            regions: ["local"],
-            viewServerTopic: "orders",
+        });
+        const resolved = yield* resolveViewServerRuntimeOptions(kafkaBackedViewServer, {
+          kafka: {
+            consumerGroupId: "view-server-direct-null-key-upsert",
           },
-        },
-      });
-
-      const error = yield* processKafkaMessage(
-        kafkaBackedViewServer,
-        runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
-        kafkaOptions,
-        health,
-        "local",
-        kafkaProcessorMessage({
+        });
+        const kafkaOptions = Option.getOrThrow(Option.fromNullishOr(resolved.kafkaOptions));
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(kafkaBackedViewServer, {});
+        const health = makeViewServerKafkaHealthLedger<typeof kafkaBackedViewServer.topics>({
+          regions: kafkaOptions.regions,
+          startFrom: kafkaOptions.consume,
+          topics: {
+            "orders-source": {
+              regions: ["local"],
+              viewServerTopic: "orders",
+            },
+          },
+        });
+        const committedOffsets: Array<bigint> = [];
+        const keylessMessage = kafkaProcessorMessage({
           key: null,
           offset: 1n,
           topic: "orders-source",
@@ -1445,30 +1454,50 @@ describe("@effect-view-server/runtime Kafka ingress", () => {
             customerId: "customer-1",
             price: 10,
           }),
-        }),
-      ).pipe(Effect.flip);
-      const snapshot = yield* runtimeCore.client.snapshot("orders", {
-        select: ["id", "customerId", "price"],
-        limit: 10,
-      });
-      yield* runtimeCore.close;
+        });
 
-      expect(error).toStrictEqual(
-        new ViewServerKafkaIngressError({
-          message: "Failed to map Kafka message for source topic orders-source",
-          cause: "missing-kafka-key",
-          region: "local",
-          sourceTopic: "orders-source",
-        }),
-      );
-      expect(snapshot).toStrictEqual({
-        version: 0,
-        rows: [],
-        totalRows: 0,
-        status: "ready",
-        statusCode: "Ready",
-      });
-    }),
+        yield* processKafkaMessage(
+          kafkaBackedViewServer,
+          runtimeCore.internalClient,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          health,
+          "local",
+          {
+            ...keylessMessage,
+            commit: () => {
+              committedOffsets.push(keylessMessage.offset);
+            },
+          },
+        );
+        const snapshot = yield* runtimeCore.client.snapshot("orders", {
+          select: ["id", "customerId", "price"],
+          limit: 10,
+        });
+        const degradedHealth = health.healthOverlay(yield* runtimeCore.client.health(), 41);
+        yield* runtimeCore.close;
+
+        expect(committedOffsets).toStrictEqual([1n]);
+        expect({
+          committedOffset:
+            degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.committedOffset,
+          lastError: degradedHealth.kafka?.topics["orders-source"]?.regions["local"]?.lastError,
+          mappingFailures:
+            degradedHealth.kafka?.topics["orders-source"]?.regions["local"]
+              ?.mappingFailuresPerSecond,
+        }).toStrictEqual({
+          committedOffset: "2",
+          lastError: "Kafka source key bytes are required",
+          mappingFailures: 1,
+        });
+        expect(snapshot).toStrictEqual({
+          version: 0,
+          rows: [],
+          totalRows: 0,
+          status: "ready",
+          statusCode: "Ready",
+        });
+      }),
   );
 
   it.effect("validates topic-owned Kafka mapped rows with decoded transform schema values", () =>

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -37,7 +37,9 @@ import {
   type DecodedKafkaBatchTombstoneMessage,
   type DecodedKafkaBatchUpsertMessage,
   type KafkaBatchTopic,
+  kafkaConsumerMessageHasKey,
   type KafkaConsumerMessage,
+  type KeyedKafkaConsumerMessage,
 } from "./kafka-delivery-contract";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
@@ -641,29 +643,22 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
   function* <
     const Topics extends ViewServerRuntimeTopicDefinitions,
     const Regions extends RuntimeRegions,
+    const Topic extends ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>["topics"][string],
   >(
-    config: ViewServerTopicConfig<Topics>,
     requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
     health: ViewServerKafkaHealthLedger<Topics>,
     region: string,
-    message: KafkaConsumerMessage,
+    sourceTopic: string,
+    topic: Topic,
+    topicRegion: Topic["regions"][number],
+    viewServerTopic: KafkaBatchTopic<Topics>,
+    topicDefinition: Topics[KafkaBatchTopic<Topics>],
+    message: KeyedKafkaConsumerMessage,
   ) {
-    const sourceTopic = message.topic;
-    const topic = options.topics[sourceTopic];
-    if (topic === undefined) {
-      return Option.none<DecodedKafkaBatchMessage<Topics>>();
-    }
-    const topicRegion = topic.regions.find(
-      (candidate: (typeof topic.regions)[number]) => candidate === region,
-    );
-    if (topicRegion === undefined) {
-      return Option.none<DecodedKafkaBatchMessage<Topics>>();
-    }
     const nowMillis = yield* Clock.currentTimeMillis;
     const keyBytes = message.key;
     const valueBytes = message.value;
-    const messageBytes = (valueBytes?.byteLength ?? 0) + (keyBytes?.byteLength ?? 0);
+    const messageBytes = (valueBytes?.byteLength ?? 0) + keyBytes.byteLength;
     const metadata: KafkaMessageMetadata<typeof topicRegion> = {
       sourceTopic,
       sourceRegion: topicRegion,
@@ -672,17 +667,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
       timestamp: Number(message.timestamp),
       headers: kafkaHeadersFromMessage(message.headers),
     };
-    const viewServerTopic = topic.viewServerTopic;
-    if (!isKafkaBatchTopic(config, viewServerTopic)) {
-      const viewServerTopicMessage = String(viewServerTopic);
-      return yield* new ViewServerKafkaIngressError({
-        message: `Kafka source references unknown View Server topic: ${viewServerTopicMessage}`,
-        cause: "missing-view-server-topic",
-        region,
-        sourceTopic,
-      });
-    }
-    const topicDefinition = kafkaBatchTopicDefinition(config, viewServerTopic);
     const requestHealthRefreshAfterLedgerUpdate = requestKafkaHealthRefresh(requestHealthRefresh);
     const handleMappingFailure = (failure: unknown, cause: Cause.Cause<unknown>) =>
       health
@@ -755,27 +739,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
           ),
         );
     };
-    if (keyBytes === null || keyBytes === undefined) {
-      return yield* health
-        .mappingFailed(sourceTopic, region, {
-          bytes: messageBytes,
-          message: "Kafka source key bytes are required",
-          nowMillis,
-        })
-        .pipe(
-          Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
-          Effect.andThen(
-            Effect.fail(
-              new ViewServerKafkaIngressError({
-                message: `Failed to map Kafka message for source topic ${sourceTopic}`,
-                cause: "missing-kafka-key",
-                region,
-                sourceTopic,
-              }),
-            ),
-          ),
-        );
-    }
     if (valueBytes === undefined) {
       return yield* health
         .decodeFailed(sourceTopic, region, {
@@ -837,7 +800,7 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
         sourceTopic,
       };
     }
-    return Option.some(decodedBatchMessage);
+    return decodedBatchMessage;
   },
 );
 
@@ -885,6 +848,67 @@ const publishKafkaRowsForMessages = Effect.fn("ViewServerRuntime.kafka.batch.pub
     );
   },
 );
+
+const commitSkippedKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.skipAndCommit")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
+    health: ViewServerKafkaHealthLedger<Topics>,
+    region: string,
+    sourceTopic: string,
+    message: KafkaConsumerMessage,
+    input: {
+      readonly nowMillis: number;
+    },
+  ) {
+    const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
+    yield* Effect.uninterruptible(
+      Effect.tryPromise({
+        try: () => Promise.resolve(message.commit()),
+        catch: (cause) => kafkaMessageCommitError(region, sourceTopic, cause),
+      }).pipe(
+        Effect.matchEffect({
+          onFailure: (error) =>
+            health
+              .messageCommitFailed(sourceTopic, region, {
+                bytes: messageBytes,
+                message: `${error.message}: ${messageFromUnknown(error.cause)}`,
+                nowMillis: input.nowMillis,
+                recountMessage: false,
+              })
+              .pipe(Effect.andThen(Effect.fail(error))),
+          onSuccess: () =>
+            health.messageSkippedCommitted(sourceTopic, region, {
+              committedOffset: String(message.offset + 1n),
+              nowMillis: input.nowMillis,
+            }),
+        }),
+      ),
+    ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
+  },
+);
+
+const recordAndCommitKeylessKafkaMessage = Effect.fn(
+  "ViewServerRuntime.kafka.message.keylessSkipAndCommit",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
+  health: ViewServerKafkaHealthLedger<Topics>,
+  region: string,
+  message: KafkaConsumerMessage,
+) {
+  const nowMillis = yield* Clock.currentTimeMillis;
+  const sourceTopic = message.topic;
+  const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
+  yield* health
+    .mappingFailed(sourceTopic, region, {
+      bytes: messageBytes,
+      message: "Kafka source key bytes are required",
+      nowMillis,
+    })
+    .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh)));
+  yield* commitSkippedKafkaMessage(requestHealthRefresh, health, region, sourceTopic, message, {
+    nowMillis,
+  });
+});
 
 const publishKafkaDecodedTombstone = Effect.fn("ViewServerRuntime.kafka.tombstone.publish")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
@@ -1028,12 +1052,58 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
   ) {
     const decodedMessages: Array<DecodedKafkaBatchMessage<Topics>> = [];
     for (const message of batch) {
+      const sourceTopic = message.topic;
+      const topic = options.topics[sourceTopic];
+      if (topic === undefined) {
+        continue;
+      }
+      const topicRegion = topic.regions.find(
+        (candidate: (typeof topic.regions)[number]) => candidate === region,
+      );
+      if (topicRegion === undefined) {
+        continue;
+      }
+      if (!isKafkaBatchTopic(config, topic.viewServerTopic)) {
+        const viewServerTopicMessage = String(topic.viewServerTopic);
+        yield* publishAndCommitKafkaDecodedBatch(
+          client,
+          requestHealthRefresh,
+          health,
+          region,
+          decodedMessages,
+          {
+            preserveLastErrorForSourceTopic: sourceTopic,
+          },
+        );
+        decodedMessages.length = 0;
+        return yield* new ViewServerKafkaIngressError({
+          message: `Kafka source references unknown View Server topic: ${viewServerTopicMessage}`,
+          cause: "missing-view-server-topic",
+          region,
+          sourceTopic,
+        });
+      }
+      if (!kafkaConsumerMessageHasKey(message)) {
+        yield* publishAndCommitKafkaDecodedBatch(
+          client,
+          requestHealthRefresh,
+          health,
+          region,
+          decodedMessages,
+        );
+        decodedMessages.length = 0;
+        yield* recordAndCommitKeylessKafkaMessage(requestHealthRefresh, health, region, message);
+        continue;
+      }
       const decoded = yield* decodeKafkaMessageForBatch(
-        config,
         requestHealthRefresh,
-        options,
         health,
         region,
+        sourceTopic,
+        topic,
+        topicRegion,
+        topic.viewServerTopic,
+        kafkaBatchTopicDefinition(config, topic.viewServerTopic),
         message,
       ).pipe(
         Effect.catchCause((cause) => {
@@ -1063,9 +1133,7 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
           );
         }),
       );
-      if (Option.isSome(decoded)) {
-        decodedMessages.push(decoded.value);
-      }
+      decodedMessages.push(decoded);
     }
     yield* publishAndCommitKafkaDecodedBatch(
       client,

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -1065,23 +1065,30 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
       }
       if (!isKafkaBatchTopic(config, topic.viewServerTopic)) {
         const viewServerTopicMessage = String(topic.viewServerTopic);
-        yield* publishAndCommitKafkaDecodedBatch(
-          client,
-          requestHealthRefresh,
-          health,
-          region,
-          decodedMessages,
-          {
-            preserveLastErrorForSourceTopic: sourceTopic,
-          },
-        );
-        decodedMessages.length = 0;
-        return yield* new ViewServerKafkaIngressError({
+        const missingTopicError = new ViewServerKafkaIngressError({
           message: `Kafka source references unknown View Server topic: ${viewServerTopicMessage}`,
           cause: "missing-view-server-topic",
           region,
           sourceTopic,
         });
+        const flushExit = yield* Effect.exit(
+          publishAndCommitKafkaDecodedBatch(
+            client,
+            requestHealthRefresh,
+            health,
+            region,
+            decodedMessages,
+            {
+              preserveLastErrorForSourceTopic: sourceTopic,
+            },
+          ),
+        );
+        decodedMessages.length = 0;
+        return yield* Effect.failCause(
+          Exit.isFailure(flushExit)
+            ? Cause.combine(Cause.fail(missingTopicError), flushExit.cause)
+            : Cause.fail(missingTopicError),
+        );
       }
       if (!kafkaConsumerMessageHasKey(message)) {
         yield* publishAndCommitKafkaDecodedBatch(

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -446,7 +446,15 @@ const resolveKafkaOptions: <
       ? emptyKafkaSourceTopics<Topics, Regions>()
       : yield* kafkaSourcesFromConfig(config);
   const topics = configuredTopics;
-  if (Object.keys(topics).length > 0 && Object.keys(regions).length === 0) {
+  const sourceTopicCount = Object.keys(topics).length;
+  if (sourceTopicCount === 0) {
+    return yield* new ViewServerKafkaIngressError({
+      message:
+        "runtime options.kafka was provided, but no topic-owned Kafka sources were declared; remove options.kafka or add kafkaSource to a View Server topic.",
+      cause: "missing-kafka-source-topics",
+    });
+  }
+  if (Object.keys(regions).length === 0) {
     return yield* new ViewServerKafkaIngressError({
       message:
         "Kafka sources are configured, but no Kafka regions were provided on config.kafka or runtime options.kafka.regions.",

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -431,16 +431,6 @@ const resolveKafkaOptions: <
     });
   }
   const consumerGroupId = yield* validateKafkaConsumerGroupId(options.consumerGroupId);
-  const configuredRegions = options.regions ?? config?.kafka;
-  const entries = yield* Effect.forEach(
-    Object.entries(configuredRegions ?? {}),
-    ([region, value]) =>
-      resolveRuntimeValue(value).pipe(Effect.map((bootstrap) => [region, bootstrap] as const)),
-  );
-  const regions: Record<string, string> = Object.create(null);
-  for (const [region, bootstrap] of entries) {
-    regions[region] = bootstrap;
-  }
   const configuredTopics =
     config === undefined
       ? emptyKafkaSourceTopics<Topics, Regions>()
@@ -453,6 +443,16 @@ const resolveKafkaOptions: <
         "runtime options.kafka was provided, but no topic-owned Kafka sources were declared; remove options.kafka or add kafkaSource to a View Server topic.",
       cause: "missing-kafka-source-topics",
     });
+  }
+  const configuredRegions = options.regions ?? config?.kafka;
+  const entries = yield* Effect.forEach(
+    Object.entries(configuredRegions ?? {}),
+    ([region, value]) =>
+      resolveRuntimeValue(value).pipe(Effect.map((bootstrap) => [region, bootstrap] as const)),
+  );
+  const regions: Record<string, string> = Object.create(null);
+  for (const [region, bootstrap] of entries) {
+    regions[region] = bootstrap;
   }
   if (Object.keys(regions).length === 0) {
     return yield* new ViewServerKafkaIngressError({

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -19,6 +19,11 @@ import type {
   ViewServerRuntimeError,
   GrpcRuntimeClients,
 } from "@effect-view-server/config";
+import type {
+  RuntimeKafkaSourceOwnershipConstraint,
+  RuntimeKafkaSourceRegionConstraint,
+  TopicOwnedKafkaSourceTopic,
+} from "@effect-view-server/config/internal";
 import type { Duration, Effect, Schema } from "effect";
 
 export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
@@ -141,17 +146,6 @@ type RuntimeGroupedIncrementalAdmissionLimitsExactKeysConstraint<Options> = Opti
     }
   : unknown;
 
-type TopicOwnedKafkaSourceTopic<Topics extends object> = Extract<
-  {
-    readonly [Topic in keyof Topics]: Topics[Topic] extends {
-      readonly kafkaSource: object;
-    }
-      ? Topic
-      : never;
-  }[keyof Topics],
-  string
->;
-
 type TopicOwnedGrpcSourceTopic<Topics extends object> = Extract<
   {
     readonly [Topic in keyof Topics]: Topics[Topic] extends {
@@ -166,71 +160,6 @@ type TopicOwnedGrpcSourceTopic<Topics extends object> = Extract<
 type TopicOwnedSourceTopic<Topics extends object> =
   | TopicOwnedKafkaSourceTopic<Topics>
   | TopicOwnedGrpcSourceTopic<Topics>;
-
-type TopicOwnedKafkaSourceRegion<Topics extends object> = Extract<
-  {
-    readonly [Topic in keyof Topics]: Topics[Topic] extends {
-      readonly kafkaSource: {
-        readonly regions: infer Regions extends ReadonlyArray<string>;
-      };
-    }
-      ? Regions[number]
-      : never;
-  }[keyof Topics],
-  string
->;
-
-type RuntimeRegionsAreBroad<Regions extends RuntimeRegions> = string extends keyof Regions
-  ? true
-  : false;
-
-type RuntimeKafkaSourceRegionConstraint<
-  Topics extends object,
-  ConfigRegions extends RuntimeRegions,
-  Options,
-> = [TopicOwnedKafkaSourceRegion<Topics>] extends [never]
-  ? unknown
-  : Options extends {
-        readonly kafka: {
-          readonly regions: infer Regions extends RuntimeRegions;
-        };
-      }
-    ? RuntimeRegionsAreBroad<Regions> extends true
-      ? {
-          readonly kafka: {
-            readonly regions: never;
-          };
-        }
-      : Exclude<TopicOwnedKafkaSourceRegion<Topics>, keyof Regions> extends never
-        ? unknown
-        : {
-            readonly kafka: {
-              readonly regions: never;
-            };
-          }
-    : RuntimeRegionsAreBroad<ConfigRegions> extends true
-      ? {
-          readonly kafka: {
-            readonly regions: never;
-          };
-        }
-      : unknown;
-
-type RuntimeKafkaSourceOwnershipConstraint<Topics extends object, Options> = [
-  TopicOwnedKafkaSourceTopic<Topics>,
-] extends [never]
-  ? unknown
-  : Options extends {
-        readonly kafka: infer CandidateKafka;
-      }
-    ? {
-        readonly kafka: CandidateKafka & {
-          readonly consumerGroupId: string;
-        };
-      }
-    : {
-        readonly kafka: never;
-      };
 
 type RuntimeSourceOwnedTopic<Topics extends object, _Options> = Extract<
   TopicOwnedSourceTopic<Topics>,
@@ -277,7 +206,11 @@ export type ViewServerRuntimeOptionsArgs<
   GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
   Options extends object = ViewServerRuntimeOptions<Topics, ConfigRegions, GrpcClients>,
 > = [TopicOwnedKafkaSourceTopic<Topics>] extends [never]
-  ? [options?: ViewServerRuntimeOptionsInput<Topics, ConfigRegions, GrpcClients, Options>]
+  ? [
+      options?: ViewServerRuntimeOptionsInput<Topics, ConfigRegions, GrpcClients, Options> & {
+        readonly kafka?: never;
+      },
+    ]
   : [options: ViewServerRuntimeOptionsInput<Topics, ConfigRegions, GrpcClients, Options>];
 
 type RuntimePublicMutationTopic<Topics extends object, SourceOwnedTopics extends string> = Extract<

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -180,6 +180,14 @@ type RuntimeRegionsOf<Options, ConfigRegions extends RuntimeRegions> = Options e
   ? Regions
   : ConfigRegions;
 
+type RuntimeKafkaSourceFreeInputConstraint<Topics extends object> = [
+  TopicOwnedKafkaSourceTopic<Topics>,
+] extends [never]
+  ? {
+      readonly kafka?: never;
+    }
+  : unknown;
+
 export type ViewServerRuntimeOptionsInput<
   Topics extends ViewServerRuntimeTopicDefinitions,
   ConfigRegions extends RuntimeRegions = RuntimeRegions,
@@ -196,6 +204,7 @@ export type ViewServerRuntimeOptionsInput<
   RuntimeGrpcExactKeysConstraint<Options> &
   RuntimeGrpcMaterializedReconnectExactKeysConstraint<Options> &
   RuntimeGroupedIncrementalAdmissionLimitsExactKeysConstraint<Options> &
+  RuntimeKafkaSourceFreeInputConstraint<Topics> &
   RuntimeKafkaSourceOwnershipConstraint<Topics, Options> &
   RuntimeKafkaSourceRegionConstraint<Topics, ConfigRegions, Options> &
   RuntimeGrpcSourceOwnershipConstraint<Topics, Options>;
@@ -206,11 +215,7 @@ export type ViewServerRuntimeOptionsArgs<
   GrpcClients extends GrpcRuntimeClients = GrpcRuntimeClients,
   Options extends object = ViewServerRuntimeOptions<Topics, ConfigRegions, GrpcClients>,
 > = [TopicOwnedKafkaSourceTopic<Topics>] extends [never]
-  ? [
-      options?: ViewServerRuntimeOptionsInput<Topics, ConfigRegions, GrpcClients, Options> & {
-        readonly kafka?: never;
-      },
-    ]
+  ? [options?: ViewServerRuntimeOptionsInput<Topics, ConfigRegions, GrpcClients, Options>]
   : [options: ViewServerRuntimeOptionsInput<Topics, ConfigRegions, GrpcClients, Options>];
 
 type RuntimePublicMutationTopic<Topics extends object, SourceOwnedTopics extends string> = Extract<


### PR DESCRIPTION
## Summary
- handle keyless Kafka records deterministically by skipping/committing only for configured source topics and regions
- prevent runtime Kafka options when no topic-owned Kafka source exists
- flush decoded Kafka microbatch prefixes before failures, preserve commit/health attribution, and document contiguous-only delivery grouping
- add regression/type coverage for keyless records, missing-topic prefix flush, source-free runtime options, and Kafka delivery grouping

## Validation
- 3-agent review loop clean: Hooke, Sagan, Gauss
- vp check --fix
- strict Effect LSP across packages/examples: 0 errors, 0 warnings, 0 messages
- vp run @effect-view-server/config#test
- vp test run src/index.test.ts --typecheck (config)
- vp test run src/index.test-d.ts --typecheck (runtime)
- vp run @effect-view-server/runtime#test
- vp run -w check:package-exports
- vp run -w check:internal-seams
- vp run -w ready

@codex review