### PR TITLE
Centralize topic source binding resolution

### DIFF
--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -34,7 +34,20 @@ export {
   collectSourceOwnershipConflicts,
   makeSourceOwnershipPolicy,
 } from "./source-ownership-policy";
+export {
+  makeTopicSourceBindings,
+  topicGrpcSourceMetadataFromUnknown,
+} from "./source-binding-resolution";
 export { makeRuntimeCoreMutationPipeline } from "./source-mutation-pipeline";
+export type {
+  TopicDefinitionHasRequiredDefinedObjectProperty,
+  TopicDefinitionHasSourceOwner,
+  TopicGrpcSourceLifecycle,
+  TopicGrpcSourceMetadata,
+  TopicGrpcSourceValidMetadata,
+  TopicSourceBinding,
+  TopicSourceOwner,
+} from "./source-binding-resolution";
 export type {
   RuntimeCoreDecodedRowWithStorageKey,
   RuntimeCoreMutationPipeline,

--- a/packages/runtime-core/src/public-client.ts
+++ b/packages/runtime-core/src/public-client.ts
@@ -18,24 +18,13 @@ import type {
   ViewServerTransportError,
 } from "@effect-view-server/config";
 import type { Effect } from "effect";
-
-type HasRequiredDefinedObjectProperty<Definition, Key extends string> = Key extends keyof Definition
-  ? undefined extends Definition[Key]
-    ? false
-    : Exclude<Definition[Key], undefined> extends object
-      ? true
-      : false
-  : false;
-
-type HasSourceOwner<Definition> = true extends
-  | HasRequiredDefinedObjectProperty<Definition, "kafkaSource">
-  | HasRequiredDefinedObjectProperty<Definition, "grpcSource">
-  ? true
-  : false;
+import type { TopicDefinitionHasSourceOwner } from "./source-binding-resolution";
 
 type RuntimeCorePublicTopic<Topics extends TopicDefinitions> = Extract<
   {
-    readonly [Topic in keyof Topics]: HasSourceOwner<Topics[Topic]> extends true ? never : Topic;
+    readonly [Topic in keyof Topics]: TopicDefinitionHasSourceOwner<Topics[Topic]> extends true
+      ? never
+      : Topic;
   }[keyof Topics],
   string
 >;
@@ -56,7 +45,9 @@ type RuntimeCoreLeasedTopic<Topics extends TopicDefinitions> = Extract<
 
 type RuntimeCoreSourceOwnedTopic<Topics extends TopicDefinitions> = Extract<
   {
-    readonly [Topic in keyof Topics]: HasSourceOwner<Topics[Topic]> extends true ? Topic : never;
+    readonly [Topic in keyof Topics]: TopicDefinitionHasSourceOwner<Topics[Topic]> extends true
+      ? Topic
+      : never;
   }[keyof Topics],
   string
 >;

--- a/packages/runtime-core/src/source-binding-resolution.test.ts
+++ b/packages/runtime-core/src/source-binding-resolution.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, kafka } from "@effect-view-server/config";
+import { grpcSourceMarkers } from "@effect-view-server/config/internal";
+import { Schema } from "effect";
+import {
+  makeTopicSourceBindings,
+  topicGrpcSourceMetadataFromUnknown,
+} from "./source-binding-resolution";
+
+const Row = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+  region: Schema.String,
+});
+
+const viewServer = defineViewServerConfig({
+  kafka: {
+    usa: "localhost:9092",
+  },
+  topics: {
+    externalOrders: {
+      schema: Row,
+      key: "id",
+    },
+    kafkaOrders: {
+      schema: Row,
+      key: "id",
+      kafkaSource: kafka.source({
+        topic: "orders-source",
+        regions: ["usa"],
+        value: kafka.json(Row),
+        key: kafka.stringKey(),
+        rowKey: ({ key }) => key,
+        map: ({ value }) => ({
+          price: value.price,
+          region: value.region,
+        }),
+      }),
+    },
+    leasedOrders: {
+      schema: Row,
+      key: "id",
+      grpcSource: grpcSourceMarkers.leased({
+        routeBy: ["region"],
+      }),
+    },
+    materializedOrders: {
+      schema: Row,
+      key: "id",
+      grpcSource: grpcSourceMarkers.materialized(),
+    },
+  },
+});
+
+describe("source binding resolution", () => {
+  it("derives canonical source bindings from topic-owned config", () => {
+    const bindings = makeTopicSourceBindings(viewServer);
+
+    expect(
+      [...bindings].map(([topic, binding]) => ({
+        grpcLeased: binding.grpcLeased,
+        grpcMetadata: binding.grpcMetadata,
+        owners: binding.owners,
+        sourceOwned: binding.sourceOwned,
+        topic,
+      })),
+    ).toStrictEqual([
+      {
+        grpcLeased: false,
+        grpcMetadata: { _tag: "absent" },
+        owners: [],
+        sourceOwned: false,
+        topic: "externalOrders",
+      },
+      {
+        grpcLeased: false,
+        grpcMetadata: { _tag: "absent" },
+        owners: [{ _tag: "kafka" }],
+        sourceOwned: true,
+        topic: "kafkaOrders",
+      },
+      {
+        grpcLeased: true,
+        grpcMetadata: { _tag: "valid", lifecycle: "leased", routeBy: ["region"] },
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        sourceOwned: true,
+        topic: "leasedOrders",
+      },
+      {
+        grpcLeased: false,
+        grpcMetadata: { _tag: "valid", lifecycle: "materialized" },
+        owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+        sourceOwned: true,
+        topic: "materializedOrders",
+      },
+    ]);
+  });
+
+  it("keeps malformed gRPC source metadata local to the binding", () => {
+    const malformedViewServer = defineViewServerConfig({
+      topics: {
+        malformedOrders: {
+          schema: Row,
+          key: "id",
+        },
+      },
+    });
+    const malformedSource = { kind: "grpc", lifecycle: "wat" };
+    Object.defineProperty(malformedViewServer.topics.malformedOrders, "grpcSource", {
+      value: malformedSource,
+    });
+
+    expect(
+      [...makeTopicSourceBindings(malformedViewServer)].map(([topic, binding]) => ({
+        grpcMetadata: binding.grpcMetadata,
+        owners: binding.owners,
+        sourceOwned: binding.sourceOwned,
+        topic,
+      })),
+    ).toStrictEqual([
+      {
+        grpcMetadata: { _tag: "invalid", cause: malformedSource },
+        owners: [{ _tag: "grpc", lifecycle: "unknown" }],
+        sourceOwned: true,
+        topic: "malformedOrders",
+      },
+    ]);
+  });
+
+  it("classifies hostile gRPC source shapes without caller reflection", () => {
+    const hostileViewServer = defineViewServerConfig({
+      topics: {
+        incompleteConcreteLeased: {
+          schema: Row,
+          key: "id",
+        },
+        incompleteConcreteMaterialized: {
+          schema: Row,
+          key: "id",
+        },
+        invalidKind: {
+          schema: Row,
+          key: "id",
+        },
+        invalidLeasedRouteBy: {
+          schema: Row,
+          key: "id",
+        },
+        invalidLifecycle: {
+          schema: Row,
+          key: "id",
+        },
+        materializedExtraKey: {
+          schema: Row,
+          key: "id",
+        },
+        materializedWrongTag: {
+          schema: Row,
+          key: "id",
+        },
+        nonStringLeasedRouteBy: {
+          schema: Row,
+          key: "id",
+        },
+        primitiveSource: {
+          schema: Row,
+          key: "id",
+        },
+        validConcreteLeased: {
+          schema: Row,
+          key: "id",
+        },
+        validConcreteMaterialized: {
+          schema: Row,
+          key: "id",
+        },
+        leasedExtraKey: {
+          schema: Row,
+          key: "id",
+        },
+        leasedWrongTag: {
+          schema: Row,
+          key: "id",
+        },
+        releaseIsNotCallable: {
+          schema: Row,
+          key: "id",
+        },
+      },
+    });
+    const request = () => undefined;
+    const acquire = () => undefined;
+    const release = () => undefined;
+    const map = () => undefined;
+    Object.defineProperty(hostileViewServer.topics.incompleteConcreteLeased, "grpcSource", {
+      value: {
+        _tag: "GrpcLeasedTopicSource",
+        kind: "grpc",
+        lifecycle: "leased",
+        routeBy: ["region"],
+        client: "orders",
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.incompleteConcreteMaterialized, "grpcSource", {
+      value: {
+        _tag: "GrpcMaterializedTopicSource",
+        kind: "grpc",
+        lifecycle: "materialized",
+        client: "orders",
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.invalidKind, "grpcSource", {
+      value: { kind: "not-grpc", lifecycle: "leased" },
+    });
+    Object.defineProperty(hostileViewServer.topics.invalidLeasedRouteBy, "grpcSource", {
+      value: {
+        _tag: "GrpcLeasedTopicSource",
+        kind: "grpc",
+        lifecycle: "leased",
+        routeBy: [],
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.invalidLifecycle, "grpcSource", {
+      value: { kind: "grpc", lifecycle: "wat" },
+    });
+    Object.defineProperty(hostileViewServer.topics.materializedExtraKey, "grpcSource", {
+      value: {
+        _tag: "GrpcMaterializedTopicSource",
+        extra: true,
+        kind: "grpc",
+        lifecycle: "materialized",
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.materializedWrongTag, "grpcSource", {
+      value: { _tag: "Wrong", kind: "grpc", lifecycle: "materialized" },
+    });
+    Object.defineProperty(hostileViewServer.topics.nonStringLeasedRouteBy, "grpcSource", {
+      value: {
+        _tag: "GrpcLeasedTopicSource",
+        kind: "grpc",
+        lifecycle: "leased",
+        routeBy: ["region", 1],
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.primitiveSource, "grpcSource", {
+      value: "not-an-object",
+    });
+    Object.defineProperty(hostileViewServer.topics.validConcreteLeased, "grpcSource", {
+      value: {
+        _tag: "GrpcLeasedTopicSource",
+        kind: "grpc",
+        lifecycle: "leased",
+        routeBy: ["region"],
+        client: "orders",
+        method: "stream",
+        request,
+        acquire,
+        release,
+        map,
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.validConcreteMaterialized, "grpcSource", {
+      value: {
+        _tag: "GrpcMaterializedTopicSource",
+        kind: "grpc",
+        lifecycle: "materialized",
+        client: "orders",
+        method: "stream",
+        request,
+        acquire,
+        map,
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.leasedExtraKey, "grpcSource", {
+      value: {
+        _tag: "GrpcLeasedTopicSource",
+        extra: true,
+        kind: "grpc",
+        lifecycle: "leased",
+        routeBy: ["region"],
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.leasedWrongTag, "grpcSource", {
+      value: {
+        _tag: "Wrong",
+        kind: "grpc",
+        lifecycle: "leased",
+        routeBy: ["region"],
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics.releaseIsNotCallable, "grpcSource", {
+      value: {
+        _tag: "GrpcMaterializedTopicSource",
+        kind: "grpc",
+        lifecycle: "materialized",
+        client: "orders",
+        method: "stream",
+        request,
+        acquire,
+        release: "nope",
+        map,
+      },
+    });
+    Object.defineProperty(hostileViewServer.topics, "primitiveTopic", {
+      enumerable: true,
+      value: null,
+    });
+
+    expect(
+      [...makeTopicSourceBindings(hostileViewServer)].map(([topic, binding]) => ({
+        grpcMetadataTag: binding.grpcMetadata._tag,
+        owners: binding.owners,
+        topic,
+      })),
+    ).toStrictEqual([
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        topic: "incompleteConcreteLeased",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+        topic: "incompleteConcreteMaterialized",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "unknown" }],
+        topic: "invalidKind",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        topic: "invalidLeasedRouteBy",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "unknown" }],
+        topic: "invalidLifecycle",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        topic: "leasedExtraKey",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        topic: "leasedWrongTag",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+        topic: "materializedExtraKey",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+        topic: "materializedWrongTag",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        topic: "nonStringLeasedRouteBy",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "unknown" }],
+        topic: "primitiveSource",
+      },
+      {
+        grpcMetadataTag: "absent",
+        owners: [],
+        topic: "primitiveTopic",
+      },
+      {
+        grpcMetadataTag: "invalid",
+        owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+        topic: "releaseIsNotCallable",
+      },
+      {
+        grpcMetadataTag: "valid",
+        owners: [{ _tag: "grpc", lifecycle: "leased" }],
+        topic: "validConcreteLeased",
+      },
+      {
+        grpcMetadataTag: "valid",
+        owners: [{ _tag: "grpc", lifecycle: "materialized" }],
+        topic: "validConcreteMaterialized",
+      },
+    ]);
+  });
+
+  it("treats primitive topic definitions as absent gRPC source metadata", () => {
+    expect(topicGrpcSourceMetadataFromUnknown(undefined)).toStrictEqual({ _tag: "absent" });
+    expect(topicGrpcSourceMetadataFromUnknown(null)).toStrictEqual({ _tag: "absent" });
+  });
+});

--- a/packages/runtime-core/src/source-binding-resolution.ts
+++ b/packages/runtime-core/src/source-binding-resolution.ts
@@ -1,0 +1,229 @@
+import type { DecodableTopicDefinitions } from "@effect-view-server/column-live-view-engine";
+import type { ViewServerTopicConfig } from "@effect-view-server/config";
+
+export type TopicDefinitionHasRequiredDefinedObjectProperty<
+  Definition,
+  Key extends string,
+> = Key extends keyof Definition
+  ? undefined extends Definition[Key]
+    ? false
+    : Exclude<Definition[Key], undefined> extends object
+      ? true
+      : false
+  : false;
+
+export type TopicDefinitionHasSourceOwner<Definition> = true extends
+  | TopicDefinitionHasRequiredDefinedObjectProperty<Definition, "kafkaSource">
+  | TopicDefinitionHasRequiredDefinedObjectProperty<Definition, "grpcSource">
+  ? true
+  : false;
+
+export type TopicGrpcSourceLifecycle = "leased" | "materialized" | "unknown";
+
+export type TopicGrpcSourceMetadata =
+  | {
+      readonly _tag: "absent";
+    }
+  | {
+      readonly _tag: "invalid";
+      readonly cause: unknown;
+    }
+  | {
+      readonly _tag: "valid";
+      readonly lifecycle: "materialized";
+    }
+  | {
+      readonly _tag: "valid";
+      readonly lifecycle: "leased";
+      readonly routeBy: ReadonlyArray<string>;
+    };
+
+export type TopicGrpcSourceValidMetadata = Extract<
+  TopicGrpcSourceMetadata,
+  { readonly _tag: "valid" }
+>;
+
+export type TopicSourceOwner =
+  | {
+      readonly _tag: "kafka";
+    }
+  | {
+      readonly _tag: "grpc";
+      readonly lifecycle: TopicGrpcSourceLifecycle;
+    };
+
+export type TopicSourceBinding = {
+  readonly grpcLeased: boolean;
+  readonly grpcMetadata: TopicGrpcSourceMetadata;
+  readonly grpcSource: unknown;
+  readonly kafkaSource: unknown;
+  readonly owners: ReadonlyArray<TopicSourceOwner>;
+  readonly sourceOwned: boolean;
+  readonly topic: string;
+};
+
+const hasDefinedOwnProperty = (value: object, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key) && Reflect.get(value, key) !== undefined;
+
+const hasOnlyOwnStringKeys = (value: object, allowedKeys: ReadonlyArray<string>): boolean =>
+  Object.getOwnPropertyNames(value).every((key) => allowedKeys.includes(key));
+
+const hasCallableOwnProperty = (value: object, key: string): boolean =>
+  typeof Reflect.get(value, key) === "function";
+
+const hasConcreteGrpcBinding = (source: object): boolean =>
+  ["client", "method", "request", "acquire", "release", "map"].some((key) =>
+    hasDefinedOwnProperty(source, key),
+  );
+
+const hasCompleteConcreteGrpcBinding = (source: object): boolean =>
+  hasDefinedOwnProperty(source, "client") &&
+  hasDefinedOwnProperty(source, "method") &&
+  hasCallableOwnProperty(source, "request") &&
+  hasCallableOwnProperty(source, "acquire") &&
+  hasCallableOwnProperty(source, "map") &&
+  (!hasDefinedOwnProperty(source, "release") || hasCallableOwnProperty(source, "release"));
+
+const grpcTopicSourceFromUnknown = (source: unknown): TopicGrpcSourceMetadata => {
+  if (typeof source !== "object" || source === null) {
+    return { _tag: "invalid", cause: source };
+  }
+  if (Reflect.get(source, "kind") !== "grpc") {
+    return { _tag: "invalid", cause: source };
+  }
+  const lifecycle = Reflect.get(source, "lifecycle");
+  if (lifecycle !== "leased" && lifecycle !== "materialized") {
+    return { _tag: "invalid", cause: source };
+  }
+  const sourceTag = Reflect.get(source, "_tag");
+  if (lifecycle === "materialized") {
+    if (
+      !hasOnlyOwnStringKeys(source, [
+        "_tag",
+        "kind",
+        "lifecycle",
+        "client",
+        "method",
+        "request",
+        "acquire",
+        "release",
+        "map",
+      ])
+    ) {
+      return { _tag: "invalid", cause: source };
+    }
+    if (sourceTag !== "GrpcMaterializedTopicSource") {
+      return { _tag: "invalid", cause: source };
+    }
+    if (hasConcreteGrpcBinding(source) && !hasCompleteConcreteGrpcBinding(source)) {
+      return { _tag: "invalid", cause: source };
+    }
+    return { _tag: "valid", lifecycle };
+  }
+  if (
+    !hasOnlyOwnStringKeys(source, [
+      "_tag",
+      "kind",
+      "lifecycle",
+      "routeBy",
+      "client",
+      "method",
+      "request",
+      "acquire",
+      "release",
+      "map",
+    ])
+  ) {
+    return { _tag: "invalid", cause: source };
+  }
+  if (sourceTag !== "GrpcLeasedTopicSource") {
+    return { _tag: "invalid", cause: source };
+  }
+  if (hasConcreteGrpcBinding(source) && !hasCompleteConcreteGrpcBinding(source)) {
+    return { _tag: "invalid", cause: source };
+  }
+  const routeBy = Reflect.get(source, "routeBy");
+  if (
+    !Array.isArray(routeBy) ||
+    routeBy.length === 0 ||
+    !routeBy.every((field) => typeof field === "string")
+  ) {
+    return { _tag: "invalid", cause: source };
+  }
+  return { _tag: "valid", lifecycle, routeBy };
+};
+
+export const topicGrpcSourceMetadataFromUnknown = (
+  topicDefinition: unknown,
+): TopicGrpcSourceMetadata => {
+  if (typeof topicDefinition !== "object" || topicDefinition === null) {
+    return { _tag: "absent" };
+  }
+  if (!hasDefinedOwnProperty(topicDefinition, "grpcSource")) {
+    return { _tag: "absent" };
+  }
+  return grpcTopicSourceFromUnknown(Reflect.get(topicDefinition, "grpcSource"));
+};
+
+const topicKafkaSourceFromUnknown = (topicDefinition: unknown): unknown => {
+  if (typeof topicDefinition !== "object" || topicDefinition === null) {
+    return undefined;
+  }
+  return hasDefinedOwnProperty(topicDefinition, "kafkaSource")
+    ? Reflect.get(topicDefinition, "kafkaSource")
+    : undefined;
+};
+
+const topicGrpcSourceFromUnknown = (topicDefinition: unknown): unknown => {
+  if (typeof topicDefinition !== "object" || topicDefinition === null) {
+    return undefined;
+  }
+  return hasDefinedOwnProperty(topicDefinition, "grpcSource")
+    ? Reflect.get(topicDefinition, "grpcSource")
+    : undefined;
+};
+
+const grpcDeclaredLifecycleFromUnknown = (source: unknown): TopicGrpcSourceLifecycle => {
+  if (typeof source !== "object" || source === null || Reflect.get(source, "kind") !== "grpc") {
+    return "unknown";
+  }
+  const lifecycle = Reflect.get(source, "lifecycle");
+  return lifecycle === "leased" || lifecycle === "materialized" ? lifecycle : "unknown";
+};
+
+const topicSourceBinding = (topic: string, definition: unknown): TopicSourceBinding => {
+  const kafkaSource = topicKafkaSourceFromUnknown(definition);
+  const grpcSource = topicGrpcSourceFromUnknown(definition);
+  const grpcMetadata = topicGrpcSourceMetadataFromUnknown(definition);
+  const owners: Array<TopicSourceOwner> = [];
+  if (kafkaSource !== undefined) {
+    owners.push({ _tag: "kafka" });
+  }
+  if (grpcSource !== undefined) {
+    owners.push({
+      _tag: "grpc",
+      lifecycle: grpcDeclaredLifecycleFromUnknown(grpcSource),
+    });
+  }
+  return {
+    grpcLeased: owners.some((owner) => owner._tag === "grpc" && owner.lifecycle === "leased"),
+    grpcMetadata,
+    grpcSource,
+    kafkaSource,
+    owners,
+    sourceOwned: owners.length > 0,
+    topic,
+  };
+};
+
+export const makeTopicSourceBindings = <const Topics extends DecodableTopicDefinitions>(
+  config: ViewServerTopicConfig<Topics>,
+): ReadonlyMap<string, TopicSourceBinding> =>
+  new Map(
+    Object.entries(config.topics)
+      .map(
+        ([topic, definition]) =>
+          [topic, topicSourceBinding(topic, definition)] satisfies [string, TopicSourceBinding],
+      )
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );

--- a/packages/runtime-core/src/source-ownership-policy.test.ts
+++ b/packages/runtime-core/src/source-ownership-policy.test.ts
@@ -251,6 +251,48 @@ describe("SourceOwnershipPolicy", () => {
     }),
   );
 
+  it.effect("preserves leased runtime protection for invalid declared leased metadata", () =>
+    Effect.gen(function* () {
+      const malformedLeasedViewServer = defineViewServerConfig({
+        topics: {
+          malformedLeasedOrders: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      Object.defineProperty(malformedLeasedViewServer.topics.malformedLeasedOrders, "grpcSource", {
+        value: {
+          _tag: "GrpcLeasedTopicSource",
+          kind: "grpc",
+          lifecycle: "leased",
+          routeBy: [],
+        },
+      });
+      const policy = makeSourceOwnershipPolicy(malformedLeasedViewServer);
+
+      const runtimeCoreReadError = yield* policy
+        .requirePublicReadAllowed("malformedLeasedOrders", "runtimeCore")
+        .pipe(Effect.flip);
+
+      expect([...policy.grpcLeasedTopics]).toStrictEqual(["malformedLeasedOrders"]);
+      expect([...policy.topics]).toStrictEqual([
+        [
+          "malformedLeasedOrders",
+          {
+            grpcLeased: true,
+            owners: [{ _tag: "grpc", lifecycle: "leased" }],
+            sourceOwned: true,
+            topic: "malformedLeasedOrders",
+          },
+        ],
+      ]);
+      expect(runtimeCoreReadError).toStrictEqual(
+        runtimeCoreLeasedAccessError("malformedLeasedOrders"),
+      );
+    }),
+  );
+
   it("classifies malformed and conflicting source declarations without caller reflection", () => {
     const malformedViewServer = defineViewServerConfig({
       kafka: {

--- a/packages/runtime-core/src/source-ownership-policy.ts
+++ b/packages/runtime-core/src/source-ownership-policy.ts
@@ -8,17 +8,15 @@ import {
   sourceOwnedRuntimeMutationError,
   sourceOwnedRuntimeResetError,
 } from "./runtime-error";
+import {
+  makeTopicSourceBindings,
+  type TopicGrpcSourceLifecycle,
+  type TopicSourceOwner,
+} from "./source-binding-resolution";
 
 export type SourceOwnershipAccessProfile = "managedRuntime" | "runtimeCore";
-export type SourceOwnershipGrpcLifecycle = "leased" | "materialized" | "unknown";
-export type SourceOwnershipOwner =
-  | {
-      readonly _tag: "kafka";
-    }
-  | {
-      readonly _tag: "grpc";
-      readonly lifecycle: SourceOwnershipGrpcLifecycle;
-    };
+export type SourceOwnershipGrpcLifecycle = TopicGrpcSourceLifecycle;
+export type SourceOwnershipOwner = TopicSourceOwner;
 
 export type SourceOwnershipTopic = {
   readonly grpcLeased: boolean;
@@ -48,52 +46,6 @@ export type SourceOwnershipKafkaOptions = {
 
 export type SourceOwnershipGrpcOptions = {
   readonly feeds: Readonly<Record<string, { readonly topic: string }>>;
-};
-
-const hasDefinedOwnProperty = (value: object, key: string): boolean =>
-  Object.prototype.hasOwnProperty.call(value, key) && Reflect.get(value, key) !== undefined;
-
-const topicGrpcSource = (definition: object): unknown => {
-  if (hasDefinedOwnProperty(definition, "grpcSource")) {
-    return Reflect.get(definition, "grpcSource");
-  }
-  return undefined;
-};
-
-const grpcLifecycle = (source: unknown): SourceOwnershipGrpcLifecycle => {
-  if (typeof source !== "object" || source === null || Reflect.get(source, "kind") !== "grpc") {
-    return "unknown";
-  }
-  const lifecycle = Reflect.get(source, "lifecycle");
-  if (lifecycle === "leased" || lifecycle === "materialized") {
-    return lifecycle;
-  }
-  return "unknown";
-};
-
-const topicOwners = (definition: object): ReadonlyArray<SourceOwnershipOwner> => {
-  const owners: Array<SourceOwnershipOwner> = [];
-  if (hasDefinedOwnProperty(definition, "kafkaSource")) {
-    owners.push({ _tag: "kafka" });
-  }
-  const grpcSource = topicGrpcSource(definition);
-  if (grpcSource !== undefined) {
-    owners.push({
-      _tag: "grpc",
-      lifecycle: grpcLifecycle(grpcSource),
-    });
-  }
-  return owners;
-};
-
-const topicOwnership = (topic: string, definition: object): SourceOwnershipTopic => {
-  const owners = topicOwners(definition);
-  return {
-    grpcLeased: owners.some((owner) => owner._tag === "grpc" && owner.lifecycle === "leased"),
-    owners,
-    sourceOwned: owners.length > 0,
-    topic,
-  };
 };
 
 export type SourceOwnershipPolicy = {
@@ -153,8 +105,13 @@ export const makeSourceOwnershipPolicy = <const Topics extends DecodableTopicDef
   const grpcLeasedTopics = new Set<string>();
   const sourceOwnedTopics = new Set<string>();
   const topics = new Map<string, SourceOwnershipTopic>();
-  for (const [topic, definition] of Object.entries(config.topics)) {
-    const ownership = topicOwnership(topic, definition);
+  for (const [topic, binding] of makeTopicSourceBindings(config)) {
+    const ownership = {
+      grpcLeased: binding.grpcLeased,
+      owners: binding.owners,
+      sourceOwned: binding.sourceOwned,
+      topic: binding.topic,
+    };
     topics.set(topic, ownership);
     if (ownership.sourceOwned) {
       sourceOwnedTopics.add(topic);

--- a/packages/runtime/src/runtime-options.ts
+++ b/packages/runtime/src/runtime-options.ts
@@ -1,6 +1,8 @@
 import type { ViewServerRuntimeCoreOptionsFor } from "@effect-view-server/runtime-core";
 import {
   collectSourceOwnershipConflicts,
+  makeTopicSourceBindings,
+  type TopicGrpcSourceValidMetadata,
   type SourceOwnershipGrpcOptions,
   type SourceOwnershipKafkaOptions,
 } from "@effect-view-server/runtime-core/internal";
@@ -157,8 +159,6 @@ type BoundGrpcSource = {
   readonly map: RuntimeGrpcFeedCallable;
 };
 
-type ValidGrpcTopicSourceMetadata = Extract<GrpcTopicSourceMetadata, { readonly _tag: "valid" }>;
-
 const runtimeGrpcFeedCallable = (value: unknown): value is RuntimeGrpcFeedCallable =>
   typeof value === "function";
 
@@ -169,7 +169,7 @@ const grpcMethodIsServerStreaming = (method: unknown): boolean =>
 
 const boundGrpcSourceFromUnknown = (
   source: unknown,
-  sourceMetadata: ValidGrpcTopicSourceMetadata,
+  sourceMetadata: TopicGrpcSourceValidMetadata,
 ): BoundGrpcSource | undefined => {
   const sourceObject = Object(source);
   const lifecycle = sourceMetadata.lifecycle;
@@ -223,18 +223,11 @@ const grpcFeedsFromConfig = <
   if (config === undefined) {
     return feeds;
   }
-  for (const [topic, topicDefinition] of Object.entries(config.topics)) {
-    const source =
-      typeof topicDefinition === "object" &&
-      topicDefinition !== null &&
-      Object.prototype.hasOwnProperty.call(topicDefinition, "grpcSource")
-        ? Reflect.get(topicDefinition, "grpcSource")
-        : undefined;
-    const sourceMetadata = grpcTopicSourceMetadata(topicDefinition);
-    if (sourceMetadata._tag !== "valid") {
+  for (const [topic, binding] of makeTopicSourceBindings(config)) {
+    if (binding.grpcMetadata._tag !== "valid") {
       continue;
     }
-    const bound = boundGrpcSourceFromUnknown(source, sourceMetadata);
+    const bound = boundGrpcSourceFromUnknown(binding.grpcSource, binding.grpcMetadata);
     if (bound === undefined) {
       continue;
     }
@@ -264,14 +257,13 @@ const validateConfigGrpcSourceMetadata = <
     if (config === undefined) {
       return;
     }
-    for (const [topic, topicDefinition] of Object.entries(config.topics)) {
-      const sourceMetadata = grpcTopicSourceMetadata(topicDefinition);
-      if (sourceMetadata._tag !== "invalid") {
+    for (const [topic, binding] of makeTopicSourceBindings(config)) {
+      if (binding.grpcMetadata._tag !== "invalid") {
         continue;
       }
       return yield* new ViewServerGrpcIngressError({
         message: `View Server topic ${topic} declares invalid gRPC source metadata.`,
-        cause: sourceMetadata.cause,
+        cause: binding.grpcMetadata.cause,
         feedName: topic,
         topic,
         phase: "configuration",
@@ -682,129 +674,6 @@ export const validateSourceOwnership: (
   }
 });
 
-type GrpcTopicSourceMetadata =
-  | {
-      readonly _tag: "absent";
-    }
-  | {
-      readonly _tag: "invalid";
-      readonly cause: unknown;
-    }
-  | {
-      readonly _tag: "valid";
-      readonly lifecycle: "materialized";
-    }
-  | {
-      readonly _tag: "valid";
-      readonly lifecycle: "leased";
-      readonly routeBy: ReadonlyArray<string>;
-    };
-
-const hasDefinedOwnProperty = (value: object, key: string): boolean =>
-  Object.prototype.hasOwnProperty.call(value, key) && Reflect.get(value, key) !== undefined;
-
-const hasOnlyOwnStringKeys = (value: object, allowedKeys: ReadonlyArray<string>): boolean =>
-  Object.getOwnPropertyNames(value).every((key) => allowedKeys.includes(key));
-
-const hasConcreteGrpcBinding = (source: object): boolean =>
-  ["client", "method", "request", "acquire", "release", "map"].some((key) =>
-    hasDefinedOwnProperty(source, key),
-  );
-
-const hasCompleteConcreteGrpcBinding = (source: object): boolean => {
-  const request = Reflect.get(source, "request");
-  const acquire = Reflect.get(source, "acquire");
-  const release = Reflect.get(source, "release");
-  const map = Reflect.get(source, "map");
-  return (
-    hasDefinedOwnProperty(source, "client") &&
-    hasDefinedOwnProperty(source, "method") &&
-    runtimeGrpcFeedCallable(request) &&
-    runtimeGrpcFeedCallable(acquire) &&
-    runtimeGrpcFeedCallable(map) &&
-    (release === undefined || runtimeGrpcFeedCallable(release))
-  );
-};
-
-const grpcTopicSourceFromUnknown = (source: unknown): GrpcTopicSourceMetadata => {
-  if (typeof source !== "object" || source === null) {
-    return { _tag: "invalid", cause: source };
-  }
-  if (Reflect.get(source, "kind") !== "grpc") {
-    return { _tag: "invalid", cause: source };
-  }
-  const lifecycle = Reflect.get(source, "lifecycle");
-  if (lifecycle !== "leased" && lifecycle !== "materialized") {
-    return { _tag: "invalid", cause: source };
-  }
-  const sourceTag = Reflect.get(source, "_tag");
-  if (lifecycle === "materialized") {
-    if (
-      !hasOnlyOwnStringKeys(source, [
-        "_tag",
-        "kind",
-        "lifecycle",
-        "client",
-        "method",
-        "request",
-        "acquire",
-        "release",
-        "map",
-      ])
-    ) {
-      return { _tag: "invalid", cause: source };
-    }
-    if (sourceTag !== "GrpcMaterializedTopicSource") {
-      return { _tag: "invalid", cause: source };
-    }
-    if (hasConcreteGrpcBinding(source) && !hasCompleteConcreteGrpcBinding(source)) {
-      return { _tag: "invalid", cause: source };
-    }
-    return { _tag: "valid", lifecycle };
-  }
-  if (
-    !hasOnlyOwnStringKeys(source, [
-      "_tag",
-      "kind",
-      "lifecycle",
-      "routeBy",
-      "client",
-      "method",
-      "request",
-      "acquire",
-      "release",
-      "map",
-    ])
-  ) {
-    return { _tag: "invalid", cause: source };
-  }
-  if (sourceTag !== "GrpcLeasedTopicSource") {
-    return { _tag: "invalid", cause: source };
-  }
-  if (hasConcreteGrpcBinding(source) && !hasCompleteConcreteGrpcBinding(source)) {
-    return { _tag: "invalid", cause: source };
-  }
-  const routeBy = Reflect.get(source, "routeBy");
-  if (
-    !Array.isArray(routeBy) ||
-    routeBy.length === 0 ||
-    !routeBy.every((field) => typeof field === "string")
-  ) {
-    return { _tag: "invalid", cause: source };
-  }
-  return { _tag: "valid", lifecycle, routeBy };
-};
-
-const grpcTopicSourceMetadata = (topicDefinition: unknown): GrpcTopicSourceMetadata => {
-  if (typeof topicDefinition !== "object" || topicDefinition === null) {
-    return { _tag: "absent" };
-  }
-  if (hasDefinedOwnProperty(topicDefinition, "grpcSource")) {
-    return grpcTopicSourceFromUnknown(Reflect.get(topicDefinition, "grpcSource"));
-  }
-  return { _tag: "absent" };
-};
-
 const grpcFeedLeasedRouteBy = (feed: unknown): ReadonlyArray<string> | undefined => {
   const routeBy = Reflect.get(Object(feed), "routeBy");
   return Array.isArray(routeBy) && routeBy.every((field) => typeof field === "string")
@@ -831,21 +700,21 @@ export const validateGrpcSourceFeeds: <
   grpcOptions: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients> | undefined,
 ) {
   const feedEntries = Object.entries(grpcOptions?.feeds ?? {});
-  for (const [topic, topicDefinition] of Object.entries(config.topics)) {
-    const sourceMetadata = grpcTopicSourceMetadata(topicDefinition);
-    if (sourceMetadata._tag === "absent") {
+  const bindings = makeTopicSourceBindings(config);
+  for (const [topic, binding] of bindings) {
+    if (binding.grpcMetadata._tag === "absent") {
       continue;
     }
-    if (sourceMetadata._tag === "invalid") {
+    if (binding.grpcMetadata._tag === "invalid") {
       return yield* new ViewServerGrpcIngressError({
         message: `View Server topic ${topic} declares invalid gRPC source metadata.`,
-        cause: sourceMetadata.cause,
+        cause: binding.grpcMetadata.cause,
         feedName: topic,
         topic,
         phase: "configuration",
       });
     }
-    const lifecycle = sourceMetadata.lifecycle;
+    const lifecycle = binding.grpcMetadata.lifecycle;
     const matchingFeeds = feedEntries.filter(([_feedName, feed]) => feed.topic === topic);
     if (matchingFeeds.length === 0) {
       return yield* new ViewServerGrpcIngressError({
@@ -866,7 +735,7 @@ export const validateGrpcSourceFeeds: <
       });
     }
     if (lifecycle === "leased") {
-      const sourceRouteBy = sourceMetadata.routeBy;
+      const sourceRouteBy = binding.grpcMetadata.routeBy;
       const routeMismatch = matchingFeeds.find(([_feedName, feed]) => {
         const feedRouteBy = grpcFeedLeasedRouteBy(feed);
         return feedRouteBy === undefined || !sameRouteBy(sourceRouteBy, feedRouteBy);
@@ -884,8 +753,8 @@ export const validateGrpcSourceFeeds: <
     }
   }
   for (const [feedName, feed] of feedEntries) {
-    const topicDefinition = config.topics[feed.topic];
-    if (topicDefinition === undefined) {
+    const binding = bindings.get(feed.topic);
+    if (binding === undefined) {
       return yield* new ViewServerGrpcIngressError({
         message: `gRPC feed ${feedName} references unknown View Server topic ${feed.topic}.`,
         cause: feed.topic,
@@ -893,8 +762,7 @@ export const validateGrpcSourceFeeds: <
         topic: feed.topic,
       });
     }
-    const sourceMetadata = grpcTopicSourceMetadata(topicDefinition);
-    if (sourceMetadata._tag === "absent") {
+    if (binding.grpcMetadata._tag === "absent") {
       return yield* new ViewServerGrpcIngressError({
         message: `gRPC feed ${feedName} targets View Server topic ${feed.topic}, but that topic does not declare a gRPC source.`,
         cause: feed.topic,


### PR DESCRIPTION
## Summary
- Add a runtime-core Source Binding Resolution Module as the canonical source ownership and gRPC metadata seam.
- Reuse the binding map from SourceOwnershipPolicy, public-client type filtering, and runtime gRPC option validation.
- Preserve declared leased/materialized gRPC ownership even when metadata is invalid, so malformed leased sources still reject direct runtime-core access.

## Validation
- vp run @effect-view-server/runtime-core#test
- vp run @effect-view-server/runtime#test
- vp run -w check:package-exports
- vp run -w check:internal-seams
- vp check
- vp run -w check:effect
- vp run -w ready

## Review
- 3 local reviewer agents found no code-level P0/P1/P2 issues; two noted only the expected untracked new-file state before commit.