### PR TITLE
fix(runtime): bound leased grouped-key translations

### DIFF
--- a/.changeset/bound-leased-grouped-key-translations.md
+++ b/.changeset/bound-leased-grouped-key-translations.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Bound leased grouped-key translation memory to each grouped live subscription.

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -140,12 +140,16 @@ type ActiveLease = LeaseRowOwner & {
   readonly route: LeasedFeedRoute;
   readonly scope: Scope.Scope;
   readonly publicToInternalKeys: Map<string, string>;
-  readonly internalToPublicGroupedKeys: Map<string, string>;
   readonly cleanupRows: Effect.Effect<void, ViewServerGrpcIngressError, never>;
   readonly terminalSignals: Set<Deferred.Deferred<LeaseTerminal>>;
   readonly subscriptions: Set<ActiveLeaseSubscription>;
   subscribers: number;
   acceptingSubscribers: boolean;
+};
+
+type GroupedKeyTranslations = {
+  readonly query: Pick<GroupedQuery<object>, "groupBy">;
+  readonly byInternalKey: Map<string, string>;
 };
 
 type ActiveLeaseSubscription = {
@@ -161,6 +165,11 @@ export type ViewServerGrpcLeaseManager<Topics extends ViewServerRuntimeTopicDefi
   readonly client: ViewServerRuntimeClient<Topics>;
   readonly liveClient: ViewServerRuntimeLiveClient<Topics>;
   readonly close: Effect.Effect<void>;
+};
+
+/** @internal Package-local test probe; not exported from @effect-view-server/runtime. */
+type ViewServerGrpcLeaseManagerTestProbe = {
+  readonly onGroupedKeyTranslationsCreated: (translations: ReadonlyMap<string, string>) => void;
 };
 
 const grpcMessageBatchSize = 256;
