### PR TITLE
Deepen Kafka delivery contract

### DIFF
--- a/packages/runtime/src/kafka-delivery-contract.test.ts
+++ b/packages/runtime/src/kafka-delivery-contract.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "@effect/vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Buffer } from "node:buffer";
-import { Schema } from "effect";
+import { Effect, Exit, Schema } from "effect";
 import {
+  publishAndCommitKafkaDecodedBatch,
   planKafkaDecodedPublishRuns,
   planKafkaUpsertPublishRuns,
+  recordAndCommitKeylessKafkaMessage,
   type DecodedKafkaBatchMessage,
   type DecodedKafkaBatchTombstoneMessage,
   type DecodedKafkaBatchUpsertMessage,
+  type KafkaDeliveryRuntimeClient,
   type KafkaConsumerMessage,
 } from "./kafka-delivery-contract";
+import { makeViewServerKafkaHealthLedger } from "./kafka-health";
 
 const Order = Schema.Struct({
   id: Schema.String,
@@ -37,10 +41,11 @@ const viewServer = defineViewServerConfig({
 type Topics = typeof viewServer.topics;
 
 const kafkaMessage = (input: {
+  readonly commit?: KafkaConsumerMessage["commit"];
   readonly offset: bigint;
   readonly sourceTopic: string;
 }): KafkaConsumerMessage => ({
-  commit: () => undefined,
+  commit: input.commit ?? (() => undefined),
   headers: new Map(),
   key: Buffer.from(`key-${input.offset}`),
   metadata: {},
@@ -62,6 +67,7 @@ const kafkaMessage = (input: {
 });
 
 const upsertMessage = (input: {
+  readonly commit?: KafkaConsumerMessage["commit"];
   readonly offset: bigint;
   readonly row: object;
   readonly rowKey: string;
@@ -74,6 +80,7 @@ const upsertMessage = (input: {
     viewServerTopic: input.viewServerTopic,
   },
   message: kafkaMessage({
+    ...(input.commit === undefined ? {} : { commit: input.commit }),
     offset: input.offset,
     sourceTopic: input.sourceTopic,
   }),
@@ -83,6 +90,7 @@ const upsertMessage = (input: {
 });
 
 const tombstoneMessage = (input: {
+  readonly commit?: KafkaConsumerMessage["commit"];
   readonly offset: bigint;
   readonly rowKey: string;
   readonly sourceTopic: string;
@@ -94,6 +102,7 @@ const tombstoneMessage = (input: {
     viewServerTopic: input.viewServerTopic,
   },
   message: kafkaMessage({
+    ...(input.commit === undefined ? {} : { commit: input.commit }),
     offset: input.offset,
     sourceTopic: input.sourceTopic,
   }),
@@ -101,6 +110,54 @@ const tombstoneMessage = (input: {
   nowMillis: Number(input.offset),
   sourceTopic: input.sourceTopic,
 });
+
+const makeDeliveryClient = (
+  operations: Array<string>,
+  options?: {
+    readonly publishFails?: boolean;
+    readonly publishFailsForTopic?: Extract<keyof Topics, string>;
+  },
+): KafkaDeliveryRuntimeClient<Topics> => ({
+  delete: (topic, key) =>
+    Effect.sync(() => {
+      operations.push(`delete:${topic}:${key}`);
+    }),
+  publishManyDecodedRowsWithStorageKeys: (topic, rows) =>
+    options?.publishFails === true || options?.publishFailsForTopic === topic
+      ? Effect.sync(() => {
+          operations.push(`publish-fail:${topic}:${rows.map((row) => row.storageKey).join(",")}`);
+        }).pipe(Effect.andThen(Effect.die("publish-down")))
+      : Effect.sync(() => {
+          operations.push(`publish:${topic}:${rows.map((row) => row.storageKey).join(",")}`);
+        }),
+});
+
+const makeKafkaHealthLedger = () =>
+  makeViewServerKafkaHealthLedger<Topics>({
+    regions: {
+      local: "localhost:9092",
+    },
+    startFrom: {
+      consumerGroupId: "view-server-delivery-contract-test",
+      fallbackMode: "earliest",
+      mode: "earliest",
+    },
+    topics: {
+      "orders-source": {
+        regions: ["local"],
+        viewServerTopic: "orders",
+      },
+      "trades-source": {
+        regions: ["local"],
+        viewServerTopic: "trades",
+      },
+    },
+  });
+
+const healthRefresh = (operations: Array<string>) =>
+  Effect.sync(() => {
+    operations.push("health");
+  });
 
 describe("Kafka delivery contract", () => {
   it("plans contiguous upsert runs and tombstone runs without reordering messages", () => {
@@ -287,4 +344,166 @@ describe("Kafka delivery contract", () => {
       },
     ]);
   });
+
+  it.effect("publishes and commits decoded runs in Kafka order", () =>
+    Effect.gen(function* () {
+      const operations: Array<string> = [];
+      const firstUpsert = upsertMessage({
+        commit: () => {
+          operations.push("commit:1");
+        },
+        offset: 1n,
+        row: { id: "a", price: 10 },
+        rowKey: "a",
+        sourceTopic: "orders-source",
+        viewServerTopic: "orders",
+      });
+      const secondUpsert = upsertMessage({
+        commit: () => {
+          operations.push("commit:2");
+        },
+        offset: 2n,
+        row: { id: "b", price: 20 },
+        rowKey: "b",
+        sourceTopic: "orders-source",
+        viewServerTopic: "orders",
+      });
+      const tombstone = tombstoneMessage({
+        commit: () => {
+          operations.push("commit:3");
+        },
+        offset: 3n,
+        rowKey: "a",
+        sourceTopic: "orders-source",
+        viewServerTopic: "orders",
+      });
+      const finalUpsert = upsertMessage({
+        commit: () => {
+          operations.push("commit:4");
+        },
+        offset: 4n,
+        row: { id: "c", price: 30 },
+        rowKey: "c",
+        sourceTopic: "orders-source",
+        viewServerTopic: "orders",
+      });
+
+      yield* publishAndCommitKafkaDecodedBatch(
+        makeDeliveryClient(operations),
+        healthRefresh(operations),
+        makeKafkaHealthLedger(),
+        "local",
+        [firstUpsert, secondUpsert, tombstone, finalUpsert],
+      );
+
+      expect(operations).toStrictEqual([
+        "publish:orders:a,b",
+        "commit:1",
+        "commit:2",
+        "health",
+        "delete:orders:a",
+        "commit:3",
+        "health",
+        "publish:orders:c",
+        "commit:4",
+        "health",
+      ]);
+    }),
+  );
+
+  it.effect("does not commit decoded messages after publish failure", () =>
+    Effect.gen(function* () {
+      const operations: Array<string> = [];
+      const message = upsertMessage({
+        commit: () => {
+          operations.push("commit:1");
+        },
+        offset: 1n,
+        row: { id: "a", price: 10 },
+        rowKey: "a",
+        sourceTopic: "orders-source",
+        viewServerTopic: "orders",
+      });
+
+      const exit = yield* Effect.exit(
+        publishAndCommitKafkaDecodedBatch(
+          makeDeliveryClient(operations, { publishFails: true }),
+          healthRefresh(operations),
+          makeKafkaHealthLedger(),
+          "local",
+          [message],
+        ),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(operations).toStrictEqual(["publish-fail:orders:a", "health"]);
+    }),
+  );
+
+  it.effect("commits each successful compatible upsert run before publishing the next run", () =>
+    Effect.gen(function* () {
+      const operations: Array<string> = [];
+      const ordersMessage = upsertMessage({
+        commit: () => {
+          operations.push("commit:orders");
+        },
+        offset: 1n,
+        row: { id: "a", price: 10 },
+        rowKey: "a",
+        sourceTopic: "orders-source",
+        viewServerTopic: "orders",
+      });
+      const tradesMessage = upsertMessage({
+        commit: () => {
+          operations.push("commit:trades");
+        },
+        offset: 2n,
+        row: { id: "t1", quantity: 20 },
+        rowKey: "t1",
+        sourceTopic: "trades-source",
+        viewServerTopic: "trades",
+      });
+
+      const exit = yield* Effect.exit(
+        publishAndCommitKafkaDecodedBatch(
+          makeDeliveryClient(operations, { publishFailsForTopic: "trades" }),
+          healthRefresh(operations),
+          makeKafkaHealthLedger(),
+          "local",
+          [ordersMessage, tradesMessage],
+        ),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(operations).toStrictEqual([
+        "publish:orders:a",
+        "commit:orders",
+        "health",
+        "publish-fail:trades:t1",
+        "health",
+      ]);
+    }),
+  );
+
+  it.effect("records and commits keyless source messages as skipped delivery failures", () =>
+    Effect.gen(function* () {
+      const operations: Array<string> = [];
+      const message = kafkaMessage({
+        commit: () => {
+          operations.push("commit:5");
+        },
+        offset: 5n,
+        sourceTopic: "orders-source",
+      });
+
+      yield* recordAndCommitKeylessKafkaMessage(
+        healthRefresh(operations),
+        makeKafkaHealthLedger(),
+        "local",
+        message,
+      );
+
+      expect(operations).toStrictEqual(["health", "commit:5", "health"]);
+    }),
+  );
 });

--- a/packages/runtime/src/kafka-delivery-contract.ts
+++ b/packages/runtime/src/kafka-delivery-contract.ts
@@ -1,5 +1,17 @@
 import type { Message } from "@platformatic/kafka";
+import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
 import { Buffer } from "node:buffer";
+import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
+import { Cause, Clock, Effect, Option } from "effect";
+import type { ViewServerKafkaHealthLedger } from "./kafka-health";
+import {
+  kafkaFailureCause,
+  kafkaIngressFailureCause,
+  kafkaMessageCommitError,
+  kafkaMessageProcessingError,
+  kafkaNonFailureCause,
+  messageFromUnknown,
+} from "./kafka-ingress-error";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
 type KafkaMessageBytes = Buffer | null | undefined;
@@ -68,6 +80,25 @@ export type KafkaUpsertPublishRun<Topics extends ViewServerRuntimeTopicDefinitio
   readonly sourceTopic: string;
   readonly topic: KafkaBatchTopic<Topics>;
 };
+
+export type KafkaDeliveryRuntimeClient<Topics extends ViewServerRuntimeTopicDefinitions> = Pick<
+  ViewServerRuntimeCoreInternalClient<Topics>,
+  "delete" | "publishManyDecodedRowsWithStorageKeys"
+>;
+
+export type KafkaDeliveryHealthRefreshRequest = Effect.Effect<void>;
+
+export type KafkaDecodedCommitOptions = {
+  readonly preserveLastErrorForSourceTopic: string | undefined;
+};
+
+const ignoreKafkaDeliveryHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring Kafka delivery health refresh failure.",
+);
+
+const requestKafkaDeliveryHealthRefresh = (
+  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+) => requestHealthRefresh.pipe(ignoreKafkaDeliveryHealthRefreshFailure);
 
 export const kafkaBatchMessageIsTombstone = <
   const Topics extends ViewServerRuntimeTopicDefinitions,
@@ -139,3 +170,238 @@ export const planKafkaUpsertPublishRuns = <const Topics extends ViewServerRuntim
   }
   return runs;
 };
+
+const publishKafkaRowsForMessages = Effect.fn("ViewServerRuntime.kafka.delivery.publishRows")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+    health: ViewServerKafkaHealthLedger<Topics>,
+    region: string,
+    sourceTopic: string,
+    messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
+    publishEffect: Effect.Effect<void, unknown>,
+  ) {
+    yield* publishEffect.pipe(
+      Effect.matchCauseEffect({
+        onFailure: (cause) => {
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.failCause(kafkaNonFailureCause(cause));
+          }
+          const error = Cause.findErrorOption(cause);
+          const failure = Option.match(error, {
+            onNone: () => Cause.squash(cause),
+            onSome: (value) => value,
+          });
+          const processingError = kafkaMessageProcessingError(
+            region,
+            sourceTopic,
+            kafkaFailureCause(failure, cause),
+          );
+          return Effect.forEach(
+            messages,
+            (message) =>
+              health.messagePublishFailed(message.sourceTopic, region, {
+                bytes: message.messageBytes,
+                message: messageFromUnknown(failure),
+                nowMillis: message.nowMillis,
+              }),
+            { discard: true },
+          ).pipe(
+            Effect.andThen(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)),
+            Effect.andThen(Effect.failCause(kafkaIngressFailureCause(processingError, cause))),
+          );
+        },
+        onSuccess: () => Effect.void,
+      }),
+    );
+  },
+);
+
+export const commitSkippedKafkaMessage = Effect.fn(
+  "ViewServerRuntime.kafka.delivery.skipAndCommit",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+  health: ViewServerKafkaHealthLedger<Topics>,
+  region: string,
+  sourceTopic: string,
+  message: KafkaConsumerMessage,
+  input: {
+    readonly nowMillis: number;
+  },
+) {
+  const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
+  yield* Effect.uninterruptible(
+    Effect.tryPromise({
+      try: () => Promise.resolve(message.commit()),
+      catch: (cause) => kafkaMessageCommitError(region, sourceTopic, cause),
+    }).pipe(
+      Effect.matchEffect({
+        onFailure: (error) =>
+          health
+            .messageCommitFailed(sourceTopic, region, {
+              bytes: messageBytes,
+              message: `${error.message}: ${messageFromUnknown(error.cause)}`,
+              nowMillis: input.nowMillis,
+              recountMessage: false,
+            })
+            .pipe(Effect.andThen(Effect.fail(error))),
+        onSuccess: () =>
+          health.messageSkippedCommitted(sourceTopic, region, {
+            committedOffset: String(message.offset + 1n),
+            nowMillis: input.nowMillis,
+          }),
+      }),
+    ),
+  ).pipe(Effect.ensuring(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)));
+});
+
+export const recordAndCommitKeylessKafkaMessage = Effect.fn(
+  "ViewServerRuntime.kafka.delivery.keylessSkipAndCommit",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+  health: ViewServerKafkaHealthLedger<Topics>,
+  region: string,
+  message: KafkaConsumerMessage,
+) {
+  const nowMillis = yield* Clock.currentTimeMillis;
+  const sourceTopic = message.topic;
+  const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
+  yield* health
+    .mappingFailed(sourceTopic, region, {
+      bytes: messageBytes,
+      message: "Kafka source key bytes are required",
+      nowMillis,
+    })
+    .pipe(Effect.andThen(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)));
+  yield* commitSkippedKafkaMessage(requestHealthRefresh, health, region, sourceTopic, message, {
+    nowMillis,
+  });
+});
+
+const publishKafkaDecodedTombstone = Effect.fn("ViewServerRuntime.kafka.delivery.publishTombstone")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    client: KafkaDeliveryRuntimeClient<Topics>,
+    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+    health: ViewServerKafkaHealthLedger<Topics>,
+    region: string,
+    message: DecodedKafkaBatchTombstoneMessage<Topics>,
+  ) {
+    yield* publishKafkaRowsForMessages(
+      requestHealthRefresh,
+      health,
+      region,
+      message.sourceTopic,
+      [message],
+      client.delete(message.decoded.viewServerTopic, message.decoded.rowKey),
+    );
+  },
+);
+
+const publishKafkaDecodedUpsertRun = Effect.fn("ViewServerRuntime.kafka.delivery.publishUpserts")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    client: KafkaDeliveryRuntimeClient<Topics>,
+    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+    health: ViewServerKafkaHealthLedger<Topics>,
+    region: string,
+    run: KafkaUpsertPublishRun<Topics>,
+  ) {
+    yield* publishKafkaRowsForMessages(
+      requestHealthRefresh,
+      health,
+      region,
+      run.sourceTopic,
+      run.rows.map((row) => row.message),
+      client.publishManyDecodedRowsWithStorageKeys(
+        run.topic,
+        run.rows.map((row) => ({
+          row: row.row,
+          storageKey: row.storageKey,
+        })),
+      ),
+    );
+  },
+);
+
+export const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.delivery.commit")(
+  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+    health: ViewServerKafkaHealthLedger<Topics>,
+    region: string,
+    messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
+    options?: KafkaDecodedCommitOptions,
+  ) {
+    yield* Effect.gen(function* () {
+      for (const message of messages) {
+        yield* Effect.uninterruptible(
+          Effect.tryPromise({
+            try: () => Promise.resolve(message.message.commit()),
+            catch: (cause) => kafkaMessageCommitError(region, message.sourceTopic, cause),
+          }).pipe(
+            Effect.matchEffect({
+              onFailure: (error) =>
+                health
+                  .messageCommitFailed(message.sourceTopic, region, {
+                    bytes: message.messageBytes,
+                    message: `${error.message}: ${messageFromUnknown(error.cause)}`,
+                    nowMillis: message.nowMillis,
+                  })
+                  .pipe(Effect.andThen(Effect.fail(error))),
+              onSuccess: () =>
+                health.messageDecoded(message.sourceTopic, region, {
+                  bytes: message.messageBytes,
+                  committedOffset: String(message.message.offset + 1n),
+                  nowMillis: message.nowMillis,
+                  ...(options?.preserveLastErrorForSourceTopic === message.sourceTopic
+                    ? { preserveLastError: true }
+                    : {}),
+                }),
+            }),
+          ),
+        );
+      }
+    }).pipe(Effect.ensuring(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)));
+  },
+);
+
+export const publishAndCommitKafkaDecodedBatch = Effect.fn(
+  "ViewServerRuntime.kafka.delivery.publishAndCommit",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  client: KafkaDeliveryRuntimeClient<Topics>,
+  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
+  health: ViewServerKafkaHealthLedger<Topics>,
+  region: string,
+  messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
+  options?: KafkaDecodedCommitOptions,
+) {
+  const runs = planKafkaDecodedPublishRuns(messages);
+
+  for (const run of runs) {
+    if (run._tag === "Upserts") {
+      const upsertRuns = planKafkaUpsertPublishRuns(run.messages);
+      for (const upsertRun of upsertRuns) {
+        yield* publishKafkaDecodedUpsertRun(
+          client,
+          requestHealthRefresh,
+          health,
+          region,
+          upsertRun,
+        );
+        yield* commitKafkaDecodedBatch(
+          requestHealthRefresh,
+          health,
+          region,
+          upsertRun.rows.map((row) => row.message),
+          options,
+        );
+      }
+    } else {
+      yield* publishKafkaDecodedTombstone(
+        client,
+        requestHealthRefresh,
+        health,
+        region,
+        run.message,
+      );
+      yield* commitKafkaDecodedBatch(requestHealthRefresh, health, region, [run.message], options);
+    }
+  }
+});

