### PR TITLE
fix(runtime): make TCP publish shutdown joinable

### DIFF
--- a/.changeset/join-tcp-publish-shutdown.md
+++ b/.changeset/join-tcp-publish-shutdown.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Make concurrent TCP publish shutdown paths join the same drain before Runtime Core teardown.

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -58,6 +58,7 @@ import {
   installTcpPublishAcceptedSocket,
   installTcpServerSteadyStateErrorHandler,
   makeViewServerTcpPublishIngress,
+  makeViewServerTcpPublishIngressWithServerFactory,
   rejectTcpSocketWhenClosed,
   tcpPublishUrl,
   ViewServerTcpPublishIngressError,
@@ -3795,6 +3796,213 @@ describe("@effect-view-server/runtime", () => {
       });
       yield* Effect.sync(() => server.removeAllListeners());
     }),
+  );
+
+  it.live(
+    "joins listener, explicit ingress, and runtime shutdown before runtime-core teardown",
+    () =>
+      Effect.gen(function* () {
+        const commandStarted = yield* Deferred.make<void>();
+        const commandInterruptStarted = yield* Deferred.make<void>();
+        const allowCommandFinalize = yield* Deferred.make<void>();
+        const commandFinalized = yield* Deferred.make<void>();
+        const explicitIngressCloseCompleted = yield* Deferred.make<void>();
+        const runtimeIngressCloseEntered = yield* Deferred.make<void>();
+        const runtimeCoreCloseStarted = yield* Deferred.make<void>();
+        const runtimeCloseCompleted = yield* Deferred.make<void>();
+        let tcpServerCloseCount = 0;
+        let tcpServer: Net.Server | undefined;
+        let explicitIngressClose: Effect.Effect<void> | undefined;
+        const dependencies: ViewServerRuntimeDependencies<typeof viewServer.topics> = {
+          ...makeDefaultRuntimeDependencies<typeof viewServer.topics>(),
+          makeRuntimeCore: (config, options) =>
+            makeViewServerRuntimeCoreInternal(config, options).pipe(
+              Effect.map((runtimeCore) => ({
+                ...runtimeCore,
+                internalClient: {
+                  ...runtimeCore.internalClient,
+                  publishManyDecodedRows: () =>
+                    Deferred.succeed(commandStarted, undefined).pipe(
+                      Effect.andThen(Effect.never),
+                      Effect.ensuring(
+                        Deferred.succeed(commandInterruptStarted, undefined).pipe(
+                          Effect.andThen(Deferred.await(allowCommandFinalize)),
+                          Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
+                        ),
+                      ),
+                    ),
+                },
+                close: Deferred.succeed(runtimeCoreCloseStarted, undefined).pipe(
+                  Effect.andThen(runtimeCore.close),
+                ),
+              })),
+            ),
+          makeServer: () =>
+            Effect.succeed({
+              url: "ws://127.0.0.1:0/rpc",
+              healthUrl: "http://127.0.0.1:0/health",
+              metricsUrl: "http://127.0.0.1:0/metrics",
+              close: Effect.void,
+            }),
+          makeTcpPublishIngress: (config, client, options) =>
+            makeViewServerTcpPublishIngressWithServerFactory(
+              config,
+              client,
+              options,
+              (connectionListener) => {
+                const server = Net.createServer(connectionListener);
+                const closeServer = server.close.bind(server);
+                const countedClose: Net.Server["close"] = (callback) => {
+                  tcpServerCloseCount += 1;
+                  return closeServer(callback);
+                };
+                Object.defineProperty(server, "close", {
+                  value: countedClose,
+                });
+                tcpServer = server;
+                return server;
+              },
+            ).pipe(
+              Effect.map((ingress) => {
+                explicitIngressClose = ingress.close;
+                return {
+                  ...ingress,
+                  close: Deferred.succeed(runtimeIngressCloseEntered, undefined).pipe(
+                    Effect.andThen(ingress.close),
+                  ),
+                };
+              }),
+            ),
+        };
+        yield* Effect.acquireUseRelease(
+          makeViewServerRuntimeWithDependencies(dependencies, viewServer, {
+            tcpPublishPort: 0,
+            websocketPort: 0,
+          }),
+          (runtime) =>
+            Effect.gen(function* () {
+              const tcpPublishUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+              const server = yield* Effect.fromNullishOr(tcpServer);
+              const ingressClose = yield* Effect.fromNullishOr(explicitIngressClose);
+              yield* Effect.acquireUseRelease(
+                connectTcpPublishSocket(tcpPublishUrl),
+                (socket) =>
+                  Effect.gen(function* () {
+                    socket.write(
+                      `${JSON.stringify({
+                        op: "publish",
+                        topic: "orders",
+                        row: order("shutdown-overlap", 10),
+                      })}\n`,
+                    );
+                    yield* Deferred.await(commandStarted).pipe(Effect.timeout("1 second"));
+
+                    server.emit("error", new Error("tcp shutdown overlap"));
+                    yield* Deferred.await(commandInterruptStarted).pipe(Effect.timeout("1 second"));
+                    const explicitIngressCloseFiber = yield* ingressClose.pipe(
+                      Effect.ensuring(Deferred.succeed(explicitIngressCloseCompleted, undefined)),
+                      Effect.forkChild({ startImmediately: true }),
+                    );
+                    const runtimeCloseFiber = yield* runtime.close.pipe(
+                      Effect.ensuring(Deferred.succeed(runtimeCloseCompleted, undefined)),
+                      Effect.forkChild({ startImmediately: true }),
+                    );
+                    yield* Deferred.await(runtimeIngressCloseEntered).pipe(
+                      Effect.timeout("1 second"),
+                    );
+
+                    expect({
+                      commandFinalized: yield* Deferred.isDone(commandFinalized),
+                      explicitIngressCloseCompleted: yield* Deferred.isDone(
+                        explicitIngressCloseCompleted,
+                      ),
+                      runtimeCloseCompleted: yield* Deferred.isDone(runtimeCloseCompleted),
+                      runtimeCoreCloseStarted: yield* Deferred.isDone(runtimeCoreCloseStarted),
+                    }).toStrictEqual({
+                      commandFinalized: false,
+                      explicitIngressCloseCompleted: false,
+                      runtimeCloseCompleted: false,
+                      runtimeCoreCloseStarted: false,
+                    });
+
+                    yield* Deferred.succeed(allowCommandFinalize, undefined);
+                    yield* Fiber.join(explicitIngressCloseFiber).pipe(Effect.timeout("1 second"));
+                    yield* Fiber.join(runtimeCloseFiber).pipe(Effect.timeout("1 second"));
+                    const priorCloseExit = Effect.runSyncExit(ingressClose);
+
+                    expect({
+                      commandFinalized: yield* Deferred.isDone(commandFinalized),
+                      explicitIngressCloseCompleted: yield* Deferred.isDone(
+                        explicitIngressCloseCompleted,
+                      ),
+                      priorCloseSucceeded: Exit.isSuccess(priorCloseExit),
+                      runtimeCloseCompleted: yield* Deferred.isDone(runtimeCloseCompleted),
+                      runtimeCoreCloseStarted: yield* Deferred.isDone(runtimeCoreCloseStarted),
+                      tcpServerCloseCount,
+                    }).toStrictEqual({
+                      commandFinalized: true,
+                      explicitIngressCloseCompleted: true,
+                      priorCloseSucceeded: true,
+                      runtimeCloseCompleted: true,
+                      runtimeCoreCloseStarted: true,
+                      tcpServerCloseCount: 1,
+                    });
+                  }).pipe(Effect.ensuring(Deferred.succeed(allowCommandFinalize, undefined))),
+                (socket) => Effect.sync(() => socket.destroy()),
+              );
+            }),
+          (runtime) =>
+            Deferred.succeed(allowCommandFinalize, undefined).pipe(Effect.andThen(runtime.close)),
+        );
+      }),
+  );
+
+  it.live("closes TCP publish startup interrupted before listen completes", () =>
+    Effect.acquireUseRelease(
+      makeViewServerRuntimeCoreInternal(viewServer, {}),
+      (runtimeCore) =>
+        Effect.gen(function* () {
+          const listenStarted = yield* Deferred.make<void>();
+          const serverClosed = yield* Deferred.make<void>();
+          let server: Net.Server | undefined;
+          const startupFiber = yield* makeViewServerTcpPublishIngressWithServerFactory(
+            viewServer,
+            runtimeCore.internalClient,
+            { port: 0 },
+            (connectionListener) => {
+              const createdServer = Net.createServer(connectionListener);
+              server = createdServer;
+              Object.defineProperty(createdServer, "listen", {
+                value: (_options: Net.ListenOptions, _callback: () => void) => {
+                  Deferred.doneUnsafe(listenStarted, Effect.void);
+                  return createdServer;
+                },
+              });
+              Object.defineProperty(createdServer, "close", {
+                value: (callback?: (error?: Error) => void) => {
+                  Deferred.doneUnsafe(serverClosed, Effect.void);
+                  callback?.();
+                  return createdServer;
+                },
+              });
+              return createdServer;
+            },
+          ).pipe(Effect.forkChild({ startImmediately: true }));
+
+          yield* Effect.gen(function* () {
+            yield* Deferred.await(listenStarted).pipe(Effect.timeout("1 second"));
+            yield* Fiber.interrupt(startupFiber);
+            expect(yield* Deferred.isDone(serverClosed)).toBe(true);
+          }).pipe(
+            Effect.ensuring(
+              Fiber.interrupt(startupFiber).pipe(
+                Effect.andThen(Effect.sync(() => server?.removeAllListeners())),
+              ),
+            ),
+          );
+        }),
+      (runtimeCore) => runtimeCore.close,
+    ),
   );
 
   it.live("fails startup when the TCP publish port is already bound", () =>

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -65,6 +65,8 @@ type TcpErrorHandlingServer = {
   readonly on: (event: "error", listener: (cause: Error) => void) => unknown;
 };
 
+type TcpPublishServerFactory = (connectionListener: (socket: Net.Socket) => void) => Net.Server;
+
 type TcpResponseSocket = {
   readonly destroyed: boolean;
   readonly off: (event: "close" | "error", listener: () => void) => unknown;
@@ -422,9 +424,6 @@ const installSocketHandler = <const Topics extends ViewServerRuntimeTopicDefinit
 
 const closeTcpServer = (server: Net.Server, state: TcpPublishServerState): Effect.Effect<void> =>
   Effect.gen(function* () {
-    if (state.closed) {
-      return;
-    }
     state.closed = true;
     for (const socketState of state.socketStates.values()) {
       socketState.closed = true;
@@ -563,57 +562,76 @@ export const installTcpPublishAcceptedSocket = <
   installSocketHandler(socket, socketState, state, config, client, options, sourceOwnership);
 };
 
+/** @internal Package-local test seam; not exported from @effect-view-server/runtime. */
+export const makeViewServerTcpPublishIngressWithServerFactory = Effect.fn(
+  "ViewServerRuntime.tcpPublish.makeWithServerFactory",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  config: ViewServerTopicConfig<Topics>,
+  client: ViewServerRuntimeCoreInternalClient<Topics>,
+  options: ViewServerTcpPublishIngressOptions,
+  createServer: TcpPublishServerFactory,
+) {
+  yield* validateTcpPublishOptions(options);
+  const host = options.host ?? "127.0.0.1";
+  const state: TcpPublishServerState = {
+    activeChains: new Set(),
+    activeFibers: new Set(),
+    closed: false,
+    preCommandDeadlineMs: undefined,
+    queuedCommands: 0,
+    socketStates: new Map(),
+    sockets: new Set(),
+  };
+  const server = createServer((socket) => {
+    installTcpPublishAcceptedSocket(socket, state, config, client, options);
+  });
+  return yield* Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const close = (yield* Effect.cached(closeTcpServer(server, state))).pipe(
+        Effect.uninterruptible,
+      );
+      yield* restore(
+        Effect.callback<void, ViewServerTcpPublishIngressError>((resume) => {
+          const onStartupError = (cause: Error) => {
+            resume(
+              Effect.fail(
+                new ViewServerTcpPublishIngressError({
+                  message: "TCP publish server failed to listen.",
+                  cause,
+                  phase: "listen",
+                }),
+              ),
+            );
+          };
+          server.once("error", onStartupError);
+          server.listen({ host, port: options.port }, () => {
+            server.off("error", onStartupError);
+            installTcpServerSteadyStateErrorHandler(server, close);
+            resume(Effect.void);
+          });
+          return close;
+        }),
+      );
+      const address = Schema.decodeUnknownSync(TcpAddress)(server.address());
+      return {
+        url: tcpPublishUrl(address),
+        close,
+      };
+    }),
+  );
+});
+
 export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpPublish.make")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     config: ViewServerTopicConfig<Topics>,
     client: ViewServerRuntimeCoreInternalClient<Topics>,
     options: ViewServerTcpPublishIngressOptions,
   ) {
-    yield* validateTcpPublishOptions(options);
-    const host = options.host ?? "127.0.0.1";
-    const state: TcpPublishServerState = {
-      activeChains: new Set(),
-      activeFibers: new Set(),
-      closed: false,
-      preCommandDeadlineMs: undefined,
-      queuedCommands: 0,
-      socketStates: new Map(),
-      sockets: new Set(),
-    };
-    const server = Net.createServer((socket) => {
-      installTcpPublishAcceptedSocket(socket, state, config, client, options);
-    });
-    return yield* Effect.uninterruptibleMask((restore) =>
-      Effect.gen(function* () {
-        const close = closeTcpServer(server, state);
-        yield* restore(
-          Effect.callback<void, ViewServerTcpPublishIngressError>((resume) => {
-            const onStartupError = (cause: Error) => {
-              resume(
-                Effect.fail(
-                  new ViewServerTcpPublishIngressError({
-                    message: "TCP publish server failed to listen.",
-                    cause,
-                    phase: "listen",
-                  }),
-                ),
-              );
-            };
-            server.once("error", onStartupError);
-            server.listen({ host, port: options.port }, () => {
-              server.off("error", onStartupError);
-              installTcpServerSteadyStateErrorHandler(server, close);
-              resume(Effect.void);
-            });
-            return close;
-          }),
-        );
-        const address = Schema.decodeUnknownSync(TcpAddress)(server.address());
-        return {
-          url: tcpPublishUrl(address),
-          close,
-        };
-      }),
+    return yield* makeViewServerTcpPublishIngressWithServerFactory(
+      config,
+      client,
+      options,
+      (connectionListener) => Net.createServer(connectionListener),
     );
   },
 );


### PR DESCRIPTION
## Summary
- make every TCP publish shutdown path join one cached, uninterruptible drain
- prevent Runtime Core teardown until sockets, command fibers/chains, and the listener finish
- add deterministic overlap and pre-listen interruption regressions
- add a patch changeset for the corrected public shutdown behavior

## Validation
- regression first failed on premature explicit/runtime close and Runtime Core teardown
- runtime package: 360 tests and type tests, 100% statements/branches/functions/lines
- strict Effect diagnostics: zero errors, warnings, or messages
- vp check
- vp run -w ready
- vp run -w bench:baseline:smoke (19 tasks, comparison passed)

## Independent reviews
- Effect/lifecycle: CLEAN
- Vitest/type safety: CLEAN
- architecture/thermonuclear: CLEAN

Closes #295