@@ -584,9 +593,6 @@ const validateLeasedRowRoute = Effect.fn("ViewServerRuntime.grpc.leased.row.vali
 const publicKeyForInternalKey = (lease: ActiveLease, key: string): string =>
   lease.internalToPublicKeys.get(key) ?? key;
 
-const publicGroupedKeyForInternalKey = (lease: ActiveLease, key: string): string | undefined =>
-  lease.internalToPublicGroupedKeys.get(key);
-
 const externalizeLeasedRow = <Row extends object>(
   lease: ActiveLease,
   keyField: string,
@@ -656,20 +662,6 @@ const groupedKeyFromExternalizedRow = (
     tokens.push(token);
   }
   return `["array",[${tokens.join(",")}]]`;
-};
-
-const externalizedGroupedOperationKey = (
-  lease: ActiveLease,
-  key: string,
-  query: Pick<GroupedQuery<object>, "groupBy">,
-  row: object,
-): string | undefined => {
-  const publicKey = groupedKeyFromExternalizedRow(query, row);
-  if (publicKey === undefined) {
-    return undefined;
-  }
-  lease.internalToPublicGroupedKeys.set(key, publicKey);
-  return publicKey;
 };
 
 const groupedKeyEncodingErrorStatus = (lease: ActiveLease, queryId: string): StatusEvent => ({
@@ -755,26 +747,30 @@ const resetLeaseRowCount = Effect.fn("ViewServerRuntime.grpc.leased.health.rowCo
 const externalizeLeasedEvent = <Row extends object>(
   lease: ActiveLease,
   keyField: string,
-  query: unknown,
+  groupedKeyTranslations: GroupedKeyTranslations | undefined,
   event: ViewServerLiveEvent<Row>,
 ): ViewServerLiveEvent<Row> => {
-  const groupedQuery = isGroupedRuntimeQuery(query) ? query : undefined;
   if (event.type === "snapshot") {
     const rows = event.rows.map((row) => externalizeLeasedRow(lease, keyField, row));
     const keys: Array<string> = [];
-    if (groupedQuery === undefined) {
+    if (groupedKeyTranslations === undefined) {
       for (const key of event.keys) {
         keys.push(publicKeyForInternalKey(lease, key));
       }
     } else {
+      const nextTranslations = new Map<string, string>();
       for (const [index, internalKey] of event.keys.entries()) {
         const row = Object(rows[index]);
-        const publicKey = groupedKeyFromExternalizedRow(groupedQuery, row);
+        const publicKey = groupedKeyFromExternalizedRow(groupedKeyTranslations.query, row);
         if (publicKey === undefined) {
           return groupedKeyEncodingErrorStatus(lease, event.queryId);
         }
-        lease.internalToPublicGroupedKeys.set(internalKey, publicKey);
+        nextTranslations.set(internalKey, publicKey);
         keys.push(publicKey);
+      }
+      groupedKeyTranslations.byInternalKey.clear();
+      for (const [internalKey, publicKey] of nextTranslations) {
+        groupedKeyTranslations.byInternalKey.set(internalKey, publicKey);
       }
     }
     return {
@@ -785,34 +781,65 @@ const externalizeLeasedEvent = <Row extends object>(
   }
   if (event.type === "delta") {
     const operations: Array<(typeof event.operations)[number]> = [];
+    if (groupedKeyTranslations === undefined) {
+      for (const operation of event.operations) {
+        if (operation.type === "move" || operation.type === "remove") {
+          operations.push({
+            ...operation,
+            key: publicKeyForInternalKey(lease, operation.key),
+          });
+          continue;
+        }
+        const row = externalizeLeasedRow(lease, keyField, operation.row);
+        operations.push({
+          ...operation,
+          key: publicKeyForInternalKey(lease, operation.key),
+          row,
+        });
+      }
+      return {
+        ...event,
+        operations,
+      };
+    }
+    const pendingTranslations = new Map<string, string | undefined>();
+    const publicGroupedKeyForInternalKey = (key: string): string | undefined =>
+      pendingTranslations.has(key)
+        ? pendingTranslations.get(key)
+        : groupedKeyTranslations.byInternalKey.get(key);
     for (const operation of event.operations) {
       if (operation.type === "move" || operation.type === "remove") {
-        const publicGroupedKey =
-          groupedQuery === undefined
-            ? undefined
-            : publicGroupedKeyForInternalKey(lease, operation.key);
-        if (groupedQuery !== undefined && publicGroupedKey === undefined) {
+        const publicGroupedKey = publicGroupedKeyForInternalKey(operation.key);
+        if (publicGroupedKey === undefined) {
           return groupedKeyEncodingErrorStatus(lease, event.queryId);
         }
         operations.push({
           ...operation,
-          key: publicGroupedKey ?? publicKeyForInternalKey(lease, operation.key),
+          key: publicGroupedKey,
         });
+        if (operation.type === "remove") {
+          pendingTranslations.set(operation.key, undefined);
+        }
         continue;
       }
       const row = externalizeLeasedRow(lease, keyField, operation.row);
-      const publicGroupedKey =
-        groupedQuery === undefined
-          ? undefined
-          : externalizedGroupedOperationKey(lease, operation.key, groupedQuery, row);
-      if (groupedQuery !== undefined && publicGroupedKey === undefined) {
+      const publicGroupedKey = groupedKeyFromExternalizedRow(groupedKeyTranslations.query, row);
+      if (publicGroupedKey === undefined) {
         return groupedKeyEncodingErrorStatus(lease, event.queryId);
       }
       operations.push({
         ...operation,
-        key: publicGroupedKey ?? publicKeyForInternalKey(lease, operation.key),
+        key: publicGroupedKey,
         row,
       });
+      pendingTranslations.set(operation.key, publicGroupedKey);
+    }
+    for (const [internalKey, publicKey] of pendingTranslations) {
+      if (publicKey === undefined) {
+        groupedKeyTranslations.byInternalKey.delete(internalKey);
+      } else {
+        groupedKeyTranslations.byInternalKey.set(internalKey, publicKey);
+      }
     }
     return {
       ...event,
@@ -1095,6 +1122,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
   options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
   health: ViewServerGrpcHealthLedger<Topics>,
   makeClient: ViewServerGrpcClientFactory = makeDefaultGrpcClient,
+  testProbe?: ViewServerGrpcLeaseManagerTestProbe,
 ) {
   const leases = new Map<string, ActiveLease>();
   const feedsByTopic = leasedFeedsByTopic(options);
@@ -1228,7 +1256,6 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       route,
       scope,
       publicToInternalKeys: new Map<string, string>(),
-      internalToPublicGroupedKeys: new Map<string, string>(),
       cleanupRows,
       terminalSignals: new Set<Deferred.Deferred<LeaseTerminal>>([terminalSignal]),
       subscriptions: new Set<ActiveLeaseSubscription>(),
@@ -1359,6 +1386,17 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     readonly terminalRegistration: LeaseTerminalRegistration;
   }): Effect.Effect<ViewServerLiveSubscription<Row>, never, never> =>
     Effect.gen(function* () {
+      const groupedKeyTranslations: GroupedKeyTranslations | undefined = isGroupedRuntimeQuery(
+        input.query,
+      )
+        ? {
+            query: input.query,
+            byInternalKey: new Map<string, string>(),
+          }
+        : undefined;
+      if (groupedKeyTranslations !== undefined) {
+        testProbe?.onGroupedKeyTranslationsCreated(groupedKeyTranslations.byInternalKey);
+      }
       function close(): Effect.Effect<void, never, never> {
         return closeEffect;
       }
@@ -1371,6 +1409,9 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             input.subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
             releaseLease(input.lease),
             Effect.sync(() => input.lease.subscriptions.delete(subscriptionOwner)),
+            Effect.sync(() => {
+              groupedKeyTranslations?.byInternalKey.clear();
+            }),
           ]);
         }).pipe(Effect.withSpan("ViewServerRuntime.grpc.leased.subscription.close")),
       )).pipe(Effect.uninterruptible);
@@ -1384,7 +1425,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         });
       const runtimeEvents = input.subscription.events.pipe(
         Stream.map((event) =>
-          externalizeLeasedEvent(input.lease, input.keyField, input.query, event),
+          externalizeLeasedEvent(input.lease, input.keyField, groupedKeyTranslations, event),
         ),
         Stream.filterEffect((event) => {
           if (isGroupedKeyEncodingErrorStatus(event)) {

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -52,6 +52,7 @@ import {
 import { makeViewServerGrpcHealthLedger, type ViewServerGrpcHealthLedger } from "./grpc-health";
 import { makeViewServerGrpcIngress, ViewServerGrpcIngressError } from "./grpc-ingress";
 import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+import { makeDefaultGrpcClient } from "./grpc-source-lifecycle";
 import { makeViewServerRuntime, runViewServerRuntime } from "./index";
 import { messageFromUnknown, ViewServerKafkaIngressError } from "./kafka-ingress";
 import {
@@ -8069,6 +8070,324 @@ describe("@effect-view-server/runtime", () => {
       yield* subscription.close();
       yield* manager.close;
       yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("bounds grouped-key translations to each leased subscription lifetime", () =>
+    Effect.gen(function* () {
+      const churnRows = Array.from({ length: 64 }, (_, index) => ({
+        customerId: `customer-${index}`,
+        rowCount: 1n,
+      }));
+      const churnInternalKeys = churnRows.map((_row, index) => `customer-internal-${index}`);
+      const removalOperations: ReadonlyArray<{ readonly type: "remove"; readonly key: string }> =
+        churnInternalKeys.slice(1).map((key) => ({ type: "remove", key }));
+      const replacementRows = [
+        { customerId: "replacement-a", rowCount: 1n },
+        { customerId: "replacement-b", rowCount: 1n },
+      ];
+      const replacementInternalKeys = ["replacement-internal-a", "replacement-internal-b"];
+      const customerSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "customer-groups",
+        version: 0,
+        keys: churnInternalKeys,
+        rows: churnRows,
+        totalRows: churnRows.length,
+      } as const;
+      const customerRemovalDelta = {
+        type: "delta",
+        topic: "orders",
+        queryId: "customer-groups",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: removalOperations,
+        totalRows: 1,
+      } as const;
+      const customerReplacementSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "customer-groups",
+        version: 2,
+        keys: replacementInternalKeys,
+        rows: replacementRows,
+        totalRows: replacementRows.length,
+      } as const;
+      const statusSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "status-groups",
+        version: 0,
+        keys: ["status-internal-open"],
+        rows: [{ status: "open", rowCount: 64n }],
+        totalRows: 1,
+      } as const;
+      const statusMoveDelta = {
+        type: "delta",
+        topic: "orders",
+        queryId: "status-groups",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "update",
+            key: "status-internal-open",
+            row: { status: "open", rowCount: 65n },
+            index: 0,
+          },
+          {
+            type: "move",
+            key: "status-internal-open",
+            fromIndex: 0,
+            toIndex: 0,
+          },
+        ],
+        totalRows: 1,
+      } as const;
+      const publicGroupedStringKey = (field: string, value: string): string => {
+        const fieldToken = `["array",[["string",${JSON.stringify(field)}],["string",${JSON.stringify(value)}]]]`;
+        return `["array",[${fieldToken}]]`;
+      };
+      const releaseCustomerRemovals = yield* Deferred.make<void>();
+      const releaseCustomerReplacement = yield* Deferred.make<void>();
+      const releaseStatusMove = yield* Deferred.make<void>();
+      const translationStates: Array<ReadonlyMap<string, string>> = [];
+      const feed = grpcLeasedFeed({
+        streamForRegion: () => Stream.never,
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+
+      yield* Effect.acquireUseRelease(
+        makeViewServerRuntimeCoreInternal(leasedGrpcViewServer, {}),
+        (runtimeCore) => {
+          let subscriptionIndex = 0;
+          const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+            typeof leasedGrpcViewServer.topics
+          > = {
+            ...runtimeCore.internalLiveClient,
+            subscribeRuntimeObservedInternal: (_topic, _query, observer) => {
+              if (subscriptionIndex === 0) {
+                subscriptionIndex += 1;
+                return observer.onQueryRegistered(customerSnapshot.queryId).pipe(
+                  Effect.as({
+                    events: Stream.make(customerSnapshot).pipe(
+                      Stream.concat(
+                        Stream.fromEffect(
+                          Deferred.await(releaseCustomerRemovals).pipe(
+                            Effect.as(customerRemovalDelta),
+                          ),
+                        ),
+                      ),
+                      Stream.concat(
+                        Stream.fromEffect(
+                          Deferred.await(releaseCustomerReplacement).pipe(
+                            Effect.as(customerReplacementSnapshot),
+                          ),
+                        ),
+                      ),
+                      Stream.concat(Stream.never),
+                    ),
+                    close: () => Effect.void,
+                  }),
+                );
+              }
+              subscriptionIndex += 1;
+              return observer.onQueryRegistered(statusSnapshot.queryId).pipe(
+                Effect.as({
+                  events: Stream.make(statusSnapshot).pipe(
+                    Stream.concat(
+                      Stream.fromEffect(
+                        Deferred.await(releaseStatusMove).pipe(Effect.as(statusMoveDelta)),
+                      ),
+                    ),
+                    Stream.concat(Stream.never),
+                  ),
+                  close: () => Effect.void,
+                }),
+              );
+            },
+          };
+          const health = makeLeasedGrpcHealth(grpcOptions);
+          return Effect.acquireUseRelease(
+            makeViewServerGrpcLeaseManager(
+              leasedGrpcViewServer,
+              runtimeCore.internalClient,
+              runtimeCore.liveClient,
+              fakeInternalLiveClient,
+              Effect.void,
+              grpcOptions,
+              health,
+              makeDefaultGrpcClient,
+              {
+                onGroupedKeyTranslationsCreated: (translations) => {
+                  translationStates.push(translations);
+                },
+              },
+            ),
+            (manager) =>
+              Effect.acquireUseRelease(
+                manager.liveClient.subscribeRuntime("orders", {
+                  groupBy: ["customerId"],
+                  aggregates: {
+                    rowCount: { aggFunc: "count" },
+                  },
+                  where: {
+                    region: { eq: "usa" },
+                  },
+                  limit: 100,
+                }),
+                (customerSubscription) =>
+                  Effect.acquireUseRelease(
+                    manager.liveClient.subscribeRuntime("orders", {
+                      groupBy: ["status"],
+                      aggregates: {
+                        rowCount: { aggFunc: "count" },
+                      },
+                      where: {
+                        region: { eq: "usa" },
+                      },
+                      limit: 10,
+                    }),
+                    (statusSubscription) =>
+                      Effect.gen(function* () {
+                        const customerTranslations = yield* Effect.fromNullishOr(
+                          translationStates[0],
+                        );
+                        const statusTranslations = yield* Effect.fromNullishOr(
+                          translationStates[1],
+                        );
+                        const customerEventQueue = yield* Queue.unbounded<unknown>();
+                        const customerEventsFiber = yield* customerSubscription.events.pipe(
+                          Stream.runForEach((event) => Queue.offer(customerEventQueue, event)),
+                          Effect.forkChild({ startImmediately: true }),
+                        );
+                        const customerSnapshotEvent = yield* Queue.take(customerEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(customerTranslations.size).toBe(64);
+
+                        yield* Deferred.succeed(releaseCustomerRemovals, undefined);
+                        const customerRemovalEvent = yield* Queue.take(customerEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(customerTranslations.size).toBe(1);
+
+                        yield* Deferred.succeed(releaseCustomerReplacement, undefined);
+                        const customerReplacementEvent = yield* Queue.take(customerEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(customerTranslations.size).toBe(2);
+                        const customerEvents = [
+                          customerSnapshotEvent,
+                          customerRemovalEvent,
+                          customerReplacementEvent,
+                        ];
+                        const statusEventQueue = yield* Queue.unbounded<unknown>();
+                        const statusEventsFiber = yield* statusSubscription.events.pipe(
+                          Stream.runForEach((event) => Queue.offer(statusEventQueue, event)),
+                          Effect.forkChild({ startImmediately: true }),
+                        );
+                        const statusSnapshotEvent = yield* Queue.take(statusEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+
+                        expect({
+                          customerTranslations: customerTranslations.size,
+                          statusTranslations: statusTranslations.size,
+                        }).toStrictEqual({
+                          customerTranslations: 2,
+                          statusTranslations: 1,
+                        });
+
+                        yield* customerSubscription.close();
+                        expect({
+                          customerTranslations: customerTranslations.size,
+                          statusTranslations: statusTranslations.size,
+                        }).toStrictEqual({
+                          customerTranslations: 0,
+                          statusTranslations: 1,
+                        });
+                        yield* Fiber.interrupt(customerEventsFiber);
+                        yield* Deferred.succeed(releaseStatusMove, undefined);
+                        const statusMoveEvent = yield* Queue.take(statusEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        const statusEvents = [statusSnapshotEvent, statusMoveEvent];
+
+                        expect(customerEvents).toStrictEqual([
+                          {
+                            ...customerSnapshot,
+                            keys: churnRows.map((row) =>
+                              publicGroupedStringKey("customerId", row.customerId),
+                            ),
+                          },
+                          {
+                            ...customerRemovalDelta,
+                            operations: churnRows.slice(1).map((row) => ({
+                              type: "remove",
+                              key: publicGroupedStringKey("customerId", row.customerId),
+                            })),
+                          },
+                          {
+                            ...customerReplacementSnapshot,
+                            keys: replacementRows.map((row) =>
+                              publicGroupedStringKey("customerId", row.customerId),
+                            ),
+                          },
+                        ]);
+                        expect(statusEvents).toStrictEqual([
+                          {
+                            ...statusSnapshot,
+                            keys: [publicGroupedStringKey("status", "open")],
+                          },
+                          {
+                            ...statusMoveDelta,
+                            operations: [
+                              {
+                                ...statusMoveDelta.operations[0],
+                                key: publicGroupedStringKey("status", "open"),
+                              },
+                              {
+                                ...statusMoveDelta.operations[1],
+                                key: publicGroupedStringKey("status", "open"),
+                              },
+                            ],
+                          },
+                        ]);
+                        expect({
+                          customerTranslations: customerTranslations.size,
+                          statusTranslations: statusTranslations.size,
+                        }).toStrictEqual({
+                          customerTranslations: 0,
+                          statusTranslations: 1,
+                        });
+                        yield* statusSubscription.close();
+                        expect({
+                          customerTranslations: customerTranslations.size,
+                          statusTranslations: statusTranslations.size,
+                        }).toStrictEqual({
+                          customerTranslations: 0,
+                          statusTranslations: 0,
+                        });
+                        yield* Fiber.interrupt(statusEventsFiber);
+                      }).pipe(
+                        Effect.ensuring(
+                          Deferred.succeed(releaseCustomerRemovals, undefined).pipe(
+                            Effect.andThen(Deferred.succeed(releaseCustomerReplacement, undefined)),
+                            Effect.andThen(Deferred.succeed(releaseStatusMove, undefined)),
+                          ),
+                        ),
+                      ),
+                    (subscription) => subscription.close(),
+                  ),
+                (subscription) => subscription.close(),
+              ),
+            (manager) => manager.close,
+          );
+        },
+        (runtimeCore) => runtimeCore.close,
+      );
     }),
   );
 


### PR DESCRIPTION
## Summary

- move grouped-key translation state from the shared leased feed to each owning Subscription
- reconcile translation state atomically on replacement Snapshots and staged Deltas
- delete removed group translations after preserving their public wire keys
- clear owned translation state on Subscription close without changing Snapshot or Delta wire shapes
- add a deterministic high-cardinality churn and shared-lease isolation regression

Closes #296

## TDD evidence

- RED: after a 64-group Snapshot and 63 removes, retained translation cardinality was expected to be 1 but remained 64
- GREEN: the regression now proves 64 -> 1 -> 2 -> 0, exact public keys, replacement reconciliation, and independent 2/1 -> 0/1 -> 0/0 cleanup for two Subscriptions sharing one lease

## Validation

- `vp run @effect-view-server/runtime#test`: 8 files, 361 tests, no type errors, 100% statements/branches/functions/lines
- strict Effect diagnostics: 33/33 runtime files, 0 messages
- `vp check`: 611 formatted files and 322 lint/typechecked files, clean
- `vp run -w ready`: passed
- three independent reviews: Effect/lifecycle CLEAN, Vitest/type-safety CLEAN, architecture/thermonuclear CLEAN
- gRPC materialized baseline: passed
- gRPC leased 500-row baseline: passed
- gRPC leased retained 50k-row baseline: passed

The combined local `grpc:gate` wrapper was decomposed after its nested second `ready` exhausted the sandboxed Vite+ IPC/process allowance. Its complete `ready` prerequisite and all three serial benchmark comparisons passed independently. CI remains the authoritative combined gate.
