### PR TITLE
Deepen runtime source mutation pipeline

### DIFF
--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -319,6 +319,7 @@ describe("@effect-view-server/runtime-core", () => {
 
       const spansByName = new Map(observedSpans.map((span) => [span.name, span]));
       const clientPublish = spansByName.get("ViewServerRuntimeCore.client.publish");
+      const sourceMutationApply = spansByName.get("ViewServerRuntimeCore.sourceMutation.apply");
       const publish = spansByName.get("ColumnLiveViewEngine.publish");
       const topicStorePublish = spansByName.get("ColumnLiveViewEngine.topicStore.publish");
       const mutationTransaction = spansByName.get(
@@ -367,6 +368,12 @@ describe("@effect-view-server/runtime-core", () => {
           parentSpanId: publish?.parentSpanId,
           traceId: publish?.traceId,
         },
+        sourceMutationApply: {
+          name: sourceMutationApply?.name,
+          parentName: sourceMutationApply?.parentName,
+          parentSpanId: sourceMutationApply?.parentSpanId,
+          traceId: sourceMutationApply?.traceId,
+        },
         topicStorePublish: {
           name: topicStorePublish?.name,
           parentName: topicStorePublish?.parentName,
@@ -409,6 +416,12 @@ describe("@effect-view-server/runtime-core", () => {
         },
         publish: {
           name: "ColumnLiveViewEngine.publish",
+          parentName: "ViewServerRuntimeCore.sourceMutation.apply",
+          parentSpanId: sourceMutationApply?.spanId,
+          traceId: clientPublish?.traceId,
+        },
+        sourceMutationApply: {
+          name: "ViewServerRuntimeCore.sourceMutation.apply",
           parentName: "ViewServerRuntimeCore.client.publish",
           parentSpanId: clientPublish?.spanId,
           traceId: clientPublish?.traceId,

--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -34,6 +34,13 @@ export {
   collectSourceOwnershipConflicts,
   makeSourceOwnershipPolicy,
 } from "./source-ownership-policy";
+export { makeRuntimeCoreMutationPipeline } from "./source-mutation-pipeline";
+export type {
+  RuntimeCoreDecodedRowWithStorageKey,
+  RuntimeCoreMutationPipeline,
+  ViewServerRuntimeCoreCheckedMutations,
+  ViewServerRuntimeCoreInternalMutations,
+} from "./source-mutation-pipeline";
 export type {
   SourceOwnershipAccessProfile,
   SourceOwnershipConflict,

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -23,6 +23,10 @@ import {
   type RuntimeCoreTransportHealth,
 } from "./health";
 import { engineErrorToRuntimeError, invalidRuntimeQueryError } from "./runtime-error";
+import {
+  makeRuntimeCoreMutationPipeline,
+  type ViewServerRuntimeCoreInternalMutations,
+} from "./source-mutation-pipeline";
 import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
 
 export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> = {
@@ -34,26 +38,7 @@ export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> 
 };
 
 export type ViewServerRuntimeCoreInternalClient<Topics extends DecodableTopicDefinitions> =
-  ViewServerRuntimeClient<Topics> & {
-    readonly publishManyDecodedRows: (
-      topic: Extract<keyof Topics, string>,
-      rows: ReadonlyArray<object>,
-    ) => Effect.Effect<void, ViewServerRuntimeError>;
-    readonly publishManyDecodedRowsWithStorageKeys: (
-      topic: Extract<keyof Topics, string>,
-      rows: ReadonlyArray<{
-        readonly storageKey: string;
-        readonly row: object;
-      }>,
-    ) => Effect.Effect<void, ViewServerRuntimeError>;
-    readonly publishManyWithStorageKeys: <Topic extends Extract<keyof Topics, string>>(
-      topic: Topic,
-      rows: ReadonlyArray<{
-        readonly storageKey: string;
-        readonly row: TopicRow<Topics, Topic>;
-      }>,
-    ) => Effect.Effect<void, ViewServerRuntimeError>;
-  };
+  ViewServerRuntimeClient<Topics> & ViewServerRuntimeCoreInternalMutations<Topics>;
 
 export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.make")(
   <const Topics extends DecodableTopicDefinitions>(
@@ -117,6 +102,11 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
           );
         },
       );
+      const mutationPipeline = makeRuntimeCoreMutationPipeline(
+        config,
+        engine,
+        requestHealthRefresh(),
+      );
       const snapshot = <
         Topic extends Extract<keyof Topics, string>,
         const Query extends
@@ -138,79 +128,19 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
             .snapshot<Topic, Query>(topic, query)
             .pipe(Effect.mapError(engineErrorToRuntimeError));
         });
-      const publish = Effect.fn("ViewServerRuntimeCore.client.publish")(function* <
-        Topic extends Extract<keyof Topics, string>,
-      >(topic: Topic, row: TopicRow<Topics, Topic>) {
-        yield* Effect.uninterruptible(
-          engine.publish(topic, row).pipe(Effect.tap(() => requestHealthRefresh())),
-        ).pipe(Effect.mapError(engineErrorToRuntimeError));
-      });
       const internalClient: ViewServerRuntimeCoreInternalClient<Topics> = {
-        publish,
-        publishMany: (topic, rows) =>
-          Effect.uninterruptible(
-            engine.publishMany(topic, rows).pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-        publishManyDecodedRows: (topic, rows) =>
-          Effect.uninterruptible(
-            engine
-              .publishManyDecodedRows(topic, rows)
-              .pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-        publishManyDecodedRowsWithStorageKeys: (topic, rows) =>
-          Effect.uninterruptible(
-            engine
-              .publishManyDecodedRowsWithStorageKeys(topic, rows)
-              .pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-        publishManyWithStorageKeys: (topic, rows) =>
-          Effect.uninterruptible(
-            engine
-              .publishManyWithStorageKeys(topic, rows)
-              .pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-        patch: (topic, key, patch) =>
-          Effect.uninterruptible(
-            engine.patch(topic, key, patch).pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
-        delete: (topic, key) =>
-          Effect.uninterruptible(
-            engine.delete(topic, key).pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
+        ...mutationPipeline.internalMutations,
         snapshot,
         health: () => healthReader(),
-        reset: () =>
-          Effect.uninterruptible(
-            engine.reset().pipe(Effect.tap(() => requestHealthRefresh())),
-          ).pipe(Effect.mapError(engineErrorToRuntimeError)),
       };
       return {
         client: {
-          publish: (topic, row) =>
-            sourceOwnership
-              .requirePublicMutationAllowed(topic, "runtimeCore")
-              .pipe(Effect.flatMap(() => internalClient.publish(topic, row))),
-          publishMany: (topic, rows) =>
-            sourceOwnership
-              .requirePublicMutationAllowed(topic, "runtimeCore")
-              .pipe(Effect.flatMap(() => internalClient.publishMany(topic, rows))),
-          patch: (topic, key, patch) =>
-            sourceOwnership
-              .requirePublicMutationAllowed(topic, "runtimeCore")
-              .pipe(Effect.flatMap(() => internalClient.patch(topic, key, patch))),
-          delete: (topic, key) =>
-            sourceOwnership
-              .requirePublicMutationAllowed(topic, "runtimeCore")
-              .pipe(Effect.flatMap(() => internalClient.delete(topic, key))),
+          ...mutationPipeline.checkedMutations,
           snapshot: (topic, query) =>
             sourceOwnership
               .requirePublicReadAllowed(topic, "runtimeCore")
               .pipe(Effect.flatMap(() => internalClient.snapshot(topic, query))),
           health: internalClient.health,
-          reset: () =>
-            sourceOwnership
-              .requirePublicResetAllowed("runtimeCore")
-              .pipe(Effect.flatMap(() => internalClient.reset())),
         },
         internalClient,
         close: healthRefreshScheduler.close,

--- a/packages/runtime-core/src/source-mutation-pipeline.ts
+++ b/packages/runtime-core/src/source-mutation-pipeline.ts
@@ -1,0 +1,162 @@
+import type {
+  ColumnLiveViewEngineError,
+  DecodableTopicDefinitions,
+} from "@effect-view-server/column-live-view-engine";
+import type { ColumnLiveViewEngineInternal } from "@effect-view-server/column-live-view-engine/internal";
+import type {
+  ExactPatch,
+  TopicRow,
+  ViewServerRuntimeClient,
+  ViewServerRuntimeError,
+  ViewServerTopicConfig,
+} from "@effect-view-server/config";
+import { Effect } from "effect";
+import { engineErrorToRuntimeError } from "./runtime-error";
+import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
+
+export type RuntimeCoreDecodedRowWithStorageKey = {
+  readonly storageKey: string;
+  readonly row: object;
+};
+
+export type ViewServerRuntimeCoreInternalMutations<Topics extends DecodableTopicDefinitions> = Pick<
+  ViewServerRuntimeClient<Topics>,
+  "delete" | "patch" | "publish" | "publishMany" | "reset"
+> & {
+  readonly publishManyDecodedRows: (
+    topic: Extract<keyof Topics, string>,
+    rows: ReadonlyArray<object>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly publishManyDecodedRowsWithStorageKeys: (
+    topic: Extract<keyof Topics, string>,
+    rows: ReadonlyArray<RuntimeCoreDecodedRowWithStorageKey>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly publishManyWithStorageKeys: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    rows: ReadonlyArray<{
+      readonly storageKey: string;
+      readonly row: TopicRow<Topics, Topic>;
+    }>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+};
+
+export type ViewServerRuntimeCoreCheckedMutations<Topics extends DecodableTopicDefinitions> = Pick<
+  ViewServerRuntimeClient<Topics>,
+  "delete" | "patch" | "publish" | "publishMany" | "reset"
+>;
+
+export type RuntimeCoreMutationPipeline<Topics extends DecodableTopicDefinitions> = {
+  readonly internalMutations: ViewServerRuntimeCoreInternalMutations<Topics>;
+  readonly checkedMutations: ViewServerRuntimeCoreCheckedMutations<Topics>;
+};
+
+const applyEngineMutation = Effect.fn("ViewServerRuntimeCore.sourceMutation.apply")(function* (
+  mutation: Effect.Effect<void, ColumnLiveViewEngineError>,
+  requestHealthRefresh: Effect.Effect<void>,
+) {
+  yield* Effect.uninterruptible(mutation.pipe(Effect.tap(() => requestHealthRefresh))).pipe(
+    Effect.mapError(engineErrorToRuntimeError),
+  );
+});
+
+export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTopicDefinitions>(
+  config: ViewServerTopicConfig<Topics>,
+  engine: ColumnLiveViewEngineInternal<Topics>,
+  requestHealthRefresh: Effect.Effect<void>,
+): RuntimeCoreMutationPipeline<Topics> => {
+  const sourceOwnership = makeSourceOwnershipPolicy(config);
+  const publish = Effect.fn("ViewServerRuntimeCore.client.publish")(function* <
+    Topic extends Extract<keyof Topics, string>,
+  >(topic: Topic, row: TopicRow<Topics, Topic>) {
+    yield* applyEngineMutation(engine.publish(topic, row), requestHealthRefresh);
+  });
+  const publishMany = Effect.fn("ViewServerRuntimeCore.client.publishMany")(function* <
+    Topic extends Extract<keyof Topics, string>,
+  >(topic: Topic, rows: ReadonlyArray<TopicRow<Topics, Topic>>) {
+    yield* applyEngineMutation(engine.publishMany(topic, rows), requestHealthRefresh);
+  });
+  const publishManyDecodedRows = Effect.fn(
+    "ViewServerRuntimeCore.sourceMutation.publishManyDecodedRows",
+  )(function* (topic: Extract<keyof Topics, string>, rows: ReadonlyArray<object>) {
+    yield* applyEngineMutation(engine.publishManyDecodedRows(topic, rows), requestHealthRefresh);
+  });
+  const publishManyDecodedRowsWithStorageKeys = Effect.fn(
+    "ViewServerRuntimeCore.sourceMutation.publishManyDecodedRowsWithStorageKeys",
+  )(function* (
+    topic: Extract<keyof Topics, string>,
+    rows: ReadonlyArray<RuntimeCoreDecodedRowWithStorageKey>,
+  ) {
+    yield* applyEngineMutation(
+      engine.publishManyDecodedRowsWithStorageKeys(topic, rows),
+      requestHealthRefresh,
+    );
+  });
+  const publishManyWithStorageKeys = Effect.fn(
+    "ViewServerRuntimeCore.sourceMutation.publishManyWithStorageKeys",
+  )(function* <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    rows: ReadonlyArray<{
+      readonly storageKey: string;
+      readonly row: TopicRow<Topics, Topic>;
+    }>,
+  ) {
+    yield* applyEngineMutation(
+      engine.publishManyWithStorageKeys(topic, rows),
+      requestHealthRefresh,
+    );
+  });
+  const patch = Effect.fn("ViewServerRuntimeCore.client.patch")(function* <
+    Topic extends Extract<keyof Topics, string>,
+    const Patch,
+  >(
+    topic: Topic,
+    key: string,
+    patch: Patch & Partial<TopicRow<Topics, Topic>> & ExactPatch<TopicRow<Topics, Topic>, Patch>,
+  ) {
+    yield* applyEngineMutation(engine.patch(topic, key, patch), requestHealthRefresh);
+  });
+  const deleteRow = Effect.fn("ViewServerRuntimeCore.client.delete")(function* <
+    Topic extends Extract<keyof Topics, string>,
+  >(topic: Topic, key: string) {
+    yield* applyEngineMutation(engine.delete(topic, key), requestHealthRefresh);
+  });
+  const reset = Effect.fn("ViewServerRuntimeCore.client.reset")(function* () {
+    yield* applyEngineMutation(engine.reset(), requestHealthRefresh);
+  });
+  const internalMutations: ViewServerRuntimeCoreInternalMutations<Topics> = {
+    publish,
+    publishMany,
+    publishManyDecodedRows,
+    publishManyDecodedRowsWithStorageKeys,
+    publishManyWithStorageKeys,
+    patch,
+    delete: deleteRow,
+    reset,
+  };
+  const checkedMutations: ViewServerRuntimeCoreCheckedMutations<Topics> = {
+    publish: (topic, row) =>
+      sourceOwnership
+        .requirePublicMutationAllowed(topic, "runtimeCore")
+        .pipe(Effect.flatMap(() => internalMutations.publish(topic, row))),
+    publishMany: (topic, rows) =>
+      sourceOwnership
+        .requirePublicMutationAllowed(topic, "runtimeCore")
+        .pipe(Effect.flatMap(() => internalMutations.publishMany(topic, rows))),
+    patch: (topic, key, patch) =>
+      sourceOwnership
+        .requirePublicMutationAllowed(topic, "runtimeCore")
+        .pipe(Effect.flatMap(() => internalMutations.patch(topic, key, patch))),
+    delete: (topic, key) =>
+      sourceOwnership
+        .requirePublicMutationAllowed(topic, "runtimeCore")
+        .pipe(Effect.flatMap(() => internalMutations.delete(topic, key))),
+    reset: () =>
+      sourceOwnership
+        .requirePublicResetAllowed("runtimeCore")
+        .pipe(Effect.flatMap(() => internalMutations.reset())),
+  };
+  return {
+    internalMutations,
+    checkedMutations,
+  };
+};

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -477,6 +477,28 @@ const topicDefinitionFor = <const Topics extends ViewServerRuntimeTopicDefinitio
     });
   });
 
+const isRuntimeTopic = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: ViewServerTopicConfig<Topics>,
+  topic: string,
+): topic is Extract<keyof Topics, string> => Object.hasOwn(config.topics, topic);
+
+const runtimeTopicFor = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: ViewServerTopicConfig<Topics>,
+  topic: string,
+  feedName: string,
+): Effect.Effect<Extract<keyof Topics, string>, ViewServerGrpcIngressError> =>
+  Effect.suspend(() => {
+    if (isRuntimeTopic(config, topic)) {
+      return Effect.succeed(topic);
+    }
+    return grpcLeaseError({
+      message: `gRPC leased feed ${feedName} references unknown topic ${topic}`,
+      cause: topic,
+      feedName,
+      topic,
+    });
+  });
+
 const mapLeasedValue = Effect.fn("ViewServerRuntime.grpc.leased.map")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(
@@ -820,16 +842,16 @@ const externalizeLeasedEvent = <Row extends object>(
 
 const callRuntimePublishMany = Effect.fn(
   "ViewServerRuntime.grpc.leased.runtime.publishManyDecoded",
-)(function* <const Topics extends ViewServerRuntimeTopicDefinitions, const Topic extends string>(
+)(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  const Topic extends Extract<keyof Topics, string>,
+>(
   runtimeClient: ViewServerRuntimeCoreInternalClient<Topics>,
   topic: Topic,
   rows: ReadonlyArray<LeasedRowWithStorageKey>,
   feedName: string,
 ) {
-  const effect = Reflect.apply(runtimeClient.publishManyDecodedRowsWithStorageKeys, runtimeClient, [
-    topic,
-    rows,
-  ]);
+  const effect = runtimeClient.publishManyDecodedRowsWithStorageKeys(topic, rows);
   if (!isRuntimeMutationEffect(effect)) {
     return yield* grpcLeaseError({
       message: `Runtime publishManyDecodedRowsWithStorageKeys did not return an Effect for leased gRPC feed ${feedName}`,
@@ -853,14 +875,14 @@ const callRuntimePublishMany = Effect.fn(
 
 const callRuntimeDelete = Effect.fn("ViewServerRuntime.grpc.leased.runtime.delete")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
-  const Topic extends string,
+  const Topic extends Extract<keyof Topics, string>,
 >(
   runtimeClient: ViewServerRuntimeCoreInternalClient<Topics>,
   topic: Topic,
   key: string,
   feedName: string,
 ) {
-  const effect = Reflect.apply(runtimeClient.delete, runtimeClient, [topic, key]);
+  const effect = runtimeClient.delete(topic, key);
   if (!isRuntimeMutationEffect(effect)) {
     return yield* grpcLeaseError({
       message: `Runtime delete did not return an Effect for leased gRPC feed ${feedName}`,
@@ -911,7 +933,8 @@ const publishLeasedBatch = Effect.fn("ViewServerRuntime.grpc.leased.publishBatch
   const internalRows = yield* Effect.forEach(rows, (row) =>
     internalizeLeasedRow(config, lease, row),
   );
-  yield* callRuntimePublishMany(runtimeClient, lease.feed.topic, internalRows, lease.feedName).pipe(
+  const topic = yield* runtimeTopicFor(config, lease.feed.topic, lease.feedName);
+  yield* callRuntimePublishMany(runtimeClient, topic, internalRows, lease.feedName).pipe(
     Effect.tapError((error) =>
       Clock.currentTimeMillis.pipe(
         Effect.flatMap((nowMillis) =>
@@ -969,7 +992,7 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
         yield* releaseResources();
         yield* health.feedDegraded(lease.feedKey, input.healthMessage);
         yield* health.clientDegraded(lease.feed.client, input.healthMessage);
-        const cleanupExit = yield* closeLeaseRows(runtimeClient, lease).pipe(Effect.exit);
+        const cleanupExit = yield* closeLeaseRows(config, runtimeClient, lease).pipe(Effect.exit);
         if (Exit.isSuccess(cleanupExit)) {
           yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
         } else {
@@ -1020,10 +1043,15 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
 
 const closeLeaseRows = Effect.fn("ViewServerRuntime.grpc.leased.rows.close")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
->(runtimeClient: ViewServerRuntimeCoreInternalClient<Topics>, lease: ActiveLease) {
+>(
+  config: ViewServerTopicConfig<Topics>,
+  runtimeClient: ViewServerRuntimeCoreInternalClient<Topics>,
+  lease: ActiveLease,
+) {
+  const topic = yield* runtimeTopicFor(config, lease.feed.topic, lease.feedName);
   yield* Effect.forEach(
     lease.internalToPublicKeys.keys(),
-    (key) => callRuntimeDelete(runtimeClient, lease.feed.topic, key, lease.feedName),
+    (key) => callRuntimeDelete(runtimeClient, topic, key, lease.feedName),
     {
       discard: true,
     },
@@ -1294,7 +1322,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     "ViewServerRuntime.grpc.leased.releaseLease.cleanup",
   )(function* (lease: ActiveLease) {
     yield* Scope.close(lease.scope, Exit.void);
-    const cleanupExit = yield* closeLeaseRows(runtimeClient, lease).pipe(Effect.exit);
+    const cleanupExit = yield* closeLeaseRows(config, runtimeClient, lease).pipe(Effect.exit);
     if (Exit.isFailure(cleanupExit)) {
       yield* ignoreLeasedReleaseFailure(Effect.failCause(cleanupExit.cause));
       yield* health.feedDegraded(
@@ -1570,7 +1598,9 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             }),
           ),
           Effect.andThen(Effect.sync(() => lease.statusQueues.clear())),
-          Effect.andThen(closeLeaseRows(runtimeClient, lease).pipe(ignoreLeasedReleaseFailure)),
+          Effect.andThen(
+            closeLeaseRows(config, runtimeClient, lease).pipe(ignoreLeasedReleaseFailure),
+          ),
           Effect.andThen(health.leasedFeedRemoved(lease.feedKey)),
         ),
       ),

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -9818,6 +9818,81 @@ describe("@effect-view-server/runtime", () => {
       }),
   );
 
+  it.live("marks leased gRPC cleanup degraded when runtime topic disappears before close", () =>
+    Effect.gen(function* () {
+      const localViewServer = defineViewServerConfig({
+        topics: {
+          orders: {
+            schema: GrpcOrder,
+            key: "id",
+            grpcSource: grpcSourceMarkers.leased({
+              routeBy: ["region"],
+            }),
+          },
+        },
+      });
+      const localGrpcFeed = defineGrpcFeed(localViewServer)<typeof grpcClients>();
+      const feed = localGrpcFeed.leasedFeed({
+        topic: "orders",
+        client: "orders",
+        method: "streamOrders",
+        routeBy: ["region"],
+        request: ({ region }) => ({ orderId: region }),
+        acquire: ({ request }) =>
+          longRunningGrpcStream([grpcOrderValue(`${request.orderId}-order-1`, 10)]),
+        map: ({ value, route }) => ({
+          id: `${route.region}:${value.customerId}`,
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region: route.region,
+          updatedAt: value.updatedAt,
+        }),
+      });
+      const resolvedOptions = yield* resolveViewServerRuntimeOptions<
+        typeof localViewServer.topics,
+        Record<string, string>,
+        typeof grpcClients
+      >({
+        grpc: {
+          clients: grpcClients,
+          feeds: {
+            ordersLease: feed,
+          },
+        },
+      });
+      const grpcOptions = yield* Effect.fromNullishOr(resolvedOptions.grpcOptions);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+      Reflect.deleteProperty(localViewServer.topics, "orders");
+
+      yield* subscription.close();
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+
+      expect(
+        currentHealth.grpc?.feeds["orders"]?.leased[
+          "orders/ordersLease/leased/region=string%3A3%3Ausa"
+        ]?.lastError,
+      ).toBe("gRPC leased feed row cleanup failed for ordersLease");
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.live("fails leased gRPC subscription when acquire does not return a Stream", () =>
     Effect.gen(function* () {
       let released = 0;

--- a/scripts/check-package-exports.ts
+++ b/scripts/check-package-exports.ts
@@ -444,8 +444,18 @@ requireExport(
   runtimeCoreInternalPackage,
   "makeSourceOwnershipPolicy",
 );
+requireExport(
+  "@effect-view-server/runtime-core/internal",
+  runtimeCoreInternalPackage,
+  "makeRuntimeCoreMutationPipeline",
+);
 rejectExport("@effect-view-server/runtime-core", runtimeCorePackage, "makeViewServerRuntimeCoreInternal");
 rejectExport("@effect-view-server/runtime-core", runtimeCorePackage, "makeSourceOwnershipPolicy");
+rejectExport(
+  "@effect-view-server/runtime-core",
+  runtimeCorePackage,
+  "makeRuntimeCoreMutationPipeline",
+);
 rejectExport(
   "@effect-view-server/runtime-core",
   runtimeCorePackage,


### PR DESCRIPTION
## Summary

- Add a runtime-core source mutation pipeline that centralizes engine mutation execution, runtime error mapping, and health refresh scheduling.
- Split runtime-core mutation surfaces into internal source mutations and runtime-checked public mutations, while preserving the existing compile-time public client seam.
- Route leased gRPC publish/delete cleanup through typed internal runtime-core mutations and validate runtime topics before cleanup/publish.
- Add coverage for source-mutation tracing, leased cleanup degradation on missing runtime topics, and package export boundaries.

## Validation

- `vp check`
- `vp run runtime-core#test`
- `vp run runtime#test`
- `vp run -w check:effect`
- `vp run -w check:package-exports`
- `vp run -w check:internal-seams`
- Forbidden-pattern scan over touched runtime/runtime-core/scripts paths; only false positives were test titles containing the text "as unknown".
- 3 reviewer agents re-reviewed the patch; only finding was to ensure the new source-mutation-pipeline file was tracked, which is fixed in this commit.
