### PR TITLE
Version effect-view-server 0.0.6

### DIFF
--- a/.changeset/polite-garlics-release.md
+++ b/.changeset/polite-garlics-release.md
@@ -1,5 +1,0 @@
----
-"effect-view-server": patch
----
-
-Prepare the `0.0.6` release by hardening Kafka source edge cases, removing the bare package root export, shipping the package README, and making `effect` a required peer dependency so applications share one Effect runtime and type surface.

--- a/packages/effect-view-server/CHANGELOG.md
+++ b/packages/effect-view-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # effect-view-server
 
+## 0.0.6
+
+### Patch Changes
+
+- 1bf3981: Prepare the `0.0.6` release by hardening Kafka source edge cases, removing the bare package root export, shipping the package README, and making `effect` a required peer dependency so applications share one Effect runtime and type surface.
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-view-server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Typed Effect View Server for live query snapshots, deltas, React bindings, and runtime ingress adapters.",
   "keywords": [
     "effect",


### PR DESCRIPTION
## Summary
- apply the pending Changesets patch for effect-view-server
- bump the public package to 0.0.6
- move the 0.0.6 release note into the package changelog

## Validation
- vp check --fix
- vp run effect-view-server#test
- vp run -w check:package-exports