--- a/packages/runtime/src/kafka-ingress-error.ts
+++ b/packages/runtime/src/kafka-ingress-error.ts
@@ -1,0 +1,158 @@
+import { Cause, Option, Schema } from "effect";
+
+export class ViewServerKafkaIngressError extends Schema.TaggedErrorClass<ViewServerKafkaIngressError>()(
+  "ViewServerKafkaIngressError",
+  {
+    message: Schema.String,
+    cause: Schema.Unknown,
+    region: Schema.optionalKey(Schema.String),
+    sourceTopic: Schema.optionalKey(Schema.String),
+  },
+) {}
+
+export const messageFromUnknown = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = Reflect.get(error, "message");
+    if (typeof message === "string") {
+      return message;
+    }
+  }
+  return String(error);
+};
+
+export const kafkaConsumerStartError = (
+  region: string,
+  cause: unknown,
+): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: `Failed to start Kafka consumer for region ${region}`,
+    cause,
+    region,
+  });
+
+export const mapKafkaConsumerStartError =
+  (region: string) =>
+  (cause: unknown): ViewServerKafkaIngressError =>
+    kafkaConsumerStartError(region, cause);
+
+export const kafkaStreamError = (region: string, cause: unknown): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: `Kafka stream failed for region ${region}`,
+    cause,
+    region,
+  });
+
+export const mapKafkaStreamError =
+  (region: string) =>
+  (cause: unknown): ViewServerKafkaIngressError =>
+    kafkaStreamError(region, cause);
+
+export const kafkaStreamCloseError = (cause: unknown): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: "Failed to close Kafka stream",
+    cause,
+  });
+
+export const kafkaConsumerCloseError = (cause: unknown): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: "Failed to close Kafka consumer",
+    cause,
+  });
+
+export const kafkaMessageCommitError = (
+  region: string,
+  sourceTopic: string,
+  cause: unknown,
+): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: `Failed to commit Kafka message for source topic ${sourceTopic}`,
+    cause,
+    region,
+    sourceTopic,
+  });
+
+export const kafkaMessageDecodeError = (
+  region: string,
+  sourceTopic: string,
+  cause: unknown,
+): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: `Failed to decode Kafka message for source topic ${sourceTopic}`,
+    cause,
+    region,
+    sourceTopic,
+  });
+
+export const kafkaMessageMappingError = (
+  region: string,
+  sourceTopic: string,
+  cause: unknown,
+): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: `Failed to map Kafka message for source topic ${sourceTopic}`,
+    cause,
+    region,
+    sourceTopic,
+  });
+
+export const kafkaMessageProcessingError = (
+  region: string,
+  sourceTopic: string,
+  cause: unknown,
+): ViewServerKafkaIngressError =>
+  new ViewServerKafkaIngressError({
+    message: `Failed to process Kafka message for source topic ${sourceTopic}`,
+    cause,
+    region,
+    sourceTopic,
+  });
+
+const isNonFailureKafkaCauseReason = (
+  reason: Cause.Reason<unknown>,
+): reason is Cause.Die | Cause.Interrupt =>
+  Cause.isDieReason(reason) || Cause.isInterruptReason(reason);
+
+export const kafkaFailureCause = (error: unknown, cause: Cause.Cause<unknown>): unknown =>
+  cause.reasons.length > 1 || Cause.hasDies(cause) || Cause.hasInterrupts(cause) ? cause : error;
+
+const preservedKafkaFailureError = (
+  primaryError: ViewServerKafkaIngressError,
+  error: unknown,
+): ViewServerKafkaIngressError =>
+  error instanceof ViewServerKafkaIngressError
+    ? error
+    : new ViewServerKafkaIngressError({
+        cause: error,
+        message: messageFromUnknown(error),
+        ...(primaryError.region === undefined ? {} : { region: primaryError.region }),
+        ...(primaryError.sourceTopic === undefined
+          ? {}
+          : { sourceTopic: primaryError.sourceTopic }),
+      });
+
+export const kafkaIngressFailureCause = (
+  error: ViewServerKafkaIngressError,
+  cause: Cause.Cause<unknown>,
+): Cause.Cause<ViewServerKafkaIngressError> => {
+  const failureReasons = cause.reasons
+    .filter(Cause.isFailReason)
+    .map((reason) => Cause.makeFailReason(preservedKafkaFailureError(error, reason.error)));
+  const nonFailureReasons = cause.reasons.filter(isNonFailureKafkaCauseReason);
+  const hasPrimaryFailure = failureReasons.some((reason) => reason.error === error);
+  return Cause.fromReasons([
+    ...(hasPrimaryFailure ? [] : [Cause.makeFailReason(error)]),
+    ...failureReasons,
+    ...nonFailureReasons,
+  ]);
+};
+
+export const kafkaNonFailureCause = (cause: Cause.Cause<unknown>): Cause.Cause<never> =>
+  Cause.fromReasons(cause.reasons.filter(isNonFailureKafkaCauseReason));
+
+export const kafkaIngressErrorSourceTopic = (error: unknown): Option.Option<string> =>
+  error instanceof ViewServerKafkaIngressError
+    ? Option.fromUndefinedOr(error.sourceTopic)
+    : Option.none();

