### PR TITLE
Deepen runtime lifecycle composition

### DIFF
--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -14655,6 +14655,50 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
+  it.live("releases the runtime core when startup is interrupted before returning a runtime", () =>
+    Effect.gen(function* () {
+      let runtimeCoreClosed = false;
+      const serverStartupStarted = yield* Deferred.make<void>();
+      const releaseServerStartup = yield* Deferred.make<void>();
+      const dependencies: ViewServerRuntimeDependencies<typeof viewServer.topics> = {
+        ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
+        makeRuntimeCore: (config, options) =>
+          makeViewServerRuntimeCoreInternal(config, options).pipe(
+            Effect.map((runtimeCore) => ({
+              ...runtimeCore,
+              close: runtimeCore.close.pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    runtimeCoreClosed = true;
+                  }),
+                ),
+              ),
+            })),
+          ),
+        makeServer: () =>
+          Deferred.succeed(serverStartupStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseServerStartup)),
+            Effect.as({
+              url: "ws://127.0.0.1:0/rpc",
+              healthUrl: "http://127.0.0.1:0/health",
+              metricsUrl: "http://127.0.0.1:0/metrics",
+              close: Effect.void,
+            }),
+          ),
+      };
+
+      const startupFiber = yield* makeViewServerRuntimeWithDependencies(
+        dependencies,
+        viewServer,
+      ).pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(serverStartupStarted);
+      yield* Fiber.interrupt(startupFiber);
+
+      expect(runtimeCoreClosed).toBe(true);
+    }),
+  );
+
   it.live("releases server and runtime core when Kafka ingress startup fails", () =>
     Effect.gen(function* () {
       let runtimeCoreClosed = false;

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -8,7 +8,7 @@ import type {
 } from "@effect-view-server/config";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
 import type { ViewServerRuntimeCoreOptionsFor } from "@effect-view-server/runtime-core";
-import { Config, Effect, Exit, Layer } from "effect";
+import { Config, Effect, Layer } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
 import {
   makeDefaultRuntimeDependencies,
@@ -19,6 +19,7 @@ import type { ViewServerKafkaIngressError } from "./kafka-ingress";
 import type { ViewServerGrpcIngressError } from "./grpc-ingress";
 import type { ViewServerTcpPublishIngressError } from "./tcp-publish-ingress";
 import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+import { makeViewServerRuntimeLifecycle } from "./runtime-lifecycle";
 import {
   resolveViewServerRuntimeOptions,
   resolveViewServerRuntimeOptionsWithRuntimeFeeds,
@@ -208,134 +209,101 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
         : grpcHealth.healthOverlay(kafkaOverlayed, nowMillis);
     };
   }
-  const runtimeCore = yield* dependencies.makeRuntimeCore(dependencyConfig, runtimeCoreInput);
-  const refreshTransportHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
-  const grpcLeaseManager =
-    grpcOptions === undefined || grpcHealth === undefined
-      ? undefined
-      : yield* makeViewServerGrpcLeaseManager(
+  const lifecycle = yield* makeViewServerRuntimeLifecycle();
+  return yield* Effect.gen(function* () {
+    const runtimeCore = yield* lifecycle.acquire(
+      "runtimeCore",
+      dependencies.makeRuntimeCore(dependencyConfig, runtimeCoreInput),
+      (resource) => resource.close,
+    );
+    const refreshTransportHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
+    const grpcLeaseManager =
+      grpcOptions === undefined || grpcHealth === undefined
+        ? undefined
+        : yield* lifecycle.acquire(
+            "grpcLeaseManager",
+            makeViewServerGrpcLeaseManager(
+              dependencyConfig,
+              runtimeCore.internalClient,
+              runtimeCore.liveClient,
+              runtimeCore.internalLiveClient,
+              runtimeCore.requestHealthRefresh,
+              grpcOptions,
+              grpcHealth,
+            ),
+            (resource) => resource.close,
+          );
+    const runtimeLiveClient = grpcLeaseManager?.liveClient ?? runtimeCore.liveClient;
+    const runtimeClient = grpcLeaseManager?.client ?? runtimeCore.client;
+    const tcpPublishIngress =
+      resolvedOptions.tcpPublishOptions === undefined
+        ? undefined
+        : yield* lifecycle.acquire(
+            "tcpPublishIngress",
+            dependencies.makeTcpPublishIngress(dependencyConfig, runtimeCore.internalClient, {
+              ...resolvedOptions.tcpPublishOptions,
+              ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
+            }),
+            (resource) => resource.close,
+          );
+    const server = yield* lifecycle.acquire(
+      "server",
+      dependencies.makeServer(
+        dependencyConfig,
+        {
+          ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
+          liveClient: runtimeLiveClient,
+          runtime: runtimeClient,
+          transport: {
+            clientOpened: transportHealth.clientOpened.pipe(Effect.andThen(refreshTransportHealth)),
+            clientClosed: transportHealth.clientClosed.pipe(Effect.andThen(refreshTransportHealth)),
+            streamOpened: transportHealth.streamOpened.pipe(Effect.andThen(refreshTransportHealth)),
+            streamClosed: transportHealth.streamClosed.pipe(Effect.andThen(refreshTransportHealth)),
+          },
+        },
+        resolvedOptions.serverOptions,
+      ),
+      (resource) => resource.close,
+    );
+    if (kafkaOptions !== undefined && kafkaHealth !== undefined) {
+      yield* lifecycle.acquire(
+        "kafkaIngress",
+        dependencies.makeKafkaIngress(
           dependencyConfig,
           runtimeCore.internalClient,
-          runtimeCore.liveClient,
-          runtimeCore.internalLiveClient,
+          runtimeCore.requestHealthRefresh,
+          kafkaOptions,
+          kafkaHealth,
+        ),
+        (resource) => resource.close,
+      );
+    }
+    if (grpcOptions !== undefined && grpcHealth !== undefined) {
+      yield* lifecycle.acquire(
+        "grpcIngress",
+        dependencies.makeGrpcIngress(
+          dependencyConfig,
+          runtimeCore.internalClient,
           runtimeCore.requestHealthRefresh,
           grpcOptions,
           grpcHealth,
-        );
-  const runtimeLiveClient = grpcLeaseManager?.liveClient ?? runtimeCore.liveClient;
-  const runtimeClient = grpcLeaseManager?.client ?? runtimeCore.client;
-  const closeGrpcLeaseManager =
-    grpcLeaseManager === undefined ? Effect.void : grpcLeaseManager.close;
-  const tcpPublishIngress =
-    resolvedOptions.tcpPublishOptions === undefined
-      ? undefined
-      : yield* dependencies
-          .makeTcpPublishIngress(dependencyConfig, runtimeCore.internalClient, {
-            ...resolvedOptions.tcpPublishOptions,
-            ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
-          })
-          .pipe(
-            Effect.onExit((exit) =>
-              Exit.isFailure(exit)
-                ? closeGrpcLeaseManager.pipe(Effect.ensuring(runtimeCore.close))
-                : Effect.void,
-            ),
-          );
-  const server = yield* dependencies
-    .makeServer(
-      dependencyConfig,
-      {
-        ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
-        liveClient: runtimeLiveClient,
-        runtime: runtimeClient,
-        transport: {
-          clientOpened: transportHealth.clientOpened.pipe(Effect.andThen(refreshTransportHealth)),
-          clientClosed: transportHealth.clientClosed.pipe(Effect.andThen(refreshTransportHealth)),
-          streamOpened: transportHealth.streamOpened.pipe(Effect.andThen(refreshTransportHealth)),
-          streamClosed: transportHealth.streamClosed.pipe(Effect.andThen(refreshTransportHealth)),
-        },
-      },
-      resolvedOptions.serverOptions,
-    )
-    .pipe(
-      Effect.onExit((exit) =>
-        Exit.isFailure(exit)
-          ? (tcpPublishIngress?.close ?? Effect.void).pipe(
-              Effect.ensuring(closeGrpcLeaseManager),
-              Effect.ensuring(runtimeCore.close),
-            )
-          : Effect.void,
-      ),
-    );
-  const kafkaIngress =
-    kafkaOptions === undefined || kafkaHealth === undefined
-      ? undefined
-      : yield* dependencies
-          .makeKafkaIngress(
-            dependencyConfig,
-            runtimeCore.internalClient,
-            runtimeCore.requestHealthRefresh,
-            kafkaOptions,
-            kafkaHealth,
-          )
-          .pipe(
-            Effect.onExit((exit) =>
-              Exit.isFailure(exit)
-                ? (tcpPublishIngress?.close ?? Effect.void).pipe(
-                    Effect.ensuring(server.close),
-                    Effect.ensuring(closeGrpcLeaseManager),
-                    Effect.ensuring(runtimeCore.close),
-                  )
-                : Effect.void,
-            ),
-          );
-  const grpcIngress =
-    grpcOptions === undefined || grpcHealth === undefined
-      ? undefined
-      : yield* dependencies
-          .makeGrpcIngress(
-            dependencyConfig,
-            runtimeCore.internalClient,
-            runtimeCore.requestHealthRefresh,
-            grpcOptions,
-            grpcHealth,
-          )
-          .pipe(
-            Effect.onExit((exit) =>
-              Exit.isFailure(exit)
-                ? (tcpPublishIngress?.close ?? Effect.void).pipe(
-                    Effect.ensuring(kafkaIngress?.close ?? Effect.void),
-                    Effect.ensuring(closeGrpcLeaseManager),
-                    Effect.ensuring(server.close),
-                    Effect.ensuring(runtimeCore.close),
-                  )
-                : Effect.void,
-            ),
-          );
-  const closeGrpcIngress: Effect.Effect<void> =
-    grpcIngress === undefined ? Effect.void : grpcIngress.close;
-  const closeKafkaIngress: Effect.Effect<void> =
-    kafkaIngress === undefined ? Effect.void : kafkaIngress.close;
-  const closeTcpPublishIngress: Effect.Effect<void> =
-    tcpPublishIngress === undefined ? Effect.void : tcpPublishIngress.close;
-  const close: Effect.Effect<void> = closeTcpPublishIngress.pipe(
-    Effect.ensuring(closeGrpcIngress),
-    Effect.ensuring(closeGrpcLeaseManager),
-    Effect.ensuring(closeKafkaIngress),
-    Effect.ensuring(server.close),
-    Effect.ensuring(runtimeCore.close),
-  );
-  const publicLiveClient = toPublicLiveClient(runtimeLiveClient, close);
-  return {
-    url: server.url,
-    healthUrl: server.healthUrl,
-    metricsUrl: server.metricsUrl,
-    ...(tcpPublishIngress === undefined ? {} : { tcpPublishUrl: tcpPublishIngress.url }),
-    client: runtimeClient,
-    liveClient: publicLiveClient,
-    health: runtimeClient.health,
-    close,
-  };
+        ),
+        (resource) => resource.close,
+      );
+    }
+    const close: Effect.Effect<void> = lifecycle.close;
+    const publicLiveClient = toPublicLiveClient(runtimeLiveClient, close);
+    return {
+      url: server.url,
+      healthUrl: server.healthUrl,
+      metricsUrl: server.metricsUrl,
+      ...(tcpPublishIngress === undefined ? {} : { tcpPublishUrl: tcpPublishIngress.url }),
+      client: runtimeClient,
+      liveClient: publicLiveClient,
+      health: runtimeClient.health,
+      close,
+    };
+  }).pipe(Effect.onInterrupt(() => lifecycle.close));
 });
 
 const logRuntimeStarted = Effect.fn("ViewServerRuntime.logStarted")(function* <

--- a/packages/runtime/src/runtime-lifecycle.test.ts
+++ b/packages/runtime/src/runtime-lifecycle.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Deferred, Effect, Exit, Fiber } from "effect";
+import {
+  makeViewServerRuntimeLifecycle,
+  type ViewServerRuntimeLifecycleResource,
+} from "./runtime-lifecycle";
+
+const resourceNames = [
+  "runtimeCore",
+  "grpcLeaseManager",
+  "tcpPublishIngress",
+  "server",
+  "kafkaIngress",
+  "grpcIngress",
+] satisfies ReadonlyArray<ViewServerRuntimeLifecycleResource>;
+
+const expectedCloseOrder = [
+  "tcpPublishIngress",
+  "grpcIngress",
+  "kafkaIngress",
+  "server",
+  "grpcLeaseManager",
+  "runtimeCore",
+] satisfies ReadonlyArray<ViewServerRuntimeLifecycleResource>;
+
+const trackedClose =
+  (closed: Array<ViewServerRuntimeLifecycleResource>) =>
+  (resource: ViewServerRuntimeLifecycleResource): Effect.Effect<void> =>
+    Effect.sync(() => {
+      closed.push(resource);
+    });
+
+describe("ViewServerRuntimeLifecycle", () => {
+  it.effect("closes acquired runtime resources in canonical order", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+
+      for (const resource of resourceNames) {
+        yield* lifecycle.acquire(resource, Effect.succeed(resource), trackedClose(closed));
+      }
+
+      yield* lifecycle.close;
+      yield* lifecycle.close;
+
+      expect(closed).toStrictEqual(expectedCloseOrder);
+    }),
+  );
+
+  it.effect("closes already acquired resources when a later acquisition fails", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+      const server: ViewServerRuntimeLifecycleResource = "server";
+      yield* lifecycle.acquire("runtimeCore", Effect.succeed(runtimeCore), trackedClose(closed));
+      yield* lifecycle.acquire("server", Effect.succeed(server), trackedClose(closed));
+
+      const exit = yield* lifecycle
+        .acquire("kafkaIngress", Effect.fail("kafka startup failed"), trackedClose(closed))
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(closed).toStrictEqual(["server", "runtimeCore"]);
+    }),
+  );
+
+  it.effect("preserves the startup failure when cleanup also fails", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+      const server: ViewServerRuntimeLifecycleResource = "server";
+      yield* lifecycle.acquire("runtimeCore", Effect.succeed(runtimeCore), trackedClose(closed));
+      yield* lifecycle.acquire("server", Effect.succeed(server), (resource) =>
+        trackedClose(closed)(resource).pipe(Effect.andThen(Effect.die("server close failed"))),
+      );
+
+      const exit = yield* lifecycle
+        .acquire("kafkaIngress", Effect.fail("kafka startup failed"), trackedClose(closed))
+        .pipe(Effect.exit);
+
+      expect(exit).toStrictEqual(Exit.fail("kafka startup failed"));
+      expect(closed).toStrictEqual(["server", "runtimeCore"]);
+    }),
+  );
+
+  it.effect("rejects duplicate resource acquisition without overwriting finalizers", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      let acquiredDuplicateResourceCount = 0;
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+      yield* lifecycle.acquire("runtimeCore", Effect.succeed(runtimeCore), trackedClose(closed));
+
+      const duplicateExit = yield* lifecycle
+        .acquire(
+          "runtimeCore",
+          Effect.sync(() => {
+            acquiredDuplicateResourceCount += 1;
+            return runtimeCore;
+          }),
+          trackedClose(closed),
+        )
+        .pipe(Effect.exit);
+
+      expect(Exit.hasDies(duplicateExit)).toBe(true);
+      expect(acquiredDuplicateResourceCount).toBe(0);
+      expect(closed).toStrictEqual(["runtimeCore"]);
+    }),
+  );
+
+  it.effect("serializes concurrent duplicate resource acquisition", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const acquireStarted = yield* Deferred.make<void>();
+      const releaseAcquire = yield* Deferred.make<void>();
+      let acquiredDuplicateResourceCount = 0;
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+
+      const firstAcquire = yield* lifecycle
+        .acquire(
+          "runtimeCore",
+          Deferred.succeed(acquireStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseAcquire)),
+            Effect.as(runtimeCore),
+          ),
+          trackedClose(closed),
+        )
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(acquireStarted);
+
+      const duplicateAcquire = yield* lifecycle
+        .acquire(
+          "runtimeCore",
+          Effect.sync(() => {
+            acquiredDuplicateResourceCount += 1;
+            return runtimeCore;
+          }),
+          trackedClose(closed),
+        )
+        .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.succeed(releaseAcquire, undefined);
+      yield* Fiber.join(firstAcquire);
+      const duplicateExit = yield* Fiber.join(duplicateAcquire);
+
+      expect(Exit.hasDies(duplicateExit)).toBe(true);
+      expect(acquiredDuplicateResourceCount).toBe(0);
+      expect(closed).toStrictEqual(["runtimeCore"]);
+    }),
+  );
+
+  it.effect("waits for in-flight resource acquisition before closing", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const acquireStarted = yield* Deferred.make<void>();
+      const releaseAcquire = yield* Deferred.make<void>();
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+
+      const acquireFiber = yield* lifecycle
+        .acquire(
+          "runtimeCore",
+          Deferred.succeed(acquireStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseAcquire)),
+            Effect.as(runtimeCore),
+          ),
+          trackedClose(closed),
+        )
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(acquireStarted);
+      const closeFiber = yield* lifecycle.close.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.succeed(releaseAcquire, undefined);
+      yield* Fiber.join(acquireFiber);
+      yield* Fiber.join(closeFiber);
+
+      expect(closed).toStrictEqual(["runtimeCore"]);
+    }),
+  );
+
+  it.effect("keeps pending acquisition cancellable and drains already acquired resources", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const acquireStarted = yield* Deferred.make<void>();
+      const releaseAcquire = yield* Deferred.make<void>();
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+      const server: ViewServerRuntimeLifecycleResource = "server";
+      yield* lifecycle.acquire("runtimeCore", Effect.succeed(runtimeCore), trackedClose(closed));
+
+      const acquireFiber = yield* lifecycle
+        .acquire(
+          "server",
+          Deferred.succeed(acquireStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseAcquire)),
+            Effect.as(server),
+          ),
+          trackedClose(closed),
+        )
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(acquireStarted);
+      yield* Fiber.interrupt(acquireFiber);
+      const interruptExit = yield* Fiber.await(acquireFiber);
+
+      expect(Exit.hasInterrupts(interruptExit)).toBe(true);
+      expect(closed).toStrictEqual(["runtimeCore"]);
+    }),
+  );
+
+  it.effect("finishes finalizers when close is interrupted during cleanup", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const cleanupStarted = yield* Deferred.make<void>();
+      const releaseCleanup = yield* Deferred.make<void>();
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+      yield* lifecycle.acquire("runtimeCore", Effect.succeed(runtimeCore), (resource) =>
+        Deferred.succeed(cleanupStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseCleanup)),
+          Effect.andThen(trackedClose(closed)(resource)),
+        ),
+      );
+
+      const closeFiber = yield* lifecycle.close.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(cleanupStarted);
+      const interruptFiber = yield* Fiber.interrupt(closeFiber).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.succeed(releaseCleanup, undefined);
+      yield* Fiber.join(interruptFiber);
+      yield* lifecycle.close;
+
+      expect(closed).toStrictEqual(["runtimeCore"]);
+    }),
+  );
+
+  it.effect("rejects queued acquisitions while startup failure cleanup is draining", () =>
+    Effect.gen(function* () {
+      const lifecycle = yield* makeViewServerRuntimeLifecycle();
+      const closed: Array<ViewServerRuntimeLifecycleResource> = [];
+      const cleanupStarted = yield* Deferred.make<void>();
+      const releaseCleanup = yield* Deferred.make<void>();
+      let queuedAcquireCount = 0;
+      const runtimeCore: ViewServerRuntimeLifecycleResource = "runtimeCore";
+      const kafkaIngress: ViewServerRuntimeLifecycleResource = "kafkaIngress";
+      yield* lifecycle.acquire("runtimeCore", Effect.succeed(runtimeCore), (resource) =>
+        Deferred.succeed(cleanupStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseCleanup)),
+          Effect.andThen(trackedClose(closed)(resource)),
+        ),
+      );
+
+      const failingAcquire = yield* lifecycle
+        .acquire("server", Effect.fail("server startup failed"), trackedClose(closed))
+        .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(cleanupStarted);
+      const queuedAcquire = yield* lifecycle
+        .acquire(
+          "kafkaIngress",
+          Effect.sync(() => {
+            queuedAcquireCount += 1;
+            return kafkaIngress;
+          }),
+          trackedClose(closed),
+        )
+        .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.succeed(releaseCleanup, undefined);
+      const failingExit = yield* Fiber.join(failingAcquire);
+      const queuedExit = yield* Fiber.join(queuedAcquire);
+
+      expect(failingExit).toStrictEqual(Exit.fail("server startup failed"));
+      expect(Exit.hasDies(queuedExit)).toBe(true);
+      expect(queuedAcquireCount).toBe(0);
+      expect(closed).toStrictEqual(["runtimeCore"]);
+    }),
+  );
+});

