### PR TITLE
Decode TCP publish commands through topic schemas

### DIFF
--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -189,6 +189,11 @@ export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
 
 export type ColumnLiveViewEngineInternal<Topics extends DecodableTopicDefinitions> =
   ColumnLiveViewEngine<Topics> & {
+    readonly patchDecodedFields: (
+      topic: Extract<keyof Topics, string>,
+      key: string,
+      patch: object,
+    ) => Effect.Effect<void, ColumnLiveViewEngineError>;
     readonly publishManyDecodedRows: (
       topic: Extract<keyof Topics, string>,
       rows: ReadonlyArray<object>,

--- a/packages/column-live-view-engine/src/engine.ts
+++ b/packages/column-live-view-engine/src/engine.ts
@@ -38,6 +38,7 @@ import {
   acquireTopicStoreSubscription,
   closeTopicStoreSubscriptions,
   deleteTopicStoreRow,
+  patchTopicStoreDecodedFields,
   patchTopicStoreRow,
   publishTopicStoreDecodedRows,
   publishTopicStoreDecodedRowsWithStorageKeys,
@@ -160,6 +161,15 @@ class InMemoryColumnLiveViewEngine<
       yield* this.ensureOpen();
       const store = yield* this.getStore(topic);
       yield* publishTopicStoreRowsWithStorageKeys(store, rows, invalidRow);
+    });
+
+  readonly patchDecodedFields: ColumnLiveViewEngineInternal<Topics>["patchDecodedFields"] =
+    Effect.fn("ColumnLiveViewEngine.patchDecodedFields")({ self: this }, function* <
+      Topic extends Extract<keyof Topics, string>,
+    >(this: InMemoryColumnLiveViewEngine<Topics>, topic: Topic, key: string, patch: object) {
+      yield* this.ensureOpen();
+      const store = yield* this.getStore(topic);
+      yield* patchTopicStoreDecodedFields(store, key, patch, invalidRow);
     });
 
   readonly patch: ColumnLiveViewEngine<Topics>["patch"] = Effect.fn("ColumnLiveViewEngine.patch")(

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -12804,6 +12804,101 @@ describe("ColumnLiveViewEngine validation and health", () => {
     }),
   );
 
+  it.effect("patches decoded runtime fields through the internal engine entrypoint", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: viewServer.topics,
+      });
+
+      yield* engine.publishManyDecodedRows("orders", [
+        {
+          customerId: "customer-decoded-1",
+          id: "decoded-1",
+          price: 42,
+          region: "emea",
+          status: "open",
+          updatedAt: 1,
+        },
+      ]);
+      yield* engine.patchDecodedFields("orders", "decoded-1", {
+        price: 43,
+        status: "closed",
+      });
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "price", "status"],
+        limit: 10,
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [
+          {
+            id: "decoded-1",
+            price: 43,
+            status: "closed",
+          },
+        ],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 2,
+      });
+    }),
+  );
+
+  it.effect("validates decoded runtime patches against the merged topic row schema", () =>
+    Effect.gen(function* () {
+      const PublicOrder = Schema.Struct({
+        id: Schema.String.pipe(Schema.check(Schema.isPattern(/^public-/))),
+        price: Schema.Number,
+      });
+      const publicViewServer = defineViewServerConfig({
+        topics: {
+          orders: {
+            schema: PublicOrder,
+            key: "id",
+          },
+        },
+      });
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: publicViewServer.topics,
+      });
+
+      yield* engine.publishManyDecodedRows("orders", [
+        {
+          id: "public-1",
+          price: 42,
+        },
+      ]);
+      const error = yield* Effect.flip(
+        engine.patchDecodedFields("orders", "public-1", {
+          id: "private-1",
+        }),
+      );
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+        limit: 10,
+      });
+
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+      });
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(snapshot).toStrictEqual({
+        rows: [
+          {
+            id: "public-1",
+            price: 42,
+          },
+        ],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
+    }),
+  );
+
   it.effect("does not decode internal decoded runtime rows twice", () =>
     Effect.gen(function* () {
       const TransformId = Schema.String.pipe(
@@ -12987,17 +13082,19 @@ describe("ColumnLiveViewEngine validation and health", () => {
       }),
   );
 
-  it.effect("does not expose internal publishing from the public engine factory", () =>
+  it.effect("does not expose internal decoded mutations from the public engine factory", () =>
     Effect.gen(function* () {
       const engine = yield* createColumnLiveViewEngine({
         topics: viewServer.topics,
       });
 
       expect({
+        patchDecodedFields: "patchDecodedFields" in engine,
         publishManyDecodedRows: "publishManyDecodedRows" in engine,
         publishManyDecodedRowsWithStorageKeys: "publishManyDecodedRowsWithStorageKeys" in engine,
         publishManyWithStorageKeys: "publishManyWithStorageKeys" in engine,
       }).toStrictEqual({
+        patchDecodedFields: false,
         publishManyDecodedRows: false,
         publishManyDecodedRowsWithStorageKeys: false,
         publishManyWithStorageKeys: false,

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -65,6 +65,22 @@ const normalizeDecodedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decode
   },
 );
 
+const validateDecodedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decoded.validate")(
+  function* <Error>(
+    context: TopicRowPreparationContext,
+    row: RowObject,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) {
+    return yield* Effect.try({
+      try: () => {
+        const decoded = Schema.decodeUnknownSync(Schema.toType(context.schema))(row);
+        return normalizedDecodedTopicRow(context, decoded);
+      },
+      catch: (cause) => invalidRow(context.topic, String(cause)),
+    });
+  },
+);
+
 const topicRowKey = Effect.fn("ColumnLiveViewEngine.topicRow.key")(function* <Error>(
   context: TopicRowPreparationContext,
   row: RowObject,
@@ -161,19 +177,20 @@ export const prepareDecodedTopicRowWithStorageKey = Effect.fn(
   } satisfies PreparedTopicRow;
 });
 
-export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.prepare")(
+const preparePatchedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.patch.preparePatched")(
   function* <Patch extends Partial<RowObject>, Error>(
     context: TopicRowPreparationContext,
     key: string,
     current: RowObject | undefined,
     patch: Patch,
     invalidRow: InvalidRowErrorFactory<Error>,
+    preparePatchedRow: (row: RowObject) => Effect.Effect<RowObject, Error>,
   ) {
     yield* validateTopicPatchKeys(context, patch, invalidRow);
     if (current === undefined) {
       return yield* Effect.fail(invalidRow(context.topic, `Cannot patch missing key: ${key}`));
     }
-    const decoded = yield* decodeTopicRow(context, { ...current, ...patch }, invalidRow);
+    const decoded = yield* preparePatchedRow({ ...current, ...patch });
     const decodedKey = yield* topicRowKey(context, decoded, invalidRow);
     if (decodedKey !== key) {
       return yield* Effect.fail(invalidRow(context.topic, "Patch must not change the row key."));
@@ -199,3 +216,31 @@ export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.
     } satisfies PreparedTopicRow;
   },
 );
+
+export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.prepare")(
+  function* <Patch extends Partial<RowObject>, Error>(
+    context: TopicRowPreparationContext,
+    key: string,
+    current: RowObject | undefined,
+    patch: Patch,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) {
+    return yield* preparePatchedTopicRow(context, key, current, patch, invalidRow, (row) =>
+      decodeTopicRow(context, row, invalidRow),
+    );
+  },
+);
+
+export const prepareDecodedTopicPatch = Effect.fn(
+  "ColumnLiveViewEngine.topicRow.decodedPatch.prepare",
+)(function* <Patch extends Partial<RowObject>, Error>(
+  context: TopicRowPreparationContext,
+  key: string,
+  current: RowObject | undefined,
+  patch: Patch,
+  invalidRow: InvalidRowErrorFactory<Error>,
+) {
+  return yield* preparePatchedTopicRow(context, key, current, patch, invalidRow, (row) =>
+    validateDecodedTopicRow(context, row, invalidRow),
+  );
+});

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -33,6 +33,7 @@ import {
 } from "./topic-row-change-journal";
 import { deleteCompactingTopicRowSlot } from "./topic-row-storage-lifecycle";
 import {
+  prepareDecodedTopicPatch,
   prepareDecodedTopicRow,
   prepareDecodedTopicRowWithStorageKey,
   prepareTopicPatch,
@@ -380,6 +381,23 @@ export class TopicRowStorage {
       invalidRow,
     );
   });
+
+  prepareDecodedPatch = Effect.fn("ColumnLiveViewEngine.topicRowStorage.decodedPatch.prepare")(
+    function* <Patch extends Partial<RowObject>, Error>(
+      this: TopicRowStorage,
+      key: string,
+      patch: Patch,
+      invalidRow: InvalidRowErrorFactory<Error>,
+    ) {
+      return yield* prepareDecodedTopicPatch(
+        this.rowPreparation,
+        key,
+        this.rowForKey(key),
+        patch,
+        invalidRow,
+      );
+    },
+  );
 
   private writeSlot(slot: number, prepared: PreparedTopicRow): void {
     this.slots[slot] = {

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -24,6 +24,11 @@ export type TopicStoreMutationContext = {
     patch: Patch,
     invalidRow: InvalidRowErrorFactory<Error>,
   ) => Effect.Effect<number, Error>;
+  readonly patchDecoded: <Patch extends Partial<RowObject>, Error>(
+    key: string,
+    patch: Patch,
+    invalidRow: InvalidRowErrorFactory<Error>,
+  ) => Effect.Effect<number, Error>;
   readonly delete: (key: string) => number;
 };
 
@@ -107,6 +112,11 @@ const topicStoreMutationContext = (state: TopicStoreMutationState): TopicStoreMu
   patch: (key, patch, invalidRow) =>
     Effect.gen(function* () {
       const prepared = yield* state.storage.preparePatch(key, patch, invalidRow);
+      return state.storage.setPrepared(prepared);
+    }),
+  patchDecoded: (key, patch, invalidRow) =>
+    Effect.gen(function* () {
+      const prepared = yield* state.storage.prepareDecodedPatch(key, patch, invalidRow);
       return state.storage.setPrepared(prepared);
     }),
   delete: (key) => state.storage.delete(key),
@@ -258,6 +268,19 @@ export const patchTopicStoreRow = Effect.fn("ColumnLiveViewEngine.topicStore.pat
 >(store: TopicStore, key: string, patch: Patch, invalidRow: InvalidRowErrorFactory<Error>) {
   yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
     mutation.patch(key, patch, invalidRow),
+  );
+});
+
+export const patchTopicStoreDecodedFields = Effect.fn(
+  "ColumnLiveViewEngine.topicStore.patchDecodedFields",
+)(function* <Patch extends Partial<RowObject>, Error>(
+  store: TopicStore,
+  key: string,
+  patch: Patch,
+  invalidRow: InvalidRowErrorFactory<Error>,
+) {
+  yield* runTopicStoreMutationTransaction(topicStoreState(store), store, (mutation) =>
+    mutation.patchDecoded(key, patch, invalidRow),
   );
 });
 

--- a/packages/column-live-view-engine/src/topic-store.ts
+++ b/packages/column-live-view-engine/src/topic-store.ts
@@ -3,6 +3,7 @@ import { TopicStore } from "./topic-store-state";
 export { TopicStore };
 export {
   deleteTopicStoreRow,
+  patchTopicStoreDecodedFields,
   patchTopicStoreRow,
   publishTopicStoreDecodedRows,
   publishTopicStoreDecodedRowsWithStorageKeys,

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -960,6 +960,31 @@ describe("@effect-view-server/runtime-core", () => {
     }),
   );
 
+  it.effect("allows internal decoded field patching for source-owned runtime internals", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      yield* runtimeCore.internalClient.publishManyDecodedRows("orders", [order("decoded", 30)]);
+      yield* runtimeCore.internalClient.patchDecodedFields("orders", "decoded", {
+        price: 31,
+        status: "closed",
+      });
+      const snapshot = yield* runtimeCore.internalClient.snapshot("orders", {
+        select: ["id", "price", "status"],
+        limit: 1,
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "decoded", price: 31, status: "closed" }],
+        totalRows: 1,
+        version: 2,
+        status: "ready",
+        statusCode: "Ready",
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("rejects public leased subscriptions when effects execute", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(leasedViewServer, {});

--- a/packages/runtime-core/src/source-mutation-pipeline.ts
+++ b/packages/runtime-core/src/source-mutation-pipeline.ts
@@ -23,6 +23,11 @@ export type ViewServerRuntimeCoreInternalMutations<Topics extends DecodableTopic
   ViewServerRuntimeClient<Topics>,
   "delete" | "patch" | "publish" | "publishMany" | "reset"
 > & {
+  readonly patchDecodedFields: (
+    topic: Extract<keyof Topics, string>,
+    key: string,
+    patch: object,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
   readonly publishManyDecodedRows: (
     topic: Extract<keyof Topics, string>,
     rows: ReadonlyArray<object>,
@@ -105,6 +110,14 @@ export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTo
       requestHealthRefresh,
     );
   });
+  const patchDecodedFields = Effect.fn("ViewServerRuntimeCore.sourceMutation.patchDecodedFields")(
+    function* (topic: Extract<keyof Topics, string>, key: string, patch: object) {
+      yield* applyEngineMutation(
+        engine.patchDecodedFields(topic, key, patch),
+        requestHealthRefresh,
+      );
+    },
+  );
   const patch = Effect.fn("ViewServerRuntimeCore.client.patch")(function* <
     Topic extends Extract<keyof Topics, string>,
     const Patch,
@@ -129,6 +142,7 @@ export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTo
     publishManyDecodedRows,
     publishManyDecodedRowsWithStorageKeys,
     publishManyWithStorageKeys,
+    patchDecodedFields,
     patch,
     delete: deleteRow,
     reset,

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -197,6 +197,21 @@ const unionCodecTcpViewServer = defineViewServerConfig({
   },
 });
 
+const DefaultedTcpOrder = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+  status: Schema.String.pipe(Schema.withDecodingDefaultKey(Effect.succeed("open"))),
+});
+
+const defaultedTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: DefaultedTcpOrder,
+      key: "id",
+    },
+  },
+});
+
 const JsonCodecTcpNested = Schema.Struct({
   encodedQuantity: Schema.BigIntFromString,
   runtimeAmount: Schema.BigDecimal,
@@ -1359,6 +1374,51 @@ describe("@effect-view-server/runtime", () => {
       expect(snapshot).toStrictEqual({
         rows: [{ id: "a", quantity: 9007199254740995n }],
         totalRows: 1,
+        version: 2,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("preserves TCP publish rows materialized by the topic schema decoder", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(defaultedTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const response = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "publish",
+        topic: "orders",
+        row: { id: "a", price: 12 },
+      });
+      const publishManyResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "publishMany",
+        topic: "orders",
+        rows: [
+          { id: "b", price: 24 },
+          { id: "c", price: 36 },
+        ],
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price", "status"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(response).toStrictEqual({ ok: true });
+      expect(publishManyResponse).toStrictEqual({ ok: true });
+      expect(snapshot).toStrictEqual({
+        rows: [
+          { id: "a", price: 12, status: "open" },
+          { id: "b", price: 24, status: "open" },
+          { id: "c", price: 36, status: "open" },
+        ],
+        totalRows: 3,
         version: 2,
         status: "ready",
         statusCode: "Ready",

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -38,6 +38,7 @@ import {
   Queue,
   Schedule,
   Schema,
+  SchemaGetter,
   Stream,
 } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
@@ -80,7 +81,6 @@ import {
   readTcpPublishResponse,
   readTcpPublishResponses,
   reserveTcpPort,
-  RuntimeTcpTestFailure,
   RuntimeTestFailure,
   sendTcpPublishCommand,
   sendTcpPublishLine,
@@ -140,6 +140,58 @@ const transformTcpViewServer = defineViewServerConfig({
   topics: {
     orders: {
       schema: TransformTcpOrder,
+      key: "id",
+    },
+  },
+});
+
+const KeyTransformTcpId = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: SchemaGetter.transform((value) => `decoded-${value}`),
+    encode: SchemaGetter.transform((value) =>
+      value.startsWith("decoded-") ? value.slice("decoded-".length) : value,
+    ),
+  }),
+);
+
+const KeyTransformTcpOrder = Schema.Struct({
+  id: KeyTransformTcpId,
+  price: Schema.Number,
+});
+
+const keyTransformTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: KeyTransformTcpOrder,
+      key: "id",
+    },
+  },
+});
+
+const NonStringKeyTcpOrder = Schema.Struct({
+  id: Schema.BigIntFromString,
+  price: Schema.Number,
+});
+
+// @ts-expect-error non-string row keys are rejected by the public config contract.
+const nonStringKeyTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: NonStringKeyTcpOrder,
+      key: "id",
+    },
+  },
+});
+
+const UnionCodecTcpOrder = Schema.Struct({
+  id: Schema.String,
+  quantity: Schema.NullOr(Schema.BigInt),
+});
+
+const unionCodecTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: UnionCodecTcpOrder,
       key: "id",
     },
   },
