### PR TITLE
Deepen gRPC source lifecycle

### DIFF
--- a/packages/runtime/src/grpc-ingress.ts
+++ b/packages/runtime/src/grpc-ingress.ts
@@ -1,78 +1,47 @@
-import { createClient } from "@connectrpc/connect";
-import { createGrpcTransport } from "@connectrpc/connect-node";
-import {
-  type GrpcClientValue,
-  type GrpcConnectClientDefinition,
-  type GrpcRuntimeClients,
-  type ViewServerTopicConfig,
-} from "@effect-view-server/config";
+import { type GrpcRuntimeClients, type ViewServerTopicConfig } from "@effect-view-server/config";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
 import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
 import { Cause, Clock, Effect, Exit, Fiber, Option, Schema, Scope, Stream } from "effect";
 import type { ViewServerGrpcHealthLedger } from "./grpc-health";
+import {
+  callMaterializedGrpcSourceAcquire,
+  callMaterializedGrpcSourceRelease,
+  callMaterializedGrpcSourceRequest,
+  makeGrpcSourceInput,
+  makeDefaultGrpcClient,
+  makeViewServerGrpcSourceError,
+  ViewServerGrpcIngressError,
+  type ViewServerGrpcClientFactory,
+  type ViewServerGrpcRuntimeCallable,
+} from "./grpc-source-lifecycle";
 import type { ResolvedViewServerGrpcRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
-export class ViewServerGrpcIngressError extends Schema.TaggedErrorClass<ViewServerGrpcIngressError>()(
-  "ViewServerGrpcIngressError",
-  {
-    message: Schema.String,
-    cause: Schema.Unknown,
-    phase: Schema.optionalKey(
-      Schema.Literals([
-        "configuration",
-        "client",
-        "request",
-        "acquire",
-        "stream",
-        "mapping",
-        "publish",
-        "release",
-      ]),
-    ),
-    feedName: Schema.optionalKey(Schema.String),
-    topic: Schema.optionalKey(Schema.String),
-  },
-) {}
+export { ViewServerGrpcIngressError } from "./grpc-source-lifecycle";
 
 export type ViewServerGrpcIngress = {
   readonly close: Effect.Effect<void>;
 };
-
-type RuntimeCallable = (...args: ReadonlyArray<never>) => unknown;
 
 type RuntimeMaterializedFeedDefinition<Topic extends string = string> = {
   readonly lifecycle: "materialized";
   readonly topic: Topic;
   readonly client: string;
   readonly method: string;
-  readonly request: RuntimeCallable;
-  readonly acquire: RuntimeCallable;
-  readonly release?: RuntimeCallable;
-  readonly map: RuntimeCallable;
+  readonly request: ViewServerGrpcRuntimeCallable;
+  readonly acquire: ViewServerGrpcRuntimeCallable;
+  readonly release?: ViewServerGrpcRuntimeCallable;
+  readonly map: ViewServerGrpcRuntimeCallable;
 };
 
 const isRuntimeMaterializedFeed = <const Topic extends string>(feed: {
   readonly lifecycle: string;
 }): feed is RuntimeMaterializedFeedDefinition<Topic> => feed.lifecycle === "materialized";
 
-export type ViewServerGrpcClientFactory = <
-  const ClientDefinition extends GrpcConnectClientDefinition,
->(
-  definition: ClientDefinition,
-  baseUrl: string,
-) => GrpcClientValue<ClientDefinition>;
-
 type ViewServerGrpcHealthRefreshRequest = Effect.Effect<void>;
 
 const grpcMessageBatchSize = 256;
 const grpcMessageBatchFlushInterval = "2 millis";
-
-const materializedFeedSession = {
-  id: null,
-  forwardedHeaders: {},
-  systemHeaders: {},
-};
 
 const ignoreGrpcFeedReleaseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
   "Ignoring gRPC feed release failure.",
@@ -81,35 +50,13 @@ const ignoreGrpcHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTyped
   "Ignoring gRPC health refresh failure.",
 );
 
-const isRuntimeMaterializedStream = (
-  value: unknown,
-): value is Stream.Stream<unknown, unknown, never> => Stream.isStream(value);
-
-const isRuntimeReleaseEffect = (value: unknown): value is Effect.Effect<void, unknown, never> =>
-  Effect.isEffect(value);
-
-export function makeDefaultGrpcClient<const ClientDefinition extends GrpcConnectClientDefinition>(
-  definition: ClientDefinition,
-  baseUrl: string,
-): GrpcClientValue<ClientDefinition>;
-export function makeDefaultGrpcClient(definition: GrpcConnectClientDefinition, baseUrl: string) {
-  return createClient(definition.service, createGrpcTransport({ baseUrl }));
-}
-
 const grpcIngressError = (input: {
   readonly message: string;
   readonly cause: unknown;
   readonly phase: NonNullable<ViewServerGrpcIngressError["phase"]>;
   readonly feedName: string;
   readonly topic: string;
-}) =>
-  new ViewServerGrpcIngressError({
-    message: input.message,
-    cause: input.cause,
-    phase: input.phase,
-    feedName: input.feedName,
-    topic: input.topic,
-  });
+}) => makeViewServerGrpcSourceError(input);
 
 const hasMessage = (value: unknown): value is { readonly message: string } =>
   typeof value === "object" &&
