### PR TITLE
Configure GitHub issue workflow for autonomous remediation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,20 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 
 ## Agent Skills
 
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub at `bmvantunes/effect-view-server`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repository using root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.
+
+### Engineering workflows
+
 - Use `.agents/skills/effect-ts/SKILL.md` for all Effect-related implementation and review work. The repository tracks `.repos/effect` as a submodule for source-level Effect checks.
 - Use `.agents/skills/vitest/SKILL.md` for tests, coverage, fixtures, and especially type tests. For type-heavy packages, read `.agents/skills/vitest/references/advanced-type-testing.md` before reviewing or writing tests.
 - Use `.agents/skills/vite/SKILL.md` for `vite.config.ts`, build, library packaging, and Vite/Vite+ integration work.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,17 @@
+# Domain documentation
+
+This is a single-context repository.
+
+## Required reading
+
+Before planning, reviewing, or implementing repository work:
+
+1. Read the root `CONTEXT.md` and use its domain vocabulary.
+2. Read the ADRs in `docs/adr/` that affect the work.
+3. Read relevant active material in `plans/`, while treating accepted ADRs and current implementation as authoritative when plan text is stale.
+
+Do not silently contradict an accepted ADR. If a proposed change conflicts with one, mark the issue `ready-for-human` and explain which decision must be reopened.
+
+When an issue title, PRD, test, or refactoring proposal names a domain concept, use the term defined in `CONTEXT.md`. Avoid inventing synonyms that weaken the project language.
+
+If a required domain concept is genuinely missing, record that gap and use the `grill-with-docs` workflow before finalizing the design.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,29 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repository live in GitHub Issues at `bmvantunes/effect-view-server`.
+
+Use the connected GitHub integration when available. The `gh` CLI is the local fallback and infers the repository from `git remote -v`.
+
+## Conventions
+
+- Create issues with a concise title, a complete Markdown body, and exactly one triage-state label from `docs/agents/triage-labels.md`.
+- Read an issue and its discussion before implementing it.
+- Publish PRDs as parent GitHub issues.
+- Reference the parent PRD from every implementation issue.
+- Publish implementation issues in dependency order so `Blocked by` can reference real issue numbers.
+- Select a `ready-for-agent` issue only after every issue referenced in its `Blocked by` section is closed.
+- Do not close or rewrite a parent PRD while creating or completing child issues.
+- Use one implementation issue per independently verifiable vertical slice.
+- Link the implementation PR from its issue and include the validation evidence in the PR body.
+
+## Common CLI operations
+
+- Create: `gh issue create --title "..." --body-file <path> --label "<triage-label>"`
+- Read: `gh issue view <number> --comments`
+- List ready work: `gh issue list --state open --label "ready-for-agent"`
+- Comment: `gh issue comment <number> --body "..."`
+- Add a label: `gh issue edit <number> --add-label "..."`
+- Remove a label: `gh issue edit <number> --remove-label "..."`
+- Close after the linked work is merged: `gh issue close <number> --comment "..."`
+
+When a skill says to publish to the issue tracker, create a GitHub issue in this repository.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage labels
+
+The engineering skills use five canonical triage roles. This table maps each role to the corresponding GitHub label.
+
+| Canonical role    | GitHub label      | Meaning                                        |
+| ----------------- | ----------------- | ---------------------------------------------- |
+| `needs-triage`    | `needs-triage`    | A maintainer must evaluate the issue           |
+| `needs-info`      | `needs-info`      | More information is required from the reporter |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and ready for autonomous work  |
+| `ready-for-human` | `ready-for-human` | Requires a human decision or implementation    |
+| `wontfix`         | `wontfix`         | Will not be actioned                           |
+
+When a skill names a canonical role, apply the GitHub label from the second column. An issue must have exactly one label from this table at a time. Preserve unrelated non-state labels already on the issue.


### PR DESCRIPTION
## Summary

- document GitHub Issues as the repository issue tracker
- define the five mutually exclusive triage-state labels
- configure the root domain context and ADR/plan precedence
- require dependency closure before an autonomous agent selects ready work

This is the prerequisite repository configuration for the remediation program in #292. It does not close the parent PRD.

## Validation

- `vp check`
- `git diff --check`
- Effect workflow review: clean
- Vitest/type/queue workflow review: clean after follow-up
- architecture/domain review: clean

## Release

No changeset: documentation and private workflow configuration only.