@@ -349,6 +401,20 @@ const PublicKeyGrpcOrder = Schema.Struct({
   price: Schema.Number,
   region: Schema.String,
   updatedAt: Schema.Number,
+});
+
+const PositivePriceTcpOrder = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+}).check(Schema.makeFilter((row) => row.price >= 0, { expected: "price >= 0" }));
+
+const positivePriceTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: PositivePriceTcpOrder,
+      key: "id",
+    },
+  },
 });
 
 const publicKeyLeasedGrpcViewServer = defineViewServerConfig({
@@ -1154,6 +1220,146 @@ describe("@effect-view-server/runtime", () => {
         ],
         totalRows: 2,
         version: 3,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("decodes TCP command keys before patching and deleting rows", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(keyTransformTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const publishResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "publish",
+        topic: "orders",
+        row: { id: "a", price: 10 },
+      });
+      const patchResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "a",
+        patch: { price: 20 },
+      });
+      const patchedSnapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price"],
+        limit: 10,
+      });
+      const deleteResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "delete",
+        topic: "orders",
+        key: "a",
+      });
+      const deletedSnapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price"],
+        limit: 10,
+      });
+
+      expect(publishResponse).toStrictEqual({ ok: true });
+      expect(patchResponse).toStrictEqual({ ok: true });
+      expect(patchedSnapshot).toStrictEqual({
+        rows: [{ id: "decoded-a", price: 20 }],
+        totalRows: 1,
+        version: 2,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      expect(deleteResponse).toStrictEqual({ ok: true });
+      expect(deletedSnapshot).toStrictEqual({
+        rows: [],
+        totalRows: 0,
+        version: 3,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("rejects TCP command keys that decode to non-string runtime keys", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(nonStringKeyTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const patchResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "1",
+        patch: { price: 20 },
+      });
+      const deleteResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "delete",
+        topic: "orders",
+        key: "1",
+      });
+
+      expect([patchResponse, deleteResponse]).toStrictEqual([
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish key did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish key did not match View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+      ]);
+      yield* runtime.close;
+    }),
+  );
+
+  it.live("decodes TCP union JSON codec fields through the matching member", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(unionCodecTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const responses = [
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publish",
+          topic: "orders",
+          row: { id: "a", quantity: "9007199254740993" },
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: { quantity: "9007199254740995" },
+        }),
+      ];
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "quantity"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(responses).toStrictEqual([{ ok: true }, { ok: true }]);
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "a", quantity: 9007199254740995n }],
+        totalRows: 1,
+        version: 2,
         status: "ready",
         statusCode: "Ready",
       });
