### PR TITLE
Prepare effect-view-server 0.0.6 release

### DIFF
--- a/.changeset/polite-garlics-release.md
+++ b/.changeset/polite-garlics-release.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Prepare the `0.0.6` release by hardening Kafka source edge cases, removing the bare package root export, shipping the package README, and making `effect` a required peer dependency so applications share one Effect runtime and type surface.

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -1,0 +1,19 @@
+# effect-view-server
+
+Typed Effect View Server for live query snapshots, deltas, React bindings, and runtime ingress adapters.
+
+This package intentionally has no root export. Import from explicit subpaths so applications only load the surface they use:
+
+```ts
+import { defineViewServerConfig } from "effect-view-server/config";
+import { createViewServerReact } from "effect-view-server/react";
+import { runViewServerRuntime } from "effect-view-server/runtime";
+```
+
+React applications should install compatible peer dependencies:
+
+```sh
+vp add effect react react-dom @effect/atom-react
+```
+
+See the repository README and examples for Kafka, gRPC, TCP publishing, in-memory testing, and React usage.

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -10,10 +10,10 @@ import { createViewServerReact } from "effect-view-server/react";
 import { runViewServerRuntime } from "effect-view-server/runtime";
 ```
 
-React applications should install compatible peer dependencies:
+React applications should install the package and compatible peer dependencies:
 
 ```sh