--- a/packages/runtime/src/runtime-lifecycle.ts
+++ b/packages/runtime/src/runtime-lifecycle.ts
@@ -1,0 +1,165 @@
+import { runAllFinalizers } from "@effect-view-server/effect-utils";
+import { Effect, Ref, Semaphore } from "effect";
+
+type ViewServerRuntimeLifecycleState = {
+  readonly closed: boolean;
+  readonly grpcIngress?: Effect.Effect<void>;
+  readonly grpcLeaseManager?: Effect.Effect<void>;
+  readonly kafkaIngress?: Effect.Effect<void>;
+  readonly runtimeCore?: Effect.Effect<void>;
+  readonly server?: Effect.Effect<void>;
+  readonly tcpPublishIngress?: Effect.Effect<void>;
+};
+
+export type ViewServerRuntimeLifecycleResource =
+  | "grpcIngress"
+  | "grpcLeaseManager"
+  | "kafkaIngress"
+  | "runtimeCore"
+  | "server"
+  | "tcpPublishIngress";
+
+export type ViewServerRuntimeLifecycle = {
+  readonly acquire: <A, E, R>(
+    resource: ViewServerRuntimeLifecycleResource,
+    acquire: Effect.Effect<A, E, R>,
+    close: (value: A) => Effect.Effect<void>,
+  ) => Effect.Effect<A, E, R>;
+  readonly close: Effect.Effect<void>;
+};
+
+const emptyLifecycleState: ViewServerRuntimeLifecycleState = {
+  closed: false,
+};
+
+const closedLifecycleState: ViewServerRuntimeLifecycleState = {
+  closed: true,
+};
+
+const ignoreRuntimeStartupCleanupFailure = <R>(
+  cleanup: Effect.Effect<void, never, R>,
+): Effect.Effect<void, never, R> =>
+  cleanup.pipe(
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Ignoring runtime startup cleanup failure.", cause),
+    ),
+  );
+
+const lifecycleStateWithResource = (
+  state: ViewServerRuntimeLifecycleState,
+  resource: ViewServerRuntimeLifecycleResource,
+  close: Effect.Effect<void>,
+): ViewServerRuntimeLifecycleState => {
+  switch (resource) {
+    case "grpcIngress":
+      return { ...state, grpcIngress: close };
+    case "grpcLeaseManager":
+      return { ...state, grpcLeaseManager: close };
+    case "kafkaIngress":
+      return { ...state, kafkaIngress: close };
+    case "runtimeCore":
+      return { ...state, runtimeCore: close };
+    case "server":
+      return { ...state, server: close };
+    case "tcpPublishIngress":
+      return { ...state, tcpPublishIngress: close };
+  }
+};
+
+const lifecycleFinalizers = (
+  state: ViewServerRuntimeLifecycleState,
+): ReadonlyArray<Effect.Effect<void>> => {
+  const finalizers: Array<Effect.Effect<void>> = [];
+  if (state.tcpPublishIngress !== undefined) {
+    finalizers.push(state.tcpPublishIngress);
+  }
+  if (state.grpcIngress !== undefined) {
+    finalizers.push(state.grpcIngress);
+  }
+  if (state.kafkaIngress !== undefined) {
+    finalizers.push(state.kafkaIngress);
+  }
+  if (state.server !== undefined) {
+    finalizers.push(state.server);
+  }
+  if (state.grpcLeaseManager !== undefined) {
+    finalizers.push(state.grpcLeaseManager);
+  }
+  if (state.runtimeCore !== undefined) {
+    finalizers.push(state.runtimeCore);
+  }
+  return finalizers;
+};
+
+const lifecycleStateHasResource = (
+  state: ViewServerRuntimeLifecycleState,
+  resource: ViewServerRuntimeLifecycleResource,
+): boolean => {
+  switch (resource) {
+    case "grpcIngress":
+      return state.grpcIngress !== undefined;
+    case "grpcLeaseManager":
+      return state.grpcLeaseManager !== undefined;
+    case "kafkaIngress":
+      return state.kafkaIngress !== undefined;
+    case "runtimeCore":
+      return state.runtimeCore !== undefined;
+    case "server":
+      return state.server !== undefined;
+    case "tcpPublishIngress":
+      return state.tcpPublishIngress !== undefined;
+  }
+};
+
+const lifecycleStateRejectsAcquire = (
+  state: ViewServerRuntimeLifecycleState,
+  resource: ViewServerRuntimeLifecycleResource,
+): boolean => state.closed || lifecycleStateHasResource(state, resource);
+
+export const makeViewServerRuntimeLifecycle = Effect.fn("ViewServerRuntimeLifecycle.make")(
+  function* () {
+    const state = yield* Ref.make<ViewServerRuntimeLifecycleState>(emptyLifecycleState);
+    const acquireLock = yield* Semaphore.make(1);
+    const drain = Effect.fn("ViewServerRuntimeLifecycle.drain")(function* () {
+      const finalizers = lifecycleFinalizers(yield* Ref.getAndSet(state, closedLifecycleState));
+      yield* runAllFinalizers(finalizers);
+    });
+    const drainUninterruptibly = Effect.uninterruptible(drain());
+    const close = Effect.fn("ViewServerRuntimeLifecycle.close")(function* () {
+      yield* acquireLock.withPermit(drainUninterruptibly);
+    });
+    const acquire: ViewServerRuntimeLifecycle["acquire"] = (
+      resource,
+      acquireResource,
+      closeResource,
+    ) => {
+      const acquireWithAtomicRegistration = Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const current = yield* Ref.get(state);
+          if (lifecycleStateRejectsAcquire(current, resource)) {
+            return yield* Effect.die(
+              new Error(`Runtime lifecycle resource already acquired: ${resource}`),
+            );
+          }
+          const value = yield* restore(acquireResource);
+          yield* Ref.update(state, (next) =>
+            lifecycleStateWithResource(next, resource, closeResource(value)),
+          );
+          return value;
+        }),
+      ).pipe(
+        Effect.catchCause((cause) =>
+          ignoreRuntimeStartupCleanupFailure(drainUninterruptibly).pipe(
+            Effect.andThen(Effect.failCause(cause)),
+          ),
+        ),
+        Effect.onInterrupt(() => ignoreRuntimeStartupCleanupFailure(drainUninterruptibly)),
+      );
+      return acquireLock.withPermit(acquireWithAtomicRegistration);
+    };
+    return {
+      acquire,
+      close: close(),
+    };
+  },
+);


### PR DESCRIPTION
## Summary
- add a runtime lifecycle Module that owns acquisition, finalizer registration, canonical close order, startup-failure cleanup, and idempotent close
- route runtime construction through the lifecycle seam instead of hand-written cleanup chains
- add lifecycle regression coverage for duplicate acquisition, concurrent acquire/close, interruption, startup failure cleanup, finalizer interruption, and runtime startup interruption before the public handle is returned

## Validation
- vp check --fix packages/runtime/src/runtime-lifecycle.ts packages/runtime/src/runtime-lifecycle.test.ts packages/runtime/src/internal.ts packages/runtime/src/index.test.ts
- vp run @effect-view-server/runtime#test
- vp exec effect-language-service diagnostics --project packages/runtime/tsconfig.json --format text --strict
- vp run @effect-view-server/runtime#build
- vp run -w ready

## Review
- 3 local reviewer agents: clean