### PR TITLE
chore(repo): enforce consumer facade imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "@effect-view-server/server": "workspace:*",
     "@effect/language-service": "catalog:",
     "@effect/vitest": "catalog:",
+    "@types/markdown-it": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
     "effect-view-server": "workspace:*",
+    "markdown-it": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ catalogs:
     '@tanstack/router-plugin':
       specifier: 1.168.18
       version: 1.168.18
+    '@types/markdown-it':
+      specifier: ^14.1.2
+      version: 14.1.2
     '@types/node':
       specifier: 25.9.1
       version: 25.9.1
@@ -69,6 +72,9 @@ catalogs:
     effect:
       specifier: 4.0.0-beta.91
       version: 4.0.0-beta.91
+    markdown-it:
+      specifier: ^14.3.0
+      version: 14.3.0
     scheduler:
       specifier: 0.27.0
       version: 0.27.0
@@ -142,12 +148,18 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+      '@types/markdown-it':
+        specifier: 'catalog:'
+        version: 14.1.2
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
       effect-view-server:
         specifier: workspace:*
         version: link:packages/effect-view-server
+      markdown-it:
+        specifier: 'catalog:'
+        version: 14.3.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2459,6 +2471,15 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -2814,6 +2835,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -3109,6 +3134,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3141,6 +3169,13 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3319,6 +3354,10 @@ packages:
   protobufjs@8.6.0:
     resolution: {integrity: sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==}
     engines: {node: '>=12.0.0'}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
@@ -3537,6 +3576,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -4950,6 +4992,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@25.9.1':
@@ -5307,6 +5358,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@4.5.0: {}
+
   es-module-lexer@2.1.0: {}
 
   esbuild@0.28.1:
@@ -5566,6 +5619,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -5598,6 +5655,17 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.1
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -5776,6 +5844,8 @@ snapshots:
       long: 5.3.2
     optional: true
 
+  punycode.js@2.3.1: {}
+
   pure-rand@8.4.0: {}
 
   quansync@0.2.11: {}
@@ -5952,6 +6022,8 @@ snapshots:
       fsevents: 2.3.3
 
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,8 @@ catalog:
   tailwindcss: 4.3.1
   tsx: 4.22.4
   "@changesets/cli": 2.31.0