@@ -2129,6 +2335,60 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
+  it.live("rejects TCP decoded patches that violate the merged row schema", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(positivePriceTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const publishResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "publish",
+        topic: "orders",
+        row: {
+          id: "order-1",
+          price: 10,
+        },
+      });
+      const patchResponse = yield* sendTcpPublishCommand(tcpUrl, {
+        op: "patch",
+        topic: "orders",
+        key: "order-1",
+        patch: { price: -1 },
+      });
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "price"],
+        limit: 10,
+      });
+
+      expect(publishResponse).toStrictEqual({ ok: true });
+      expect(patchResponse).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidRow",
+          message: expect.any(String),
+          topic: "orders",
+        },
+      });
+      expect(snapshot).toStrictEqual({
+        rows: [
+          {
+            id: "order-1",
+            price: 10,
+          },
+        ],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      yield* runtime.close;
+    }),
+  );
+
   it.live("returns typed TCP publish errors for malformed commands", () =>
     Effect.gen(function* () {
       const runtime = yield* makeViewServerRuntime(viewServer, {
@@ -2386,6 +2646,84 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
+  it.live("rejects TCP publish commands for malformed runtime topic definitions", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const missingTopicSchemaConfig = {
+        topics: {
+          orders: {
+            key: "id",
+          },
+        },
+      };
+      const missingTopicKeyFieldConfig = {
+        topics: {
+          orders: {
+            schema: Order,
+            key: "missing",
+          },
+        },
+      };
+      const missingTopicSchemaIngress = yield* makeViewServerTcpPublishIngress(
+        // @ts-expect-error intentionally malformed config for the runtime defensive guard.
+        missingTopicSchemaConfig,
+        runtimeCore.internalClient,
+        { port: 0 },
+      );
+      const missingTopicKeyFieldIngress = yield* makeViewServerTcpPublishIngress(
+        missingTopicKeyFieldConfig,
+        runtimeCore.internalClient,
+        { port: 0 },
+      );
+
+      const missingTopicSchemaSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(missingTopicSchemaIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      const missingTopicKeyFieldSocket = yield* Effect.acquireRelease(
+        connectTcpPublishSocket(missingTopicKeyFieldIngress.url),
+        (socket) => Effect.sync(() => socket.destroy()),
+      );
+      const command = `${JSON.stringify({
+        op: "publish",
+        topic: "orders",
+        row: order("a", 10),
+      })}\n`;
+      missingTopicSchemaSocket.write(command);
+      missingTopicKeyFieldSocket.write(command);
+      const missingTopicSchemaResponse = yield* readTcpPublishResponse(
+        missingTopicSchemaSocket,
+      ).pipe(Effect.timeout("1 second"));
+      const missingTopicKeyFieldResponse = yield* readTcpPublishResponse(
+        missingTopicKeyFieldSocket,
+      ).pipe(Effect.timeout("1 second"));
+
+      expect([missingTopicSchemaResponse, missingTopicKeyFieldResponse]).toStrictEqual([
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish cannot find View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish cannot find key field missing for View Server topic orders.",
+            phase: "decode",
+            topic: "orders",
+          },
+        },
+      ]);
+      yield* missingTopicSchemaIngress.close;
+      yield* missingTopicKeyFieldIngress.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.live("rejects non-strict TCP publish patch field values at the decode boundary", () =>
     Effect.gen(function* () {
       const runtime = yield* makeViewServerRuntime(nestedTcpViewServer, {
@@ -2417,10 +2755,7 @@ describe("@effect-view-server/runtime", () => {
 
   it.live("rejects invalid TCP publish server options before listening", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeViewServerRuntime(viewServer, {
-        host: "127.0.0.1",
-        websocketPort: 0,
-      });
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
       const invalidOptions = [
         { port: -1 },
         { port: 65536 },
@@ -2433,7 +2768,9 @@ describe("@effect-view-server/runtime", () => {
         { maxGlobalQueuedCommands: 0, port: 0 },
       ];
       const errors = yield* Effect.forEach(invalidOptions, (options) =>
-        makeViewServerTcpPublishIngress(viewServer, runtime.client, options).pipe(Effect.flip),
+        makeViewServerTcpPublishIngress(viewServer, runtimeCore.internalClient, options).pipe(
+          Effect.flip,
+        ),
       );
 
       expect(
@@ -2479,7 +2816,7 @@ describe("@effect-view-server/runtime", () => {
           phase: "configuration",
         },
       ]);
-      yield* runtime.close;
+      yield* runtimeCore.close;
     }),
   );
 
@@ -2509,7 +2846,7 @@ describe("@effect-view-server/runtime", () => {
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(sourceOwnedViewServer, {});
       const ingress = yield* makeViewServerTcpPublishIngress(
         sourceOwnedViewServer,
-        runtimeCore.client,
+        runtimeCore.internalClient,
         {
           port: 0,
         },
@@ -2726,10 +3063,7 @@ describe("@effect-view-server/runtime", () => {
 
   it.live("bounds TCP publish line size and command queue", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeViewServerRuntime(viewServer, {
-        host: "127.0.0.1",
-        websocketPort: 0,
-      });
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
       const rejectedAcceptedSocket = new Net.Socket();
       const partialAcceptedSocket = new Net.Socket();
       const partialAcceptedSocketDestroyed: Array<"socket"> = [];
@@ -2749,7 +3083,7 @@ describe("@effect-view-server/runtime", () => {
           sockets: new Set(),
         },
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         { port: 0 },
       );
       const partialAcceptedSocketState = {
@@ -2765,7 +3099,7 @@ describe("@effect-view-server/runtime", () => {
         partialAcceptedSocket,
         partialAcceptedSocketState,
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         { port: 0 },
       );
       partialAcceptedSocket.emit("data", "  ");
@@ -2792,7 +3126,7 @@ describe("@effect-view-server/runtime", () => {
         unauthorizedSocket,
         unauthorizedSocketState,
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         {
           auth: bearerAuth,
           port: 0,
@@ -2819,46 +3153,52 @@ describe("@effect-view-server/runtime", () => {
       const disconnectedPublishInterrupted = yield* Deferred.make<void>();
       const closedQueuePublishStarted = yield* Deferred.make<void>();
       const closedQueuePublishInterrupted = yield* Deferred.make<void>();
-      const slowPublishClient = Object.create(runtime.client);
-      Object.defineProperty(slowPublishClient, "publish", {
-        value: () =>
+      const slowPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () =>
           Deferred.succeed(slowPublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
             Effect.ensuring(Deferred.succeed(slowPublishInterrupted, undefined)),
           ),
-      });
-      const deadlineClearedPublishClient = Object.create(runtime.client);
-      Object.defineProperty(deadlineClearedPublishClient, "publish", {
-        value: () =>
+      };
+      const deadlineClearedPublishClient: ViewServerRuntimeCoreInternalClient<
+        typeof viewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () =>
           Deferred.succeed(deadlineClearedPublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
             Effect.ensuring(Deferred.succeed(deadlineClearedPublishInterrupted, undefined)),
           ),
-      });
-      const globalPublishClient = Object.create(runtime.client);
-      Object.defineProperty(globalPublishClient, "publish", {
-        value: () =>
+      };
+      const globalPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () =>
           Deferred.succeed(globalPublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
             Effect.ensuring(Deferred.succeed(globalPublishInterrupted, undefined)),
           ),
-      });
-      const disconnectedPublishClient = Object.create(runtime.client);
-      Object.defineProperty(disconnectedPublishClient, "publish", {
-        value: () =>
+      };
+      const disconnectedPublishClient: ViewServerRuntimeCoreInternalClient<
+        typeof viewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () =>
           Deferred.succeed(disconnectedPublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
             Effect.ensuring(Deferred.succeed(disconnectedPublishInterrupted, undefined)),
           ),
-      });
-      const closedQueuePublishClient = Object.create(runtime.client);
-      Object.defineProperty(closedQueuePublishClient, "publish", {
-        value: () =>
+      };
+      const closedQueuePublishClient: ViewServerRuntimeCoreInternalClient<
+        typeof viewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () =>
           Deferred.succeed(closedQueuePublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
             Effect.ensuring(Deferred.succeed(closedQueuePublishInterrupted, undefined)),
           ),
-      });
+      };
       const compactCommandLine = `${JSON.stringify({
         op: "publish",
         topic: "orders",
@@ -2918,7 +3258,7 @@ describe("@effect-view-server/runtime", () => {
         rearmedSocket,
         rearmedSocketState,
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         { port: 0 },
       );
       rearmedSocket.emit(
@@ -2930,22 +3270,30 @@ describe("@effect-view-server/runtime", () => {
         })}\n`,
       );
       yield* Effect.sleep("20 millis");
-      const oversizedIngress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
-        maxLineBytes: 8,
-        port: 0,
-      });
-      const oversizedCompleteLineIngress = yield* makeViewServerTcpPublishIngress(
+      const oversizedIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         {
           maxLineBytes: 8,
           port: 0,
         },
       );
-      const coalescedIngress = yield* makeViewServerTcpPublishIngress(viewServer, runtime.client, {
-        maxLineBytes: Buffer.byteLength(compactCommandLine, "utf8"),
-        port: 0,
-      });
+      const oversizedCompleteLineIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        runtimeCore.internalClient,
+        {
+          maxLineBytes: 8,
+          port: 0,
+        },
+      );
+      const coalescedIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        runtimeCore.internalClient,
+        {
+          maxLineBytes: Buffer.byteLength(compactCommandLine, "utf8"),
+          port: 0,
+        },
+      );
       const queuedIngress = yield* makeViewServerTcpPublishIngress(viewServer, slowPublishClient, {
         maxQueuedCommands: 2,
         port: 0,
@@ -2966,7 +3314,7 @@ describe("@effect-view-server/runtime", () => {
       );
       const connectionCappedIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         {
           maxConnections: 1,
           port: 0,
@@ -3127,9 +3475,10 @@ describe("@effect-view-server/runtime", () => {
       expect(unauthorizedSocketResponses).toStrictEqual([
         '{"ok":false,"error":{"_tag":"ViewServerAuthError","message":"Missing or invalid authorization header.","status":401}}\n',
       ]);
-      expect(unauthorizedSocketState.socketStates.get(unauthorizedSocket)?.preCommandDeadline).toBe(
-        initialUnauthorizedDeadline,
-      );
+      const rearmedUnauthorizedDeadline =
+        unauthorizedSocketState.socketStates.get(unauthorizedSocket)?.preCommandDeadline;
+      expect(rearmedUnauthorizedDeadline).not.toBeUndefined();
+      expect(rearmedUnauthorizedDeadline).not.toBe(initialUnauthorizedDeadline);
       expect(deadlineClearedSocketDestroyed).toStrictEqual([]);
       expect(rearmedSocketResponses).toStrictEqual(['{"ok":true}\n']);
       expect(rearmedSocketDestroyed).toStrictEqual(["socket"]);
@@ -3150,16 +3499,13 @@ describe("@effect-view-server/runtime", () => {
       yield* oversizedCompleteLineIngress.close;
       yield* oversizedIngress.close;
       yield* oversizedIngress.close;
-      yield* runtime.close;
+      yield* runtimeCore.close;
     }),
   );
 
   it.live("keeps TCP response backpressure non-fatal through deterministic internals", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeViewServerRuntime(viewServer, {
-        host: "127.0.0.1",
-        websocketPort: 0,
-      });
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
       const writtenChunks: Array<string> = [];
       const destroyed: Array<"socket"> = [];
       const listeners: Partial<Record<"close" | "error", () => void>> = {};
@@ -3246,7 +3592,7 @@ describe("@effect-view-server/runtime", () => {
         ignoredAfterCloseSocket,
         closedServerState,
         viewServer,
-        runtime.client,
+        runtimeCore.internalClient,
         { port: 0 },
       );
       closedServerState.closed = true;
@@ -3270,74 +3616,39 @@ describe("@effect-view-server/runtime", () => {
         stateClosed: false,
         writtenChunks: ['{"ok":true}\n'],
       });
-      yield* runtime.close;
+      yield* runtimeCore.close;
     }),
   );
 
-  it.live("returns typed TCP publish errors for malformed runtime clients", () =>
+  it.live("returns typed TCP publish errors for runtime mutation failures", () =>
     Effect.gen(function* () {
-      const runtime = yield* makeViewServerRuntime(viewServer, {
-        host: "127.0.0.1",
-        websocketPort: 0,
-      });
-      const missingPublishClient = Object.create(runtime.client);
-      Object.defineProperty(missingPublishClient, "publish", {
-        value: undefined,
-      });
-      const nonEffectPublishClient = Object.create(runtime.client);
-      Object.defineProperty(nonEffectPublishClient, "publish", {
-        value: () => "not-an-effect",
-      });
-      const defectPublishClient = Object.create(runtime.client);
-      Object.defineProperty(defectPublishClient, "publish", {
-        value: () => Effect.die("tcp publish defect"),
-      });
-      const failingPublishClient = Object.create(runtime.client);
-      Object.defineProperty(failingPublishClient, "publish", {
-        value: () =>
-          Effect.fail(
-            new RuntimeTcpTestFailure({
-              cause: "typed runtime failure",
-              message: "typed runtime publish failure",
-            }),
-          ),
-      });
-      const stringFailingPublishClient = Object.create(runtime.client);
-      Object.defineProperty(stringFailingPublishClient, "publish", {
-        value: () => Effect.fail("string runtime failure"),
-      });
-      const unavailablePublishClient = Object.create(runtime.client);
-      Object.defineProperty(unavailablePublishClient, "publish", {
-        value: () =>
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const defectPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () => Effect.die("tcp publish defect"),
+      };
+      const unavailablePublishClient: ViewServerRuntimeCoreInternalClient<
+        typeof viewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+        publishManyDecodedRows: () =>
           Effect.fail({
             _tag: "ViewServerRuntimeError",
             code: "RuntimeUnavailable",
             message: "runtime unavailable for tcp test",
           } satisfies ViewServerRuntimeError),
+      };
+      const typedFailurePublishClient: ViewServerRuntimeCoreInternalClient<
+        typeof viewServer.topics
+      > = {
+        ...runtimeCore.internalClient,
+      };
+      Object.defineProperty(typedFailurePublishClient, "publishManyDecodedRows", {
+        value: () => Effect.fail(new RuntimeTestFailure({ message: "runtime typed failure" })),
       });
-      const missingPublishIngress = yield* makeViewServerTcpPublishIngress(
-        viewServer,
-        missingPublishClient,
-        { port: 0 },
-      );
-      const nonEffectPublishIngress = yield* makeViewServerTcpPublishIngress(
-        viewServer,
-        nonEffectPublishClient,
-        { port: 0 },
-      );
       const defectPublishIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
         defectPublishClient,
-        { port: 0 },
-      );
-      const failingPublishIngress = yield* makeViewServerTcpPublishIngress(
-        viewServer,
-        failingPublishClient,
-        { port: 0 },
-      );
-      const stringFailingPublishIngress = yield* makeViewServerTcpPublishIngress(
-        viewServer,
-        stringFailingPublishClient,
         { port: 0 },
       );
       const unavailablePublishIngress = yield* makeViewServerTcpPublishIngress(
@@ -3345,34 +3656,24 @@ describe("@effect-view-server/runtime", () => {
         unavailablePublishClient,
         { port: 0 },
       );
+      const typedFailurePublishIngress = yield* makeViewServerTcpPublishIngress(
+        viewServer,
+        typedFailurePublishClient,
+        { port: 0 },
+      );
 
       const responses = [
-        yield* sendTcpPublishCommand(missingPublishIngress.url, {
-          op: "publish",
-          topic: "orders",
-          row: order("a", 10),
-        }),
-        yield* sendTcpPublishCommand(nonEffectPublishIngress.url, {
-          op: "publish",
-          topic: "orders",
-          row: order("a", 10),
-        }),
         yield* sendTcpPublishCommand(defectPublishIngress.url, {
           op: "publish",
           topic: "orders",
           row: order("a", 10),
         }),
-        yield* sendTcpPublishCommand(failingPublishIngress.url, {
-          op: "publish",
-          topic: "orders",
-          row: order("a", 10),
-        }),
-        yield* sendTcpPublishCommand(stringFailingPublishIngress.url, {
-          op: "publish",
-          topic: "orders",
-          row: order("a", 10),
-        }),
         yield* sendTcpPublishCommand(unavailablePublishIngress.url, {
+          op: "publish",
+          topic: "orders",
+          row: order("a", 10),
+        }),
+        yield* sendTcpPublishCommand(typedFailurePublishIngress.url, {
           op: "publish",
           topic: "orders",
           row: order("a", 10),
@@ -3384,44 +3685,8 @@ describe("@effect-view-server/runtime", () => {
           ok: false,
           error: {
             _tag: "ViewServerTcpPublishIngressError",
-            message: "Runtime publish did not return an Effect for TCP publish topic orders.",
-            phase: "runtime",
-            topic: "orders",
-          },
-        },
-        {
-          ok: false,
-          error: {
-            _tag: "ViewServerTcpPublishIngressError",
-            message: "Runtime publish did not return an Effect for TCP publish topic orders.",
-            phase: "runtime",
-            topic: "orders",
-          },
-        },
-        {
-          ok: false,
-          error: {
-            _tag: "ViewServerTcpPublishIngressError",
             message: "TCP publish command failed with an untyped cause.",
             phase: "runtime",
-          },
-        },
-        {
-          ok: false,
-          error: {
-            _tag: "ViewServerTcpPublishIngressError",
-            message: "TCP publish runtime publish failed for topic orders.",
-            phase: "runtime",
-            topic: "orders",
-          },
-        },
-        {
-          ok: false,
-          error: {
-            _tag: "ViewServerTcpPublishIngressError",
-            message: "TCP publish runtime publish failed for topic orders.",
-            phase: "runtime",
-            topic: "orders",
           },
         },
         {
@@ -3432,15 +3697,21 @@ describe("@effect-view-server/runtime", () => {
             message: "runtime unavailable for tcp test",
           },
         },
+        {
+          ok: false,
+          error: {
+            _tag: "ViewServerTcpPublishIngressError",
+            message: "TCP publish runtime publish failed for topic orders.",
+            phase: "runtime",
+            topic: "orders",
+          },
+        },
       ]);
 
+      yield* typedFailurePublishIngress.close;
       yield* unavailablePublishIngress.close;
-      yield* stringFailingPublishIngress.close;
-      yield* failingPublishIngress.close;
       yield* defectPublishIngress.close;
-      yield* nonEffectPublishIngress.close;
-      yield* missingPublishIngress.close;
-      yield* runtime.close;
+      yield* runtimeCore.close;
     }),
   );
 

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -230,7 +230,7 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
     resolvedOptions.tcpPublishOptions === undefined
       ? undefined
       : yield* dependencies
-          .makeTcpPublishIngress(dependencyConfig, runtimeClient, {
+          .makeTcpPublishIngress(dependencyConfig, runtimeCore.internalClient, {
             ...resolvedOptions.tcpPublishOptions,
             ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
           })

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -1,7 +1,6 @@
 import type {
   GrpcRuntimeClients,
   RuntimeRegions,
-  ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@effect-view-server/config";
 import { type ViewServerRuntimeCoreOptionsFor } from "@effect-view-server/runtime-core";
@@ -69,7 +68,7 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
   ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError>;
   readonly makeTcpPublishIngress: (
     config: ViewServerRuntimeDependencyConfig<Topics>,
-    client: ViewServerRuntimeClient<Topics>,
+    client: ViewServerRuntimeCoreInternalClient<Topics>,
     options: ViewServerTcpPublishIngressOptions,
   ) => Effect.Effect<ViewServerTcpPublishIngress, ViewServerTcpPublishIngressError>;
   readonly makeGrpcIngress: <const Clients extends GrpcRuntimeClients>(

--- a/packages/runtime/src/tcp-publish-command.ts
+++ b/packages/runtime/src/tcp-publish-command.ts
@@ -1,0 +1,377 @@
+import type { RowSchema, ViewServerRuntimeError } from "@effect-view-server/config";
+import type {
+  SourceOwnershipPolicy,
+  ViewServerRuntimeCoreInternalClient,
+} from "@effect-view-server/runtime-core/internal";
+import type { ViewServerAuth, ViewServerAuthRequest } from "@effect-view-server/server";
+import { validateViewServerAuthRequest, ViewServerAuthError } from "@effect-view-server/server";
+import { Effect, Option, Result, Schema } from "effect";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+export class ViewServerTcpPublishIngressError extends Schema.TaggedErrorClass<ViewServerTcpPublishIngressError>()(
+  "ViewServerTcpPublishIngressError",
+  {
+    cause: Schema.Unknown,
+    message: Schema.String,
+    phase: Schema.Literals(["configuration", "listen", "decode", "runtime", "backpressure"]),
+    topic: Schema.optional(Schema.String),
+  },
+) {}
+
+export type TcpPublishCommandError =
+  | ViewServerAuthError
+  | ViewServerRuntimeError
+  | ViewServerTcpPublishIngressError;
+
+export type TcpPublishCommandOptions = {
+  readonly auth?: ViewServerAuth;
+};
+
+export type TcpPublishCommandAuthContext = {
+  readonly remoteAddress: Option.Option<string>;
+};
+
+type TcpFieldSchema = NonNullable<RowSchema["fields"][string]>;
+type TcpDecodePhase = "key" | "patch" | "row";
+type TcpConfiguredTopic<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly fieldSchemas: ReadonlyMap<string, TcpFieldSchema>;
+  readonly keyField: string;
+  readonly keySchema: TcpFieldSchema;
+  readonly schema: RowSchema;
+  readonly topic: Extract<keyof Topics, string>;
+};
+
+const TcpJsonObject = Schema.Record(Schema.String, Schema.Json);
+const TcpHeaders = Schema.Record(Schema.String, Schema.String);
+
+const TcpPublishCommandSchema = Schema.Union([
+  Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
+    op: Schema.Literal("publish"),
+    topic: Schema.String,
+    row: TcpJsonObject,
+  }),
+  Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
+    op: Schema.Literal("publishMany"),
+    topic: Schema.String,
+    rows: Schema.Array(TcpJsonObject),
+  }),
+  Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
+    op: Schema.Literal("patch"),
+    topic: Schema.String,
+    key: Schema.String,
+    patch: TcpJsonObject,
+  }),
+  Schema.Struct({
+    headers: Schema.optional(TcpHeaders),
+    op: Schema.Literal("delete"),
+    topic: Schema.String,
+    key: Schema.String,
+  }),
+]);
+
+type TcpPublishCommand = typeof TcpPublishCommandSchema.Type;
+
+const strictParseOptions = {
+  onExcessProperty: "error",
+} as const;
+
+const hasConfiguredTopic = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  topics: Topics,
+  topic: string,
+): topic is Extract<keyof Topics, string> => Object.hasOwn(topics, topic);
+
+const isTopicDefinitionWithSchema = (
+  value: unknown,
+): value is { readonly key: string; readonly schema: RowSchema } =>
+  typeof value === "object" &&
+  value !== null &&
+  "key" in value &&
+  typeof value.key === "string" &&
+  "schema" in value &&
+  Schema.isSchema(value.schema);
+
+const tcpDecodeError = (line: string, cause: unknown): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: "TCP publish command must be valid JSON.",
+    cause: { cause, line },
+    phase: "decode",
+  });
+
+const parseCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.parse")(function* (
+  line: string,
+) {
+  const value = yield* Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)(
+    line,
+    strictParseOptions,
+  ).pipe(Effect.mapError((cause) => tcpDecodeError(line, cause)));
+  return yield* Result.match(
+    Schema.decodeUnknownResult(TcpPublishCommandSchema)(value, strictParseOptions),
+    {
+      onSuccess: Effect.succeed,
+      onFailure: (cause) =>
+        Effect.fail(
+          new ViewServerTcpPublishIngressError({
+            message: "TCP publish command must match the publish command schema.",
+            cause,
+            phase: "decode",
+          }),
+        ),
+    },
+  );
+});
+
+const tcpAuthRequest = (
+  command: TcpPublishCommand,
+  context: TcpPublishCommandAuthContext,
+): ViewServerAuthRequest => ({
+  headers: command.headers ?? {},
+  method: "POST",
+  remoteAddress: context.remoteAddress,
+  url: "tcp://view-server/tcp-publish",
+});
+
+const topicSchema = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: { readonly topics: Topics },
+  topic: string,
+): Effect.Effect<TcpConfiguredTopic<Topics>, ViewServerTcpPublishIngressError> => {
+  if (!hasConfiguredTopic(config.topics, topic)) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: `TCP publish cannot find View Server topic ${topic}.`,
+        cause: topic,
+        phase: "decode",
+        topic,
+      }),
+    );
+  }
+  const topicDefinition = config.topics[topic];
+  if (!isTopicDefinitionWithSchema(topicDefinition)) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: `TCP publish cannot find View Server topic ${topic}.`,
+        cause: topic,
+        phase: "decode",
+        topic,
+      }),
+    );
+  }
+  const fieldSchemas = new Map(
+    Object.entries(topicDefinition.schema.fields).filter(
+      (entry): entry is [string, TcpFieldSchema] => entry[1] !== undefined,
+    ),
+  );
+  const keySchema = fieldSchemas.get(topicDefinition.key);
+  if (keySchema === undefined) {
+    return Effect.fail(
+      new ViewServerTcpPublishIngressError({
+        message: `TCP publish cannot find key field ${topicDefinition.key} for View Server topic ${topic}.`,
+        cause: { key: topicDefinition.key, topic },
+        phase: "decode",
+        topic,
+      }),
+    );
+  }
+  return Effect.succeed({
+    fieldSchemas,
+    keyField: topicDefinition.key,
+    keySchema,
+    schema: topicDefinition.schema,
+    topic,
+  });
+};
+
+const tcpDecodeSchemaError = (
+  topic: string,
+  phase: TcpDecodePhase,
+  cause: unknown,
+): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish ${phase} did not match View Server topic ${topic}.`,
+    cause,
+    phase: "decode",
+    topic,
+  });
+
+const tcpRuntimeError = (
+  topic: string,
+  operation: "delete" | "patch" | "publish" | "publishMany",
+  cause: unknown,
+): ViewServerTcpPublishIngressError =>
+  new ViewServerTcpPublishIngressError({
+    message: `TCP publish runtime ${operation} failed for topic ${topic}.`,
+    cause,
+    phase: "runtime",
+    topic,
+  });
+
+const setDecodedField = (record: Record<string, unknown>, field: string, value: unknown): void => {
+  Object.defineProperty(record, field, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const decodeTcpFieldForRuntimeInternal: (
+  schema: TcpFieldSchema,
+  topic: string,
+  phase: TcpDecodePhase,
+  value: unknown,
+) => Effect.Effect<unknown, ViewServerTcpPublishIngressError> = Effect.fn(
+  "ViewServerRuntime.tcpPublish.field.decode.internal",
+)(function* (schema, topic, phase, value) {
+  return yield* Result.match(
+    Schema.decodeUnknownResult(Schema.toCodecJson(schema))(value, strictParseOptions),
+    {
+      onSuccess: Effect.succeed,
+      onFailure: () =>
+        Result.match(Schema.decodeUnknownResult(schema)(value, strictParseOptions), {
+          onSuccess: Effect.succeed,
+          onFailure: (cause) => Effect.fail(tcpDecodeSchemaError(topic, phase, cause)),
+        }),
+    },
+  );
+});
+
+const decodeTcpFieldForRuntime = Effect.fn("ViewServerRuntime.tcpPublish.field.decode")(function* (
+  schema: TcpFieldSchema,
+  topic: string,
+  phase: TcpDecodePhase,
+  value: unknown,
+) {
+  return yield* decodeTcpFieldForRuntimeInternal(schema, topic, phase, value);
+});
+
+const decodeTcpKey = Effect.fn("ViewServerRuntime.tcpPublish.key.decode")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(topicDefinition: TcpConfiguredTopic<Topics>, key: string) {
+  const decodedKey = yield* decodeTcpFieldForRuntime(
+    topicDefinition.keySchema,
+    topicDefinition.topic,
+    "key",
+    key,
+  );
+  if (typeof decodedKey !== "string") {
+    return yield* tcpDecodeSchemaError(topicDefinition.topic, "key", {
+      key: topicDefinition.keyField,
+      value: key,
+    });
+  }
+  return decodedKey;
+});
+
+const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(topicDefinition: TcpConfiguredTopic<Topics>, topic: string, row: Record<string, unknown>) {
+  const decodedRow: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(row)) {
+    const fieldSchema = topicDefinition.fieldSchemas.get(field);
+    if (fieldSchema === undefined) {
+      return yield* tcpDecodeSchemaError(topic, "row", { field });
+    }
+    setDecodedField(
+      decodedRow,
+      field,
+      yield* decodeTcpFieldForRuntime(fieldSchema, topic, "row", value),
+    );
+  }
+  yield* Schema.decodeUnknownEffect(Schema.toType(topicDefinition.schema))(
+    decodedRow,
+    strictParseOptions,
+  ).pipe(
+    Effect.asVoid,
+    Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)),
+  );
+  return decodedRow;
+});
+
+const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  topicDefinition: TcpConfiguredTopic<Topics>,
+  topic: string,
+  rows: ReadonlyArray<Record<string, unknown>>,
+) {
+  return yield* Effect.forEach(rows, (row) => decodeTcpRow(topicDefinition, topic, row));
+});
+
+const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(topicDefinition: TcpConfiguredTopic<Topics>, topic: string, patch: Record<string, unknown>) {
+  const decodedPatch: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(patch)) {
+    const fieldSchema = topicDefinition.fieldSchemas.get(field);
+    if (fieldSchema === undefined) {
+      return yield* tcpDecodeSchemaError(topic, "patch", { field });
+    }
+    setDecodedField(
+      decodedPatch,
+      field,
+      yield* decodeTcpFieldForRuntime(fieldSchema, topic, "patch", value),
+    );
+  }
+  return decodedPatch;
+});
+
+const ensureTopicCanBeMutated = (
+  topic: string,
+  sourceOwnership: SourceOwnershipPolicy,
+): Effect.Effect<void, ViewServerRuntimeError> =>
+  sourceOwnership.requirePublicMutationAllowed(topic, "runtimeCore");
+
+const mapRuntimeError =
+  (topic: string, operation: "delete" | "patch" | "publish" | "publishMany") =>
+  (cause: unknown): TcpPublishCommandError =>
+    isViewServerRuntimeError(cause) ? cause : tcpRuntimeError(topic, operation, cause);
+
+const isViewServerRuntimeError = (value: unknown): value is ViewServerRuntimeError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  (value._tag === "ViewServerRuntimeError" || value._tag === "ViewServerBackpressureError");
+
+export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    context: TcpPublishCommandAuthContext,
+    config: { readonly topics: Topics },
+    client: ViewServerRuntimeCoreInternalClient<Topics>,
+    options: TcpPublishCommandOptions,
+    sourceOwnership: SourceOwnershipPolicy,
+    line: string,
+  ) {
+    const command = yield* parseCommand(line);
+    yield* validateViewServerAuthRequest(options.auth, tcpAuthRequest(command, context));
+    const topicDefinition = yield* topicSchema(config, command.topic);
+    yield* ensureTopicCanBeMutated(topicDefinition.topic, sourceOwnership);
+    if (command.op === "publish") {
+      const row = yield* decodeTcpRow(topicDefinition, topicDefinition.topic, command.row);
+      yield* client
+        .publishManyDecodedRows(topicDefinition.topic, [row])
+        .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publish")));
+      return;
+    }
+    if (command.op === "publishMany") {
+      const rows = yield* decodeTcpRows(topicDefinition, topicDefinition.topic, command.rows);
+      yield* client
+        .publishManyDecodedRows(topicDefinition.topic, rows)
+        .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publishMany")));
+      return;
+    }
+    if (command.op === "patch") {
+      const key = yield* decodeTcpKey(topicDefinition, command.key);
+      const patch = yield* decodeTcpPatch(topicDefinition, topicDefinition.topic, command.patch);
+      yield* client
+        .patchDecodedFields(topicDefinition.topic, key, patch)
+        .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "patch")));
+      return;
+    }
+    const key = yield* decodeTcpKey(topicDefinition, command.key);
+    yield* client
+      .delete(topicDefinition.topic, key)
+      .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "delete")));
+  },
+);

--- a/packages/runtime/src/tcp-publish-command.ts
+++ b/packages/runtime/src/tcp-publish-command.ts
@@ -33,6 +33,7 @@ export type TcpPublishCommandAuthContext = {
 
 type TcpFieldSchema = NonNullable<RowSchema["fields"][string]>;
 type TcpDecodePhase = "key" | "patch" | "row";
+type TcpFieldDefaultDecoder = Effect.Effect<Option.Option<unknown>>;
 type TcpConfiguredTopic<Topics extends ViewServerRuntimeTopicDefinitions> = {
   readonly fieldSchemas: ReadonlyMap<string, TcpFieldSchema>;
   readonly keyField: string;
@@ -246,6 +247,32 @@ const decodeTcpFieldForRuntime = Effect.fn("ViewServerRuntime.tcpPublish.field.d
   return yield* decodeTcpFieldForRuntimeInternal(schema, topic, phase, value);
 });
 
+const makeTcpMissingFieldDefaultDecoder = (
+  schema: TcpFieldSchema,
+  field: string,
+): TcpFieldDefaultDecoder => {
+  const fieldDefaultSchema = Schema.Struct({ [field]: schema });
+  return Effect.suspend(() =>
+    Result.match(Schema.decodeUnknownResult(fieldDefaultSchema)({}, strictParseOptions), {
+      onSuccess: (decodedDefault) =>
+        Object.hasOwn(decodedDefault, field)
+          ? Effect.succeed(Option.some(decodedDefault[field]))
+          : Effect.succeed(Option.none()),
+      onFailure: () => Effect.succeed(Option.none()),
+    }),
+  ).pipe(Effect.withSpan("ViewServerRuntime.tcpPublish.field.default.decode"));
+};
+
+const makeTcpRowDefaultDecoders = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  topicDefinition: TcpConfiguredTopic<Topics>,
+): ReadonlyMap<string, TcpFieldDefaultDecoder> => {
+  const defaultDecoders = new Map<string, TcpFieldDefaultDecoder>();
+  for (const [field, fieldSchema] of topicDefinition.fieldSchemas) {
+    defaultDecoders.set(field, makeTcpMissingFieldDefaultDecoder(fieldSchema, field));
+  }
+  return defaultDecoders;
+};
+
 const decodeTcpKey = Effect.fn("ViewServerRuntime.tcpPublish.key.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(topicDefinition: TcpConfiguredTopic<Topics>, key: string) {
@@ -266,7 +293,12 @@ const decodeTcpKey = Effect.fn("ViewServerRuntime.tcpPublish.key.decode")(functi
 
 const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
->(topicDefinition: TcpConfiguredTopic<Topics>, topic: string, row: Record<string, unknown>) {
+>(
+  topicDefinition: TcpConfiguredTopic<Topics>,
+  topic: string,
+  row: Record<string, unknown>,
+  defaultDecoders: ReadonlyMap<string, TcpFieldDefaultDecoder>,
+) {
   const decodedRow: Record<string, unknown> = {};
   for (const [field, value] of Object.entries(row)) {
     const fieldSchema = topicDefinition.fieldSchemas.get(field);
@@ -279,14 +311,18 @@ const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(functi
       yield* decodeTcpFieldForRuntime(fieldSchema, topic, "row", value),
     );
   }
-  yield* Schema.decodeUnknownEffect(Schema.toType(topicDefinition.schema))(
+  for (const [field, defaultDecoder] of defaultDecoders) {
+    if (!Object.hasOwn(row, field)) {
+      const defaultValue = yield* defaultDecoder;
+      if (Option.isSome(defaultValue)) {
+        setDecodedField(decodedRow, field, defaultValue.value);
+      }
+    }
+  }
+  return yield* Schema.decodeUnknownEffect(Schema.toType(topicDefinition.schema))(
     decodedRow,
     strictParseOptions,
-  ).pipe(
-    Effect.asVoid,
-    Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)),
-  );
-  return decodedRow;
+  ).pipe(Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)));
 });
 
 const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(function* <
@@ -296,7 +332,10 @@ const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(func
   topic: string,
   rows: ReadonlyArray<Record<string, unknown>>,
 ) {
-  return yield* Effect.forEach(rows, (row) => decodeTcpRow(topicDefinition, topic, row));
+  const defaultDecoders = makeTcpRowDefaultDecoders(topicDefinition);
+  return yield* Effect.forEach(rows, (row) =>
+    decodeTcpRow(topicDefinition, topic, row, defaultDecoders),
+  );
 });
 
 const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(function* <
@@ -348,7 +387,12 @@ export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPubli
     const topicDefinition = yield* topicSchema(config, command.topic);
     yield* ensureTopicCanBeMutated(topicDefinition.topic, sourceOwnership);
     if (command.op === "publish") {
-      const row = yield* decodeTcpRow(topicDefinition, topicDefinition.topic, command.row);
+      const row = yield* decodeTcpRow(
+        topicDefinition,
+        topicDefinition.topic,
+        command.row,
+        makeTcpRowDefaultDecoders(topicDefinition),
+      );
       yield* client
         .publishManyDecodedRows(topicDefinition.topic, [row])
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publish")));

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -1,28 +1,21 @@
-import type {
-  RowSchema,
-  ViewServerTopicConfig,
-  ViewServerRuntimeClient,
-  ViewServerRuntimeError,
-} from "@effect-view-server/config";
-import type { ViewServerAuth, ViewServerAuthRequest } from "@effect-view-server/server";
-import { validateViewServerAuthRequest, ViewServerAuthError } from "@effect-view-server/server";
+import type { ViewServerRuntimeError, ViewServerTopicConfig } from "@effect-view-server/config";
+import type { ViewServerAuth } from "@effect-view-server/server";
+import { ViewServerAuthError } from "@effect-view-server/server";
 import {
   makeSourceOwnershipPolicy,
   type SourceOwnershipPolicy,
+  type ViewServerRuntimeCoreInternalClient,
 } from "@effect-view-server/runtime-core/internal";
-import { Cause, Effect, Exit, Fiber, Option, Result, Schema, SchemaAST } from "effect";
+import { Cause, Effect, Exit, Fiber, Option, Schema } from "effect";
 import * as Net from "node:net";
+import {
+  handleTcpPublishCommandLine,
+  type TcpPublishCommandError,
+  ViewServerTcpPublishIngressError,
+} from "./tcp-publish-command";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
-export class ViewServerTcpPublishIngressError extends Schema.TaggedErrorClass<ViewServerTcpPublishIngressError>()(
-  "ViewServerTcpPublishIngressError",
-  {
-    cause: Schema.Unknown,
-    message: Schema.String,
-    phase: Schema.Literals(["configuration", "listen", "decode", "runtime", "backpressure"]),
-    topic: Schema.optional(Schema.String),
-  },
-) {}
+export { ViewServerTcpPublishIngressError } from "./tcp-publish-command";
 
 export type ViewServerTcpPublishIngressOptions = {
   readonly host?: string;
@@ -39,50 +32,11 @@ export type ViewServerTcpPublishIngress = {
   readonly close: Effect.Effect<void>;
 };
 
-type RuntimeMutationEffect = Effect.Effect<unknown, unknown, never>;
-type TcpPublishCommandError =
-  | ViewServerAuthError
-  | ViewServerRuntimeError
-  | ViewServerTcpPublishIngressError;
-
 const TcpAddress = Schema.Struct({
   address: Schema.String,
   family: Schema.String,
   port: Schema.Number,
 });
-
-const TcpJsonObject = Schema.Record(Schema.String, Schema.Json);
-const TcpHeaders = Schema.Record(Schema.String, Schema.String);
-
-const TcpPublishCommandSchema = Schema.Union([
-  Schema.Struct({
-    headers: Schema.optional(TcpHeaders),
-    op: Schema.Literal("publish"),
-    topic: Schema.String,
-    row: TcpJsonObject,
-  }),
-  Schema.Struct({
-    headers: Schema.optional(TcpHeaders),
-    op: Schema.Literal("publishMany"),
-    topic: Schema.String,
-    rows: Schema.Array(TcpJsonObject),
-  }),
-  Schema.Struct({
-    headers: Schema.optional(TcpHeaders),
-    op: Schema.Literal("patch"),
-    topic: Schema.String,
-    key: Schema.String,
-    patch: TcpJsonObject,
-  }),
-  Schema.Struct({
-    headers: Schema.optional(TcpHeaders),
-    op: Schema.Literal("delete"),
-    topic: Schema.String,
-    key: Schema.String,
-  }),
-]);
-
-type TcpPublishCommand = typeof TcpPublishCommandSchema.Type;
 
 type TcpPublishSocketState = {
   readonly activeFibers: Set<Fiber.Fiber<void, TcpPublishCommandError>>;
@@ -118,393 +72,12 @@ type TcpResponseSocket = {
   readonly write: (chunk: string, callback: () => void) => boolean;
 };
 
-type TcpFieldSchema = NonNullable<RowSchema["fields"][string]>;
-type TcpSuspendedSchema = {
-  readonly ast: SchemaAST.Suspend;
-};
-
 const defaultMaxLineBytes = 1024 * 1024;
 const defaultMaxConnections = 1024;
 const defaultMaxGlobalQueuedCommands = 1024;
 const defaultMaxQueuedCommands = 1024;
 const acceptedSocketPreCommandDeadlineMs = 30_000;
 const rejectedSocketDestroyTimeoutMs = 1_000;
-const strictParseOptions = {
-  onExcessProperty: "error",
-} as const;
-
-const isTopicDefinitionWithSchema = (value: unknown): value is { readonly schema: RowSchema } =>
-  typeof value === "object" && value !== null && Schema.isSchema(Reflect.get(value, "schema"));
-
-const isRuntimeMutationEffect = (value: unknown): value is RuntimeMutationEffect =>
-  Effect.isEffect(value);
-
-const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
-
-const isSuspendSchema = (schema: TcpFieldSchema): schema is TcpFieldSchema & TcpSuspendedSchema =>
-  SchemaAST.isSuspend(schema.ast);
-
-const isViewServerRuntimeError = (value: unknown): value is ViewServerRuntimeError => {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const tag = Reflect.get(value, "_tag");
-  const code = Reflect.get(value, "code");
-  const message = Reflect.get(value, "message");
-  return (
-    (tag === "ViewServerRuntimeError" || tag === "ViewServerBackpressureError") &&
-    typeof code === "string" &&
-    typeof message === "string"
-  );
-};
-
-const tcpDecodeError = (line: string, cause: unknown): ViewServerTcpPublishIngressError =>
-  new ViewServerTcpPublishIngressError({
-    message: "TCP publish command must be valid JSON.",
-    cause: { cause, line },
-    phase: "decode",
-  });
-
-const parseCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.parse")(function* (
-  line: string,
-) {
-  const value = yield* Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)(
-    line,
-    strictParseOptions,
-  ).pipe(Effect.mapError((cause) => tcpDecodeError(line, cause)));
-  return yield* Result.match(
-    Schema.decodeUnknownResult(TcpPublishCommandSchema)(value, strictParseOptions),
-    {
-      onSuccess: Effect.succeed,
-      onFailure: (cause) =>
-        Effect.fail(
-          new ViewServerTcpPublishIngressError({
-            message: "TCP publish command must match the publish command schema.",
-            cause,
-            phase: "decode",
-          }),
-        ),
-    },
-  );
-});
-
-const tcpAuthRequest = (command: TcpPublishCommand, socket: Net.Socket): ViewServerAuthRequest => ({
-  headers: command.headers ?? {},
-  method: "POST",
-  remoteAddress: Option.fromUndefinedOr(socket.remoteAddress),
-  url: "tcp://view-server/tcp-publish",
-});
-
-const runtimeCallFailed = (
-  method: string,
-  topic: string,
-  cause: unknown,
-): ViewServerTcpPublishIngressError =>
-  new ViewServerTcpPublishIngressError({
-    message: `Runtime ${method} did not return an Effect for TCP publish topic ${topic}.`,
-    cause,
-    phase: "runtime",
-    topic,
-  });
-
-const runRuntimeMutation = Effect.fn("ViewServerRuntime.tcpPublish.runtime.mutate")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(
-  client: ViewServerRuntimeClient<Topics>,
-  method: "delete" | "patch" | "publish" | "publishMany",
-  topic: string,
-  args: ReadonlyArray<unknown>,
-) {
-  const fn = Reflect.get(client, method);
-  if (typeof fn !== "function") {
-    return yield* runtimeCallFailed(method, topic, fn);
-  }
-  const effect = Reflect.apply(fn, client, args);
-  if (!isRuntimeMutationEffect(effect)) {
-    return yield* runtimeCallFailed(method, topic, effect);
-  }
-  yield* effect.pipe(
-    Effect.asVoid,
-    Effect.mapError(
-      (cause): TcpPublishCommandError =>
-        isViewServerRuntimeError(cause)
-          ? cause
-          : new ViewServerTcpPublishIngressError({
-              message: `TCP publish runtime ${method} failed for topic ${topic}.`,
-              cause,
-              phase: "runtime",
-              topic,
-            }),
-    ),
-  );
-});
-
-const topicSchema = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  config: ViewServerTopicConfig<Topics>,
-  topic: string,
-): Effect.Effect<RowSchema, ViewServerTcpPublishIngressError> => {
-  const topicDefinition = Reflect.get(config.topics, topic);
-  return isTopicDefinitionWithSchema(topicDefinition)
-    ? Effect.succeed(topicDefinition.schema)
-    : Effect.fail(
-        new ViewServerTcpPublishIngressError({
-          message: `TCP publish cannot find View Server topic ${topic}.`,
-          cause: topic,
-          phase: "decode",
-          topic,
-        }),
-      );
-};
-
-const tcpDecodeSchemaError = (
-  topic: string,
-  phase: "patch" | "row",
-  cause: unknown,
-): ViewServerTcpPublishIngressError =>
-  new ViewServerTcpPublishIngressError({
-    message: `TCP publish ${phase} did not match View Server topic ${topic}.`,
-    cause,
-    phase: "decode",
-    topic,
-  });
-
-const tcpFieldSchemaFromAst = (ast: SchemaAST.AST): TcpFieldSchema => Schema.make(ast);
-
-const setDecodedField = (record: Record<string, unknown>, field: string, value: unknown): void => {
-  Object.defineProperty(record, field, {
-    configurable: true,
-    enumerable: true,
-    value,
-    writable: true,
-  });
-};
-
-const nestedTcpFieldAst = (ast: SchemaAST.Objects, field: string): SchemaAST.AST | undefined =>
-  ast.propertySignatures.find((property) => property.name === field)?.type;
-
-const arrayElementAst = (
-  ast: SchemaAST.Arrays,
-  index: number,
-  length: number,
-): SchemaAST.AST | undefined => {
-  if (index < ast.elements.length) {
-    return ast.elements[index];
-  }
-  if (ast.rest.length === 0) {
-    return undefined;
-  }
-  if (ast.rest.length === 1) {
-    return ast.rest[0];
-  }
-  const trailingCount = ast.rest.length - 1;
-  const firstTrailingIndex = length - trailingCount;
-  if (index >= firstTrailingIndex) {
-    const trailingIndex = index - firstTrailingIndex + 1;
-    return ast.rest[trailingIndex];
-  }
-  return ast.rest[0];
-};
-
-const decodeTcpFieldForRuntimeInternal: (
-  schema: TcpFieldSchema,
-  topic: string,
-  phase: "patch" | "row",
-  value: unknown,
-) => Effect.Effect<unknown, ViewServerTcpPublishIngressError> = Effect.fn(
-  "ViewServerRuntime.tcpPublish.field.decode.internal",
-)(function* (schema, topic, phase, value) {
-  const rawDecode = yield* Effect.exit(
-    Schema.decodeUnknownEffect(schema)(value, strictParseOptions),
-  );
-  if (Exit.isSuccess(rawDecode)) {
-    // Transform schemas such as BigIntFromString must keep the JSON input shape for the engine path.
-    return value;
-  }
-  if (isSuspendSchema(schema)) {
-    const decodedValue = yield* decodeTcpFieldForRuntimeInternal(
-      Schema.make(schema.ast.thunk()),
-      topic,
-      phase,
-      value,
-    );
-    const decodeError = tcpDecodeSchemaError.bind(undefined, topic, phase);
-    yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
-      Effect.asVoid,
-      Effect.mapError(decodeError),
-    );
-    return decodedValue;
-  }
-  if (SchemaAST.isObjects(schema.ast) && isPlainRecord(value)) {
-    const decodedValue: Record<string, unknown> = {};
-    const indexSignature = schema.ast.indexSignatures[0];
-    for (const [field, fieldValue] of Object.entries(value)) {
-      const fieldAst = nestedTcpFieldAst(schema.ast, field) ?? indexSignature?.type;
-      if (fieldAst === undefined) {
-        return yield* tcpDecodeSchemaError(topic, phase, { field });
-      }
-      setDecodedField(
-        decodedValue,
-        field,
-        yield* decodeTcpFieldForRuntimeInternal(
-          tcpFieldSchemaFromAst(fieldAst),
-          topic,
-          phase,
-          fieldValue,
-        ),
-      );
-    }
-    yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
-      Effect.asVoid,
-      Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)),
-    );
-    return decodedValue;
-  }
-  if (SchemaAST.isArrays(schema.ast) && Array.isArray(value)) {
-    const decodedValue: Array<unknown> = Array.from(value);
-    for (const [index, item] of value.entries()) {
-      const elementAst = arrayElementAst(schema.ast, index, value.length);
-      if (elementAst !== undefined) {
-        decodedValue[index] = yield* decodeTcpFieldForRuntimeInternal(
-          tcpFieldSchemaFromAst(elementAst),
-          topic,
-          phase,
-          item,
-        );
-      }
-    }
-    yield* Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
-      Effect.asVoid,
-      Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)),
-    );
-    return decodedValue;
-  }
-  if (SchemaAST.isUnion(schema.ast)) {
-    for (const member of schema.ast.types) {
-      const memberDecode = yield* Effect.exit(
-        decodeTcpFieldForRuntimeInternal(tcpFieldSchemaFromAst(member), topic, phase, value).pipe(
-          Effect.flatMap((decodedValue) =>
-            Schema.decodeUnknownEffect(schema)(decodedValue, strictParseOptions).pipe(
-              Effect.as(decodedValue),
-            ),
-          ),
-        ),
-      );
-      if (Exit.isSuccess(memberDecode)) {
-        return memberDecode.value;
-      }
-    }
-  }
-  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(
-    value,
-    strictParseOptions,
-  ).pipe(Effect.mapError((cause) => tcpDecodeSchemaError(topic, phase, cause)));
-});
-
-const decodeTcpFieldForRuntime = Effect.fn("ViewServerRuntime.tcpPublish.field.decode")(function* (
-  schema: TcpFieldSchema,
-  topic: string,
-  phase: "patch" | "row",
-  value: unknown,
-) {
-  return yield* decodeTcpFieldForRuntimeInternal(schema, topic, phase, value);
-});
-
-const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(config: ViewServerTopicConfig<Topics>, topic: string, row: Record<string, unknown>) {
-  const schema = yield* topicSchema(config, topic);
-  const decodedRow: Record<string, unknown> = {};
-  for (const [field, value] of Object.entries(row)) {
-    const fieldSchema = Object.entries(schema.fields).find(
-      ([fieldName]) => fieldName === field,
-    )?.[1];
-    if (fieldSchema === undefined) {
-      return yield* tcpDecodeSchemaError(topic, "row", { field });
-    }
-    setDecodedField(
-      decodedRow,
-      field,
-      yield* decodeTcpFieldForRuntime(fieldSchema, topic, "row", value),
-    );
-  }
-  yield* Schema.decodeUnknownEffect(schema)(decodedRow, strictParseOptions).pipe(
-    Effect.asVoid,
-    Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)),
-  );
-  return decodedRow;
-});
-
-const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(
-  config: ViewServerTopicConfig<Topics>,
-  topic: string,
-  rows: ReadonlyArray<Record<string, unknown>>,
-) {
-  return yield* Effect.forEach(rows, (row) => decodeTcpRow(config, topic, row));
-});
-
-const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(config: ViewServerTopicConfig<Topics>, topic: string, patch: Record<string, unknown>) {
-  const schema = yield* topicSchema(config, topic);
-  const decodedPatch: Record<string, unknown> = {};
-  for (const [field, value] of Object.entries(patch)) {
-    const fieldSchema = Object.entries(schema.fields).find(
-      ([fieldName]) => fieldName === field,
-    )?.[1];
-    if (fieldSchema === undefined) {
-      return yield* tcpDecodeSchemaError(topic, "patch", { field });
-    }
-    setDecodedField(
-      decodedPatch,
-      field,
-      yield* decodeTcpFieldForRuntime(fieldSchema, topic, "patch", value),
-    );
-  }
-  return decodedPatch;
-});
-
-const handleCommand = Effect.fn("ViewServerRuntime.tcpPublish.command.handle")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(
-  socket: Net.Socket,
-  state: TcpPublishSocketState,
-  config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
-  options: ViewServerTcpPublishIngressOptions,
-  sourceOwnership: SourceOwnershipPolicy,
-  line: string,
-) {
-  const command = yield* parseCommand(line);
-  yield* validateViewServerAuthRequest(options.auth, tcpAuthRequest(command, socket));
-  clearTcpPreCommandDeadline(state);
-  yield* ensureTopicCanBeMutated(command.topic, sourceOwnership);
-  if (command.op === "publish") {
-    const row = yield* decodeTcpRow(config, command.topic, command.row);
-    yield* runRuntimeMutation(client, "publish", command.topic, [command.topic, row]);
-    return;
-  }
-  if (command.op === "publishMany") {
-    const rows = yield* decodeTcpRows(config, command.topic, command.rows);
-    yield* runRuntimeMutation(client, "publishMany", command.topic, [command.topic, rows]);
-    return;
-  }
-  if (command.op === "patch") {
-    const patch = yield* decodeTcpPatch(config, command.topic, command.patch);
-    yield* runRuntimeMutation(client, "patch", command.topic, [command.topic, command.key, patch]);
-    return;
-  }
-  yield* topicSchema(config, command.topic);
-  yield* runRuntimeMutation(client, "delete", command.topic, [command.topic, command.key]);
-});
-
-const ensureTopicCanBeMutated = (
-  topic: string,
-  sourceOwnership: SourceOwnershipPolicy,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  sourceOwnership.requirePublicMutationAllowed(topic, "runtimeCore");
 
 const wireError = (cause: Cause.Cause<TcpPublishCommandError>): object => {
   const failure = Cause.findErrorOption(cause);
@@ -549,6 +122,20 @@ const wireError = (cause: Cause.Cause<TcpPublishCommandError>): object => {
     },
   };
 };
+
+const logUntypedTcpCommandCause = (cause: Cause.Cause<TcpPublishCommandError>): Promise<void> => {
+  if (Cause.findErrorOption(cause)._tag === "Some") {
+    return Promise.resolve();
+  }
+  return Effect.runPromise(
+    Effect.logWarning("TCP publish command failed with an untyped cause.").pipe(
+      Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+    ),
+  );
+};
+
+const isViewServerRuntimeError = (value: TcpPublishCommandError): value is ViewServerRuntimeError =>
+  value._tag === "ViewServerRuntimeError" || value._tag === "ViewServerBackpressureError";
 
 const wireSuccess = (): object => ({ ok: true });
 
@@ -669,7 +256,7 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
   state: TcpPublishSocketState,
   serverState: TcpPublishServerState,
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  client: ViewServerRuntimeCoreInternalClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
   sourceOwnership: SourceOwnershipPolicy,
   line: string,
@@ -679,7 +266,16 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
       return;
     }
     const fiber = Effect.runFork(
-      handleCommand(socket, state, config, client, options, sourceOwnership, line),
+      handleTcpPublishCommandLine(
+        {
+          remoteAddress: Option.fromUndefinedOr(socket.remoteAddress),
+        },
+        config,
+        client,
+        options,
+        sourceOwnership,
+        line,
+      ),
     );
     serverState.activeFibers.add(fiber);
     state.activeFibers.add(fiber);
@@ -693,6 +289,7 @@ const executeLine = async <const Topics extends ViewServerRuntimeTopicDefinition
       await writeTcpJsonLine(socket, state, wireSuccess());
       return;
     }
+    await logUntypedTcpCommandCause(exit.cause);
     await writeTcpJsonLine(socket, state, wireError(exit.cause));
   } finally {
     state.queuedCommands -= 1;
@@ -727,7 +324,7 @@ const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   state: TcpPublishSocketState,
   serverState: TcpPublishServerState,
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  client: ViewServerRuntimeCoreInternalClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
   sourceOwnership: SourceOwnershipPolicy,
   line: string,
@@ -747,6 +344,7 @@ const enqueueLine = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   }
   state.queuedCommands += 1;
   serverState.queuedCommands += 1;
+  clearTcpPreCommandDeadline(state);
   const previousChain = state.chain;
   const chain = (async () => {
     await Promise.allSettled([previousChain]);
@@ -792,7 +390,7 @@ const installSocketHandler = <const Topics extends ViewServerRuntimeTopicDefinit
   state: TcpPublishSocketState,
   serverState: TcpPublishServerState,
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  client: ViewServerRuntimeCoreInternalClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
   sourceOwnership: SourceOwnershipPolicy,
 ): void => {
@@ -927,7 +525,7 @@ export const installTcpPublishAcceptedSocket = <
   socket: Net.Socket,
   state: TcpPublishServerState,
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeClient<Topics>,
+  client: ViewServerRuntimeCoreInternalClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
 ): void => {
   const sourceOwnership = makeSourceOwnershipPolicy(config);
@@ -968,7 +566,7 @@ export const installTcpPublishAcceptedSocket = <
 export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpPublish.make")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     config: ViewServerTopicConfig<Topics>,
-    client: ViewServerRuntimeClient<Topics>,
+    client: ViewServerRuntimeCoreInternalClient<Topics>,
     options: ViewServerTcpPublishIngressOptions,
   ) {
     yield* validateTcpPublishOptions(options);

--- a/packages/runtime/test-harness/kafka-ingress.ts
+++ b/packages/runtime/test-harness/kafka-ingress.ts
@@ -280,6 +280,7 @@ export const failingClient: ViewServerRuntimeCoreInternalClient<Topics> = {
   delete: () => Effect.fail(runtimeUnavailable),
   health: () => Effect.fail(runtimeUnavailable),
   patch: () => Effect.fail(runtimeUnavailable),
+  patchDecodedFields: () => Effect.fail(runtimeUnavailable),
   publish: () => Effect.fail(runtimeUnavailable),
   publishMany: () => Effect.fail(runtimeUnavailable),
   publishManyDecodedRows: () => Effect.fail(runtimeUnavailable),


### PR DESCRIPTION
## Summary\n- Add a schema-safe TCP publish command interpreter that decodes JSON command envelopes and topic row/patch/key values through Effect Schema before runtime mutation.\n- Route TCP mutations through internal decoded runtime/engine seams so public clients stay unchanged.\n- Add decoded patch support inside runtime-core and the column live view engine, with regression coverage for transformed keys, malformed topic definitions, and schema-invalid decoded patches.\n\n## Validation\n- vp check --fix\n- vp run runtime#test\n- vp run -w check:package-exports\n- vp run -w check:internal-seams\n- vp run -w check:effect\n- vp run -w ready