--- a/packages/runtime/src/kafka-ingress.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress.internal.test.ts
@@ -4658,18 +4658,8 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
       > = {
         ...runtimeCore.internalClient,
         publish: () => Effect.die("Kafka stream should publish batches with publishMany"),
-        publishManyDecodedRows: (topic, rows) =>
-          Effect.sync(() => {
-            operations.push(`publishMany:${topic}:${rows.length}`);
-          }).pipe(
-            Effect.andThen(
-              rows.some(
-                (row) => Reflect.get(row, "customerId") === "customer-payment-publish-failed",
-              )
-                ? Effect.fail(runtimeUnavailable)
-                : runtimeCore.internalClient.publishManyDecodedRows(topic, rows),
-            ),
-          ),
+        publishManyDecodedRows: () =>
+          Effect.die("Kafka stream should publish decoded rows with storage keys"),
         publishManyDecodedRowsWithStorageKeys: (topic, rows) =>
           Effect.sync(() => {
             operations.push(`publishMany:${topic}:${rows.length}`);
@@ -4701,6 +4691,9 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
                 price: 10,
               }),
               offset: 1n,
+              onCommit: () => {
+                operations.push("commit:orders:1");
+              },
             });
             yield kafkaMessage({
               topic: paymentsSourceTopic,
@@ -4710,6 +4703,9 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
                 price: 20,
               }),
               offset: 2n,
