### PR TITLE
fix: harden engine lifecycle and runtime health

### DIFF
--- a/.changeset/free-bags-jump.md
+++ b/.changeset/free-bags-jump.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Make engine reset and close linearizable with concurrent mutations, and report clock-derived runtime uptime.

--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ The runtime derives gRPC feeds from topic-owned source bindings. A materialized
 gRPC topic starts at runtime startup. A leased gRPC topic opens one shared
 upstream stream per route key when the first matching subscription arrives.
 
-The same-server `GET /health` endpoint serves the cached runtime health snapshot
-for deployment readiness checks. Internal `bigint` health fields, such as Kafka
-lag, are encoded as decimal strings in the JSON response.
+The same-server `GET /health` endpoint performs a fresh runtime health read for
+deployment readiness checks. Overlapping concurrent reads are coalesced so they
+share one runtime read. Internal `bigint` health fields, such as Kafka lag, are
+encoded as decimal strings in the JSON response.
 
 When `tcpPublishPort` is configured, the runtime also opens a non-browser TCP
 NDJSON publish endpoint and exposes its `tcpPublishUrl`. That endpoint supports
@@ -191,12 +192,15 @@ own `tcpPublishHost` and defaults to `127.0.0.1`; it does not inherit the public
 WebSocket/HTTP host. The TCP endpoint is bounded by connection, line-size, and
 queued-command limits.
 
-The same-server `GET /metrics` endpoint serves Prometheus text exposition derived
-from the same cached health snapshot. It exposes scrape-safe runtime, transport,
-engine, Kafka, and gRPC gauges/counters. It is not a full mirror of health:
-high-cardinality values such as raw error messages and route-specific leased
-feed keys remain in `GET /health`. Scrape failures that cannot decode health return `200` with
-`view_server_metrics_error 1` so the scrape itself remains observable.
+The same-server `GET /metrics` endpoint performs the same fresh, coalesced
+runtime health read and renders Prometheus text exposition from that result. It
+exposes scrape-safe runtime, transport, engine, Kafka, and gRPC gauges/counters.
+It is not a full mirror of health: high-cardinality values such as raw error
+messages and route-specific leased feed keys remain in `GET /health`. Scrape
+failures that cannot decode health return `200` with the
+`view_server_metrics_error` metric set to `1` so the scrape itself remains
+observable. Pushed React health remains cadence-controlled and reads cached
+client health; the HTTP routes are not UI polling interfaces.
 
 Browser React code keeps using the normal provider and hooks:
 

--- a/docs/health-and-metrics.md
+++ b/docs/health-and-metrics.md
@@ -3,6 +3,8 @@
 ## React Hooks
 
 React applications should use pushed health hooks, not UI polling.
+Pushed health is refreshed on a bounded cadence and reads cached client health;
+that cadence is separate from the on-demand HTTP health routes.
 
 `useViewServerHealthSummary()` returns the small summary shape for page chrome
 and global status indicators:
@@ -21,7 +23,9 @@ topic/source data.
 ## Infrastructure Health
 
 The runtime exposes `GET /health` on the same server as the WebSocket endpoint.
-It serves the cached runtime health snapshot for infrastructure checks.
+Each request performs a fresh runtime health read for infrastructure checks.
+Overlapping concurrent requests are coalesced so they share one runtime read;
+the route does not serve a possibly stale client health atom.
 
 - `200`: runtime is ready.
 - non-`200`: runtime is starting, degraded, or stopping.
@@ -29,8 +33,8 @@ It serves the cached runtime health snapshot for infrastructure checks.
 If runtime auth is configured, health requests are authenticated before the
 health snapshot is served. Kubernetes probes must either send accepted
 credentials or the auth implementation must explicitly allow the health path.
-The endpoint can also return `500` if reading or encoding the cached health
-snapshot fails.
+The endpoint can also return `500` if reading or encoding current runtime health
+fails.
 
 Internal `bigint` values, such as Kafka lag, are encoded as decimal strings in
 the JSON response.
@@ -38,7 +42,7 @@ the JSON response.
 ## Metrics
 
 The runtime exposes `GET /metrics` in Prometheus text exposition format. Metrics
-are derived from the same cached health snapshot as `GET /health`.
+are derived from a fresh, coalesced runtime health read just like `GET /health`.
 
 Metrics intentionally keep labels low-cardinality. Raw error messages,
 route-specific leased feed keys, and detailed offsets remain available from
@@ -51,11 +55,11 @@ If metrics cannot decode health, the endpoint returns `200` with
 
 Health covers:
 
-- runtime status, version, uptime, and current time
+- runtime status, version, and uptime
 - transport active connections, subscriptions, queues, and backpressure
 - engine topic row counts, versions, queues, and backpressure
 - Kafka region status, assignments, lag, and failure rates
 - gRPC client/feed status, row counts, reconnects, and failure rates
-- TCP publish ingress status when configured
 
-Health is a status plane. It should not be used as a high-rate data stream.
+Health is a status plane. Pushed health stays cadence-controlled, while the HTTP
+routes read health on demand. Neither should be used as a high-rate data stream.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -13,7 +13,9 @@ ready only after its sources are connected and runtime health is ready.
 ## Prometheus Metrics
 
 Scrape `GET /metrics` on the same HTTP server as WebSocket RPC. Metrics use
-low-cardinality labels and are derived from cached runtime health.
+low-cardinality labels and are derived from a fresh runtime health read for each
+scrape. Overlapping concurrent health reads are coalesced. This on-demand path
+is separate from cadence-controlled cached health pushed to UI clients.
 
 Useful alert/query examples:
 
@@ -56,7 +58,8 @@ starting points and validate names against the current `/metrics` output.
 
 Use `GET /health` for readiness and startup checks. It returns `200` only when
 the runtime is ready, and returns a non-`200` status while the runtime is
