### PR TITLE
Harden Playwright dependency install in CI

### DIFF
--- a/.github/scripts/prepare-playwright-apt.sh
+++ b/.github/scripts/prepare-playwright-apt.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub hosted runners include Microsoft apt sources that are unrelated to
+# Playwright browser dependencies. Those sources occasionally return invalid
+# InRelease metadata and make `playwright install --with-deps` fail before tests
+# or benchmarks run. Remove only those optional sources; Ubuntu and Google Chrome
+# sources remain available for the actual browser dependency install.
+sudo rm -f \
+  /etc/apt/sources.list.d/azure-cli.list \
+  /etc/apt/sources.list.d/azure-cli.sources \
+  /etc/apt/sources.list.d/microsoft-prod.list \
+  /etc/apt/sources.list.d/microsoft-prod.sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
+      - name: Prepare Playwright apt sources
+        run: bash .github/scripts/prepare-playwright-apt.sh
+
       - name: Install browser test dependencies
         working-directory: packages/react
         run: vp exec playwright install --with-deps chromium firefox webkit
@@ -73,6 +76,9 @@ jobs:
 
       - name: Build packages
         run: vp run -r build
+
+      - name: Prepare Playwright apt sources
+        run: bash .github/scripts/prepare-playwright-apt.sh
 
       - name: Install Chromium benchmark dependencies
         working-directory: packages/react

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
+      - name: Prepare Playwright apt sources
+        run: bash .github/scripts/prepare-playwright-apt.sh
+
       - name: Install browser test dependencies
         working-directory: packages/react
         run: vp exec playwright install --with-deps chromium firefox webkit
@@ -79,6 +82,9 @@ jobs:
 
       - name: Install dependencies
         run: vp install --frozen-lockfile
+
+      - name: Prepare Playwright apt sources
+        run: bash .github/scripts/prepare-playwright-apt.sh
 
       - name: Install browser test dependencies
         working-directory: packages/react


### PR DESCRIPTION
## Summary
- remove unrelated Microsoft apt sources before Playwright installs Linux browser dependencies
- apply the guard to CI validate, smoke benchmarks, and release jobs
- keep Playwright --with-deps so browser system dependency coverage remains intact

## Validation
- bash -n .github/scripts/prepare-playwright-apt.sh
- vp check --fix .github/workflows/ci.yml .github/workflows/release.yml .github/scripts/prepare-playwright-apt.sh