+              onCommit: () => {
+                operations.push("commit:payments:2");
+              },
             });
           })(),
         ),
@@ -4739,7 +4735,7 @@ describe("@effect-view-server/runtime Kafka ingress internals", () => {
           message: `Failed to process Kafka message for source topic ${paymentsSourceTopic}`,
           sourceTopic: paymentsSourceTopic,
         },
-        operations: ["publishMany:orders:1", "publishMany:payments:1"],
+        operations: ["publishMany:orders:1", "commit:orders:1", "publishMany:payments:1"],
         health: {
           ordersPublishFailures: 0,
           paymentsPublishFailures: 1,

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -8,7 +8,6 @@ import {
   type ViewServerTopicConfig,
 } from "@effect-view-server/config";
 import { decodeKafkaTopicMessage } from "@effect-view-server/config/internal";
-import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
 import {
   ignoreLoggedTypedFailuresPreserveNonTypedFailures,
   runAllFinalizers,
@@ -25,34 +24,53 @@ import {
   Option,
   Queue,
   Ref,
-  Schema,
   Semaphore,
   Scope,
 } from "effect";
 import type { ViewServerKafkaHealthLedger } from "./kafka-health";
 import {
-  planKafkaDecodedPublishRuns,
-  planKafkaUpsertPublishRuns,
+  publishAndCommitKafkaDecodedBatch,
+  recordAndCommitKeylessKafkaMessage,
   type DecodedKafkaBatchMessage,
-  type DecodedKafkaBatchTombstoneMessage,
-  type DecodedKafkaBatchUpsertMessage,
+  type KafkaDeliveryRuntimeClient,
   type KafkaBatchTopic,
   kafkaConsumerMessageHasKey,
   type KafkaConsumerMessage,
   type KeyedKafkaConsumerMessage,
 } from "./kafka-delivery-contract";
+import {
+  kafkaConsumerCloseError,
+  kafkaFailureCause,
+  kafkaIngressErrorSourceTopic,
+  kafkaIngressFailureCause,
+  kafkaMessageDecodeError,
+  kafkaMessageMappingError,
+  kafkaNonFailureCause,
+  kafkaStreamCloseError,
+  kafkaStreamError,
+  mapKafkaConsumerStartError,
+  mapKafkaStreamError,
+  messageFromUnknown,
+  ViewServerKafkaIngressError,
+} from "./kafka-ingress-error";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
-export class ViewServerKafkaIngressError extends Schema.TaggedErrorClass<ViewServerKafkaIngressError>()(
-  "ViewServerKafkaIngressError",
-  {
-    message: Schema.String,
-    cause: Schema.Unknown,
-    region: Schema.optionalKey(Schema.String),
-    sourceTopic: Schema.optionalKey(Schema.String),
-  },
-) {}
+export {
+  kafkaConsumerCloseError,
+  kafkaConsumerStartError,
+  kafkaIngressErrorSourceTopic,
+  kafkaMessageCommitError,
+  kafkaMessageDecodeError,
+  kafkaMessageMappingError,
+  kafkaMessageProcessingError,
+  kafkaStreamCloseError,
+  kafkaStreamError,
+  mapKafkaConsumerStartError,
+  mapKafkaStreamError,
+  messageFromUnknown,
+  ViewServerKafkaIngressError,
+} from "./kafka-ingress-error";
 
 export type ViewServerKafkaIngress = {
   readonly close: Effect.Effect<void>;
@@ -103,10 +121,8 @@ type KafkaMessageBatchTakeResult =
       readonly batch: ReadonlyArray<KafkaConsumerMessage>;
       readonly terminal: KafkaStreamTerminalEvent | null;
     };
-type KafkaIngressRuntimeClient<Topics extends ViewServerRuntimeTopicDefinitions> = Pick<
-  ViewServerRuntimeCoreInternalClient<Topics>,
-  "delete" | "publishManyDecodedRows" | "publishManyDecodedRowsWithStorageKeys"
->;
+type KafkaIngressRuntimeClient<Topics extends ViewServerRuntimeTopicDefinitions> =
+  KafkaDeliveryRuntimeClient<Topics>;
 type KafkaConsumerHealthListenerWaiter = {
   readonly expected: number;
   readonly deferred: Deferred.Deferred<void>;
@@ -155,19 +171,6 @@ const logKafkaHealthListenerDispatchFailure = <A, E, R>(
 const kafkaHeaderIsRepeated = (
   value: string | Uint8Array | ReadonlyArray<string | Uint8Array>,
 ): value is ReadonlyArray<string | Uint8Array> => Array.isArray(value);
-
-export const messageFromUnknown = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (typeof error === "object" && error !== null && "message" in error) {
-    const message = Reflect.get(error, "message");
-    if (typeof message === "string") {
-      return message;
-    }
-  }
-  return String(error);
-};
 
 export const bootstrapBrokers = (brokers: string): ReadonlyArray<string> =>
   brokers
@@ -240,140 +243,6 @@ const consumerLagMessagesFromLag = (lags: ReadonlyArray<bigint>): bigint | null 
   }
   return hasKnownLag ? total : null;
 };
-
-export const kafkaConsumerStartError = (
-  region: string,
-  cause: unknown,
-): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: `Failed to start Kafka consumer for region ${region}`,
-    cause,
-    region,
-  });
-
-export const mapKafkaConsumerStartError =
-  (region: string) =>
-  (cause: unknown): ViewServerKafkaIngressError =>
-    kafkaConsumerStartError(region, cause);
-
-export const kafkaStreamError = (region: string, cause: unknown): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: `Kafka stream failed for region ${region}`,
-    cause,
-    region,
-  });
-
-export const mapKafkaStreamError =
-  (region: string) =>
-  (cause: unknown): ViewServerKafkaIngressError =>
-    kafkaStreamError(region, cause);
-
-export const kafkaStreamCloseError = (cause: unknown): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: "Failed to close Kafka stream",
-    cause,
-  });
-
-export const kafkaConsumerCloseError = (cause: unknown): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: "Failed to close Kafka consumer",
-    cause,
-  });
-
-export const kafkaMessageCommitError = (
-  region: string,
-  sourceTopic: string,
-  cause: unknown,
-): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: `Failed to commit Kafka message for source topic ${sourceTopic}`,
-    cause,
-    region,
-    sourceTopic,
-  });
-
-export const kafkaMessageDecodeError = (
-  region: string,
-  sourceTopic: string,
-  cause: unknown,
-): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: `Failed to decode Kafka message for source topic ${sourceTopic}`,
-    cause,
-    region,
-    sourceTopic,
-  });
-
-export const kafkaMessageMappingError = (
-  region: string,
-  sourceTopic: string,
-  cause: unknown,
-): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: `Failed to map Kafka message for source topic ${sourceTopic}`,
-    cause,
-    region,
-    sourceTopic,
-  });
-
-export const kafkaMessageProcessingError = (
-  region: string,
-  sourceTopic: string,
-  cause: unknown,
-): ViewServerKafkaIngressError =>
-  new ViewServerKafkaIngressError({
-    message: `Failed to process Kafka message for source topic ${sourceTopic}`,
-    cause,
-    region,
-    sourceTopic,
-  });
-
-const isNonFailureKafkaCauseReason = (
-  reason: Cause.Reason<unknown>,
-): reason is Cause.Die | Cause.Interrupt =>
-  Cause.isDieReason(reason) || Cause.isInterruptReason(reason);
-
-const kafkaFailureCause = (error: unknown, cause: Cause.Cause<unknown>): unknown =>
-  cause.reasons.length > 1 || Cause.hasDies(cause) || Cause.hasInterrupts(cause) ? cause : error;
-
-const preservedKafkaFailureError = (
-  primaryError: ViewServerKafkaIngressError,
-  error: unknown,
-): ViewServerKafkaIngressError =>
-  error instanceof ViewServerKafkaIngressError
-    ? error
-    : new ViewServerKafkaIngressError({
-        cause: error,
-        message: messageFromUnknown(error),
-        ...(primaryError.region === undefined ? {} : { region: primaryError.region }),
-        ...(primaryError.sourceTopic === undefined
-          ? {}
-          : { sourceTopic: primaryError.sourceTopic }),
-      });
-
-const kafkaIngressFailureCause = (
-  error: ViewServerKafkaIngressError,
-  cause: Cause.Cause<unknown>,
-): Cause.Cause<ViewServerKafkaIngressError> => {
-  const failureReasons = cause.reasons
-    .filter(Cause.isFailReason)
-    .map((reason) => Cause.makeFailReason(preservedKafkaFailureError(error, reason.error)));
-  const nonFailureReasons = cause.reasons.filter(isNonFailureKafkaCauseReason);
-  const hasPrimaryFailure = failureReasons.some((reason) => reason.error === error);
-  return Cause.fromReasons([
-    ...(hasPrimaryFailure ? [] : [Cause.makeFailReason(error)]),
-    ...failureReasons,
-    ...nonFailureReasons,
-  ]);
-};
-
-const kafkaNonFailureCause = (cause: Cause.Cause<unknown>): Cause.Cause<never> =>
-  Cause.fromReasons(cause.reasons.filter(isNonFailureKafkaCauseReason));
-
-export const kafkaIngressErrorSourceTopic = (error: unknown): Option.Option<string> =>
-  error instanceof ViewServerKafkaIngressError
-    ? Option.fromUndefinedOr(error.sourceTopic)
-    : Option.none();
 
 export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   health: ViewServerKafkaHealthLedger<Topics>,