-starting, degraded, or stopping.
+starting, degraded, or stopping. Each request reads fresh runtime health;
+overlapping concurrent reads share the same coalesced read.
 
 ```yaml
 readinessProbe:

--- a/packages/column-live-view-engine/src/engine-close-mutation-barrier.test.ts
+++ b/packages/column-live-view-engine/src/engine-close-mutation-barrier.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Cause, Clock, Deferred, Effect, Exit, Fiber, Option, Schema, SchemaGetter } from "effect";
+import { createColumnLiveViewEngine, EngineClosedError } from "./index";
+import { createColumnLiveViewEngineInternal } from "./internal";
+
+const Row = Schema.Struct({
+  id: Schema.String,
+  value: Schema.Number,
+});
+
+const blockingTerminalObserver = (
+  terminalStarted: Deferred.Deferred<void>,
+  continueTerminal: Deferred.Deferred<void>,
+) => ({
+  onQueryRegistered: () => Effect.void,
+  onTerminalOccurrence: () =>
+    Effect.gen(function* () {
+      yield* Deferred.succeed(terminalStarted, undefined);
+      yield* Deferred.await(continueTerminal);
+    }),
+  onTerminalReady: () => Effect.void,
+});
+
+describe("ColumnLiveViewEngine close mutation barrier", () => {
+  it.effect("rejects a publish that passed its open check before close completed", () =>
+    Effect.gen(function* () {
+      const decodingStarted = yield* Deferred.make<void>();
+      const continueDecoding = yield* Deferred.make<void>();
+      const DelayedString = Schema.String.pipe(
+        Schema.decode({
+          decode: new SchemaGetter.Getter((value) =>
+            Effect.gen(function* () {
+              yield* Deferred.succeed(decodingStarted, undefined);
+              yield* Deferred.await(continueDecoding);
+              return value;
+            }),
+          ),
+          encode: SchemaGetter.passthrough(),
+        }),
+      );
+      const DelayedRow = Schema.Struct({
+        id: DelayedString,
+        value: Schema.Number,
+      });
+      const engine = yield* createColumnLiveViewEngine({
+        topics: {
+          rows: {
+            schema: DelayedRow,
+            key: "id",
+          },
+        },
+      });
+
+      const publishFiber = yield* engine
+        .publish("rows", { id: "late", value: 1 })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(decodingStarted);
+      yield* engine.close();
+      yield* Deferred.succeed(continueDecoding, undefined);
+
+      const error = yield* Fiber.join(publishFiber).pipe(Effect.flip);
+      const health = yield* engine.health();
+
+      expect(error).toBeInstanceOf(EngineClosedError);
+      expect(health.topics.rows.rowCount).toBe(0);
+      expect(health.version).toBe(0);
+    }),
+  );
+
+  it.effect("rejects every public and internal mutation entrypoint after close", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: {
+          rows: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("rows", { id: "existing", value: 1 });
+      yield* engine.close();
+
+      const errors = yield* Effect.forEach(
+        [
+          engine.publish("rows", { id: "publish", value: 2 }),
+          engine.publishMany("rows", [{ id: "publish-many", value: 3 }]),
+          engine.patch("rows", "existing", { value: 4 }),
+          engine.delete("rows", "existing"),
+          engine.publishManyDecodedRows("rows", [{ id: "decoded", value: 5 }]),
+          engine.publishManyDecodedRowsWithStorageKeys("rows", [
+            {
+              storageKey: "decoded-storage-key",
+              row: { id: "decoded-storage", value: 6 },
+            },
+          ]),
+          engine.publishManyWithStorageKeys("rows", [
+            {
+              storageKey: "storage-key",
+              row: { id: "storage", value: 7 },
+            },
+          ]),
+          engine.patchDecodedFields("rows", "existing", { value: 8 }),
+          engine.reset(),
+        ],
+        Effect.flip,
+      );
+      const health = yield* engine.health();
+
+      expect(errors.map((error) => error._tag)).toStrictEqual([
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+        "EngineClosedError",
+      ]);
+      expect(health.topics.rows.rowCount).toBe(1);
+      expect(health.version).toBe(1);
+    }),
+  );
+
+  it.effect("does not run an interrupted close waiting for active mutations", () =>
+    Effect.gen(function* () {
+      const mutationStarted = yield* Deferred.make<void>();
+      const continueMutation = yield* Deferred.make<void>();
+      const blockedMutationClock: Clock.Clock = {
+        currentTimeMillisUnsafe: () => 0,
+        currentTimeMillis: Effect.gen(function* () {
+          yield* Deferred.succeed(mutationStarted, undefined);
+          yield* Deferred.await(continueMutation);
+          return 0;
+        }),
+        currentTimeNanosUnsafe: () => 0n,
+        currentTimeNanos: Effect.succeed(0n),
+        sleep: () => Effect.void,
+      };
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: {
+          rows: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("rows", { id: "existing", value: 1 });
+      const patchFiber = yield* engine
+        .patch("rows", "existing", { value: 2 })
+        .pipe(
+          Effect.provideService(Clock.Clock, blockedMutationClock),
+          Effect.forkChild({ startImmediately: true }),
+        );
+      yield* Deferred.await(mutationStarted);
+      const closeFiber = yield* engine.close().pipe(Effect.forkChild({ startImmediately: true }));
+      const interruptFiber = yield* Fiber.interrupt(closeFiber).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      yield* Deferred.succeed(continueMutation, undefined);
+      yield* Fiber.join(patchFiber);
+      yield* Fiber.join(interruptFiber);
+      const closeExit = yield* Fiber.await(closeFiber);
+      const closeCause = Exit.getCause(closeExit).pipe(Option.getOrThrow);
+      yield* engine.publish("rows", { id: "after-interrupt", value: 1 });
+      const health = yield* engine.health();
+
+      expect(Cause.hasInterruptsOnly(closeCause)).toBe(true);
+      expect(health.status).toBe("ready");
+      expect(health.topics.rows.rowCount).toBe(2);
+      expect(health.topics.rows.version).toBe(3);
+      expect(health.version).toBe(3);
+    }),
+  );
+
+  it.effect("admits concurrent mutations on independent topics", () =>
+    Effect.gen(function* () {
+      const firstMutationStarted = yield* Deferred.make<void>();
+      const secondMutationStarted = yield* Deferred.make<void>();
+      const continueFirstMutation = yield* Deferred.make<void>();
+      const continueSecondMutation = yield* Deferred.make<void>();
+      const firstClock: Clock.Clock = {
+        currentTimeMillisUnsafe: () => 0,
+        currentTimeMillis: Effect.gen(function* () {
+          yield* Deferred.succeed(firstMutationStarted, undefined);
+          yield* Deferred.await(continueFirstMutation);
+          return 0;
+        }),
+        currentTimeNanosUnsafe: () => 0n,
+        currentTimeNanos: Effect.succeed(0n),
+        sleep: () => Effect.void,
+      };
+      const secondClock: Clock.Clock = {
+        currentTimeMillisUnsafe: () => 0,
+        currentTimeMillis: Effect.gen(function* () {
+          yield* Deferred.succeed(secondMutationStarted, undefined);
+          yield* Deferred.await(continueSecondMutation);
+          return 0;
+        }),
+        currentTimeNanosUnsafe: () => 0n,
+        currentTimeNanos: Effect.succeed(0n),
+        sleep: () => Effect.void,
+      };
+      const engine = yield* createColumnLiveViewEngine({
+        topics: {
+          first: {
+            schema: Row,
+            key: "id",
+          },
+          second: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("first", { id: "first", value: 1 });
+      yield* engine.publish("second", { id: "second", value: 2 });
+
+      const firstPatchFiber = yield* engine
+        .patch("first", "first", { value: 3 })
+        .pipe(
+          Effect.provideService(Clock.Clock, firstClock),
+          Effect.forkChild({ startImmediately: true }),
+        );
+      yield* Deferred.await(firstMutationStarted);
+      const secondPatchFiber = yield* engine
+        .patch("second", "second", { value: 4 })
+        .pipe(
+          Effect.provideService(Clock.Clock, secondClock),
+          Effect.forkChild({ startImmediately: true }),
+        );
+      yield* Deferred.await(secondMutationStarted);
+      const secondMutationActiveAlongsideFirst = secondPatchFiber.pollUnsafe() === undefined;
+
+      yield* Deferred.succeed(continueFirstMutation, undefined);
+      yield* Fiber.join(firstPatchFiber);
+      const secondMutationStillActive = secondPatchFiber.pollUnsafe() === undefined;
+      yield* Deferred.succeed(continueSecondMutation, undefined);
+      yield* Fiber.join(secondPatchFiber);
+      const firstSnapshot = yield* engine.snapshot("first", { select: ["id", "value"] });
+      const secondSnapshot = yield* engine.snapshot("second", { select: ["id", "value"] });
+
+      expect(secondMutationActiveAlongsideFirst).toBe(true);
+      expect(secondMutationStillActive).toBe(true);
+      expect(firstSnapshot.rows).toStrictEqual([{ id: "first", value: 3 }]);
+      expect(secondSnapshot.rows).toStrictEqual([{ id: "second", value: 4 }]);
+    }),
+  );
+
+  it.effect("does not run an interrupted mutation waiting behind reset", () =>
+    Effect.gen(function* () {
+      const terminalStarted = yield* Deferred.make<void>();
+      const continueTerminal = yield* Deferred.make<void>();
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: {
+          first: {
+            schema: Row,
+            key: "id",
+          },
+          second: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("first", { id: "first", value: 1 });
+      yield* engine.publish("second", { id: "second", value: 2 });
+      yield* engine.subscribeRuntimeObserved(
+        "second",
+        { select: ["id"] },
+        blockingTerminalObserver(terminalStarted, continueTerminal),
+      );
+
+      const resetFiber = yield* engine.reset().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(terminalStarted);
+      const publishFiber = yield* engine
+        .publish("first", { id: "interrupted", value: 3 })
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      const publishWaitingForReset = publishFiber.pollUnsafe() === undefined;
+      yield* Fiber.interrupt(publishFiber);
+      const publishExit = yield* Fiber.await(publishFiber);
+      const publishCause = Exit.getCause(publishExit).pipe(Option.getOrThrow);
+
+      yield* Deferred.succeed(continueTerminal, undefined);
+      yield* Fiber.join(resetFiber);
+      yield* engine.publish("first", { id: "after-reset", value: 4 });
+      const health = yield* engine.health();
+      const snapshot = yield* engine.snapshot("first", { select: ["id", "value"] });
+
+      expect(publishWaitingForReset).toBe(true);
+      expect(Cause.hasInterruptsOnly(publishCause)).toBe(true);
+      expect(health.version).toBe(1);
+      expect(health.topics.first.version).toBe(1);
+      expect(snapshot.rows).toStrictEqual([{ id: "after-reset", value: 4 }]);
+    }),
+  );
+
+  it.effect("serializes a write to an already-cleared topic after a multi-topic reset", () =>
+    Effect.gen(function* () {
+      const terminalStarted = yield* Deferred.make<void>();
+      const continueTerminal = yield* Deferred.make<void>();
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: {
+          first: {
+            schema: Row,
+            key: "id",
+          },
+          second: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("first", { id: "first", value: 1 });
+      yield* engine.publish("second", { id: "second", value: 2 });
+      yield* engine.subscribeRuntimeObserved(
+        "second",
+        { select: ["id"] },
+        blockingTerminalObserver(terminalStarted, continueTerminal),
+      );
+
+      const resetFiber = yield* engine.reset().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(terminalStarted);
+      const publishFiber = yield* engine
+        .publish("first", { id: "after-reset", value: 3 })
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      const publishBlockedByReset = publishFiber.pollUnsafe() === undefined;
+      const healthWhileResetBlocked = yield* engine.health();
+
+      yield* Deferred.succeed(continueTerminal, undefined);
+      yield* Fiber.join(resetFiber);
+      yield* Fiber.join(publishFiber);
+      const health = yield* engine.health();
+      const snapshot = yield* engine.snapshot("first", {
+        select: ["id", "value"],
+      });
+
+      expect(healthWhileResetBlocked.topics.first.rowCount).toBe(0);
+      expect(healthWhileResetBlocked.topics.first.version).toBe(0);
+      expect(publishBlockedByReset).toBe(true);
+      expect(health.topics.first.rowCount).toBe(1);
+      expect(health.topics.first.version).toBe(1);
+      expect(health.topics.second.rowCount).toBe(0);
+      expect(health.topics.second.version).toBe(0);
+      expect(health.version).toBe(1);
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "after-reset", value: 3 }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
+    }),
+  );
+
+  it.effect("finishes an admitted reset before a queued close", () =>
+    Effect.gen(function* () {
+      const terminalStarted = yield* Deferred.make<void>();
+      const continueTerminal = yield* Deferred.make<void>();
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: {
+          rows: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("rows", { id: "existing", value: 1 });
+      yield* engine.subscribeRuntimeObserved(
+        "rows",
+        { select: ["id"] },
+        blockingTerminalObserver(terminalStarted, continueTerminal),
+      );
+
+      const resetFiber = yield* engine.reset().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(terminalStarted);
+      const closeFiber = yield* engine.close().pipe(Effect.forkChild({ startImmediately: true }));
+      const closeQueuedBehindReset = closeFiber.pollUnsafe() === undefined;
+      const healthWhileResetBlocked = yield* engine.health();
+
+      yield* Deferred.succeed(continueTerminal, undefined);
+      yield* Fiber.join(resetFiber);
+      yield* Fiber.join(closeFiber);
+      const health = yield* engine.health();
+
+      expect(closeQueuedBehindReset).toBe(true);
+      expect(healthWhileResetBlocked.status).toBe("ready");
+      expect(health.status).toBe("stopping");
+      expect(health.topics.rows.rowCount).toBe(0);
+      expect(health.topics.rows.version).toBe(0);
+      expect(health.version).toBe(0);
+    }),
+  );
+
+  it.effect("rejects a reset queued behind an admitted close before reset side effects", () =>
+    Effect.gen(function* () {
+      const terminalStarted = yield* Deferred.make<void>();
+      const continueTerminal = yield* Deferred.make<void>();
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: {
+          rows: {
+            schema: Row,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("rows", { id: "existing", value: 1 });
+      yield* engine.subscribeRuntimeObserved(
+        "rows",
+        { select: ["id"] },
+        blockingTerminalObserver(terminalStarted, continueTerminal),
+      );
+
+      const closeFiber = yield* engine.close().pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(terminalStarted);
+      const resetFiber = yield* engine.reset().pipe(Effect.forkChild({ startImmediately: true }));
+      const resetQueuedBehindClose = resetFiber.pollUnsafe() === undefined;
+      const healthWhileCloseBlocked = yield* engine.health();
+
+      yield* Deferred.succeed(continueTerminal, undefined);
+      yield* Fiber.join(closeFiber);
+      const resetError = yield* Fiber.join(resetFiber).pipe(Effect.flip);
+      const health = yield* engine.health();
+
+      expect(resetQueuedBehindClose).toBe(true);
+      expect(healthWhileCloseBlocked.status).toBe("stopping");
+      expect(resetError).toBeInstanceOf(EngineClosedError);
+      expect(health.status).toBe("stopping");
+      expect(health.topics.rows.rowCount).toBe(1);
+      expect(health.topics.rows.version).toBe(1);
+      expect(health.version).toBe(1);
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/engine.ts
+++ b/packages/column-live-view-engine/src/engine.ts
@@ -12,7 +12,7 @@ import type {
   TopicRow,
   ValidateLiveQuery,
 } from "@effect-view-server/config";
-import { Effect } from "effect";
+import { Effect, Latch, Semaphore } from "effect";
 import type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
@@ -64,15 +64,82 @@ const invalidRow = (topic: string, message: string) =>
     message,
   });
 
+const runEngineLifecycleTransaction = Effect.fn("ColumnLiveViewEngine.lifecycle.transaction")(
+  function* <Success, Error, Requirements>(
+    lifecycleSemaphore: Semaphore.Semaphore,
+    admissionGate: Latch.Latch,
+    idle: Latch.Latch,
+    transaction: Effect.Effect<Success, Error, Requirements>,
+  ): Effect.fn.Return<Success, Error, Requirements> {
+    return yield* lifecycleSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        yield* admissionGate.close;
+        yield* idle.await;
+        return yield* Effect.uninterruptible(transaction);
+      }).pipe(Effect.ensuring(admissionGate.open)),
+    );
+  },
+);
+
+class EngineMutationBarrier {
+  private readonly lifecycleSemaphore = Semaphore.makeUnsafe(1);
+  private readonly admissionGate = Latch.makeUnsafe(true);
+  private readonly idle = Latch.makeUnsafe(true);
+  private activeTransactions = 0;
+  private readonly tryAcquire = Effect.sync(() => {
+    if (!this.admissionGate.isOpen()) {
+      return false;
+    }
+    if (this.activeTransactions === 0) {
+      this.idle.closeUnsafe();
+    }
+    this.activeTransactions += 1;
+    return true;
+  });
+  private readonly release = Effect.sync(() => {
+    this.activeTransactions -= 1;
+    if (this.activeTransactions === 0) {
+      this.idle.openUnsafe();
+    }
+  });
+
+  readonly withMutation = <Success, Error, Requirements>(
+    transaction: Effect.Effect<Success, Error, Requirements>,
+  ): Effect.Effect<Success, Error, Requirements> =>
+    Effect.acquireUseRelease(
+      this.tryAcquire,
+      (acquired) =>
+        acquired
+          ? Effect.uninterruptible(transaction)
+          : this.admissionGate.await.pipe(Effect.flatMap(() => this.withMutation(transaction))),
+      (acquired) => (acquired ? this.release : Effect.void),
+    );
+
+  readonly withLifecycle = <Success, Error, Requirements>(
+    transaction: Effect.Effect<Success, Error, Requirements>,
+  ): Effect.Effect<Success, Error, Requirements> =>
+    runEngineLifecycleTransaction(
+      this.lifecycleSemaphore,
+      this.admissionGate,
+      this.idle,
+      transaction,
+    );
+}
+
 class InMemoryColumnLiveViewEngine<
   Topics extends DecodableTopicDefinitions,
 > implements ColumnLiveViewEngine<Topics> {
   private readonly stores = new Map<string, TopicStore>();
   private readonly groupedIncrementalAdmissionLimits: GroupedIncrementalAdmissionLimits;
   private readonly subscriptionQueueCapacity: number;
+  private readonly mutationBarrier = new EngineMutationBarrier();
+  private readonly withMutationAdmission = <Success, Error, Requirements>(
+    transaction: Effect.Effect<Success, Error, Requirements>,
+  ): Effect.Effect<Success, Error, Requirements> => this.mutationBarrier.withMutation(transaction);
   private engineVersion = 0;
   private nextQueryId = 0;
   private closed = false;
+  private readonly mutationsAllowed = (): boolean => !this.closed;
 
   constructor(config: ColumnLiveViewEngineInternalConfig<Topics>) {
     const configuredCapacity = config.subscriptionQueueCapacity ?? defaultSubscriptionQueueCapacity;
@@ -86,9 +153,16 @@ class InMemoryColumnLiveViewEngine<
     for (const [topic, definition] of Object.entries(config.topics)) {
       this.stores.set(
         topic,
-        new TopicStore(topic, definition.schema, definition.key, () => {
-          this.engineVersion += 1;
-        }),
+        new TopicStore(
+          topic,
+          definition.schema,
+          definition.key,
+          () => {
+            this.engineVersion += 1;
+          },
+          this.mutationsAllowed,
+          this.withMutationAdmission,
+        ),
       );
     }
   }
@@ -439,9 +513,9 @@ class InMemoryColumnLiveViewEngine<
   readonly reset: ColumnLiveViewEngine<Topics>["reset"] = Effect.fn("ColumnLiveViewEngine.reset")(
     { self: this },
     function* (this: InMemoryColumnLiveViewEngine<Topics>) {
-      yield* this.ensureOpen();
-      yield* Effect.uninterruptible(
+      yield* this.mutationBarrier.withLifecycle(
         Effect.gen({ self: this }, function* () {
+          yield* this.ensureOpen();
           for (const store of this.stores.values()) {
             yield* resetTopicStore(store);
           }
@@ -454,7 +528,7 @@ class InMemoryColumnLiveViewEngine<
   readonly close: ColumnLiveViewEngine<Topics>["close"] = Effect.fn("ColumnLiveViewEngine.close")(
     { self: this },
     function* (this: InMemoryColumnLiveViewEngine<Topics>) {
-      yield* Effect.uninterruptible(
+      yield* this.mutationBarrier.withLifecycle(
         Effect.gen({ self: this }, function* () {
           this.closed = true;
           for (const store of this.stores.values()) {

--- a/packages/column-live-view-engine/src/grouped-aggregate.bench.ts
+++ b/packages/column-live-view-engine/src/grouped-aggregate.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { format as formatBigDecimal, isBigDecimal, type BigDecimal } from "effect/BigDecimal";

--- a/packages/column-live-view-engine/src/grouped-key-width.bench.ts
+++ b/packages/column-live-view-engine/src/grouped-key-width.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";

--- a/packages/column-live-view-engine/src/grouped-write.bench.ts
+++ b/packages/column-live-view-engine/src/grouped-write.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Cause, Effect, Exit, Schema, Scope, Stream } from "effect";

--- a/packages/column-live-view-engine/src/query-delta-operations.bench.ts
+++ b/packages/column-live-view-engine/src/query-delta-operations.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, bench, describe, expect } from "vitest";
 import {
   benchmarkOutputJsonPath,

--- a/packages/column-live-view-engine/src/raw-active-retained-delta.bench.ts
+++ b/packages/column-live-view-engine/src/raw-active-retained-delta.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Cause, Effect, Exit, Schema, Scope, Stream } from "effect";

--- a/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
+++ b/packages/column-live-view-engine/src/raw-live-fanout.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Cause, Effect, Exit, Schema, Scope, Stream } from "effect";

--- a/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-index.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { Schema } from "effect";
 import {

--- a/packages/column-live-view-engine/src/raw-snapshot.bench.ts
+++ b/packages/column-live-view-engine/src/raw-snapshot.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Cause, Effect, Exit, Schema, Scope, Stream } from "effect";

--- a/packages/column-live-view-engine/src/raw-write.bench.ts
+++ b/packages/column-live-view-engine/src/raw-write.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe } from "vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";

--- a/packages/column-live-view-engine/src/topic-store-mutation.ts
+++ b/packages/column-live-view-engine/src/topic-store-mutation.ts
@@ -1,4 +1,5 @@
 import { Clock, Effect, Semaphore } from "effect";
+import { EngineClosedError } from "./engine-errors";
 import type { TopicRowStorage } from "./topic-row-storage";
 import type { InvalidRowErrorFactory, PreparedTopicRow } from "./topic-row-preparation";
 import type { createTopicHealthLedger } from "./topic-health-ledger";
@@ -13,8 +14,14 @@ export type TopicStoreMutationState = {
   readonly mutationSemaphore: Semaphore.Semaphore;
   readonly notificationSemaphore: Semaphore.Semaphore;
   readonly healthLedger: ReturnType<typeof createTopicHealthLedger>;
+  readonly mutationsAllowed: () => boolean;
   readonly onCommit: () => void;
+  readonly withMutationAdmission: TopicStoreMutationAdmission;
 };
+
+export type TopicStoreMutationAdmission = <Success, Error, Requirements>(
+  transaction: Effect.Effect<Success, Error, Requirements>,
+) => Effect.Effect<Success, Error, Requirements>;
 
 export type TopicStoreMutationContext = {
   readonly publishPrepared: (prepared: PreparedTopicRow) => number;
@@ -165,19 +172,26 @@ export const runTopicStoreMutationTransaction = Effect.fn(
   store: TopicStore,
   mutate: (mutation: TopicStoreMutationContext) => Effect.Effect<number, Error, Requirements>,
 ) {
-  yield* withTopicStoreMutationBatch(
-    state,
-    Effect.gen(function* () {
-      const subscribers = yield* withTopicStoreStateTransaction(
-        state,
-        Effect.gen(function* () {
-          const rowsChanged = yield* mutate(topicStoreMutationContext(state));
-          const occurredAt = yield* Clock.currentTimeMillis;
-          return recordTopicStoreMutation(state, rowsChanged, occurredAt);
-        }),
-      );
-      yield* notifyTopicStoreSubscribers(state, store, subscribers);
-    }),
+  yield* state.withMutationAdmission(
+    withTopicStoreMutationBatch(
+      state,
+      Effect.gen(function* () {
+        const subscribers = yield* withTopicStoreStateTransaction(
+          state,
+          Effect.gen(function* () {
+            if (!state.mutationsAllowed()) {
+              return yield* EngineClosedError.make({
+                message: "ColumnLiveViewEngine is closed.",
+              });
+            }
+            const rowsChanged = yield* mutate(topicStoreMutationContext(state));
+            const occurredAt = yield* Clock.currentTimeMillis;
+            return recordTopicStoreMutation(state, rowsChanged, occurredAt);
+          }),
+        );
+        yield* notifyTopicStoreSubscribers(state, store, subscribers);
+      }),
+    ),
   );
 });
 

--- a/packages/column-live-view-engine/src/topic-store-state.ts
+++ b/packages/column-live-view-engine/src/topic-store-state.ts
@@ -7,7 +7,7 @@ import {
 } from "./active-query";
 import { TopicRowStorage } from "./topic-row-storage";
 import { createTopicHealthLedger } from "./topic-health-ledger";
-import type { TopicStoreMutationState } from "./topic-store-mutation";
+import type { TopicStoreMutationAdmission, TopicStoreMutationState } from "./topic-store-mutation";
 import type { RawQueryCompilerMetadata } from "./raw-query-compiler";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 
@@ -28,6 +28,8 @@ export type TopicStoreHealthSource = {
   readonly topic: string;
 };
 
+const identityMutationAdmission: TopicStoreMutationAdmission = (transaction) => transaction;
+
 export class TopicStore {
   declare private readonly topicStoreBrand: void;
 
@@ -36,6 +38,8 @@ export class TopicStore {
     schema: Schema.Codec<object, unknown, never, unknown>,
     keyField: string,
     onCommit: () => void,
+    mutationsAllowed: () => boolean = () => true,
+    withMutationAdmission: TopicStoreMutationAdmission = identityMutationAdmission,
   ) {
     const storage = new TopicRowStorage(topic, schema, keyField);
     const subscribers = new Set<LiveTopicSubscriber>();
@@ -45,7 +49,9 @@ export class TopicStore {
       mutationSemaphore: Semaphore.makeUnsafe(1),
       notificationSemaphore: Semaphore.makeUnsafe(1),
       healthLedger: createTopicHealthLedger(),
+      mutationsAllowed,
       onCommit,
+      withMutationAdmission,
     };
     topicStoreStates.set(this, state);
   }

--- a/packages/react/src/in-memory-live-query.bench.tsx
+++ b/packages/react/src/in-memory-live-query.bench.tsx
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { commands, server } from "vitest/browser";
 import {

--- a/packages/runtime-core/src/health.ts
+++ b/packages/runtime-core/src/health.ts
@@ -10,21 +10,53 @@ type EngineHealthReader<Topics extends DecodableTopicDefinitions> = {
   readonly health: () => Effect.Effect<ColumnLiveViewEngineHealth<Topics>, never>;
 };
 
+type RuntimeCoreHealthTiming = {
+  readonly nowMillis: number;
+  readonly nowNanos: bigint;
+  readonly runtimeStartedAtNanos: bigint;
+};
+
+type RuntimeCoreHealthInput<Topics extends DecodableTopicDefinitions> = {
+  readonly transportHealth?: RuntimeCoreTransportHealth<Topics>;
+  readonly healthOverlay?: RuntimeCoreHealthOverlay<Topics>;
+  readonly timing?: RuntimeCoreHealthTiming;
+};
+
+type ReadHealthInput<Topics extends DecodableTopicDefinitions> = {
+  readonly runtimeStartedAtNanos?: bigint;
+  readonly transportHealth?: RuntimeCoreTransportHealth<Topics>;
+  readonly healthOverlay?: RuntimeCoreHealthOverlay<Topics>;
+  readonly shouldInstall?: () => boolean;
+  readonly onInstall?: () => void;
+};
+
+const zeroRuntimeCoreHealthTiming: RuntimeCoreHealthTiming = {
+  nowMillis: 0,
+  nowNanos: 0n,
+  runtimeStartedAtNanos: 0n,
+};
+
+const uptimeMillis = (timing: RuntimeCoreHealthTiming): number => {
+  const elapsedNanos = timing.nowNanos - timing.runtimeStartedAtNanos;
+  return elapsedNanos <= 0n ? 0 : Number(elapsedNanos / 1_000_000n);
+};
+
 export const healthFromEngine = <Topics extends DecodableTopicDefinitions>(
   engineHealth: ColumnLiveViewEngineHealth<Topics>,
-  transportHealth: RuntimeCoreTransportHealth<Topics> = defaultRuntimeCoreTransportHealth,
-  healthOverlay: RuntimeCoreHealthOverlay<Topics> = defaultRuntimeCoreHealthOverlay,
-  nowMillis = 0,
+  input: RuntimeCoreHealthInput<Topics> = {},
 ): ViewServerHealth<Topics> => {
+  const transportHealth = input.transportHealth ?? defaultRuntimeCoreTransportHealth;
+  const healthOverlay = input.healthOverlay ?? defaultRuntimeCoreHealthOverlay;
+  const timing = input.timing ?? zeroRuntimeCoreHealthTiming;
   return healthOverlay(
     {
       status: engineHealth.status,
       version: engineHealth.version,
-      uptimeMs: 0,
+      uptimeMs: uptimeMillis(timing),
       engine: { topics: engineHealth.topics },
       transport: transportHealth(engineHealth),
     },
-    nowMillis,
+    timing.nowMillis,
   );
 };
 
@@ -73,17 +105,23 @@ export const readHealth = Effect.fn("ViewServerRuntimeCore.health.read")(functio
 >(
   engine: EngineHealthReader<Topics>,
   health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
-  transportHealth: RuntimeCoreTransportHealth<Topics> = defaultRuntimeCoreTransportHealth,
-  healthOverlay: RuntimeCoreHealthOverlay<Topics> = defaultRuntimeCoreHealthOverlay,
-  shouldInstall: () => boolean = () => true,
-  onInstall: () => void = () => undefined,
+  input: ReadHealthInput<Topics> = {},
 ) {
   const nowMillis = yield* Clock.currentTimeMillis;
-  const value = healthFromEngine(yield* engine.health(), transportHealth, healthOverlay, nowMillis);
+  const nowNanos = yield* Clock.currentTimeNanos;
+  const value = healthFromEngine(yield* engine.health(), {
+    transportHealth: input.transportHealth ?? defaultRuntimeCoreTransportHealth,
+    healthOverlay: input.healthOverlay ?? defaultRuntimeCoreHealthOverlay,
+    timing: {
+      nowMillis,
+      nowNanos,
+      runtimeStartedAtNanos: input.runtimeStartedAtNanos ?? 0n,
+    },
+  });
   yield* Effect.sync(() => {
-    if (shouldInstall()) {
+    if (input.shouldInstall === undefined || input.shouldInstall()) {
       health.update((current) => nextHealthValue(current, value));
-      onInstall();
+      input.onInstall?.();
     }
   });
   return health.value;

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -7,7 +7,8 @@ import {
   type ViewServerRuntimeError,
 } from "@effect-view-server/config";
 import { grpcSourceMarkers } from "@effect-view-server/config/internal";
-import { Deferred, Effect, Fiber, Option, Queue, Schema, Stream, Tracer } from "effect";
+import { Clock, Deferred, Effect, Fiber, Option, Queue, Schema, Stream, Tracer } from "effect";
+import { TestClock } from "effect/testing";
 import { AtomRef } from "effect/unstable/reactivity";
 import {
   healthFromEngine,
@@ -259,6 +260,73 @@ const engineHealth = (
 });
 
 describe("@effect-view-server/runtime-core", () => {
+  it.effect("reports elapsed runtime uptime and passes refresh time to health overlays", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(10_000);
+      const overlayTimes: Array<number> = [];
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {
+        healthOverlay: (health, nowMillis) => {
+          overlayTimes.push(nowMillis);
+          return health;
+        },
+      });
+
+      expect(runtimeCore.liveClient.health.value.uptimeMs).toBe(0);
+      expect(overlayTimes).toStrictEqual([10_000]);
+
+      yield* TestClock.adjust("2500 millis");
+      const refreshedHealth = yield* runtimeCore.refreshHealth;
+
+      expect(refreshedHealth.uptimeMs).toBe(2_500);
+      expect(overlayTimes).toStrictEqual([10_000, 12_500]);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("clamps runtime uptime when the clock moves before the runtime start", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(10_000);
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {});
+
+      yield* TestClock.setTime(9_000);
+      const refreshedHealth = yield* runtimeCore.refreshHealth;
+
+      expect(refreshedHealth.uptimeMs).toBe(0);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("uses monotonic time for uptime when wall time moves backward", () =>
+    Effect.gen(function* () {
+      let wallMillis = 10_000;
+      let monotonicNanos = 5_000_000_000n;
+      const clock: Clock.Clock = {
+        currentTimeMillisUnsafe: () => wallMillis,
+        currentTimeMillis: Effect.sync(() => wallMillis),
+        currentTimeNanosUnsafe: () => monotonicNanos,
+        currentTimeNanos: Effect.sync(() => monotonicNanos),
+        sleep: () => Effect.void,
+      };
+      const overlayTimes: Array<number> = [];
+      const runtimeCore = yield* makeViewServerRuntimeCore(viewServer, {
+        healthOverlay: (health, nowMillis) => {
+          overlayTimes.push(nowMillis);
+          return health;
+        },
+      }).pipe(Effect.provideService(Clock.Clock, clock));
+
+      wallMillis = 9_000;
+      monotonicNanos = 7_500_000_000n;
+      const refreshedHealth = yield* runtimeCore.refreshHealth.pipe(
+        Effect.provideService(Clock.Clock, clock),
+      );
+
+      expect(refreshedHealth.uptimeMs).toBe(2_500);
+      expect(overlayTimes).toStrictEqual([10_000, 9_000]);
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("records runtime core publish, engine mutation, and subscription fanout spans", () =>
     Effect.gen(function* () {
       const recording = makeRecordingTracer();
@@ -2162,7 +2230,10 @@ describe("@effect-view-server/runtime-core", () => {
         },
       };
       const coalescedHealth = makeCoalescedHealthReader(
-        (readEpoch) => readHealth(engine, health, undefined, undefined, () => epoch === readEpoch),
+        (readEpoch) =>
+          readHealth(engine, health, {
+            shouldInstall: () => epoch === readEpoch,
+          }),
         () => epoch,
       );
 
@@ -2210,16 +2281,12 @@ describe("@effect-view-server/runtime-core", () => {
       const scheduler = yield* makeHealthRefreshScheduler(
         Effect.gen(function* () {
           const readInstallEpoch = installEpoch;
-          yield* readHealth(
-            engine,
-            health,
-            undefined,
-            undefined,
-            () => installEpoch === readInstallEpoch,
-            () => {
+          yield* readHealth(engine, health, {
+            shouldInstall: () => installEpoch === readInstallEpoch,
+            onInstall: () => {
               installEpoch += 1;
             },
-          );
+          });
           yield* Deferred.succeed(scheduledReadFinished, undefined);
         }),
         "0 millis",
@@ -2227,8 +2294,10 @@ describe("@effect-view-server/runtime-core", () => {
 
       yield* scheduler.request;
       yield* Deferred.await(scheduledReadStarted).pipe(Effect.timeout("1 second"));
-      const freshHealth = yield* readHealth(engine, health, undefined, undefined, undefined, () => {
-        installEpoch += 1;
+      const freshHealth = yield* readHealth(engine, health, {
+        onInstall: () => {
+          installEpoch += 1;
+        },
       });
       yield* Deferred.succeed(releaseScheduledRead, undefined);
       yield* Deferred.await(scheduledReadFinished).pipe(Effect.timeout("1 second"));
@@ -2274,16 +2343,12 @@ describe("@effect-view-server/runtime-core", () => {
       const scheduler = yield* makeHealthRefreshScheduler(
         Effect.gen(function* () {
           const readInstallEpoch = installEpoch;
-          yield* readHealth(
-            engine,
-            health,
-            undefined,
-            undefined,
-            () => installEpoch === readInstallEpoch,
-            () => {
+          yield* readHealth(engine, health, {
+            shouldInstall: () => installEpoch === readInstallEpoch,
+            onInstall: () => {
               installEpoch += 1;
             },
-          );
+          });
           yield* Queue.offer(refreshCompleted, undefined);
         }),
         "0 millis",

--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -112,14 +112,24 @@ export const makeViewServerRuntimeCoreInternal: <const Topics extends DecodableT
     };
     const engine = yield* createColumnLiveViewEngineInternal<Topics>(engineConfig);
     const engineHealth = yield* engine.health();
-    const nowMillis = yield* Clock.currentTimeMillis;
+    const runtimeStartedAtMillis = yield* Clock.currentTimeMillis;
+    const runtimeStartedAtNanos = yield* Clock.currentTimeNanos;
     const health: AtomRef.AtomRef<ViewServerHealth<Topics>> = AtomRef.make(
-      healthFromEngine(engineHealth, transportHealth, healthOverlay, nowMillis),
+      healthFromEngine(engineHealth, {
+        transportHealth,
+        ...(healthOverlay === undefined ? {} : { healthOverlay }),
+        timing: {
+          nowMillis: runtimeStartedAtMillis,
+          nowNanos: runtimeStartedAtNanos,
+          runtimeStartedAtNanos,
+        },
+      }),
     );
     const runtimeClient = yield* makeRuntimeCoreClient<Topics>(
       config,
       engine,
       health,
+      runtimeStartedAtNanos,
       transportHealth,
       healthOverlay,
       input.healthRefreshCadence,

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -45,6 +45,7 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
     config: ViewServerTopicConfig<Topics>,
     engine: ColumnLiveViewEngineInternal<Topics>,
     health: AtomRef.AtomRef<ViewServerHealth<Topics>>,
+    runtimeStartedAtNanos: bigint,
     transportHealth: RuntimeCoreTransportHealth<Topics>,
     healthOverlay?: RuntimeCoreHealthOverlay<Topics>,
     healthRefreshCadence?: Duration.Input,
@@ -58,18 +59,17 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
       });
       const readRuntimeHealth = (epoch: number, installMode: "strict" | "scheduled") => {
         const installEpoch = healthInstallEpoch;
-        return readHealth(
-          engine,
-          health,
+        return readHealth(engine, health, {
+          runtimeStartedAtNanos,
           transportHealth,
-          healthOverlay,
-          () =>
+          ...(healthOverlay === undefined ? {} : { healthOverlay }),
+          shouldInstall: () =>
             healthInstallEpoch === installEpoch &&
             (installMode === "scheduled" || healthReadEpoch === epoch),
-          () => {
+          onInstall: () => {
             healthInstallEpoch += 1;
           },
-        );
+        });
       };
       const healthReader = makeCoalescedHealthReader(
         (epoch) => readRuntimeHealth(epoch, "strict"),

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -41,17 +41,20 @@ The runtime exposes a same-server `GET /health` endpoint for deployment
 readiness checks. It returns `200` when the runtime status is `ready` and a
 non-`200` status when the runtime is starting, degraded, or stopping.
 
-The JSON response is the current runtime health snapshot. Internal `bigint`
-fields, such as Kafka lag, are encoded as decimal strings.
+Each request performs a fresh runtime health read. Overlapping concurrent reads
+are coalesced so they share one runtime read. Internal `bigint` fields, such as
+Kafka lag, are encoded as decimal strings.
 
 React applications should use the pushed health hooks from `effect-view-server/react`;
 `GET /health` is for infrastructure and smoke checks, not UI polling.
+Those hooks consume cached client health refreshed on a bounded cadence; the
+HTTP health routes read runtime health on demand.
 
 ## Metrics
 
 The runtime exposes a same-server `GET /metrics` endpoint for Prometheus-style
 scrapes. The response uses `text/plain; version=0.0.4; charset=utf-8` and is
-derived from the same cached runtime health snapshot as `GET /health`.
+derived from a fresh, coalesced runtime health read just like `GET /health`.
 
 Metrics include runtime status/version/uptime, transport pressure, engine topic
 rows/versions/queues/backpressure, Kafka region lag and failure rates, and gRPC

--- a/packages/runtime/src/grpc-leased.bench.ts
+++ b/packages/runtime/src/grpc-leased.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import { create, toBinary } from "@bufbuild/protobuf";
 import type { Message } from "@bufbuild/protobuf";

--- a/packages/runtime/src/grpc-materialized.bench.ts
+++ b/packages/runtime/src/grpc-materialized.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe } from "vitest";
 import { create, toBinary } from "@bufbuild/protobuf";
 import type { Message } from "@bufbuild/protobuf";

--- a/packages/runtime/src/kafka-ingest.bench.ts
+++ b/packages/runtime/src/kafka-ingest.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe } from "vitest";
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import { create, toBinary } from "@bufbuild/protobuf";

--- a/packages/runtime/src/websocket-firehose.bench.ts
+++ b/packages/runtime/src/websocket-firehose.bench.ts
@@ -1,4 +1,5 @@
-// Benchmarks intentionally import Vitest directly: @effect/vitest does not expose `bench`.
+// Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
+// distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, beforeAll, bench, describe, expect } from "vitest";
 import {
   makeViewServerClient,

--- a/plans/grpc.md
+++ b/plans/grpc.md
@@ -44,7 +44,7 @@ Validation result:
   runtime. Declarative `grpc.clients` and Topic-owned `grpcSource` bindings can remain in the shared
   typed config without teaching React hooks about gRPC.
 - Compatible with the React/provider model because `useLiveQuery` does not learn about gRPC. The server resolves leased feeds behind the same Live Query contract.
-- Compatible with the health cadence rule because gRPC health is a ledger/cached snapshot, not a full per-message health rebuild.
+- Compatible with the health cadence rule because gRPC updates cheap Health Ledger state and does not rebuild full health per message.
 - Compatible with the transport policy because browser live data continues over Effect RPC WebSocket with NDJSON. gRPC is ingress only.
 - Compatible with the one-engine rule because leased-feed row isolation is an internal partitioning concern before a query reaches the existing engine. The engine still executes the same query semantics; the runtime only narrows the retained row universe to the single resolved feed instance.
 
@@ -55,7 +55,7 @@ Important boundaries carried forward from the v2 plan:
   runtime API remains the typed React provider/hooks.
 - In-memory testing must continue to use the same runtime-core and engine. gRPC leased/materialized feeds are server runtime Adapters, not a special test engine.
 - Production browser live traffic stays on Effect RPC WebSocket + NDJSON until a separate transport decision changes that. gRPC is not a browser transport.
-- Runtime health must remain cached/coalesced. gRPC message ingestion may update cheap counters, but it must not rebuild full health per upstream event.
+- Runtime health reads must remain coalesced, and pushed health must remain cadence-controlled. gRPC message ingestion may update cheap counters, but it must not rebuild full health per upstream event.
 - Topic ownership must stay explicit. One public View Server topic cannot be silently populated by Kafka and gRPC, or by multiple gRPC feed definitions, unless a future multi-source contract defines ordering, dedupe, health, and restart semantics.
 
 ## Core Vocabulary
@@ -615,8 +615,8 @@ Health cadence rules from the v2 plan still apply:
 
 - hot paths may update cheap counters
 - do not rebuild full health per message
-- `/health` returns a cached snapshot
-- health updates should be around once per second by default
+- `/health` performs a fresh runtime health read; overlapping concurrent reads are coalesced
+- pushed health updates should be around once per second by default
 
 ## Lifecycle And Resource Ownership
 
@@ -899,7 +899,7 @@ Implement in slices that keep `vp run -w ready`, strict Effect LSP, package seam
 
 5. Health and lifecycle hardening
    - Expose gRPC client/feed health separately from engine topic health.
-   - Keep health cached/coalesced.
+   - Keep runtime health reads coalesced and pushed health cadence-controlled.
    - Handle stream defects with degraded health and deterministic cleanup.
    - Avoid detached fibers for stream ownership.
 

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -638,23 +638,24 @@ Kafka health should always include `viewServerTopic`, so source-topic lag can be
 Kafka lag policy:
 
 - Include Kafka consumer lag when it is cheap/native from the Kafka client or already available from consumed high-watermark metadata.
-- Sample lag on the same cached health cadence, around once per second.
+- Sample lag on the same bounded pushed-health cadence, around once per second.
 - Do not add per-message or per-batch broker round trips just to compute lag.
 - If precise lag is expensive, expose the best cheap approximation and mark the sample time with `lagSampledAt`.
 - If lag cannot be obtained cheaply, return `consumerLagMessages: null` rather than harming ingest throughput.
 - Lag should never be computed in the row ingestion hot loop.
 
-Health snapshot cadence:
+Health read and push cadence:
 
-- `/health` should return a cached snapshot refreshed at most once per second by default.
+- `client.health()`, `/health`, and `/metrics` initiate fresh runtime health reads on demand. Overlapping concurrent reads are coalesced.
+- Pushed provider health uses cached/coalesced refreshes on a bounded cadence, around once per second by default.
 - Hot paths may increment cheap counters, but they must not rebuild the full health object per message.
-- A topic receiving 1M messages/sec should still update the exported health JSON around 1 time/sec, not 1M times/sec.
-- `/metrics` can expose monotonic counters/histograms suitable for Prometheus-style scraping.
-- Tests should assert health eventually reflects row counts/lag, not that it updates synchronously after every mutation.
+- A topic receiving 1M messages/sec should still update pushed health around 1 time/sec, not 1M times/sec.
+- `/metrics` renders monotonic counters and gauges from its fresh runtime health read for Prometheus-style scraping.
+- Tests should assert pushed health eventually reflects row counts/lag, while explicit runtime and HTTP reads observe a fresh snapshot.
 
 Health endpoint shape:
 
-- `GET /health` returns one full cached runtime snapshot.
+- `GET /health` returns one full fresh runtime snapshot; overlapping concurrent reads are coalesced.
 - There is no `GET /health/stream` endpoint.
 - If a client needs streaming health, it should subscribe through the normal WebSocket/live-query path.
 
@@ -680,9 +681,9 @@ Streaming health should use the same WebSocket transport as everything else, but
 const health = useViewServerHealth();
 ```
 
