### PR TITLE
Reject inherited Topic Row fields at the Wire Protocol

### DIFF
--- a/.changeset/reject-inherited-query-fields.md
+++ b/.changeset/reject-inherited-query-fields.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Reject inherited object-property names in raw and grouped wire queries with a typed `InvalidQuery` error.

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -79,6 +79,21 @@ const viewServer = defineViewServerConfig({
   },
 });
 
+const nonOwnTopicRowFields = [
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "constructor",
+  "missing",
+] as const;
+
+const unknownTopicRowFieldError = {
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidQuery",
+  message: "Query references an unknown field for topic: orders",
+  topic: "orders",
+} as const;
+
 const formatDecodedDecimal = (value: unknown): string =>
   BigDecimal.isBigDecimal(value) ? BigDecimal.format(value) : String(value);
 
@@ -1410,6 +1425,99 @@ describe("@effect-view-server/protocol", () => {
         ],
         totalRows: 2,
       });
+    }),
+  );
+
+  it.effect("rejects non-own Topic Row fields in raw select encoding and decoding", () =>
+    Effect.gen(function* () {
+      for (const field of nonOwnTopicRowFields) {
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeRawQuery(viewServer, "orders", { select: [field] }),
+        );
+        expect(encodeError).toStrictEqual(unknownTopicRowFieldError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeRawQuery(viewServer, "orders", { select: [field] }),
+        );
+        expect(decodeError).toStrictEqual(unknownTopicRowFieldError);
+      }
+    }),
+  );
+
+  it.effect("rejects non-own Topic Row fields in raw where encoding and decoding", () =>
+    Effect.gen(function* () {
+      for (const field of nonOwnTopicRowFields) {
+        const query = { select: ["id"], where: { [field]: "x" } };
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeRawQuery(viewServer, "orders", query),
+        );
+        expect(encodeError).toStrictEqual(unknownTopicRowFieldError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeRawQuery(viewServer, "orders", query),
+        );
+        expect(decodeError).toStrictEqual(unknownTopicRowFieldError);
+      }
+    }),
+  );
+
+  it.effect("rejects non-own Topic Row fields in raw orderBy encoding and decoding", () =>
+    Effect.gen(function* () {
+      for (const field of nonOwnTopicRowFields) {
+        const query = {
+          select: ["id"],
+          orderBy: [{ field, direction: "asc" }],
+        };
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeRawQuery(viewServer, "orders", query),
+        );
+        expect(encodeError).toStrictEqual(unknownTopicRowFieldError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeRawQuery(viewServer, "orders", query),
+        );
+        expect(decodeError).toStrictEqual(unknownTopicRowFieldError);
+      }
+    }),
+  );
+
+  it.effect("rejects non-own Topic Row fields in grouped groupBy encoding and decoding", () =>
+    Effect.gen(function* () {
+      for (const field of nonOwnTopicRowFields) {
+        const query = {
+          groupBy: [field],
+          aggregates: { rowCount: { aggFunc: "count" } },
+        };
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeGroupedQuery(viewServer, "orders", query),
+        );
+        expect(encodeError).toStrictEqual(unknownTopicRowFieldError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeGroupedQuery(viewServer, "orders", query),
+        );
+        expect(decodeError).toStrictEqual(unknownTopicRowFieldError);
+      }
+    }),
+  );
+
+  it.effect("rejects non-own Topic Row fields in grouped aggregate encoding and decoding", () =>
+    Effect.gen(function* () {
+      for (const field of nonOwnTopicRowFields) {
+        const query = {
+          groupBy: ["id"],
+          aggregates: { total: { aggFunc: "sum", field } },
+        };
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeGroupedQuery(viewServer, "orders", query),
+        );
+        expect(encodeError).toStrictEqual(unknownTopicRowFieldError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeGroupedQuery(viewServer, "orders", query),
+        );
+        expect(decodeError).toStrictEqual(unknownTopicRowFieldError);
+      }
     }),
   );
 

--- a/packages/protocol/src/protocol-grouped-query-codec.ts
+++ b/packages/protocol/src/protocol-grouped-query-codec.ts
@@ -15,6 +15,7 @@ import {
   decodeWhere,
   encodeWhere,
   hasOnlyKnownFields,
+  hasOwnField,
   hasTopic,
   invalidQuery,
   invalidTopic,
@@ -62,7 +63,7 @@ const validateGroupedQuery = Effect.fn("ViewServerProtocol.groupedQuery.validate
     );
   }
   for (const groupField of decoded.groupBy) {
-    if (schema.fields[groupField] === undefined) {
+    if (!hasOwnField(schema, groupField)) {
       return yield* Effect.fail(
         invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
       );
@@ -79,7 +80,7 @@ const validateGroupedQuery = Effect.fn("ViewServerProtocol.groupedQuery.validate
         invalidQuery(topic, `Aggregate alias collides with groupBy field: ${alias}`),
       );
     }
-    if (aggregate.aggFunc !== "count" && schema.fields[aggregate.field] === undefined) {
+    if (aggregate.aggFunc !== "count" && !hasOwnField(schema, aggregate.field)) {
       return yield* Effect.fail(
         invalidQuery(topic, `Query references an unknown field for topic: ${topic}`),
       );

--- a/packages/protocol/src/protocol-query-common.ts
+++ b/packages/protocol/src/protocol-query-common.ts
@@ -36,16 +36,20 @@ export const hasTopic = <Topics extends TopicDefinitions>(
   topic: string,
 ): topic is Extract<keyof Topics, string> => Object.hasOwn(config.topics, topic);
 
+export const hasOwnField = (schema: RowSchema, field: string): boolean =>
+  Object.hasOwn(schema.fields, field);
+
 export const getFieldSchema = <const Topics extends TopicDefinitions>(
   config: { readonly topics: Topics },
   topic: Extract<keyof Topics, string>,
   field: string,
 ) => {
-  return config.topics[topic]!.schema.fields[field];
+  const schema = config.topics[topic]!.schema;
+  return hasOwnField(schema, field) ? schema.fields[field] : undefined;
 };
 
 export const hasOnlyKnownFields = (schema: RowSchema, fields: Iterable<string>): boolean =>
-  Array.from(fields).every((field) => schema.fields[field] !== undefined);
+  Array.from(fields).every((field) => hasOwnField(schema, field));
 
 export const validateWindow = Effect.fn("ViewServerProtocol.query.window.validate")(function* (
   topic: string,


### PR DESCRIPTION
## Summary

- reject inherited object-property names in raw and grouped wire-query fields
- route raw and grouped validation through one canonical `Object.hasOwn` predicate
- add 50 exact encode/decode regression assertions across five field names and five query positions
- declare a patch release for the publishable `effect-view-server` package

## Why

Field membership previously used prototype-sensitive property lookup. Names such as `toString` could be accepted as configured fields, and inherited filter fields could escape the Wire Protocol as defects instead of typed `InvalidQuery` failures.

## Validation

- `vp run @effect-view-server/protocol#test` — 14/14, including type tests, at 100% statement/branch/function/line coverage
- strict Effect diagnostics — 20/20 files, zero findings
- `vp check` — clean
- `vp run -w ready` — passed end to end
- `vp run -w bench:baseline:smoke` — 19/19 passed
- Effect, Vitest/type-safety, and architecture/thermonuclear reviewers — unanimous after the release-intent review loop

Closes #293
Parent: #292