-vp add effect react react-dom @effect/atom-react
+npm install effect-view-server effect react react-dom @effect/atom-react
 ```
 
 See the repository README and examples for Kafka, gRPC, TCP publishing, in-memory testing, and React usage.

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -28,10 +28,6 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
     "./client": {
       "types": "./dist/client.d.ts",
       "import": "./dist/client.js"
@@ -110,8 +106,7 @@
     "@connectrpc/connect-node": "2.1.2",
     "@effect/platform-browser": "4.0.0-beta.91",
     "@effect/platform-node": "4.0.0-beta.91",
-    "@platformatic/kafka": "2.2.3",
-    "effect": "4.0.0-beta.91"
+    "@platformatic/kafka": "2.2.3"
   },
   "devDependencies": {
     "@effect-view-server/client": "workspace:*",
@@ -127,11 +122,13 @@
     "@types/react-dom": "19.2.3",
     "@vitest/coverage-istanbul": "catalog:",
     "@vitest/runner": "catalog:",
+    "effect": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {
     "@effect/atom-react": "4.0.0-beta.91",
+    "effect": "4.0.0-beta.91",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
-import { defineViewServerConfig } from "effect-view-server";
+import { defineViewServerConfig } from "effect-view-server/config";
 import { decodeKafkaCodec as decodeKafkaCodecFromConfig } from "effect-view-server/config";
 import { decodeKafkaCodec } from "effect-view-server/config/kafka";
 import type { LiveQueryResult } from "effect-view-server/config";
@@ -30,7 +30,12 @@ const viewServer = defineViewServerConfig({
 
 const react = createViewServerReact(viewServer);
 
-describe("public effect-view-server facade type contracts", () => {
+describe("public effect-view-server subpath type contracts", () => {
+  it("rejects bare root package imports", () => {
+    // @ts-expect-error effect-view-server intentionally has no root export.
+    expectTypeOf<typeof import("effect-view-server")>().not.toBeAny();
+  });
+
   it("exposes public package subpaths", () => {
     expectTypeOf(defineViewServerConfig).not.toBeAny();
     expectTypeOf(createViewServerReact).not.toBeAny();

--- a/packages/effect-view-server/src/index.ts
+++ b/packages/effect-view-server/src/index.ts
@@ -1,1 +1,0 @@
-export * from "./config";

--- a/packages/effect-view-server/vite.config.ts
+++ b/packages/effect-view-server/vite.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
     },
   },
   pack: libraryPack([
-    "src/index.ts",
     "src/client.ts",
     "src/client-remote.ts",
     "src/column-live-view-engine.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,9 +889,6 @@ importers:
       '@platformatic/kafka':
         specifier: 2.2.3
         version: 2.2.3
-      effect:
-        specifier: 4.0.0-beta.91
-        version: 4.0.0-beta.91
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -938,6 +935,9 @@ importers:
       '@vitest/runner':
         specifier: 'catalog:'
         version: 4.1.9
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.91
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -1377,6 +1377,27 @@ describe("internal seam checker", () => {
     ).toStrictEqual([]);
   });
 
+  it("rejects public effect-view-server root package export", () => {
+    expect(
+      packageExportViolationsForManifest({
+        manifestContents: JSON.stringify({
+          name: "effect-view-server",
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              types: "./dist/index.d.ts",
+            },
+          },
+        }),
+        packageDirectoryName: "effect-view-server",
+      }),
+    ).toStrictEqual([
+      "packages/effect-view-server/package.json exports effect-view-server: add intentional public specifier approval or remove the export.",
+      "packages/effect-view-server/package.json export . points at ./dist/index.js without a matching packed src entrypoint.",
+      "packages/effect-view-server/package.json export . points at ./dist/index.d.ts without a matching packed src entrypoint.",
+    ]);
+  });
+
   it("rejects unapproved public effect-view-server facade deep exports", () => {
     expect(
       packageExportViolationsForManifest({

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1544,7 +1544,6 @@ const approvedPublicViewServerSpecifiers = new Set([
   "@effect-view-server/runtime-core",
   "@effect-view-server/runtime-core/internal",
   "@effect-view-server/server",
-  "effect-view-server",
   "effect-view-server/client",
   "effect-view-server/client/remote",
   "effect-view-server/column-live-view-engine",

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -39,7 +39,6 @@ import * as runtimeRootPackage from "@effect-view-server/runtime";
 import * as serverPackage from "@effect-view-server/server";
 import * as publicClientPackage from "effect-view-server/client";
 import * as publicClientRemotePackage from "effect-view-server/client/remote";
-import * as publicRootPackage from "effect-view-server";
 import * as publicConfigPackage from "effect-view-server/config";
 import * as publicConfigGrpcPackage from "effect-view-server/config/grpc";
 import * as publicConfigHealthPackage from "effect-view-server/config/health";
@@ -156,7 +155,6 @@ const approvedPackageExports = [
   "@effect-view-server/runtime-core",
   "@effect-view-server/runtime-core/internal",
   "@effect-view-server/server",
-  "effect-view-server",
   "effect-view-server/client",
   "effect-view-server/client/remote",
   "effect-view-server/column-live-view-engine",
@@ -344,6 +342,8 @@ for (const specifier of stalePackageExports) {
   rejectResolvablePackageExport(specifier);
 }
 
+rejectResolvablePackageExport("effect-view-server");
+
 for (const specifier of forbiddenPackageDeepImports) {
   rejectResolvablePackageExport(specifier);
 }
@@ -380,7 +380,6 @@ rejectExport("@effect-view-server/config/kafka", kafkaPackage, "KafkaTopicDefini
 rejectExport("@effect-view-server/config/kafka", kafkaPackage, "KafkaRuntimeTopicDefinition");
 requireExport("effect-view-server/config/kafka", publicConfigKafkaPackage, "decodeKafkaCodec");
 requireExport("effect-view-server/config", publicConfigPackage, "decodeKafkaCodec");
-requireExport("effect-view-server", publicRootPackage, "decodeKafkaCodec");
 requireExport("@effect-view-server/config/grpc", grpcPackage, "grpc");
 rejectExport("@effect-view-server/config/grpc", grpcPackage, "defineGrpcFeed");
 requireExport("@effect-view-server/config/runtime", runtimePackage, "runtimeConfig");
@@ -466,11 +465,6 @@ requireExport("@effect-view-server/runtime", runtimeRootPackage, "runViewServerR
 requireExport("@effect-view-server/server", serverPackage, "makeViewServerWebSocketServer");
 requireExport("@effect-view-server/server", serverPackage, "createViewServerWebSocketServer");
 
-requireExport("effect-view-server", publicRootPackage, "defineViewServerConfig");
-rejectExport("effect-view-server", publicRootPackage, "defineGrpcFeed");
-requireExport("effect-view-server", publicRootPackage, "grpc");
-requireExport("effect-view-server", publicRootPackage, "kafka");
-rejectExport("effect-view-server", publicRootPackage, "defineKafkaTopic");
 requireExport("effect-view-server/config", publicConfigPackage, "defineViewServerConfig");
 rejectExport("effect-view-server/config", publicConfigPackage, "defineGrpcFeed");
 requireExport("effect-view-server/config", publicConfigPackage, "grpc");

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -255,6 +255,13 @@ describe("release publish policy", () => {
     expect(result.stdout).toBe("");
   });
 
+  it("stages the package README instead of the repository README", () => {
+    const releaseScript = readFileSync(new URL("./release-publish.mjs", import.meta.url), "utf8");
+
+    expect(releaseScript).toContain("../packages/effect-view-server/README.md");
+    expect(releaseScript).not.toContain("../README.md");
+  });
+
   it("does not create version pull requests from the main-branch release workflow", () => {
     const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
 

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -258,7 +258,7 @@ try {
     filter: (source) => !source.endsWith(".map"),
   });
   stripPublishedSourceMapReferences(distDirectory);
-  cpSync(new URL("../README.md", import.meta.url), join(stageDirectory, "README.md"));
+  cpSync(new URL("../packages/effect-view-server/README.md", import.meta.url), join(stageDirectory, "README.md"));
   writeFileSync(
     join(stageDirectory, "package.json"),
     `${JSON.stringify(sanitizePublicPackageJson(packageJson), null, 2)}\n`,


### PR DESCRIPTION
## What changed
- Removes the bare `effect-view-server` root export so consumers must import explicit subpaths like `effect-view-server/react` or `effect-view-server/config`.
- Adds a package-local README so npm renders the package documentation.
- Moves `effect` from a bundled dependency to a required peer dependency while keeping it as a dev dependency for local builds.
- Keeps `react` and `react-dom` as optional peer dependencies because only React subpaths require them.
- Adds package export and type-test coverage proving the bare root import is rejected.
- Adds a patch changeset for the 0.0.6 release.

## Validation
- `vp check --fix`
- `vp test run scripts/check-internal-seams.test.ts --testNamePattern effect-view-server`
- `vp run -w check:internal-seams`
- `vp run -w check:package-exports`
- `vp run effect-view-server#test`
- `vp run effect-view-server#build`
- `vp run -w ready`