-`useViewServerHealth()` should return detailed live health rows for all topics, plus runtime, connection, and merged status fields. The full cached runtime health document remains available from `/health` for deployment checks and admin integrations. The common operator question is overall runtime health, not a single topic's health. Topic filtering can be derived by the UI from the returned rows if needed.
+`useViewServerHealth()` should return detailed live health rows for all topics, plus runtime, connection, and merged status fields. The hook consumes cadence-controlled pushed health, while the full fresh runtime health document remains available from `/health` for deployment checks and admin integrations. The common operator question is overall runtime health, not a single topic's health. Topic filtering can be derived by the UI from the returned rows if needed.
 
-Kubernetes/readiness/liveness should use the full cached `/health` document. Dashboards that need live health should use WebSockets through `useViewServerHealth()`. Do not add HTTP streaming for health.
+Kubernetes/readiness/liveness should use the full fresh `/health` document. Dashboards that need cadence-controlled live health should use WebSockets through `useViewServerHealth()`. Do not add HTTP streaming for health.
 
 Health degradation rules:
 


### PR DESCRIPTION
## Summary

- make engine reset and close linearizable with concurrent mutations through a deep mutation/lifecycle barrier
- reject or cancel queued mutations without ghost writes while preserving independent-topic concurrency
- derive runtime uptime from monotonic clock time and keep wall time for health overlays
- reconcile health/metrics documentation with fresh coalesced runtime reads and cadence-controlled pushed health
- document the benchmark-only direct Vitest import exception so Effect test-runtime loading cannot distort heap, JIT, or GC measurements
- add a patch Changeset for the publishable corrections

## Validation

- Engine package: 278 tests, no type errors, exact 100% statements/branches/functions/lines
- Runtime Core package: 60 tests, no type errors, exact 100% statements/branches/functions/lines
- vp check
- strict Effect diagnostics across all packages and examples
- full grpc:gate, including readiness, materialized, leased, and 50k retained profiles
- full pre-grpc:gate, including smoke, raw read/write, active-query sharing, grouped admission/order-neutral, WebSocket, Kafka ingest, and sustained Kafka firehose
- no benchmark baselines updated

## Review

- Effect/concurrency review: approved with no findings
- Vitest/type-safety review: approved with no findings
- architecture/maintainability review: approved with no findings

Issue: #307
Parent PRD: #292