@@ -352,13 +299,6 @@ const publishMaterializedBatch = Effect.fn("ViewServerRuntime.grpc.materialized.
   },
 );
 
-const materializedAcquireInput = (grpcClient: unknown, request: unknown) => ({
-  client: grpcClient,
-  request,
-  route: undefined,
-  session: materializedFeedSession,
-});
-
 const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.start")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
   const Clients extends GrpcRuntimeClients,
@@ -406,19 +346,8 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
         topic: feed.topic,
       }),
   });
-  const request = yield* Effect.try({
-    try: () => feed.request(),
-    catch: (cause) =>
-      grpcIngressError({
-        message: `gRPC feed request creation failed for ${feedName}`,
-        cause,
-        phase: "request",
-        feedName,
-        topic: feed.topic,
-      }),
-  });
-  const input = materializedAcquireInput(grpcClient, request);
-  const releaseFeed = feed.release;
+  const request = yield* callMaterializedGrpcSourceRequest(feedName, feed);
+  const input = makeGrpcSourceInput(grpcClient, request, undefined);
   const startedAt = yield* Clock.currentTimeMillis;
   yield* health.clientConnected(feed.client, startedAt);
   yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
@@ -431,70 +360,8 @@ const startMaterializedFeed = Effect.fn("ViewServerRuntime.grpc.materialized.sta
   registerCloseFeedState(() => {
     closing = true;
   });
-  const releaseFeedEffect = Effect.fn("ViewServerRuntime.grpc.materialized.feed.release")(
-    function* () {
-      if (releaseFeed === undefined) {
-        return;
-      }
-      const releaseCandidate = yield* Effect.try({
-        try: () => Reflect.apply(releaseFeed, undefined, [input]),
-        catch: (cause) =>
-          grpcIngressError({
-            message: `gRPC feed release failed for ${feedName}`,
-            cause,
-            phase: "release",
-            feedName,
-            topic: feed.topic,
-          }),
-      });
-      if (!isRuntimeReleaseEffect(releaseCandidate)) {
-        return yield* grpcIngressError({
-          message: `gRPC feed release did not return an Effect for ${feedName}`,
-          cause: releaseCandidate,
-          phase: "release",
-          feedName,
-          topic: feed.topic,
-        });
-      }
-      yield* releaseCandidate.pipe(
-        Effect.mapError((cause) =>
-          grpcIngressError({
-            message: `gRPC feed release failed for ${feedName}`,
-            cause,
-            phase: "release",
-            feedName,
-            topic: feed.topic,
-          }),
-        ),
-      );
-    },
-  );
-  const acquireFeedStream = Effect.try({
-    try: () => Reflect.apply(feed.acquire, undefined, [input]),
-    catch: (cause) =>
-      grpcIngressError({
-        message: `gRPC feed acquire failed for ${feedName}`,
-        cause,
-        phase: "acquire",
-        feedName,
-        topic: feed.topic,
-      }),
-  }).pipe(
-    Effect.flatMap((stream) => {
-      if (isRuntimeMaterializedStream(stream)) {
-        return Effect.succeed(stream);
-      }
-      return Effect.fail(
-        grpcIngressError({
-          message: `gRPC feed acquire did not return a Stream for ${feedName}`,
-          cause: stream,
-          phase: "acquire",
-          feedName,
-          topic: feed.topic,
-        }),
-      );
-    }),
-  );
+  const releaseFeedEffect = () => callMaterializedGrpcSourceRelease(feedName, feed, input);
+  const acquireFeedStream = callMaterializedGrpcSourceAcquire(feedName, feed, input);
   const runFeedStream = Effect.fn("ViewServerRuntime.grpc.materialized.stream")(function* (
     stream: Stream.Stream<unknown, unknown>,
   ) {

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -38,10 +38,17 @@ import {
 import * as BigDecimal from "effect/BigDecimal";
 import type { ViewServerGrpcHealthLedger } from "./grpc-health";
 import {
+  callLeasedGrpcSourceAcquire,
+  callLeasedGrpcSourceRelease,
+  callLeasedGrpcSourceRequest,
+  makeGrpcSourceInput,
   makeDefaultGrpcClient,
+  makeViewServerGrpcSourceError,
   ViewServerGrpcIngressError,
   type ViewServerGrpcClientFactory,
-} from "./grpc-ingress";
+  type ViewServerGrpcRuntimeCallable,
+  type ViewServerGrpcSourceInput,
+} from "./grpc-source-lifecycle";
 import type { ResolvedViewServerGrpcRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 import {
@@ -52,17 +59,15 @@ import {
 
 type ViewServerGrpcHealthRefreshRequest = Effect.Effect<void>;
 
-type RuntimeCallable = (...args: ReadonlyArray<never>) => unknown;
-
 type RuntimeLeasedFeedDefinition = {
   readonly lifecycle: "leased";
   readonly topic: string;
   readonly client: string;
   readonly routeBy: ReadonlyArray<string>;
-  readonly request: RuntimeCallable;
-  readonly acquire: RuntimeCallable;
-  readonly release?: RuntimeCallable;
-  readonly map: RuntimeCallable;
+  readonly request: ViewServerGrpcRuntimeCallable;
+  readonly acquire: ViewServerGrpcRuntimeCallable;
+  readonly release?: ViewServerGrpcRuntimeCallable;
+  readonly map: ViewServerGrpcRuntimeCallable;
 };
 
 const isRuntimeLeasedFeed = (feed: {
@@ -88,16 +93,7 @@ type CanonicalRouteValue =
 
 type LeasedFeedRoute = Readonly<Record<string, CanonicalRouteValue>>;
 
-type LeasedFeedRuntimeInput = {
-  readonly client: unknown;
-  readonly request: unknown;
-  readonly route: LeasedFeedRoute;
-  readonly session: {
-    readonly id: string | null;
-    readonly forwardedHeaders: Readonly<Record<string, string>>;
-    readonly systemHeaders: Readonly<Record<string, string>>;
-  };
-};
+type LeasedFeedRuntimeInput = ViewServerGrpcSourceInput<LeasedFeedRoute>;
 
 type ActiveLease = {
   readonly feedName: string;
@@ -133,18 +129,6 @@ export type ViewServerGrpcLeaseManager<Topics extends ViewServerRuntimeTopicDefi
 const grpcMessageBatchSize = 256;
 const grpcMessageBatchFlushInterval = "2 millis";
 
-const sharedLeasedFeedSession = {
-  id: null,
-  forwardedHeaders: {},
-  systemHeaders: {},
-};
-
-const isRuntimeLeasedStream = (value: unknown): value is Stream.Stream<unknown, unknown, never> =>
-  Stream.isStream(value);
-
-const isRuntimeReleaseEffect = (value: unknown): value is Effect.Effect<void, unknown, never> =>
-  Effect.isEffect(value);
-
 const isRuntimeMutationEffect = (value: unknown): value is Effect.Effect<unknown, unknown, never> =>
   Effect.isEffect(value);
 
@@ -178,12 +162,14 @@ const runtimeError = (input: {
 const grpcLeaseError = (input: {
   readonly message: string;
   readonly cause: unknown;
+  readonly phase: NonNullable<ViewServerGrpcIngressError["phase"]>;
   readonly feedName: string;
   readonly topic: string;
 }) =>
-  new ViewServerGrpcIngressError({
+  makeViewServerGrpcSourceError({
     message: input.message,
     cause: input.cause,
+    phase: input.phase,
     feedName: input.feedName,
     topic: input.topic,
   });
@@ -368,6 +354,7 @@ const routeFeedKey = Effect.fn("ViewServerRuntime.grpc.leased.route.feedKey")(fu
       return yield* grpcLeaseError({
         message: `Leased gRPC route is missing configured field ${field}`,
         cause: route,
+        phase: "request",
         feedName,
         topic,
       });
@@ -381,83 +368,23 @@ const routeFeedKey = Effect.fn("ViewServerRuntime.grpc.leased.route.feedKey")(fu
 const internalRowKey = (feedKey: string, publicKey: string): string =>
   `${feedKey}/row/${publicKey}`;
 
-const callFeedRequest: (
+const callFeedRequest = (
   feedName: string,
   feed: RuntimeLeasedFeedDefinition,
   route: LeasedFeedRoute,
-) => Effect.Effect<unknown, ViewServerGrpcIngressError, never> = Effect.fn(
-  "ViewServerRuntime.grpc.leased.request",
-)(function* (feedName, feed, route) {
-  return yield* Effect.try({
-    try: () => Reflect.apply(feed.request, undefined, [route]),
-    catch: (cause) =>
-      grpcLeaseError({
-        message: `gRPC leased feed request creation failed for ${feedName}`,
-        cause,
-        feedName,
-        topic: feed.topic,
-      }),
-  });
-});
+) => callLeasedGrpcSourceRequest(feedName, feed, route);
 
-const callFeedAcquire: (
+const callFeedAcquire = (
   feedName: string,
   feed: RuntimeLeasedFeedDefinition,
   input: LeasedFeedRuntimeInput,
-) => Effect.Effect<Stream.Stream<unknown, unknown, never>, ViewServerGrpcIngressError, never> =
-  Effect.fn("ViewServerRuntime.grpc.leased.acquire")(function* (feedName, feed, input) {
-    const stream = yield* Effect.try({
-      try: () => Reflect.apply(feed.acquire, undefined, [input]),
-      catch: (cause) =>
-        grpcLeaseError({
-          message: `gRPC leased feed acquire failed for ${feedName}`,
-          cause,
-          feedName,
-          topic: feed.topic,
-        }),
-    });
-    if (isRuntimeLeasedStream(stream)) {
-      return stream;
-    }
-    return yield* grpcLeaseError({
-      message: `gRPC leased feed acquire did not return a Stream for ${feedName}`,
-      cause: stream,
-      feedName,
-      topic: feed.topic,
-    });
-  });
+) => callLeasedGrpcSourceAcquire(feedName, feed, input);
 
-const callFeedRelease: (
+const callFeedRelease = (
   feedName: string,
   feed: RuntimeLeasedFeedDefinition,
   input: LeasedFeedRuntimeInput,
-) => Effect.Effect<void, unknown, never> = Effect.fn("ViewServerRuntime.grpc.leased.release")(
-  function* (feedName, feed, input) {
-    const releaseCallback = feed.release;
-    if (releaseCallback === undefined) {
-      return;
-    }
-    const release = yield* Effect.try({
-      try: () => Reflect.apply(releaseCallback, undefined, [input]),
-      catch: (cause) =>
-        grpcLeaseError({
-          message: `gRPC leased feed release failed for ${feedName}`,
-          cause,
-          feedName,
-          topic: feed.topic,
-        }),
-    });
-    if (!isRuntimeReleaseEffect(release)) {
-      return yield* grpcLeaseError({
-        message: `gRPC leased feed release did not return an Effect for ${feedName}`,
-        cause: release,
-        feedName,
-        topic: feed.topic,
-      });
-    }
-    yield* release.pipe(Effect.asVoid);
-  },
-);
+) => callLeasedGrpcSourceRelease(feedName, feed, input);
 
 const topicDefinitionFor = <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerTopicConfig<Topics>,
@@ -472,6 +399,7 @@ const topicDefinitionFor = <const Topics extends ViewServerRuntimeTopicDefinitio
     return grpcLeaseError({
       message: `gRPC leased feed ${feedName} references unknown topic ${topic}`,
       cause: topic,
+      phase: "configuration",
       feedName,
       topic,
     });
@@ -494,6 +422,7 @@ const runtimeTopicFor = <const Topics extends ViewServerRuntimeTopicDefinitions>
     return grpcLeaseError({
       message: `gRPC leased feed ${feedName} references unknown topic ${topic}`,
       cause: topic,
+      phase: "configuration",
       feedName,
       topic,
     });
@@ -522,6 +451,7 @@ const mapLeasedValue = Effect.fn("ViewServerRuntime.grpc.leased.map")(function* 
       grpcLeaseError({
         message: `gRPC leased feed mapping failed for ${feedName}`,
         cause,
+        phase: "mapping",
         feedName,
         topic: feed.topic,
       }),
@@ -531,6 +461,7 @@ const mapLeasedValue = Effect.fn("ViewServerRuntime.grpc.leased.map")(function* 
       grpcLeaseError({
         message: `gRPC leased feed mapping produced an invalid row for ${feedName}`,
         cause,
+        phase: "mapping",
         feedName,
         topic: feed.topic,
       }),
@@ -555,6 +486,7 @@ const rowKey = <const Topics extends ViewServerRuntimeTopicDefinitions>(
     return yield* grpcLeaseError({
       message: `gRPC leased feed row key ${keyField} for ${topic} is not a string`,
       cause: key,
+      phase: "mapping",
       feedName,
       topic,
     });
@@ -602,6 +534,7 @@ const validateLeasedRowRoute = Effect.fn("ViewServerRuntime.grpc.leased.row.vali
             rowValue,
             routeValue,
           },
+          phase: "mapping",
           feedName: lease.feedName,
           topic: lease.feed.topic,
         });
@@ -856,6 +789,7 @@ const callRuntimePublishMany = Effect.fn(
     return yield* grpcLeaseError({
       message: `Runtime publishManyDecodedRowsWithStorageKeys did not return an Effect for leased gRPC feed ${feedName}`,
       cause: effect,
+      phase: "publish",
       feedName,
       topic,
     });
@@ -866,6 +800,7 @@ const callRuntimePublishMany = Effect.fn(
       grpcLeaseError({
         message: `gRPC leased feed publish failed for ${feedName}`,
         cause,
+        phase: "publish",
         feedName,
         topic,
       }),
@@ -887,6 +822,7 @@ const callRuntimeDelete = Effect.fn("ViewServerRuntime.grpc.leased.runtime.delet
     return yield* grpcLeaseError({
       message: `Runtime delete did not return an Effect for leased gRPC feed ${feedName}`,
       cause: effect,
+      phase: "release",
       feedName,
       topic,
     });
@@ -897,6 +833,7 @@ const callRuntimeDelete = Effect.fn("ViewServerRuntime.grpc.leased.runtime.delet
       grpcLeaseError({
         message: `gRPC leased feed row cleanup failed for ${feedName}`,
         cause,
+        phase: "release",
         feedName,
         topic,
       }),
@@ -1007,6 +944,7 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
       grpcLeaseError({
         message: `gRPC leased feed stream failed for ${lease.feedName}`,
         cause,
+        phase: "stream",
         feedName: lease.feedName,
         topic: lease.feed.topic,
       }),
@@ -1195,6 +1133,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         grpcLeaseError({
           message: `gRPC leased client creation failed for ${feedName}`,
           cause,
+          phase: "client",
           feedName,
           topic,
         }),
@@ -1235,12 +1174,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         leases.set(feedKey, lease);
-        const input: LeasedFeedRuntimeInput = {
-          client: grpcClient,
-          request,
-          route,
-          session: sharedLeasedFeedSession,
-        };
+        const input: LeasedFeedRuntimeInput = makeGrpcSourceInput(grpcClient, request, route);
         const startedAt = yield* Clock.currentTimeMillis;
         yield* health.clientConnected(feed.client, startedAt);
         yield* health.leasedFeedStarting({

--- a/packages/runtime/src/grpc-source-lifecycle.test.ts
+++ b/packages/runtime/src/grpc-source-lifecycle.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Stream } from "effect";
+import {
+  callLeasedGrpcSourceAcquire,
+  callLeasedGrpcSourceRelease,
+  callLeasedGrpcSourceRequest,
+  callMaterializedGrpcSourceAcquire,
+  callMaterializedGrpcSourceRelease,
+  callMaterializedGrpcSourceRequest,
+  makeGrpcSourceInput,
+  makeViewServerGrpcSourceError,
+} from "./grpc-source-lifecycle";
+
+const sourceInput = <Route>(request: unknown, route: Route) =>
+  makeGrpcSourceInput({ name: "orders-client" }, request, route);
+
+describe("gRPC source lifecycle", () => {
+  it.effect("calls request, acquire, and release through one source lifecycle seam", () =>
+    Effect.gen(function* () {
+      const operations: Array<string> = [];
+      const feed = {
+        topic: "orders",
+        request: () => {
+          operations.push("request");
+          return "orders-request";
+        },
+        acquire: (input: ReturnType<typeof sourceInput>) => {
+          expect(input.request).toBe("orders-request");
+          operations.push("acquire");
+          return Stream.make("row-1", "row-2");
+        },
+        release: (input: ReturnType<typeof sourceInput>) =>
+          Effect.sync(() => {
+            expect(input.request).toBe("orders-request");
+            operations.push("release");
+          }),
+      };
+
+      const request = yield* callMaterializedGrpcSourceRequest("ordersFeed", feed);
+      const stream = yield* callMaterializedGrpcSourceAcquire(
+        "ordersFeed",
+        feed,
+        sourceInput(request, undefined),
+      );
+      const rows = yield* Stream.runCollect(stream);
+      yield* callMaterializedGrpcSourceRelease("ordersFeed", feed, sourceInput(request, undefined));
+
+      expect({
+        operations,
+        rows: Array.from(rows),
+      }).toStrictEqual({
+        operations: ["request", "acquire", "release"],
+        rows: ["row-1", "row-2"],
+      });
+    }),
+  );
+
+  it.effect("normalizes request construction failures with source context", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => {
+          throw "request exploded";
+        },
+        acquire: () => Stream.never,
+      };
+
+      const error = yield* Effect.flip(
+        callLeasedGrpcSourceRequest("ordersLease", feed, { region: "usa" }),
+      );
+      expect({
+        _tag: error._tag,
+        cause: error.cause,
+        feedName: error.feedName,
+        message: error.message,
+        phase: error.phase,
+        topic: error.topic,
+      }).toStrictEqual({
+        _tag: "ViewServerGrpcIngressError",
+        cause: "request exploded",
+        feedName: "ordersLease",
+        message: "gRPC leased feed request creation failed for ordersLease",
+        phase: "request",
+        topic: "orders",
+      });
+    }),
+  );
+
+  it.effect("rejects acquire callbacks that do not return a stream", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => undefined,
+        acquire: () => "not-a-stream",
+      };
+
+      const error = yield* Effect.flip(
+        callMaterializedGrpcSourceAcquire("ordersFeed", feed, sourceInput(undefined, undefined)),
+      );
+
+      expect({
+        _tag: error._tag,
+        cause: error.cause,
+        feedName: error.feedName,
+        message: error.message,
+        phase: error.phase,
+        topic: error.topic,
+      }).toStrictEqual({
+        _tag: "ViewServerGrpcIngressError",
+        cause: "not-a-stream",
+        feedName: "ordersFeed",
+        message: "gRPC feed acquire did not return a Stream for ordersFeed",
+        phase: "acquire",
+        topic: "orders",
+      });
+    }),
+  );
+
+  it.effect("normalizes acquire callback defects with source context", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => undefined,
+        acquire: () => {
+          throw "acquire exploded";
+        },
+      };
+
+      const error = yield* Effect.flip(
+        callLeasedGrpcSourceAcquire("ordersLease", feed, sourceInput(undefined, { region: "usa" })),
+      );
+
+      expect({
+        _tag: error._tag,
+        cause: error.cause,
+        feedName: error.feedName,
+        message: error.message,
+        phase: error.phase,
+        topic: error.topic,
+      }).toStrictEqual({
+        _tag: "ViewServerGrpcIngressError",
+        cause: "acquire exploded",
+        feedName: "ordersLease",
+        message: "gRPC leased feed acquire failed for ordersLease",
+        phase: "acquire",
+        topic: "orders",
+      });
+    }),
+  );
+
+  it.effect("treats missing release callbacks as a no-op", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => undefined,
+        acquire: () => Stream.never,
+      };
+
+      const result = yield* callMaterializedGrpcSourceRelease(
+        "ordersFeed",
+        feed,
+        sourceInput(undefined, undefined),
+      );
+
+      expect(result).toBeUndefined();
+    }),
+  );
+
+  it.effect("normalizes release callback defects with source context", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => undefined,
+        acquire: () => Stream.never,
+        release: () => {
+          throw "release exploded";
+        },
+      };
+
+      const error = yield* Effect.flip(
+        callMaterializedGrpcSourceRelease("ordersFeed", feed, sourceInput(undefined, undefined)),
+      );
+
+      expect({
+        _tag: error._tag,
+        cause: error.cause,
+        feedName: error.feedName,
+        message: error.message,
+        phase: error.phase,
+        topic: error.topic,
+      }).toStrictEqual({
+        _tag: "ViewServerGrpcIngressError",
+        cause: "release exploded",
+        feedName: "ordersFeed",
+        message: "gRPC feed release failed for ordersFeed",
+        phase: "release",
+        topic: "orders",
+      });
+    }),
+  );
+
+  it.effect("rejects release callbacks that do not return an Effect", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => undefined,
+        acquire: () => Stream.never,
+        release: () => "not-an-effect",
+      };
+
+      const error = yield* Effect.flip(
+        callLeasedGrpcSourceRelease("ordersLease", feed, sourceInput(undefined, { region: "usa" })),
+      );
+
+      expect({
+        _tag: error._tag,
+        cause: error.cause,
+        feedName: error.feedName,
+        message: error.message,
+        phase: error.phase,
+        topic: error.topic,
+      }).toStrictEqual({
+        _tag: "ViewServerGrpcIngressError",
+        cause: "not-an-effect",
+        feedName: "ordersLease",
+        message: "gRPC leased feed release did not return an Effect for ordersLease",
+        phase: "release",
+        topic: "orders",
+      });
+    }),
+  );
+
+  it.effect("normalizes release effect failures with source context", () =>
+    Effect.gen(function* () {
+      const feed = {
+        topic: "orders",
+        request: () => undefined,
+        acquire: () => Stream.never,
+        release: () => Effect.fail("release effect failed"),
+      };
+
+      const error = yield* Effect.flip(
+        callLeasedGrpcSourceRelease("ordersLease", feed, sourceInput(undefined, { region: "usa" })),
+      );
+
+      expect({
+        _tag: error._tag,
+        cause: error.cause,
+        feedName: error.feedName,
+        message: error.message,
+        phase: error.phase,
+        topic: error.topic,
+      }).toStrictEqual({
+        _tag: "ViewServerGrpcIngressError",
+        cause: "release effect failed",
+        feedName: "ordersLease",
+        message: "gRPC leased feed release failed for ordersLease",
+        phase: "release",
+        topic: "orders",
+      });
+    }),
+  );
+
+  it("constructs source errors without a phase when the caller has no phase to report", () => {
+    const error = makeViewServerGrpcSourceError({
+      cause: "route",
+      feedName: "ordersLease",
+      message: "leased route failed",
+      topic: "orders",
+    });
+
+    expect({
+      _tag: error._tag,
+      cause: error.cause,
+      feedName: error.feedName,
+      message: error.message,
+      phase: error.phase,
+      topic: error.topic,
+    }).toStrictEqual({
+      _tag: "ViewServerGrpcIngressError",
+      cause: "route",
+      feedName: "ordersLease",
+      message: "leased route failed",
+      phase: undefined,
+      topic: "orders",
+    });
+  });
+
+  it("creates isolated immutable session objects for each source input", () => {
+    const firstInput = sourceInput({ requestId: "first" }, undefined);
+    const secondInput = sourceInput({ requestId: "second" }, undefined);
+
+    expect(firstInput.session).not.toBe(secondInput.session);
+    expect(firstInput.session.forwardedHeaders).not.toBe(secondInput.session.forwardedHeaders);
+    expect(firstInput.session.systemHeaders).not.toBe(secondInput.session.systemHeaders);
+    expect({
+      firstSessionFrozen: Object.isFrozen(firstInput.session),
+      firstForwardedHeadersFrozen: Object.isFrozen(firstInput.session.forwardedHeaders),
+      firstSystemHeadersFrozen: Object.isFrozen(firstInput.session.systemHeaders),
+      secondSessionFrozen: Object.isFrozen(secondInput.session),
+      secondForwardedHeadersFrozen: Object.isFrozen(secondInput.session.forwardedHeaders),
+      secondSystemHeadersFrozen: Object.isFrozen(secondInput.session.systemHeaders),
+    }).toStrictEqual({
+      firstSessionFrozen: true,
+      firstForwardedHeadersFrozen: true,
+      firstSystemHeadersFrozen: true,
+      secondSessionFrozen: true,
+      secondForwardedHeadersFrozen: true,
+      secondSystemHeadersFrozen: true,
+    });
+  });
+});

--- a/packages/runtime/src/grpc-source-lifecycle.ts
+++ b/packages/runtime/src/grpc-source-lifecycle.ts
@@ -1,0 +1,269 @@
+import { createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import type { GrpcClientValue, GrpcConnectClientDefinition } from "@effect-view-server/config";
+import { Effect, Schema, Stream } from "effect";
+
+export class ViewServerGrpcIngressError extends Schema.TaggedErrorClass<ViewServerGrpcIngressError>()(
+  "ViewServerGrpcIngressError",
+  {
+    message: Schema.String,
+    cause: Schema.Unknown,
+    phase: Schema.optionalKey(
+      Schema.Literals([
+        "configuration",
+        "client",
+        "request",
+        "acquire",
+        "stream",
+        "mapping",
+        "publish",
+        "release",
+      ]),
+    ),
+    feedName: Schema.optionalKey(Schema.String),
+    topic: Schema.optionalKey(Schema.String),
+  },
+) {}
+
+export type ViewServerGrpcRuntimeCallable = (...args: ReadonlyArray<never>) => unknown;
+
+export type ViewServerGrpcRuntimeSourceDefinition = {
+  readonly topic: string;
+  readonly request: ViewServerGrpcRuntimeCallable;
+  readonly acquire: ViewServerGrpcRuntimeCallable;
+  readonly release?: ViewServerGrpcRuntimeCallable;
+};
+
+export type ViewServerGrpcFeedSession = {
+  readonly id: string | null;
+  readonly forwardedHeaders: Readonly<Record<string, string>>;
+  readonly systemHeaders: Readonly<Record<string, string>>;
+};
+
+export type ViewServerGrpcSourceInput<Route> = {
+  readonly client: unknown;
+  readonly request: unknown;
+  readonly route: Route;
+  readonly session: ViewServerGrpcFeedSession;
+};
+
+export type ViewServerGrpcClientFactory = <
+  const ClientDefinition extends GrpcConnectClientDefinition,
+>(
+  definition: ClientDefinition,
+  baseUrl: string,
+) => GrpcClientValue<ClientDefinition>;
+
+type ViewServerGrpcSourceKind = "materialized" | "leased";
+
+const grpcSourceLabel = (kind: ViewServerGrpcSourceKind) => {
+  switch (kind) {
+    case "materialized":
+      return "gRPC feed";
+    case "leased":
+      return "gRPC leased feed";
+  }
+};
+
+const emptyHeaders = (): Readonly<Record<string, string>> => Object.freeze({});
+
+export const makeGrpcFeedSession = (): ViewServerGrpcFeedSession =>
+  Object.freeze({
+    id: null,
+    forwardedHeaders: emptyHeaders(),
+    systemHeaders: emptyHeaders(),
+  });
+
+export const makeGrpcSourceInput = <Route>(
+  client: unknown,
+  request: unknown,
+  route: Route,
+): ViewServerGrpcSourceInput<Route> => ({
+  client,
+  request,
+  route,
+  session: makeGrpcFeedSession(),
+});
+
+export const makeViewServerGrpcSourceError = (input: {
+  readonly message: string;
+  readonly cause: unknown;
+  readonly phase?: NonNullable<ViewServerGrpcIngressError["phase"]>;
+  readonly feedName: string;
+  readonly topic: string;
+}) =>
+  new ViewServerGrpcIngressError({
+    message: input.message,
+    cause: input.cause,
+    ...(input.phase === undefined ? {} : { phase: input.phase }),
+    feedName: input.feedName,
+    topic: input.topic,
+  });
+
+export function makeDefaultGrpcClient<const ClientDefinition extends GrpcConnectClientDefinition>(
+  definition: ClientDefinition,
+  baseUrl: string,
+): GrpcClientValue<ClientDefinition>;
+export function makeDefaultGrpcClient(definition: GrpcConnectClientDefinition, baseUrl: string) {
+  return createClient(definition.service, createGrpcTransport({ baseUrl }));
+}
+
+const isRuntimeGrpcStream = (value: unknown): value is Stream.Stream<unknown, unknown, never> =>
+  Stream.isStream(value);
+
+const isRuntimeGrpcReleaseEffect = (value: unknown): value is Effect.Effect<void, unknown, never> =>
+  Effect.isEffect(value);
+
+const callGrpcSourceRequest = Effect.fn("ViewServerRuntime.grpc.source.request")(function* (
+  kind: ViewServerGrpcSourceKind,
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "request" | "topic">,
+  args: ReadonlyArray<unknown>,
+) {
+  const label = grpcSourceLabel(kind);
+  return yield* Effect.try({
+    try: () => Reflect.apply(feed.request, undefined, args),
+    catch: (cause) =>
+      makeViewServerGrpcSourceError({
+        message: `${label} request creation failed for ${feedName}`,
+        cause,
+        phase: "request",
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+});
+
+export const callMaterializedGrpcSourceRequest = Effect.fn(
+  "ViewServerRuntime.grpc.materialized.source.request",
+)(function* (
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "request" | "topic">,
+) {
+  return yield* callGrpcSourceRequest("materialized", feedName, feed, []);
+});
+
+export const callLeasedGrpcSourceRequest = Effect.fn(
+  "ViewServerRuntime.grpc.leased.source.request",
+)(function* <Route>(
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "request" | "topic">,
+  route: Route,
+) {
+  return yield* callGrpcSourceRequest("leased", feedName, feed, [route]);
+});
+
+const callGrpcSourceAcquire = Effect.fn("ViewServerRuntime.grpc.source.acquire")(function* <Route>(
+  kind: ViewServerGrpcSourceKind,
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "acquire" | "topic">,
+  input: ViewServerGrpcSourceInput<Route>,
+) {
+  const label = grpcSourceLabel(kind);
+  const stream = yield* Effect.try({
+    try: () => Reflect.apply(feed.acquire, undefined, [input]),
+    catch: (cause) =>
+      makeViewServerGrpcSourceError({
+        message: `${label} acquire failed for ${feedName}`,
+        cause,
+        phase: "acquire",
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+  if (isRuntimeGrpcStream(stream)) {
+    return stream;
+  }
+  return yield* makeViewServerGrpcSourceError({
+    message: `${label} acquire did not return a Stream for ${feedName}`,
+    cause: stream,
+    phase: "acquire",
+    feedName,
+    topic: feed.topic,
+  });
+});
+
+export const callMaterializedGrpcSourceAcquire = Effect.fn(
+  "ViewServerRuntime.grpc.materialized.source.acquire",
+)(function* (
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "acquire" | "topic">,
+  input: ViewServerGrpcSourceInput<undefined>,
+) {
+  return yield* callGrpcSourceAcquire("materialized", feedName, feed, input);
+});
+
+export const callLeasedGrpcSourceAcquire = Effect.fn(
+  "ViewServerRuntime.grpc.leased.source.acquire",
+)(function* <Route>(
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "acquire" | "topic">,
+  input: ViewServerGrpcSourceInput<Route>,
+) {
+  return yield* callGrpcSourceAcquire("leased", feedName, feed, input);
+});
+
+const callGrpcSourceRelease = Effect.fn("ViewServerRuntime.grpc.source.release")(function* <Route>(
+  kind: ViewServerGrpcSourceKind,
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "release" | "topic">,
+  input: ViewServerGrpcSourceInput<Route>,
+) {
+  const label = grpcSourceLabel(kind);
+  const releaseCallback = feed.release;
+  if (releaseCallback === undefined) {
+    return;
+  }
+  const release = yield* Effect.try({
+    try: () => Reflect.apply(releaseCallback, undefined, [input]),
+    catch: (cause) =>
+      makeViewServerGrpcSourceError({
+        message: `${label} release failed for ${feedName}`,
+        cause,
+        phase: "release",
+        feedName,
+        topic: feed.topic,
+      }),
+  });
+  if (!isRuntimeGrpcReleaseEffect(release)) {
+    return yield* makeViewServerGrpcSourceError({
+      message: `${label} release did not return an Effect for ${feedName}`,
+      cause: release,
+      phase: "release",
+      feedName,
+      topic: feed.topic,
+    });
+  }
+  yield* release.pipe(
+    Effect.asVoid,
+    Effect.mapError((cause) =>
+      makeViewServerGrpcSourceError({
+        message: `${label} release failed for ${feedName}`,
+        cause,
+        phase: "release",
+        feedName,
+        topic: feed.topic,
+      }),
+    ),
+  );
+});
+
+export const callMaterializedGrpcSourceRelease = Effect.fn(
+  "ViewServerRuntime.grpc.materialized.source.release",
+)(function* (
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "release" | "topic">,
+  input: ViewServerGrpcSourceInput<undefined>,
+) {
+  yield* callGrpcSourceRelease("materialized", feedName, feed, input);
+});
+
+export const callLeasedGrpcSourceRelease = Effect.fn(
+  "ViewServerRuntime.grpc.leased.source.release",
+)(function* <Route>(
+  feedName: string,
+  feed: Pick<ViewServerGrpcRuntimeSourceDefinition, "release" | "topic">,
+  input: ViewServerGrpcSourceInput<Route>,
+) {
+  yield* callGrpcSourceRelease("leased", feedName, feed, input);
+});


### PR DESCRIPTION
## Summary

- Add a focused gRPC Source Lifecycle Module for materialized and leased gRPC feeds.
- Centralize request/acquire/release callback invocation, stream/effect validation, error shaping, default client construction, and per-feed session creation.
- Replace duplicated materialized/leased lifecycle logic with semantic wrappers while preserving existing runtime behavior.
- Add focused tests for lifecycle success, callback defects, invalid callback returns, release failures, optional phase construction, and isolated immutable sessions.

## Local review

- 3 local agents reviewed the slice with AGENTS.md, Effect guidance, and improve-codebase-architecture vocabulary.
- All 3 reported no findings after the fixes.

## Validation

- vp run @effect-view-server/runtime#test
- vp run -w check:package-exports
- vp run -w check:effect
- vp check
- vp run -w check:internal-seams