+  markdown-it: ^14.3.0
+  "@types/markdown-it": ^14.1.2
 overrides:
   "@babel/core": 7.29.7
   undici: 8.5.0

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -3,13 +3,19 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import {
+  assertNoConsumerImportViolations,
   assertNoPackageImportViolations,
   assertNoPackageExportViolations,
   assertNoEngineSeamViolations,
+  collectConsumerImportViolations,
   collectEngineSeamViolations,
   collectPackageExportViolations,
   collectPackageImportViolations,
+  consumerImportViolationsFor,
+  consumerImportViolationMessage,
+  consumerMarkdownImportViolationsFor,
   importSpecifiersFromSource,
+  isTestFile,
   libraryPackEntrypointPaths,
   packageExportSpecifiersForManifest,
   packageExportViolationMessage,
@@ -35,20 +41,468 @@ import {
 const makeDirectory = () => mkdtempSync(join(tmpdir(), "view-server-internal-seams-"));
 
 describe("internal seam checker", () => {
-  it("scans TypeScript and TSX source files recursively", () => {
+  it("rejects private workspace imports from consumer source", () => {
+    expect(
+      consumerImportViolationsFor({
+        contents: 'import { defineViewServerConfig } from "@effect-view-server/config";',
+        relativePath: "apps/example/src/view-server.config.ts",
+      }),
+    ).toStrictEqual([
+      "apps/example/src/view-server.config.ts imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("allows only approved publishable consumer subpaths", () => {
+    const staleScope = "@view" + "-server";
+
+    expect(
+      consumerImportViolationsFor({
+        contents: [
+          'import "@effect-view-server/config";',
+          'import "@effect-view-server/runtime/internal";',
+          `import "${staleScope}/react";`,
+          'import "effect-view-server";',
+          'import "effect-view-server/config/internal";',
+          'import "effect-view-server/config";',
+          'import "effect-view-server/react/testing";',
+          'import "effect-view-server/runtime";',
+          'import "effect";',
+        ].join("\n"),
+        relativePath: "examples/example/src/index.ts",
+      }),
+    ).toStrictEqual([
+      "examples/example/src/index.ts imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+      "examples/example/src/index.ts imports @effect-view-server/runtime/internal: consumers must import the publishable effect-view-server/* facade.",
+      `examples/example/src/index.ts imports ${staleScope}/react: stale View Server package scope; consumers must use approved effect-view-server/* subpaths.`,
+      "examples/example/src/index.ts imports effect-view-server: the package root is not exported; consumers must use an approved effect-view-server/* subpath.",
+      "examples/example/src/index.ts imports effect-view-server/config/internal: consumers must use approved effect-view-server/* package exports.",
+    ]);
+  });
+
+  it("rejects private workspace imports from consumer TypeScript code fences", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "# Consumer setup",
+          "```ts",
+          'import { defineViewServerConfig } from "@effect-view-server/config";',
+          "```",
+        ].join("\n"),
+        relativePath: "README.md",
+      }),
+    ).toStrictEqual([
+      "README.md:2 imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("checks TSX, MTS, and CTS fences with Markdown fence semantics", () => {
+    const staleScope = "@view" + "-server";
+
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "# More examples",
+          "~~~tsx",
+          'import "@effect-view-server/react";',
+          "```",
+          "~~~~",
+          "```mts",
+          `export * from "${staleScope}/runtime";`,
+          "``",
+          "````",
+          "````cts",
+          'const facade = require("effect-view-server");',
+          "`````",
+          "```typescript",
+          'import "effect-view-server/config";',
+          "```",
+        ].join("\r\n"),
+        relativePath: "docs/examples.md",
+      }),
+    ).toStrictEqual([
+      "docs/examples.md:2 imports @effect-view-server/react: consumers must import the publishable effect-view-server/* facade.",
+      `docs/examples.md:6 imports ${staleScope}/runtime: stale View Server package scope; consumers must use approved effect-view-server/* subpaths.`,
+      "docs/examples.md:10 imports effect-view-server: the package root is not exported; consumers must use an approved effect-view-server/* subpath.",
+    ]);
+  });
+
+  it("checks fenced source inside blockquote containers", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "> ```ts",
+          '> import "@effect-view-server/config";',
+          "> ````",
+          ">",
+          "> > ~~~~custom-language",
+          '> > export * from "@effect-view-server/runtime";',
+          "> > ~~~~~",
+        ].join("\n"),
+        relativePath: "docs/blockquote-examples.md",
+      }),
+    ).toStrictEqual([
+      "docs/blockquote-examples.md:1 imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+      "docs/blockquote-examples.md:5 imports @effect-view-server/runtime: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("checks fenced source inside sufficiently indented list containers", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "- ```ts",
+          '  import "@effect-view-server/client";',
+          "  ````",
+          "",
+          "- Outer item",
+          "  1. ~~~~custom-language",
+          '       export * from "@effect-view-server/server";',
+          "       ~~~~~",
+          "",
+          "-     ```ts",
+          '      import "@effect-view-server/config";',
+          "      ```",
+          "",
+          ">     ```ts",
+          '>     import "@effect-view-server/react";',
+          ">     ```",
+          "",
+          "    ```ts",
+          '    import "@effect-view-server/runtime";',
+          "    ```",
+        ].join("\n"),
+        relativePath: "examples/list-examples.md",
+      }),
+    ).toStrictEqual([
+      "examples/list-examples.md:1 imports @effect-view-server/client: consumers must import the publishable effect-view-server/* facade.",
+      "examples/list-examples.md:6 imports @effect-view-server/server: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("checks fences continued beneath list item content indentation", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "- Example:",
+          "    ```ts",
+          '    import "@effect-view-server/config";',
+          "    ````",
+          "",
+          "10. Ordered example:",
+          "    ~~~~custom-language",
+          '    export * from "@effect-view-server/runtime";',
+          "    ~~~~~",
+          "",
+          "- Parent",
+          "",
+          "    - ```ts",
+          '      import "@effect-view-server/server";',
+          "      ````",
+          "",
+          "- Tab-indented parent",
+          "",
+          "\t- ~~~~ts",
+          '\t  import "@effect-view-server/client";',
+          "\t  ~~~~~",
+        ].join("\n"),
+        relativePath: "docs/list-continuations.md",
+      }),
+    ).toStrictEqual([
+      "docs/list-continuations.md:2 imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+      "docs/list-continuations.md:7 imports @effect-view-server/runtime: consumers must import the publishable effect-view-server/* facade.",
+      "docs/list-continuations.md:13 imports @effect-view-server/server: consumers must import the publishable effect-view-server/* facade.",
+      "docs/list-continuations.md:19 imports @effect-view-server/client: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("checks a fence in a tab-padded list item", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "-\t```ts",
+          '\timport "@effect-view-server/config";',
+          "\t````",
+        ].join("\n"),
+        relativePath: "docs/tab-padded-list.md",
+      }),
+    ).toStrictEqual([
+      "docs/tab-padded-list.md:1 imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("checks a fence beneath an empty ordered list item", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "10.",
+          "    ```ts",
+          '    import "@effect-view-server/runtime";',
+          "    ````",
+        ].join("\n"),
+        relativePath: "docs/empty-list-item.md",
+      }),
+    ).toStrictEqual([
+      "docs/empty-list-item.md:2 imports @effect-view-server/runtime: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("does not treat a non-one ordered paragraph continuation as a list", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "Paragraph",
+          "2. continuation",
+          "    ```ts",
+          '    import "@effect-view-server/server";',
+          "    ```",
+        ].join("\n"),
+        relativePath: "docs/paragraph-continuation.md",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("stops a contained fence when its Markdown container ends", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "> ```ts",
+          '> import "effect-view-server/config";',
+          'import "@effect-view-server/server";',
+          "```ts",
+          'import "@effect-view-server/client";',
+          "```",
+        ].join("\n"),
+        relativePath: "docs/blockquote-boundary.md",
+      }),
+    ).toStrictEqual([
+      "docs/blockquote-boundary.md:4 imports @effect-view-server/client: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "- Example:",
+          "    ```ts",
+          "",
+          '    import "effect-view-server/config";',
+          'import "@effect-view-server/runtime";',
+        ].join("\n"),
+        relativePath: "docs/list-boundary.md",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("checks every fence while ignoring prose, inline code, task names, and data values", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          'Prose may explain `import "@effect-view-server/config"` without being executable.',
+          "```sh",
+          "vp run @effect-view-server/example#test",
+          "```",
+          "```json",
+          '{ "task": "@effect-view-server/runtime" }',
+          "```",
+          "```ts",
+          'const taskName = "@effect-view-server/runtime";',
+          "```",
+          "```text",
+          'import "@effect-view-server/server";',
+          "```",
+          "```",
+          'export * from "@effect-view-server/client";',
+          "```",
+          "```custom-language",
+          'const protocol = require("@effect-view-server/protocol");',
+          "```",
+        ].join("\n"),
+        relativePath: "plans/example.md",
+      }),
+    ).toStrictEqual([
+      "plans/example.md:11 imports @effect-view-server/server: consumers must import the publishable effect-view-server/* facade.",
+      "plans/example.md:14 imports @effect-view-server/client: consumers must import the publishable effect-view-server/* facade.",
+      "plans/example.md:17 imports @effect-view-server/protocol: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("checks an unclosed source fence through end of file", () => {
+    expect(
+      consumerMarkdownImportViolationsFor({
+        contents: [
+          "Consumer example:",
+          "~~~javascript",
+          'const runtime = import("@effect-view-server/runtime");',
+          "~~",
+        ].join("\n"),
+        relativePath: "examples/example/README.md",
+      }),
+    ).toStrictEqual([
+      "examples/example/README.md:2 imports @effect-view-server/runtime: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("scans every supported TypeScript module extension recursively", () => {
     const directory = makeDirectory();
     const nested = join(directory, "nested");
     mkdirSync(nested);
     writeFileSync(join(directory, "index.ts"), "");
     writeFileSync(join(directory, "component.tsx"), "");
+    writeFileSync(join(directory, "module.mts"), "");
+    writeFileSync(join(directory, "common.cts"), "");
     writeFileSync(join(directory, "ignore.js"), "");
+    writeFileSync(join(directory, "ignore.jsx"), "");
     writeFileSync(join(nested, "testing.tsx"), "");
+    writeFileSync(join(nested, "testing.mts"), "");
+    writeFileSync(join(nested, "testing.cts"), "");
 
-    expect(sourceFiles(directory).map((path) => basename(path)).sort()).toStrictEqual([
+    expect(sourceFiles(directory).map((path) => basename(path))).toStrictEqual([
+      "common.cts",
       "component.tsx",
       "index.ts",
+      "module.mts",
+      "testing.cts",
+      "testing.mts",
       "testing.tsx",
     ]);
+  });
+
+  it("collects consumer source violations across apps, examples, tests, and module extensions", () => {
+    const directory = makeDirectory();
+    const appRoot = join(directory, "apps", "z-app");
+    const exampleRoot = join(directory, "examples", "a-example");
+    mkdirSync(join(appRoot, "src"), { recursive: true });
+    mkdirSync(join(appRoot, "node_modules"), { recursive: true });
+    mkdirSync(join(appRoot, "dist"), { recursive: true });
+    mkdirSync(join(exampleRoot, "src"), { recursive: true });
+    mkdirSync(join(exampleRoot, "coverage"), { recursive: true });
+    mkdirSync(join(exampleRoot, ".vite"), { recursive: true });
+    writeFileSync(
+      join(appRoot, "src", "component.test.tsx"),
+      'import "@effect-view-server/react";',
+    );
+    writeFileSync(join(appRoot, "vite.config.ts"), 'import "@effect-view-server/config";');
+    writeFileSync(
+      join(exampleRoot, "runtime.cts"),
+      'const runtime = require("@effect-view-server/runtime");',
+    );
+    writeFileSync(
+      join(exampleRoot, "src", "module.test.mts"),
+      'export * from "@effect-view-server/server";',
+    );
+    writeFileSync(
+      join(appRoot, "node_modules", "private.ts"),
+      'import "@effect-view-server/config";',
+    );
+    writeFileSync(join(appRoot, "dist", "generated.ts"), 'import "@effect-view-server/config";');
+    writeFileSync(
+      join(exampleRoot, "coverage", "ignored.mts"),
+      'import "@effect-view-server/config";',
+    );
+    writeFileSync(
+      join(exampleRoot, ".vite", "ignored.cts"),
+      'import "@effect-view-server/config";',
+    );
+
+    expect(collectConsumerImportViolations(directory)).toStrictEqual([
+      "apps/z-app/src/component.test.tsx imports @effect-view-server/react: consumers must import the publishable effect-view-server/* facade.",
+      "apps/z-app/vite.config.ts imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+      "examples/a-example/runtime.cts imports @effect-view-server/runtime: consumers must import the publishable effect-view-server/* facade.",
+      "examples/a-example/src/module.test.mts imports @effect-view-server/server: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("collects consumer Markdown violations from the approved documentation scope", () => {
+    const directory = makeDirectory();
+    mkdirSync(join(directory, "apps", "example"), { recursive: true });
+    mkdirSync(join(directory, "docs"), { recursive: true });
+    mkdirSync(join(directory, "examples", "example"), { recursive: true });
+    mkdirSync(join(directory, "packages", "facade"), { recursive: true });
+    mkdirSync(join(directory, "plans"), { recursive: true });
+    mkdirSync(join(directory, ".agents"), { recursive: true });
+    const markdownWithPrivateImport = (specifier: string) =>
+      ["```ts", `import "${specifier}";`, "```"].join("\n");
+    writeFileSync(
+      join(directory, "README.md"),
+      markdownWithPrivateImport("@effect-view-server/config"),
+    );
+    writeFileSync(
+      join(directory, "apps", "example", "guide.md"),
+      markdownWithPrivateImport("@effect-view-server/react"),
+    );
+    writeFileSync(
+      join(directory, "docs", "guide.md"),
+      markdownWithPrivateImport("@effect-view-server/client"),
+    );
+    writeFileSync(
+      join(directory, "examples", "example", "README.md"),
+      markdownWithPrivateImport("@effect-view-server/runtime"),
+    );
+    writeFileSync(
+      join(directory, "packages", "facade", "README.md"),
+      markdownWithPrivateImport("@effect-view-server/server"),
+    );
+    writeFileSync(
+      join(directory, "plans", "active.md"),
+      markdownWithPrivateImport("@effect-view-server/protocol"),
+    );
+    writeFileSync(
+      join(directory, "packages", "facade", "internal.md"),
+      markdownWithPrivateImport("@effect-view-server/config"),
+    );
+    writeFileSync(join(directory, "packages", "not-a-package.txt"), "");
+    writeFileSync(
+      join(directory, ".agents", "README.md"),
+      markdownWithPrivateImport("@effect-view-server/config"),
+    );
+
+    expect(collectConsumerImportViolations(directory)).toStrictEqual([
+      "README.md:1 imports @effect-view-server/config: consumers must import the publishable effect-view-server/* facade.",
+      "apps/example/guide.md:1 imports @effect-view-server/react: consumers must import the publishable effect-view-server/* facade.",
+      "docs/guide.md:1 imports @effect-view-server/client: consumers must import the publishable effect-view-server/* facade.",
+      "examples/example/README.md:1 imports @effect-view-server/runtime: consumers must import the publishable effect-view-server/* facade.",
+      "packages/facade/README.md:1 imports @effect-view-server/server: consumers must import the publishable effect-view-server/* facade.",
+      "plans/active.md:1 imports @effect-view-server/protocol: consumers must import the publishable effect-view-server/* facade.",
+    ]);
+  });
+
+  it("formats and throws consumer import violation summaries", () => {
+    const violations = [
+      "apps/example/src/index.ts imports @effect-view-server/config: consumers must use the facade.",
+    ];
+
+    expect(consumerImportViolationMessage(violations)).toStrictEqual(
+      [
+        "Consumer facade import violations found.",
+        "- apps/example/src/index.ts imports @effect-view-server/config: consumers must use the facade.",
+      ].join("\n"),
+    );
+    expect(() => assertNoConsumerImportViolations(violations)).toThrowError(
+      "Consumer facade import violations found.",
+    );
+    expect(assertNoConsumerImportViolations([])).toStrictEqual(undefined);
+  });
+
+  it("keeps current consumer source and documentation imports facade-only", () => {
+    expect(collectConsumerImportViolations()).toStrictEqual([]);
+  });
+
+  it("classifies tests and benchmarks for every supported TypeScript module extension", () => {
+    const paths = [
+      "src/index.test.ts",
+      "src/component.test.tsx",
+      "src/module.test.mts",
+      "src/common.test.cts",
+      "src/index.test-d.ts",
+      "src/module.test-d.mts",
+      "src/index.bench.ts",
+      "src/component.bench.tsx",
+      "src/module.bench.mts",
+      "src/common.bench.cts",
+      "src/index.ts",
+      "src/test.ts",
+    ];
+
+    expect(paths.filter(isTestFile)).toStrictEqual(paths.slice(0, 10));
   });
 
   it("collects engine seam violations for restricted helpers and re-exports", () => {
@@ -1224,8 +1678,12 @@ describe("internal seam checker", () => {
   it("normalizes safe libraryPack source entrypoints only", () => {
     expect(sourceEntrypointForPackEntry("src/index.ts")).toStrictEqual("index");
     expect(sourceEntrypointForPackEntry("src/testing.tsx")).toStrictEqual("testing");
+    expect(sourceEntrypointForPackEntry("src/module.mts")).toStrictEqual("module");
+    expect(sourceEntrypointForPackEntry("src/common.cts")).toStrictEqual("common");
     expect(sourceEntrypointForPackEntry("generated/index.ts")).toStrictEqual(undefined);
     expect(sourceEntrypointForPackEntry("src/index.js")).toStrictEqual(undefined);
+    expect(sourceEntrypointForPackEntry("src/index.mjs")).toStrictEqual(undefined);
+    expect(sourceEntrypointForPackEntry("src/index.cjs")).toStrictEqual(undefined);
     expect(sourceEntrypointForPackEntry("src/../index.ts")).toStrictEqual(undefined);
   });
 
@@ -1258,6 +1716,21 @@ describe("internal seam checker", () => {
       true,
     );
     expect(sourceEntrypointForRelativeDistEntrypoint("react", "missing")).toStrictEqual(undefined);
+  });
+
+  it("resolves MTS and CTS package source entrypoint files", () => {
+    const directory = makeDirectory();
+    const sourceRoot = join(directory, "packages", "example", "src");
+    mkdirSync(sourceRoot, { recursive: true });
+    writeFileSync(join(sourceRoot, "module.mts"), "");
+    writeFileSync(join(sourceRoot, "common.cts"), "");
+
+    expect(
+      sourceEntrypointForRelativeDistEntrypoint("example", "module", directory),
+    ).toStrictEqual(join(sourceRoot, "module.mts"));
+    expect(
+      sourceEntrypointForRelativeDistEntrypoint("example", "common", directory),
+    ).toStrictEqual(join(sourceRoot, "common.cts"));
   });
 
   it("collects root conditional package export maps as the root specifier", () => {

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const packageSourceRoot = (name: string): string => join(repoRoot, "packages", name, "src");
@@ -12,6 +14,10 @@ const topicStoreMutationFile = join(engineSourceRoot, "topic-store-mutation.ts")
 const topicStoreQueryFile = join(engineSourceRoot, "topic-store-query.ts");
 const topicStoreStateFile = join(engineSourceRoot, "topic-store-state.ts");
 const topicStoreSubscriptionFile = join(engineSourceRoot, "topic-store-subscription.ts");
+const typescriptModuleExtensions = [".ts", ".tsx", ".mts", ".cts"] as const;
+
+const typescriptModuleExtensionFor = (path: string): string | undefined =>
+  typescriptModuleExtensions.find((extension) => path.endsWith(extension));
 
 const restrictedTopicStoreHelpers = [
   {
@@ -36,17 +42,26 @@ const restrictedTopicStoreHelpers = [
   },
 ] as const;
 
-export const sourceFiles = (directory: string): ReadonlyArray<string> => {
-  const entries = readdirSync(directory, { withFileTypes: true });
+const noIgnoredSourceDirectories: ReadonlySet<string> = new Set();
+
+export const sourceFiles = (
+  directory: string,
+  ignoredDirectoryNames: ReadonlySet<string> = noIgnoredSourceDirectories,
+): ReadonlyArray<string> => {
+  const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
   const files: Array<string> = [];
 
   for (const entry of entries) {
     const path = join(directory, entry.name);
     if (entry.isDirectory()) {
-      files.push(...sourceFiles(path));
+      if (!ignoredDirectoryNames.has(entry.name)) {
+        files.push(...sourceFiles(path, ignoredDirectoryNames));
+      }
       continue;
     }
-    if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+    if (entry.isFile() && typescriptModuleExtensionFor(entry.name) !== undefined) {
       files.push(path);
     }
   }
@@ -54,12 +69,8 @@ export const sourceFiles = (directory: string): ReadonlyArray<string> => {
   return files;
 };
 
-const isTestFile = (path: string): boolean =>
-  path.endsWith(".test.ts") ||
-  path.endsWith(".test.tsx") ||
-  path.endsWith(".test-d.ts") ||
-  path.endsWith(".bench.ts") ||
-  path.endsWith(".bench.tsx");
+export const isTestFile = (path: string): boolean =>
+  /\.(?:test|test-d|bench)\.(?:ts|tsx|mts|cts)$/.test(path);
 
 type RestrictedPackageImport = {
   readonly allowedRelativePathSpecifiers?: ReadonlyMap<string, ReadonlySet<string>>;
@@ -1562,6 +1573,182 @@ const approvedPublicViewServerSpecifiers = new Set([
   "effect-view-server/server",
 ]);
 
+const approvedConsumerViewServerSpecifiers = new Set(
+  Array.from(approvedPublicViewServerSpecifiers).filter(isPublicViewServerSpecifier),
+);
+
+export const consumerImportViolationsFor = ({
+  contents,
+  relativePath,
+}: {
+  readonly contents: string;
+  readonly relativePath: string;
+}): ReadonlyArray<string> =>
+  importedViewServerSpecifiers(contents).flatMap((specifier) => {
+    if (isCurrentViewServerSpecifier(specifier)) {
+      return [
+        `${relativePath} imports ${specifier}: consumers must import the publishable effect-view-server/* facade.`,
+      ];
+    }
+    if (isStaleViewServerSpecifier(specifier)) {
+      return [
+        `${relativePath} imports ${specifier}: stale View Server package scope; consumers must use approved effect-view-server/* subpaths.`,
+      ];
+    }
+    if (specifier === publicViewServerPackage) {
+      return [
+        `${relativePath} imports ${specifier}: the package root is not exported; consumers must use an approved effect-view-server/* subpath.`,
+      ];
+    }
+    return approvedConsumerViewServerSpecifiers.has(specifier)
+      ? []
+      : [
+          `${relativePath} imports ${specifier}: consumers must use approved effect-view-server/* package exports.`,
+        ];
+  });
+
+type ConsumerMarkdownSourceFence = {
+  readonly contents: string;
+  readonly openingLine: number;
+};
+
+type ConsumerMarkdownFenceToken = Token & {
+  readonly map: [number, number];
+  readonly type: "fence";
+};
+
+const consumerMarkdown = new MarkdownIt("commonmark");
+
+// markdown-it's fence rule assigns a source map whenever it emits a fence token.
+const isConsumerMarkdownFenceToken = (token: Token): token is ConsumerMarkdownFenceToken =>
+  token.type === "fence";
+
+const consumerSourceFencesFromMarkdown = (
+  contents: string,
+): ReadonlyArray<ConsumerMarkdownSourceFence> =>
+  consumerMarkdown
+    .parse(contents, {})
+    .filter(isConsumerMarkdownFenceToken)
+    .map((token) => ({
+      contents: token.content,
+      openingLine: token.map[0] + 1,
+    }));
+
+export const consumerMarkdownImportViolationsFor = ({
+  contents,
+  relativePath,
+}: {
+  readonly contents: string;
+  readonly relativePath: string;
+}): ReadonlyArray<string> =>
+  consumerSourceFencesFromMarkdown(contents).flatMap((sourceFence) =>
+    consumerImportViolationsFor({
+      contents: sourceFence.contents,
+      relativePath: `${relativePath}:${sourceFence.openingLine}`,
+    }),
+  );
+
+const consumerIgnoredDirectoryNames = new Set([
+  ".next",
+  ".output",
+  ".vite",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+const consumerMarkdownFiles = (repositoryRoot: string): ReadonlyArray<string> => {
+  const markdownFiles = (directory: string): ReadonlyArray<string> => {
+    if (!existsSync(directory)) {
+      return [];
+    }
+    const files: Array<string> = [];
+    const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!consumerIgnoredDirectoryNames.has(entry.name)) {
+          files.push(...markdownFiles(path));
+        }
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(path);
+      }
+    }
+
+    return files;
+  };
+
+  const rootReadmePath = join(repositoryRoot, "README.md");
+  const files = existsSync(rootReadmePath) ? [rootReadmePath] : [];
+  for (const directoryName of ["apps", "docs", "examples", "plans"]) {
+    files.push(...markdownFiles(join(repositoryRoot, directoryName)));
+  }
+  const packagesRoot = join(repositoryRoot, "packages");
+  if (!existsSync(packagesRoot)) {
+    return files.sort();
+  }
+  const packageEntries = readdirSync(packagesRoot, { withFileTypes: true }).sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  for (const entry of packageEntries) {
+    if (entry.isDirectory()) {
+      const readmePath = join(packagesRoot, entry.name, "README.md");
+      if (existsSync(readmePath)) {
+        files.push(readmePath);
+      }
+    }
+  }
+
+  return files.sort();
+};
+
+export const collectConsumerImportViolations = (
+  repositoryRoot = repoRoot,
+): ReadonlyArray<string> => {
+  const violations: Array<string> = [];
+
+  for (const directoryName of ["apps", "examples"]) {
+    const directory = join(repositoryRoot, directoryName);
+    for (const path of sourceFiles(directory, consumerIgnoredDirectoryNames)) {
+      violations.push(
+        ...consumerImportViolationsFor({
+          contents: readFileSync(path, "utf8"),
+          relativePath: toPosixRelativePath(relative(repositoryRoot, path)),
+        }),
+      );
+    }
+  }
+
+  for (const path of consumerMarkdownFiles(repositoryRoot)) {
+    violations.push(
+      ...consumerMarkdownImportViolationsFor({
+        contents: readFileSync(path, "utf8"),
+        relativePath: toPosixRelativePath(relative(repositoryRoot, path)),
+      }),
+    );
+  }
+
+  return violations.sort();
+};
+
+export const consumerImportViolationMessage = (violations: ReadonlyArray<string>): string =>
+  ["Consumer facade import violations found.", ...violations.map((violation) => `- ${violation}`)].join(
+    "\n",
+  );
+
+export const assertNoConsumerImportViolations = (violations: ReadonlyArray<string>) => {
+  if (violations.length === 0) {
+    return;
+  }
+  throw new Error(consumerImportViolationMessage(violations));
+};
+
 type PackageExportConditionTarget = {
   readonly condition: string;
   readonly suffix: ".d.ts" | ".js";
@@ -1783,21 +1970,23 @@ const distTargetEntrypoint = (target: string, suffix: ".d.ts" | ".js"): string |
 export const sourceEntrypointForRelativeDistEntrypoint = (
   packageName: string,
   relativeEntrypoint: string,
+  repositoryRoot = repoRoot,
 ): string | undefined => {
-  const sourceBase = join(repoRoot, "packages", packageName, "src", relativeEntrypoint);
-  const tsEntrypoint = `${sourceBase}.ts`;
-  if (existsSync(tsEntrypoint)) {
-    return tsEntrypoint;
+  const sourceBase = join(repositoryRoot, "packages", packageName, "src", relativeEntrypoint);
+  for (const extension of typescriptModuleExtensions) {
+    const sourceEntrypoint = `${sourceBase}${extension}`;
+    if (existsSync(sourceEntrypoint)) {
+      return sourceEntrypoint;
+    }
   }
-  const tsxEntrypoint = `${sourceBase}.tsx`;
-  return existsSync(tsxEntrypoint) ? tsxEntrypoint : undefined;
+  return undefined;
 };
 
 export const sourceEntrypointForPackEntry = (entryPath: string): string | undefined => {
-  if (!entryPath.startsWith("src/") || (!entryPath.endsWith(".ts") && !entryPath.endsWith(".tsx"))) {
+  const sourceExtension = typescriptModuleExtensionFor(entryPath);
+  if (!entryPath.startsWith("src/") || sourceExtension === undefined) {
     return undefined;
   }
-  const sourceExtension = entryPath.endsWith(".tsx") ? ".tsx" : ".ts";
   const relativeEntrypoint = entryPath.slice("src/".length, -sourceExtension.length);
   const segments = relativeEntrypoint.split(/[\\/]/);
   if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
@@ -2400,3 +2589,4 @@ export const assertNoPackageImportViolations = (violations: ReadonlyArray<string
 };
 
 assertNoPackageImportViolations(collectPackageImportViolations());
+assertNoConsumerImportViolations(collectConsumerImportViolations());


### PR DESCRIPTION
## Summary

- add a consumer-only package-facade policy without changing the existing internal workspace-package direction rules
- scan application/example TypeScript across `.ts`, `.tsx`, `.mts`, and `.cts`, including tests and root configs, with deterministic traversal and generated-directory pruning
- enforce approved `effect-view-server/*` imports in consumer-facing Markdown fences across README/docs/plans/app/example/package surfaces
- reject private `@effect-view-server/*`, stale `@view-server/*`, the unexported package root, and unapproved/deep facade paths
- extend test/benchmark classification and package source-entrypoint resolution to MTS/CTS
- use root-only `markdown-it` CommonMark fence tokens; the existing source import parser remains untouched for #302

## TDD and review-driven evidence

RED slices covered:

- missing consumer policy and high-level app/example collector
- incomplete facade allowlisting
- omitted MTS/CTS discovery, test classification, pack normalization, and source resolution
- Markdown labels, backticks/tildes, CRLF, longer/mismatched/unclosed fences, and repository scope
- reviewer-discovered label-removal, blockquote, continued/nested list, tab-padding, empty-list, container-exit, and ordered-paragraph false-positive cases

The hand-rolled Markdown container grammar was removed after those adversarial cases proved it unreliable. Strict CommonMark `fence` tokens now own block parsing; the View Server import parser still owns import semantics.

GREEN:

- focused Seam suite: 144/144
- repository scripts: 335/335 with exactly 100% statements, branches, functions, and lines
- current repository consumer assertion: clean

## Validation

- `vp run -w ready`: explicit exit 0; runtime 363/363, real Kafka 22/22, 100% coverage gates, browser/type/package suites green
- `vp run -w bench:baseline:smoke`: explicit exit 0; 19/19 tasks and baseline comparison passed
- `vp run -w test:repository-scripts`: 335/335, exact 100% coverage
- focused `check-internal-seams` suite: 144/144
- `vp check`: 613 files formatted; 322 files linted/typechecked clean
- strict Effect diagnostics, internal Seam check, and package export check: passed
- `git diff --check` and forbidden-pattern scans: clean
- final diff SHA-256: `4277bc77122dea3718412e2d7617801bab44bb831d3816bd4ebc113ac0d30b3f`
- independent Effect, Vitest/TDD, and architecture/thermonuclear reviews: zero blocking and zero non-blocking findings

`markdown-it` and `@types/markdown-it` are root-only development dependencies used by repository policy tooling. This private CI/policy change intentionally has no changeset.

Closes #301
Relates to #292