@@ -803,239 +672,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
     return decodedBatchMessage;
   },
 );
-
-const publishKafkaRowsForMessages = Effect.fn("ViewServerRuntime.kafka.batch.publishRows")(
-  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
-    region: string,
-    sourceTopic: string,
-    messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
-    publishEffect: Effect.Effect<void, unknown>,
-  ) {
-    yield* publishEffect.pipe(
-      Effect.matchCauseEffect({
-        onFailure: (cause) => {
-          if (Cause.hasInterruptsOnly(cause)) {
-            return Effect.failCause(kafkaNonFailureCause(cause));
-          }
-          const error = Cause.findErrorOption(cause);
-          const failure = Option.match(error, {
-            onNone: () => Cause.squash(cause),
-            onSome: (value) => value,
-          });
-          const processingError = kafkaMessageProcessingError(
-            region,
-            sourceTopic,
-            kafkaFailureCause(failure, cause),
-          );
-          return Effect.forEach(
-            messages,
-            (message) =>
-              health.messagePublishFailed(message.sourceTopic, region, {
-                bytes: message.messageBytes,
-                message: messageFromUnknown(failure),
-                nowMillis: message.nowMillis,
-              }),
-            { discard: true },
-          ).pipe(
-            Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh)),
-            Effect.andThen(Effect.failCause(kafkaIngressFailureCause(processingError, cause))),
-          );
-        },
-        onSuccess: () => Effect.void,
-      }),
-    );
-  },
-);
-
-const commitSkippedKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.skipAndCommit")(
-  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
-    region: string,
-    sourceTopic: string,
-    message: KafkaConsumerMessage,
-    input: {
-      readonly nowMillis: number;
-    },
-  ) {
-    const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
-    yield* Effect.uninterruptible(
-      Effect.tryPromise({
-        try: () => Promise.resolve(message.commit()),
-        catch: (cause) => kafkaMessageCommitError(region, sourceTopic, cause),
-      }).pipe(
-        Effect.matchEffect({
-          onFailure: (error) =>
-            health
-              .messageCommitFailed(sourceTopic, region, {
-                bytes: messageBytes,
-                message: `${error.message}: ${messageFromUnknown(error.cause)}`,
-                nowMillis: input.nowMillis,
-                recountMessage: false,
-              })
-              .pipe(Effect.andThen(Effect.fail(error))),
-          onSuccess: () =>
-            health.messageSkippedCommitted(sourceTopic, region, {
-              committedOffset: String(message.offset + 1n),
-              nowMillis: input.nowMillis,
-            }),
-        }),
-      ),
-    ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
-  },
-);
-
-const recordAndCommitKeylessKafkaMessage = Effect.fn(
-  "ViewServerRuntime.kafka.message.keylessSkipAndCommit",
-)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  health: ViewServerKafkaHealthLedger<Topics>,
-  region: string,
-  message: KafkaConsumerMessage,
-) {
-  const nowMillis = yield* Clock.currentTimeMillis;
-  const sourceTopic = message.topic;
-  const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
-  yield* health
-    .mappingFailed(sourceTopic, region, {
-      bytes: messageBytes,
-      message: "Kafka source key bytes are required",
-      nowMillis,
-    })
-    .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh)));
-  yield* commitSkippedKafkaMessage(requestHealthRefresh, health, region, sourceTopic, message, {
-    nowMillis,
-  });
-});
-
-const publishKafkaDecodedTombstone = Effect.fn("ViewServerRuntime.kafka.tombstone.publish")(
-  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-    client: KafkaIngressRuntimeClient<Topics>,
-    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
-    region: string,
-    message: DecodedKafkaBatchTombstoneMessage<Topics>,
-  ) {
-    yield* publishKafkaRowsForMessages(
-      requestHealthRefresh,
-      health,
-      region,
-      message.sourceTopic,
-      [message],
-      client.delete(message.decoded.viewServerTopic, message.decoded.rowKey),
-    );
-  },
-);
-
-const publishKafkaDecodedUpsertBatch = Effect.fn("ViewServerRuntime.kafka.batch.publishUpserts")(
-  function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-    client: KafkaIngressRuntimeClient<Topics>,
-    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
-    region: string,
-    messages: ReadonlyArray<DecodedKafkaBatchUpsertMessage<Topics>>,
-  ) {
-    const runs = planKafkaUpsertPublishRuns(messages);
-    for (const run of runs) {
-      yield* publishKafkaRowsForMessages(
-        requestHealthRefresh,
-        health,
-        region,
-        run.sourceTopic,
-        run.rows.map((row) => row.message),
-        client.publishManyDecodedRowsWithStorageKeys(
-          run.topic,
-          run.rows.map((row) => ({
-            row: row.row,
-            storageKey: row.storageKey,
-          })),
-        ),
-      );
-    }
-  },
-);
-
-const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.batch.commit")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  health: ViewServerKafkaHealthLedger<Topics>,
-  region: string,
-  messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
-  options?: {
-    readonly preserveLastErrorForSourceTopic: string | undefined;
-  },
-) {
-  yield* Effect.gen(function* () {
-    for (const message of messages) {
-      yield* Effect.uninterruptible(
-        Effect.tryPromise({
-          try: () => Promise.resolve(message.message.commit()),
-          catch: (cause) => kafkaMessageCommitError(region, message.sourceTopic, cause),
-        }).pipe(
-          Effect.matchEffect({
-            onFailure: (error) =>
-              health
-                .messageCommitFailed(message.sourceTopic, region, {
-                  bytes: message.messageBytes,
-                  message: `${error.message}: ${messageFromUnknown(error.cause)}`,
-                  nowMillis: message.nowMillis,
-                })
-                .pipe(Effect.andThen(Effect.fail(error))),
-            onSuccess: () =>
-              health.messageDecoded(message.sourceTopic, region, {
-                bytes: message.messageBytes,
-                committedOffset: String(message.message.offset + 1n),
-                nowMillis: message.nowMillis,
-                ...(options?.preserveLastErrorForSourceTopic === message.sourceTopic
-                  ? { preserveLastError: true }
-                  : {}),
-              }),
-          }),
-        ),
-      );
-    }
-  }).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
-});
-
-const publishAndCommitKafkaDecodedBatch = Effect.fn(
-  "ViewServerRuntime.kafka.batch.publishAndCommit",
-)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  client: KafkaIngressRuntimeClient<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  health: ViewServerKafkaHealthLedger<Topics>,
-  region: string,
-  messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
-  options?: {
-    readonly preserveLastErrorForSourceTopic: string | undefined;
-  },
-) {
-  const runs = planKafkaDecodedPublishRuns(messages);
-
-  for (const run of runs) {
-    if (run._tag === "Upserts") {
-      yield* publishKafkaDecodedUpsertBatch(
-        client,
-        requestHealthRefresh,
-        health,
-        region,
-        run.messages,
-      );
-      yield* commitKafkaDecodedBatch(requestHealthRefresh, health, region, run.messages, options);
-    } else {
-      yield* publishKafkaDecodedTombstone(
-        client,
-        requestHealthRefresh,
-        health,
-        region,
-        run.message,
-      );
-      yield* commitKafkaDecodedBatch(requestHealthRefresh, health, region, [run.message], options);
-    }
-  }
-});
 
 export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messageBatch.process")(
   function* <


### PR DESCRIPTION
## Summary
- move Kafka publish/commit/skip behavior into a focused delivery contract module
- extract Kafka ingress error construction/cause helpers into a dedicated module
- keep ingress responsible for stream/decode/map flow while delivery owns publish, tombstone delete, commit, keyless skip, and health attribution
- add regressions for publish-before-commit ordering, storage-key publish path use, publish failure health attribution, and keyless skip-and-commit

## Validation
- vp run @effect-view-server/runtime#test -- src/kafka-delivery-contract.test.ts src/kafka-ingress.internal.test.ts
- vp check --fix
- vp run -w check:effect
- vp run @effect-view-server/runtime#test
- forbidden-pattern scan for casts, testing-library/vitest direct imports, toEqual, assert, try/catch/finally in tests, coverage ignores, Date usage
- git diff --check

## Review loop
- 3 local reviewer agents passed after fixing the publish-before-commit blocker and strengthening the ingress test seam
