### PR TITLE
Terminate leased gRPC subscriptions on terminal events

### DIFF
--- a/.changeset/end-leased-grpc-terminal-streams.md
+++ b/.changeset/end-leased-grpc-terminal-streams.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+End leased gRPC subscriptions after engine or upstream terminal events and release their retained resources automatically.

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -62,6 +62,12 @@ export type ColumnLiveViewSubscription<Row> = {
   readonly close: () => Effect.Effect<void, never>;
 };
 
+export type ColumnLiveViewTerminalObserver = {
+  readonly onQueryRegistered: (queryId: string) => Effect.Effect<void, never>;
+  readonly onTerminalOccurrence: (event: StatusEvent) => Effect.Effect<void, never>;
+  readonly onTerminalReady: (event: StatusEvent) => Effect.Effect<void, never>;
+};
+
 type EngineSnapshot<Topics extends DecodableTopicDefinitions> = {
   <
     Topic extends Extract<keyof Topics, string>,
@@ -140,6 +146,48 @@ type EngineSubscribe<Topics extends DecodableTopicDefinitions> = {
   >;
 };
 
+type EngineSubscribeObserved<Topics extends DecodableTopicDefinitions> = {
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+};
+
 export type AnyTopicRow<Topics extends DecodableTopicDefinitions> = TopicRow<
   Topics,
   Extract<keyof Topics, string>
@@ -189,6 +237,12 @@ export type ColumnLiveViewEngine<Topics extends DecodableTopicDefinitions> = {
 
 export type ColumnLiveViewEngineInternal<Topics extends DecodableTopicDefinitions> =
   ColumnLiveViewEngine<Topics> & {
+    readonly subscribeObserved: EngineSubscribeObserved<Topics>;
+    readonly subscribeRuntimeObserved: <Topic extends Extract<keyof Topics, string>>(
+      topic: Topic,
+      query: unknown,
+      observer: ColumnLiveViewTerminalObserver,
+    ) => Effect.Effect<ColumnLiveViewSubscription<object>, ColumnLiveViewEngineError>;
     readonly patchDecodedFields: (
       topic: Extract<keyof Topics, string>,
       key: string,

--- a/packages/column-live-view-engine/src/engine.ts
+++ b/packages/column-live-view-engine/src/engine.ts
@@ -19,6 +19,7 @@ import type {
   ColumnLiveViewEngineInternalConfig,
   ColumnLiveViewEngineInternal,
   ColumnLiveViewSubscription,
+  ColumnLiveViewTerminalObserver,
   DecodableTopicDefinitions,
 } from "./engine-contract";
 import {
@@ -50,6 +51,12 @@ import {
 } from "./topic-store";
 
 const defaultSubscriptionQueueCapacity = 1_024;
+
+const unobservedTerminal: ColumnLiveViewTerminalObserver = {
+  onQueryRegistered: () => Effect.void,
+  onTerminalOccurrence: () => Effect.void,
+  onTerminalReady: () => Effect.void,
+};
 
 const invalidRow = (topic: string, message: string) =>
   new InvalidRowError({
@@ -272,6 +279,7 @@ class InMemoryColumnLiveViewEngine<
   >(
     topic: Topic,
     query: unknown,
+    terminalObserver: ColumnLiveViewTerminalObserver,
   ) =>
     Effect.fn("ColumnLiveViewEngine.subscribe")(
       { self: this },
@@ -293,6 +301,7 @@ class InMemoryColumnLiveViewEngine<
                 permit,
                 queryId,
                 queueCapacity: this.subscriptionQueueCapacity,
+                terminalObserver,
               });
               yield* markAcquired(acquiredSubscription);
               return acquiredSubscription;
@@ -354,11 +363,69 @@ class InMemoryColumnLiveViewEngine<
     ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
     ColumnLiveViewEngineError
   > {
-    return this.subscribeQuery(topic, query);
+    return this.subscribeQuery(topic, query, unobservedTerminal);
   }
 
   readonly subscribeRuntime: ColumnLiveViewEngine<Topics>["subscribeRuntime"] = (topic, query) =>
-    this.subscribeQuery(topic, query);
+    this.subscribeQuery(topic, query, unobservedTerminal);
+
+  subscribeObserved<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  subscribeObserved<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactGroupedQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<GroupedResult<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  subscribeObserved<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactRawQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<PickRawFields<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  >;
+  subscribeObserved<
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: Query &
+      ExactLiveQuery<TopicRow<Topics, Topic>, NoInfer<Query>> &
+      ValidateLiveQuery<NoInfer<Query>>,
+    observer: ColumnLiveViewTerminalObserver,
+  ): Effect.Effect<
+    ColumnLiveViewSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ColumnLiveViewEngineError
+  > {
+    return this.subscribeQuery(topic, query, observer);
+  }
+
+  readonly subscribeRuntimeObserved: ColumnLiveViewEngineInternal<Topics>["subscribeRuntimeObserved"] =
+    (topic, query, observer) => this.subscribeQuery(topic, query, observer);
 
   readonly health: ColumnLiveViewEngine<Topics>["health"] = Effect.fn(
     "ColumnLiveViewEngine.health",

--- a/packages/column-live-view-engine/src/index.test.ts
+++ b/packages/column-live-view-engine/src/index.test.ts
@@ -12767,6 +12767,74 @@ describe("ColumnLiveViewEngine validation and health", () => {
     }),
   );
 
+  it.effect("observes producer terminal occurrence before the terminal queue is ready", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: viewServer.topics,
+        subscriptionQueueCapacity: 1,
+      });
+      const phases: Array<string> = [];
+      const observedStatuses: Array<StatusEvent> = [];
+      const observer = {
+        onQueryRegistered: (queryId: string) =>
+          Effect.sync(() => {
+            phases.push(`registered:${queryId}`);
+          }),
+        onTerminalOccurrence: (event: StatusEvent) =>
+          Effect.sync(() => {
+            phases.push("occurrence");
+            observedStatuses.push(event);
+          }),
+        onTerminalReady: (event: StatusEvent) =>
+          Effect.sync(() => {
+            phases.push("ready");
+            observedStatuses.push(event);
+          }),
+      };
+      const subscription = yield* engine.subscribeObserved(
+        "orders",
+        {
+          select: ["id"],
+          limit: 10,
+        },
+        observer,
+      );
+
+      expect(phases).toStrictEqual(["registered:query-0"]);
+      yield* engine.publish("orders", order("observed", "open", 10, 1));
+      expect(phases).toStrictEqual(["registered:query-0", "occurrence", "ready"]);
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+      const expectedStatus = {
+        type: "status",
+        topic: "orders",
+        queryId: "query-0",
+        status: "closed",
+        code: "BackpressureExceeded",
+        message: "Subscription closed because its event queue exceeded capacity.",
+      } as const;
+      expect(Array.from(events)).toStrictEqual([expectedStatus]);
+      expect(observedStatuses).toStrictEqual([expectedStatus, expectedStatus]);
+
+      const runtimeQueryIds: Array<string> = [];
+      const runtimeSubscription = yield* engine.subscribeRuntimeObserved(
+        "orders",
+        { select: ["id"] },
+        {
+          onQueryRegistered: (queryId) =>
+            Effect.sync(() => {
+              runtimeQueryIds.push(queryId);
+            }),
+          onTerminalOccurrence: () => Effect.void,
+          onTerminalReady: () => Effect.void,
+        },
+      );
+      expect(runtimeQueryIds).toStrictEqual(["query-1"]);
+      yield* runtimeSubscription.close();
+      yield* subscription.close();
+      yield* engine.close();
+    }),
+  );
+
   it.effect("publishes decoded runtime rows through the internal engine entrypoint", () =>
     Effect.gen(function* () {
       const engine = yield* createColumnLiveViewEngineInternal({

--- a/packages/column-live-view-engine/src/internal.ts
+++ b/packages/column-live-view-engine/src/internal.ts
@@ -1,2 +1,5 @@
 export { createColumnLiveViewEngineInternal } from "./engine";
-export type { ColumnLiveViewEngineInternal } from "./engine-contract";
+export type {
+  ColumnLiveViewEngineInternal,
+  ColumnLiveViewTerminalObserver,
+} from "./engine-contract";

--- a/packages/column-live-view-engine/src/live-subscription.test.ts
+++ b/packages/column-live-view-engine/src/live-subscription.test.ts
@@ -59,6 +59,11 @@ describe("live subscription observability", () => {
         execution,
         permit,
         release: Effect.void,
+        terminalObserver: {
+          onQueryRegistered: () => Effect.void,
+          onTerminalOccurrence: () => Effect.void,
+          onTerminalReady: () => Effect.void,
+        },
       });
       const subscribers = Array.from(topicStoreState(store).subscribers);
 

--- a/packages/column-live-view-engine/src/live-subscription.ts
+++ b/packages/column-live-view-engine/src/live-subscription.ts
@@ -1,6 +1,7 @@
 import type { DeltaEvent, SnapshotEvent, StatusEvent } from "@effect-view-server/config";
 import { Cause, Effect, Option, Queue, Stream } from "effect";
 import type { LiveQueryExecution } from "./active-query";
+import type { ColumnLiveViewTerminalObserver } from "./engine-contract";
 import type { TopicStore, TopicStoreSubscriptionPermit } from "./topic-store";
 import {
   closeBackpressuredTopicStoreSubscription,
@@ -23,6 +24,7 @@ type MakeLiveSubscriptionOptions<ResultRow extends RowObject> = {
   readonly execution: LiveQueryExecution<ResultRow>;
   readonly permit: TopicStoreSubscriptionPermit;
   readonly release: Effect.Effect<void>;
+  readonly terminalObserver: ColumnLiveViewTerminalObserver;
 };
 
 export type LiveSubscription<ResultRow extends RowObject> = {
@@ -66,13 +68,17 @@ const closeForBackpressure = Effect.fn(
   subscriber: LiveTopicSubscriber,
   queue: Queue.Queue<LiveSubscriptionEvent<ResultRow>, Cause.Done>,
   release: Effect.Effect<void>,
+  terminalObserver: ColumnLiveViewTerminalObserver,
 ) {
+  const event = backpressureStatusEvent(store, subscriber);
   yield* Effect.uninterruptible(
     Effect.gen(function* () {
+      yield* terminalObserver.onTerminalOccurrence(event);
       yield* closeBackpressuredTopicStoreSubscription(store, subscriber, release);
       yield* clearBufferedEvents(queue);
-      yield* offerTerminalStatusEvent(queue, backpressureStatusEvent(store, subscriber));
+      yield* offerTerminalStatusEvent(queue, event);
       yield* Queue.end(queue);
+      yield* terminalObserver.onTerminalReady(event);
     }),
   );
 });
@@ -87,6 +93,7 @@ const notifyLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.
   execution: LiveQueryExecution<ResultRow>,
   cursor: ReturnType<LiveQueryExecution<ResultRow>["createCursor"]>,
   releaseExecution: Effect.Effect<void>,
+  terminalObserver: ColumnLiveViewTerminalObserver,
 ) {
   yield* Effect.annotateCurrentSpan({
     queryId,
@@ -98,7 +105,7 @@ const notifyLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.
   }
   const offered = yield* Queue.offer(queue, nextEvent.value);
   if (!offered) {
-    yield* closeForBackpressure(store, subscriber, queue, releaseExecution);
+    yield* closeForBackpressure(store, subscriber, queue, releaseExecution, terminalObserver);
     return;
   }
 
@@ -108,7 +115,7 @@ const notifyLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.
 
 export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscription.make")(
   function* <ResultRow extends RowObject>(options: MakeLiveSubscriptionOptions<ResultRow>) {
-    const { execution, permit, queryId, queueCapacity } = options;
+    const { execution, permit, queryId, queueCapacity, terminalObserver } = options;
     const { release } = options;
     const { store } = permit;
     const queue = yield* Queue.dropping<LiveSubscriptionEvent<ResultRow>, Cause.Done>(
@@ -130,17 +137,22 @@ export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscrip
           execution,
           cursor,
           releaseExecution,
+          terminalObserver,
         ),
       queuedEvents: Queue.size(queue),
       end: Queue.end(queue),
       closeWithStatus: (event) =>
-        Effect.gen(function* () {
-          subscriber.closed = true;
-          yield* clearBufferedEvents(queue);
-          yield* releaseExecution;
-          yield* offerTerminalStatusEvent(queue, event);
-          yield* Queue.end(queue);
-        }),
+        Effect.uninterruptible(
+          Effect.gen(function* () {
+            yield* terminalObserver.onTerminalOccurrence(event);
+            subscriber.closed = true;
+            yield* clearBufferedEvents(queue);
+            yield* releaseExecution;
+            yield* offerTerminalStatusEvent(queue, event);
+            yield* Queue.end(queue);
+            yield* terminalObserver.onTerminalReady(event);
+          }),
+        ),
       maxQueueDepth: 0,
       backpressureEvents: 0,
       closed: false,
@@ -149,6 +161,7 @@ export const makeLiveSubscription = Effect.fn("ColumnLiveViewEngine.liveSubscrip
     yield* registerTopicStoreSubscription(permit, subscriber);
     yield* Queue.offer(queue, execution.initial(queryId));
     yield* trackTopicStoreSubscriptionQueueDepth(store, subscriber, yield* Queue.size(queue));
+    yield* terminalObserver.onQueryRegistered(queryId);
 
     const close = Effect.fn("ColumnLiveViewEngine.liveSubscription.close")(function* () {
       yield* closeTopicStoreSubscription(

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import type { ColumnLiveViewTerminalObserver } from "./engine-contract";
 import { makeLiveSubscription } from "./live-subscription";
 import type { CompiledGroupedQuery } from "./grouped-query-compiler";
 import type { GroupedIncrementalAdmissionLimits } from "./grouped-incremental-admission";
@@ -75,6 +76,7 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
       readonly permit: TopicStoreSubscriptionPermit;
       readonly queryId: string;
       readonly queueCapacity: number;
+      readonly terminalObserver: ColumnLiveViewTerminalObserver;
     },
   ) {
     const { store } = input.permit;
@@ -87,6 +89,7 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
         execution,
         queueCapacity: input.queueCapacity,
         release: releaseTopicStoreRawQueryExecution(store, executable.compiled),
+        terminalObserver: input.terminalObserver,
       });
     }
 
@@ -101,6 +104,7 @@ export const subscribeExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExe
       execution,
       queueCapacity: input.queueCapacity,
       release: releaseTopicStoreMaterializedQueryExecution(store, executable.compiled),
+      terminalObserver: input.terminalObserver,
     });
   },
 );

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
-import {
-  createColumnLiveViewEngine,
-  type ColumnLiveViewEngineHealth,
-} from "@effect-view-server/column-live-view-engine";
+import type { ColumnLiveViewEngineHealth } from "@effect-view-server/column-live-view-engine";
+import { createColumnLiveViewEngineInternal } from "@effect-view-server/column-live-view-engine/internal";
 import {
   defineViewServerConfig,
   kafka,
@@ -1111,9 +1109,126 @@ describe("@effect-view-server/runtime-core", () => {
     }),
   );
 
+  it.effect("forwards producer terminal observation through the internal live client", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {
+        subscriptionQueueCapacity: 1,
+      });
+      const phases: Array<string> = [];
+      const subscription = yield* runtimeCore.internalLiveClient.subscribeObservedInternal(
+        "orders",
+        {
+          select: ["id"],
+          limit: 10,
+        },
+        {
+          onQueryRegistered: (queryId) =>
+            Effect.sync(() => {
+              phases.push(`registered:${queryId}`);
+            }),
+          onTerminalOccurrence: () =>
+            Effect.sync(() => {
+              phases.push("occurrence");
+            }),
+          onTerminalReady: () =>
+            Effect.sync(() => {
+              phases.push("ready");
+            }),
+        },
+      );
+
+      yield* runtimeCore.internalClient.publish("orders", order("observed", 10));
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+      expect(phases).toStrictEqual(["registered:query-0", "occurrence", "ready"]);
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "Subscription closed because its event queue exceeded capacity.",
+        },
+      ]);
+
+      const runtimeQueryIds: Array<string> = [];
+      const runtimeSubscription =
+        yield* runtimeCore.internalLiveClient.subscribeRuntimeObservedInternal(
+          "orders",
+          { select: ["id"] },
+          {
+            onQueryRegistered: (queryId) =>
+              Effect.sync(() => {
+                runtimeQueryIds.push(queryId);
+              }),
+            onTerminalOccurrence: () => Effect.void,
+            onTerminalReady: () => Effect.void,
+          },
+        );
+      expect(runtimeQueryIds).toStrictEqual(["query-1"]);
+      yield* runtimeSubscription.close();
+      yield* subscription.close();
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("releases observed subscriptions when initial health refresh fails", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
+      const health = AtomRef.make(healthFromEngine(yield* engine.health()));
+      const liveClient = yield* makeRuntimeCoreLiveClient(
+        viewServer,
+        engine,
+        health,
+        Effect.fail(refreshFailed),
+      );
+      const observer = {
+        onQueryRegistered: () => Effect.void,
+        onTerminalOccurrence: () => Effect.void,
+        onTerminalReady: () => Effect.void,
+      };
+
+      const failedTyped = yield* liveClient
+        .subscribeObservedInternal(
+          "orders",
+          {
+            select: ["id"],
+            limit: 1,
+          },
+          observer,
+        )
+        .pipe(Effect.flip);
+      const afterTypedFailure = yield* engine.health();
+      const failedRuntime = yield* liveClient
+        .subscribeRuntimeObservedInternal(
+          "orders",
+          {
+            select: ["id"],
+            limit: 1,
+          },
+          observer,
+        )
+        .pipe(Effect.flip);
+      const afterRuntimeFailure = yield* engine.health();
+
+      expect({
+        failedTyped,
+        typedSubscriptions: afterTypedFailure.activeSubscriptions,
+        failedRuntime,
+        runtimeSubscriptions: afterRuntimeFailure.activeSubscriptions,
+      }).toStrictEqual({
+        failedTyped: refreshFailed,
+        typedSubscriptions: 0,
+        failedRuntime: refreshFailed,
+        runtimeSubscriptions: 0,
+      });
+      yield* liveClient.close;
+    }),
+  );
+
   it.effect("releases acquired live subscriptions when initial health refresh fails", () =>
     Effect.gen(function* () {
-      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
         viewServer,
@@ -1148,7 +1263,7 @@ describe("@effect-view-server/runtime-core", () => {
 
   it.effect("releases pushed health subscriptions when initial health refresh fails", () =>
     Effect.gen(function* () {
-      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
         viewServer,
@@ -1470,7 +1585,7 @@ describe("@effect-view-server/runtime-core", () => {
 
   it.effect("closes slow pushed health summary subscriptions with typed backpressure", () =>
     Effect.gen(function* () {
-      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
         viewServer,
@@ -1510,7 +1625,7 @@ describe("@effect-view-server/runtime-core", () => {
     "keeps detailed health subscription acquisition stable when health changes during refresh",
     () =>
       Effect.gen(function* () {
-        const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+        const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
         const health = AtomRef.make(healthFromEngine(yield* engine.health()));
         const refreshStarted = yield* Deferred.make<void>();
         const releaseRefresh = yield* Deferred.make<void>();
@@ -1625,7 +1740,7 @@ describe("@effect-view-server/runtime-core", () => {
     "rejects pending pushed health subscriptions when live client closes during refresh",
     () =>
       Effect.gen(function* () {
-        const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+        const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
         const health = AtomRef.make(healthFromEngine(yield* engine.health()));
         const refreshStarted = yield* Deferred.make<void>();
         const releaseRefresh = yield* Deferred.make<void>();
@@ -1695,7 +1810,7 @@ describe("@effect-view-server/runtime-core", () => {
 
   it.effect("closes slow pushed detailed health subscriptions with typed backpressure", () =>
     Effect.gen(function* () {
-      const engine = yield* createColumnLiveViewEngine({ topics: viewServer.topics });
+      const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
       const health = AtomRef.make(healthFromEngine(yield* engine.health()));
       const liveClient = yield* makeRuntimeCoreLiveClient(
         viewServer,

--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -66,7 +66,10 @@ export type {
   SourceOwnershipTopic,
 } from "./source-ownership-policy";
 
-export type { ViewServerRuntimeCoreInternalLiveClient } from "./live-client";
+export type {
+  ViewServerRuntimeCoreInternalLiveClient,
+  ViewServerRuntimeCoreTerminalObserver,
+} from "./live-client";
 export type { ViewServerRuntimeCoreInternalClient } from "./runtime-client";
 
 export type ViewServerRuntimeCoreInternalInstance<Topics extends DecodableTopicDefinitions> = Omit<

--- a/packages/runtime-core/src/live-client.ts
+++ b/packages/runtime-core/src/live-client.ts
@@ -1,7 +1,12 @@
 import type {
-  ColumnLiveViewEngine,
+  ColumnLiveViewEngineError,
+  ColumnLiveViewSubscription,
   DecodableTopicDefinitions,
 } from "@effect-view-server/column-live-view-engine";
+import type {
+  ColumnLiveViewEngineInternal,
+  ColumnLiveViewTerminalObserver,
+} from "@effect-view-server/column-live-view-engine/internal";
 import type {
   ViewServerLiveEvent,
   ViewServerLiveSubscription,
@@ -60,6 +65,8 @@ export type ViewServerRuntimeCoreEngineQueryInput<
   Query,
 > = ExactLiveQueryInput<TopicRow<Topics, Topic>, Query>;
 
+export type ViewServerRuntimeCoreTerminalObserver = ColumnLiveViewTerminalObserver;
+
 export type ViewServerRuntimeCoreInternalLiveClient<Topics extends DecodableTopicDefinitions> = {
   readonly subscribeInternal: <
     Topic extends Extract<keyof Topics, string>,
@@ -71,9 +78,28 @@ export type ViewServerRuntimeCoreInternalLiveClient<Topics extends DecodableTopi
     ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
     ViewServerRuntimeError | ViewServerTransportError
   >;
+  readonly subscribeObservedInternal: <
+    Topic extends Extract<keyof Topics, string>,
+    const Query extends RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  >(
+    topic: Topic,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+    terminalObserver: ColumnLiveViewTerminalObserver,
+  ) => Effect.Effect<
+    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
   readonly subscribeRuntimeInternal: <Topic extends Extract<keyof Topics, string>>(
     topic: Topic,
     query: RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+  ) => Effect.Effect<
+    ViewServerLiveSubscription<object>,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
+  readonly subscribeRuntimeObservedInternal: <Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+    query: RawQuery<TopicRow<Topics, Topic>> | GroupedQuery<TopicRow<Topics, Topic>>,
+    terminalObserver: ColumnLiveViewTerminalObserver,
   ) => Effect.Effect<
     ViewServerLiveSubscription<object>,
     ViewServerRuntimeError | ViewServerTransportError
@@ -97,7 +123,7 @@ const runtimeHealthBackpressureStatus = <Topic extends string>(
 export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveClient.make")(
   <const Topics extends DecodableTopicDefinitions>(
     config: ViewServerTopicConfig<Topics>,
-    engine: ColumnLiveViewEngine<Topics>,
+    engine: ColumnLiveViewEngineInternal<Topics>,
     health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
     refreshHealth: Effect.Effect<ViewServerHealth<Topics>, ViewServerRuntimeError>,
   ): Effect.Effect<
@@ -107,6 +133,26 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
       ViewServerRuntimeLiveClient<Topics> & ViewServerRuntimeCoreInternalLiveClient<Topics>
     >(() => {
       const sourceOwnership = makeSourceOwnershipPolicy(config);
+      function wrapEngineSubscription<Row>(
+        acquisition: Effect.Effect<ColumnLiveViewSubscription<Row>, ColumnLiveViewEngineError>,
+      ): Effect.Effect<ViewServerLiveSubscription<Row>, ViewServerRuntimeError> {
+        return Effect.suspend(() => {
+          const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
+          return acquisition.pipe(
+            Effect.mapError(engineErrorToRuntimeError),
+            Effect.flatMap((subscription) => {
+              const wrapped = {
+                events: subscription.events,
+                close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
+              } satisfies ViewServerLiveSubscription<Row>;
+              return refreshHealth.pipe(
+                Effect.as(wrapped),
+                Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
+              );
+            }),
+          );
+        });
+      }
       function subscribeInternal<
         Topic extends Extract<keyof Topics, string>,
         const Query extends
@@ -131,41 +177,43 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
         ViewServerRuntimeError | ViewServerTransportError
       > {
-        return Effect.suspend(() => {
-          const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
-          return engine.subscribe<Topic, Query>(topic, query).pipe(
-            Effect.mapError(engineErrorToRuntimeError),
-            Effect.flatMap((subscription) =>
-              refreshHealth.pipe(
-                Effect.as({
-                  events: subscription.events,
-                  close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
-                }),
-                Effect.onError(() => subscription.close().pipe(ignoreLiveSubscriptionCloseFailure)),
-              ),
-            ),
-          );
-        });
+        return wrapEngineSubscription(engine.subscribe<Topic, Query>(topic, query));
+      }
+      function subscribeObservedInternal<
+        Topic extends Extract<keyof Topics, string>,
+        const Query extends
+          | RawQuery<TopicRow<Topics, Topic>>
+          | GroupedQuery<TopicRow<Topics, Topic>>,
+      >(
+        topic: Topic,
+        query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+        terminalObserver: ColumnLiveViewTerminalObserver,
+      ): Effect.Effect<
+        ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+        ViewServerRuntimeError | ViewServerTransportError
+      >;
+      function subscribeObservedInternal<
+        Topic extends Extract<keyof Topics, string>,
+        const Query extends
+          | RawQuery<TopicRow<Topics, Topic>>
+          | GroupedQuery<TopicRow<Topics, Topic>>,
+      >(
+        topic: Topic,
+        query: ViewServerRuntimeCoreEngineQueryInput<Topics, Topic, Query>,
+        terminalObserver: ColumnLiveViewTerminalObserver,
+      ): Effect.Effect<
+        ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+        ViewServerRuntimeError | ViewServerTransportError
+      > {
+        return wrapEngineSubscription(
+          engine.subscribeObserved<Topic, Query>(topic, query, terminalObserver),
+        );
       }
       const subscribeRuntimeInternal: ViewServerRuntimeCoreInternalLiveClient<Topics>["subscribeRuntimeInternal"] =
-        (topic, query) =>
-          Effect.suspend(() => {
-            const closeRefresh = ignoreRuntimeHealthRefreshFailure(refreshHealth);
-            return engine.subscribeRuntime(topic, query).pipe(
-              Effect.mapError(engineErrorToRuntimeError),
-              Effect.flatMap((subscription) =>
-                refreshHealth.pipe(
-                  Effect.as({
-                    events: subscription.events,
-                    close: () => subscription.close().pipe(Effect.andThen(closeRefresh)),
-                  }),
-                  Effect.onError(() =>
-                    subscription.close().pipe(ignoreLiveSubscriptionCloseFailure),
-                  ),
-                ),
-              ),
-            );
-          });
+        (topic, query) => wrapEngineSubscription(engine.subscribeRuntime(topic, query));
+      const subscribeRuntimeObservedInternal: ViewServerRuntimeCoreInternalLiveClient<Topics>["subscribeRuntimeObservedInternal"] =
+        (topic, query, terminalObserver) =>
+          wrapEngineSubscription(engine.subscribeRuntimeObserved(topic, query, terminalObserver));
       function subscribe<
         Topic extends Extract<keyof Topics, string>,
         const Query extends
@@ -397,7 +445,9 @@ export const makeRuntimeCoreLiveClient = Effect.fn("ViewServerRuntimeCore.liveCl
         subscribe,
         subscribeRuntime,
         subscribeInternal,
+        subscribeObservedInternal,
         subscribeRuntimeInternal,
+        subscribeRuntimeObservedInternal,
         subscribeHealthSummary: () =>
           makeHealthSubscription<
             typeof VIEW_SERVER_HEALTH_SUMMARY_TOPIC,

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -25,12 +25,11 @@ import type {
 import {
   Cause,
   Clock,
+  Deferred,
   Effect,
   Exit,
   Option,
-  Queue,
   Schema,
-  Sink,
   Scope,
   Semaphore,
   Stream,
@@ -55,6 +54,7 @@ import {
   makeSourceOwnershipPolicy,
   type ViewServerRuntimeCoreInternalClient,
   type ViewServerRuntimeCoreInternalLiveClient,
+  type ViewServerRuntimeCoreTerminalObserver,
 } from "@effect-view-server/runtime-core/internal";
 
 type ViewServerGrpcHealthRefreshRequest = Effect.Effect<void>;
@@ -95,20 +95,57 @@ type LeasedFeedRoute = Readonly<Record<string, CanonicalRouteValue>>;
 
 type LeasedFeedRuntimeInput = ViewServerGrpcSourceInput<LeasedFeedRoute>;
 
-type ActiveLease = {
+type UpstreamLeaseTerminal = {
+  readonly _tag: "Upstream";
+  readonly message: string;
+};
+
+type EngineLeaseTerminal = {
+  readonly _tag: "Engine";
+  readonly ready: Deferred.Deferred<void>;
+  readonly status: StatusEvent;
+};
+
+type RuntimeLeaseTerminal = {
+  readonly _tag: "Runtime";
+};
+
+type ClosedLeaseTerminal = {
+  readonly _tag: "Closed";
+};
+
+type LeaseTerminal =
+  | UpstreamLeaseTerminal
+  | EngineLeaseTerminal
+  | RuntimeLeaseTerminal
+  | ClosedLeaseTerminal;
+
+type LeaseTerminalRegistration = {
+  readonly observer: ViewServerRuntimeCoreTerminalObserver;
+  readonly queryId: Deferred.Deferred<string>;
+};
+
+const closedLeaseTerminal: ClosedLeaseTerminal = {
+  _tag: "Closed",
+};
+
+type LeaseRowOwner = {
   readonly feedName: string;
-  readonly feedKey: string;
   readonly feed: RuntimeLeasedFeedDefinition;
+  readonly internalToPublicKeys: Map<string, string>;
+};
+
+type ActiveLease = LeaseRowOwner & {
+  readonly feedKey: string;
   readonly route: LeasedFeedRoute;
   readonly scope: Scope.Scope;
   readonly publicToInternalKeys: Map<string, string>;
-  readonly internalToPublicKeys: Map<string, string>;
   readonly internalToPublicGroupedKeys: Map<string, string>;
-  readonly statusQueues: Set<Queue.Queue<StatusEvent>>;
+  readonly cleanupRows: Effect.Effect<void, ViewServerGrpcIngressError, never>;
+  readonly terminalSignals: Set<Deferred.Deferred<LeaseTerminal>>;
   readonly subscriptions: Set<ActiveLeaseSubscription>;
   subscribers: number;
   acceptingSubscribers: boolean;
-  resourcesReleased: boolean;
 };
 
 type ActiveLeaseSubscription = {
@@ -117,7 +154,7 @@ type ActiveLeaseSubscription = {
 
 type AcquiredLease = {
   readonly lease: ActiveLease;
-  readonly statusQueue: Queue.Queue<StatusEvent>;
+  readonly terminalSignal: Deferred.Deferred<LeaseTerminal>;
 };
 
 export type ViewServerGrpcLeaseManager<Topics extends ViewServerRuntimeTopicDefinitions> = {
@@ -650,6 +687,31 @@ const isGroupedKeyEncodingErrorStatus = (event: ViewServerLiveEvent<unknown>): b
   event.code === "RuntimeUnavailable" &&
   event.message?.startsWith(groupedKeyEncodingErrorPrefix) === true;
 
+const isTerminalStatusEvent = (event: ViewServerLiveEvent<unknown>): event is StatusEvent =>
+  event.type === "status" && (event.status === "closed" || event.status === "error");
+
+const makeLeaseTerminalRegistration = Effect.fn(
+  "ViewServerRuntime.grpc.leased.terminalRegistration.make",
+)(function* (terminalSignal: Deferred.Deferred<LeaseTerminal>) {
+  const ready = yield* Deferred.make<void>();
+  const queryId = yield* Deferred.make<string>();
+  const observer: ViewServerRuntimeCoreTerminalObserver = {
+    onQueryRegistered: (registeredQueryId) =>
+      Deferred.succeed(queryId, registeredQueryId).pipe(Effect.asVoid),
+    onTerminalOccurrence: (status) =>
+      Deferred.succeed(terminalSignal, {
+        _tag: "Engine",
+        ready,
+        status,
+      }).pipe(Effect.asVoid),
+    onTerminalReady: () => Deferred.succeed(ready, undefined).pipe(Effect.asVoid),
+  };
+  return {
+    observer,
+    queryId,
+  } satisfies LeaseTerminalRegistration;
+});
+
 const internalizeLeasedQuery = <Query extends Readonly<Record<string, unknown>>>(
   query: Query,
 ): Query => {
@@ -661,26 +723,13 @@ const internalizeLeasedQuery = <Query extends Readonly<Record<string, unknown>>>
   };
 };
 
-const leasedFeedUnavailableStatus = (lease: ActiveLease, message: string): StatusEvent => ({
-  type: "status",
-  topic: lease.feed.topic,
-  queryId: lease.feedKey,
-  status: "error",
-  code: "RuntimeUnavailable",
-  message,
-});
-
 const notifyLeaseSubscribers = Effect.fn("ViewServerRuntime.grpc.leased.subscribers.notify")(
   function* (lease: ActiveLease, message: string) {
-    const status = leasedFeedUnavailableStatus(lease, message);
-    yield* Effect.forEach(
-      lease.subscriptions,
-      (subscription) => subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
-      {
-        discard: true,
-      },
-    );
-    yield* Effect.forEach(lease.statusQueues, (queue) => Queue.offer(queue, status), {
+    const terminal: UpstreamLeaseTerminal = {
+      _tag: "Upstream",
+      message,
+    };
+    yield* Effect.forEach(lease.terminalSignals, (signal) => Deferred.succeed(signal, terminal), {
       discard: true,
     });
   },
@@ -908,16 +957,12 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
   route: LeasedFeedRoute,
   input: LeasedFeedRuntimeInput,
 ) {
-  const releaseResources = Effect.fn("ViewServerRuntime.grpc.leased.resources.release")(
-    function* () {
-      if (lease.resourcesReleased) {
-        return;
-      }
-      lease.resourcesReleased = true;
-      yield* ignoreGrpcFeedReleaseFailure(callFeedRelease(lease.feedName, lease.feed, input));
-    },
-  );
-  yield* Scope.addFinalizer(lease.scope, releaseResources());
+  const releaseResources = (yield* Effect.cached(
+    ignoreGrpcFeedReleaseFailure(callFeedRelease(lease.feedName, lease.feed, input)).pipe(
+      Effect.withSpan("ViewServerRuntime.grpc.leased.resources.release"),
+    ),
+  )).pipe(Effect.uninterruptible);
+  yield* Scope.addFinalizer(lease.scope, releaseResources);
   const stream = yield* callFeedAcquire(lease.feedName, lease.feed, input);
   const degradeInactiveLease = (input: {
     readonly publicMessage: string;
@@ -926,17 +971,22 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
     lock.withPermit(
       Effect.gen(function* () {
         lease.acceptingSubscribers = false;
-        yield* releaseResources();
-        yield* health.feedDegraded(lease.feedKey, input.healthMessage);
-        yield* health.clientDegraded(lease.feed.client, input.healthMessage);
-        const cleanupExit = yield* closeLeaseRows(config, runtimeClient, lease).pipe(Effect.exit);
-        if (Exit.isSuccess(cleanupExit)) {
-          yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
-        } else {
+        const cleanupRows = Effect.gen(function* () {
+          const cleanupExit = yield* lease.cleanupRows.pipe(Effect.exit);
+          if (Exit.isSuccess(cleanupExit)) {
+            yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
+            return;
+          }
           yield* ignoreLeasedReleaseFailure(Effect.failCause(cleanupExit.cause));
           yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-        }
-        yield* notifyLeaseSubscribers(lease, input.publicMessage);
+        });
+        yield* runAllFinalizers([
+          releaseResources,
+          health.feedDegraded(lease.feedKey, input.healthMessage),
+          health.clientDegraded(lease.feed.client, input.healthMessage),
+          cleanupRows,
+          notifyLeaseSubscribers(lease, input.publicMessage),
+        ]);
       }),
     );
   const runFeed = stream.pipe(
@@ -984,7 +1034,7 @@ const closeLeaseRows = Effect.fn("ViewServerRuntime.grpc.leased.rows.close")(fun
 >(
   config: ViewServerTopicConfig<Topics>,
   runtimeClient: ViewServerRuntimeCoreInternalClient<Topics>,
-  lease: ActiveLease,
+  lease: LeaseRowOwner,
 ) {
   const topic = yield* runtimeTopicFor(config, lease.feed.topic, lease.feedName);
   yield* Effect.forEach(
@@ -1024,6 +1074,13 @@ const normalizeAcquireLeaseError =
     return error;
   };
 
+const normalizeAcquireLeaseCause =
+  (topic: string) =>
+  (
+    cause: Cause.Cause<ViewServerRuntimeError | ViewServerGrpcIngressError>,
+  ): Cause.Cause<ViewServerRuntimeError> =>
+    Cause.map(cause, normalizeAcquireLeaseError(topic));
+
 export const makeViewServerGrpcLeaseManager = Effect.fn(
   "ViewServerRuntime.grpc.leased.makeManager",
 )(function* <
@@ -1043,6 +1100,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
   const feedsByTopic = leasedFeedsByTopic(options);
   const sourceOwnership = makeSourceOwnershipPolicy(config);
   const lock = yield* Semaphore.make(1);
+  const subscriptionScope = yield* Scope.make("parallel");
   let closed = false;
 
   const acquireLease = Effect.fn("ViewServerRuntime.grpc.leased.acquireLease")(function* <
@@ -1082,12 +1140,12 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       );
     }
     const existing = leases.get(feedKey);
-    const statusQueue = yield* Queue.unbounded<StatusEvent>();
+    const terminalSignal = yield* Deferred.make<LeaseTerminal>();
     if (existing !== undefined) {
       return yield* Effect.uninterruptible(
         Effect.gen(function* () {
           if (!existing.acceptingSubscribers) {
-            yield* Queue.shutdown(statusQueue);
+            yield* Deferred.succeed(terminalSignal, closedLeaseTerminal);
             return yield* Effect.fail(
               runtimeError({
                 code: "RuntimeUnavailable",
@@ -1098,11 +1156,11 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             );
           }
           existing.subscribers += 1;
-          existing.statusQueues.add(statusQueue);
+          existing.terminalSignals.add(terminalSignal);
           yield* health.subscriberAdded(feedKey);
           return Option.some({
             lease: existing,
-            statusQueue,
+            terminalSignal,
           });
         }),
       );
@@ -1156,20 +1214,26 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       ),
     );
     const scope = yield* Scope.make("parallel");
-    const lease: ActiveLease = {
+    const rowOwner: LeaseRowOwner = {
       feedName,
-      feedKey,
       feed,
+      internalToPublicKeys: new Map<string, string>(),
+    };
+    const cleanupRows = (yield* Effect.cached(
+      closeLeaseRows(config, runtimeClient, rowOwner),
+    )).pipe(Effect.uninterruptible);
+    const lease: ActiveLease = {
+      ...rowOwner,
+      feedKey,
       route,
       scope,
       publicToInternalKeys: new Map<string, string>(),
-      internalToPublicKeys: new Map<string, string>(),
       internalToPublicGroupedKeys: new Map<string, string>(),
-      statusQueues: new Set<Queue.Queue<StatusEvent>>([statusQueue]),
+      cleanupRows,
+      terminalSignals: new Set<Deferred.Deferred<LeaseTerminal>>([terminalSignal]),
       subscriptions: new Set<ActiveLeaseSubscription>(),
       subscribers: 1,
       acceptingSubscribers: true,
-      resourcesReleased: false,
     };
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
@@ -1186,7 +1250,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         yield* health.subscriberAdded(feedKey);
         yield* health.feedReady(feedKey);
         yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-        yield* restore(
+        const startExit = yield* restore(
           startLeaseStream(
             config,
             runtimeClient,
@@ -1197,32 +1261,27 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             route,
             input,
           ),
-        ).pipe(
-          Effect.onError((cause) =>
-            Scope.close(scope, Exit.void).pipe(
-              Effect.andThen(
-                health.clientDegraded(
-                  feed.client,
-                  `gRPC leased feed ${feedName} failed to start: ${String(cause)}`,
-                ),
-              ),
-              Effect.andThen(Queue.shutdown(statusQueue)),
-              Effect.andThen(health.leasedFeedRemoved(feedKey)),
-              Effect.andThen(Effect.sync(() => leases.delete(feedKey))),
-              Effect.andThen(ignoreGrpcHealthRefreshFailure(requestHealthRefresh)),
+        ).pipe(Effect.exit);
+        if (Exit.isFailure(startExit)) {
+          const cleanupExit = yield* runAllFinalizers([
+            Scope.close(scope, Exit.void),
+            health.clientDegraded(
+              feed.client,
+              `gRPC leased feed ${feedName} failed to start: ${String(startExit.cause)}`,
             ),
-          ),
-          Effect.mapError((error) =>
-            runtimeError({
-              code: "RuntimeUnavailable",
-              topic,
-              message: error.message,
-            }),
-          ),
-        );
+            Deferred.succeed(terminalSignal, closedLeaseTerminal),
+            health.leasedFeedRemoved(feedKey),
+            Effect.sync(() => leases.delete(feedKey)),
+            ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
+          ]).pipe(Effect.exit);
+          const cause = Exit.isFailure(cleanupExit)
+            ? Cause.combine(startExit.cause, cleanupExit.cause)
+            : startExit.cause;
+          return yield* Effect.failCause(normalizeAcquireLeaseCause(topic)(cause));
+        }
         return Option.some({
           lease,
-          statusQueue,
+          terminalSignal,
         });
       }),
     );
@@ -1255,29 +1314,31 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
   const cleanupReleasedLease: (lease: ActiveLease) => Effect.Effect<void, never, never> = Effect.fn(
     "ViewServerRuntime.grpc.leased.releaseLease.cleanup",
   )(function* (lease: ActiveLease) {
-    yield* Scope.close(lease.scope, Exit.void);
-    const cleanupExit = yield* closeLeaseRows(config, runtimeClient, lease).pipe(Effect.exit);
-    if (Exit.isFailure(cleanupExit)) {
-      yield* ignoreLeasedReleaseFailure(Effect.failCause(cleanupExit.cause));
-      yield* health.feedDegraded(
-        lease.feedKey,
-        `gRPC leased feed row cleanup failed for ${lease.feedName}`,
-      );
-      yield* health.clientDegraded(
-        lease.feed.client,
-        `gRPC leased feed row cleanup failed for ${lease.feedName}`,
+    const cleanupRowsAndHealth = Effect.gen(function* () {
+      const cleanupExit = yield* lease.cleanupRows.pipe(Effect.exit);
+      if (Exit.isFailure(cleanupExit)) {
+        yield* ignoreLeasedReleaseFailure(Effect.failCause(cleanupExit.cause));
+        yield* health.feedDegraded(
+          lease.feedKey,
+          `gRPC leased feed row cleanup failed for ${lease.feedName}`,
+        );
+        yield* health.clientDegraded(
+          lease.feed.client,
+          `gRPC leased feed row cleanup failed for ${lease.feedName}`,
+        );
+        yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+        return;
+      }
+      yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
+      yield* lock.withPermit(
+        Effect.gen(function* () {
+          leases.delete(lease.feedKey);
+          yield* health.leasedFeedRemoved(lease.feedKey);
+        }),
       );
       yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-      return;
-    }
-    yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
-    yield* lock.withPermit(
-      Effect.gen(function* () {
-        leases.delete(lease.feedKey);
-        yield* health.leasedFeedRemoved(lease.feedKey);
-      }),
-    );
-    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+    });
+    yield* runAllFinalizers([Scope.close(lease.scope, Exit.void), cleanupRowsAndHealth]);
   });
 
   const releaseLease: (lease: ActiveLease) => Effect.Effect<void, never, never> = Effect.fn(
@@ -1294,71 +1355,117 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     readonly lease: ActiveLease;
     readonly keyField: string;
     readonly query: unknown;
-    readonly statusQueue: Queue.Queue<StatusEvent>;
-  }): ViewServerLiveSubscription<Row> => {
-    let closed = false;
-    const close: () => Effect.Effect<void, never, never> = Effect.fn(
-      "ViewServerRuntime.grpc.leased.subscription.close",
-    )(function* () {
-      yield* Effect.uninterruptible(
+    readonly terminalSignal: Deferred.Deferred<LeaseTerminal>;
+    readonly terminalRegistration: LeaseTerminalRegistration;
+  }): Effect.Effect<ViewServerLiveSubscription<Row>, never, never> =>
+    Effect.gen(function* () {
+      function close(): Effect.Effect<void, never, never> {
+        return closeEffect;
+      }
+      const subscriptionOwner: ActiveLeaseSubscription = { close };
+      const closeEffect = (yield* Effect.cached(
         Effect.gen(function* () {
-          if (closed) {
-            return;
+          input.lease.terminalSignals.delete(input.terminalSignal);
+          yield* Deferred.succeed(input.terminalSignal, closedLeaseTerminal);
+          yield* runAllFinalizers([
+            input.subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
+            releaseLease(input.lease),
+            Effect.sync(() => input.lease.subscriptions.delete(subscriptionOwner)),
+          ]);
+        }).pipe(Effect.withSpan("ViewServerRuntime.grpc.leased.subscription.close")),
+      )).pipe(Effect.uninterruptible);
+      const runtimeTerminal: RuntimeLeaseTerminal = {
+        _tag: "Runtime",
+      };
+      const claimRuntimeTerminal = (terminal: RuntimeLeaseTerminal) =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(input.terminalSignal, terminal);
+          return (yield* Deferred.await(input.terminalSignal)) === terminal;
+        });
+      const runtimeEvents = input.subscription.events.pipe(
+        Stream.map((event) =>
+          externalizeLeasedEvent(input.lease, input.keyField, input.query, event),
+        ),
+        Stream.filterEffect((event) => {
+          if (isGroupedKeyEncodingErrorStatus(event)) {
+            return claimRuntimeTerminal(runtimeTerminal);
           }
-          closed = true;
-          input.lease.statusQueues.delete(input.statusQueue);
-          input.lease.subscriptions.delete(input.subscription);
-          yield* Queue.shutdown(input.statusQueue);
-          yield* input.subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure);
-          yield* releaseLease(input.lease);
+          if (isTerminalStatusEvent(event)) {
+            return Effect.succeed(false);
+          }
+          return Effect.succeed(true);
+        }),
+        Stream.takeUntil(isGroupedKeyEncodingErrorStatus),
+      );
+      const terminalStatusEvents = Stream.fromEffect(Deferred.await(input.terminalSignal)).pipe(
+        Stream.flatMap((terminal) => {
+          if (terminal._tag === "Engine") {
+            return Stream.succeed(terminal.status);
+          }
+          if (terminal._tag === "Upstream") {
+            return Stream.fromEffect(Deferred.await(input.terminalRegistration.queryId)).pipe(
+              Stream.map(
+                (queryId): StatusEvent => ({
+                  type: "status",
+                  topic: input.lease.feed.topic,
+                  queryId,
+                  status: "error",
+                  code: "RuntimeUnavailable",
+                  message: terminal.message,
+                }),
+              ),
+            );
+          }
+          return Stream.empty;
         }),
       );
-    });
-    input.lease.subscriptions.add(input.subscription);
-    const runtimeEvents = input.subscription.events.pipe(
-      Stream.map((event) =>
-        externalizeLeasedEvent(input.lease, input.keyField, input.query, event),
-      ),
-      Stream.takeUntil(isGroupedKeyEncodingErrorStatus),
-    );
-    const fallbackStatusQueryId = `${input.lease.feed.topic}/leased-status`;
-    const statusEventsWithQueryId = (queryId: string) =>
-      Stream.fromQueue(input.statusQueue).pipe(
-        Stream.take(1),
-        Stream.map((event) => ({
-          ...event,
-          queryId,
-        })),
+      const wrappedSubscription: ViewServerLiveSubscription<Row> = {
+        events: runtimeEvents.pipe(
+          Stream.concat(terminalStatusEvents),
+          Stream.takeUntil(isTerminalStatusEvent),
+          Stream.ensuring(close()),
+        ),
+        close: () => close(),
+      };
+      const closeAfterTerminal = Deferred.await(input.terminalSignal).pipe(
+        Effect.flatMap((terminal) => {
+          if (terminal._tag === "Engine") {
+            return Deferred.await(terminal.ready).pipe(Effect.andThen(close()));
+          }
+          return terminal._tag === "Runtime" || terminal._tag === "Upstream"
+            ? close()
+            : Effect.void;
+        }),
       );
-    const eventsWithStableStatusQueryId = Stream.unwrap(
-      Effect.gen(function* () {
-        const [initialEvents, remainingEvents] = yield* Stream.peel(runtimeEvents, Sink.take(1));
-        const initialEvent = initialEvents[0];
-        if (initialEvent === undefined) {
-          return statusEventsWithQueryId(fallbackStatusQueryId);
+      const registered = yield* lock.withPermit(
+        Effect.gen(function* () {
+          const terminalAlreadyClaimed = yield* Deferred.isDone(input.terminalSignal);
+          if (closed || !input.lease.acceptingSubscribers || terminalAlreadyClaimed) {
+            return false;
+          }
+          input.lease.subscriptions.add(subscriptionOwner);
+          yield* closeAfterTerminal.pipe(
+            Effect.forkIn(subscriptionScope, { startImmediately: true }),
+          );
+          return true;
+        }),
+      );
+      if (!registered) {
+        const terminal = yield* Deferred.await(input.terminalSignal);
+        if (terminal._tag === "Engine") {
+          yield* Deferred.await(terminal.ready);
         }
-        const statusEvents = statusEventsWithQueryId(initialEvent.queryId);
-        return Stream.succeed(initialEvent).pipe(
-          Stream.concat(remainingEvents),
-          Stream.concat(statusEvents),
-        );
-      }),
-    );
-    return {
-      events: eventsWithStableStatusQueryId.pipe(
-        Stream.takeUntil(isGroupedKeyEncodingErrorStatus),
-        Stream.ensuring(close()),
-      ),
-      close: () => close(),
-    };
-  };
+        yield* close();
+      }
+      return wrappedSubscription;
+    });
 
   const releaseAcquiredLeaseUnderPermit = (
     acquired: AcquiredLease,
   ): Effect.Effect<Option.Option<ActiveLease>, never, never> =>
     Effect.gen(function* () {
-      acquired.lease.statusQueues.delete(acquired.statusQueue);
-      yield* Queue.shutdown(acquired.statusQueue);
+      acquired.lease.terminalSignals.delete(acquired.terminalSignal);
+      yield* Deferred.succeed(acquired.terminalSignal, closedLeaseTerminal);
       return yield* releaseLeaseUnderPermit(acquired.lease);
     });
   const releaseAcquiredLease = (acquired: AcquiredLease): Effect.Effect<void, never, never> =>
@@ -1392,7 +1499,9 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     return Effect.gen(function* () {
       const lease = yield* lock
         .withPermit(acquireLease(topic, query))
-        .pipe(Effect.mapError(normalizeAcquireLeaseError(topic)));
+        .pipe(
+          Effect.catchCause((cause) => Effect.failCause(normalizeAcquireLeaseCause(topic)(cause))),
+        );
       if (Option.isNone(lease)) {
         return yield* internalLiveClient.subscribeInternal<Topic, Query>(topic, query);
       }
@@ -1409,15 +1518,23 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             ),
           );
           const internalQuery = internalizeLeasedQuery(query);
-          const subscription = yield* restore(
-            internalLiveClient.subscribeInternal<Topic, Query>(topic, internalQuery),
+          const terminalRegistration = yield* makeLeaseTerminalRegistration(
+            acquired.terminalSignal,
           );
-          return withLeaseClose({
+          const subscription = yield* restore(
+            internalLiveClient.subscribeObservedInternal<Topic, Query>(
+              topic,
+              internalQuery,
+              terminalRegistration.observer,
+            ),
+          );
+          return yield* withLeaseClose({
             subscription,
             lease: acquired.lease,
             keyField,
             query,
-            statusQueue: acquired.statusQueue,
+            terminalSignal: acquired.terminalSignal,
+            terminalRegistration,
           });
         }),
       ).pipe(Effect.onError(() => releaseAcquiredLease(acquired)));
@@ -1431,7 +1548,9 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     Effect.gen(function* () {
       const lease = yield* lock
         .withPermit(acquireLease(topic, query))
-        .pipe(Effect.mapError(normalizeAcquireLeaseError(topic)));
+        .pipe(
+          Effect.catchCause((cause) => Effect.failCause(normalizeAcquireLeaseCause(topic)(cause))),
+        );
       if (Option.isNone(lease)) {
         return yield* internalLiveClient.subscribeRuntimeInternal(topic, query);
       }
@@ -1448,15 +1567,23 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             ),
           );
           const internalQuery = internalizeLeasedQuery(query);
-          const subscription = yield* restore(
-            internalLiveClient.subscribeRuntimeInternal(topic, internalQuery),
+          const terminalRegistration = yield* makeLeaseTerminalRegistration(
+            acquired.terminalSignal,
           );
-          return withLeaseClose({
+          const subscription = yield* restore(
+            internalLiveClient.subscribeRuntimeObservedInternal(
+              topic,
+              internalQuery,
+              terminalRegistration.observer,
+            ),
+          );
+          return yield* withLeaseClose({
             subscription,
             lease: acquired.lease,
             keyField,
             query,
-            statusQueue: acquired.statusQueue,
+            terminalSignal: acquired.terminalSignal,
+            terminalRegistration,
           });
         }),
       ).pipe(Effect.onError(() => releaseAcquiredLease(acquired)));
@@ -1499,59 +1626,57 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     reset,
   };
 
-  const close: () => Effect.Effect<void, never, never> = Effect.fn(
-    "ViewServerRuntime.grpc.leased.close",
-  )(function* () {
-    const activeLeases = yield* lock.withPermit(
-      Effect.sync(() => {
-        closed = true;
-        const currentLeases = Array.from(leases.values());
-        leases.clear();
-        for (const lease of currentLeases) {
-          lease.acceptingSubscribers = false;
-        }
-        return currentLeases;
-      }),
-    );
-    yield* runAllFinalizers(
-      activeLeases.map((lease) =>
-        Scope.close(lease.scope, Exit.void).pipe(
-          Effect.andThen(
-            Effect.forEach(
-              lease.subscriptions,
-              (subscription) => subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
-              {
-                discard: true,
-              },
-            ),
+  const close = (yield* Effect.cached(
+    Effect.gen(function* () {
+      const activeLeases = yield* lock.withPermit(
+        Effect.sync(() => {
+          closed = true;
+          const currentLeases = Array.from(leases.values());
+          leases.clear();
+          for (const lease of currentLeases) {
+            lease.acceptingSubscribers = false;
+          }
+          return currentLeases;
+        }),
+      );
+      yield* runAllFinalizers([
+        runAllFinalizers(
+          activeLeases.map((lease) =>
+            runAllFinalizers([
+              Scope.close(lease.scope, Exit.void),
+              runAllFinalizers(
+                Array.from(lease.terminalSignals, (signal) =>
+                  Deferred.succeed(signal, closedLeaseTerminal),
+                ),
+              ),
+              Effect.sync(() => lease.terminalSignals.clear()),
+              runAllFinalizers(
+                Array.from(lease.subscriptions, (subscription) =>
+                  subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
+                ),
+              ),
+              Effect.sync(() => lease.subscriptions.clear()),
+              lease.cleanupRows.pipe(ignoreLeasedReleaseFailure),
+              health.leasedFeedRemoved(lease.feedKey),
+            ]),
           ),
-          Effect.andThen(Effect.sync(() => lease.subscriptions.clear())),
-          Effect.andThen(
-            Effect.forEach(lease.statusQueues, (queue) => Queue.shutdown(queue), {
-              discard: true,
-            }),
-          ),
-          Effect.andThen(Effect.sync(() => lease.statusQueues.clear())),
-          Effect.andThen(
-            closeLeaseRows(config, runtimeClient, lease).pipe(ignoreLeasedReleaseFailure),
-          ),
-          Effect.andThen(health.leasedFeedRemoved(lease.feedKey)),
         ),
-      ),
-    );
-    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-  });
+        Scope.close(subscriptionScope, Exit.void),
+        ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
+      ]);
+    }).pipe(Effect.withSpan("ViewServerRuntime.grpc.leased.close")),
+  )).pipe(Effect.uninterruptible);
 
   return {
     client,
     liveClient: {
-      close: liveClient.close.pipe(Effect.ensuring(close())),
+      close: liveClient.close.pipe(Effect.ensuring(close)),
       health: liveClient.health,
       subscribe,
       subscribeRuntime,
       subscribeHealth: liveClient.subscribeHealth,
       subscribeHealthSummary: liveClient.subscribeHealthSummary,
     },
-    close: close(),
+    close,
   };
 });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -49,7 +49,7 @@ import {
   makeViewServerRuntimeWithRuntimeFeedsAndDependencies,
   runViewServerRuntimeWithDependencies,
 } from "./internal";
-import { makeViewServerGrpcHealthLedger } from "./grpc-health";
+import { makeViewServerGrpcHealthLedger, type ViewServerGrpcHealthLedger } from "./grpc-health";
 import { makeViewServerGrpcIngress, ViewServerGrpcIngressError } from "./grpc-ingress";
 import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
 import { makeViewServerRuntime, runViewServerRuntime } from "./index";
@@ -939,6 +939,17 @@ const makeLeasedGrpcHealth = (
     clients: grpcOptions.clientBaseUrls,
     feeds: {},
   });
+
+const captureLeasedGrpcDegradation = (
+  health: ViewServerGrpcHealthLedger<typeof leasedGrpcViewServer.topics>,
+  messages: Array<string>,
+): ViewServerGrpcHealthLedger<typeof leasedGrpcViewServer.topics> => ({
+  ...health,
+  feedDegraded: (feedKey, message) =>
+    Effect.sync(() => {
+      messages.push(message.split("\n", 1)[0] ?? message);
+    }).pipe(Effect.andThen(health.feedDegraded(feedKey, message))),
+});
 
 type LeasedOrdersQuery = {
   readonly select: readonly ["id", "customerId", "price", "region"];
@@ -5172,8 +5183,9 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: () => Queue.take(subscribeResults).pipe(Effect.flatten),
-        subscribeRuntimeInternal: runtimeCore.internalLiveClient.subscribeRuntimeInternal,
+        subscribeObservedInternal: () => Queue.take(subscribeResults).pipe(Effect.flatten),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -7860,7 +7872,7 @@ describe("@effect-view-server/runtime", () => {
         method: "streamOrders",
         routeBy: ["text"],
         request: ({ text }) => ({ orderId: text }),
-        acquire: () => Stream.make(grpcOrderValue("route-encoding-1", 10)),
+        acquire: () => longRunningGrpcStream([grpcOrderValue("route-encoding-1", 10)]),
         map: ({ value }) => ({
           id: value.customerId,
           ...routeEncodingValues,
@@ -8513,16 +8525,31 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: () =>
           Effect.succeed({
             events: Stream.make(statusEvent),
             close: () => Effect.void,
           }),
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(statusEvent.queryId).pipe(
+            Effect.as({
+              events: Stream.make(statusEvent),
+              close: () => Effect.void,
+            }),
+          ),
         subscribeRuntimeInternal: () =>
           Effect.succeed({
             events: Stream.make(statusEvent),
             close: () => Effect.void,
           }),
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(statusEvent.queryId).pipe(
+            Effect.as({
+              events: Stream.make(statusEvent),
+              close: () => Effect.void,
+            }),
+          ),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -8535,11 +8562,2337 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const events = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+      const events = yield* subscription.events.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.timeout("1 second"),
+      );
 
       expect(Array.from(events)).toStrictEqual([statusEvent]);
       yield* subscription.close();
       yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "keeps the first engine terminal and releases a stalled leased gRPC consumer automatically",
+    () =>
+      Effect.gen(function* () {
+        let releaseCount = 0;
+        const upstreamRows = yield* Queue.unbounded<GrpcOrderValueMessage>();
+        const upstreamFinalized = yield* Deferred.make<void>();
+        const feed = grpcLeasedFeed({
+          streamForRegion: () =>
+            Stream.fromQueue(upstreamRows).pipe(
+              Stream.ensuring(Deferred.succeed(upstreamFinalized, undefined)),
+            ),
+          release: Effect.sync(() => {
+            releaseCount += 1;
+          }),
+        });
+        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {
+          subscriptionQueueCapacity: 1,
+        });
+        const health = makeLeasedGrpcHealth(grpcOptions);
+        const manager = yield* makeViewServerGrpcLeaseManager(
+          leasedGrpcViewServer,
+          runtimeCore.internalClient,
+          runtimeCore.liveClient,
+          runtimeCore.internalLiveClient,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const subscription = yield* manager.liveClient.subscribe(
+          "orders",
+          leasedOrdersQuery("usa"),
+        );
+        const events = yield* Queue.unbounded<unknown>();
+        const releaseConsumer = yield* Deferred.make<void>();
+        let eventCount = 0;
+        const eventsFiber = yield* subscription.events.pipe(
+          Stream.runForEach((event) =>
+            Effect.gen(function* () {
+              yield* Queue.offer(events, event);
+              eventCount += 1;
+              if (eventCount === 1) {
+                yield* Deferred.await(releaseConsumer);
+              }
+            }),
+          ),
+          Effect.forkChild,
+        );
+        const snapshot = yield* Queue.take(events).pipe(Effect.timeout("1 second"));
+        yield* Queue.offer(upstreamRows, grpcOrderValue("queued-order", 10));
+        yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+        const upstreamFinalizedBeforeEngineTerminal = yield* Deferred.isDone(upstreamFinalized);
+        yield* Queue.offer(upstreamRows, grpcOrderValue("backpressured-order", 20));
+        const backpressuredHealth = yield* runtimeCore.client.health().pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (currentHealth) => currentHealth.engine.topics.orders.backpressureEvents === 1,
+          }),
+          Effect.timeout("1 second"),
+        );
+        yield* Deferred.await(upstreamFinalized).pipe(Effect.timeout("1 second"));
+        const upstreamStillAccepted = yield* Queue.offer(
+          upstreamRows,
+          grpcOrderValue("still-open-upstream", 20),
+        );
+        const cleanedHealth = yield* Effect.gen(function* () {
+          return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+        }).pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (currentHealth) =>
+              currentHealth.engine.topics.orders.activeSubscriptions === 0 &&
+              currentHealth.engine.topics.orders.rowCount === 0 &&
+              Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+          }),
+          Effect.timeout("1 second"),
+        );
+
+        yield* Deferred.succeed(releaseConsumer, undefined);
+        const terminal = yield* Queue.take(events).pipe(Effect.timeout("1 second"));
+        yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+
+        expect([snapshot, terminal]).toStrictEqual([
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "query-0",
+            status: "closed",
+            code: "BackpressureExceeded",
+            message: "Subscription closed because its event queue exceeded capacity.",
+          },
+        ]);
+        expect({
+          releaseCount,
+          upstreamFinalizedBeforeEngineTerminal,
+          upstreamStillAccepted,
+          backpressureEvents: backpressuredHealth.engine.topics.orders.backpressureEvents,
+          activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+          retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+          leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+        }).toStrictEqual({
+          releaseCount: 1,
+          upstreamFinalizedBeforeEngineTerminal: false,
+          upstreamStillAccepted: true,
+          backpressureEvents: 1,
+          activeSubscriptions: 0,
+          retainedRows: 0,
+          leasedFeedKeys: [],
+        });
+        yield* subscription.close();
+        yield* manager.close;
+        expect(releaseCount).toBe(1);
+        yield* runtimeCore.close;
+      }),
+  );
+
+  it.live("isolates an engine-terminal subscriber from its shared leased gRPC peer", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const upstreamRows = yield* Queue.unbounded<GrpcOrderValueMessage>();
+      const upstreamFinalized = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromQueue(upstreamRows).pipe(
+            Stream.ensuring(Deferred.succeed(upstreamFinalized, undefined)),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {
+        subscriptionQueueCapacity: 1,
+      });
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const stalled = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const peer = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const stalledEvents = yield* Queue.unbounded<unknown>();
+      const peerEvents = yield* Queue.unbounded<unknown>();
+      const releaseStalledConsumer = yield* Deferred.make<void>();
+      let stalledEventCount = 0;
+      const stalledFiber = yield* stalled.events.pipe(
+        Stream.runForEach((event) =>
+          Effect.gen(function* () {
+            yield* Queue.offer(stalledEvents, event);
+            stalledEventCount += 1;
+            if (stalledEventCount === 1) {
+              yield* Deferred.await(releaseStalledConsumer);
+            }
+          }),
+        ),
+        Effect.forkChild,
+      );
+      const peerFiber = yield* peer.events.pipe(
+        Stream.runForEach((event) => Queue.offer(peerEvents, event)),
+        Effect.forkChild,
+      );
+      const stalledSnapshot = yield* Queue.take(stalledEvents).pipe(Effect.timeout("1 second"));
+      const peerSnapshot = yield* Queue.take(peerEvents).pipe(Effect.timeout("1 second"));
+
+      yield* Queue.offer(upstreamRows, grpcOrderValue("shared-1", 10));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+      const firstPeerDelta = yield* Queue.take(peerEvents).pipe(Effect.timeout("1 second"));
+      yield* Queue.offer(upstreamRows, grpcOrderValue("shared-2", 20));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 2);
+      const secondPeerDelta = yield* Queue.take(peerEvents).pipe(Effect.timeout("1 second"));
+      const isolatedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.engine.topics.orders.activeSubscriptions === 1 &&
+            currentHealth.engine.topics.orders.backpressureEvents === 1 &&
+            currentHealth.grpc?.feeds.orders?.leased[
+              "orders/ordersLease/leased/region=string%3A3%3Ausa"
+            ]?.subscriberCount === 1,
+        }),
+        Effect.timeout("1 second"),
+      );
+      const upstreamFinalizedWithPeerActive = yield* Deferred.isDone(upstreamFinalized);
+
+      yield* Deferred.succeed(releaseStalledConsumer, undefined);
+      const stalledTerminal = yield* Queue.take(stalledEvents).pipe(Effect.timeout("1 second"));
+      yield* Fiber.join(stalledFiber).pipe(Effect.timeout("1 second"));
+      yield* Queue.offer(upstreamRows, grpcOrderValue("shared-3", 30));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 3);
+      const thirdPeerDelta = yield* Queue.take(peerEvents).pipe(Effect.timeout("1 second"));
+
+      expect([stalledSnapshot, stalledTerminal]).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "Subscription closed because its event queue exceeded capacity.",
+        },
+      ]);
+      expect({
+        peerSnapshot,
+        peerEventTypes: [firstPeerDelta, secondPeerDelta, thirdPeerDelta].map(
+          (event) => Object(event)["type"],
+        ),
+        activeSubscriptions: isolatedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: isolatedHealth.engine.topics.orders.rowCount,
+        subscriberCount:
+          isolatedHealth.grpc?.feeds.orders?.leased[
+            "orders/ordersLease/leased/region=string%3A3%3Ausa"
+          ]?.subscriberCount,
+        releaseCount,
+        upstreamFinalizedWithPeerActive,
+      }).toStrictEqual({
+        peerSnapshot: {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-1",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        peerEventTypes: ["delta", "delta", "delta"],
+        activeSubscriptions: 1,
+        retainedRows: 2,
+        subscriberCount: 1,
+        releaseCount: 0,
+        upstreamFinalizedWithPeerActive: false,
+      });
+
+      yield* peer.close();
+      yield* Fiber.join(peerFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(upstreamFinalized).pipe(Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.engine.topics.orders.activeSubscriptions === 0 &&
+            currentHealth.engine.topics.orders.rowCount === 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      yield* stalled.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("releases an unconsumed leased subscription after upstream failure", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const upstreamReleased = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(Effect.andThen(Deferred.succeed(upstreamReleased, undefined)), Effect.asVoid),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Deferred.await(upstreamReleased).pipe(Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.engine.topics.orders.activeSubscriptions === 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      const events = yield* subscription.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "gRPC leased upstream failed.",
+        },
+      ]);
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        leasedFeedKeys: [],
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("closes a raw subscription that registers after leased upstream failure", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      let rawCloseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const subscribeStarted = yield* Deferred.make<void>();
+      const releaseSubscribe = yield* Deferred.make<void>();
+      const rawClosed = yield* Deferred.make<void>();
+      const degradeReached = yield* Deferred.make<void>();
+      const allowDegrade = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const baseHealth = makeLeasedGrpcHealth(grpcOptions);
+      const health = {
+        ...baseHealth,
+        clientDegraded: (clientName: string, message: string) =>
+          baseHealth
+            .clientDegraded(clientName, message)
+            .pipe(
+              Effect.andThen(Deferred.succeed(degradeReached, undefined)),
+              Effect.andThen(Deferred.await(allowDegrade)),
+            ),
+      };
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(subscribeStarted, undefined);
+            yield* Deferred.await(releaseSubscribe);
+            yield* observer.onQueryRegistered("delayed-query");
+            return {
+              events: Stream.fromEffect(Deferred.await(rawClosed)).pipe(Stream.drain),
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(Effect.andThen(Deferred.succeed(rawClosed, undefined)), Effect.asVoid),
+            };
+          }),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscriptionFiber = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(subscribeStarted).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Deferred.await(degradeReached).pipe(Effect.timeout("1 second"));
+      const rejectedLateSubscriberFiber = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.flip, Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.succeed(allowDegrade, undefined);
+      const rejectedLateSubscriber = yield* Fiber.join(rejectedLateSubscriberFiber).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.succeed(releaseSubscribe, undefined);
+      const subscription = yield* Fiber.join(subscriptionFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(rawClosed).pipe(Effect.timeout("1 second"));
+      const events = yield* subscription.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+
+      expect(rejectedLateSubscriber).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "RuntimeUnavailable",
+        topic: "orders",
+        message:
+          "gRPC leased upstream is not accepting new subscribers after completion or failure.",
+      });
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "delayed-query",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "gRPC leased upstream failed.",
+        },
+      ]);
+      expect({
+        releaseCount,
+        rawCloseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        rawCloseCount: 1,
+        activeSubscriptions: 0,
+        leasedFeedKeys: [],
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("closes a raw subscription that registers after the lease manager closes", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      let rawCloseCount = 0;
+      const subscribeStarted = yield* Deferred.make<void>();
+      const releaseSubscribe = yield* Deferred.make<void>();
+      const rawClosed = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(subscribeStarted, undefined);
+            yield* Deferred.await(releaseSubscribe);
+            yield* observer.onQueryRegistered("manager-close-query");
+            return {
+              events: Stream.fromEffect(Deferred.await(rawClosed)).pipe(Stream.drain),
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(Effect.andThen(Deferred.succeed(rawClosed, undefined)), Effect.asVoid),
+            };
+          }),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscriptionFiber = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(subscribeStarted).pipe(Effect.timeout("1 second"));
+      yield* manager.close.pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(releaseSubscribe, undefined);
+      const subscription = yield* Fiber.join(subscriptionFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(rawClosed).pipe(Effect.timeout("1 second"));
+      const events = yield* subscription.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect(Array.from(events)).toStrictEqual([]);
+      expect({
+        releaseCount,
+        rawCloseCount,
+        activeSubscriptions: currentHealth.engine.topics.orders.activeSubscriptions,
+        leasedFeedKeys: Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        rawCloseCount: 1,
+        activeSubscriptions: 0,
+        leasedFeedKeys: [],
+      });
+      yield* subscription.close();
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("joins overlapping leased subscription close callers through full cleanup", () =>
+    Effect.gen(function* () {
+      let rawCloseCount = 0;
+      let releaseCount = 0;
+      const rawCloseStarted = yield* Deferred.make<void>();
+      const allowRawClose = yield* Deferred.make<void>();
+      const secondCloseReturned = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered("overlapping-subscription-close").pipe(
+            Effect.as({
+              events: Stream.never,
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(
+                  Effect.andThen(Deferred.succeed(rawCloseStarted, undefined)),
+                  Effect.andThen(Deferred.await(allowRawClose)),
+                ),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+
+      const firstClose = yield* subscription
+        .close()
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(rawCloseStarted).pipe(Effect.timeout("1 second"));
+      const secondClose = yield* subscription
+        .close()
+        .pipe(
+          Effect.andThen(Deferred.succeed(secondCloseReturned, undefined)),
+          Effect.forkChild({ startImmediately: true }),
+        );
+      yield* Effect.yieldNow;
+      const secondReturnedBeforeCleanup = yield* Deferred.isDone(secondCloseReturned);
+      yield* Deferred.succeed(allowRawClose, undefined);
+      yield* Fiber.join(firstClose).pipe(Effect.timeout("1 second"));
+      yield* Fiber.join(secondClose).pipe(Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+
+      expect({
+        secondReturnedBeforeCleanup,
+        secondReturnedAfterCleanup: yield* Deferred.isDone(secondCloseReturned),
+        rawCloseCount,
+        releaseCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        secondReturnedBeforeCleanup: false,
+        secondReturnedAfterCleanup: true,
+        rawCloseCount: 1,
+        releaseCount: 1,
+        leasedFeedKeys: [],
+      });
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "joins overlapping subscription and manager close callers and replays the raw-close defect",
+    () =>
+      Effect.gen(function* () {
+        let rawCloseCount = 0;
+        let releaseCount = 0;
+        const rawCloseDefect = { _tag: "LeasedRawCloseDefect" } as const;
+        const rawCloseStarted = yield* Deferred.make<void>();
+        const allowRawClose = yield* Deferred.make<void>();
+        const feed = grpcLeasedFeed({
+          streamForRegion: () => Stream.never,
+          release: Effect.sync(() => {
+            releaseCount += 1;
+          }),
+        });
+        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+        const health = makeLeasedGrpcHealth(grpcOptions);
+        const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+          typeof leasedGrpcViewServer.topics
+        > = {
+          ...runtimeCore.internalLiveClient,
+          subscribeObservedInternal: (_topic, _query, observer) =>
+            observer.onQueryRegistered("subscription-manager-overlap").pipe(
+              Effect.as({
+                events: Stream.never,
+                close: () =>
+                  Effect.sync(() => {
+                    rawCloseCount += 1;
+                  }).pipe(
+                    Effect.andThen(Deferred.succeed(rawCloseStarted, undefined)),
+                    Effect.andThen(Deferred.await(allowRawClose)),
+                    Effect.andThen(Effect.die(rawCloseDefect)),
+                  ),
+              }),
+            ),
+        };
+        const manager = yield* makeViewServerGrpcLeaseManager(
+          leasedGrpcViewServer,
+          runtimeCore.internalClient,
+          runtimeCore.liveClient,
+          fakeInternalLiveClient,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+        const subscription = yield* manager.liveClient.subscribe(
+          "orders",
+          leasedOrdersQuery("usa"),
+        );
+
+        const subscriptionClose = yield* subscription
+          .close()
+          .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(rawCloseStarted).pipe(Effect.timeout("1 second"));
+        const managerClose = yield* manager.close.pipe(
+          Effect.exit,
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        const managerDoneBeforeRawClose = managerClose.pollUnsafe() !== undefined;
+        yield* Deferred.succeed(allowRawClose, undefined);
+        const subscriptionExit = yield* Fiber.join(subscriptionClose).pipe(
+          Effect.timeout("1 second"),
+        );
+        const managerExit = yield* Fiber.join(managerClose).pipe(Effect.timeout("1 second"));
+        const lateExit = yield* subscription.close().pipe(Effect.exit, Effect.timeout("1 second"));
+        const subscriptionDefect = Exit.isFailure(subscriptionExit)
+          ? subscriptionExit.cause.reasons.find(Cause.isDieReason)?.defect
+          : undefined;
+        const managerDefect = Exit.isFailure(managerExit)
+          ? managerExit.cause.reasons.find(Cause.isDieReason)?.defect
+          : undefined;
+        const lateDefect = Exit.isFailure(lateExit)
+          ? lateExit.cause.reasons.find(Cause.isDieReason)?.defect
+          : undefined;
+        const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+        expect({
+          managerDoneBeforeRawClose,
+          rawCloseCount,
+          releaseCount,
+          retainedRows: currentHealth.engine.topics.orders.rowCount,
+          leasedFeedKeys: Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}),
+        }).toStrictEqual({
+          managerDoneBeforeRawClose: false,
+          rawCloseCount: 1,
+          releaseCount: 1,
+          retainedRows: 0,
+          leasedFeedKeys: [],
+        });
+        expect(subscriptionDefect).toBe(rawCloseDefect);
+        expect(managerDefect).toBe(rawCloseDefect);
+        expect(lateDefect).toBe(rawCloseDefect);
+        yield* runtimeCore.close;
+      }),
+  );
+
+  it.live("continues explicit leased cleanup after a feed-release defect", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const releaseDefect = { _tag: "LeasedFeedReleaseDefect" } as const;
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          longRunningGrpcStream([grpcOrderValue("explicit-release-defect-row", 10)]),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(Effect.andThen(Effect.die(releaseDefect))),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+
+      const firstExit = yield* subscription.close().pipe(Effect.exit, Effect.timeout("1 second"));
+      const lateExit = yield* subscription.close().pipe(Effect.exit, Effect.timeout("1 second"));
+      const firstDefect = Exit.isFailure(firstExit)
+        ? firstExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const lateDefect = Exit.isFailure(lateExit)
+        ? lateExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        releaseCount,
+        retainedRows: currentHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      expect(firstDefect).toBe(releaseDefect);
+      expect(lateDefect).toBe(releaseDefect);
+      yield* manager.close.pipe(Effect.exit);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("continues engine-terminal cleanup after a feed-release defect", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const releaseDefect = { _tag: "EngineTerminalFeedReleaseDefect" } as const;
+      const upstreamRows = yield* Queue.unbounded<GrpcOrderValueMessage>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.fromQueue(upstreamRows),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(Effect.andThen(Effect.die(releaseDefect))),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {
+        subscriptionQueueCapacity: 1,
+      });
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const emittedEvents = yield* Queue.unbounded<unknown>();
+      const releaseConsumer = yield* Deferred.make<void>();
+      let eventCount = 0;
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runForEach((event) =>
+          Effect.gen(function* () {
+            yield* Queue.offer(emittedEvents, event);
+            eventCount += 1;
+            if (eventCount === 1) {
+              yield* Deferred.await(releaseConsumer);
+            }
+          }),
+        ),
+        Effect.exit,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const snapshot = yield* Queue.take(emittedEvents).pipe(Effect.timeout("1 second"));
+
+      yield* Queue.offer(upstreamRows, grpcOrderValue("engine-defect-1", 10));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+      yield* Queue.offer(upstreamRows, grpcOrderValue("engine-defect-2", 20));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.engine.topics.orders.activeSubscriptions === 0 &&
+            currentHealth.engine.topics.orders.rowCount === 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.succeed(releaseConsumer, undefined);
+      const terminal = yield* Queue.take(emittedEvents).pipe(Effect.timeout("1 second"));
+      const streamExit = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+      const lateExit = yield* subscription.close().pipe(Effect.exit, Effect.timeout("1 second"));
+      const streamDefect = Exit.isFailure(streamExit)
+        ? streamExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const lateDefect = Exit.isFailure(lateExit)
+        ? lateExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+
+      expect([snapshot, terminal]).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "closed",
+          code: "BackpressureExceeded",
+          message: "Subscription closed because its event queue exceeded capacity.",
+        },
+      ]);
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      expect(streamDefect).toBe(releaseDefect);
+      expect(lateDefect).toBe(releaseDefect);
+      yield* manager.close.pipe(Effect.exit);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("delivers upstream failure and cleanup when feed release defects", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const releaseDefect = { _tag: "UpstreamFeedReleaseDefect" } as const;
+      const failUpstream = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(Effect.andThen(Effect.die(releaseDefect))),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const emittedEvents = yield* Queue.unbounded<unknown>();
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runForEach((event) => Queue.offer(emittedEvents, event)),
+        Effect.exit,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const snapshot = yield* Queue.take(emittedEvents).pipe(Effect.timeout("1 second"));
+
+      yield* Deferred.succeed(failUpstream, undefined);
+      const terminal = yield* Queue.take(emittedEvents).pipe(Effect.timeout("1 second"));
+      const streamExit = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+      const lateExit = yield* subscription.close().pipe(Effect.exit, Effect.timeout("1 second"));
+      const streamDefect = Exit.isFailure(streamExit)
+        ? streamExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const lateDefect = Exit.isFailure(lateExit)
+        ? lateExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.engine.topics.orders.activeSubscriptions === 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+
+      expect([snapshot, terminal]).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "gRPC leased upstream failed.",
+        },
+      ]);
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      expect(streamDefect).toBe(releaseDefect);
+      expect(lateDefect).toBe(releaseDefect);
+      yield* manager.close.pipe(Effect.exit);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("cleans retained rows exactly once when leased upstream terminates", () =>
+    Effect.gen(function* () {
+      let deleteCount = 0;
+      let releaseCount = 0;
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.make(grpcOrderValue("exactly-once-row", 10)),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const runtimeDelete = runtimeCore.internalClient.delete;
+      Object.defineProperty(runtimeCore.internalClient, "delete", {
+        value: (topic: "orders", key: string) =>
+          Effect.sync(() => {
+            deleteCount += 1;
+          }).pipe(Effect.andThen(runtimeDelete(topic, key))),
+      });
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const events = yield* subscription.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            currentHealth.engine.topics.orders.rowCount === 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* subscription.close();
+      yield* manager.close;
+
+      expect(Array.from(events).map((event) => event.type)).toStrictEqual([
+        "snapshot",
+        "delta",
+        "delta",
+        "status",
+      ]);
+      expect({
+        deleteCount,
+        releaseCount,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        deleteCount: 1,
+        releaseCount: 1,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("releases a leased subscription and shares raw-close defects across callers", () =>
+    Effect.gen(function* () {
+      let rawCloseCount = 0;
+      let releaseCount = 0;
+      const rawCloseDefect = { _tag: "OverlappingRawCloseDefect" } as const;
+      const releaseStarted = yield* Deferred.make<void>();
+      const allowRelease = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(
+          Effect.andThen(Deferred.succeed(releaseStarted, undefined)),
+          Effect.andThen(Deferred.await(allowRelease)),
+        ),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered("raw-close-defect").pipe(
+            Effect.as({
+              events: Stream.never,
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(Effect.andThen(Effect.die(rawCloseDefect))),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+
+      const firstClose = yield* subscription
+        .close()
+        .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+      yield* Effect.yieldNow;
+      const secondClose = yield* subscription
+        .close()
+        .pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(releaseStarted).pipe(Effect.timeout("1 second"));
+      const firstDoneBeforeRelease = firstClose.pollUnsafe() !== undefined;
+      const secondDoneBeforeRelease = secondClose.pollUnsafe() !== undefined;
+      yield* Deferred.succeed(allowRelease, undefined);
+      const firstExit = yield* Fiber.join(firstClose).pipe(Effect.timeout("1 second"));
+      const secondExit = yield* Fiber.join(secondClose).pipe(Effect.timeout("1 second"));
+      const firstDefect = Exit.isFailure(firstExit)
+        ? firstExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const secondDefect = Exit.isFailure(secondExit)
+        ? secondExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        firstDoneBeforeRelease,
+        secondDoneBeforeRelease,
+        rawCloseCount,
+        releaseCount,
+        leasedFeedKeys: Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        firstDoneBeforeRelease: false,
+        secondDoneBeforeRelease: false,
+        rawCloseCount: 1,
+        releaseCount: 1,
+        leasedFeedKeys: [],
+      });
+      expect(firstDefect).toBe(rawCloseDefect);
+      expect(secondDefect).toBe(rawCloseDefect);
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("joins overlapping leased manager close callers through full cleanup", () =>
+    Effect.gen(function* () {
+      let rawCloseCount = 0;
+      let releaseCount = 0;
+      const releaseStarted = yield* Deferred.make<void>();
+      const allowRelease = yield* Deferred.make<void>();
+      const secondCloseReturned = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => longRunningGrpcStream([grpcOrderValue("manager-close-row", 10)]),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(
+          Effect.andThen(Deferred.succeed(releaseStarted, undefined)),
+          Effect.andThen(Deferred.await(allowRelease)),
+        ),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered("overlapping-manager-close").pipe(
+            Effect.as({
+              events: Stream.never,
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+
+      const firstClose = yield* manager.close.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(releaseStarted).pipe(Effect.timeout("1 second"));
+      const secondClose = yield* manager.close.pipe(
+        Effect.andThen(Deferred.succeed(secondCloseReturned, undefined)),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Effect.yieldNow;
+      const secondReturnedBeforeCleanup = yield* Deferred.isDone(secondCloseReturned);
+      yield* Deferred.succeed(allowRelease, undefined);
+      yield* Fiber.join(firstClose).pipe(Effect.timeout("1 second"));
+      yield* Fiber.join(secondClose).pipe(Effect.timeout("1 second"));
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        secondReturnedBeforeCleanup,
+        secondReturnedAfterCleanup: yield* Deferred.isDone(secondCloseReturned),
+        rawCloseCount,
+        releaseCount,
+        retainedRows: currentHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        secondReturnedBeforeCleanup: false,
+        secondReturnedAfterCleanup: true,
+        rawCloseCount: 1,
+        releaseCount: 1,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("continues manager cleanup and shares lease-release defects across callers", () =>
+    Effect.gen(function* () {
+      let rawCloseCount = 0;
+      let releaseCount = 0;
+      const releaseDefect = { _tag: "ManagerLeaseReleaseDefect" } as const;
+      const rawCloseStarted = yield* Deferred.make<void>();
+      const allowRawClose = yield* Deferred.make<void>();
+      const rawEvents = yield* Queue.unbounded<never, Cause.Done>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => longRunningGrpcStream([grpcOrderValue("release-defect-row", 10)]),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }).pipe(Effect.andThen(Effect.die(releaseDefect))),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered("lease-release-defect").pipe(
+            Effect.as({
+              events: Stream.fromQueue(rawEvents),
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(
+                  Effect.andThen(Deferred.succeed(rawCloseStarted, undefined)),
+                  Effect.andThen(Deferred.await(allowRawClose)),
+                  Effect.andThen(Queue.end(rawEvents)),
+                ),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      yield* waitForLeasedGrpcSnapshotRows(runtimeCore.internalClient, "usa", 1);
+
+      const firstClose = yield* manager.close.pipe(
+        Effect.exit,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(rawCloseStarted).pipe(Effect.timeout("1 second"));
+      const secondClose = yield* manager.close.pipe(
+        Effect.exit,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Effect.yieldNow;
+      const secondDoneBeforeCleanup = secondClose.pollUnsafe() !== undefined;
+      yield* Deferred.succeed(allowRawClose, undefined);
+      const firstExit = yield* Fiber.join(firstClose).pipe(Effect.timeout("1 second"));
+      const secondExit = yield* Fiber.join(secondClose).pipe(Effect.timeout("1 second"));
+      const lateExit = yield* manager.close.pipe(Effect.exit, Effect.timeout("1 second"));
+      const firstDefect = Exit.isFailure(firstExit)
+        ? firstExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const secondDefect = Exit.isFailure(secondExit)
+        ? secondExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const lateDefect = Exit.isFailure(lateExit)
+        ? lateExit.cause.reasons.find(Cause.isDieReason)?.defect
+        : undefined;
+      const events = yield* subscription.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+      const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        secondDoneBeforeCleanup,
+        events: Array.from(events),
+        rawCloseCount,
+        releaseCount,
+        retainedRows: currentHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        secondDoneBeforeCleanup: false,
+        events: [],
+        rawCloseCount: 1,
+        releaseCount: 1,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      expect(firstDefect).toBe(releaseDefect);
+      expect(secondDefect).toBe(releaseDefect);
+      expect(lateDefect).toBe(releaseDefect);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("closes an additional raw subscriber that registers after upstream failure", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      let subscribeCount = 0;
+      let firstRawCloseCount = 0;
+      let secondRawCloseCount = 0;
+      let firstRawCloseStarted = false;
+      let secondRawCloseStarted = false;
+      const failUpstream = yield* Deferred.make<void>();
+      const secondSubscribeStarted = yield* Deferred.make<void>();
+      const releaseSecondSubscribe = yield* Deferred.make<void>();
+      const firstRawClosed = yield* Deferred.make<void>();
+      const secondRawClosed = yield* Deferred.make<void>();
+      const degradeReached = yield* Deferred.make<void>();
+      const allowDegrade = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const baseHealth = makeLeasedGrpcHealth(grpcOptions);
+      const health = {
+        ...baseHealth,
+        clientDegraded: (clientName: string, message: string) =>
+          baseHealth
+            .clientDegraded(clientName, message)
+            .pipe(
+              Effect.andThen(Deferred.succeed(degradeReached, undefined)),
+              Effect.andThen(Deferred.await(allowDegrade)),
+            ),
+      };
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          Effect.gen(function* () {
+            const currentSubscribe = subscribeCount;
+            subscribeCount += 1;
+            if (currentSubscribe === 1) {
+              yield* Deferred.succeed(secondSubscribeStarted, undefined);
+              yield* Deferred.await(releaseSecondSubscribe);
+            }
+            const queryId = currentSubscribe === 0 ? "first-query" : "second-query";
+            const rawClosed = currentSubscribe === 0 ? firstRawClosed : secondRawClosed;
+            yield* observer.onQueryRegistered(queryId);
+            return {
+              events: Stream.fromEffect(Deferred.await(rawClosed)).pipe(Stream.drain),
+              close: () =>
+                Effect.sync(() => {
+                  if (currentSubscribe === 0 && !firstRawCloseStarted) {
+                    firstRawCloseStarted = true;
+                    firstRawCloseCount += 1;
+                  }
+                  if (currentSubscribe === 1 && !secondRawCloseStarted) {
+                    secondRawCloseStarted = true;
+                    secondRawCloseCount += 1;
+                  }
+                }).pipe(Effect.andThen(Deferred.succeed(rawClosed, undefined)), Effect.asVoid),
+            };
+          }),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const firstSubscription = yield* manager.liveClient.subscribe(
+        "orders",
+        leasedOrdersQuery("usa"),
+      );
+      const secondSubscriptionFiber = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(secondSubscribeStarted).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Deferred.await(degradeReached).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(allowDegrade, undefined);
+      yield* Deferred.await(firstRawClosed).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(releaseSecondSubscribe, undefined);
+      const secondSubscription = yield* Fiber.join(secondSubscriptionFiber).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.await(secondRawClosed).pipe(Effect.timeout("1 second"));
+      const firstEvents = yield* firstSubscription.events.pipe(
+        Stream.runCollect,
+        Effect.timeout("1 second"),
+      );
+      const secondEvents = yield* secondSubscription.events.pipe(
+        Stream.runCollect,
+        Effect.timeout("1 second"),
+      );
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+
+      expect([Array.from(firstEvents), Array.from(secondEvents)]).toStrictEqual([
+        [
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "first-query",
+            status: "error",
+            code: "RuntimeUnavailable",
+            message: "gRPC leased upstream failed.",
+          },
+        ],
+        [
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "second-query",
+            status: "error",
+            code: "RuntimeUnavailable",
+            message: "gRPC leased upstream failed.",
+          },
+        ],
+      ]);
+      expect({
+        releaseCount,
+        firstRawCloseCount,
+        secondRawCloseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        firstRawCloseCount: 1,
+        secondRawCloseCount: 1,
+        activeSubscriptions: 0,
+        leasedFeedKeys: [],
+      });
+      yield* firstSubscription.close();
+      yield* secondSubscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("delivers one upstream failure status to an already-running leased consumer", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const initialEventSeen = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(initialEventSeen, undefined)),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* Deferred.await(initialEventSeen).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* subscription.close();
+      yield* manager.close;
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "gRPC leased upstream failed.",
+        },
+      ]);
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("emits only the first leased terminal source when upstream fails before the engine", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const initialEventSeen = yield* Deferred.make<void>();
+      const rawSubscriptionClosed = yield* Deferred.make<void>();
+      const emitEngineTerminal = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const initialSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "engine-query",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
+      } as const;
+      const engineTerminalStatus = {
+        type: "status",
+        topic: "orders",
+        queryId: "engine-query",
+        status: "closed",
+        code: "BackpressureExceeded",
+        message: "engine terminal arrived second",
+      } as const;
+      const controlledRuntimeEvents = Stream.make(initialSnapshot).pipe(
+        Stream.concat(
+          Stream.fromEffect(
+            Deferred.await(emitEngineTerminal).pipe(Effect.as(engineTerminalStatus)),
+          ),
+        ),
+      );
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeInternal: () =>
+          Effect.succeed({
+            events: controlledRuntimeEvents,
+            close: () => Deferred.succeed(rawSubscriptionClosed, undefined).pipe(Effect.asVoid),
+          }),
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(initialSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(initialSnapshot).pipe(
+                Stream.concat(
+                  Stream.fromEffect(
+                    Deferred.await(emitEngineTerminal).pipe(
+                      Effect.tap(() => observer.onTerminalOccurrence(engineTerminalStatus)),
+                      Effect.as(engineTerminalStatus),
+                      Effect.tap(() => observer.onTerminalReady(engineTerminalStatus)),
+                    ),
+                  ),
+                ),
+              ),
+              close: () => Deferred.succeed(rawSubscriptionClosed, undefined).pipe(Effect.asVoid),
+            }),
+          ),
+        subscribeRuntimeInternal: () =>
+          Effect.succeed({
+            events: controlledRuntimeEvents,
+            close: () => Deferred.succeed(rawSubscriptionClosed, undefined).pipe(Effect.asVoid),
+          }),
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(initialSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(initialSnapshot).pipe(
+                Stream.concat(
+                  Stream.fromEffect(
+                    Deferred.await(emitEngineTerminal).pipe(
+                      Effect.tap(() => observer.onTerminalOccurrence(engineTerminalStatus)),
+                      Effect.as(engineTerminalStatus),
+                      Effect.tap(() => observer.onTerminalReady(engineTerminalStatus)),
+                    ),
+                  ),
+                ),
+              ),
+              close: () => Deferred.succeed(rawSubscriptionClosed, undefined).pipe(Effect.asVoid),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(initialEventSeen, undefined)),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* Deferred.await(initialEventSeen).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Deferred.await(rawSubscriptionClosed).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(emitEngineTerminal, undefined);
+      const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* subscription.close();
+      yield* manager.close;
+
+      expect(Array.from(events)).toStrictEqual([
+        initialSnapshot,
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "engine-query",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "gRPC leased upstream failed.",
+        },
+      ]);
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("keeps an engine terminal that occurs before a later upstream failure", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const engineOccurred = yield* Deferred.make<void>();
+      const allowEngineReady = yield* Deferred.make<void>();
+      const rawSubscriptionClosed = yield* Deferred.make<void>();
+      const degradeReached = yield* Deferred.make<void>();
+      const allowDegrade = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const baseHealth = makeLeasedGrpcHealth(grpcOptions);
+      const health = {
+        ...baseHealth,
+        clientDegraded: (clientName: string, message: string) =>
+          baseHealth
+            .clientDegraded(clientName, message)
+            .pipe(
+              Effect.andThen(Deferred.succeed(degradeReached, undefined)),
+              Effect.andThen(Deferred.await(allowDegrade)),
+            ),
+      };
+      const engineTerminalStatus = {
+        type: "status",
+        topic: "orders",
+        queryId: "engine-first-query",
+        status: "closed",
+        code: "BackpressureExceeded",
+        message: "engine terminal occurred first",
+      } as const;
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          Effect.gen(function* () {
+            yield* observer.onQueryRegistered(engineTerminalStatus.queryId);
+            yield* observer.onTerminalOccurrence(engineTerminalStatus);
+            yield* Deferred.succeed(engineOccurred, undefined);
+            yield* Deferred.await(allowEngineReady).pipe(
+              Effect.andThen(observer.onTerminalReady(engineTerminalStatus)),
+              Effect.forkChild({ startImmediately: true }),
+            );
+            return {
+              events: Stream.fromEffect(Deferred.await(allowEngineReady)).pipe(
+                Stream.map(() => engineTerminalStatus),
+              ),
+              close: () => Deferred.succeed(rawSubscriptionClosed, undefined).pipe(Effect.asVoid),
+            };
+          }),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscriptionFiber = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(engineOccurred).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Deferred.await(degradeReached).pipe(Effect.timeout("1 second"));
+      const rejectedLateSubscriberFiber = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.flip, Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.succeed(allowDegrade, undefined);
+      const rejectedLateSubscriber = yield* Fiber.join(rejectedLateSubscriberFiber).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.succeed(allowEngineReady, undefined);
+      const subscription = yield* Fiber.join(subscriptionFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(rawSubscriptionClosed).pipe(Effect.timeout("1 second"));
+      const events = yield* subscription.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
+
+      expect(rejectedLateSubscriber).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "RuntimeUnavailable",
+        topic: "orders",
+        message:
+          "gRPC leased upstream is not accepting new subscribers after completion or failure.",
+      });
+      expect(Array.from(events)).toStrictEqual([engineTerminalStatus]);
+      expect(releaseCount).toBe(1);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("keeps a grouped runtime terminal that occurs before upstream failure", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const allowRawClose = yield* Deferred.make<void>();
+      const allowConsumer = yield* Deferred.make<void>();
+      const rawCloseCalls = yield* Queue.unbounded<void>();
+      const emittedEvents = yield* Queue.unbounded<unknown>();
+      const degradeReached = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const baseHealth = makeLeasedGrpcHealth(grpcOptions);
+      const health = {
+        ...baseHealth,
+        clientDegraded: (clientName: string, message: string) =>
+          baseHealth
+            .clientDegraded(clientName, message)
+            .pipe(Effect.andThen(Deferred.succeed(degradeReached, undefined))),
+      };
+      const malformedGroupedSnapshot = {
+        type: "delta",
+        topic: "orders",
+        queryId: "grouped-query",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "remove",
+            key: "missing-internal-group",
+          },
+        ],
+        totalRows: 0,
+      } as const;
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(malformedGroupedSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(malformedGroupedSnapshot),
+              close: () =>
+                Queue.offer(rawCloseCalls, undefined).pipe(
+                  Effect.andThen(Deferred.await(allowRawClose)),
+                ),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["customerId"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        limit: 10,
+      });
+
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runForEach((event) =>
+          Queue.offer(emittedEvents, event).pipe(Effect.andThen(Deferred.await(allowConsumer))),
+        ),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const groupedTerminal = yield* Queue.take(emittedEvents).pipe(Effect.timeout("1 second"));
+      yield* Queue.take(rawCloseCalls).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Deferred.await(degradeReached).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(allowRawClose, undefined);
+      yield* Deferred.succeed(allowConsumer, undefined);
+      yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+
+      expect(groupedTerminal).toStrictEqual({
+        type: "status",
+        topic: "orders",
+        queryId: "grouped-query",
+        status: "error",
+        code: "RuntimeUnavailable",
+        message: "Leased gRPC grouped key value cannot be encoded as a stable public key",
+      });
+      expect(releaseCount).toBe(1);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("suppresses a grouped runtime terminal after upstream failure wins", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const failUpstream = yield* Deferred.make<void>();
+      const allowRawClose = yield* Deferred.make<void>();
+      const rawCloseCalls = yield* Queue.unbounded<void>();
+      const emittedEvents = yield* Queue.unbounded<unknown>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () =>
+          Stream.fromEffect(
+            Deferred.await(failUpstream).pipe(Effect.andThen(Effect.fail("upstream down"))),
+          ),
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const malformedGroupedSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-query",
+        version: 1,
+        keys: ["internal-group"],
+        rows: [
+          {
+            customerId: new Uint8Array([1]),
+            rowCount: 1n,
+          },
+        ],
+        totalRows: 1,
+      } as const;
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(malformedGroupedSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(malformedGroupedSnapshot),
+              close: () =>
+                Queue.offer(rawCloseCalls, undefined).pipe(
+                  Effect.andThen(Deferred.await(allowRawClose)),
+                ),
+            }),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["customerId"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        limit: 10,
+      });
+
+      yield* Deferred.succeed(failUpstream, undefined);
+      yield* Queue.take(rawCloseCalls).pipe(Effect.timeout("1 second"));
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runForEach((event) => Queue.offer(emittedEvents, event)),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const upstreamTerminal = yield* Queue.take(emittedEvents).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(allowRawClose, undefined);
+      yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+
+      expect(upstreamTerminal).toStrictEqual({
+        type: "status",
+        topic: "orders",
+        queryId: "grouped-query",
+        status: "error",
+        code: "RuntimeUnavailable",
+        message: "gRPC leased upstream failed.",
+      });
+      expect(releaseCount).toBe(1);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("keeps an engine terminal when grouped runtime termination occurs second", () =>
+    Effect.gen(function* () {
+      let rawCloseCount = 0;
+      let releaseCount = 0;
+      let runtimeEventRead = false;
+      const emitEngineTerminal = yield* Deferred.make<void>();
+      const engineOccurred = yield* Deferred.make<void>();
+      const allowEngineReady = yield* Deferred.make<void>();
+      const engineTerminalStatus = {
+        type: "status",
+        topic: "orders",
+        queryId: "engine-runtime-order",
+        status: "closed",
+        code: "BackpressureExceeded",
+        message: "engine terminal occurred first",
+      } as const;
+      const malformedGroupedDelta = {
+        type: "delta",
+        topic: "orders",
+        queryId: "engine-runtime-order",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "remove",
+            get key() {
+              runtimeEventRead = true;
+              return "missing-internal-group";
+            },
+          },
+        ],
+        totalRows: 0,
+      } as const;
+      const rawEvents = yield* Queue.unbounded<typeof malformedGroupedDelta, Cause.Done>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          Effect.gen(function* () {
+            yield* observer.onQueryRegistered(engineTerminalStatus.queryId);
+            yield* Deferred.await(emitEngineTerminal).pipe(
+              Effect.andThen(observer.onTerminalOccurrence(engineTerminalStatus)),
+              Effect.andThen(Deferred.succeed(engineOccurred, undefined)),
+              Effect.andThen(Deferred.await(allowEngineReady)),
+              Effect.andThen(Queue.end(rawEvents)),
+              Effect.andThen(observer.onTerminalReady(engineTerminalStatus)),
+              Effect.forkChild({ startImmediately: true }),
+            );
+            return {
+              events: Stream.fromQueue(rawEvents),
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(Effect.andThen(Queue.end(rawEvents)), Effect.asVoid),
+            };
+          }),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["customerId"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        limit: 10,
+      });
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      yield* Deferred.succeed(emitEngineTerminal, undefined);
+      yield* Deferred.await(engineOccurred).pipe(Effect.timeout("1 second"));
+      yield* Queue.offer(rawEvents, malformedGroupedDelta);
+      yield* Effect.sync(() => runtimeEventRead).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("1 millis")),
+          until: (wasRead) => wasRead,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.succeed(allowEngineReady, undefined);
+      const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+
+      expect(Array.from(events)).toStrictEqual([engineTerminalStatus]);
+      expect({ rawCloseCount, releaseCount }).toStrictEqual({
+        rawCloseCount: 1,
+        releaseCount: 1,
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("keeps a grouped runtime terminal when engine termination occurs second", () =>
+    Effect.gen(function* () {
+      let rawCloseCount = 0;
+      let releaseCount = 0;
+      let runtimeEventRead = false;
+      const emitEngineTerminal = yield* Deferred.make<void>();
+      const engineOccurred = yield* Deferred.make<void>();
+      const allowEngineReady = yield* Deferred.make<void>();
+      const engineTerminalStatus = {
+        type: "status",
+        topic: "orders",
+        queryId: "runtime-engine-order",
+        status: "closed",
+        code: "BackpressureExceeded",
+        message: "engine terminal occurred second",
+      } as const;
+      const malformedGroupedDelta = {
+        type: "delta",
+        topic: "orders",
+        queryId: "runtime-engine-order",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "remove",
+            get key() {
+              runtimeEventRead = true;
+              return "missing-internal-group";
+            },
+          },
+        ],
+        totalRows: 0,
+      } as const;
+      const rawEvents = yield* Queue.unbounded<typeof malformedGroupedDelta, Cause.Done>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          Effect.gen(function* () {
+            yield* observer.onQueryRegistered(engineTerminalStatus.queryId);
+            yield* Deferred.await(emitEngineTerminal).pipe(
+              Effect.andThen(observer.onTerminalOccurrence(engineTerminalStatus)),
+              Effect.andThen(Deferred.succeed(engineOccurred, undefined)),
+              Effect.andThen(Deferred.await(allowEngineReady)),
+              Effect.andThen(Queue.end(rawEvents)),
+              Effect.andThen(observer.onTerminalReady(engineTerminalStatus)),
+              Effect.forkChild({ startImmediately: true }),
+            );
+            return {
+              events: Stream.fromQueue(rawEvents),
+              close: () =>
+                Effect.sync(() => {
+                  rawCloseCount += 1;
+                }).pipe(Effect.andThen(Queue.end(rawEvents)), Effect.asVoid),
+            };
+          }),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["customerId"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        limit: 10,
+      });
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      yield* Queue.offer(rawEvents, malformedGroupedDelta);
+      yield* Effect.sync(() => runtimeEventRead).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("1 millis")),
+          until: (wasRead) => wasRead,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.succeed(emitEngineTerminal, undefined);
+      yield* Deferred.await(engineOccurred).pipe(Effect.timeout("1 second"));
+      yield* Deferred.succeed(allowEngineReady, undefined);
+      const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "runtime-engine-order",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "Leased gRPC grouped key value cannot be encoded as a stable public key",
+        },
+      ]);
+      expect({ rawCloseCount, releaseCount }).toStrictEqual({
+        rawCloseCount: 1,
+        releaseCount: 1,
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("releases a leased gRPC subscription once when event consumption is interrupted", () =>
+    Effect.gen(function* () {
+      let releaseCount = 0;
+      const initialEventSeen = yield* Deferred.make<void>();
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+        release: Effect.sync(() => {
+          releaseCount += 1;
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(initialEventSeen, undefined)),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
+      yield* Deferred.await(initialEventSeen).pipe(Effect.timeout("1 second"));
+      yield* Fiber.interrupt(eventsFiber);
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+        Effect.timeout("1 second"),
+      );
+      yield* subscription.close();
+      yield* manager.close;
+
+      expect({
+        releaseCount,
+        activeSubscriptions: cleanedHealth.engine.topics.orders.activeSubscriptions,
+        retainedRows: cleanedHealth.engine.topics.orders.rowCount,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        releaseCount: 1,
+        activeSubscriptions: 0,
+        retainedRows: 0,
+        leasedFeedKeys: [],
+      });
       yield* runtimeCore.close;
     }),
   );
@@ -8555,16 +10908,31 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: () =>
           Effect.succeed({
             events: Stream.empty,
             close: () => Effect.void,
           }),
+        subscribeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered("empty-query").pipe(
+            Effect.as({
+              events: Stream.empty,
+              close: () => Effect.void,
+            }),
+          ),
         subscribeRuntimeInternal: () =>
           Effect.succeed({
             events: Stream.empty,
             close: () => Effect.void,
           }),
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered("empty-query").pipe(
+            Effect.as({
+              events: Stream.empty,
+              close: () => Effect.void,
+            }),
+          ),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -8587,7 +10955,7 @@ describe("@effect-view-server/runtime", () => {
         {
           type: "status",
           topic: "orders",
-          queryId: "orders/leased-status",
+          queryId: "empty-query",
           status: "error",
           code: "RuntimeUnavailable",
           message: "gRPC leased upstream completed unexpectedly.",
@@ -8624,12 +10992,20 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: runtimeCore.internalLiveClient.subscribeInternal,
         subscribeRuntimeInternal: () =>
           Effect.succeed({
             events: Stream.make(malformedSnapshot),
             close: () => Effect.void,
           }),
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(malformedSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(malformedSnapshot),
+              close: () => Effect.void,
+            }),
+          ),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -8684,6 +11060,7 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: (_topic, query) =>
           Effect.succeed({
             events: Stream.make({
@@ -8696,6 +11073,20 @@ describe("@effect-view-server/runtime", () => {
             }),
             close: () => Effect.void,
           }),
+        subscribeObservedInternal: (_topic, query, observer) =>
+          observer.onQueryRegistered("internal-query").pipe(
+            Effect.as({
+              events: Stream.make({
+                type: "status",
+                topic: "orders",
+                queryId: "internal-query",
+                status: "ready",
+                code: "Ready",
+                message: JSON.stringify(query),
+              }),
+              close: () => Effect.void,
+            }),
+          ),
         subscribeRuntimeInternal: (_topic, query) =>
           Effect.succeed({
             events: Stream.make({
@@ -8708,6 +11099,20 @@ describe("@effect-view-server/runtime", () => {
             }),
             close: () => Effect.void,
           }),
+        subscribeRuntimeObservedInternal: (_topic, query, observer) =>
+          observer.onQueryRegistered("internal-query").pipe(
+            Effect.as({
+              events: Stream.make({
+                type: "status",
+                topic: "orders",
+                queryId: "internal-query",
+                status: "ready",
+                code: "Ready",
+                message: JSON.stringify(query),
+              }),
+              close: () => Effect.void,
+            }),
+          ),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -8782,8 +11187,11 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: () => Effect.fail(subscriptionFailure),
+        subscribeObservedInternal: () => Effect.fail(subscriptionFailure),
         subscribeRuntimeInternal: () => Effect.fail(subscriptionFailure),
+        subscribeRuntimeObservedInternal: () => Effect.fail(subscriptionFailure),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -8850,8 +11258,9 @@ describe("@effect-view-server/runtime", () => {
       const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
         typeof leasedGrpcViewServer.topics
       > = {
+        ...runtimeCore.internalLiveClient,
         subscribeInternal: () => Queue.take(subscribeResults).pipe(Effect.flatten),
-        subscribeRuntimeInternal: runtimeCore.internalLiveClient.subscribeRuntimeInternal,
+        subscribeObservedInternal: () => Queue.take(subscribeResults).pipe(Effect.flatten),
       };
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
@@ -9839,6 +12248,95 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
+  it.live(
+    "rolls back a failed leased acquire when release defects and allows a fresh acquire",
+    () =>
+      Effect.gen(function* () {
+        let acquireCount = 0;
+        let releaseCount = 0;
+        const acquireFailure = new Error("leased acquire exploded before stream creation");
+        const releaseDefect = { _tag: "AcquireRollbackReleaseDefect" } as const;
+        const feed = grpcLeasedFeed({
+          streamForRegion: () => {
+            acquireCount += 1;
+            if (acquireCount === 1) {
+              throw acquireFailure;
+            }
+            return Stream.never;
+          },
+          release: Effect.suspend(() => {
+            releaseCount += 1;
+            return releaseCount === 1 ? Effect.die(releaseDefect) : Effect.void;
+          }),
+        });
+        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+        const health = makeLeasedGrpcHealth(grpcOptions);
+        const manager = yield* makeViewServerGrpcLeaseManager(
+          leasedGrpcViewServer,
+          runtimeCore.internalClient,
+          runtimeCore.liveClient,
+          runtimeCore.internalLiveClient,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const failedAcquireExit = yield* manager.liveClient
+          .subscribe("orders", leasedOrdersQuery("usa"))
+          .pipe(Effect.exit);
+        const failedAcquireTypedError = Exit.isFailure(failedAcquireExit)
+          ? failedAcquireExit.cause.reasons.find(Cause.isFailReason)?.error
+          : undefined;
+        const failedAcquireDefect = Exit.isFailure(failedAcquireExit)
+          ? failedAcquireExit.cause.reasons.find(Cause.isDieReason)?.defect
+          : undefined;
+        const afterFailedAcquire = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+        const releaseCountAfterFailedAcquire = releaseCount;
+
+        const freshSubscription = yield* manager.liveClient.subscribe(
+          "orders",
+          leasedOrdersQuery("usa"),
+        );
+        const afterFreshAcquire = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+        const releaseCountAfterFreshAcquire = releaseCount;
+        const freshCloseExit = yield* freshSubscription.close().pipe(Effect.exit);
+        const releaseCountAfterFreshClose = releaseCount;
+        const managerCloseExit = yield* manager.close.pipe(Effect.exit);
+        yield* runtimeCore.close;
+
+        expect(failedAcquireTypedError).toStrictEqual({
+          _tag: "ViewServerRuntimeError",
+          code: "RuntimeUnavailable",
+          topic: "orders",
+          message: "gRPC leased feed acquire failed for ordersLease",
+        });
+        expect(failedAcquireDefect).toBe(releaseDefect);
+        expect({
+          acquireCount,
+          releaseCountAfterFailedAcquire,
+          releaseCountAfterFreshAcquire,
+          releaseCountAfterFreshClose,
+          failedLeaseKeys: Object.keys(afterFailedAcquire.grpc?.feeds.orders?.leased ?? {}),
+          freshSubscriberCount:
+            afterFreshAcquire.grpc?.feeds.orders?.leased[
+              "orders/ordersLease/leased/region=string%3A3%3Ausa"
+            ]?.subscriberCount,
+          freshCloseSucceeded: Exit.isSuccess(freshCloseExit),
+          managerCloseSucceeded: Exit.isSuccess(managerCloseExit),
+        }).toStrictEqual({
+          acquireCount: 2,
+          releaseCountAfterFailedAcquire: 1,
+          releaseCountAfterFreshAcquire: 1,
+          releaseCountAfterFreshClose: 2,
+          failedLeaseKeys: [],
+          freshSubscriberCount: 1,
+          freshCloseSucceeded: true,
+          managerCloseSucceeded: true,
+        });
+      }),
+  );
+
   it.live("fails leased gRPC subscription when client creation throws", () =>
     Effect.gen(function* () {
       const feed = grpcLeasedFeed({
@@ -10247,59 +12745,60 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
-  it.live(
-    "marks leased gRPC feed degraded when runtime publishMany violates the client contract",
-    () =>
-      Effect.gen(function* () {
-        const feed = grpcLeasedFeed({
-          streamForRegion: (region) => Stream.make(grpcOrderValue(`${region}-order-1`, 10)),
-        });
-        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
-        Object.defineProperty(runtimeCore.internalClient, "publishManyDecodedRowsWithStorageKeys", {
-          value: () => "not-an-effect",
-        });
-        const health = makeLeasedGrpcHealth(grpcOptions);
-        const manager = yield* makeViewServerGrpcLeaseManager(
-          leasedGrpcViewServer,
-          runtimeCore.internalClient,
-          runtimeCore.liveClient,
-          runtimeCore.internalLiveClient,
-          Effect.void,
-          grpcOptions,
-          health,
-        );
+  it.live("cleans a leased gRPC feed when runtime publishMany violates the client contract", () =>
+    Effect.gen(function* () {
+      const feed = grpcLeasedFeed({
+        streamForRegion: (region) => Stream.make(grpcOrderValue(`${region}-order-1`, 10)),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
+      Object.defineProperty(runtimeCore.internalClient, "publishManyDecodedRowsWithStorageKeys", {
+        value: () => "not-an-effect",
+      });
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        leasedGrpcViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
 
-        const subscription = yield* manager.liveClient.subscribe(
-          "orders",
-          leasedOrdersQuery("usa"),
-        );
-        const degradedHealth = yield* Effect.gen(function* () {
-          return health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
-        }).pipe(
-          Effect.repeat({
-            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
-            until: (currentHealth) =>
-              currentHealth.grpc?.feeds["orders"]?.leased[
-                "orders/ordersLease/leased/region=string%3A3%3Ausa"
-              ]?.status === "degraded",
-          }),
-        );
+      const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const cleanedHealth = yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (currentHealth) =>
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
+        }),
+      );
 
-        expect(
-          degradedHealth.grpc?.feeds["orders"]?.leased[
-            "orders/ordersLease/leased/region=string%3A3%3Ausa"
-          ]?.lastError,
-        ).toContain(
-          "Runtime publishManyDecodedRowsWithStorageKeys did not return an Effect for leased gRPC feed ordersLease",
-        );
-        yield* subscription.close();
-        yield* manager.close;
-        yield* runtimeCore.close;
-      }),
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease failed: ViewServerGrpcIngressError: Runtime publishManyDecodedRowsWithStorageKeys did not return an Effect for leased gRPC feed ordersLease",
+      ]);
+      expect({
+        runtimeStatus: cleanedHealth.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        runtimeStatus: "ready",
+        leasedFeedKeys: [],
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
   );
 
-  it.live("marks leased gRPC feed degraded when runtime publishMany fails", () =>
+  it.live("cleans a leased gRPC feed when runtime publishMany fails", () =>
     Effect.gen(function* () {
       const feed = grpcLeasedFeed({
         streamForRegion: (region) => Stream.make(grpcOrderValue(`${region}-order-1`, 10)),
@@ -10314,7 +12813,11 @@ describe("@effect-view-server/runtime", () => {
             }),
           ),
       });
-      const health = makeLeasedGrpcHealth(grpcOptions);
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
         runtimeCore.internalClient,
@@ -10326,23 +12829,27 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const cleanedHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
 
-      expect(
-        degradedHealth.grpc?.feeds["orders"]?.leased[
-          "orders/ordersLease/leased/region=string%3A3%3Ausa"
-        ]?.lastError,
-      ).toContain("gRPC leased feed publish failed for ordersLease");
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease failed: ViewServerGrpcIngressError: gRPC leased feed publish failed for ordersLease",
+      ]);
+      expect({
+        runtimeStatus: cleanedHealth.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        runtimeStatus: "ready",
+        leasedFeedKeys: [],
+      });
       yield* subscription.close();
       yield* manager.close;
       yield* runtimeCore.close;
@@ -10571,7 +13078,7 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
-  it.live("marks leased gRPC feed degraded when mapped rows have a non-string row key", () =>
+  it.live("cleans a leased gRPC feed when mapped rows have a non-string row key", () =>
     Effect.gen(function* () {
       const localViewServer = defineViewServerConfig({
         topics: {
@@ -10617,10 +13124,14 @@ describe("@effect-view-server/runtime", () => {
       });
       const grpcOptions = yield* Effect.fromNullishOr(resolvedOptions.grpcOptions);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
-      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
-        clients: grpcOptions.clientBaseUrls,
-        feeds: {},
-      });
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeViewServerGrpcHealthLedger({
+          clients: grpcOptions.clientBaseUrls,
+          feeds: {},
+        }),
+        degradationMessages,
+      );
       const manager = yield* makeViewServerGrpcLeaseManager(
         localViewServer,
         runtimeCore.internalClient,
@@ -10642,23 +13153,27 @@ describe("@effect-view-server/runtime", () => {
         value: "price",
       });
       yield* Deferred.succeed(firstValue, grpcOrderValue("numeric-key", 10));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const cleanedHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
 
-      expect(
-        degradedHealth.grpc?.feeds["orders"]?.leased[
-          "orders/ordersLease/leased/region=string%3A3%3Ausa"
-        ]?.lastError,
-      ).toContain("gRPC leased feed row key price for orders is not a string");
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease failed: ViewServerGrpcIngressError: gRPC leased feed row key price for orders is not a string",
+      ]);
+      expect({
+        runtimeStatus: cleanedHealth.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        runtimeStatus: "ready",
+        leasedFeedKeys: [],
+      });
       yield* subscription.close();
       yield* manager.close;
       yield* runtimeCore.close;
@@ -10872,7 +13387,7 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
-  it.live("marks leased gRPC feed degraded when mapping throws", () =>
+  it.live("cleans a leased gRPC feed when mapping throws", () =>
     Effect.gen(function* () {
       const feed = leasedGrpcFeed.leasedFeed({
         topic: "orders",
@@ -10887,7 +13402,11 @@ describe("@effect-view-server/runtime", () => {
       });
       const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
         runtimeCore.internalClient,
@@ -10899,31 +13418,34 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const cleanedHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
 
-      expect(degradedHealth.status).toBe("degraded");
-      expect(
-        degradedHealth.grpc?.feeds["orders"]?.leased[
-          "orders/ordersLease/leased/region=string%3A3%3Ausa"
-        ]?.lastError,
-      ).toContain("gRPC leased feed mapping failed for ordersLease");
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease failed: ViewServerGrpcIngressError: gRPC leased feed mapping failed for ordersLease",
+      ]);
+      expect({
+        runtimeStatus: cleanedHealth.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        runtimeStatus: "ready",
+        leasedFeedKeys: [],
+      });
       yield* subscription.close();
       yield* manager.close;
       yield* runtimeCore.close;
     }),
   );
 
-  it.live("marks leased gRPC feed degraded when mapping returns an invalid row", () =>
+  it.live("cleans a leased gRPC feed when mapping returns an invalid row", () =>
     Effect.gen(function* () {
       const feed = leasedGrpcFeed.leasedFeed({
         topic: "orders",
@@ -10948,7 +13470,11 @@ describe("@effect-view-server/runtime", () => {
       });
       const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
         runtimeCore.internalClient,
@@ -10960,38 +13486,45 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const cleanedHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
 
-      expect(degradedHealth.status).toBe("degraded");
-      expect(
-        degradedHealth.grpc?.feeds["orders"]?.leased[
-          "orders/ordersLease/leased/region=string%3A3%3Ausa"
-        ]?.lastError,
-      ).toContain("gRPC leased feed mapping produced an invalid row for ordersLease");
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease failed: ViewServerGrpcIngressError: gRPC leased feed mapping produced an invalid row for ordersLease",
+      ]);
+      expect({
+        runtimeStatus: cleanedHealth.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
+      }).toStrictEqual({
+        runtimeStatus: "ready",
+        leasedFeedKeys: [],
+      });
       yield* subscription.close();
       yield* manager.close;
       yield* runtimeCore.close;
     }),
   );
 
-  it.live("marks leased gRPC feed degraded when upstream stream fails", () =>
+  it.live("cleans a leased gRPC feed when its upstream stream fails", () =>
     Effect.gen(function* () {
       const feed = grpcLeasedFeed({
         streamForRegion: () => Stream.fail("upstream down"),
       });
       const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
         runtimeCore.internalClient,
@@ -11003,29 +13536,28 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const cleanedHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
 
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease failed: ViewServerGrpcIngressError: gRPC leased feed stream failed for ordersLease",
+      ]);
       expect({
-        runtimeStatus: degradedHealth.status,
-        clientStatus: degradedHealth.grpc?.clients["orders"]?.status,
-        feedStatus:
-          degradedHealth.grpc?.feeds["orders"]?.leased[
-            "orders/ordersLease/leased/region=string%3A3%3Ausa"
-          ]?.status,
+        runtimeStatus: cleanedHealth.status,
+        clientStatus: cleanedHealth.grpc?.clients["orders"]?.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
       }).toStrictEqual({
-        runtimeStatus: "degraded",
-        clientStatus: "degraded",
-        feedStatus: "degraded",
+        runtimeStatus: "ready",
+        clientStatus: "connected",
+        leasedFeedKeys: [],
       });
       yield* subscription.close();
       yield* manager.close;
@@ -11235,14 +13767,18 @@ describe("@effect-view-server/runtime", () => {
     }),
   );
 
-  it.live("marks leased gRPC feed degraded when upstream self-interrupts", () =>
+  it.live("cleans a leased gRPC feed when upstream self-interrupts", () =>
     Effect.gen(function* () {
       const feed = grpcLeasedFeed({
         streamForRegion: () => Stream.fromEffect(Effect.interrupt),
       });
       const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
       const manager = yield* makeViewServerGrpcLeaseManager(
         leasedGrpcViewServer,
         runtimeCore.internalClient,
@@ -11254,28 +13790,28 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const subscription = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const cleanedHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.clients["orders"]?.status === "degraded" &&
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            degradationMessages.length > 0 &&
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
 
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed ordersLease interrupted unexpectedly.",
+      ]);
       expect({
-        clientStatus: degradedHealth.grpc?.clients["orders"]?.status,
-        feedStatus:
-          degradedHealth.grpc?.feeds["orders"]?.leased[
-            "orders/ordersLease/leased/region=string%3A3%3Ausa"
-          ]?.status,
+        runtimeStatus: cleanedHealth.status,
+        clientStatus: cleanedHealth.grpc?.clients["orders"]?.status,
+        leasedFeedKeys: Object.keys(cleanedHealth.grpc?.feeds.orders?.leased ?? {}),
       }).toStrictEqual({
-        clientStatus: "degraded",
-        feedStatus: "degraded",
+        runtimeStatus: "ready",
+        clientStatus: "connected",
+        leasedFeedKeys: [],
       });
       yield* subscription.close();
       yield* manager.close;
@@ -11471,91 +14007,41 @@ describe("@effect-view-server/runtime", () => {
       );
 
       const first = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const degradedHealth = yield* Effect.gen(function* () {
+      const idleHealth = yield* Effect.gen(function* () {
         return health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
       }).pipe(
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/ordersLease/leased/region=string%3A3%3Ausa"
-            ]?.status === "degraded",
+            Object.keys(currentHealth.grpc?.feeds.orders?.leased ?? {}).length === 0,
         }),
       );
-      const rejectedDuringActiveTerminal = yield* Effect.flip(
-        manager.liveClient.subscribe("orders", leasedOrdersQuery("usa")),
-      );
-      const eventQueue = yield* Queue.unbounded<unknown>();
-      const eventsFiber = yield* first.events.pipe(
-        Stream.runForEach((event) => Queue.offer(eventQueue, event)),
-        Effect.forkChild,
-      );
-      const terminalStatus = yield* Queue.take(eventQueue).pipe(
-        Effect.repeat({
-          until: (event) => Reflect.get(Object(event), "type") === "status",
-        }),
-        Effect.timeout("1 second"),
-      );
-
-      expect(terminalStatus).toStrictEqual({
-        type: "status",
-        topic: "orders",
-        queryId: "query-0",
-        status: "error",
-        code: "RuntimeUnavailable",
-        message: "gRPC leased upstream completed unexpectedly.",
-      });
-      expect({
-        released,
-        runtimeStatus: degradedHealth.status,
-        clientStatus: degradedHealth.grpc?.clients["orders"]?.status,
-        feedStatus:
-          degradedHealth.grpc?.feeds["orders"]?.leased[
-            "orders/ordersLease/leased/region=string%3A3%3Ausa"
-          ]?.status,
-        rejectedDuringActiveTerminal,
-      }).toStrictEqual({
-        released: 1,
-        runtimeStatus: "degraded",
-        clientStatus: "degraded",
-        feedStatus: "degraded",
-        rejectedDuringActiveTerminal: {
-          _tag: "ViewServerRuntimeError",
-          code: "RuntimeUnavailable",
-          topic: "orders",
-          message:
-            "gRPC leased upstream is not accepting new subscribers after completion or failure.",
-        },
-      });
-      yield* first.close();
-      yield* Fiber.interrupt(eventsFiber);
-      const idleHealth = yield* Effect.gen(function* () {
-        return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
-      }).pipe(
-        Effect.repeat({
-          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
-          until: (currentHealth) =>
-            Object.keys(currentHealth.grpc?.feeds["orders"]?.leased ?? {}).length === 0,
-        }),
-      );
+      const firstEvents = yield* first.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
       expect({
         released,
         runtimeStatus: idleHealth.status,
         clientStatus: idleHealth.grpc?.clients["orders"]?.status,
-        leasedFeeds: Object.keys(idleHealth.grpc?.feeds["orders"]?.leased ?? {}),
+        leasedFeeds: Object.keys(idleHealth.grpc?.feeds.orders?.leased ?? {}),
+        eventTypes: Array.from(firstEvents).map((event) => event.type),
       }).toStrictEqual({
         released: 1,
         runtimeStatus: "ready",
         clientStatus: "connected",
         leasedFeeds: [],
+        eventTypes: ["snapshot", "delta", "delta", "status"],
       });
+      yield* first.close();
 
       const second = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
-      const secondEvents = yield* second.events.pipe(Stream.take(4), Stream.runCollect);
+      const secondEvents = yield* second.events.pipe(Stream.runCollect, Effect.timeout("1 second"));
 
-      expect(
-        Array.from(secondEvents).map((event) => Reflect.get(Object(event), "type")),
-      ).toStrictEqual(["snapshot", "delta", "delta", "status"]);
+      expect({
+        released,
+        eventTypes: Array.from(secondEvents).map((event) => event.type),
+      }).toStrictEqual({
+        released: 2,
+        eventTypes: ["snapshot", "delta", "delta", "status"],
+      });
       yield* second.close();
       yield* manager.close;
       yield* runtimeCore.close;


### PR DESCRIPTION
## Summary

- add an internal engine observer seam for query registration and terminal occurrence/ready ordering without expanding the public engine API
- arbitrate engine, upstream, runtime, explicit-close, and manager-close termination through one first-winner subscription lifetime
- make leased resource release, retained-row cleanup, subscription close, manager close, and failed-acquisition rollback cached, joinable, exactly-once, and Cause-preserving
- automatically converge lease references, retained rows, terminal status delivery, and health even when cleanup defects
- add deterministic regressions for all terminal orderings, overlapping closes, late callers, peer isolation, exact defect replay, failed acquisition rollback, and exact query identifiers
- add a patch changeset for effect-view-server

## Validation

- vp check
- strict Effect diagnostics across all packages: zero findings
- column live view engine: 270 tests, typecheck, 100% coverage
- runtime-core: 57 tests, typecheck, 100% coverage
- runtime: 358 tests, typecheck, 100% coverage, including real Kafka tests
- internal seam and package export checks
- vp run -w grpc:gate
- vp run -w bench:baseline:smoke
- independent Effect, Vitest/type-safety, and architecture reviews: CLEAN

Closes #294