### PR TITLE
Preserve schema-decoded Live Query values

### DIFF
--- a/.changeset/preserve-topic-row-value-semantics.md
+++ b/.changeset/preserve-topic-row-value-semantics.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": major
+---
+
+Preserve schema-decoded values and optional-field presence across Live Query results, normalize order-insensitive persistent-collection identity, apply configured field semantics to equality filters and ordering, and reject opaque, non-injective, unrecognized, or equivalence-incongruent value domains that cannot retain one meaning across local, gRPC, and NDJSON boundaries. Topic schemas using `Option`, `Chunk`, `HashMap`, or `HashSet` must use the corresponding `viewSchema` factory; `viewSchema.BigDecimal` is the admitted `Schema.BigDecimal` declaration, so either spelling remains valid. A concrete `Schema.Class` must be registered with `viewSchema.admitClass(Profile)` before it is used by a Topic. Topic row, query, source, and mutation types now contain schema fields only; class methods are not data columns. Direct `createColumnLiveViewEngine` consumers must now handle `InvalidRowError` in the constructor Effect error channel when configured schema semantics cannot be compiled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,6 @@ jobs:
         working-directory: packages/react
         run: vp exec playwright install --with-deps chromium firefox webkit
 
-      - name: Effect LSP diagnostics
-        run: |
-          vp exec effect-language-service diagnostics --project packages/config/tsconfig.json --format text --strict
-          vp exec effect-language-service diagnostics --project packages/column-live-view-engine/tsconfig.json --format text --strict
-          vp exec effect-language-service diagnostics --project packages/react/tsconfig.json --format text --strict
-
       - name: Ready gate
         run: vp run -w ready
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,10 @@ _Avoid_: Kafka topic, channel, collection
 A schema-decoded object stored in a View Server Topic.
 _Avoid_: Record, document, message
 
+**Topic Row Value Semantics**:
+The schema-derived ownership, equivalence, canonical JSON representation, and ordering rules for every configured Topic Row field. The Column Live View Engine compiles these rules once per View Server Topic and reuses them at ingestion, projection, grouping, comparison, Snapshot, and Delta boundaries. Canonical identity normalizes order-insensitive persistent collections while preserving ordinary sequence order. Topic configuration rejects non-injective or unrecognized codec transformations and equality domains without a congruent canonical identity/order witness.
+_Avoid_: Deep clone helper, generic object equality, JSON stringify semantics
+
 **Row Key**:
 The configured string field that uniquely identifies a Topic Row and acts as the final deterministic sort tiebreaker.
 _Avoid_: Primary key when discussing external databases, id unless the configured field is actually named id
@@ -98,6 +102,10 @@ _Avoid_: Sort cache, ordered array helper, top-k shortcut
 The compiled internal representation of a Grouped Query, including group key calculation, aggregate definitions, ordering, window settings, and cache keys.
 _Avoid_: Grouped query object, aggregate config, groupBy helper
 
+**Query Result Semantics**:
+The compiled projection witness that owns and compares one Raw or Grouped Query result shape. It materializes consumer-owned semantic values without exposing authoritative Topic Row or Active Query state.
+_Avoid_: Result cast, structured clone, caller-selected result generic
+
 **Health Ledger**:
 The owner of counters and sampled health state for mutations, subscriptions, queues, backpressure, ingestion, and transport pressure.
 _Avoid_: Health object builder, metrics dump
@@ -123,6 +131,10 @@ _Avoid_: Runtime client, publishing client
 **Wire Protocol**:
 The Effect RPC WebSocket protocol using NDJSON serialization and schema-aware JSON-safe encoding for configured topic rows and query values.
 _Avoid_: Raw WebSocket protocol, HTTP stream, SSE, MessagePack protocol
+
+**Strict JSON Materializer**:
+The neutral Effect utility that turns an already schema-encoded value into a fresh canonical JSON tree or a path-aware typed error. It rejects opaque prototypes, cycles, accessors, sparse arrays, symbols, functions, non-finite numbers, and other values that NDJSON would silently erase or change.
+_Avoid_: JSON clone, Schema.Json validator, serializer
 
 **Field Filter Codec**:
 The Wire Protocol module that encodes and decodes schema-aware JSON-safe Raw Query filter values, including operator filters and structured-value fallback.
@@ -218,6 +230,7 @@ _Avoid_: Browser write, send, emit
 - A **View Server** owns one or more **View Server Topics**.
 - A **View Server Topic** has exactly one configured **Row Key**.
 - A **Topic Row** belongs to exactly one **View Server Topic**.
+- **Topic Row Value Semantics** are derived from that Topic Row's configured schema and are shared by local and Wire Protocol ownership boundaries.
 - A **Live Query** targets exactly one **View Server Topic**.
 - A **Raw Query** returns selected Topic Row fields.
 - A **Grouped Query** returns group fields plus aggregate aliases.
@@ -231,10 +244,12 @@ _Avoid_: Browser write, send, emit
 - A **Raw Predicate Plan** is part of a **Raw Query Plan** and lets storage narrow scans without replacing the correctness callback unless it is proven exact.
 - A **Topic Store Module** may maintain **Raw Ordered Window Indexes** to accelerate bounded **Raw Query** windows.
 - A **Grouped Query Plan** is compiled once from a **Grouped Query** before grouped full-scan or incremental execution.
+- Every compiled Raw or Grouped Query carries **Query Result Semantics** determined by its selected fields, group fields, and aggregate definitions.
 - An **Active Query** may serve many equivalent **Subscriptions**.
 - A **Live Client** can subscribe to **Live Queries** but cannot publish mutations.
 - A **Runtime Client** can publish mutations but is not exposed to browsers by the Real View Server.
 - A **Remote Browser Client** is a **Live Client** adapter for the **Wire Protocol**.
+- The **Strict JSON Materializer** makes local semantic materialization and NDJSON acceptance agree; explicit schema codecs restore semantic runtime values after the strict JSON boundary.
 - A **Field Filter Codec** protects the **Wire Protocol** from unsafe or incorrectly typed filter values.
 - A **Raw Query Codec** protects Raw Query wire payloads from unknown fields, unsafe filters, and invalid windows.
 - A **Grouped Query Codec** protects Grouped Query wire payloads from invalid group fields, aggregate aliases, aggregate fields, grouped ordering, and invalid windows.

--- a/docs/adr/0003-canonical-topic-row-value-semantics.md
+++ b/docs/adr/0003-canonical-topic-row-value-semantics.md
@@ -1,0 +1,68 @@
+# ADR 0003: Topic Row values use canonical schema-derived semantics
+
+## Status
+
+Accepted on 2026-07-12. Implementation is tracked by issue #324.
+
+## Context
+
+A Topic Row schema promises more than a TypeScript object shape. Effect schemas can decode values such as Schema classes, `Option`, `Chunk`, `HashMap`, and `BigDecimal` whose prototypes and equality rules are part of their runtime meaning. Raw and Grouped Live Queries must preserve that meaning while keeping authoritative Topic Row and Active Query state isolated from callers.
+
+Generic cloning cannot satisfy both requirements. A platform structured clone may detach mutable state, but it does not reconstruct arbitrary schema-decoded values through their declared codec. Plain recursive cloning preserves only JSON-like containers. Referential equality also treats separately decoded but semantically equal values as changes, while broad stringification does not provide a collision-safe group identity for prototype-bearing values.
+
+The production Wire Protocol adds a second constraint. Effect RPC WebSocket uses NDJSON, so every encoded payload must be a real JSON tree. Effect's `Schema.Json` decoder is intentionally permissive enough to accept some JavaScript container values that `JSON.stringify` subsequently changes or erases. For example, an opaque `Map` accepted beneath `Schema.ObjectKeyword` does not have a faithful NDJSON representation. Local and remote View Servers must not disagree about whether such a Topic Row is valid.
+
+The project therefore needs one explicit semantic contract for ownership, equivalence, canonical identity, and JSON safety.
+
+## Decision
+
+Each View Server Topic compiles **Topic Row Value Semantics** from its configured schema once.
+
+1. Schema decoding remains the authority for the Topic Row type.
+2. `Schema.toCodecJson` is the authority for the canonical wire representation of explicit schema values.
+3. A neutral **Strict JSON Materializer** validates and copies the encoded value before it can cross an ownership or NDJSON boundary.
+4. Decoding that fresh canonical JSON value through the same codec reconstructs a fresh semantic runtime value.
+5. Enumerable own-field presence is part of Topic Row identity. For equally present values, `Schema.toEquivalence` is the authority for semantic equality. Separately instantiated values that the configured schema considers equal do not advance a Topic version or emit a Delta.
+6. Raw and Grouped Query Plans carry **Query Result Semantics** derived from their selected fields, group fields, and aggregate results. Active Query caches may retain engine-owned values; one-shot results, Snapshots, and row-bearing Delta operations receive fresh consumer-owned values.
+7. Missing optional fields remain omitted. A present field whose declared value includes `undefined` remains present and follows its canonical codec.
+8. Raw equality filters canonicalize their operands through the configured field schema and use the same field equivalence. Raw ordering uses schema-compatible field comparison, and equivalent query cache keys use schema-canonical filter tokens.
+9. Group identity, `countDistinct`, and ordered aggregate state use schema-canonical field tokens and schema-compatible comparison. They do not use object identity or generic object stringification.
+10. Topic configuration rejects schema domains whose canonical JSON codec is not a semantic identity witness. This includes unions whose distinct runtime members can decode from the same JSON value, arbitrary custom equivalence or codec transformations without an explicit canonical/order witness, unrecognized declaration codecs, and native `ReadonlyMap`/`ReadonlySet` domains whose iteration-ordered codec conflicts with order-insensitive equality.
+11. `Option`, `Chunk`, `HashMap`, and `HashSet` are admitted through the corresponding public `viewSchema` factories. `viewSchema.BigDecimal` is the admitted `Schema.BigDecimal` declaration, so either spelling is valid. A concrete Effect Schema class is admitted explicitly with `viewSchema.admitClass(Profile)`. Admission belongs to that exact declaration, is idempotent for reuse, and is independent for each concrete class. Class annotations belong in the `Schema.Class` definition before admission; a subsequently derived codec is a distinct schema and does not inherit admission.
+12. Topic Row data types come from `Schema.Struct.Type<S["fields"]>` for the configured row schema `S`. A decoded class instance may retain its methods, but only declared schema fields participate in topic keys, source mappings, queries, aggregates, results, and mutations.
+
+The Strict JSON Materializer accepts only:
+
+- `null`, strings, booleans, and finite numbers, with negative zero normalized to zero;
+- dense arrays with no extra own properties; and
+- plain or null-prototype records containing enumerable own string-keyed data properties.
+
+It recursively produces fresh arrays and records. It preserves an own `__proto__` key as data rather than invoking the prototype setter. It tracks the active recursion path so a shared acyclic input value is accepted and copied at each location, while a cycle is rejected.
+
+It rejects values that NDJSON would silently omit, coerce, invoke, or degrade: `undefined`, naked `bigint`, symbols, functions, non-finite numbers, symbol keys, accessors, non-enumerable properties, sparse arrays, extra array properties, opaque or custom prototypes, cycles, and failed reflection through hostile proxies. Failures retain an exact value path and reason so callers can map them to the typed boundary error they own.
+
+The Strict JSON Materializer does not inspect Schema ASTs and does not decide which semantic types are supported. Explicit schema codecs own that decision. A value beneath `Schema.Unknown` or `Schema.ObjectKeyword` is accepted only when its encoded result is already a faithful strict JSON tree.
+
+## Group identity and custom equivalence
+
+Canonical field tokens come from the strict JSON output of the field's canonical codec. The compiled identity plan recursively sorts encoded `HashMap` entries and `HashSet` elements by their normalized JSON tokens, including collision-node values whose iteration order depends on insertion order. Ordinary arrays and `Chunk` values remain order-sensitive. Structured tokens may be cached by object identity as a performance optimization, but the token content remains the source of group identity.
+
+`Schema.overrideToEquivalence` can define equality that has no lawful matching hash or total order. A custom encode transformation can likewise collapse distinct decoded values into one JSON value. The current configuration Interface has no separate canonical/order witness, so arbitrary custom equivalence and unrecognized codec transformations are rejected recursively when the Topic is defined. The public `viewSchema` members provide the identity witness for the admitted Effect declarations, and `viewSchema.admitClass` provides it for one already-defined concrete Schema class. A future Interface may admit other custom behavior only together with an explicit witness whose canonical key is identical for equivalent values and whose comparison orders equivalence classes lawfully.
+
+Likewise, a JSON codec must be injective over the admitted runtime domain. For example, `Schema.Union([Schema.Null, Schema.Undefined])` maps two distinct values to JSON `null`, while `Schema.Union([Schema.String, Schema.BigInt])` can map both `"1"` and `1n` to the same JSON string. Such unions are rejected recursively at Topic configuration time, before Raw, Grouped, gRPC, or NDJSON behavior can diverge. Disjoint unions such as string-or-undefined and tagged object unions remain supported.
+
+Effect's `HashMap` and `HashSet` codecs preserve their runtime types but may expose collision-node insertion order in their encoded arrays. The shared schema identity Module normalizes that encoded order before deriving engine, grouped-public-key, or leased-route identity. Native `ReadonlyMap` and `ReadonlySet` are not admitted as Topic fields because their codecs preserve iteration order while their schema equivalence does not. They can be reconsidered only with an order-neutral canonical codec shared by the engine, Wire Protocol, and gRPC route-key derivation.
+
+## Consequences
+
+Local, in-memory, WebSocket, and NDJSON behavior share one acceptance contract. Semantic values retain their declared runtime form in Raw and Grouped results, and consumer mutation cannot reach authoritative storage or shared Active Query cursors.
+
+Opaque local-only values beneath broad schemas are rejected with typed `InvalidRow` errors instead of being silently changed by transport serialization. This deliberately narrows that behavior and requires release intent.
+
+Non-injective and equivalence-incongruent schema domains fail while defining the View Server configuration rather than accepting typed values that would later merge, reorder, or change across transports.
+
+The Column Live View Engine and Wire Protocol may depend on the neutral `@effect-view-server/effect-utils` package for strict JSON materialization. The utility remains independent of View Server packages. Schema decoding, projection shape, grouping, aggregate behavior, and typed boundary errors stay in their owning Modules.
+
+Canonical encode/decode adds work at ownership boundaries. Compiled codecs, equivalence functions, field plans, and structured canonical tokens must be reused. Performance gates must cover both Raw read/write and grouped admission/order-neutral behavior so semantic correctness cannot hide an unacceptable ingestion or subscription cost.
+
+Issue #325 may replace caller-selected result generics and identity overloads with the runtime projection witnesses introduced here. This ADR does not preserve those overloads as compatibility APIs.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -73,6 +73,64 @@ export const viewServerReact = createViewServerReact(viewServer);
 export const { ViewServerProvider, useLiveQuery, useViewServerHealthSummary } = viewServerReact;
 ```
 
+### Schema value admission
+
+Topic values must have one canonical identity across the in-memory engine, gRPC,
+and the NDJSON Wire Protocol. Use ordinary Effect Schema constructors for
+JSON-faithful primitives and structural composition. Use `viewSchema` for the
+supported Effect values whose runtime equality or codec requires an explicit
+View Server identity witness:
+
+- `viewSchema.BigDecimal`
+- `viewSchema.Option(value)`
+- `viewSchema.Chunk(value)`
+- `viewSchema.HashMap(key, value)`
+- `viewSchema.HashSet(value)`
+
+Define a concrete `Schema.Class` normally, then admit that exact class before
+using it in a Topic schema:
+
+```ts
+import { defineViewServerConfig, viewSchema } from "effect-view-server/config";
+import { Schema } from "effect";
+
+class Profile extends Schema.Class<Profile>("Profile")(
+  {
+    id: Schema.String,
+    score: Schema.NumberFromString,
+    backup: viewSchema.Option(Schema.String),
+  },
+  { title: "Profile" },
+) {
+  label(): string {
+    return `${this.id}:${this.score}`;
+  }
+}
+
+viewSchema.admitClass(Profile);
+
+export const profiles = defineViewServerConfig({
+  topics: {
+    profiles: {
+      schema: Profile,
+      key: "id",
+    },
+  },
+});
+```
+
+Admission is attached to the exact schema declaration and is idempotent, so the
+same concrete class may be admitted more than once and independent classes are
+admitted separately. Supply class annotations in the `Schema.Class` definition
+before admission. Derived codecs produced by operations such as
+`Profile.annotate(...)` are distinct schemas and do not inherit admission or the
+root Class field Interface.
+
+The Topic Row type is derived from `Profile.fields`. Class methods remain
+available on decoded `Profile` instances, but they are not Topic columns and
+cannot appear in keys, source mappings, `select`, `where`, `orderBy`, `groupBy`,
+aggregates, or patches.
+
 Topics without `kafkaSource` or `grpcSource` are externally/manual published
 topics, for example through TCP publish or an in-memory test client. A topic can
 only have one source owner.

--- a/examples/combined-sources-react/vite.config.ts
+++ b/examples/combined-sources-react/vite.config.ts
@@ -1,39 +1,10 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-  },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
+  browserProvider: playwright(),
 });

--- a/examples/grpc-leased-react/vite.config.ts
+++ b/examples/grpc-leased-react/vite.config.ts
@@ -1,39 +1,10 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-  },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
+  browserProvider: playwright(),
 });

--- a/examples/grpc-materialized-react/vite.config.ts
+++ b/examples/grpc-materialized-react/vite.config.ts
@@ -1,39 +1,10 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-  },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
+  browserProvider: playwright(),
 });

--- a/examples/in-memory-react/vite.config.ts
+++ b/examples/in-memory-react/vite.config.ts
@@ -1,55 +1,26 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-    coverage: {
-      provider: "istanbul",
-      include: ["src/**/*.ts", "src/**/*.tsx"],
-      exclude: [
-        "src/router.tsx",
-        "src/routeTree.gen.ts",
-        "src/routes/**/*.tsx",
-        "src/**/*.test.ts",
-        "src/**/*.test.tsx",
-        "src/**/*.test-d.ts",
-      ],
-      reporter: ["text"],
-      thresholds: {
-        "100": true,
-      },
+  browserProvider: playwright(),
+  coverage: {
+    provider: "istanbul",
+    include: ["src/**/*.ts", "src/**/*.tsx"],
+    exclude: [
+      "src/router.tsx",
+      "src/routeTree.gen.ts",
+      "src/routes/**/*.tsx",
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "src/**/*.test-d.ts",
+    ],
+    reporter: ["text"],
+    thresholds: {
+      "100": true,
     },
   },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
 });

--- a/examples/kafka-react/vite.config.ts
+++ b/examples/kafka-react/vite.config.ts
@@ -1,39 +1,10 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-  },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
+  browserProvider: playwright(),
 });

--- a/examples/ssr-react/vite.config.ts
+++ b/examples/ssr-react/vite.config.ts
@@ -1,39 +1,10 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-  },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
+  browserProvider: playwright(),
 });

--- a/examples/tcp-publisher-react/vite.config.ts
+++ b/examples/tcp-publisher-react/vite.config.ts
@@ -1,39 +1,10 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite-plus";
 import { playwright } from "@vitest/browser-playwright";
+import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 
-export default defineConfig({
-  optimizeDeps: {
-    include: ["@effect/vitest", "react-dom/client", "vitest-browser-react"],
-    exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
-  },
+export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
-  test: {
-    include: ["src/**/*.test.ts"],
-    typecheck: {
-      enabled: true,
-      checker: "tsc",
-      include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
-      tsconfig: "./tsconfig.json",
-    },
-    browser: {
-      enabled: true,
-      provider: playwright(),
-      headless: true,
-      instances: [
-        { browser: "chromium", name: "chromium", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "firefox", name: "firefox", include: ["src/**/*.browser.test.tsx"] },
-        { browser: "webkit", name: "webkit", include: ["src/**/*.browser.test.tsx"] },
-      ],
-    },
-  },
-  lint: {
-    options: {
-      typeAware: true,
-      typeCheck: true,
-    },
-  },
-  fmt: {},
+  browserProvider: playwright(),
 });

--- a/examples/vite.config.shared.ts
+++ b/examples/vite.config.shared.ts
@@ -1,0 +1,60 @@
+import { defineConfig, type PluginOption, type TestUserConfig } from "vite-plus";
+import type { BrowserProviderOption } from "vite-plus/test/node";
+
+interface TanStackReactExampleConfigOptions {
+  readonly plugins: Array<PluginOption>;
+  readonly browserProvider: BrowserProviderOption;
+  readonly coverage?: NonNullable<TestUserConfig["coverage"]>;
+}
+
+export const defineTanStackReactExampleConfig = ({
+  plugins,
+  browserProvider,
+  coverage,
+}: TanStackReactExampleConfigOptions) =>
+  defineConfig({
+    optimizeDeps: {
+      include: ["@effect/vitest", "effect/Array", "react-dom/client", "vitest-browser-react"],
+      exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
+    },
+    plugins,
+    test: {
+      include: ["src/**/*.test.ts"],
+      typecheck: {
+        enabled: true,
+        checker: "tsc",
+        include: ["src/**/*.test-d.ts", "src/**/*.browser.test.tsx"],
+        tsconfig: "./tsconfig.json",
+      },
+      browser: {
+        enabled: true,
+        provider: browserProvider,
+        headless: true,
+        instances: [
+          {
+            browser: "chromium",
+            name: "chromium",
+            include: ["src/**/*.browser.test.tsx"],
+          },
+          {
+            browser: "firefox",
+            name: "firefox",
+            include: ["src/**/*.browser.test.tsx"],
+          },
+          {
+            browser: "webkit",
+            name: "webkit",
+            include: ["src/**/*.browser.test.tsx"],
+          },
+        ],
+      },
+      ...(coverage === undefined ? {} : { coverage }),
+    },
+    lint: {
+      options: {
+        typeAware: true,
+        typeCheck: true,
+      },
+    },
+    fmt: {},
+  });

--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -48,7 +48,7 @@ const BadJsonField = Schema.String.pipe(
 );
 
 const BadJsonRow = Schema.Struct({
-  id: BadJsonField,
+  id: Schema.String,
 });
 
 const viewServer = defineViewServerConfig({
@@ -60,7 +60,7 @@ const viewServer = defineViewServerConfig({
   },
 });
 
-const edgeViewServer = defineViewServerConfig({
+const safeEdgeViewServer = defineViewServerConfig({
   topics: {
     badjson: {
       schema: BadJsonRow,
@@ -68,6 +68,21 @@ const edgeViewServer = defineViewServerConfig({
     },
   },
 });
+Object.defineProperty(BadJsonRow.fields, "id", {
+  configurable: true,
+  enumerable: true,
+  value: BadJsonField,
+  writable: true,
+});
+const edgeViewServer = {
+  ...safeEdgeViewServer,
+  topics: {
+    badjson: {
+      ...safeEdgeViewServer.topics.badjson,
+      schema: BadJsonRow,
+    },
+  },
+};
 
 type OrderRow = typeof Order.Type;
 

--- a/packages/column-live-view-engine/package.json
+++ b/packages/column-live-view-engine/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@effect-view-server/config": "workspace:*",
+    "@effect-view-server/effect-utils": "workspace:*",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/column-live-view-engine/src/active-materialized-query.ts
+++ b/packages/column-live-view-engine/src/active-materialized-query.ts
@@ -4,6 +4,7 @@ import type { ActiveQueryStoreState, LiveQueryExecution } from "./active-query";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
 import type { GroupedIncrementalExecutionDiagnosticCounts } from "./grouped-incremental-execution";
+import type { QueryResultSemantics } from "./query-result-semantics";
 
 type RowObject = object;
 
@@ -42,12 +43,13 @@ const getActiveMaterializedQueryMap = (
 const leaseMaterializedQueryExecution = <ResultRow extends RowObject>(
   store: ActiveQueryStoreState,
   execution: ActiveMaterializedQueryExecution,
+  resultSemantics: QueryResultSemantics,
 ): LiveQueryExecution<ResultRow> => {
   const latestEvaluation = () => typedQueryEvaluation<ResultRow>(execution.latest());
 
   return {
     initial: (queryId): SnapshotEvent<ResultRow> =>
-      snapshotEvent(store, queryId, latestEvaluation()),
+      snapshotEvent(store, queryId, latestEvaluation(), resultSemantics),
     createCursor: () => ({
       evaluation: latestEvaluation(),
     }),
@@ -55,12 +57,14 @@ const leaseMaterializedQueryExecution = <ResultRow extends RowObject>(
       Effect.sync(() => {
         const previous = cursor.evaluation;
         const next = latestEvaluation();
-        const operations = deltaOperations(previous, next);
+        const operations = deltaOperations(previous, next, resultSemantics);
         if (operations.length === 0 && previous.totalRows === next.totalRows) {
           return Option.none();
         }
         cursor.evaluation = next;
-        return Option.some(deltaEvent(store, queryId, previous.version, next, operations));
+        return Option.some(
+          deltaEvent(store, queryId, previous.version, next, operations, resultSemantics),
+        );
       }),
   };
 };
@@ -77,6 +81,7 @@ export const acquireMaterializedQueryExecution = Effect.fn(
 )(function <ResultRow extends RowObject>(
   store: ActiveQueryStoreState,
   cacheKey: string,
+  resultSemantics: QueryResultSemantics,
   makeExecution: (releaseRetainedChanges: () => void) => MaterializedQueryExecution<ResultRow>,
 ) {
   return Effect.sync(() => {
@@ -85,7 +90,7 @@ export const acquireMaterializedQueryExecution = Effect.fn(
     if (existing !== undefined) {
       const entry = existing;
       entry.refs += 1;
-      return leaseMaterializedQueryExecution<ResultRow>(store, entry.execution);
+      return leaseMaterializedQueryExecution<ResultRow>(store, entry.execution, resultSemantics);
     }
 
     let retainedChanges = false;
@@ -106,7 +111,7 @@ export const acquireMaterializedQueryExecution = Effect.fn(
       releaseRetainedChanges,
       refs: 1,
     });
-    return leaseMaterializedQueryExecution<ResultRow>(store, execution);
+    return leaseMaterializedQueryExecution<ResultRow>(store, execution, resultSemantics);
   });
 });
 

--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -10,6 +10,7 @@ import {
   releaseRawQueryExecution,
 } from "./active-query";
 import { replaceRetainedMatchingEntryAtIndex } from "./active-raw-query";
+import { prepareGroupedQuery } from "./grouped-query-compiler";
 import { prepareRawQuery } from "./raw-query-compiler";
 import { makeQueryResultSemantics } from "./query-result-semantics";
 import {
@@ -3313,36 +3314,64 @@ describe("column-live-view-engine active query execution", () => {
     }),
   );
 
-  it.effect("rejects non-plain object filter values before cache-keying", () =>
+  it.effect("canonicalizes schema-backed null-prototype filter values before cache-keying", () =>
     Effect.gen(function* () {
       const store = new TopicStore(
         "special",
         Schema.Struct({
           id: Schema.String,
-          payload: Schema.Struct({
-            value: Schema.BigInt,
-            label: Schema.String,
-          }),
+          payload: Schema.Record(Schema.String, Schema.String),
         }),
         "id",
         () => {},
       );
-      const queryPayload: Record<string, unknown> = Object.create(null);
-      queryPayload["value"] = 1n;
-      queryPayload["label"] = "special";
+      const queryPayload: Record<string, string> = Object.create(null);
+      queryPayload["venue"] = "xnys";
 
-      const invalidPayload = yield* Effect.flip(
-        prepareRawQuery("special", topicStoreRawQueryMetadata(store), {
+      const nullPrototypeQuery = yield* prepareRawQuery(
+        "special",
+        topicStoreRawQueryMetadata(store),
+        {
           select: ["id", "payload"],
           where: {
             payload: queryPayload,
           },
-        }),
+        },
       );
-      expect(invalidPayload).toMatchObject({
-        _tag: "InvalidQueryError",
-        message: expect.stringContaining("unsupported query value"),
+      const plainRecordQuery = yield* prepareRawQuery(
+        "special",
+        topicStoreRawQueryMetadata(store),
+        {
+          select: ["id", "payload"],
+          where: {
+            payload: { venue: "xnys" },
+          },
+        },
+      );
+      const nullPrototypeGrouped = yield* prepareGroupedQuery<object, object>(
+        "special",
+        topicStoreRawQueryMetadata(store),
+        {
+          groupBy: ["payload"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          where: { payload: queryPayload },
+        },
+      );
+      const plainRecordGrouped = yield* prepareGroupedQuery<object, object>(
+        "special",
+        topicStoreRawQueryMetadata(store),
+        {
+          groupBy: ["payload"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          where: { payload: { venue: "xnys" } },
+        },
+      );
+
+      expect(nullPrototypeQuery.query.where).toStrictEqual({
+        payload: { venue: "xnys" },
       });
+      expect(nullPrototypeQuery.plan.queryCacheKey).toBe(plainRecordQuery.plan.queryCacheKey);
+      expect(nullPrototypeGrouped.cacheKey).toBe(plainRecordGrouped.cacheKey);
     }),
   );
 

--- a/packages/column-live-view-engine/src/active-query.test.ts
+++ b/packages/column-live-view-engine/src/active-query.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./active-query";
 import { replaceRetainedMatchingEntryAtIndex } from "./active-raw-query";
 import { prepareRawQuery } from "./raw-query-compiler";
+import { makeQueryResultSemantics } from "./query-result-semantics";
 import {
   deleteTopicStoreRow,
   patchTopicStoreRow,
@@ -22,6 +23,7 @@ import {
 import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 
 const invalidRow = (_topic: string, message: string): Error => new Error(message);
+const emptyResultSemantics = makeQueryResultSemantics([]);
 
 describe("column-live-view-engine active query execution", () => {
   it("falls back when an indexed retained replacement points at a different key", () => {
@@ -221,16 +223,21 @@ describe("column-live-view-engine active query execution", () => {
         patchedEvaluationCount: 0,
       });
 
-      yield* acquireMaterializedQueryExecution(readModel, "grouped", () => ({
+      yield* acquireMaterializedQueryExecution(readModel, "grouped", emptyResultSemantics, () => ({
         diagnostics: emptyDiagnostics,
         incremental: false,
         latest: () => emptyEvaluation(readModel.version()),
       }));
-      yield* acquireMaterializedQueryExecution(isolatedReadModel, "grouped", () => ({
-        diagnostics: emptyDiagnostics,
-        incremental: false,
-        latest: () => emptyEvaluation(isolatedReadModel.version()),
-      }));
+      yield* acquireMaterializedQueryExecution(
+        isolatedReadModel,
+        "grouped",
+        emptyResultSemantics,
+        () => ({
+          diagnostics: emptyDiagnostics,
+          incremental: false,
+          latest: () => emptyEvaluation(isolatedReadModel.version()),
+        }),
+      );
 
       expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
       expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
@@ -3094,7 +3101,7 @@ describe("column-live-view-engine active query execution", () => {
         decimalFilter,
       );
 
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(numericStore))).toBe(6);
+      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(numericStore))).toBe(5);
       expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(bigintStore))).toBe(1);
       expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(decimalStore))).toBe(1);
 

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -430,7 +430,8 @@ const leaseRawQueryExecution = <ResultRow extends RowObject>(
   const latestEvaluation = () => projectWindowEvaluation(store, compiled, execution.latest());
 
   return {
-    initial: (queryId) => snapshotEvent(store, queryId, latestEvaluation()),
+    initial: (queryId) =>
+      snapshotEvent(store, queryId, latestEvaluation(), compiled.plan.resultSemantics),
     createCursor: () => ({
       evaluation: latestEvaluation(),
     }),
@@ -438,12 +439,21 @@ const leaseRawQueryExecution = <ResultRow extends RowObject>(
       Effect.sync(() => {
         const previous = cursor.evaluation;
         const next = latestEvaluation();
-        const operations = deltaOperations(previous, next);
+        const operations = deltaOperations(previous, next, compiled.plan.resultSemantics);
         if (operations.length === 0 && previous.totalRows === next.totalRows) {
           return Option.none();
         }
         cursor.evaluation = next;
-        return Option.some(deltaEvent(store, queryId, previous.version, next, operations));
+        return Option.some(
+          deltaEvent(
+            store,
+            queryId,
+            previous.version,
+            next,
+            operations,
+            compiled.plan.resultSemantics,
+          ),
+        );
       }),
   };
 };

--- a/packages/column-live-view-engine/src/column-storage.test.ts
+++ b/packages/column-live-view-engine/src/column-storage.test.ts
@@ -115,7 +115,7 @@ it("derives topic column vectors from schema metadata and preserves slot mutatio
 
   expect(columnScalarEqualityKey(optionalPrice, 0)).toBe("number:1");
   expect(columnScalarEqualityKey(optionalPrice, 1)).toBeUndefined();
-  expect(columnScalarEqualityKey(numberKeys, 0)).toBe("number:-0");
+  expect(columnScalarEqualityKey(numberKeys, 0)).toBe("number:0");
   expect(columnScalarEqualityKey(numberKeys, 1)).toBe("number:NaN");
   expect(columnScalarEqualityKey(numberKeys, 2)).toBe("number:Infinity");
   expect(columnScalarEqualityKey(numberKeys, 3)).toBe("number:-Infinity");

--- a/packages/column-live-view-engine/src/engine-close-mutation-barrier.test.ts
+++ b/packages/column-live-view-engine/src/engine-close-mutation-barrier.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Clock, Deferred, Effect, Exit, Fiber, Option, Schema, SchemaGetter } from "effect";
-import { createColumnLiveViewEngine, EngineClosedError } from "./index";
+import { Cause, Clock, Deferred, Effect, Exit, Fiber, Option, Schema } from "effect";
+import { createColumnLiveViewEngine, EngineClosedError, InvalidRowError } from "./index";
 import { createColumnLiveViewEngineInternal } from "./internal";
+import { publishTopicStoreRow, type TopicStoreMutationAdmission } from "./topic-store-mutation";
+import { TopicStore, topicStoreState } from "./topic-store-state";
 
 const Row = Schema.Struct({
   id: Schema.String,
@@ -22,48 +24,30 @@ const blockingTerminalObserver = (
 });
 
 describe("ColumnLiveViewEngine close mutation barrier", () => {
-  it.effect("rejects a publish that passed its open check before close completed", () =>
+  it.effect("rejects a mutation when lifecycle closes admission after row preparation", () =>
     Effect.gen(function* () {
-      const decodingStarted = yield* Deferred.make<void>();
-      const continueDecoding = yield* Deferred.make<void>();
-      const DelayedString = Schema.String.pipe(
-        Schema.decode({
-          decode: new SchemaGetter.Getter((value) =>
-            Effect.gen(function* () {
-              yield* Deferred.succeed(decodingStarted, undefined);
-              yield* Deferred.await(continueDecoding);
-              return value;
-            }),
-          ),
-          encode: SchemaGetter.passthrough(),
-        }),
+      let mutationsAllowed = true;
+      const closeAdmission: TopicStoreMutationAdmission = (transaction) =>
+        Effect.sync(() => {
+          mutationsAllowed = false;
+        }).pipe(Effect.andThen(transaction));
+      const store = new TopicStore(
+        "rows",
+        Row,
+        "id",
+        () => {},
+        () => mutationsAllowed,
+        closeAdmission,
       );
-      const DelayedRow = Schema.Struct({
-        id: DelayedString,
-        value: Schema.Number,
-      });
-      const engine = yield* createColumnLiveViewEngine({
-        topics: {
-          rows: {
-            schema: DelayedRow,
-            key: "id",
-          },
-        },
-      });
 
-      const publishFiber = yield* engine
-        .publish("rows", { id: "late", value: 1 })
-        .pipe(Effect.forkChild);
-      yield* Deferred.await(decodingStarted);
-      yield* engine.close();
-      yield* Deferred.succeed(continueDecoding, undefined);
-
-      const error = yield* Fiber.join(publishFiber).pipe(Effect.flip);
-      const health = yield* engine.health();
+      const error = yield* publishTopicStoreRow(store, { id: "late", value: 1 }, (topic, message) =>
+        InvalidRowError.make({ topic, message }),
+      ).pipe(Effect.flip);
+      const state = topicStoreState(store);
 
       expect(error).toBeInstanceOf(EngineClosedError);
-      expect(health.topics.rows.rowCount).toBe(0);
-      expect(health.version).toBe(0);
+      expect(state.storage.rowCount).toBe(0);
+      expect(state.storage.version).toBe(0);
     }),
   );
 

--- a/packages/column-live-view-engine/src/engine-config-ownership.test.ts
+++ b/packages/column-live-view-engine/src/engine-config-ownership.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  defineViewServerConfig,
+  viewSchema,
+  viewServerUnsupportedRuntimeFieldDomain,
+} from "@effect-view-server/config";
+import { viewServerRowSchemaFieldsMatchAst } from "@effect-view-server/config/internal";
+import { Effect, Schema } from "effect";
+import { createColumnLiveViewEngine, InvalidRowError } from "./index";
+
+const UnregisteredString = Schema.declare((value): value is string => typeof value === "string");
+
+const makeStoreConstructionProbe = () => {
+  let astReads = 0;
+  const observedField = new Proxy(Schema.String, {
+    get(target, property) {
+      if (property === "ast") {
+        astReads += 1;
+      }
+      return Reflect.get(target, property, target);
+    },
+  });
+  const schema = Schema.Struct({
+    id: Schema.String,
+    observed: observedField,
+  });
+  astReads = 0;
+  Schema.isSchema(observedField);
+  viewServerUnsupportedRuntimeFieldDomain(observedField);
+  viewServerRowSchemaFieldsMatchAst(schema);
+  const validationAstReads = astReads;
+  astReads = 0;
+  return {
+    astReads: () => astReads,
+    schema,
+    validationAstReads,
+  };
+};
+
+class OwnedOrder extends Schema.Class<OwnedOrder>("OwnedOrder")({
+  id: Schema.String,
+  status: Schema.String,
+}) {}
+viewSchema.admitClass(OwnedOrder);
+
+describe("ColumnLiveViewEngine config ownership", () => {
+  it.effect("constructs from an owned config snapshot", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        topics: {
+          orders: {
+            schema: Schema.Struct({ id: Schema.String, status: Schema.String }),
+            key: "id",
+          },
+        },
+      });
+
+      const engine = yield* createColumnLiveViewEngine({ topics: config.topics });
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "status"],
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 0,
+        version: 0,
+      });
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("rejects a raw structural config with an unregistered declaration", () =>
+    Effect.gen(function* () {
+      const schema = Schema.Struct({
+        id: Schema.String,
+        value: UnregisteredString,
+      });
+
+      const error = yield* Effect.flip(
+        createColumnLiveViewEngine({
+          topics: {
+            unsafe: {
+              schema,
+              key: "id",
+            },
+          },
+        }),
+      );
+
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "unsafe",
+        message:
+          "Topic field value uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+      });
+    }),
+  );
+
+  it.effect("rejects malformed exposed fields during construction", () =>
+    Effect.gen(function* () {
+      const schema = Schema.Struct({
+        id: Schema.String,
+        value: Schema.String,
+      });
+      expect(Reflect.set(schema.fields, "value", "not-an-effect-schema")).toBe(true);
+
+      const error = yield* Effect.flip(
+        createColumnLiveViewEngine({
+          topics: {
+            malformed: {
+              schema,
+              key: "id",
+            },
+          },
+        }),
+      );
+
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "malformed",
+        message: "Topic field value must be an Effect Schema.",
+      });
+    }),
+  );
+
+  it.effect("rejects safe exposed fields that diverge from the row schema AST", () =>
+    Effect.gen(function* () {
+      const schema = Schema.Struct({
+        id: Schema.String,
+        value: Schema.String,
+      });
+      expect(Reflect.set(schema.fields, "value", Schema.Number)).toBe(true);
+
+      const error = yield* Effect.flip(
+        createColumnLiveViewEngine({
+          topics: {
+            divergent: {
+              schema,
+              key: "id",
+            },
+          },
+        }),
+      );
+
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "divergent",
+        message: "Topic exposed row fields do not match the row schema AST.",
+      });
+    }),
+  );
+
+  it.effect("turns hostile topic registry inspection into a typed construction error", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        topics: {
+          orders: {
+            schema: Schema.Struct({ id: Schema.String }),
+            key: "id",
+          },
+        },
+      });
+      const hostileTopics = new Proxy(config.topics, {
+        ownKeys() {
+          throw new Error("topic keys unavailable");
+        },
+      });
+
+      const error = yield* Effect.flip(createColumnLiveViewEngine({ topics: hostileTopics }));
+
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "<engine-config>",
+        message: "Topic schemas could not be safely inspected during engine construction.",
+      });
+    }),
+  );
+
+  it.effect("validates every root schema before constructing any TopicStore", () =>
+    Effect.gen(function* () {
+      const probe = makeStoreConstructionProbe();
+      const rootUnsafeSchema = Schema.Struct({
+        id: Schema.String,
+        value: UnregisteredString,
+      });
+      expect(Reflect.set(rootUnsafeSchema.fields, "value", Schema.String)).toBe(true);
+
+      const error = yield* Effect.flip(
+        createColumnLiveViewEngine({
+          topics: {
+            observed: {
+              schema: probe.schema,
+              key: "id",
+            },
+            unsafe: {
+              schema: rootUnsafeSchema,
+              key: "id",
+            },
+          },
+        }),
+      );
+
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "unsafe",
+        message:
+          "Topic row schema uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+      });
+      expect(probe.astReads()).toBe(probe.validationAstReads);
+    }),
+  );
+
+  it.effect("validates every exposed field before constructing any TopicStore", () =>
+    Effect.gen(function* () {
+      const probe = makeStoreConstructionProbe();
+      const fieldUnsafeSchema = Schema.Struct({
+        id: Schema.String,
+        value: Schema.String,
+      });
+      expect(Reflect.set(fieldUnsafeSchema.fields, "value", UnregisteredString)).toBe(true);
+
+      const error = yield* Effect.flip(
+        createColumnLiveViewEngine({
+          topics: {
+            observed: {
+              schema: probe.schema,
+              key: "id",
+            },
+            unsafe: {
+              schema: fieldUnsafeSchema,
+              key: "id",
+            },
+          },
+        }),
+      );
+
+      expect(error).toBeInstanceOf(InvalidRowError);
+      expect(error).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "unsafe",
+        message:
+          "Topic field value uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+      });
+      expect(probe.astReads()).toBe(probe.validationAstReads);
+    }),
+  );
+
+  it.effect("keeps an owned root Class proxy constructable", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        topics: {
+          orders: {
+            schema: OwnedOrder,
+            key: "id",
+          },
+        },
+      });
+      const row = new config.topics.orders.schema({ id: "1", status: "open" });
+
+      expect(row).toBeInstanceOf(OwnedOrder);
+
+      const engine = yield* createColumnLiveViewEngine({ topics: config.topics });
+      yield* engine.publish("orders", row);
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "status"],
+      });
+
+      expect(snapshot.rows).toStrictEqual([{ id: "1", status: "open" }]);
+      yield* engine.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/engine-contract.ts
+++ b/packages/column-live-view-engine/src/engine-contract.ts
@@ -26,14 +26,14 @@ import type { GroupedIncrementalAdmissionLimits } from "./grouped-incremental-ad
 export type DecodableTopicDefinitions = Record<
   string,
   {
-    readonly schema: RowSchema & Schema.Codec<object, unknown, never, unknown>;
+    readonly schema: RowSchema & Schema.Codec<object, unknown, never, never>;
     readonly key: string;
   }
 >;
 
 type ValidateEngineTopics<Topics extends DecodableTopicDefinitions> = {
   readonly [Topic in keyof Topics]: Topics[Topic] extends {
-    readonly schema: infer S extends RowSchema & Schema.Codec<object, unknown, never, unknown>;
+    readonly schema: infer S extends RowSchema & Schema.Codec<object, unknown, never, never>;
     readonly key: infer Key extends string;
   }
     ? {

--- a/packages/column-live-view-engine/src/engine-internal-mutation.test.ts
+++ b/packages/column-live-view-engine/src/engine-internal-mutation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { defineViewServerConfig, type StatusEvent } from "@effect-view-server/config";
-import { Effect, Schema, SchemaGetter, Stream } from "effect";
+import { Effect, Schema, Stream } from "effect";
 import { createColumnLiveViewEngine, InvalidRowError } from "./index";
 import { createColumnLiveViewEngineInternal } from "./internal";
 import { expectSnapshotEvent, firstEvent, makeEventReader } from "../test-harness/events";
@@ -209,14 +209,7 @@ describe("ColumnLiveViewEngine internal mutation", () => {
 
   it.effect("does not decode internal decoded runtime rows twice", () =>
     Effect.gen(function* () {
-      const TransformId = Schema.String.pipe(
-        Schema.decodeTo(Schema.String, {
-          decode: SchemaGetter.transform((value) => `decoded-${value}`),
-          encode: SchemaGetter.transform((value) =>
-            value.startsWith("decoded-") ? value.slice("decoded-".length) : value,
-          ),
-        }),
-      );
+      const TransformId = Schema.StringFromUriComponent;
       const TransformOrder = Schema.Struct({
         id: TransformId,
         price: Schema.Number,
@@ -235,7 +228,7 @@ describe("ColumnLiveViewEngine internal mutation", () => {
 
       yield* engine.publishManyDecodedRows("orders", [
         {
-          id: "decoded-1",
+          id: "decoded%2D1",
           price: 42,
         },
       ]);
@@ -247,7 +240,7 @@ describe("ColumnLiveViewEngine internal mutation", () => {
       expect(snapshot).toStrictEqual({
         rows: [
           {
-            id: "decoded-1",
+            id: "decoded%2D1",
             price: 42,
           },
         ],
@@ -259,16 +252,110 @@ describe("ColumnLiveViewEngine internal mutation", () => {
     }),
   );
 
+  it.effect("rejects encoded values at every decoded runtime mutation boundary", () =>
+    Effect.gen(function* () {
+      const DecodedOrder = Schema.Struct({
+        id: Schema.String,
+        amount: Schema.BigIntFromString,
+      });
+      const decodedViewServer = defineViewServerConfig({
+        topics: {
+          orders: {
+            schema: DecodedOrder,
+            key: "id",
+          },
+        },
+      });
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: decodedViewServer.topics,
+      });
+      yield* engine.publishManyDecodedRows("orders", [{ id: "stable", amount: 1n }]);
+
+      const publishError = yield* Effect.flip(
+        engine.publishManyDecodedRows("orders", [
+          {
+            id: "encoded-publish",
+            // This internal source boundary is intentionally object-typed and must reject at runtime.
+            amount: "42",
+          },
+        ]),
+      );
+      const storageKeyError = yield* Effect.flip(
+        engine.publishManyDecodedRowsWithStorageKeys("orders", [
+          {
+            storageKey: "encoded-storage-key",
+            row: {
+              id: "encoded-storage",
+              // This internal source boundary is intentionally object-typed and must reject at runtime.
+              amount: "43",
+            },
+          },
+        ]),
+      );
+      const patchError = yield* Effect.flip(
+        engine.patchDecodedFields("orders", "stable", {
+          // This internal source boundary is intentionally object-typed and must reject at runtime.
+          amount: "44",
+        }),
+      );
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "amount"],
+        limit: 10,
+      });
+
+      expect(publishError).toBeInstanceOf(InvalidRowError);
+      expect(storageKeyError).toBeInstanceOf(InvalidRowError);
+      expect(patchError).toBeInstanceOf(InvalidRowError);
+      expect({
+        publishError,
+        storageKeyError,
+        patchError,
+        snapshot,
+      }).toStrictEqual({
+        publishError: InvalidRowError.make({
+          topic: "orders",
+          message: 'SchemaError(Expected bigint, got "42"\n  at ["amount"])',
+        }),
+        storageKeyError: InvalidRowError.make({
+          topic: "orders",
+          message: 'SchemaError(Expected bigint, got "43"\n  at ["amount"])',
+        }),
+        patchError: InvalidRowError.make({
+          topic: "orders",
+          message: 'SchemaError(Expected bigint, got "44"\n  at ["amount"])',
+        }),
+        snapshot: {
+          rows: [{ id: "stable", amount: 1n }],
+          status: "ready",
+          statusCode: "Ready",
+          totalRows: 1,
+          version: 1,
+        },
+      });
+    }),
+  );
+
   it.effect("fails decoded runtime rows when normalization throws", () =>
     Effect.gen(function* () {
       const engine = yield* createColumnLiveViewEngineInternal({
         topics: viewServer.topics,
       });
-      const brokenRow = {};
-      Object.defineProperty(brokenRow, "id", {
+      let accessorReads = 0;
+      let descriptorReads = 0;
+      const accessorRow = {};
+      Object.defineProperty(accessorRow, "id", {
         enumerable: true,
         get: () => {
+          accessorReads += 1;
           throw new Error("decoded row getter failed");
+        },
+      });
+      const brokenRow = new Proxy(accessorRow, {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "id") {
+            descriptorReads += 1;
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
         },
       });
 
@@ -277,9 +364,11 @@ describe("ColumnLiveViewEngine internal mutation", () => {
       expect(error).toMatchObject({
         _tag: "InvalidRowError",
         topic: "orders",
-        message: expect.stringContaining("decoded row getter failed"),
+        message: "TypeError: Topic Row field id must be an own data property.",
       });
       expect(error).toBeInstanceOf(InvalidRowError);
+      expect(accessorReads).toBe(0);
+      expect(descriptorReads).toBe(1);
     }),
   );
 

--- a/packages/column-live-view-engine/src/engine-subscription-query-validation.test.ts
+++ b/packages/column-live-view-engine/src/engine-subscription-query-validation.test.ts
@@ -142,8 +142,8 @@ describe("ColumnLiveViewEngine subscription query validation", () => {
       });
 
       let getterReads = 0;
-      const throwingWhere = {};
-      Object.defineProperty(throwingWhere, "status", {
+      const singleReadWhere = {};
+      Object.defineProperty(singleReadWhere, "status", {
         enumerable: true,
         get() {
           getterReads += 1;
@@ -156,18 +156,23 @@ describe("ColumnLiveViewEngine subscription query validation", () => {
           };
         },
       });
-      const throwingWhereQuery: object = {
+      const singleReadWhereQuery: object = {
         select: ["id"],
-        where: throwingWhere,
+        where: singleReadWhere,
       };
-      const throwingWhereResult = yield* Effect.flip(
-        // @ts-expect-error hostile runtime query getters must be rejected at the boundary.
-        engine.snapshot("orders", throwingWhereQuery),
+      const singleReadWhereResult = yield* engine.snapshot(
+        "orders",
+        // @ts-expect-error runtime query accessors are observed exactly once at the boundary.
+        singleReadWhereQuery,
       );
-      expect(throwingWhereResult).toMatchObject({
-        _tag: "InvalidQueryError",
-        message: expect.stringContaining("where could not be cloned"),
+      expect(singleReadWhereResult).toStrictEqual({
+        rows: [{ id: "1" }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
       });
+      expect(getterReads).toBe(1);
 
       const stringRangeQuery: object = {
         select: ["id"],

--- a/packages/column-live-view-engine/src/engine-validation.test.ts
+++ b/packages/column-live-view-engine/src/engine-validation.test.ts
@@ -26,7 +26,7 @@ describe("ColumnLiveViewEngine validation", () => {
     }),
   );
 
-  it.effect("clones non-plain object row fields before exposing them", () =>
+  it.effect("rejects non-JSON object row fields and preserves plain records", () =>
     Effect.gen(function* () {
       const WithPayload = Schema.Struct({
         id: Schema.String,
@@ -40,8 +40,6 @@ describe("ColumnLiveViewEngine validation", () => {
           },
         },
       });
-      const payload = new Map([["venue", "xnys"]]);
-
       const emptyObjectKeywordFilter = yield* engine.snapshot("payloads", {
         select: ["id"],
         where: {
@@ -50,12 +48,31 @@ describe("ColumnLiveViewEngine validation", () => {
       });
       expect(emptyObjectKeywordFilter.rows).toStrictEqual([]);
 
-      yield* engine.publish("payloads", { id: "1", payload });
+      const mapError = yield* Effect.flip(
+        engine.publish("payloads", {
+          id: "1",
+          payload: new Map([["venue", "xnys"]]),
+        }),
+      );
+      expect(mapError).toBeInstanceOf(InvalidRowError);
+      expect(mapError).toStrictEqual(
+        InvalidRowError.make({
+          topic: "payloads",
+          message:
+            "StrictJsonMaterializationError: Expected a plain data record or dense array at $.payload.",
+        }),
+      );
+
       yield* engine.publish("payloads", { id: "2", payload: { venue: "xlon" } });
 
       const snapshot = yield* engine.snapshot("payloads", { select: ["id", "payload"] });
-      expect(snapshot.rows[0]?.payload).toStrictEqual(payload);
-      expect(snapshot.rows[0]?.payload).not.toBe(payload);
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "2", payload: { venue: "xlon" } }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
 
       const objectFilter = yield* engine.snapshot("payloads", {
         select: ["id", "payload"],
@@ -63,7 +80,13 @@ describe("ColumnLiveViewEngine validation", () => {
           payload: { venue: "xlon" },
         },
       });
-      expect(objectFilter.rows).toStrictEqual([{ id: "2", payload: { venue: "xlon" } }]);
+      expect(objectFilter).toStrictEqual({
+        rows: [{ id: "2", payload: { venue: "xlon" } }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
     }),
   );
 
@@ -122,7 +145,7 @@ describe("ColumnLiveViewEngine validation", () => {
     }),
   );
 
-  it.effect("keeps runtime guards for non-struct topic schemas", () =>
+  it.effect("rejects non-struct topic schemas during construction", () =>
     Effect.gen(function* () {
       const nonStructSchemaConfig = {
         topics: {
@@ -132,19 +155,16 @@ describe("ColumnLiveViewEngine validation", () => {
           },
         },
       };
-      // @ts-expect-error invalid configs can still reach runtime through untyped callers.
-      const engine = yield* createColumnLiveViewEngine(nonStructSchemaConfig);
-      const query: object = { select: ["id"] };
-
       const error = yield* Effect.flip(
-        // @ts-expect-error hostile untyped runtime query is still handled by runtime guards.
-        engine.snapshot("loose", query),
+        // @ts-expect-error invalid configs can still reach runtime through untyped callers.
+        createColumnLiveViewEngine(nonStructSchemaConfig),
       );
 
+      expect(error).toBeInstanceOf(InvalidRowError);
       expect(error).toMatchObject({
-        _tag: "InvalidQueryError",
+        _tag: "InvalidRowError",
         topic: "loose",
-        message: expect.stringContaining("select"),
+        message: "Topic row schema must be an Effect Schema Struct.",
       });
     }),
   );
@@ -199,6 +219,110 @@ describe("ColumnLiveViewEngine validation", () => {
         message: expect.stringContaining("Patch contains unknown field: prcie"),
       });
       expect(afterUnknownPatch.version).toBe(beforeUnknownPatch.version);
+    }),
+  );
+
+  it.effect("rejects accessor and non-enumerable patch fields without reading caller values", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeEngine();
+      yield* engine.publish("orders", order("1", "open", 10, 1));
+      let accessorReads = 0;
+      let descriptorReads = 0;
+      const accessorTarget = {};
+      Object.defineProperty(accessorTarget, "price", {
+        enumerable: true,
+        get: () => {
+          accessorReads += 1;
+          return 20;
+        },
+      });
+      const accessorPatch = new Proxy(accessorTarget, {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "price") {
+            descriptorReads += 1;
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      });
+      const nonEnumerablePatch = {};
+      Object.defineProperty(nonEnumerablePatch, "price", {
+        enumerable: false,
+        value: 20,
+      });
+      const hostilePrototypePatch = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("prototype unavailable");
+          },
+        },
+      );
+      const hostileKeysPatch = new Proxy(
+        {},
+        {
+          ownKeys() {
+            throw new Error("keys unavailable");
+          },
+        },
+      );
+      const hostileDescriptorPatch = new Proxy(
+        { price: 20 },
+        {
+          getOwnPropertyDescriptor() {
+            throw new Error("descriptor unavailable");
+          },
+        },
+      );
+
+      const accessorError = yield* Effect.flip(engine.patch("orders", "1", accessorPatch));
+      const nonEnumerableError = yield* Effect.flip(
+        engine.patch("orders", "1", nonEnumerablePatch),
+      );
+      const prototypeError = yield* Effect.flip(engine.patch("orders", "1", hostilePrototypePatch));
+      const keysError = yield* Effect.flip(engine.patch("orders", "1", hostileKeysPatch));
+      const descriptorError = yield* Effect.flip(
+        engine.patch("orders", "1", hostileDescriptorPatch),
+      );
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "price"],
+      });
+
+      expect(accessorError).toBeInstanceOf(InvalidRowError);
+      expect(accessorError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+        message: expect.stringContaining("Patch field must be a data property: price"),
+      });
+      expect(nonEnumerableError).toBeInstanceOf(InvalidRowError);
+      expect(nonEnumerableError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+        message: expect.stringContaining("Patch field must be enumerable: price"),
+      });
+      expect(prototypeError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+        message: "Could not inspect patch object.",
+      });
+      expect(keysError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+        message: "Could not inspect patch fields.",
+      });
+      expect(descriptorError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "orders",
+        message: "Could not inspect patch field: price.",
+      });
+      expect(accessorReads).toBe(0);
+      expect(descriptorReads).toBe(1);
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "1", price: 10 }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
     }),
   );
 

--- a/packages/column-live-view-engine/src/engine-validation.test.ts
+++ b/packages/column-live-view-engine/src/engine-validation.test.ts
@@ -123,6 +123,60 @@ describe("ColumnLiveViewEngine validation", () => {
     }),
   );
 
+  it.effect("matches schema-backed record filters with a null prototype", () =>
+    Effect.gen(function* () {
+      const WithPayload = Schema.Struct({
+        id: Schema.String,
+        payload: Schema.Record(Schema.String, Schema.String),
+      });
+      const engine = yield* createColumnLiveViewEngine({
+        topics: {
+          payloads: {
+            schema: WithPayload,
+            key: "id",
+          },
+        },
+      });
+      yield* engine.publish("payloads", {
+        id: "1",
+        payload: { venue: "xnys" },
+      });
+      yield* engine.publish("payloads", {
+        id: "2",
+        payload: { venue: "xlon" },
+      });
+
+      const filter: Record<string, string> = Object.create(null);
+      filter["venue"] = "xnys";
+      const snapshot = yield* engine.snapshot("payloads", {
+        select: ["id", "payload"],
+        where: { payload: filter },
+      });
+      const grouped = yield* engine.snapshot("payloads", {
+        groupBy: ["payload"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: { payload: filter },
+      });
+
+      expect({ grouped, snapshot }).toStrictEqual({
+        grouped: {
+          rows: [{ payload: { venue: "xnys" }, rowCount: 1n }],
+          status: "ready",
+          statusCode: "Ready",
+          totalRows: 1,
+          version: 2,
+        },
+        snapshot: {
+          rows: [{ id: "1", payload: { venue: "xnys" } }],
+          status: "ready",
+          statusCode: "Ready",
+          totalRows: 1,
+          version: 2,
+        },
+      });
+    }),
+  );
+
   it.effect("keeps a runtime guard for unsafely cast invalid key configs", () =>
     Effect.gen(function* () {
       const invalidKeyConfig = {

--- a/packages/column-live-view-engine/src/engine.ts
+++ b/packages/column-live-view-engine/src/engine.ts
@@ -12,7 +12,12 @@ import type {
   TopicRow,
   ValidateLiveQuery,
 } from "@effect-view-server/config";
-import { Effect, Latch, Semaphore } from "effect";
+import { viewServerUnsupportedRuntimeFieldDomain } from "@effect-view-server/config";
+import {
+  snapshotViewServerTopics,
+  viewServerRowSchemaFieldsMatchAst,
+} from "@effect-view-server/config/internal";
+import { Effect, Latch, Schema, Semaphore } from "effect";
 import type {
   ColumnLiveViewEngine,
   ColumnLiveViewEngineConfig,
@@ -63,6 +68,89 @@ const invalidRow = (topic: string, message: string) =>
     topic,
     message,
   });
+
+type EngineTopicsInspection<Topics extends DecodableTopicDefinitions> =
+  | {
+      readonly _tag: "Invalid";
+      readonly error: InvalidRowError;
+    }
+  | {
+      readonly _tag: "Valid";
+      readonly topics: Topics;
+    };
+
+const inspectEngineTopics = <Topics extends DecodableTopicDefinitions>(
+  topics: Topics,
+): EngineTopicsInspection<Topics> => {
+  const snapshot = snapshotViewServerTopics(topics);
+  for (const [topic, definition] of Object.entries(snapshot)) {
+    const schema = definition.schema;
+    if (!Schema.isSchema(schema) || !("fields" in schema)) {
+      return {
+        _tag: "Invalid",
+        error: invalidRow(topic, "Topic row schema must be an Effect Schema Struct."),
+      };
+    }
+    for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+      if (!Schema.isSchema(fieldSchema)) {
+        return {
+          _tag: "Invalid",
+          error: invalidRow(topic, `Topic field ${field} must be an Effect Schema.`),
+        };
+      }
+      const unsupportedRuntimeDomain = viewServerUnsupportedRuntimeFieldDomain(fieldSchema);
+      if (unsupportedRuntimeDomain !== undefined) {
+        return {
+          _tag: "Invalid",
+          error: invalidRow(
+            topic,
+            `Topic field ${field} uses unsupported runtime domain: ${unsupportedRuntimeDomain}`,
+          ),
+        };
+      }
+    }
+    const unsupportedRowRuntimeDomain = viewServerUnsupportedRuntimeFieldDomain(schema);
+    if (unsupportedRowRuntimeDomain !== undefined) {
+      return {
+        _tag: "Invalid",
+        error: invalidRow(
+          topic,
+          `Topic row schema uses unsupported runtime domain: ${unsupportedRowRuntimeDomain}`,
+        ),
+      };
+    }
+    if (!viewServerRowSchemaFieldsMatchAst(schema)) {
+      return {
+        _tag: "Invalid",
+        error: invalidRow(topic, "Topic exposed row fields do not match the row schema AST."),
+      };
+    }
+  }
+  return {
+    _tag: "Valid",
+    topics: snapshot,
+  };
+};
+
+const snapshotAndValidateEngineTopics = Effect.fn("ColumnLiveViewEngine.topics.snapshot")(
+  <Topics extends DecodableTopicDefinitions>(
+    topics: Topics,
+  ): Effect.Effect<Topics, InvalidRowError> =>
+    Effect.try({
+      try: () => inspectEngineTopics(topics),
+      catch: () =>
+        invalidRow(
+          "<engine-config>",
+          "Topic schemas could not be safely inspected during engine construction.",
+        ),
+    }).pipe(
+      Effect.flatMap((inspection) =>
+        inspection._tag === "Invalid"
+          ? Effect.fail(inspection.error)
+          : Effect.succeed(inspection.topics),
+      ),
+    ),
+);
 
 const runEngineLifecycleTransaction = Effect.fn("ColumnLiveViewEngine.lifecycle.transaction")(
   function* <Success, Error, Requirements>(
@@ -141,7 +229,7 @@ class InMemoryColumnLiveViewEngine<
   private closed = false;
   private readonly mutationsAllowed = (): boolean => !this.closed;
 
-  constructor(config: ColumnLiveViewEngineInternalConfig<Topics>) {
+  constructor(config: ColumnLiveViewEngineInternalConfig<Topics>, topics: Topics) {
     const configuredCapacity = config.subscriptionQueueCapacity ?? defaultSubscriptionQueueCapacity;
     this.subscriptionQueueCapacity =
       Number.isSafeInteger(configuredCapacity) && configuredCapacity > 0
@@ -150,7 +238,7 @@ class InMemoryColumnLiveViewEngine<
     this.groupedIncrementalAdmissionLimits = groupedIncrementalAdmissionLimitsFromConfig(
       config.groupedIncrementalAdmissionLimits,
     );
-    for (const [topic, definition] of Object.entries(config.topics)) {
+    for (const [topic, definition] of Object.entries(topics)) {
       this.stores.set(
         topic,
         new TopicStore(
@@ -558,13 +646,19 @@ const publicColumnLiveViewEngine = <Topics extends DecodableTopicDefinitions>(
 export const createColumnLiveViewEngine = Effect.fn("ColumnLiveViewEngine.make")(
   <const Topics extends DecodableTopicDefinitions>(
     config: ColumnLiveViewEngineConfig<Topics>,
-  ): Effect.Effect<ColumnLiveViewEngine<Topics>> =>
-    Effect.sync(() => publicColumnLiveViewEngine(new InMemoryColumnLiveViewEngine(config))),
+  ): Effect.Effect<ColumnLiveViewEngine<Topics>, InvalidRowError> =>
+    Effect.gen(function* () {
+      const topics = yield* snapshotAndValidateEngineTopics(config.topics);
+      return publicColumnLiveViewEngine(new InMemoryColumnLiveViewEngine(config, topics));
+    }),
 );
 
 export const createColumnLiveViewEngineInternal = Effect.fn("ColumnLiveViewEngine.internal.make")(
   <const Topics extends DecodableTopicDefinitions>(
     config: ColumnLiveViewEngineInternalConfig<Topics>,
-  ): Effect.Effect<ColumnLiveViewEngineInternal<Topics>> =>
-    Effect.sync(() => new InMemoryColumnLiveViewEngine(config)),
+  ): Effect.Effect<ColumnLiveViewEngineInternal<Topics>, InvalidRowError> =>
+    Effect.gen(function* () {
+      const topics = yield* snapshotAndValidateEngineTopics(config.topics);
+      return new InMemoryColumnLiveViewEngine(config, topics);
+    }),
 );

--- a/packages/column-live-view-engine/src/grouped-aggregate-state.ts
+++ b/packages/column-live-view-engine/src/grouped-aggregate-state.ts
@@ -7,9 +7,10 @@ import {
   sum as sumBigDecimal,
   type BigDecimal,
 } from "effect/BigDecimal";
-import { compareQueryValue, stableQueryValueString } from "./raw-query-compiler";
+import * as Arr from "effect/Array";
 import type { StoredRowOf } from "./query-result";
-import { cloneUnknown, trustedFieldValue } from "./row-values";
+import { trustedFieldValue } from "./row-values";
+import type { SchemaValueSemantics } from "./topic-row-value-semantics";
 
 type RowObject = object;
 
@@ -27,49 +28,103 @@ export type RuntimeGroupedAggregate =
       readonly resultKind: "bigint" | "bigDecimal";
     };
 
-export type GroupedAggregatePlan = {
-  readonly alias: string;
-  readonly aggregate: RuntimeGroupedAggregate;
+export type MissingGroupedAggregateInput = {
+  readonly _tag: "Missing";
 };
 
+export type PresentGroupedAggregateInput = {
+  readonly _tag: "Present";
+  readonly value: unknown;
+};
+
+export type GroupedAggregateInput = MissingGroupedAggregateInput | PresentGroupedAggregateInput;
+
+export type GroupedAggregateInputSemantics = {
+  readonly field: string;
+  readonly canonicalKey: (input: GroupedAggregateInput) => string;
+  readonly compare: (left: GroupedAggregateInput, right: GroupedAggregateInput) => number;
+  readonly equivalent: (left: GroupedAggregateInput, right: GroupedAggregateInput) => boolean;
+  readonly read: (row: RowObject) => GroupedAggregateInput;
+};
+
+type RuntimeFieldGroupedAggregate = Exclude<RuntimeGroupedAggregate, { readonly aggFunc: "count" }>;
+
+type CountGroupedAggregatePlan = {
+  readonly kind: "count";
+  readonly alias: string;
+  readonly aggregate: Extract<RuntimeGroupedAggregate, { readonly aggFunc: "count" }>;
+  readonly resultSemantics: SchemaValueSemantics;
+  readonly stateIndex: number;
+};
+
+export type FieldGroupedAggregatePlan = {
+  readonly kind: "field";
+  readonly alias: string;
+  readonly aggregate: RuntimeFieldGroupedAggregate;
+  readonly input: GroupedAggregateInputSemantics;
+  readonly resultSemantics: SchemaValueSemantics;
+  readonly stateIndex: number;
+};
+
+export type GroupedAggregatePlan = CountGroupedAggregatePlan | FieldGroupedAggregatePlan;
+
 type CountAggregateState = {
+  readonly alias: string;
   readonly aggFunc: "count";
   count: bigint;
 };
 
 type CountDistinctAggregateState = {
+  readonly alias: string;
   readonly aggFunc: "countDistinct";
+  readonly inputSemantics: GroupedAggregateInputSemantics;
   readonly values: Map<string, number>;
   count: bigint;
 };
 
 type BigIntSumAggregateState = {
+  readonly alias: string;
   readonly aggFunc: "sum";
+  readonly inputSemantics: GroupedAggregateInputSemantics;
   readonly resultKind: "bigint";
   bigintTotal: bigint;
 };
 
 type BigDecimalSumAggregateState = {
+  readonly alias: string;
   readonly aggFunc: "sum";
+  readonly inputSemantics: GroupedAggregateInputSemantics;
   readonly resultKind: "bigDecimal";
   decimalTotal: BigDecimal;
 };
 
 type AverageAggregateState = {
+  readonly alias: string;
   readonly aggFunc: "avg";
+  readonly inputSemantics: GroupedAggregateInputSemantics;
   count: bigint;
   total: BigDecimal;
 };
 
 type MinMaxAggregateValueState = {
   count: number;
-  value: unknown;
+  readonly input: GroupedAggregateInput;
 };
 
+type MinMaxAggregateSelection =
+  | {
+      readonly _tag: "Empty";
+    }
+  | {
+      readonly _tag: "Selected";
+      readonly input: GroupedAggregateInput;
+    };
+
 type BaseMinMaxAggregateState = {
+  readonly alias: string;
   readonly aggFunc: "min" | "max";
-  value: unknown;
-  hasValue: boolean;
+  readonly inputSemantics: GroupedAggregateInputSemantics;
+  selection: MinMaxAggregateSelection;
 };
 
 export type RetainedMinMaxAggregateState = BaseMinMaxAggregateState & {
@@ -93,11 +148,11 @@ export type ReversibleAggregateState = NonMinMaxAggregateState | RetainedMinMaxA
 export type GroupState = {
   readonly key: string;
   readonly row: Record<string, unknown>;
-  readonly aggregates: Record<string, AggregateState>;
+  readonly aggregates: ReadonlyArray<AggregateState>;
 };
 
 export type MaterializedIncrementalGroupState = Omit<GroupState, "aggregates"> & {
-  readonly aggregates: Record<string, ReversibleAggregateState>;
+  readonly aggregates: ReadonlyArray<ReversibleAggregateState>;
   readonly members: Map<string, RowObject>;
 };
 
@@ -118,16 +173,20 @@ const runtimeValueToDecimal = (value: unknown): BigDecimal | undefined => {
   return undefined;
 };
 
-const emptyAggregateState = (aggregate: RuntimeGroupedAggregate): AggregateState => {
-  if (aggregate.aggFunc === "count") {
+const emptyAggregateState = (plan: GroupedAggregatePlan): AggregateState => {
+  if (plan.kind === "count") {
     return {
+      alias: plan.alias,
       aggFunc: "count",
       count: 0n,
     };
   }
+  const aggregate = plan.aggregate;
   if (aggregate.aggFunc === "countDistinct") {
     return {
+      alias: plan.alias,
       aggFunc: "countDistinct",
+      inputSemantics: plan.input,
       values: new Map<string, number>(),
       count: 0n,
     };
@@ -135,42 +194,51 @@ const emptyAggregateState = (aggregate: RuntimeGroupedAggregate): AggregateState
   if (aggregate.aggFunc === "sum") {
     return aggregate.resultKind === "bigint"
       ? {
+          alias: plan.alias,
           aggFunc: "sum",
+          inputSemantics: plan.input,
           resultKind: "bigint",
           bigintTotal: 0n,
         }
       : {
+          alias: plan.alias,
           aggFunc: "sum",
+          inputSemantics: plan.input,
           resultKind: "bigDecimal",
           decimalTotal: fromBigInt(0n),
         };
   }
   if (aggregate.aggFunc === "avg") {
     return {
+      alias: plan.alias,
       aggFunc: "avg",
+      inputSemantics: plan.input,
       count: 0n,
       total: fromBigInt(0n),
     };
   }
   return {
+    alias: plan.alias,
     aggFunc: aggregate.aggFunc,
-    value: undefined,
-    hasValue: false,
+    inputSemantics: plan.input,
+    selection: { _tag: "Empty" },
   };
 };
 
-const emptyReversibleAggregateState = (
-  aggregate: RuntimeGroupedAggregate,
-): ReversibleAggregateState => {
-  if (aggregate.aggFunc === "count") {
+const emptyReversibleAggregateState = (plan: GroupedAggregatePlan): ReversibleAggregateState => {
+  if (plan.kind === "count") {
     return {
+      alias: plan.alias,
       aggFunc: "count",
       count: 0n,
     };
   }
+  const aggregate = plan.aggregate;
   if (aggregate.aggFunc === "countDistinct") {
     return {
+      alias: plan.alias,
       aggFunc: "countDistinct",
+      inputSemantics: plan.input,
       values: new Map<string, number>(),
       count: 0n,
     };
@@ -178,48 +246,68 @@ const emptyReversibleAggregateState = (
   if (aggregate.aggFunc === "sum") {
     return aggregate.resultKind === "bigint"
       ? {
+          alias: plan.alias,
           aggFunc: "sum",
+          inputSemantics: plan.input,
           resultKind: "bigint",
           bigintTotal: 0n,
         }
       : {
+          alias: plan.alias,
           aggFunc: "sum",
+          inputSemantics: plan.input,
           resultKind: "bigDecimal",
           decimalTotal: fromBigInt(0n),
         };
   }
   if (aggregate.aggFunc === "avg") {
     return {
+      alias: plan.alias,
       aggFunc: "avg",
+      inputSemantics: plan.input,
       count: 0n,
       total: fromBigInt(0n),
     };
   }
   return {
+    alias: plan.alias,
     aggFunc: aggregate.aggFunc,
+    inputSemantics: plan.input,
     values: new Map<string, MinMaxAggregateValueState>(),
-    value: undefined,
-    hasValue: false,
+    selection: { _tag: "Empty" },
   };
 };
 
-const aggregateFieldValue = (row: RowObject, aggregate: RuntimeGroupedAggregate): unknown =>
-  "field" in aggregate ? trustedFieldValue(row, aggregate.field) : undefined;
+const mapValueOr = <Key, Value>(
+  values: ReadonlyMap<Key, Value>,
+  key: Key,
+  fallback: Value,
+): Value => {
+  const value = values.get(key);
+  return value === undefined ? fallback : value;
+};
 
-export const updateAggregateState = (
-  state: AggregateState,
-  aggregate: RuntimeGroupedAggregate,
-  row: RowObject,
-): void => {
-  const value = aggregateFieldValue(row, aggregate);
+const minMaxAggregateValueOr = (
+  values: ReadonlyMap<string, MinMaxAggregateValueState>,
+  key: string,
+  input: GroupedAggregateInput,
+  missingCount: number,
+): MinMaxAggregateValueState => {
+  const value = values.get(key);
+  return value === undefined ? { count: missingCount, input } : value;
+};
+
+const updateAggregateState = (state: AggregateState, row: RowObject): void => {
   if (state.aggFunc === "count") {
     state.count += 1n;
     return;
   }
+  const input = state.inputSemantics.read(row);
+  const value = input._tag === "Missing" ? undefined : input.value;
   if (state.aggFunc === "countDistinct") {
-    const key = stableQueryValueString(value);
-    const count = state.values.get(key);
-    if (count === undefined) {
+    const key = state.inputSemantics.canonicalKey(input);
+    const count = mapValueOr(state.values, key, 0);
+    if (count === 0) {
       state.values.set(key, 1);
       state.count += 1n;
     } else {
@@ -250,63 +338,69 @@ export const updateAggregateState = (
   }
   if ("values" in state) {
     const values = state.values;
-    const key = stableQueryValueString(value);
-    const entry = values.get(key);
-    if (entry === undefined) {
-      values.set(key, {
-        count: 1,
-        value: cloneUnknown(value),
-      });
+    const key = state.inputSemantics.canonicalKey(input);
+    const entry = minMaxAggregateValueOr(values, key, input, 0);
+    if (entry.count === 0) {
+      entry.count = 1;
+      values.set(key, entry);
     } else {
       entry.count += 1;
     }
   }
-  if (!state.hasValue) {
-    state.value = cloneUnknown(value);
-    state.hasValue = true;
+  if (state.selection._tag === "Empty") {
+    state.selection = {
+      _tag: "Selected",
+      input,
+    };
     return;
   }
-  const comparison = compareQueryValue(value, state.value);
+  const comparison = state.inputSemantics.compare(input, state.selection.input);
   if (comparison === 0) {
     return;
   }
   if ((state.aggFunc === "min" && comparison < 0) || (state.aggFunc === "max" && comparison > 0)) {
-    state.value = cloneUnknown(value);
+    state.selection = {
+      _tag: "Selected",
+      input,
+    };
   }
 };
 
 const recomputeMinMaxAggregateState = (state: RetainedMinMaxAggregateState): void => {
-  let nextValue: unknown;
-  let hasValue = false;
+  let nextSelection: MinMaxAggregateSelection = { _tag: "Empty" };
   for (const entry of state.values.values()) {
-    if (!hasValue) {
-      nextValue = cloneUnknown(entry.value);
-      hasValue = true;
+    if (nextSelection._tag === "Empty") {
+      nextSelection = {
+        _tag: "Selected",
+        input: entry.input,
+      };
       continue;
     }
-    const comparison = compareQueryValue(entry.value, nextValue);
+    const comparison = state.inputSemantics.compare(entry.input, nextSelection.input);
     const isBetterValue = state.aggFunc === "min" ? comparison < 0 : comparison > 0;
     if (isBetterValue) {
-      nextValue = cloneUnknown(entry.value);
+      nextSelection = {
+        _tag: "Selected",
+        input: entry.input,
+      };
     }
   }
-  state.value = nextValue;
-  state.hasValue = hasValue;
+  state.selection = nextSelection;
 };
 
-export const removeAggregateState = (
+const removeAggregateState = (
   state: ReversibleAggregateState,
-  aggregate: RuntimeGroupedAggregate,
   row: RowObject,
 ): RetainedMinMaxAggregateState | undefined => {
-  const value = aggregateFieldValue(row, aggregate);
   if (state.aggFunc === "count") {
     state.count -= 1n;
     return undefined;
   }
+  const input = state.inputSemantics.read(row);
+  const value = input._tag === "Missing" ? undefined : input.value;
   if (state.aggFunc === "countDistinct") {
-    const key = stableQueryValueString(value);
-    const count = state.values.get(key)!;
+    const key = state.inputSemantics.canonicalKey(input);
+    const count = mapValueOr(state.values, key, 1);
     if (count === 1) {
       state.values.delete(key);
       state.count -= 1n;
@@ -336,15 +430,18 @@ export const removeAggregateState = (
     }
     return undefined;
   }
-  const key = stableQueryValueString(value);
+  const key = state.inputSemantics.canonicalKey(input);
   const values = state.values;
-  const entry = values.get(key)!;
+  const entry = minMaxAggregateValueOr(values, key, input, 1);
   if (entry.count > 1) {
     entry.count -= 1;
     return undefined;
   }
   values.delete(key);
-  if (state.hasValue && stableQueryValueString(state.value) === key) {
+  if (
+    state.selection._tag === "Selected" &&
+    state.inputSemantics.canonicalKey(state.selection.input) === key
+  ) {
     return state;
   }
   return undefined;
@@ -356,7 +453,7 @@ export const recomputeRetainedMinMaxAggregateState = (
   recomputeMinMaxAggregateState(state);
 };
 
-const aggregateStateValue = (state: AggregateState): unknown => {
+const aggregateStateResultValue = (state: AggregateState): unknown => {
   if (state.aggFunc === "count") {
     return state.count;
   }
@@ -369,23 +466,40 @@ const aggregateStateValue = (state: AggregateState): unknown => {
   if (state.aggFunc === "avg") {
     return state.count === 0n ? fromBigInt(0n) : divideUnsafe(state.total, fromBigInt(state.count));
   }
-  return cloneUnknown(state.value);
+  return state.selection._tag === "Selected" && state.selection.input._tag === "Present"
+    ? state.selection.input.value
+    : undefined;
 };
 
-export const aggregateStateCompareValue = (state: AggregateState): unknown => {
-  if (state.aggFunc === "count") {
-    return state.count;
+export const groupAggregateStateCompareValue = (group: GroupState, stateIndex: number): unknown =>
+  aggregateStateResultValue(Arr.getUnsafe(group.aggregates, stateIndex));
+
+export const updateGroupAggregateState = (state: AggregateState, row: RowObject): void => {
+  updateAggregateState(state, row);
+};
+
+export const removeGroupAggregateState = (
+  state: ReversibleAggregateState,
+  row: RowObject,
+): RetainedMinMaxAggregateState | undefined => removeAggregateState(state, row);
+
+const projectGroupFields = (
+  groupBy: ReadonlyArray<string>,
+  row: RowObject,
+): Record<string, unknown> => {
+  const projected: Record<string, unknown> = {};
+  for (const field of groupBy) {
+    if (!Object.prototype.propertyIsEnumerable.call(row, field)) {
+      continue;
+    }
+    Object.defineProperty(projected, field, {
+      configurable: true,
+      enumerable: true,
+      value: trustedFieldValue(row, field),
+      writable: true,
+    });
   }
-  if (state.aggFunc === "countDistinct") {
-    return state.count;
-  }
-  if (state.aggFunc === "sum") {
-    return state.resultKind === "bigint" ? state.bigintTotal : state.decimalTotal;
-  }
-  if (state.aggFunc === "avg") {
-    return state.count === 0n ? fromBigInt(0n) : divideUnsafe(state.total, fromBigInt(state.count));
-  }
-  return state.value;
+  return projected;
 };
 
 export const newGroupState = (
@@ -394,14 +508,8 @@ export const newGroupState = (
   aggregates: ReadonlyArray<GroupedAggregatePlan>,
   row: RowObject,
 ): GroupState => {
-  const resultRow: Record<string, unknown> = {};
-  for (const field of groupBy) {
-    resultRow[field] = cloneUnknown(trustedFieldValue(row, field));
-  }
-  const aggregateStates: Record<string, AggregateState> = {};
-  for (const { alias, aggregate } of aggregates) {
-    aggregateStates[alias] = emptyAggregateState(aggregate);
-  }
+  const resultRow = projectGroupFields(groupBy, row);
+  const aggregateStates = aggregates.map(emptyAggregateState);
   return {
     key,
     row: resultRow,
@@ -415,14 +523,8 @@ export const newIncrementalGroupState = (
   aggregates: ReadonlyArray<GroupedAggregatePlan>,
   row: RowObject,
 ): MaterializedIncrementalGroupState => {
-  const resultRow: Record<string, unknown> = {};
-  for (const field of groupBy) {
-    resultRow[field] = cloneUnknown(trustedFieldValue(row, field));
-  }
-  const aggregateStates: Record<string, ReversibleAggregateState> = {};
-  for (const { alias, aggregate } of aggregates) {
-    aggregateStates[alias] = emptyReversibleAggregateState(aggregate);
-  }
+  const resultRow = projectGroupFields(groupBy, row);
+  const aggregateStates = aggregates.map(emptyReversibleAggregateState);
   return {
     key,
     row: resultRow,
@@ -432,9 +534,22 @@ export const newIncrementalGroupState = (
 };
 
 export const finalizeGroup = (group: GroupState): StoredRowOf<RowObject> => {
-  const row: Record<string, unknown> = { ...group.row };
-  for (const [alias, state] of Object.entries(group.aggregates)) {
-    row[alias] = aggregateStateValue(state);
+  const row: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(group.row)) {
+    Object.defineProperty(row, field, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+  }
+  for (const state of group.aggregates) {
+    Object.defineProperty(row, state.alias, {
+      configurable: true,
+      enumerable: true,
+      value: aggregateStateResultValue(state),
+      writable: true,
+    });
   }
   return {
     key: group.key,

--- a/packages/column-live-view-engine/src/grouped-hash-map-semantics.test.ts
+++ b/packages/column-live-view-engine/src/grouped-hash-map-semantics.test.ts
@@ -1,0 +1,548 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, type GroupedQuery, viewSchema } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import * as HashMap from "effect/HashMap";
+import { createColumnLiveViewEngine } from "./index";
+import {
+  applyDelta,
+  expectDefined,
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+  stateFromSnapshot,
+} from "../test-harness/events";
+
+const collisionLeft = "8ocpIaaa";
+const collisionRight = "GpcpIaaa";
+
+const Attributes = viewSchema.HashMap(Schema.String, Schema.String);
+
+const HashMapRow = Schema.Struct({
+  id: Schema.String,
+  desk: Schema.String,
+  attributes: Attributes,
+});
+
+type HashMapRow = typeof HashMapRow.Type;
+
+type Attributes = typeof Attributes.Type;
+
+const hashMapViewServer = defineViewServerConfig({
+  topics: {
+    hashMapRows: {
+      schema: HashMapRow,
+      key: "id",
+    },
+  },
+});
+
+const byAttributes = {
+  groupBy: ["attributes"],
+  aggregates: { rowCount: { aggFunc: "count" } },
+} satisfies GroupedQuery<HashMapRow>;
+
+const distinctAttributes = {
+  groupBy: ["desk"],
+  aggregates: {
+    distinctAttributes: { aggFunc: "countDistinct", field: "attributes" },
+  },
+} satisfies GroupedQuery<HashMapRow>;
+
+const subsetAttributes = HashMap.make(["desk", "equities"], ["region", "emea"]);
+const equivalentSubsetAttributes = HashMap.make(["region", "emea"], ["desk", "equities"]);
+const supersetAttributes = HashMap.make(["desk", "equities"], ["region", "emea"], ["tier", "one"]);
+
+const hashMapRow = (id: string, attributes: Attributes): HashMapRow => ({
+  id,
+  desk: "equities",
+  attributes,
+});
+
+const sortedEntries = (
+  attributes: Attributes,
+): ReadonlyArray<readonly [key: string, value: string]> =>
+  HashMap.toEntries(attributes).toSorted(
+    ([left], [right]) => Number(left > right) - Number(left < right),
+  );
+
+const normalizedRawRows = (
+  rows: ReadonlyArray<{ readonly id: string; readonly attributes: Attributes }>,
+) =>
+  rows.map((row) => ({
+    id: row.id,
+    attributes: sortedEntries(row.attributes),
+  }));
+
+const normalizedGroupedRows = (
+  rows: ReadonlyArray<{ readonly attributes: Attributes; readonly rowCount: bigint }>,
+) =>
+  rows
+    .map((row) => ({
+      attributes: sortedEntries(row.attributes),
+      rowCount: row.rowCount,
+    }))
+    .toSorted((left, right) => left.attributes.length - right.attributes.length);
+
+describe("ColumnLiveViewEngine grouped HashMap semantics", () => {
+  it.effect("uses order-neutral HashMap identity for grouping and countDistinct", () =>
+    Effect.gen(function* () {
+      const first = HashMap.make([collisionLeft, "one"], [collisionRight, "two"]);
+      const second = HashMap.make([collisionRight, "two"], [collisionLeft, "one"]);
+      expect(Schema.toEquivalence(Attributes)(first, second)).toBe(true);
+      expect(Schema.encodeUnknownSync(Schema.toCodecJson(Attributes))(first)).not.toStrictEqual(
+        Schema.encodeUnknownSync(Schema.toCodecJson(Attributes))(second),
+      );
+
+      const engine = yield* createColumnLiveViewEngine({
+        topics: hashMapViewServer.topics,
+      });
+      yield* engine.publishMany("hashMapRows", [
+        { id: "1", desk: "equities", attributes: first },
+        { id: "2", desk: "equities", attributes: second },
+      ]);
+
+      const grouped = yield* engine.snapshot("hashMapRows", byAttributes);
+      const distinct = yield* engine.snapshot("hashMapRows", distinctAttributes);
+      const subscription = yield* engine.subscribe("hashMapRows", byAttributes);
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+      const groupedKey = initial.keys[0]!;
+
+      yield* engine.publish("hashMapRows", {
+        id: "3",
+        desk: "equities",
+        attributes: first,
+      });
+      const delta = firstEvent(yield* read(1));
+      expectDeltaEvent(delta);
+
+      expect(
+        grouped.rows.map((row) => ({
+          attributes: HashMap.toEntries(row.attributes).toSorted(
+            ([left], [right]) => Number(left > right) - Number(left < right),
+          ),
+          rowCount: row.rowCount,
+        })),
+      ).toStrictEqual([
+        {
+          attributes: [
+            [collisionLeft, "one"],
+            [collisionRight, "two"],
+          ],
+          rowCount: 2n,
+        },
+      ]);
+      expect(distinct.rows).toStrictEqual([{ desk: "equities", distinctAttributes: 1n }]);
+      expect(delta).toStrictEqual({
+        type: "delta",
+        topic: "hashMapRows",
+        queryId: initial.queryId,
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          {
+            type: "update",
+            key: groupedKey,
+            index: 0,
+            row: {
+              attributes: first,
+              rowCount: 3n,
+            },
+          },
+        ],
+        totalRows: 1,
+      });
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect(
+    "keeps subset and superset HashMaps distinct across predicates, groups, and replacements",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({
+          topics: hashMapViewServer.topics,
+        });
+        yield* engine.publishMany("hashMapRows", [
+          hashMapRow("1", subsetAttributes),
+          hashMapRow("2", supersetAttributes),
+        ]);
+
+        const subsetSnapshot = yield* engine.snapshot("hashMapRows", {
+          select: ["id"],
+          where: { attributes: { eq: subsetAttributes } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const supersetSnapshot = yield* engine.snapshot("hashMapRows", {
+          select: ["id"],
+          where: { attributes: { eq: supersetAttributes } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedSnapshot = yield* engine.snapshot("hashMapRows", byAttributes);
+        const distinctSnapshot = yield* engine.snapshot("hashMapRows", distinctAttributes);
+
+        expect({
+          subset: subsetSnapshot.rows,
+          superset: supersetSnapshot.rows,
+          grouped: normalizedGroupedRows(groupedSnapshot.rows),
+          distinct: distinctSnapshot.rows,
+        }).toStrictEqual({
+          subset: [{ id: "1" }],
+          superset: [{ id: "2" }],
+          grouped: [
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+              ],
+              rowCount: 1n,
+            },
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+              rowCount: 1n,
+            },
+          ],
+          distinct: [{ desk: "equities", distinctAttributes: 2n }],
+        });
+
+        const rawSubscription = yield* engine.subscribe("hashMapRows", {
+          select: ["id", "attributes"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const subsetSubscription = yield* engine.subscribe("hashMapRows", {
+          select: ["id"],
+          where: { attributes: { eq: subsetAttributes } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedSubscription = yield* engine.subscribe("hashMapRows", byAttributes);
+        const distinctSubscription = yield* engine.subscribe("hashMapRows", distinctAttributes);
+        const readRaw = yield* makeEventReader(rawSubscription);
+        const readSubset = yield* makeEventReader(subsetSubscription);
+        const readGrouped = yield* makeEventReader(groupedSubscription);
+        const readDistinct = yield* makeEventReader(distinctSubscription);
+        const rawInitial = firstEvent(yield* readRaw(1));
+        const subsetInitial = firstEvent(yield* readSubset(1));
+        const groupedInitial = firstEvent(yield* readGrouped(1));
+        const distinctInitial = firstEvent(yield* readDistinct(1));
+        expectSnapshotEvent(rawInitial);
+        expectSnapshotEvent(subsetInitial);
+        expectSnapshotEvent(groupedInitial);
+        expectSnapshotEvent(distinctInitial);
+        let rawState = stateFromSnapshot(rawInitial);
+        let subsetState = stateFromSnapshot(subsetInitial);
+        let groupedState = stateFromSnapshot(groupedInitial);
+        let distinctState = stateFromSnapshot(distinctInitial);
+
+        yield* engine.publish("hashMapRows", hashMapRow("1", equivalentSubsetAttributes));
+
+        const afterEquivalent = yield* engine.snapshot("hashMapRows", {
+          select: ["id", "attributes"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const equivalentHealth = yield* engine.health();
+        expect({
+          snapshotVersion: afterEquivalent.version,
+          healthVersion: equivalentHealth.version,
+          queuedEvents: equivalentHealth.queuedEvents,
+          rows: normalizedRawRows(afterEquivalent.rows),
+        }).toStrictEqual({
+          snapshotVersion: 1,
+          healthVersion: 1,
+          queuedEvents: 0,
+          rows: [
+            {
+              id: "1",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+              ],
+            },
+            {
+              id: "2",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+          ],
+        });
+
+        yield* engine.publish("hashMapRows", hashMapRow("1", supersetAttributes));
+        const rawToSuperset = firstEvent(yield* readRaw(1));
+        const subsetToSuperset = firstEvent(yield* readSubset(1));
+        const groupedToSuperset = firstEvent(yield* readGrouped(1));
+        const distinctToSuperset = firstEvent(yield* readDistinct(1));
+        expectDeltaEvent(rawToSuperset);
+        expectDeltaEvent(subsetToSuperset);
+        expectDeltaEvent(groupedToSuperset);
+        expectDeltaEvent(distinctToSuperset);
+        rawState = applyDelta(rawState, rawToSuperset);
+        subsetState = applyDelta(subsetState, subsetToSuperset);
+        groupedState = applyDelta(groupedState, groupedToSuperset);
+        distinctState = applyDelta(distinctState, distinctToSuperset);
+        const rawAfterSuperset = yield* engine.snapshot("hashMapRows", {
+          select: ["id", "attributes"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const subsetAfterSuperset = yield* engine.snapshot("hashMapRows", {
+          select: ["id"],
+          where: { attributes: { eq: subsetAttributes } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedAfterSuperset = yield* engine.snapshot("hashMapRows", byAttributes);
+        const distinctAfterSuperset = yield* engine.snapshot("hashMapRows", distinctAttributes);
+
+        expect(rawToSuperset).toStrictEqual({
+          type: "delta",
+          topic: "hashMapRows",
+          queryId: rawInitial.queryId,
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "update",
+              key: "1",
+              row: { id: "1", attributes: supersetAttributes },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+        expect(subsetToSuperset).toStrictEqual({
+          type: "delta",
+          topic: "hashMapRows",
+          queryId: subsetInitial.queryId,
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "remove", key: "1" }],
+          totalRows: 0,
+        });
+        expect({
+          raw: normalizedRawRows(rawState.rows),
+          rawFresh: normalizedRawRows(rawAfterSuperset.rows),
+          subset: subsetState.rows,
+          subsetFresh: subsetAfterSuperset.rows,
+          grouped: normalizedGroupedRows(groupedState.rows),
+          groupedFresh: normalizedGroupedRows(groupedAfterSuperset.rows),
+          distinct: distinctState.rows,
+          distinctFresh: distinctAfterSuperset.rows,
+        }).toStrictEqual({
+          raw: [
+            {
+              id: "1",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+            {
+              id: "2",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+          ],
+          rawFresh: [
+            {
+              id: "1",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+            {
+              id: "2",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+          ],
+          subset: [],
+          subsetFresh: [],
+          grouped: [
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+              rowCount: 2n,
+            },
+          ],
+          groupedFresh: [
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+              rowCount: 2n,
+            },
+          ],
+          distinct: [{ desk: "equities", distinctAttributes: 1n }],
+          distinctFresh: [{ desk: "equities", distinctAttributes: 1n }],
+        });
+
+        yield* engine.publish("hashMapRows", hashMapRow("1", subsetAttributes));
+        const rawToSubset = firstEvent(yield* readRaw(1));
+        const subsetToSubset = firstEvent(yield* readSubset(1));
+        const groupedToSubset = firstEvent(yield* readGrouped(1));
+        const distinctToSubset = firstEvent(yield* readDistinct(1));
+        expectDeltaEvent(rawToSubset);
+        expectDeltaEvent(subsetToSubset);
+        expectDeltaEvent(groupedToSubset);
+        expectDeltaEvent(distinctToSubset);
+        rawState = applyDelta(rawState, rawToSubset);
+        subsetState = applyDelta(subsetState, subsetToSubset);
+        groupedState = applyDelta(groupedState, groupedToSubset);
+        distinctState = applyDelta(distinctState, distinctToSubset);
+        const rawAfterSubset = yield* engine.snapshot("hashMapRows", {
+          select: ["id", "attributes"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const subsetAfterSubset = yield* engine.snapshot("hashMapRows", {
+          select: ["id"],
+          where: { attributes: { eq: subsetAttributes } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedAfterSubset = yield* engine.snapshot("hashMapRows", byAttributes);
+        const distinctAfterSubset = yield* engine.snapshot("hashMapRows", distinctAttributes);
+
+        expect(rawToSubset).toStrictEqual({
+          type: "delta",
+          topic: "hashMapRows",
+          queryId: rawInitial.queryId,
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            {
+              type: "update",
+              key: "1",
+              row: { id: "1", attributes: subsetAttributes },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+        expect(subsetToSubset).toStrictEqual({
+          type: "delta",
+          topic: "hashMapRows",
+          queryId: subsetInitial.queryId,
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            {
+              type: "insert",
+              key: "1",
+              row: { id: "1" },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        });
+        expect({
+          raw: normalizedRawRows(rawState.rows),
+          rawFresh: normalizedRawRows(rawAfterSubset.rows),
+          subset: subsetState.rows,
+          subsetFresh: subsetAfterSubset.rows,
+          grouped: normalizedGroupedRows(groupedState.rows),
+          groupedFresh: normalizedGroupedRows(groupedAfterSubset.rows),
+          distinct: distinctState.rows,
+          distinctFresh: distinctAfterSubset.rows,
+        }).toStrictEqual({
+          raw: [
+            {
+              id: "1",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+              ],
+            },
+            {
+              id: "2",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+          ],
+          rawFresh: [
+            {
+              id: "1",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+              ],
+            },
+            {
+              id: "2",
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+            },
+          ],
+          subset: [{ id: "1" }],
+          subsetFresh: [{ id: "1" }],
+          grouped: [
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+              ],
+              rowCount: 1n,
+            },
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+              rowCount: 1n,
+            },
+          ],
+          groupedFresh: [
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+              ],
+              rowCount: 1n,
+            },
+            {
+              attributes: [
+                ["desk", "equities"],
+                ["region", "emea"],
+                ["tier", "one"],
+              ],
+              rowCount: 1n,
+            },
+          ],
+          distinct: [{ desk: "equities", distinctAttributes: 2n }],
+          distinctFresh: [{ desk: "equities", distinctAttributes: 2n }],
+        });
+
+        expect(expectDefined(rawState.rows[0]).id).toBe("1");
+        expect(expectDefined(groupedState.rows[0]).rowCount).toBe(1n);
+        yield* rawSubscription.close();
+        yield* subsetSubscription.close();
+        yield* groupedSubscription.close();
+        yield* distinctSubscription.close();
+      }),
+  );
+});

--- a/packages/column-live-view-engine/src/grouped-hash-set-semantics.test.ts
+++ b/packages/column-live-view-engine/src/grouped-hash-set-semantics.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, type GroupedQuery, viewSchema } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import * as HashSet from "effect/HashSet";
+import { createColumnLiveViewEngine } from "./index";
+import {
+  applyDelta,
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+  stateFromSnapshot,
+} from "../test-harness/events";
+
+const Labels = viewSchema.HashSet(Schema.String);
+
+const HashSetRow = Schema.Struct({
+  id: Schema.String,
+  desk: Schema.String,
+  labels: Labels,
+});
+
+type HashSetRow = typeof HashSetRow.Type;
+
+type Labels = typeof Labels.Type;
+
+const hashSetViewServer = defineViewServerConfig({
+  topics: {
+    hashSetRows: {
+      schema: HashSetRow,
+      key: "id",
+    },
+  },
+});
+
+const byLabels = {
+  groupBy: ["labels"],
+  aggregates: { rowCount: { aggFunc: "count" } },
+} satisfies GroupedQuery<HashSetRow>;
+
+const distinctLabels = {
+  groupBy: ["desk"],
+  aggregates: {
+    distinctLabels: { aggFunc: "countDistinct", field: "labels" },
+  },
+} satisfies GroupedQuery<HashSetRow>;
+
+const subsetLabels = HashSet.make("blue", "green");
+const equivalentSubsetLabels = HashSet.make("green", "blue");
+const supersetLabels = HashSet.make("blue", "green", "red");
+
+const hashSetRow = (id: string, labels: Labels): HashSetRow => ({
+  id,
+  desk: "equities",
+  labels,
+});
+
+const sortedLabels = (labels: Labels): ReadonlyArray<string> => Array.from(labels).toSorted();
+
+const normalizedRawRows = (rows: ReadonlyArray<{ readonly id: string; readonly labels: Labels }>) =>
+  rows.map((row) => ({
+    id: row.id,
+    labels: sortedLabels(row.labels),
+  }));
+
+const normalizedGroupedRows = (
+  rows: ReadonlyArray<{ readonly labels: Labels; readonly rowCount: bigint }>,
+) =>
+  rows
+    .map((row) => ({
+      labels: sortedLabels(row.labels),
+      rowCount: row.rowCount,
+    }))
+    .toSorted((left, right) => left.labels.length - right.labels.length);
+
+const initialRawRows = [
+  { id: "1", labels: ["blue", "green"] },
+  { id: "2", labels: ["blue", "green", "red"] },
+];
+
+const supersetRawRows = [
+  { id: "1", labels: ["blue", "green", "red"] },
+  { id: "2", labels: ["blue", "green", "red"] },
+];
+
+const initialGroupedRows = [
+  { labels: ["blue", "green"], rowCount: 1n },
+  { labels: ["blue", "green", "red"], rowCount: 1n },
+];
+
+const supersetGroupedRows = [{ labels: ["blue", "green", "red"], rowCount: 2n }];
+
+describe("ColumnLiveViewEngine grouped HashSet semantics", () => {
+  it.effect(
+    "keeps subset and superset HashSets distinct across predicates, groups, and replacements",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({
+          topics: hashSetViewServer.topics,
+        });
+        yield* engine.publishMany("hashSetRows", [
+          hashSetRow("1", subsetLabels),
+          hashSetRow("2", supersetLabels),
+        ]);
+
+        const subsetSnapshot = yield* engine.snapshot("hashSetRows", {
+          select: ["id"],
+          where: { labels: { eq: subsetLabels } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const supersetSnapshot = yield* engine.snapshot("hashSetRows", {
+          select: ["id"],
+          where: { labels: { eq: supersetLabels } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedSnapshot = yield* engine.snapshot("hashSetRows", byLabels);
+        const distinctSnapshot = yield* engine.snapshot("hashSetRows", distinctLabels);
+
+        expect({
+          subset: subsetSnapshot.rows,
+          superset: supersetSnapshot.rows,
+          grouped: normalizedGroupedRows(groupedSnapshot.rows),
+          distinct: distinctSnapshot.rows,
+        }).toStrictEqual({
+          subset: [{ id: "1" }],
+          superset: [{ id: "2" }],
+          grouped: initialGroupedRows,
+          distinct: [{ desk: "equities", distinctLabels: 2n }],
+        });
+
+        const rawSubscription = yield* engine.subscribe("hashSetRows", {
+          select: ["id", "labels"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const subsetSubscription = yield* engine.subscribe("hashSetRows", {
+          select: ["id"],
+          where: { labels: { eq: subsetLabels } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedSubscription = yield* engine.subscribe("hashSetRows", byLabels);
+        const distinctSubscription = yield* engine.subscribe("hashSetRows", distinctLabels);
+        const readRaw = yield* makeEventReader(rawSubscription);
+        const readSubset = yield* makeEventReader(subsetSubscription);
+        const readGrouped = yield* makeEventReader(groupedSubscription);
+        const readDistinct = yield* makeEventReader(distinctSubscription);
+        const rawInitial = firstEvent(yield* readRaw(1));
+        const subsetInitial = firstEvent(yield* readSubset(1));
+        const groupedInitial = firstEvent(yield* readGrouped(1));
+        const distinctInitial = firstEvent(yield* readDistinct(1));
+        expectSnapshotEvent(rawInitial);
+        expectSnapshotEvent(subsetInitial);
+        expectSnapshotEvent(groupedInitial);
+        expectSnapshotEvent(distinctInitial);
+        let rawState = stateFromSnapshot(rawInitial);
+        let subsetState = stateFromSnapshot(subsetInitial);
+        let groupedState = stateFromSnapshot(groupedInitial);
+        let distinctState = stateFromSnapshot(distinctInitial);
+
+        yield* engine.publish("hashSetRows", hashSetRow("1", equivalentSubsetLabels));
+
+        const afterEquivalent = yield* engine.snapshot("hashSetRows", {
+          select: ["id", "labels"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const equivalentHealth = yield* engine.health();
+        expect({
+          snapshotVersion: afterEquivalent.version,
+          healthVersion: equivalentHealth.version,
+          queuedEvents: equivalentHealth.queuedEvents,
+          rows: normalizedRawRows(afterEquivalent.rows),
+        }).toStrictEqual({
+          snapshotVersion: 1,
+          healthVersion: 1,
+          queuedEvents: 0,
+          rows: initialRawRows,
+        });
+
+        yield* engine.publish("hashSetRows", hashSetRow("1", supersetLabels));
+        const rawToSuperset = firstEvent(yield* readRaw(1));
+        const subsetToSuperset = firstEvent(yield* readSubset(1));
+        const groupedToSuperset = firstEvent(yield* readGrouped(1));
+        const distinctToSuperset = firstEvent(yield* readDistinct(1));
+        expectDeltaEvent(rawToSuperset);
+        expectDeltaEvent(subsetToSuperset);
+        expectDeltaEvent(groupedToSuperset);
+        expectDeltaEvent(distinctToSuperset);
+        rawState = applyDelta(rawState, rawToSuperset);
+        subsetState = applyDelta(subsetState, subsetToSuperset);
+        groupedState = applyDelta(groupedState, groupedToSuperset);
+        distinctState = applyDelta(distinctState, distinctToSuperset);
+        const rawAfterSuperset = yield* engine.snapshot("hashSetRows", {
+          select: ["id", "labels"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const subsetAfterSuperset = yield* engine.snapshot("hashSetRows", {
+          select: ["id"],
+          where: { labels: { eq: subsetLabels } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedAfterSuperset = yield* engine.snapshot("hashSetRows", byLabels);
+        const distinctAfterSuperset = yield* engine.snapshot("hashSetRows", distinctLabels);
+
+        expect(rawToSuperset).toStrictEqual({
+          type: "delta",
+          topic: "hashSetRows",
+          queryId: rawInitial.queryId,
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "update",
+              key: "1",
+              row: { id: "1", labels: supersetLabels },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+        expect(subsetToSuperset).toStrictEqual({
+          type: "delta",
+          topic: "hashSetRows",
+          queryId: subsetInitial.queryId,
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "remove", key: "1" }],
+          totalRows: 0,
+        });
+        expect({
+          raw: normalizedRawRows(rawState.rows),
+          rawFresh: normalizedRawRows(rawAfterSuperset.rows),
+          subset: subsetState.rows,
+          subsetFresh: subsetAfterSuperset.rows,
+          grouped: normalizedGroupedRows(groupedState.rows),
+          groupedFresh: normalizedGroupedRows(groupedAfterSuperset.rows),
+          distinct: distinctState.rows,
+          distinctFresh: distinctAfterSuperset.rows,
+        }).toStrictEqual({
+          raw: supersetRawRows,
+          rawFresh: supersetRawRows,
+          subset: [],
+          subsetFresh: [],
+          grouped: supersetGroupedRows,
+          groupedFresh: supersetGroupedRows,
+          distinct: [{ desk: "equities", distinctLabels: 1n }],
+          distinctFresh: [{ desk: "equities", distinctLabels: 1n }],
+        });
+
+        yield* engine.publish("hashSetRows", hashSetRow("1", subsetLabels));
+        const rawToSubset = firstEvent(yield* readRaw(1));
+        const subsetToSubset = firstEvent(yield* readSubset(1));
+        const groupedToSubset = firstEvent(yield* readGrouped(1));
+        const distinctToSubset = firstEvent(yield* readDistinct(1));
+        expectDeltaEvent(rawToSubset);
+        expectDeltaEvent(subsetToSubset);
+        expectDeltaEvent(groupedToSubset);
+        expectDeltaEvent(distinctToSubset);
+        rawState = applyDelta(rawState, rawToSubset);
+        subsetState = applyDelta(subsetState, subsetToSubset);
+        groupedState = applyDelta(groupedState, groupedToSubset);
+        distinctState = applyDelta(distinctState, distinctToSubset);
+        const rawAfterSubset = yield* engine.snapshot("hashSetRows", {
+          select: ["id", "labels"],
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const subsetAfterSubset = yield* engine.snapshot("hashSetRows", {
+          select: ["id"],
+          where: { labels: { eq: subsetLabels } },
+          orderBy: [{ field: "id", direction: "asc" }],
+        });
+        const groupedAfterSubset = yield* engine.snapshot("hashSetRows", byLabels);
+        const distinctAfterSubset = yield* engine.snapshot("hashSetRows", distinctLabels);
+
+        expect(rawToSubset).toStrictEqual({
+          type: "delta",
+          topic: "hashSetRows",
+          queryId: rawInitial.queryId,
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            {
+              type: "update",
+              key: "1",
+              row: { id: "1", labels: subsetLabels },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+        expect(subsetToSubset).toStrictEqual({
+          type: "delta",
+          topic: "hashSetRows",
+          queryId: subsetInitial.queryId,
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            {
+              type: "insert",
+              key: "1",
+              row: { id: "1" },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        });
+        expect({
+          raw: normalizedRawRows(rawState.rows),
+          rawFresh: normalizedRawRows(rawAfterSubset.rows),
+          subset: subsetState.rows,
+          subsetFresh: subsetAfterSubset.rows,
+          grouped: normalizedGroupedRows(groupedState.rows),
+          groupedFresh: normalizedGroupedRows(groupedAfterSubset.rows),
+          distinct: distinctState.rows,
+          distinctFresh: distinctAfterSubset.rows,
+        }).toStrictEqual({
+          raw: initialRawRows,
+          rawFresh: initialRawRows,
+          subset: [{ id: "1" }],
+          subsetFresh: [{ id: "1" }],
+          grouped: initialGroupedRows,
+          groupedFresh: initialGroupedRows,
+          distinct: [{ desk: "equities", distinctLabels: 2n }],
+          distinctFresh: [{ desk: "equities", distinctLabels: 2n }],
+        });
+
+        yield* rawSubscription.close();
+        yield* subsetSubscription.close();
+        yield* groupedSubscription.close();
+        yield* distinctSubscription.close();
+      }),
+  );
+});

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.test.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.test.ts
@@ -1421,6 +1421,7 @@ describe("Grouped incremental query execution", () => {
       const execution = yield* acquireMaterializedQueryExecution(
         readModel,
         "missed-real-journal",
+        compiled.plan.resultSemantics,
         () => makeIncrementalGroupedQueryExecution(readModel, compiled, () => {}),
       );
       const cursor = execution.createCursor();

--- a/packages/column-live-view-engine/src/grouped-incremental-execution.ts
+++ b/packages/column-live-view-engine/src/grouped-incremental-execution.ts
@@ -1,11 +1,12 @@
 import {
   type MaterializedIncrementalGroupState,
   type RetainedMinMaxAggregateState,
+  type ReversibleAggregateState,
   finalizeGroup,
   newIncrementalGroupState,
   recomputeRetainedMinMaxAggregateState,
-  removeAggregateState,
-  updateAggregateState,
+  removeGroupAggregateState,
+  updateGroupAggregateState,
 } from "./grouped-aggregate-state";
 import { typedGroupedEvaluation } from "./grouped-query-evaluation";
 import type { GroupedQueryPlan } from "./grouped-query-plan";
@@ -26,7 +27,6 @@ import {
   type TopicRowChangeBatch,
   type TopicRowScan,
 } from "./row-scan";
-import { trustedFieldValue, valuesEqual } from "./row-values";
 
 type RowObject = object;
 
@@ -244,8 +244,8 @@ const buildMaterializedIncrementalGroupedQueryState = <Row extends RowObject>(
       admitted = false;
       return false;
     }
-    for (const { alias, aggregate } of plan.aggregatePlans) {
-      updateAggregateState(group.aggregates[alias]!, aggregate, row);
+    for (const aggregateState of group.aggregates) {
+      updateGroupAggregateState(aggregateState, row);
     }
     return undefined;
   });
@@ -302,8 +302,8 @@ const removeMaterializedIncrementalGroupedMember = <Row extends RowObject>(
     groups.delete(groupedKey);
     return true;
   }
-  for (const { alias, aggregate } of plan.aggregatePlans) {
-    removeMaterializedAggregateState(dirtyAggregateRecomputes, group, alias, aggregate, row);
+  for (const aggregateState of group.aggregates) {
+    removeMaterializedAggregateState(dirtyAggregateRecomputes, aggregateState, row);
   }
   return true;
 };
@@ -381,14 +381,12 @@ const markDirtyAggregateRecompute = (
 
 const removeMaterializedAggregateState = <Row extends RowObject>(
   dirtyAggregateRecomputes: DirtyAggregateRecomputes,
-  group: MaterializedIncrementalGroupState,
-  alias: string,
-  aggregate: GroupedQueryPlan<Row>["aggregates"][string],
+  aggregateState: ReversibleAggregateState,
   row: Row,
 ): void => {
   markDirtyAggregateRecompute(
     dirtyAggregateRecomputes,
-    removeAggregateState(group.aggregates[alias]!, aggregate, row),
+    removeGroupAggregateState(aggregateState, row),
   );
 };
 
@@ -401,20 +399,20 @@ const recomputeDirtyAggregateStates = (
 };
 
 const aggregateValueChanged = <Row extends RowObject>(
-  aggregate: GroupedQueryPlan<Row>["aggregates"][string],
+  aggregateState: ReversibleAggregateState,
   previous: Row,
   next: Row,
   changedFields: TopicRowChangedFields | undefined,
 ): boolean => {
-  if (!("field" in aggregate)) {
+  if (aggregateState.aggFunc === "count") {
     return false;
   }
   if (isTopicRowChangedFields(changedFields)) {
-    return changedFields.fields.has(aggregate.field);
+    return changedFields.fields.has(aggregateState.inputSemantics.field);
   }
-  return !valuesEqual(
-    trustedFieldValue(previous, aggregate.field),
-    trustedFieldValue(next, aggregate.field),
+  return !aggregateState.inputSemantics.equivalent(
+    aggregateState.inputSemantics.read(previous),
+    aggregateState.inputSemantics.read(next),
   );
 };
 
@@ -434,13 +432,13 @@ const upsertMatchingMaterializedIncrementalGroupedMember = <Row extends RowObjec
   const inserted = !group.members.has(key);
   const previous = group.members.get(key);
   if (previous !== undefined) {
-    for (const { alias, aggregate } of plan.aggregatePlans) {
-      removeMaterializedAggregateState(dirtyAggregateRecomputes, group, alias, aggregate, previous);
+    for (const aggregateState of group.aggregates) {
+      removeMaterializedAggregateState(dirtyAggregateRecomputes, aggregateState, previous);
     }
   }
   group.members.set(key, row);
-  for (const { alias, aggregate } of plan.aggregatePlans) {
-    updateAggregateState(group.aggregates[alias]!, aggregate, row);
+  for (const aggregateState of group.aggregates) {
+    updateGroupAggregateState(aggregateState, row);
   }
   return {
     groupSize: group.members.size,
@@ -459,15 +457,14 @@ const replaceMaterializedIncrementalGroupedMember = <Row extends RowObject>(
   changedFields: TopicRowChangedFields | undefined,
 ): void => {
   group.members.set(key, next);
-  for (const { alias, aggregate } of plan.aggregatePlans) {
-    if (aggregateValueChanged(aggregate, previous, next, changedFields)) {
-      const state = group.aggregates[alias]!;
-      markMaterializedAggregateChange(patch, plan, group, alias);
+  for (const aggregateState of group.aggregates) {
+    if (aggregateValueChanged(aggregateState, previous, next, changedFields)) {
+      markMaterializedAggregateChange(patch, plan, group, aggregateState.alias);
       markDirtyAggregateRecompute(
         dirtyAggregateRecomputes,
-        removeAggregateState(state, aggregate, previous),
+        removeGroupAggregateState(aggregateState, previous),
       );
-      updateAggregateState(state, aggregate, next);
+      updateGroupAggregateState(aggregateState, next);
     }
   }
 };

--- a/packages/column-live-view-engine/src/grouped-optional-aggregate-semantics.test.ts
+++ b/packages/column-live-view-engine/src/grouped-optional-aggregate-semantics.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, type GroupedQuery } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import { createColumnLiveViewEngine } from "./index";
+import {
+  expectDeltaEvent,
+  expectDefined,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+} from "../test-harness/events";
+
+const OptionalAggregateRow = Schema.Struct({
+  id: Schema.String,
+  team: Schema.String,
+  desk: Schema.optionalKey(Schema.String),
+});
+
+type OptionalAggregateRow = typeof OptionalAggregateRow.Type;
+
+const optionalAggregateViewServer = defineViewServerConfig({
+  topics: {
+    optionalAggregateRows: {
+      schema: OptionalAggregateRow,
+      key: "id",
+    },
+  },
+});
+
+const optionalAggregateQuery = {
+  groupBy: ["team"],
+  aggregates: {
+    distinctDesks: { aggFunc: "countDistinct", field: "desk" },
+    minDesk: { aggFunc: "min", field: "desk" },
+    maxDesk: { aggFunc: "max", field: "desk" },
+  },
+  orderBy: [{ field: "team", direction: "asc" }],
+} satisfies GroupedQuery<OptionalAggregateRow>;
+
+describe("ColumnLiveViewEngine grouped optional aggregate semantics", () => {
+  it.effect("preserves omitted optional aggregate values in full-scan results", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({
+        topics: optionalAggregateViewServer.topics,
+      });
+      yield* engine.publishMany("optionalAggregateRows", [
+        { id: "missing-1", team: "alpha" },
+        { id: "missing-2", team: "alpha" },
+        { id: "a", team: "alpha", desk: "a" },
+        { id: "b", team: "alpha", desk: "b" },
+        { id: "beta-missing", team: "beta" },
+      ]);
+
+      const snapshot = yield* engine.snapshot("optionalAggregateRows", {
+        groupBy: ["team"],
+        aggregates: {
+          distinctDesks: { aggFunc: "countDistinct", field: "desk" },
+          minDesk: { aggFunc: "min", field: "desk" },
+          maxDesk: { aggFunc: "max", field: "desk" },
+        },
+        orderBy: [
+          { aggregate: "minDesk", direction: "asc" },
+          { field: "team", direction: "asc" },
+        ],
+        limit: 2,
+      });
+
+      expect(snapshot.rows).toStrictEqual([
+        {
+          team: "alpha",
+          distinctDesks: 3n,
+          minDesk: undefined,
+          maxDesk: "b",
+        },
+        {
+          team: "beta",
+          distinctDesks: 1n,
+          minDesk: undefined,
+          maxDesk: undefined,
+        },
+      ]);
+      expect(Object.keys(snapshot.rows[0] ?? {})).toStrictEqual([
+        "team",
+        "distinctDesks",
+        "minDesk",
+        "maxDesk",
+      ]);
+    }),
+  );
+
+  it.effect(
+    "keeps optional distinct and extrema exact across incremental inserts, patches, deletes, and recomputes",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngine({
+          topics: optionalAggregateViewServer.topics,
+        });
+        yield* engine.publishMany("optionalAggregateRows", [
+          { id: "missing-1", team: "alpha" },
+          { id: "missing-2", team: "alpha" },
+          { id: "a", team: "alpha", desk: "a" },
+          { id: "b", team: "alpha", desk: "b" },
+          { id: "beta-missing", team: "beta" },
+        ]);
+
+        const subscription = yield* engine.subscribe(
+          "optionalAggregateRows",
+          optionalAggregateQuery,
+        );
+        const read = yield* makeEventReader(subscription);
+        const snapshot = firstEvent(yield* read(1));
+        expectSnapshotEvent(snapshot);
+        expect(snapshot.rows).toStrictEqual([
+          {
+            team: "alpha",
+            distinctDesks: 3n,
+            minDesk: undefined,
+            maxDesk: "b",
+          },
+          {
+            team: "beta",
+            distinctDesks: 1n,
+            minDesk: undefined,
+            maxDesk: undefined,
+          },
+        ]);
+        const alphaKey = expectDefined(snapshot.keys[0]);
+        const betaKey = expectDefined(snapshot.keys[1]);
+        const queryId = snapshot.queryId;
+
+        yield* engine.patch("optionalAggregateRows", "missing-1", { desk: "c" });
+        const missingToPresent = firstEvent(yield* read(1));
+        expectDeltaEvent(missingToPresent);
+        expect(missingToPresent).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            {
+              type: "update",
+              key: alphaKey,
+              row: {
+                team: "alpha",
+                distinctDesks: 4n,
+                minDesk: undefined,
+                maxDesk: "c",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* engine.delete("optionalAggregateRows", "missing-2");
+        const removeLastMissing = firstEvent(yield* read(1));
+        expectDeltaEvent(removeLastMissing);
+        expect(removeLastMissing).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [
+            {
+              type: "update",
+              key: alphaKey,
+              row: {
+                team: "alpha",
+                distinctDesks: 3n,
+                minDesk: "a",
+                maxDesk: "c",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* engine.patch("optionalAggregateRows", "missing-1", { desk: "aa" });
+        const patchCurrentMaximum = firstEvent(yield* read(1));
+        expectDeltaEvent(patchCurrentMaximum);
+        expect(patchCurrentMaximum).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 3,
+          toVersion: 4,
+          operations: [
+            {
+              type: "update",
+              key: alphaKey,
+              row: {
+                team: "alpha",
+                distinctDesks: 3n,
+                minDesk: "a",
+                maxDesk: "b",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* engine.delete("optionalAggregateRows", "b");
+        const deleteCurrentMaximum = firstEvent(yield* read(1));
+        expectDeltaEvent(deleteCurrentMaximum);
+        expect(deleteCurrentMaximum).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 4,
+          toVersion: 5,
+          operations: [
+            {
+              type: "update",
+              key: alphaKey,
+              row: {
+                team: "alpha",
+                distinctDesks: 2n,
+                minDesk: "a",
+                maxDesk: "aa",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* engine.publish("optionalAggregateRows", { id: "a", team: "alpha" });
+        const presentToMissing = firstEvent(yield* read(1));
+        expectDeltaEvent(presentToMissing);
+        expect(presentToMissing).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 5,
+          toVersion: 6,
+          operations: [
+            {
+              type: "update",
+              key: alphaKey,
+              row: {
+                team: "alpha",
+                distinctDesks: 2n,
+                minDesk: undefined,
+                maxDesk: "aa",
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* engine.publish("optionalAggregateRows", {
+          id: "beta-present",
+          team: "beta",
+          desk: "z",
+        });
+        const insertPresent = firstEvent(yield* read(1));
+        expectDeltaEvent(insertPresent);
+        expect(insertPresent).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 6,
+          toVersion: 7,
+          operations: [
+            {
+              type: "update",
+              key: betaKey,
+              row: {
+                team: "beta",
+                distinctDesks: 2n,
+                minDesk: undefined,
+                maxDesk: "z",
+              },
+              index: 1,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* engine.delete("optionalAggregateRows", "beta-missing");
+        const deleteMissingExtremum = firstEvent(yield* read(1));
+        expectDeltaEvent(deleteMissingExtremum);
+        expect(deleteMissingExtremum).toStrictEqual({
+          type: "delta",
+          topic: "optionalAggregateRows",
+          queryId,
+          fromVersion: 7,
+          toVersion: 8,
+          operations: [
+            {
+              type: "update",
+              key: betaKey,
+              row: {
+                team: "beta",
+                distinctDesks: 1n,
+                minDesk: "z",
+                maxDesk: "z",
+              },
+              index: 1,
+            },
+          ],
+          totalRows: 2,
+        });
+
+        yield* subscription.close();
+      }),
+  );
+});

--- a/packages/column-live-view-engine/src/grouped-projection-semantics.test.ts
+++ b/packages/column-live-view-engine/src/grouped-projection-semantics.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, type GroupedQuery, viewSchema } from "@effect-view-server/config";
+import { BigDecimal, Effect, Schema } from "effect";
+import { createColumnLiveViewEngine } from "./index";
+import {
+  applyDelta,
+  expectDefined,
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+  stateFromSnapshot,
+} from "../test-harness/events";
+
+class Venue extends Schema.Class<Venue>("Venue")({
+  code: Schema.String,
+  aliases: Schema.mutable(Schema.Array(Schema.String)),
+}) {}
+viewSchema.admitClass(Venue);
+
+class Sentinel extends Schema.Class<Sentinel>("Sentinel")({
+  code: Schema.String,
+  labels: Schema.mutable(Schema.Array(Schema.String)),
+}) {}
+viewSchema.admitClass(Sentinel);
+
+const GroupedSemanticRow = Schema.Struct({
+  id: Schema.String,
+  venue: Venue,
+  sentinel: Sentinel,
+  amount: Schema.BigDecimal,
+  desk: Schema.optionalKey(Schema.String),
+});
+
+type GroupedSemanticRow = typeof GroupedSemanticRow.Type;
+
+type GroupedSemanticResult = {
+  readonly venue: Venue;
+  readonly rowCount: bigint;
+  readonly distinctSentinels: bigint;
+  readonly totalAmount: BigDecimal.BigDecimal;
+  readonly minSentinel: Sentinel;
+  readonly maxSentinel: Sentinel;
+};
+
+const groupedSemanticViewServer = defineViewServerConfig({
+  topics: {
+    groupedSemanticRows: {
+      schema: GroupedSemanticRow,
+      key: "id",
+    },
+  },
+});
+
+const groupedSemanticQuery = {
+  groupBy: ["venue"],
+  aggregates: {
+    rowCount: { aggFunc: "count" },
+    distinctSentinels: { aggFunc: "countDistinct", field: "sentinel" },
+    totalAmount: { aggFunc: "sum", field: "amount" },
+    minSentinel: { aggFunc: "min", field: "sentinel" },
+    maxSentinel: { aggFunc: "max", field: "sentinel" },
+  },
+  orderBy: [{ field: "venue", direction: "asc" }],
+} satisfies GroupedQuery<GroupedSemanticRow>;
+
+const groupedOptionalQuery = {
+  groupBy: ["desk"],
+  aggregates: {
+    rowCount: { aggFunc: "count" },
+  },
+} satisfies GroupedQuery<GroupedSemanticRow>;
+
+const venue = (code: string, alias: string): Venue =>
+  Venue.make({
+    code,
+    aliases: [alias],
+  });
+
+const sentinel = (code: string): Sentinel =>
+  Sentinel.make({
+    code,
+    labels: [`label-${code}`],
+  });
+
+const groupedRow = (
+  id: string,
+  venueCode: string,
+  venueAlias: string,
+  sentinelCode: string,
+  amount: string,
+): GroupedSemanticRow => ({
+  id,
+  venue: venue(venueCode, venueAlias),
+  sentinel: sentinel(sentinelCode),
+  amount: BigDecimal.fromStringUnsafe(amount),
+});
+
+const expectGroupedSemanticResult = (
+  row: GroupedSemanticResult | undefined,
+  expected: {
+    readonly venueCode: string;
+    readonly venueAlias: string;
+    readonly rowCount: bigint;
+    readonly distinctSentinels: bigint;
+    readonly totalAmount: string;
+    readonly minSentinel: string;
+    readonly maxSentinel: string;
+  },
+): GroupedSemanticResult => {
+  const grouped = expectDefined(row);
+  expect(grouped.venue).toBeInstanceOf(Venue);
+  expect(grouped.minSentinel).toBeInstanceOf(Sentinel);
+  expect(grouped.maxSentinel).toBeInstanceOf(Sentinel);
+  expect(BigDecimal.isBigDecimal(grouped.totalAmount)).toBe(true);
+  expect({
+    venueCode: grouped.venue.code,
+    venueAliases: grouped.venue.aliases,
+    rowCount: grouped.rowCount,
+    distinctSentinels: grouped.distinctSentinels,
+    totalAmount: BigDecimal.format(grouped.totalAmount),
+    minSentinel: {
+      code: grouped.minSentinel.code,
+      labels: grouped.minSentinel.labels,
+    },
+    maxSentinel: {
+      code: grouped.maxSentinel.code,
+      labels: grouped.maxSentinel.labels,
+    },
+  }).toStrictEqual({
+    venueCode: expected.venueCode,
+    venueAliases: [expected.venueAlias],
+    rowCount: expected.rowCount,
+    distinctSentinels: expected.distinctSentinels,
+    totalAmount: expected.totalAmount,
+    minSentinel: {
+      code: expected.minSentinel,
+      labels: [`label-${expected.minSentinel}`],
+    },
+    maxSentinel: {
+      code: expected.maxSentinel,
+      labels: [`label-${expected.maxSentinel}`],
+    },
+  });
+  return grouped;
+};
+
+const expectGroupedSemanticRows = (
+  rows: ReadonlyArray<GroupedSemanticResult>,
+  xTotalAmount: string,
+): void => {
+  expect(rows.length).toBe(2);
+  expectGroupedSemanticResult(rows[0], {
+    venueCode: "XNAS",
+    venueAlias: "primary",
+    rowCount: 2n,
+    distinctSentinels: 2n,
+    totalAmount: xTotalAmount,
+    minSentinel: "a",
+    maxSentinel: "z",
+  });
+  expectGroupedSemanticResult(rows[1], {
+    venueCode: "XNYS",
+    venueAlias: "secondary",
+    rowCount: 1n,
+    distinctSentinels: 1n,
+    totalAmount: "3",
+    minSentinel: "m",
+    maxSentinel: "m",
+  });
+};
+
+const makeGroupedSemanticEngine = () =>
+  createColumnLiveViewEngine({
+    topics: groupedSemanticViewServer.topics,
+  });
+
+const groupedSemanticFixture = (): ReadonlyArray<GroupedSemanticRow> => [
+  groupedRow("row-1", "XNAS", "primary", "z", "1"),
+  groupedRow("row-2", "XNAS", "primary", "a", "2"),
+  groupedRow("row-3", "XNYS", "secondary", "m", "3"),
+];
+
+describe("ColumnLiveViewEngine grouped projection value semantics", () => {
+  it.effect("keeps a missing optional group field omitted from the result row", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeGroupedSemanticEngine();
+      yield* engine.publishMany("groupedSemanticRows", groupedSemanticFixture());
+
+      const snapshot = yield* engine.snapshot("groupedSemanticRows", groupedOptionalQuery);
+
+      expect(snapshot.rows).toStrictEqual([{ rowCount: 3n }]);
+      expect(Object.hasOwn(expectDefined(snapshot.rows[0]), "desk")).toBe(false);
+
+      const subscription = yield* engine.subscribe("groupedSemanticRows", groupedOptionalQuery);
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+      expect(initial.rows).toStrictEqual([{ rowCount: 3n }]);
+      expect(Object.hasOwn(expectDefined(initial.rows[0]), "desk")).toBe(false);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("groups and aggregates schema class values while isolating one-shot results", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeGroupedSemanticEngine();
+      yield* engine.publishMany("groupedSemanticRows", groupedSemanticFixture());
+
+      const snapshot = yield* engine.snapshot("groupedSemanticRows", groupedSemanticQuery);
+      expect(snapshot.totalRows).toBe(2);
+      expectGroupedSemanticRows(snapshot.rows, "3");
+
+      const xGroup = expectDefined(snapshot.rows[0]);
+      xGroup.venue.aliases.push("mutated-snapshot");
+      xGroup.minSentinel.labels.push("mutated-min");
+
+      const fresh = yield* engine.snapshot("groupedSemanticRows", groupedSemanticQuery);
+      expectGroupedSemanticRows(fresh.rows, "3");
+    }),
+  );
+
+  it.effect("isolates grouped subscription snapshots, cursors, and update delta rows", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeGroupedSemanticEngine();
+      yield* engine.publishMany("groupedSemanticRows", groupedSemanticFixture());
+
+      const firstSubscription = yield* engine.subscribe(
+        "groupedSemanticRows",
+        groupedSemanticQuery,
+      );
+      const secondSubscription = yield* engine.subscribe(
+        "groupedSemanticRows",
+        groupedSemanticQuery,
+      );
+      const readFirst = yield* makeEventReader(firstSubscription);
+      const readSecond = yield* makeEventReader(secondSubscription);
+      const firstSnapshot = firstEvent(yield* readFirst(1));
+      const secondSnapshot = firstEvent(yield* readSecond(1));
+      expectSnapshotEvent(firstSnapshot);
+      expectSnapshotEvent(secondSnapshot);
+      let firstState = stateFromSnapshot(firstSnapshot);
+      let secondState = stateFromSnapshot(secondSnapshot);
+      expectGroupedSemanticRows(firstState.rows, "3");
+
+      const firstXGroup = expectDefined(firstState.rows[0]);
+      firstXGroup.venue.aliases.push("mutated-first-subscriber");
+      firstXGroup.maxSentinel.labels.push("mutated-max");
+      expectGroupedSemanticRows(secondState.rows, "3");
+
+      const xGroupKey = expectDefined(firstSnapshot.keys[0]);
+      yield* engine.patch("groupedSemanticRows", "row-1", {
+        amount: BigDecimal.fromStringUnsafe("4"),
+      });
+
+      const firstDelta = firstEvent(yield* readFirst(1));
+      expectDeltaEvent(firstDelta);
+      expect(firstDelta.operations).toStrictEqual([
+        {
+          type: "update",
+          key: xGroupKey,
+          row: {
+            venue: venue("XNAS", "primary"),
+            rowCount: 2n,
+            distinctSentinels: 2n,
+            totalAmount: BigDecimal.fromStringUnsafe("6"),
+            minSentinel: sentinel("a"),
+            maxSentinel: sentinel("z"),
+          },
+          index: 0,
+        },
+      ]);
+      firstState = applyDelta(firstState, firstDelta);
+      expectGroupedSemanticRows(firstState.rows, "6");
+      expectDefined(firstState.rows[0]).venue.aliases.push("mutated-delta");
+
+      const secondDelta = firstEvent(yield* readSecond(1));
+      expectDeltaEvent(secondDelta);
+      expect(secondDelta.operations.length).toBe(1);
+      expect(secondDelta.operations[0]?.type).toBe("update");
+      secondState = applyDelta(secondState, secondDelta);
+      expectGroupedSemanticRows(secondState.rows, "6");
+      expectGroupedSemanticRows(
+        (yield* engine.snapshot("groupedSemanticRows", groupedSemanticQuery)).rows,
+        "6",
+      );
+
+      yield* firstSubscription.close();
+      yield* secondSubscription.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/grouped-query-compiler.test.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.test.ts
@@ -55,9 +55,9 @@ describe("Grouped query compilation and evaluation", () => {
         },
       ]);
       expect(evaluation.keys).toStrictEqual([
-        '["array",[["array",[["string","symbol"],["string","symbol-1097"]]]]]',
-        '["array",[["array",[["string","symbol"],["string","symbol-1096"]]]]]',
-        '["array",[["array",[["string","symbol"],["string","symbol-1095"]]]]]',
+        '[["symbol","[\\"present\\",\\"\\\\\\"symbol-1097\\\\\\"\\"]"]]',
+        '[["symbol","[\\"present\\",\\"\\\\\\"symbol-1096\\\\\\"\\"]"]]',
+        '[["symbol","[\\"present\\",\\"\\\\\\"symbol-1095\\\\\\"\\"]"]]',
       ]);
       expect(evaluation.totalRows).toBe(1_100);
     }),

--- a/packages/column-live-view-engine/src/grouped-query-compiler.ts
+++ b/packages/column-live-view-engine/src/grouped-query-compiler.ts
@@ -29,7 +29,11 @@ export const prepareGroupedQuery = Effect.fn("ColumnLiveViewEngine.groupedQuery.
       ...(decoded.where === undefined ? {} : { where: decoded.where }),
     });
     const { matches } = rawFilter.plan.predicate;
-    const plan = makeGroupedQueryPlan<Row>(decoded);
+    const plan = makeGroupedQueryPlan<Row>(
+      decoded,
+      metadata.valueSemantics,
+      rawFilter.plan.queryCacheKey,
+    );
     return {
       plan,
       cacheKey: plan.cacheKey,

--- a/packages/column-live-view-engine/src/grouped-query-evaluation.ts
+++ b/packages/column-live-view-engine/src/grouped-query-evaluation.ts
@@ -1,4 +1,8 @@
-import { type GroupState, newGroupState, updateAggregateState } from "./grouped-aggregate-state";
+import {
+  type GroupState,
+  newGroupState,
+  updateGroupAggregateState,
+} from "./grouped-aggregate-state";
 import type { GroupedQueryPlan } from "./grouped-query-plan";
 import { emptyGroupedEvaluation, groupedEvaluationFromGroups } from "./grouped-window-evaluation";
 import type { QueryEvaluation } from "./query-result";
@@ -48,8 +52,8 @@ export const evaluateGroupedRows = <Row extends RowObject>(
       group = newGroupState(key, plan.groupBy, plan.aggregatePlans, row);
       groups.set(key, group);
     }
-    for (const { alias, aggregate } of plan.aggregatePlans) {
-      updateAggregateState(group.aggregates[alias]!, aggregate, row);
+    for (const aggregateState of group.aggregates) {
+      updateGroupAggregateState(aggregateState, row);
     }
   });
   return groupedEvaluationFromGroups(groups.values(), plan, store.version());

--- a/packages/column-live-view-engine/src/grouped-query-plan.test.ts
+++ b/packages/column-live-view-engine/src/grouped-query-plan.test.ts
@@ -1,34 +1,50 @@
 import { describe, expect, it } from "@effect/vitest";
+import { Option, Schema } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
-import { stableQueryValueString } from "./raw-query-compiler";
 import { makeGroupedQueryPlan } from "./grouped-query-plan";
+import { rawQueryCompilerMetadata } from "./raw-query-compiler";
+
+const GroupKeyRow = Schema.Struct({
+  status: Schema.String,
+  price: Schema.Number,
+  decimalPrice: Schema.BigDecimal,
+  payload: Schema.Record(Schema.String, Schema.String),
+  venue: Schema.String,
+  negativeZero: Schema.Number,
+  quantity: Schema.BigInt,
+  active: Schema.Boolean,
+  closed: Schema.Boolean,
+  missing: Schema.Null,
+  note: Schema.Union([Schema.String, Schema.Undefined]),
+  collision: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
+const valueSemantics = rawQueryCompilerMetadata(GroupKeyRow).valueSemantics;
 
 describe("Grouped query planning", () => {
-  it("keeps scalar grouped key strings compatible with stable query value strings", () => {
-    const plan = makeGroupedQueryPlan<object>({
-      groupBy: [
-        "status",
-        "price",
-        "notANumber",
-        "positiveInfinity",
-        "negativeInfinity",
-        "negativeZero",
-        "quantity",
-        "active",
-        "closed",
-        "missing",
-        "note",
-      ],
-      aggregates: {
-        rowCount: { aggFunc: "count" },
+  it("uses canonical field tokens for scalar grouped keys", () => {
+    const plan = makeGroupedQueryPlan<object>(
+      {
+        groupBy: [
+          "status",
+          "price",
+          "negativeZero",
+          "quantity",
+          "active",
+          "closed",
+          "missing",
+          "note",
+        ],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
       },
-    });
+      valueSemantics,
+      "scalar-key-predicate",
+    );
     const row = {
       status: "open",
       price: 10,
-      notANumber: Number.NaN,
-      positiveInfinity: Number.POSITIVE_INFINITY,
-      negativeInfinity: Number.NEGATIVE_INFINITY,
       negativeZero: -0,
       quantity: 5n,
       active: true,
@@ -37,76 +53,75 @@ describe("Grouped query planning", () => {
       note: undefined,
     };
 
-    expect(plan.groupKey(row)).toBe(
-      stableQueryValueString([
-        ["status", "open"],
-        ["price", 10],
-        ["notANumber", Number.NaN],
-        ["positiveInfinity", Number.POSITIVE_INFINITY],
-        ["negativeInfinity", Number.NEGATIVE_INFINITY],
-        ["negativeZero", -0],
-        ["quantity", 5n],
-        ["active", true],
-        ["closed", false],
-        ["missing", null],
-        ["note", undefined],
-      ]),
+    expect(plan.groupKey(row)).toBe(plan.groupKey({ ...row, negativeZero: 0 }));
+    expect(plan.groupKey(row)).not.toBe(plan.groupKey({ ...row, price: 11 }));
+  });
+
+  it("normalizes BigDecimal grouped key identity through its canonical codec", () => {
+    const plan = makeGroupedQueryPlan<object>(
+      {
+        groupBy: ["status", "decimalPrice", "venue"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      },
+      valueSemantics,
+      "big-decimal-key-predicate",
+    );
+
+    expect(
+      plan.groupKey({
+        status: "open",
+        decimalPrice: fromStringUnsafe("1.50"),
+        venue: "xnys",
+      }),
+    ).toBe(
+      plan.groupKey({
+        status: "open",
+        decimalPrice: fromStringUnsafe("1.5"),
+        venue: "xnys",
+      }),
     );
   });
 
-  it("keeps BigDecimal grouped key fallback compatible with stable query value strings", () => {
-    const plan = makeGroupedQueryPlan<object>({
-      groupBy: ["status", "decimalPrice", "venue"],
-      aggregates: {
-        rowCount: { aggFunc: "count" },
+  it("uses key-order-neutral canonical tokens for structured grouped values", () => {
+    const plan = makeGroupedQueryPlan<object>(
+      {
+        groupBy: ["status", "payload", "venue"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
       },
-    });
-    const decimalPrice = fromStringUnsafe("1.50");
-    const row = {
-      status: "open",
-      decimalPrice,
-      venue: "xnys",
-    };
+      valueSemantics,
+      "structured-key-predicate",
+    );
 
-    expect(plan.groupKey(row)).toBe(
-      stableQueryValueString([
-        ["status", "open"],
-        ["decimalPrice", decimalPrice],
-        ["venue", "xnys"],
-      ]),
+    expect(
+      plan.groupKey({
+        status: "open",
+        payload: { second: "2", first: "1" },
+        venue: "xnys",
+      }),
+    ).toBe(
+      plan.groupKey({
+        status: "open",
+        payload: { first: "1", second: "2" },
+        venue: "xnys",
+      }),
     );
   });
 
-  it("keeps structured grouped key fallback compatible with stable query value strings", () => {
-    const plan = makeGroupedQueryPlan<object>({
-      groupBy: ["status", "payload", "venue"],
-      aggregates: {
-        rowCount: { aggFunc: "count" },
+  it("reads each grouped key field once", () => {
+    const plan = makeGroupedQueryPlan<object>(
+      {
+        groupBy: ["status", "payload", "venue"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
       },
-    });
-    const payload = new Map([["venue", "xnys"]]);
-    const row = {
-      status: "open",
-      payload,
-      venue: "xnys",
-    };
-
-    expect(plan.groupKey(row)).toBe(
-      stableQueryValueString([
-        ["status", "open"],
-        ["payload", payload],
-        ["venue", "xnys"],
-      ]),
+      valueSemantics,
+      "single-read-predicate",
     );
-  });
-
-  it("reads each grouped key field once when fallback is needed", () => {
-    const plan = makeGroupedQueryPlan<object>({
-      groupBy: ["status", "payload", "venue"],
-      aggregates: {
-        rowCount: { aggFunc: "count" },
-      },
-    });
     let statusReads = 0;
     let payloadReads = 0;
     let venueReads = 0;
@@ -124,7 +139,7 @@ describe("Grouped query planning", () => {
           enumerable: true,
           get() {
             payloadReads += 1;
-            return new Map([["venue", "xnys"]]);
+            return { venue: "xnys" };
           },
         },
         venue: {
@@ -144,35 +159,84 @@ describe("Grouped query planning", () => {
     expect(venueReads).toBe(1);
   });
 
-  it("does not add extra object probes before grouped key fallback", () => {
-    const plan = makeGroupedQueryPlan<object>({
-      groupBy: ["status", "payload"],
-      aggregates: {
-        rowCount: { aggFunc: "count" },
-      },
-    });
-    let hasProbeCount = 0;
-    const payload = new Proxy(
-      {},
+  it("caches canonical tokens for engine-owned structured values", () => {
+    const plan = makeGroupedQueryPlan<object>(
       {
-        has(target, key) {
-          hasProbeCount += 1;
-          return key in target;
+        groupBy: ["status", "payload"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      },
+      valueSemantics,
+      "canonical-cache-predicate",
+    );
+    let ownKeyReads = 0;
+    const payload = new Proxy(
+      { venue: "xnys" },
+      {
+        ownKeys(target) {
+          ownKeyReads += 1;
+          return Reflect.ownKeys(target);
         },
       },
     );
-    stableQueryValueString([
-      ["status", "open"],
-      ["payload", payload],
-    ]);
-    const baselineHasProbeCount = hasProbeCount;
-    hasProbeCount = 0;
-
-    plan.groupKey({
+    const row = {
       status: "open",
       payload,
-    });
+    };
 
-    expect(hasProbeCount).toBe(baselineHasProbeCount);
+    plan.groupKey(row);
+    const readsAfterFirstKey = ownKeyReads;
+    plan.groupKey(row);
+
+    expect(readsAfterFirstKey).toBeGreaterThan(0);
+    expect(ownKeyReads).toBe(readsAfterFirstKey);
+  });
+
+  it("distinguishes a missing aggregate input from a present undefined value", () => {
+    const plan = makeGroupedQueryPlan<object>(
+      {
+        groupBy: ["status"],
+        aggregates: {
+          distinctNotes: { aggFunc: "countDistinct", field: "note" },
+        },
+      },
+      valueSemantics,
+      "aggregate-input-predicate",
+    );
+    const aggregatePlan = Option.getOrThrow(
+      Option.fromNullishOr(plan.aggregatePlans.find((candidate) => candidate.kind === "field")),
+    );
+    const missing = aggregatePlan.input.read({});
+    const presentUndefined = aggregatePlan.input.read({ note: undefined });
+    const secondPresentUndefined = aggregatePlan.input.read({ note: undefined });
+    const presentValue = aggregatePlan.input.read({ note: "note" });
+
+    expect(missing).toStrictEqual({ _tag: "Missing" });
+    expect(presentUndefined).toStrictEqual({ _tag: "Present", value: undefined });
+    expect(aggregatePlan.input.canonicalKey(missing)).not.toBe(
+      aggregatePlan.input.canonicalKey(presentUndefined),
+    );
+    expect(aggregatePlan.input.equivalent(missing, presentUndefined)).toBe(false);
+    expect(aggregatePlan.input.equivalent(presentUndefined, secondPresentUndefined)).toBe(true);
+    expect(aggregatePlan.input.compare(missing, presentUndefined)).toBe(-1);
+    expect(aggregatePlan.input.compare(presentUndefined, missing)).toBe(1);
+    expect(aggregatePlan.input.compare(presentUndefined, secondPresentUndefined)).toBe(0);
+    expect(aggregatePlan.input.compare(presentUndefined, presentValue)).toBe(-1);
+  });
+
+  it("distinguishes a missing grouped field from a present value shaped like the token", () => {
+    const plan = makeGroupedQueryPlan<object>(
+      {
+        groupBy: ["collision"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      },
+      valueSemantics,
+      "presence-token-collision-predicate",
+    );
+
+    expect(plan.groupKey({})).not.toBe(plan.groupKey({ collision: ["missing"] }));
   });
 });

--- a/packages/column-live-view-engine/src/grouped-query-plan.ts
+++ b/packages/column-live-view-engine/src/grouped-query-plan.ts
@@ -1,12 +1,28 @@
 import {
-  aggregateStateCompareValue,
+  groupAggregateStateCompareValue,
+  type GroupedAggregateInput,
+  type GroupedAggregateInputSemantics,
   type GroupedAggregatePlan,
   type GroupState,
   type RuntimeGroupedAggregate,
 } from "./grouped-aggregate-state";
+import {
+  compileGroupedKeyIdentity,
+  missingSchemaValuePresenceToken,
+  presentSchemaValuePresenceToken,
+  schemaValuePresenceKey,
+  type GroupedKeyIdentityField,
+} from "@effect-view-server/effect-utils";
+import { Option } from "effect";
 import { stableQueryValueString } from "./query-value";
 import type { StoredRowOf } from "./query-result";
+import {
+  groupedQueryResultSemantics,
+  groupedResultAggregateSemantics,
+  type QueryResultSemantics,
+} from "./query-result-semantics";
 import { trustedFieldValue } from "./row-values";
+import type { SchemaValueSemantics, TopicRowValueSemantics } from "./topic-row-value-semantics";
 
 type RowObject = object;
 
@@ -30,15 +46,13 @@ export type GroupedQueryPlanInput = {
 };
 
 export type CompiledGroupedOrderBy = {
+  readonly compare: (left: unknown, right: unknown) => number;
   readonly direction: "asc" | "desc";
   readonly groupValue: (group: GroupState) => unknown;
   readonly rowValue: (entry: StoredRowOf<RowObject>) => unknown;
 };
 
-type CompiledGroupedKeyField<Row extends RowObject> = {
-  readonly field: string;
-  readonly value: (row: Row) => unknown;
-};
+const missingGroupedValueKey = schemaValuePresenceKey(missingSchemaValuePresenceToken);
 
 export type GroupedQueryPlan<Row extends RowObject> = {
   readonly query: GroupedQueryPlanInput;
@@ -50,137 +64,163 @@ export type GroupedQueryPlan<Row extends RowObject> = {
   readonly compiledOrderBy: ReadonlyArray<CompiledGroupedOrderBy>;
   readonly offset: number;
   readonly limit: number | undefined;
+  readonly resultSemantics: QueryResultSemantics;
   readonly zeroLimit: boolean;
   readonly groupKey: (row: Row) => string;
 };
 
-const groupedQueryPlanCacheKey = (query: GroupedQueryPlanInput): string =>
+const groupedQueryPlanCacheKey = (
+  query: GroupedQueryPlanInput,
+  rawPredicateCacheKey: string,
+): string =>
   stableQueryValueString([
     "grouped",
     query.groupBy,
     Object.entries(query.aggregates).toSorted(
       ([left], [right]) => Number(left > right) - Number(left < right),
     ),
-    query.where === undefined ? [] : stableQueryValueString(query.where),
+    rawPredicateCacheKey,
     query.orderBy ?? [],
     query.offset ?? null,
     query.limit ?? null,
   ]);
 
-const stableScalarGroupedKeyValueTokenString = (value: unknown): string | undefined => {
-  if (value === null) {
-    return `["null"]`;
-  }
-  if (typeof value === "bigint") {
-    return `["bigint",${JSON.stringify(value.toString())}]`;
-  }
-  if (typeof value === "number") {
-    return `["number",${JSON.stringify(Object.is(value, -0) ? "-0" : String(value))}]`;
-  }
-  if (typeof value === "string") {
-    return `["string",${JSON.stringify(value)}]`;
-  }
-  if (typeof value === "boolean") {
-    return `["boolean",${value ? "true" : "false"}]`;
-  }
-  if (value === undefined) {
-    return `["undefined"]`;
-  }
-  return undefined;
-};
-
-const stableScalarGroupedKeyFieldTokenString = (
-  field: string,
-  value: unknown,
-): string | undefined => {
-  const valueToken = stableScalarGroupedKeyValueTokenString(value);
-  if (valueToken === undefined) {
-    return undefined;
-  }
-  return `["array",[["string",${JSON.stringify(field)}],${valueToken}]]`;
-};
-
-const groupedQueryPlanGroupKey = <Row extends RowObject>(
-  keyFields: ReadonlyArray<CompiledGroupedKeyField<Row>>,
-  row: Row,
-): string => {
-  const tokens: Array<string> = [];
-  const values: Array<readonly [string, unknown]> = [];
-  for (const keyField of keyFields) {
-    const value = keyField.value(row);
-    values.push([keyField.field, value]);
-    const token = stableScalarGroupedKeyFieldTokenString(keyField.field, value);
-    if (token === undefined) {
-      for (const fallbackKeyField of keyFields.slice(values.length)) {
-        values.push([fallbackKeyField.field, fallbackKeyField.value(row)]);
-      }
-      return stableQueryValueString(values);
-    }
-    tokens.push(token);
-  }
-  return `["array",[${tokens.join(",")}]]`;
-};
-
-const compileGroupedKeyFields = <Row extends RowObject>(
+const compileGroupedKeyFields = (
+  valueSemantics: TopicRowValueSemantics,
   groupBy: ReadonlyArray<string>,
-): ReadonlyArray<CompiledGroupedKeyField<Row>> =>
-  groupBy.map((field) => ({
-    field,
-    value: (row) => trustedFieldValue(row, field),
-  }));
+): ReadonlyArray<GroupedKeyIdentityField> =>
+  groupBy.map((field) => {
+    const semantics = valueSemantics.field(field);
+    return {
+      field,
+      canonicalKey: semantics.canonicalKey,
+    };
+  });
 
 const compileGroupedAggregates = (
+  valueSemantics: TopicRowValueSemantics,
   aggregates: Readonly<Record<string, RuntimeGroupedAggregate>>,
 ): ReadonlyArray<GroupedAggregatePlan> =>
-  Object.entries(aggregates).map(([alias, aggregate]) => ({
-    alias,
-    aggregate,
-  }));
+  Object.entries(aggregates).map(([alias, aggregate], stateIndex) => {
+    const resultSemantics = groupedResultAggregateSemantics(valueSemantics, aggregate);
+    if (aggregate.aggFunc === "count") {
+      return {
+        kind: "count",
+        alias,
+        aggregate,
+        resultSemantics,
+        stateIndex,
+      };
+    }
+    const fieldSemantics = valueSemantics.field(aggregate.field);
+    const input: GroupedAggregateInputSemantics = {
+      field: aggregate.field,
+      canonicalKey: (aggregateInput) =>
+        aggregateInput._tag === "Missing"
+          ? missingGroupedValueKey
+          : schemaValuePresenceKey(
+              presentSchemaValuePresenceToken(fieldSemantics.canonicalKey(aggregateInput.value)),
+            ),
+      compare: (left, right) => {
+        if (left._tag === "Missing") {
+          return right._tag === "Missing" ? 0 : -1;
+        }
+        if (right._tag === "Missing") {
+          return 1;
+        }
+        return fieldSemantics.compare(left.value, right.value);
+      },
+      equivalent: (left, right) => {
+        if (left._tag === "Missing") {
+          return right._tag === "Missing";
+        }
+        return right._tag === "Present" && fieldSemantics.equivalent(left.value, right.value);
+      },
+      read: (row) =>
+        Object.prototype.propertyIsEnumerable.call(row, aggregate.field)
+          ? {
+              _tag: "Present",
+              value: trustedFieldValue(row, aggregate.field),
+            }
+          : missingGroupedAggregateInput,
+    };
+    return {
+      kind: "field",
+      alias,
+      aggregate,
+      input,
+      resultSemantics,
+      stateIndex,
+    };
+  });
+
+const missingGroupedAggregateInput: GroupedAggregateInput = {
+  _tag: "Missing",
+};
 
 const groupedFieldOrderColumn = (
   field: string,
   direction: "asc" | "desc",
+  semantics: SchemaValueSemantics,
 ): CompiledGroupedOrderBy => ({
+  compare: semantics.compare,
   direction,
   groupValue: (group) => trustedFieldValue(group.row, field),
   rowValue: (entry) => trustedFieldValue(entry.row, field),
 });
 
 const groupedAggregateOrderColumn = (
-  aggregate: string,
+  aggregatePlan: GroupedAggregatePlan,
   direction: "asc" | "desc",
 ): CompiledGroupedOrderBy => ({
+  compare: aggregatePlan.resultSemantics.compare,
   direction,
-  groupValue: (group) => aggregateStateCompareValue(group.aggregates[aggregate]!),
-  rowValue: (entry) => trustedFieldValue(entry.row, aggregate),
+  groupValue: (group) => groupAggregateStateCompareValue(group, aggregatePlan.stateIndex),
+  rowValue: (entry) => trustedFieldValue(entry.row, aggregatePlan.alias),
 });
 
 const compileGroupedOrderBy = (
   orderBy: ReadonlyArray<RuntimeGroupedOrderBy>,
+  valueSemantics: TopicRowValueSemantics,
+  aggregatePlans: ReadonlyArray<GroupedAggregatePlan>,
 ): ReadonlyArray<CompiledGroupedOrderBy> =>
   orderBy.map((order) =>
     "field" in order
-      ? groupedFieldOrderColumn(order.field, order.direction)
-      : groupedAggregateOrderColumn(order.aggregate, order.direction),
+      ? groupedFieldOrderColumn(order.field, order.direction, valueSemantics.field(order.field))
+      : groupedAggregateOrderColumn(
+          Option.getOrThrow(
+            Option.fromNullishOr(
+              aggregatePlans.find((aggregatePlan) => aggregatePlan.alias === order.aggregate),
+            ),
+          ),
+          order.direction,
+        ),
   );
 
 export const makeGroupedQueryPlan = <Row extends RowObject>(
   query: GroupedQueryPlanInput,
+  valueSemantics: TopicRowValueSemantics,
+  rawPredicateCacheKey: string,
 ): GroupedQueryPlan<Row> => {
   const groupBy = [...query.groupBy];
-  const keyFields = compileGroupedKeyFields<Row>(groupBy);
+  const groupedKeyIdentity = compileGroupedKeyIdentity<Row>(
+    compileGroupedKeyFields(valueSemantics, groupBy),
+    "throw",
+  );
+  const aggregatePlans = compileGroupedAggregates(valueSemantics, query.aggregates);
   const orderBy = query.orderBy === undefined ? [] : [...query.orderBy];
   return {
     query,
-    cacheKey: groupedQueryPlanCacheKey(query),
+    cacheKey: groupedQueryPlanCacheKey(query, rawPredicateCacheKey),
     groupBy,
     aggregates: query.aggregates,
-    aggregatePlans: compileGroupedAggregates(query.aggregates),
+    aggregatePlans,
     orderBy,
-    compiledOrderBy: compileGroupedOrderBy(orderBy),
+    compiledOrderBy: compileGroupedOrderBy(orderBy, valueSemantics, aggregatePlans),
     offset: query.offset ?? 0,
     limit: query.limit,
+    resultSemantics: groupedQueryResultSemantics(valueSemantics, groupBy, aggregatePlans),
     zeroLimit: query.limit === 0,
-    groupKey: (row) => groupedQueryPlanGroupKey(keyFields, row),
+    groupKey: groupedKeyIdentity.key,
   };
 };

--- a/packages/column-live-view-engine/src/grouped-snapshots.test.ts
+++ b/packages/column-live-view-engine/src/grouped-snapshots.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { defineViewServerConfig, type GroupedQuery } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
-import { createColumnLiveViewEngine, InvalidQueryError } from "./index";
+import { createColumnLiveViewEngine, InvalidQueryError, InvalidRowError } from "./index";
 import { makeEngine, order, position } from "../test-harness/public-engine";
 import { normalizeDecimalAndBigIntFields, normalizeDecimalFields } from "../test-harness/rows";
 
@@ -296,7 +296,7 @@ describe("ColumnLiveViewEngine grouped snapshots", () => {
     }),
   );
 
-  it.effect("keeps non-plain object grouped keys distinct by stable value", () =>
+  it.effect("rejects non-JSON grouped keys and groups plain records by value", () =>
     Effect.gen(function* () {
       const Payload = Schema.Struct({
         id: Schema.String,
@@ -313,10 +313,22 @@ describe("ColumnLiveViewEngine grouped snapshots", () => {
       const payloadEngine = yield* createColumnLiveViewEngine({
         topics: payloadViewServer.topics,
       });
+      const mapError = yield* Effect.flip(
+        payloadEngine.publish("payloads", {
+          id: "map-a-1",
+          payload: new Map([["venue", "xnys"]]),
+        }),
+      );
+      expect(mapError).toBeInstanceOf(InvalidRowError);
+      expect(mapError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "payloads",
+      });
+
       yield* payloadEngine.publishMany("payloads", [
-        { id: "map-a-1", payload: new Map([["venue", "xnys"]]) },
-        { id: "map-b", payload: new Map([["venue", "xlon"]]) },
-        { id: "map-a-2", payload: new Map([["venue", "xnys"]]) },
+        { id: "record-a-1", payload: { venue: "xnys" } },
+        { id: "record-b", payload: { venue: "xlon" } },
+        { id: "record-a-2", payload: { venue: "xnys" } },
       ]);
 
       const snapshot = yield* payloadEngine.snapshot("payloads", {
@@ -330,11 +342,11 @@ describe("ColumnLiveViewEngine grouped snapshots", () => {
       expect(snapshot.totalRows).toBe(2);
       expect(snapshot.rows).toStrictEqual([
         {
-          payload: new Map([["venue", "xnys"]]),
+          payload: { venue: "xnys" },
           rowCount: 2n,
         },
         {
-          payload: new Map([["venue", "xlon"]]),
+          payload: { venue: "xlon" },
           rowCount: 1n,
         },
       ]);

--- a/packages/column-live-view-engine/src/grouped-window-evaluation.ts
+++ b/packages/column-live-view-engine/src/grouped-window-evaluation.ts
@@ -1,6 +1,5 @@
 import { finalizeGroup, type GroupState } from "./grouped-aggregate-state";
 import type { CompiledGroupedOrderBy, GroupedQueryPlan } from "./grouped-query-plan";
-import { compareQueryValue } from "./raw-query-compiler";
 import type { QueryEvaluation, StoredRowOf } from "./query-result";
 
 type RowObject = object;
@@ -19,7 +18,7 @@ const compareGroupedRows = (
   orderBy: ReadonlyArray<CompiledGroupedOrderBy>,
 ): number => {
   for (const order of orderBy) {
-    const comparison = compareQueryValue(order.rowValue(left), order.rowValue(right));
+    const comparison = order.compare(order.rowValue(left), order.rowValue(right));
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
@@ -75,7 +74,7 @@ const compareBoundedGroupEntries = (
 ): number => {
   for (let index = 0; index < orderBy.length; index += 1) {
     const order = orderBy[index]!;
-    const comparison = compareQueryValue(left.orderValues[index], right.orderValues[index]);
+    const comparison = order.compare(left.orderValues[index], right.orderValues[index]);
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }
@@ -91,7 +90,7 @@ const compareGroupToBoundedGroupEntry = (
 ): number => {
   for (let index = 0; index < orderBy.length; index += 1) {
     const order = orderBy[index]!;
-    const comparison = compareQueryValue(orderValues[index], right.orderValues[index]);
+    const comparison = order.compare(orderValues[index], right.orderValues[index]);
     if (comparison !== 0) {
       return order.direction === "asc" ? comparison : -comparison;
     }

--- a/packages/column-live-view-engine/src/index.test-d.ts
+++ b/packages/column-live-view-engine/src/index.test-d.ts
@@ -19,7 +19,9 @@ import type {
   ColumnLiveViewSubscription,
   ColumnLiveViewTopicHealth,
   EngineClosedError,
+  InvalidRowError,
 } from "./index";
+import { createColumnLiveViewEngine } from "./index";
 import type { TopicStore } from "./topic-store";
 
 const Order = Schema.Struct({
@@ -62,6 +64,13 @@ declare const optionalNarrowFieldsQuery: {
 };
 
 describe("ColumnLiveViewEngine type contract", () => {
+  it("types engine construction success and initialization errors", () => {
+    const created = createColumnLiveViewEngine({ topics: viewServer.topics });
+
+    expectTypeOf<Effect.Success<typeof created>>().toEqualTypeOf<Engine>();
+    expectTypeOf<Effect.Error<typeof created>>().toEqualTypeOf<InvalidRowError>();
+  });
+
   it("requires explicit selected-row snapshots and subscription events", () => {
     const idSnapshot = engine.snapshot("orders", { select: ["id"] });
     expectTypeOf<EffectSuccess<typeof idSnapshot>>().toEqualTypeOf<

--- a/packages/column-live-view-engine/src/number-zero-semantics.test.ts
+++ b/packages/column-live-view-engine/src/number-zero-semantics.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import {
+  applyDelta,
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+  stateFromSnapshot,
+} from "../test-harness/events";
+import { createColumnLiveViewEngine } from "./index";
+
+const NumberRow = Schema.Struct({
+  id: Schema.String,
+  value: Schema.Number,
+});
+
+const numberViewServer = defineViewServerConfig({
+  topics: {
+    numberRows: {
+      schema: NumberRow,
+      key: "id",
+    },
+  },
+});
+
+const orderedIdQuery = {
+  select: ["id"],
+  orderBy: [{ field: "id", direction: "asc" }],
+} satisfies {
+  readonly select: readonly ["id"];
+  readonly orderBy: readonly [{ readonly field: "id"; readonly direction: "asc" }];
+};
+
+const makeNumberEngine = () =>
+  createColumnLiveViewEngine({
+    topics: numberViewServer.topics,
+  });
+
+describe("ColumnLiveViewEngine Schema.Number zero semantics", () => {
+  it.effect("normalizes positive and negative zero across indexed eq, neq, and in snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeNumberEngine();
+      yield* engine.publishMany("numberRows", [
+        { id: "negative-zero", value: -0 },
+        { id: "non-zero", value: 1 },
+        { id: "positive-zero", value: 0 },
+      ]);
+
+      const positiveEq = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { eq: 0 } },
+      });
+      const negativeEq = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { eq: -0 } },
+      });
+      const positiveNeq = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { neq: 0 } },
+      });
+      const negativeNeq = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { neq: -0 } },
+      });
+      const positiveIn = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { in: [0] } },
+      });
+      const negativeIn = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { in: [-0] } },
+      });
+
+      const zeroSnapshot = {
+        rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+        totalRows: 2,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      };
+      const nonZeroSnapshot = {
+        rows: [{ id: "non-zero" }],
+        totalRows: 1,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      };
+
+      expect({
+        positiveEq,
+        negativeEq,
+        positiveNeq,
+        negativeNeq,
+        positiveIn,
+        negativeIn,
+      }).toStrictEqual({
+        positiveEq: zeroSnapshot,
+        negativeEq: zeroSnapshot,
+        positiveNeq: nonZeroSnapshot,
+        negativeNeq: nonZeroSnapshot,
+        positiveIn: zeroSnapshot,
+        negativeIn: zeroSnapshot,
+      });
+
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("treats sign-only zero replacements as no-ops and keeps live views converged", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeNumberEngine();
+      yield* engine.publishMany("numberRows", [
+        { id: "negative-zero", value: -0 },
+        { id: "non-zero", value: 1 },
+        { id: "positive-zero", value: 0 },
+      ]);
+
+      const inSubscription = yield* engine.subscribe("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { in: [-0] } },
+      });
+      const readIn = yield* makeEventReader(inSubscription);
+      const inInitial = firstEvent(yield* readIn(1));
+      expectSnapshotEvent(inInitial);
+      let inState = stateFromSnapshot(inInitial);
+
+      expect(inInitial).toStrictEqual({
+        type: "snapshot",
+        topic: "numberRows",
+        queryId: inInitial.queryId,
+        version: 1,
+        keys: ["negative-zero", "positive-zero"],
+        rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+        totalRows: 2,
+      });
+
+      yield* engine.publishMany("numberRows", [
+        { id: "negative-zero", value: 0 },
+        { id: "positive-zero", value: -0 },
+      ]);
+
+      const afterSignOnlyReplacement = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { in: [0] } },
+      });
+      const noOpHealth = yield* engine.health();
+      expect(afterSignOnlyReplacement).toStrictEqual({
+        rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+        totalRows: 2,
+        version: 1,
+        status: "ready",
+        statusCode: "Ready",
+      });
+      expect({
+        version: noOpHealth.version,
+        queuedEvents: noOpHealth.queuedEvents,
+      }).toStrictEqual({
+        version: 1,
+        queuedEvents: 0,
+      });
+
+      yield* engine.publish("numberRows", { id: "positive-zero", value: 2 });
+      const inRemoved = firstEvent(yield* readIn(1));
+      expectDeltaEvent(inRemoved);
+      expect(inRemoved).toStrictEqual({
+        type: "delta",
+        topic: "numberRows",
+        queryId: inInitial.queryId,
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "remove", key: "positive-zero" }],
+        totalRows: 1,
+      });
+      inState = applyDelta(inState, inRemoved);
+
+      const equalAfterChange = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { eq: 0 } },
+      });
+      const notEqualAfterChange = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { neq: -0 } },
+      });
+      const inAfterChange = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { in: [0] } },
+      });
+      expect(inState).toStrictEqual({
+        keys: ["negative-zero"],
+        rows: inAfterChange.rows,
+      });
+      expect({ equalAfterChange, notEqualAfterChange, inAfterChange }).toStrictEqual({
+        equalAfterChange: {
+          rows: [{ id: "negative-zero" }],
+          totalRows: 1,
+          version: 2,
+          status: "ready",
+          statusCode: "Ready",
+        },
+        notEqualAfterChange: {
+          rows: [{ id: "non-zero" }, { id: "positive-zero" }],
+          totalRows: 2,
+          version: 2,
+          status: "ready",
+          statusCode: "Ready",
+        },
+        inAfterChange: {
+          rows: [{ id: "negative-zero" }],
+          totalRows: 1,
+          version: 2,
+          status: "ready",
+          statusCode: "Ready",
+        },
+      });
+
+      yield* engine.publish("numberRows", { id: "positive-zero", value: -0 });
+      const inInserted = firstEvent(yield* readIn(1));
+      expectDeltaEvent(inInserted);
+      expect(inInserted).toStrictEqual({
+        type: "delta",
+        topic: "numberRows",
+        queryId: inInitial.queryId,
+        fromVersion: 2,
+        toVersion: 3,
+        operations: [
+          {
+            type: "insert",
+            key: "positive-zero",
+            row: { id: "positive-zero" },
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+      });
+      inState = applyDelta(inState, inInserted);
+
+      const restoredPositiveEq = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { eq: 0 } },
+      });
+      const restoredNegativeEq = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { eq: -0 } },
+      });
+      expect({ inState, restoredPositiveEq, restoredNegativeEq }).toStrictEqual({
+        inState: {
+          keys: ["negative-zero", "positive-zero"],
+          rows: restoredPositiveEq.rows,
+        },
+        restoredPositiveEq: {
+          rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+          totalRows: 2,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+        },
+        restoredNegativeEq: {
+          rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+          totalRows: 2,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+        },
+      });
+
+      yield* engine.publish("numberRows", { id: "positive-zero", value: 0 });
+      const finalEqual = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { eq: -0 } },
+      });
+      const finalNotEqual = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { neq: 0 } },
+      });
+      const finalIn = yield* engine.snapshot("numberRows", {
+        ...orderedIdQuery,
+        where: { value: { in: [-0] } },
+      });
+      const finalHealth = yield* engine.health();
+      expect(inState).toStrictEqual({
+        keys: ["negative-zero", "positive-zero"],
+        rows: finalIn.rows,
+      });
+      expect({ finalEqual, finalNotEqual, finalIn }).toStrictEqual({
+        finalEqual: {
+          rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+          totalRows: 2,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+        },
+        finalNotEqual: {
+          rows: [{ id: "non-zero" }],
+          totalRows: 1,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+        },
+        finalIn: {
+          rows: [{ id: "negative-zero" }, { id: "positive-zero" }],
+          totalRows: 2,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+        },
+      });
+      expect({
+        version: finalHealth.version,
+        queuedEvents: finalHealth.queuedEvents,
+      }).toStrictEqual({
+        version: 3,
+        queuedEvents: 0,
+      });
+
+      yield* inSubscription.close();
+      yield* engine.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/number-zero-semantics.test.ts
+++ b/packages/column-live-view-engine/src/number-zero-semantics.test.ts
@@ -39,6 +39,30 @@ const makeNumberEngine = () =>
   });
 
 describe("ColumnLiveViewEngine Schema.Number zero semantics", () => {
+  it.effect("canonicalizes selected negative zero in one-shot and subscription snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeNumberEngine();
+      yield* engine.publish("numberRows", { id: "negative-zero", value: -0 });
+
+      const query = {
+        select: ["id", "value"],
+      } as const;
+      const oneShot = yield* engine.snapshot("numberRows", query);
+      const subscription = yield* engine.subscribe("numberRows", query);
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+
+      expect(oneShot.rows).toStrictEqual([{ id: "negative-zero", value: 0 }]);
+      expect(initial.rows).toStrictEqual([{ id: "negative-zero", value: 0 }]);
+      expect(Object.is(oneShot.rows[0]?.value, -0)).toBe(false);
+      expect(Object.is(initial.rows[0]?.value, -0)).toBe(false);
+
+      yield* subscription.close();
+      yield* engine.close();
+    }),
+  );
+
   it.effect("normalizes positive and negative zero across indexed eq, neq, and in snapshots", () =>
     Effect.gen(function* () {
       const engine = yield* makeNumberEngine();

--- a/packages/column-live-view-engine/src/optional-undefined-presence-semantics.test.ts
+++ b/packages/column-live-view-engine/src/optional-undefined-presence-semantics.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, type GroupedQuery } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import {
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+} from "../test-harness/events";
+import { createColumnLiveViewEngine } from "./index";
+import { createColumnLiveViewEngineInternal } from "./internal";
+
+const OptionalUndefinedRow = Schema.Struct({
+  id: Schema.String,
+  desk: Schema.optionalKey(Schema.Union([Schema.String, Schema.Undefined])),
+});
+
+type OptionalUndefinedRow = typeof OptionalUndefinedRow.Type;
+
+const optionalUndefinedViewServer = defineViewServerConfig({
+  topics: {
+    optionalUndefinedRows: {
+      schema: OptionalUndefinedRow,
+      key: "id",
+    },
+  },
+});
+
+const groupedByOptionalUndefined = {
+  groupBy: ["desk"],
+  aggregates: {
+    rowCount: { aggFunc: "count" },
+  },
+  orderBy: [{ field: "desk", direction: "asc" }],
+} satisfies GroupedQuery<OptionalUndefinedRow>;
+
+describe("ColumnLiveViewEngine optional undefined presence semantics", () => {
+  it.effect("preserves missing versus present undefined across publish and patch", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({
+        topics: optionalUndefinedViewServer.topics,
+      });
+      yield* engine.publishMany("optionalUndefinedRows", [{ id: "one" }, { id: "two" }]);
+
+      const subscription = yield* engine.subscribe(
+        "optionalUndefinedRows",
+        groupedByOptionalUndefined,
+      );
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+      expect(initial).toStrictEqual({
+        type: "snapshot",
+        topic: "optionalUndefinedRows",
+        queryId: initial.queryId,
+        version: 1,
+        keys: ['[["desk","[\\"missing\\"]"]]'],
+        rows: [{ rowCount: 2n }],
+        totalRows: 1,
+      });
+
+      yield* engine.publish("optionalUndefinedRows", {
+        id: "one",
+        desk: undefined,
+      });
+      const published = firstEvent(yield* read(1));
+      expectDeltaEvent(published);
+      expect(published).toStrictEqual({
+        type: "delta",
+        topic: "optionalUndefinedRows",
+        queryId: initial.queryId,
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          {
+            type: "update",
+            key: '[["desk","[\\"missing\\"]"]]',
+            row: { rowCount: 1n },
+            index: 0,
+          },
+          {
+            type: "insert",
+            key: '[["desk","[\\"present\\",\\"null\\"]"]]',
+            row: { desk: undefined, rowCount: 1n },
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+      });
+
+      const afterPublish = yield* engine.snapshot("optionalUndefinedRows", {
+        select: ["id", "desk"],
+        orderBy: [{ field: "id", direction: "asc" }],
+      });
+      expect(afterPublish.rows).toStrictEqual([{ id: "one", desk: undefined }, { id: "two" }]);
+      expect(Object.keys(afterPublish.rows[0] ?? {})).toStrictEqual(["id", "desk"]);
+      expect(Object.keys(afterPublish.rows[1] ?? {})).toStrictEqual(["id"]);
+
+      yield* engine.patch("optionalUndefinedRows", "two", { desk: undefined });
+      const patched = firstEvent(yield* read(1));
+      expectDeltaEvent(patched);
+      expect(patched).toStrictEqual({
+        type: "delta",
+        topic: "optionalUndefinedRows",
+        queryId: initial.queryId,
+        fromVersion: 2,
+        toVersion: 3,
+        operations: [
+          {
+            type: "remove",
+            key: '[["desk","[\\"missing\\"]"]]',
+          },
+          {
+            type: "update",
+            key: '[["desk","[\\"present\\",\\"null\\"]"]]',
+            row: { desk: undefined, rowCount: 2n },
+            index: 0,
+          },
+        ],
+        totalRows: 1,
+      });
+
+      const afterPatch = yield* engine.snapshot("optionalUndefinedRows", {
+        select: ["id", "desk"],
+        orderBy: [{ field: "id", direction: "asc" }],
+      });
+      expect(afterPatch.rows).toStrictEqual([
+        { id: "one", desk: undefined },
+        { id: "two", desk: undefined },
+      ]);
+      expect(Object.keys(afterPatch.rows[0] ?? {})).toStrictEqual(["id", "desk"]);
+      expect(Object.keys(afterPatch.rows[1] ?? {})).toStrictEqual(["id", "desk"]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("preserves presence through decoded patches and reverse replacements", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: optionalUndefinedViewServer.topics,
+      });
+      yield* engine.publishManyDecodedRows("optionalUndefinedRows", [
+        { id: "one", desk: undefined },
+        { id: "two" },
+      ]);
+
+      yield* engine.patchDecodedFields("optionalUndefinedRows", "two", { desk: undefined });
+      let snapshot = yield* engine.snapshot("optionalUndefinedRows", {
+        select: ["id", "desk"],
+        orderBy: [{ field: "id", direction: "asc" }],
+      });
+      expect(snapshot.version).toBe(2);
+      expect(snapshot.rows).toStrictEqual([
+        { id: "one", desk: undefined },
+        { id: "two", desk: undefined },
+      ]);
+      expect(Object.keys(snapshot.rows[0] ?? {})).toStrictEqual(["id", "desk"]);
+      expect(Object.keys(snapshot.rows[1] ?? {})).toStrictEqual(["id", "desk"]);
+
+      yield* engine.publishManyDecodedRows("optionalUndefinedRows", [{ id: "one" }]);
+      snapshot = yield* engine.snapshot("optionalUndefinedRows", {
+        select: ["id", "desk"],
+        orderBy: [{ field: "id", direction: "asc" }],
+      });
+      expect(snapshot.version).toBe(3);
+      expect(snapshot.rows).toStrictEqual([{ id: "one" }, { id: "two", desk: undefined }]);
+      expect(Object.keys(snapshot.rows[0] ?? {})).toStrictEqual(["id"]);
+      expect(Object.keys(snapshot.rows[1] ?? {})).toStrictEqual(["id", "desk"]);
+      yield* engine.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/public-decoded-mutation-boundary.test.ts
+++ b/packages/column-live-view-engine/src/public-decoded-mutation-boundary.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import { InvalidRowError } from "./index";
+import { createColumnLiveViewEngineInternal } from "./internal";
+
+const TransformedRow = Schema.Struct({
+  id: Schema.String,
+  amount: Schema.BigIntFromString,
+  uriPart: Schema.StringFromUriComponent,
+});
+
+class RootClassTransformedRow extends Schema.Class<RootClassTransformedRow>(
+  "RootClassTransformedRow",
+)({
+  id: Schema.String,
+  amount: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(RootClassTransformedRow);
+
+const transformedViewServer = defineViewServerConfig({
+  topics: {
+    rows: {
+      schema: TransformedRow,
+      key: "id",
+    },
+  },
+});
+
+const rootClassViewServer = defineViewServerConfig({
+  topics: {
+    rows: {
+      schema: RootClassTransformedRow,
+      key: "id",
+    },
+  },
+});
+
+describe("public decoded mutation boundary", () => {
+  it.effect(
+    "accepts decoded values across public row, batch, patch, and storage-key mutations",
+    () =>
+      Effect.gen(function* () {
+        const engine = yield* createColumnLiveViewEngineInternal({
+          topics: transformedViewServer.topics,
+        });
+
+        yield* engine.publish("rows", { id: "published", amount: 1n, uriPart: "%25" });
+        yield* engine.publishMany("rows", [{ id: "batch", amount: 2n, uriPart: "batch" }]);
+        yield* engine.patch("rows", "published", { amount: 3n });
+        yield* engine.publishManyWithStorageKeys("rows", [
+          {
+            storageKey: "storage-key",
+            row: { id: "external", amount: 4n, uriPart: "external" },
+          },
+        ]);
+
+        const snapshot = yield* engine.snapshot("rows", {
+          select: ["id", "amount", "uriPart"],
+          orderBy: [{ field: "id", direction: "asc" }],
+          limit: 10,
+        });
+
+        expect(snapshot).toStrictEqual({
+          rows: [
+            { id: "batch", amount: 2n, uriPart: "batch" },
+            { id: "external", amount: 4n, uriPart: "external" },
+            { id: "published", amount: 3n, uriPart: "%25" },
+          ],
+          status: "ready",
+          statusCode: "Ready",
+          totalRows: 3,
+          version: 4,
+        });
+        yield* engine.close();
+      }),
+  );
+
+  it.effect("rejects encoded values across every decoded-typed public mutation", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: transformedViewServer.topics,
+      });
+      yield* engine.publish("rows", { id: "stable", amount: 1n, uriPart: "stable" });
+
+      const publishError = yield* Effect.flip(
+        // @ts-expect-error public mutations accept the decoded bigint, not its wire encoding
+        engine.publish("rows", { id: "published", amount: "10", uriPart: "published" }),
+      );
+      const batchError = yield* Effect.flip(
+        engine.publishMany("rows", [
+          // @ts-expect-error public mutations accept the decoded bigint, not its wire encoding
+          { id: "batch", amount: "20", uriPart: "batch" },
+        ]),
+      );
+      const patchError = yield* Effect.flip(
+        // @ts-expect-error public patches accept the decoded bigint, not its wire encoding
+        engine.patch("rows", "stable", { amount: "30" }),
+      );
+      const storageKeyError = yield* Effect.flip(
+        engine.publishManyWithStorageKeys("rows", [
+          {
+            storageKey: "storage-key",
+            // @ts-expect-error storage-key mutations accept the decoded bigint, not its wire encoding
+            row: { id: "external", amount: "40", uriPart: "external" },
+          },
+        ]),
+      );
+      const snapshot = yield* engine.snapshot("rows", {
+        select: ["id", "amount", "uriPart"],
+        limit: 10,
+      });
+
+      expect(publishError).toBeInstanceOf(InvalidRowError);
+      expect(batchError).toBeInstanceOf(InvalidRowError);
+      expect(patchError).toBeInstanceOf(InvalidRowError);
+      expect(storageKeyError).toBeInstanceOf(InvalidRowError);
+      expect({ publishError, batchError, patchError, storageKeyError, snapshot }).toStrictEqual({
+        publishError: InvalidRowError.make({
+          topic: "rows",
+          message: 'SchemaError(Expected bigint, got "10"\n  at ["amount"])',
+        }),
+        batchError: InvalidRowError.make({
+          topic: "rows",
+          message: 'SchemaError(Expected bigint, got "20"\n  at ["amount"])',
+        }),
+        patchError: InvalidRowError.make({
+          topic: "rows",
+          message: 'SchemaError(Expected bigint, got "30"\n  at ["amount"])',
+        }),
+        storageKeyError: InvalidRowError.make({
+          topic: "rows",
+          message: 'SchemaError(Expected bigint, got "40"\n  at ["amount"])',
+        }),
+        snapshot: {
+          rows: [{ id: "stable", amount: 1n, uriPart: "stable" }],
+          status: "ready",
+          statusCode: "Ready",
+          totalRows: 1,
+          version: 1,
+        },
+      });
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("accepts plain decoded fields for admitted root Class topic schemas", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: rootClassViewServer.topics,
+      });
+
+      yield* engine.publish("rows", { id: "public", amount: 1n });
+      yield* engine.publishManyWithStorageKeys("rows", [
+        {
+          storageKey: "external-storage-key",
+          row: { id: "external", amount: 2n },
+        },
+      ]);
+      const snapshot = yield* engine.snapshot("rows", {
+        select: ["id", "amount"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [
+          { id: "external", amount: 2n },
+          { id: "public", amount: 1n },
+        ],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 2,
+        version: 2,
+      });
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("rejects a stateful row accessor without reading it", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: rootClassViewServer.topics,
+      });
+      let accessorReads = 0;
+      const row = {
+        id: "stateful",
+        get amount() {
+          accessorReads += 1;
+          return accessorReads === 1 ? 1n : 2n;
+        },
+      };
+
+      const error = yield* Effect.flip(engine.publish("rows", row));
+      const snapshot = yield* engine.snapshot("rows", {
+        select: ["id", "amount"],
+        limit: 10,
+      });
+
+      expect(accessorReads).toBe(0);
+      expect(error).toStrictEqual(
+        InvalidRowError.make({
+          topic: "rows",
+          message: "DecodedRowSnapshotError: Decoded row field must be a data property: amount.",
+        }),
+      );
+      expect(snapshot).toStrictEqual({
+        rows: [],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 0,
+        version: 0,
+      });
+      yield* engine.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/query-delta-operations.bench.ts
+++ b/packages/column-live-view-engine/src/query-delta-operations.bench.ts
@@ -1,12 +1,15 @@
 // Import Vitest directly so @effect/vitest's eager test-runtime module graph does not
 // distort the heap, JIT, and GC behavior this benchmark is measuring.
 import { afterAll, bench, describe, expect } from "vitest";
+import { Schema } from "effect";
 import {
   benchmarkOutputJsonPath,
   memorySnapshot,
   writeBenchmarkArtifact,
 } from "./benchmark-artifact";
 import { deltaOperations, type QueryEvaluation } from "./query-result";
+import { makeQueryResultSemantics } from "./query-result-semantics";
+import { makeSchemaValueSemantics } from "./topic-row-value-semantics";
 import type { DeltaOperation } from "@effect-view-server/config";
 
 declare const process: {
@@ -17,6 +20,11 @@ type Row = {
   readonly id: string;
   readonly score: number;
 };
+
+const benchmarkResultSemantics = makeQueryResultSemantics([
+  { field: "id", semantics: makeSchemaValueSemantics(Schema.String) },
+  { field: "score", semantics: makeSchemaValueSemantics(Schema.Number) },
+]);
 
 type DeltaOperationCaseName =
   | "head-replacement-batch"
@@ -225,10 +233,14 @@ const validateCase = (operations: ReturnType<typeof deltaOperations<Row>>): void
   expect(operations).toStrictEqual(benchmarkCase.expectedOperations);
 };
 
-validateCase(deltaOperations(benchmarkCase.previous, benchmarkCase.next));
+validateCase(deltaOperations(benchmarkCase.previous, benchmarkCase.next, benchmarkResultSemantics));
 
 const runCase = (): void => {
-  const operations = deltaOperations(benchmarkCase.previous, benchmarkCase.next);
+  const operations = deltaOperations(
+    benchmarkCase.previous,
+    benchmarkCase.next,
+    benchmarkResultSemantics,
+  );
   expect(operations.length).toBe(benchmarkCase.expectedOperationCount);
 };
 

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -64,7 +64,10 @@ export const evaluateExecutableQuery = <ResultRow extends RowObject>(
 export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.snapshot")(
   function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
     const executable = yield* prepareExecutableQuery<ResultRow>(store, query);
-    return liveQueryResult(evaluateExecutableQuery(store, executable));
+    return liveQueryResult(
+      evaluateExecutableQuery(store, executable),
+      executable.compiled.plan.resultSemantics,
+    );
   },
 );
 

--- a/packages/column-live-view-engine/src/query-execution.ts
+++ b/packages/column-live-view-engine/src/query-execution.ts
@@ -4,7 +4,7 @@ import { makeLiveSubscription } from "./live-subscription";
 import type { CompiledGroupedQuery } from "./grouped-query-compiler";
 import type { GroupedIncrementalAdmissionLimits } from "./grouped-incremental-admission";
 import type { CompiledRawQuery } from "./raw-query-compiler";
-import { liveQueryResult, type QueryEvaluation } from "./query-result";
+import { liveQueryResultFromOwnedEvaluation, type QueryEvaluation } from "./query-result";
 import {
   acquireTopicStoreMaterializedQueryExecution,
   acquireTopicStoreRawQueryExecution,
@@ -64,7 +64,7 @@ export const evaluateExecutableQuery = <ResultRow extends RowObject>(
 export const snapshotExecutableQuery = Effect.fn("ColumnLiveViewEngine.queryExecution.snapshot")(
   function* <ResultRow extends RowObject>(store: TopicStore, query: unknown) {
     const executable = yield* prepareExecutableQuery<ResultRow>(store, query);
-    return liveQueryResult(
+    return liveQueryResultFromOwnedEvaluation(
       evaluateExecutableQuery(store, executable),
       executable.compiled.plan.resultSemantics,
     );

--- a/packages/column-live-view-engine/src/query-result-semantics.test.ts
+++ b/packages/column-live-view-engine/src/query-result-semantics.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+import {
+  groupedResultAggregateSemantics,
+  makeQueryResultSemantics,
+} from "./query-result-semantics";
+import { makeTopicRowValueSemantics } from "./topic-row-value-semantics";
+
+const OptionalNumberRow = Schema.Struct({
+  id: Schema.String,
+  value: Schema.optionalKey(Schema.Number),
+});
+
+const topicSemantics = makeTopicRowValueSemantics(OptionalNumberRow);
+const optionalMinimumSemantics = groupedResultAggregateSemantics(topicSemantics, {
+  aggFunc: "min",
+  field: "value",
+});
+
+describe("query result semantics", () => {
+  it("borrows immutable primitives and materializes structured result values", () => {
+    const structuredSemantics = makeTopicRowValueSemantics(
+      Schema.Struct({ value: Schema.Struct({ count: Schema.Number }) }),
+    ).field("value");
+    const semantics = makeQueryResultSemantics([
+      {
+        field: "value",
+        semantics: structuredSemantics,
+      },
+    ]);
+    const structured = { count: 1 };
+
+    for (const value of [null, undefined, "immutable", 1, 1n, true]) {
+      const primitiveResult = semantics.materializeRow({ value });
+      expect(Reflect.get(primitiveResult, "value")).toBe(value);
+    }
+    const result = semantics.materializeRow({ value: structured });
+    expect(result).toStrictEqual({ value: structured });
+    expect(Reflect.get(result, "value")).not.toBe(structured);
+  });
+
+  it("keeps an undefined min/max result outside the optional field codec", () => {
+    expect(optionalMinimumSemantics.materialize(undefined)).toBeUndefined();
+    expect(optionalMinimumSemantics.materialize(1)).toBe(1);
+    expect(optionalMinimumSemantics.decodeEncoded(undefined)).toBeUndefined();
+    expect(optionalMinimumSemantics.decodeEncoded(1)).toBe(1);
+
+    expect(optionalMinimumSemantics.equivalent(undefined, undefined)).toBe(true);
+    expect(optionalMinimumSemantics.equivalent(undefined, 1)).toBe(false);
+    expect(optionalMinimumSemantics.equivalent(1, undefined)).toBe(false);
+    expect(optionalMinimumSemantics.equivalent(1, 1)).toBe(true);
+
+    expect(optionalMinimumSemantics.compare(undefined, undefined)).toBe(0);
+    expect(optionalMinimumSemantics.compare(undefined, 1)).toBe(-1);
+    expect(optionalMinimumSemantics.compare(1, undefined)).toBe(1);
+    expect(optionalMinimumSemantics.compare(1, 2)).toBe(-1);
+
+    expect(optionalMinimumSemantics.canonicalKey(undefined)).toBe("undefined:");
+    expect(optionalMinimumSemantics.canonicalKey(1)).toBe(
+      `value:${topicSemantics.field("value").canonicalKey(1)}`,
+    );
+  });
+});

--- a/packages/column-live-view-engine/src/query-result-semantics.ts
+++ b/packages/column-live-view-engine/src/query-result-semantics.ts
@@ -1,0 +1,175 @@
+import { Schema } from "effect";
+import {
+  makeSchemaValueSemantics,
+  type SchemaValueSemantics,
+  type TopicRowValueSemantics,
+} from "./topic-row-value-semantics";
+
+type RowObject = object;
+
+export type QueryResultFieldSemantics = {
+  readonly field: string;
+  readonly semantics: SchemaValueSemantics;
+};
+
+export type QueryResultSemantics = {
+  readonly equivalentRows: (left: RowObject, right: RowObject) => boolean;
+  readonly materializeRow: <Row extends RowObject>(row: Row) => Row;
+  readonly projectRow: (row: RowObject) => RowObject;
+};
+
+const defineResultField = (row: Record<string, unknown>, field: string, value: unknown): void => {
+  Object.defineProperty(row, field, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const hasEnumerableField = (row: RowObject, field: string): boolean =>
+  Object.prototype.propertyIsEnumerable.call(row, field);
+
+const borrowValue = (_semantics: SchemaValueSemantics, value: unknown): unknown => value;
+
+const isBorrowableImmutablePrimitive = (value: unknown): boolean =>
+  value === null ||
+  value === undefined ||
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "bigint" ||
+  typeof value === "boolean";
+
+const materializeValue = (semantics: SchemaValueSemantics, value: unknown): unknown =>
+  isBorrowableImmutablePrimitive(value) ? value : semantics.materialize(value);
+
+export const makeQueryResultSemantics = (
+  fields: ReadonlyArray<QueryResultFieldSemantics>,
+): QueryResultSemantics => {
+  const projectRow = (
+    row: RowObject,
+    projectValue: (semantics: SchemaValueSemantics, value: unknown) => unknown,
+  ): RowObject => {
+    const projected: Record<string, unknown> = {};
+    for (const { field, semantics } of fields) {
+      if (hasEnumerableField(row, field)) {
+        defineResultField(projected, field, projectValue(semantics, Reflect.get(row, field)));
+      }
+    }
+    return projected;
+  };
+
+  function materializeRow<Row extends RowObject>(row: Row): Row;
+  function materializeRow(row: RowObject): RowObject {
+    return projectRow(row, materializeValue);
+  }
+
+  return {
+    equivalentRows: (left, right) => {
+      for (const { field, semantics } of fields) {
+        const leftHasField = hasEnumerableField(left, field);
+        if (leftHasField !== hasEnumerableField(right, field)) {
+          return false;
+        }
+        if (
+          leftHasField &&
+          !semantics.equivalent(Reflect.get(left, field), Reflect.get(right, field))
+        ) {
+          return false;
+        }
+      }
+      return true;
+    },
+    materializeRow,
+    projectRow: (row) => projectRow(row, borrowValue),
+  };
+};
+
+export const rawQueryResultSemantics = (
+  topicRow: TopicRowValueSemantics,
+  selectedFields: ReadonlyArray<string>,
+): QueryResultSemantics =>
+  makeQueryResultSemantics(
+    selectedFields.map((field) => ({
+      field,
+      semantics: topicRow.field(field),
+    })),
+  );
+
+const countSemantics = makeSchemaValueSemantics(Schema.BigInt);
+const bigDecimalSemantics = makeSchemaValueSemantics(Schema.BigDecimal);
+
+export type GroupedResultAggregate =
+  | {
+      readonly aggFunc: "count";
+    }
+  | {
+      readonly aggFunc: "countDistinct" | "min" | "max" | "avg";
+      readonly field: string;
+    }
+  | {
+      readonly aggFunc: "sum";
+      readonly field: string;
+      readonly resultKind: "bigint" | "bigDecimal";
+    };
+
+export type GroupedResultFieldSemantics = {
+  readonly alias: string;
+  readonly resultSemantics: SchemaValueSemantics;
+};
+
+const allowUndefinedResultValueSemantics = (
+  semantics: SchemaValueSemantics,
+): SchemaValueSemantics => ({
+  canonicalKey: (value) =>
+    value === undefined ? "undefined:" : `value:${semantics.canonicalKey(value)}`,
+  compare: (left, right) => {
+    if (left === undefined) {
+      return right === undefined ? 0 : -1;
+    }
+    if (right === undefined) {
+      return 1;
+    }
+    return semantics.compare(left, right);
+  },
+  decodeEncoded: (value) => (value === undefined ? undefined : semantics.decodeEncoded(value)),
+  equivalent: (left, right) => {
+    if (left === undefined) {
+      return right === undefined;
+    }
+    return right !== undefined && semantics.equivalent(left, right);
+  },
+  materialize: (value) => (value === undefined ? undefined : semantics.materialize(value)),
+});
+
+export const groupedResultAggregateSemantics = (
+  topicRow: TopicRowValueSemantics,
+  aggregate: GroupedResultAggregate,
+): SchemaValueSemantics => {
+  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
+    return countSemantics;
+  }
+  if (aggregate.aggFunc === "avg") {
+    return bigDecimalSemantics;
+  }
+  if (aggregate.aggFunc === "sum") {
+    return aggregate.resultKind === "bigint" ? countSemantics : bigDecimalSemantics;
+  }
+  return allowUndefinedResultValueSemantics(topicRow.field(aggregate.field));
+};
+
+export const groupedQueryResultSemantics = (
+  topicRow: TopicRowValueSemantics,
+  groupBy: ReadonlyArray<string>,
+  aggregateFields: ReadonlyArray<GroupedResultFieldSemantics>,
+): QueryResultSemantics =>
+  makeQueryResultSemantics([
+    ...groupBy.map((field) => ({
+      field,
+      semantics: topicRow.field(field),
+    })),
+    ...aggregateFields.map(({ alias, resultSemantics }) => ({
+      field: alias,
+      semantics: resultSemantics,
+    })),
+  ]);

--- a/packages/column-live-view-engine/src/query-result-semantics.ts
+++ b/packages/column-live-view-engine/src/query-result-semantics.ts
@@ -14,6 +14,7 @@ export type QueryResultFieldSemantics = {
 
 export type QueryResultSemantics = {
   readonly equivalentRows: (left: RowObject, right: RowObject) => boolean;
+  readonly materializeOwnedRow: <Row extends RowObject>(row: Row) => Row;
   readonly materializeRow: <Row extends RowObject>(row: Row) => Row;
   readonly projectRow: (row: RowObject) => RowObject;
 };
@@ -36,7 +37,7 @@ const isBorrowableImmutablePrimitive = (value: unknown): boolean =>
   value === null ||
   value === undefined ||
   typeof value === "string" ||
-  typeof value === "number" ||
+  (typeof value === "number" && !Object.is(value, -0)) ||
   typeof value === "bigint" ||
   typeof value === "boolean";
 
@@ -64,6 +65,26 @@ export const makeQueryResultSemantics = (
     return projectRow(row, materializeValue);
   }
 
+  function materializeOwnedRow<Row extends RowObject>(row: Row): Row;
+  function materializeOwnedRow(row: RowObject): RowObject {
+    for (const { field, semantics } of fields) {
+      if (!hasEnumerableField(row, field)) {
+        continue;
+      }
+      const value = Reflect.get(row, field);
+      if (isBorrowableImmutablePrimitive(value)) {
+        continue;
+      }
+      Object.defineProperty(row, field, {
+        configurable: true,
+        enumerable: true,
+        value: semantics.materialize(value),
+        writable: true,
+      });
+    }
+    return row;
+  }
+
   return {
     equivalentRows: (left, right) => {
       for (const { field, semantics } of fields) {
@@ -80,6 +101,7 @@ export const makeQueryResultSemantics = (
       }
       return true;
     },
+    materializeOwnedRow,
     materializeRow,
     projectRow: (row) => projectRow(row, borrowValue),
   };

--- a/packages/column-live-view-engine/src/query-result.test.ts
+++ b/packages/column-live-view-engine/src/query-result.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from "@effect/vitest";
-import { deltaOperations, type QueryEvaluation } from "./query-result";
+import { describe, expect, expectTypeOf, it } from "@effect/vitest";
+import { Schema } from "effect";
+import { deltaOperations, liveQueryResult, type QueryEvaluation } from "./query-result";
+import { makeQueryResultSemantics } from "./query-result-semantics";
+import { makeSchemaValueSemantics } from "./topic-row-value-semantics";
 
 type TestRow = {
   readonly id: string;
   readonly value: number;
 };
+
+const testResultSemantics = makeQueryResultSemantics([
+  { field: "id", semantics: makeSchemaValueSemantics(Schema.String) },
+  { field: "value", semantics: makeSchemaValueSemantics(Schema.Number) },
+]);
 
 const evaluation = (rows: ReadonlyArray<TestRow>, version: number): QueryEvaluation<TestRow> => ({
   rows,
@@ -17,7 +25,26 @@ const evaluation = (rows: ReadonlyArray<TestRow>, version: number): QueryEvaluat
   version,
 });
 
-describe("query result delta operations", () => {
+describe("query results", () => {
+  it("materializes the typed result through configured fields without reflecting unrelated keys", () => {
+    const row = { id: "row-1", value: 1 };
+    let unrelatedReads = 0;
+    Object.defineProperty(row, "unselected", {
+      enumerable: true,
+      get() {
+        unrelatedReads += 1;
+        throw new Error("unselected result fields must not be read");
+      },
+    });
+
+    const result = liveQueryResult(evaluation([row], 1), testResultSemantics);
+
+    expectTypeOf(result.rows).toEqualTypeOf<ReadonlyArray<TestRow>>();
+    expect(result.rows).toStrictEqual([{ id: "row-1", value: 1 }]);
+    expect(Object.is(result.rows[0], row)).toBe(false);
+    expect(unrelatedReads).toBe(0);
+  });
+
   it("uses batched replacement operations when shared rows stay stable", () => {
     const previous = evaluation(
       [
@@ -42,7 +69,7 @@ describe("query result delta operations", () => {
       2,
     );
 
-    const operations = deltaOperations(previous, next);
+    const operations = deltaOperations(previous, next, testResultSemantics);
 
     expect(operations).toStrictEqual([
       { type: "remove", key: "old-1" },
@@ -74,7 +101,7 @@ describe("query result delta operations", () => {
       2,
     );
 
-    const operations = deltaOperations(previous, next);
+    const operations = deltaOperations(previous, next, testResultSemantics);
 
     expect(operations).toStrictEqual([
       { type: "remove", key: "old-1" },
@@ -108,7 +135,7 @@ describe("query result delta operations", () => {
       2,
     );
 
-    const operations = deltaOperations(previous, next);
+    const operations = deltaOperations(previous, next, testResultSemantics);
 
     expect(operations).toStrictEqual([
       { type: "remove", key: "old-1" },
@@ -147,7 +174,7 @@ describe("query result delta operations", () => {
       2,
     );
 
-    const operations = deltaOperations(previous, next);
+    const operations = deltaOperations(previous, next, testResultSemantics);
 
     expect(operations).toStrictEqual([
       { type: "remove", key: "old-1" },
@@ -174,8 +201,16 @@ describe("query result delta operations", () => {
     const updateOnlyPrevious = evaluation([{ id: "keep-1", value: 2 }], 3);
     const updateOnlyNext = evaluation([{ id: "keep-1", value: 20 }], 4);
 
-    const deleteOperations = deltaOperations(deleteOnlyPrevious, deleteOnlyNext);
-    const updateOperations = deltaOperations(updateOnlyPrevious, updateOnlyNext);
+    const deleteOperations = deltaOperations(
+      deleteOnlyPrevious,
+      deleteOnlyNext,
+      testResultSemantics,
+    );
+    const updateOperations = deltaOperations(
+      updateOnlyPrevious,
+      updateOnlyNext,
+      testResultSemantics,
+    );
 
     expect(deleteOperations).toStrictEqual([{ type: "remove", key: "old-1" }]);
     expect(updateOperations).toStrictEqual([

--- a/packages/column-live-view-engine/src/query-result.ts
+++ b/packages/column-live-view-engine/src/query-result.ts
@@ -4,7 +4,7 @@ import type {
   LiveQueryResult,
   SnapshotEvent,
 } from "@effect-view-server/config";
-import { cloneRow, rowsEqual } from "./row-values";
+import type { QueryResultSemantics } from "./query-result-semantics";
 
 type RowObject = object;
 
@@ -23,8 +23,9 @@ export type QueryEvaluation<ResultRow extends RowObject> = {
 
 export const liveQueryResult = <Row extends RowObject>(
   evaluation: QueryEvaluation<Row>,
+  semantics: QueryResultSemantics,
 ): LiveQueryResult<Row> => ({
-  rows: evaluation.rows,
+  rows: evaluation.rows.map((row) => semantics.materializeRow(row)),
   totalRows: evaluation.totalRows,
   version: evaluation.version,
   status: "ready",
@@ -35,13 +36,14 @@ export const snapshotEvent = <Row extends RowObject>(
   store: { readonly topic: string },
   queryId: string,
   evaluation: QueryEvaluation<Row>,
+  semantics: QueryResultSemantics,
 ): SnapshotEvent<Row> => ({
   type: "snapshot",
   topic: store.topic,
   queryId,
   version: evaluation.version,
   keys: [...evaluation.keys],
-  rows: evaluation.rows.map(cloneRow),
+  rows: evaluation.rows.map((row) => semantics.materializeRow(row)),
   totalRows: evaluation.totalRows,
 });
 
@@ -64,6 +66,7 @@ type SingleMovedKey = {
 const singleMovedKey = (
   previous: QueryEvaluation<RowObject>,
   next: QueryEvaluation<RowObject>,
+  semantics: QueryResultSemantics,
 ): SingleMovedKey | undefined => {
   const previousKeys = previous.keys;
   const nextKeys = next.keys;
@@ -131,11 +134,11 @@ const singleMovedKey = (
     return movedDown;
   }
 
-  const movedDownRowChanged = !rowsEqual(
+  const movedDownRowChanged = !semantics.equivalentRows(
     previous.rows[movedDown.fromIndex]!,
     next.rows[movedDown.toIndex]!,
   );
-  const movedUpRowChanged = !rowsEqual(
+  const movedUpRowChanged = !semantics.equivalentRows(
     previous.rows[movedUp.fromIndex]!,
     next.rows[movedUp.toIndex]!,
   );
@@ -145,8 +148,9 @@ const singleMovedKey = (
 const singleMoveDeltaOperations = <Row extends RowObject>(
   previous: QueryEvaluation<Row>,
   next: QueryEvaluation<Row>,
+  semantics: QueryResultSemantics,
 ): ReadonlyArray<DeltaOperation<Row>> | undefined => {
-  const moved = singleMovedKey(previous, next);
+  const moved = singleMovedKey(previous, next, semantics);
   if (moved === undefined) {
     return undefined;
   }
@@ -165,7 +169,7 @@ const singleMoveDeltaOperations = <Row extends RowObject>(
   movedRows.splice(moved.toIndex, 0, ...movedRow);
   for (const [index, { key, row }] of next.window.entries()) {
     const currentRow = movedRows[index];
-    if (currentRow === undefined || !rowsEqual(currentRow, row)) {
+    if (currentRow === undefined || !semantics.equivalentRows(currentRow, row)) {
       operations.push({
         type: "update",
         key,
@@ -183,6 +187,7 @@ const replacementDeltaOperations = <Row extends RowObject>(
   previous: QueryEvaluation<Row>,
   next: QueryEvaluation<Row>,
   nextKeys: ReadonlySet<string>,
+  semantics: QueryResultSemantics,
 ): ReadonlyArray<DeltaOperation<Row>> | undefined => {
   const previousKeys = previous.keys;
   const nextWindow = next.window;
@@ -228,7 +233,7 @@ const replacementDeltaOperations = <Row extends RowObject>(
     }
 
     const previousRow = previous.rows[previousSharedIndex];
-    if (previousRow === undefined || !rowsEqual(previousRow, row)) {
+    if (previousRow === undefined || !semantics.equivalentRows(previousRow, row)) {
       return undefined;
     }
     previousSharedIndex += 1;
@@ -259,15 +264,16 @@ const replacementDeltaOperations = <Row extends RowObject>(
 export const deltaOperations = <Row extends RowObject>(
   previous: QueryEvaluation<Row>,
   next: QueryEvaluation<Row>,
+  semantics: QueryResultSemantics,
 ): ReadonlyArray<DeltaOperation<Row>> => {
-  const singleMoveOperations = singleMoveDeltaOperations(previous, next);
+  const singleMoveOperations = singleMoveDeltaOperations(previous, next, semantics);
   if (singleMoveOperations !== undefined) {
     return singleMoveOperations;
   }
 
   const operations: Array<DeltaOperation<Row>> = [];
   const nextKeys = new Set(next.keys);
-  const replacementOperations = replacementDeltaOperations(previous, next, nextKeys);
+  const replacementOperations = replacementDeltaOperations(previous, next, nextKeys, semantics);
   if (replacementOperations !== undefined) {
     return replacementOperations;
   }
@@ -320,7 +326,7 @@ export const deltaOperations = <Row extends RowObject>(
     }
 
     const currentRow = currentRows[index];
-    if (currentRow === undefined || !rowsEqual(currentRow, row)) {
+    if (currentRow === undefined || !semantics.equivalentRows(currentRow, row)) {
       currentRows[index] = row;
       operations.push({
         type: "update",
@@ -334,14 +340,15 @@ export const deltaOperations = <Row extends RowObject>(
   return operations;
 };
 
-const cloneDeltaOperations = <Row extends RowObject>(
+const materializeDeltaOperations = <Row extends RowObject>(
   operations: ReadonlyArray<DeltaOperation<Row>>,
+  semantics: QueryResultSemantics,
 ): ReadonlyArray<DeltaOperation<Row>> =>
   operations.map((operation) => {
     if (operation.type === "insert" || operation.type === "update") {
       return {
         ...operation,
-        row: cloneRow(operation.row),
+        row: semantics.materializeRow(operation.row),
       };
     }
     return operation;
@@ -353,12 +360,13 @@ export const deltaEvent = <Row extends RowObject>(
   fromVersion: number,
   next: QueryEvaluation<Row>,
   operations: ReadonlyArray<DeltaOperation<Row>>,
+  semantics: QueryResultSemantics,
 ): DeltaEvent<Row> => ({
   type: "delta",
   topic: store.topic,
   queryId,
   fromVersion,
   toVersion: next.version,
-  operations: cloneDeltaOperations(operations),
+  operations: materializeDeltaOperations(operations, semantics),
   totalRows: next.totalRows,
 });

--- a/packages/column-live-view-engine/src/query-result.ts
+++ b/packages/column-live-view-engine/src/query-result.ts
@@ -32,6 +32,17 @@ export const liveQueryResult = <Row extends RowObject>(
   statusCode: "Ready",
 });
 
+export const liveQueryResultFromOwnedEvaluation = <Row extends RowObject>(
+  evaluation: QueryEvaluation<Row>,
+  semantics: QueryResultSemantics,
+): LiveQueryResult<Row> => ({
+  rows: evaluation.rows.map((row) => semantics.materializeOwnedRow(row)),
+  totalRows: evaluation.totalRows,
+  version: evaluation.version,
+  status: "ready",
+  statusCode: "Ready",
+});
+
 export const snapshotEvent = <Row extends RowObject>(
   store: { readonly topic: string },
   queryId: string,

--- a/packages/column-live-view-engine/src/raw-predicate-compiler.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-compiler.ts
@@ -1,38 +1,18 @@
 import { isBigDecimal } from "effect/BigDecimal";
 import { compareFilterValue } from "./query-value";
 import { isDenseArray, type RuntimeRawQuery } from "./raw-query-decoder";
-import {
-  isOperatorFilterObject,
-  predicateFilterPlans,
-  type TopicRawPredicatePlan,
-} from "./raw-predicate-plan";
+import { isOperatorFilterObject } from "./raw-query-filter";
+import { compileSchemaEquality } from "./raw-query-value-semantics";
+import { predicateFilterPlans, type TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
-import { isPlainRecord, trustedFieldValue, valuesEqual } from "./row-values";
+import { isPlainRecord, trustedFieldValue } from "./row-values";
+import type { SchemaValueSemantics } from "./topic-row-value-semantics";
 
 type RowObject = object;
 
 export type CompiledRawPredicate<Row extends RowObject> = {
   readonly plan: TopicRawPredicatePlan;
   readonly matches: (row: Row) => boolean;
-};
-
-const isEqualityComparable = (left: unknown, right: unknown): boolean => {
-  if (isBigDecimal(left) || isBigDecimal(right)) {
-    return isBigDecimal(left) && isBigDecimal(right);
-  }
-  if (typeof left === "number" || typeof right === "number") {
-    return typeof left === "number" && typeof right === "number" && Number.isFinite(right);
-  }
-  return typeof left === typeof right;
-};
-
-const includesValue = (values: ReadonlyArray<unknown>, value: unknown): boolean => {
-  for (const candidate of values) {
-    if (valuesEqual(value, candidate)) {
-      return true;
-    }
-  }
-  return false;
 };
 
 type CompiledRawPredicateClause = {
@@ -50,7 +30,9 @@ const isStructuredQueryValue = (value: unknown): boolean =>
 
 const compileStructuredFilterMatcher = (
   filter: Readonly<Record<string, unknown>>,
+  semantics: SchemaValueSemantics,
 ): ((value: unknown) => boolean) => {
+  const literalMatcher = compileSchemaEquality(semantics, filter);
   const oneOf = filter["in"];
   const oneOfMatcher =
     oneOf === undefined
@@ -58,22 +40,34 @@ const compileStructuredFilterMatcher = (
       : Array.isArray(oneOf) &&
           isDenseArray(oneOf) &&
           !oneOf.some((candidate) => candidate === undefined)
-        ? (value: unknown) => includesValue(oneOf, value)
+        ? (() => {
+            const candidates = oneOf.map((candidate) =>
+              compileSchemaEquality(semantics, candidate),
+            );
+            return candidates.every((candidate) => candidate.valid)
+              ? (value: unknown) => candidates.some((candidate) => candidate.matches(value))
+              : () => false;
+          })()
         : () => false;
   const eq = filter["eq"];
   const neq = filter["neq"];
+  const eqMatcher = eq === undefined ? undefined : compileSchemaEquality(semantics, eq);
+  const neqMatcher = neq === undefined ? undefined : compileSchemaEquality(semantics, neq);
 
   return (value) => {
-    if (valuesEqual(value, filter)) {
+    if (literalMatcher.valid && literalMatcher.matches(value)) {
       return true;
+    }
+    if (eqMatcher?.valid === false || neqMatcher?.valid === false) {
+      return false;
     }
     if (oneOfMatcher !== undefined && !oneOfMatcher(value)) {
       return false;
     }
-    if (eq !== undefined && !valuesEqual(value, eq)) {
+    if (eqMatcher !== undefined && !eqMatcher.matches(value)) {
       return false;
     }
-    if (neq !== undefined && valuesEqual(value, neq)) {
+    if (neqMatcher !== undefined && neqMatcher.matches(value)) {
       return false;
     }
     return eq !== undefined || oneOfMatcher !== undefined || neq !== undefined;
@@ -82,6 +76,7 @@ const compileStructuredFilterMatcher = (
 
 const compileScalarOperatorFilterMatcher = (
   filter: Readonly<Record<string, unknown>>,
+  semantics: SchemaValueSemantics,
 ): ((value: unknown) => boolean) => {
   if (
     ("eq" in filter && filter["eq"] === undefined) ||
@@ -104,23 +99,34 @@ const compileScalarOperatorFilterMatcher = (
   const gte = filter["gte"];
   const lt = filter["lt"];
   const lte = filter["lte"];
+  const eqMatcher = eq === undefined ? undefined : compileSchemaEquality(semantics, eq);
+  const neqMatcher = neq === undefined ? undefined : compileSchemaEquality(semantics, neq);
   const oneOfMatcher =
     oneOf === undefined
       ? undefined
       : Array.isArray(oneOf) &&
           isDenseArray(oneOf) &&
           !oneOf.some((candidate) => candidate === undefined)
-        ? (value: unknown) => includesValue(oneOf, value)
+        ? (() => {
+            const candidates = oneOf.map((candidate) =>
+              compileSchemaEquality(semantics, candidate),
+            );
+            return candidates.every((candidate) => candidate.valid)
+              ? (value: unknown) => candidates.some((candidate) => candidate.matches(value))
+              : () => false;
+          })()
         : () => false;
 
+  if (eqMatcher?.valid === false || neqMatcher?.valid === false) {
+    return () => false;
+  }
+
   return (value) => {
-    if (eq !== undefined && !valuesEqual(value, eq)) {
+    if (eqMatcher !== undefined && !eqMatcher.matches(value)) {
       return false;
     }
-    if (neq !== undefined) {
-      if (!isEqualityComparable(value, neq) || valuesEqual(value, neq)) {
-        return false;
-      }
+    if (neqMatcher !== undefined && neqMatcher.matches(value)) {
+      return false;
     }
     if (oneOfMatcher !== undefined && !oneOfMatcher(value)) {
       return false;
@@ -164,21 +170,25 @@ const compileScalarOperatorFilterMatcher = (
   };
 };
 
-const compileFilterMatcher = (filter: unknown): ((value: unknown) => boolean) => {
+const compileFilterMatcher = (
+  filter: unknown,
+  semantics: SchemaValueSemantics,
+): ((value: unknown) => boolean) => {
   if (filter === undefined) {
     return () => false;
   }
   if (!isPlainRecord(filter) || isBigDecimal(filter)) {
-    return (value) => valuesEqual(value, filter);
+    return compileSchemaEquality(semantics, filter).matches;
   }
 
-  const structuredMatcher = compileStructuredFilterMatcher(filter);
+  const structuredMatcher = compileStructuredFilterMatcher(filter, semantics);
   if (!isOperatorFilterObject(filter)) {
+    const literalMatcher = compileSchemaEquality(semantics, filter);
     return (value) =>
-      isStructuredQueryValue(value) ? structuredMatcher(value) : valuesEqual(value, filter);
+      isStructuredQueryValue(value) ? structuredMatcher(value) : literalMatcher.matches(value);
   }
 
-  const scalarMatcher = compileScalarOperatorFilterMatcher(filter);
+  const scalarMatcher = compileScalarOperatorFilterMatcher(filter, semantics);
   return (value) =>
     isStructuredQueryValue(value) ? structuredMatcher(value) : scalarMatcher(value);
 };
@@ -207,7 +217,7 @@ const compilePredicateParts = (
     callbackRequired ||= fieldPlan.callbackRequired;
     clauses.push({
       field,
-      matches: compileFilterMatcher(filter),
+      matches: compileFilterMatcher(filter, metadata.valueSemantics.field(field)),
     });
   }
   return {

--- a/packages/column-live-view-engine/src/raw-predicate-plan.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-plan.ts
@@ -1,5 +1,5 @@
 import { isBigDecimal } from "effect/BigDecimal";
-import { filterOperatorKeys, isDenseArray } from "./raw-query-decoder";
+import { filterOperatorKeys, isDenseArray } from "./raw-query-filter";
 import type { RangeValueKind, RawQueryCompilerMetadata } from "./raw-query-metadata";
 import { isPlainRecord, scalarEqualityKey, type ScalarEqualityKeyValue } from "./row-values";
 
@@ -38,17 +38,6 @@ export type TopicRawPredicatePlan = {
 export type PredicateFieldPlan = {
   readonly filters: TopicRawPredicatePlan["filters"];
   readonly callbackRequired: boolean;
-};
-
-type FilterObject = {
-  readonly eq?: unknown;
-  readonly neq?: unknown;
-  readonly in?: ReadonlyArray<unknown>;
-  readonly gt?: unknown;
-  readonly gte?: unknown;
-  readonly lt?: unknown;
-  readonly lte?: unknown;
-  readonly startsWith?: string;
 };
 
 const rangeValueKind = (value: unknown): RangeValueKind | undefined => {
@@ -115,17 +104,16 @@ const scalarEqualityKeys = (values: ReadonlyArray<ScalarEqualityKeyValue>): Read
   return keys;
 };
 
-export const isOperatorFilterObject = (filter: Record<string, unknown>): filter is FilterObject => {
-  const keys = Object.keys(filter);
-  return keys.length > 0 && keys.every((key) => filterOperatorKeys.has(key));
-};
-
 export const predicateFilterPlans = (
   field: string,
   filter: unknown,
   metadata: RawQueryCompilerMetadata,
 ): PredicateFieldPlan => {
-  if (metadata.structuredFieldNames.has(field) || filter === undefined) {
+  if (
+    metadata.structuredFieldNames.has(field) ||
+    !metadata.exactScalarEqualityFieldNames.has(field) ||
+    filter === undefined
+  ) {
     return {
       filters: [],
       callbackRequired: true,

--- a/packages/column-live-view-engine/src/raw-predicate-value-semantics.test.ts
+++ b/packages/column-live-view-engine/src/raw-predicate-value-semantics.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import { createColumnLiveViewEngine } from "./index";
+import {
+  applyDelta,
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+  stateFromSnapshot,
+} from "../test-harness/events";
+
+class Profile extends Schema.Class<Profile>("Profile")({
+  code: Schema.String,
+  aliases: Schema.mutable(Schema.Array(Schema.String)),
+}) {}
+viewSchema.admitClass(Profile);
+
+const ProfileRow = Schema.Struct({
+  id: Schema.String,
+  profile: Profile,
+});
+
+type ProfileRow = typeof ProfileRow.Type;
+
+const profileViewServer = defineViewServerConfig({
+  topics: {
+    profileRows: {
+      schema: ProfileRow,
+      key: "id",
+    },
+  },
+});
+
+const profile = (code: string): Profile =>
+  Profile.make({
+    code,
+    aliases: [`${code}-alias`],
+  });
+
+const profileRow = (id: string, code: string): ProfileRow => ({
+  id,
+  profile: profile(code),
+});
+
+const makeProfileEngine = () =>
+  createColumnLiveViewEngine({
+    topics: profileViewServer.topics,
+  });
+
+describe("Raw predicate field value semantics", () => {
+  it.effect("matches decoded Schema.Class operands and rejects encoded objects", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeProfileEngine();
+      yield* engine.publishMany("profileRows", [
+        profileRow("alpha", "alpha"),
+        profileRow("beta", "beta"),
+      ]);
+
+      const literal = yield* engine.snapshot("profileRows", {
+        select: ["id"],
+        where: { profile: profile("alpha") },
+      });
+      const plainLiteral = yield* Effect.flip(
+        engine.snapshot("profileRows", {
+          select: ["id"],
+          where: {
+            profile: {
+              code: "alpha",
+              aliases: ["alpha-alias"],
+            },
+          },
+        }),
+      );
+      const equal = yield* engine.snapshot("profileRows", {
+        select: ["id"],
+        where: { profile: { eq: profile("alpha") } },
+      });
+      const plainEqual = yield* Effect.flip(
+        engine.snapshot("profileRows", {
+          select: ["id"],
+          where: {
+            profile: {
+              eq: {
+                code: "alpha",
+                aliases: ["alpha-alias"],
+              },
+            },
+          },
+        }),
+      );
+      const notEqual = yield* engine.snapshot("profileRows", {
+        select: ["id"],
+        where: { profile: { neq: profile("alpha") } },
+      });
+      const oneOf = yield* engine.snapshot("profileRows", {
+        select: ["id"],
+        where: { profile: { in: [profile("alpha")] } },
+      });
+      const plainOneOf = yield* Effect.flip(
+        engine.snapshot("profileRows", {
+          select: ["id"],
+          where: {
+            profile: {
+              in: [
+                {
+                  code: "alpha",
+                  aliases: ["alpha-alias"],
+                },
+              ],
+            },
+          },
+        }),
+      );
+      const invalidPlainLiteral = yield* Effect.flip(
+        engine.subscribeRuntime("profileRows", {
+          select: ["id"],
+          where: {
+            profile: {
+              code: 1,
+              aliases: ["alpha-alias"],
+            },
+          },
+        }),
+      );
+
+      expect({
+        literal: literal.rows,
+        equal: equal.rows,
+        notEqual: notEqual.rows,
+        oneOf: oneOf.rows,
+      }).toStrictEqual({
+        literal: [{ id: "alpha" }],
+        equal: [{ id: "alpha" }],
+        notEqual: [{ id: "beta" }],
+        oneOf: [{ id: "alpha" }],
+      });
+      expect(plainLiteral._tag).toBe("InvalidQueryError");
+      expect(plainEqual._tag).toBe("InvalidQueryError");
+      expect(plainOneOf._tag).toBe("InvalidQueryError");
+      expect(plainLiteral.message).toBe(
+        "Raw query where field profile does not satisfy its configured schema.",
+      );
+      expect(plainEqual.message).toBe(
+        "Raw query where field profile does not satisfy its configured schema.",
+      );
+      expect(plainOneOf.message).toBe(
+        "Raw query where field profile does not satisfy its configured schema.",
+      );
+      expect(invalidPlainLiteral._tag).toBe("InvalidQueryError");
+      expect(invalidPlainLiteral.message).toBe(
+        "Raw query where field profile does not satisfy its configured schema.",
+      );
+    }),
+  );
+
+  it.effect("keeps active Schema.Class predicates correct across row changes", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeProfileEngine();
+      yield* engine.publishMany("profileRows", [
+        profileRow("alpha", "alpha"),
+        profileRow("beta", "beta"),
+      ]);
+
+      const subscription = yield* engine.subscribe("profileRows", {
+        select: ["id"],
+        where: { profile: { eq: profile("alpha") } },
+      });
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+      let state = stateFromSnapshot(initial);
+      expect(state.rows).toStrictEqual([{ id: "alpha" }]);
+
+      yield* engine.publish("profileRows", profileRow("gamma", "alpha"));
+      const inserted = firstEvent(yield* read(1));
+      expectDeltaEvent(inserted);
+      state = applyDelta(state, inserted);
+      expect(state.rows).toStrictEqual([{ id: "alpha" }, { id: "gamma" }]);
+
+      yield* engine.publish("profileRows", profileRow("alpha", "beta"));
+      const removed = firstEvent(yield* read(1));
+      expectDeltaEvent(removed);
+      state = applyDelta(state, removed);
+      expect(state.rows).toStrictEqual([{ id: "gamma" }]);
+
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("does not share active executions across distinct Schema.Class predicates", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeProfileEngine();
+      yield* engine.publishMany("profileRows", [
+        profileRow("alpha", "alpha"),
+        profileRow("beta", "beta"),
+      ]);
+
+      const alphaSubscription = yield* engine.subscribe("profileRows", {
+        select: ["id"],
+        where: { profile: { eq: profile("alpha") } },
+      });
+      const betaSubscription = yield* engine.subscribe("profileRows", {
+        select: ["id"],
+        where: { profile: { eq: profile("beta") } },
+      });
+      const readAlpha = yield* makeEventReader(alphaSubscription);
+      const readBeta = yield* makeEventReader(betaSubscription);
+      const alphaSnapshot = firstEvent(yield* readAlpha(1));
+      const betaSnapshot = firstEvent(yield* readBeta(1));
+      expectSnapshotEvent(alphaSnapshot);
+      expectSnapshotEvent(betaSnapshot);
+
+      expect({ alpha: alphaSnapshot.rows, beta: betaSnapshot.rows }).toStrictEqual({
+        alpha: [{ id: "alpha" }],
+        beta: [{ id: "beta" }],
+      });
+
+      yield* alphaSubscription.close();
+      yield* betaSubscription.close();
+    }),
+  );
+
+  it.effect("does not share grouped executions across distinct Schema.Class predicates", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeProfileEngine();
+      yield* engine.publishMany("profileRows", [
+        profileRow("alpha", "alpha"),
+        profileRow("beta", "beta"),
+      ]);
+
+      const alphaSubscription = yield* engine.subscribe("profileRows", {
+        groupBy: ["id"],
+        aggregates: { count: { aggFunc: "count" } },
+        where: { profile: { eq: profile("alpha") } },
+      });
+      const betaSubscription = yield* engine.subscribe("profileRows", {
+        groupBy: ["id"],
+        aggregates: { count: { aggFunc: "count" } },
+        where: { profile: { eq: profile("beta") } },
+      });
+      const readAlpha = yield* makeEventReader(alphaSubscription);
+      const readBeta = yield* makeEventReader(betaSubscription);
+      const alphaSnapshot = firstEvent(yield* readAlpha(1));
+      const betaSnapshot = firstEvent(yield* readBeta(1));
+      expectSnapshotEvent(alphaSnapshot);
+      expectSnapshotEvent(betaSnapshot);
+
+      expect({ alpha: alphaSnapshot.rows, beta: betaSnapshot.rows }).toStrictEqual({
+        alpha: [{ id: "alpha", count: 1n }],
+        beta: [{ id: "beta", count: 1n }],
+      });
+
+      yield* alphaSubscription.close();
+      yield* betaSubscription.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/raw-projection-semantics.test.ts
+++ b/packages/column-live-view-engine/src/raw-projection-semantics.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { BigDecimal, Chunk, Effect, HashMap, HashSet, Option, Schema } from "effect";
+import { createColumnLiveViewEngine } from "./index";
+import {
+  applyDelta,
+  expectDefined,
+  expectDeltaEvent,
+  expectSnapshotEvent,
+  firstEvent,
+  makeEventReader,
+  stateFromSnapshot,
+} from "../test-harness/events";
+
+class Profile extends Schema.Class<Profile>("Profile")({
+  code: Schema.String,
+  aliases: Schema.mutable(Schema.Array(Schema.String)),
+}) {}
+viewSchema.admitClass(Profile);
+
+const SemanticRow = Schema.Struct({
+  id: Schema.String,
+  profile: Profile,
+  backupProfile: viewSchema.Option(Profile),
+  tags: viewSchema.Chunk(Schema.String),
+  labels: viewSchema.HashSet(Schema.String),
+  assignments: viewSchema.HashMap(Schema.String, Schema.BigInt),
+  price: Schema.BigDecimal,
+  note: Schema.optionalKey(Schema.String),
+  requiredMaybe: Schema.Union([Schema.String, Schema.Undefined]),
+});
+
+type SemanticRow = typeof SemanticRow.Type;
+
+const semanticViewServer = defineViewServerConfig({
+  topics: {
+    semanticRows: {
+      schema: SemanticRow,
+      key: "id",
+    },
+  },
+});
+
+const semanticQuery = {
+  select: [
+    "id",
+    "profile",
+    "backupProfile",
+    "tags",
+    "labels",
+    "assignments",
+    "price",
+    "note",
+    "requiredMaybe",
+  ],
+  orderBy: [{ field: "id", direction: "asc" }],
+} satisfies {
+  readonly select: readonly [
+    "id",
+    "profile",
+    "backupProfile",
+    "tags",
+    "labels",
+    "assignments",
+    "price",
+    "note",
+    "requiredMaybe",
+  ];
+  readonly orderBy: readonly [{ readonly field: "id"; readonly direction: "asc" }];
+};
+
+const semanticOrderQuery = {
+  select: ["id", "profile"],
+  orderBy: [{ field: "profile", direction: "asc" }],
+} satisfies {
+  readonly select: readonly ["id", "profile"];
+  readonly orderBy: readonly [{ readonly field: "profile"; readonly direction: "asc" }];
+};
+
+const semanticRow = (id: string, revision: number): SemanticRow => ({
+  id,
+  profile: Profile.make({
+    code: `profile-${revision}`,
+    aliases: [`alias-${revision}`],
+  }),
+  backupProfile: Option.some(
+    Profile.make({
+      code: `backup-${revision}`,
+      aliases: [`backup-alias-${revision}`],
+    }),
+  ),
+  tags: Chunk.make(`tag-${revision}`, "shared"),
+  labels: HashSet.make(`label-${revision}`, "shared"),
+  assignments: HashMap.make(["desk", BigInt(revision)]),
+  price: BigDecimal.fromStringUnsafe(`${revision}.25`),
+  requiredMaybe: undefined,
+});
+
+const semanticallyOrderedRow = (id: string, profileCode: string): SemanticRow => ({
+  ...semanticRow(id, 1),
+  profile: Profile.make({
+    code: profileCode,
+    aliases: [],
+  }),
+});
+
+const semanticOrderProjection = (
+  rows: ReadonlyArray<{ readonly id: string; readonly profile: Profile }>,
+): ReadonlyArray<{ readonly id: string; readonly profileCode: string }> =>
+  rows.map((row) => ({
+    id: row.id,
+    profileCode: row.profile.code,
+  }));
+
+const expectSemanticProjection = (
+  row: SemanticRow | undefined,
+  id: string,
+  revision: number,
+): SemanticRow => {
+  const projected = expectDefined(row);
+  expect(projected.profile).toBeInstanceOf(Profile);
+  expect(Option.isSome(projected.backupProfile)).toBe(true);
+  expect(Option.getOrThrow(projected.backupProfile)).toBeInstanceOf(Profile);
+  expect(Chunk.isChunk(projected.tags)).toBe(true);
+  expect(HashSet.isHashSet(projected.labels)).toBe(true);
+  expect(HashMap.isHashMap(projected.assignments)).toBe(true);
+  expect(BigDecimal.isBigDecimal(projected.price)).toBe(true);
+  expect({
+    id: projected.id,
+    profile: {
+      code: projected.profile.code,
+      aliases: projected.profile.aliases,
+    },
+    backupProfile: {
+      code: Option.getOrThrow(projected.backupProfile).code,
+      aliases: Option.getOrThrow(projected.backupProfile).aliases,
+    },
+    tags: Array.from(projected.tags),
+    labels: Array.from(projected.labels).toSorted(),
+    assignments: HashMap.toEntries(projected.assignments),
+    price: BigDecimal.format(projected.price),
+    requiredMaybe: projected.requiredMaybe,
+  }).toStrictEqual({
+    id,
+    profile: {
+      code: `profile-${revision}`,
+      aliases: [`alias-${revision}`],
+    },
+    backupProfile: {
+      code: `backup-${revision}`,
+      aliases: [`backup-alias-${revision}`],
+    },
+    tags: [`tag-${revision}`, "shared"],
+    labels: [`label-${revision}`, "shared"].toSorted(),
+    assignments: [["desk", BigInt(revision)]],
+    price: `${revision}.25`,
+    requiredMaybe: undefined,
+  });
+  expect(Object.hasOwn(projected, "note")).toBe(false);
+  expect(Object.prototype.propertyIsEnumerable.call(projected, "note")).toBe(false);
+  expect(Object.hasOwn(projected, "requiredMaybe")).toBe(true);
+  expect(Object.prototype.propertyIsEnumerable.call(projected, "requiredMaybe")).toBe(true);
+  return projected;
+};
+
+const makeSemanticEngine = () =>
+  createColumnLiveViewEngine({
+    topics: semanticViewServer.topics,
+  });
+
+describe("ColumnLiveViewEngine raw projection value semantics", () => {
+  it.effect("orders raw snapshots and subscription moves by configured structured semantics", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeSemanticEngine();
+      yield* engine.publishMany("semanticRows", [
+        semanticallyOrderedRow("a", "z"),
+        semanticallyOrderedRow("b", "a"),
+      ]);
+
+      const oneShot = yield* engine.snapshot("semanticRows", semanticOrderQuery);
+      expect(semanticOrderProjection(oneShot.rows)).toStrictEqual([
+        { id: "b", profileCode: "a" },
+        { id: "a", profileCode: "z" },
+      ]);
+
+      const subscription = yield* engine.subscribe("semanticRows", semanticOrderQuery);
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+      let state = stateFromSnapshot(initial);
+      expect(semanticOrderProjection(state.rows)).toStrictEqual([
+        { id: "b", profileCode: "a" },
+        { id: "a", profileCode: "z" },
+      ]);
+
+      yield* engine.publish("semanticRows", semanticallyOrderedRow("a", "0"));
+      const moved = firstEvent(yield* read(1));
+      expectDeltaEvent(moved);
+      expect(moved.operations).toStrictEqual([
+        {
+          type: "move",
+          key: "a",
+          fromIndex: 1,
+          toIndex: 0,
+        },
+        {
+          type: "update",
+          key: "a",
+          row: {
+            id: "a",
+            profile: Profile.make({ code: "0", aliases: [] }),
+          },
+          index: 0,
+        },
+      ]);
+      state = applyDelta(state, moved);
+      expect(semanticOrderProjection(state.rows)).toStrictEqual([
+        { id: "a", profileCode: "0" },
+        { id: "b", profileCode: "a" },
+      ]);
+
+      const converged = yield* engine.snapshot("semanticRows", semanticOrderQuery);
+      expect(semanticOrderProjection(converged.rows)).toStrictEqual([
+        { id: "a", profileCode: "0" },
+        { id: "b", profileCode: "a" },
+      ]);
+      yield* subscription.close();
+    }),
+  );
+
+  it.effect("materializes schema values and exact optional presence in one-shot snapshots", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeSemanticEngine();
+      const source = semanticRow("row-1", 1);
+      yield* engine.publish("semanticRows", source);
+
+      const snapshot = yield* engine.snapshot("semanticRows", semanticQuery);
+      const projected = expectSemanticProjection(snapshot.rows[0], "row-1", 1);
+
+      projected.profile.aliases.push("mutated-snapshot");
+      Option.getOrThrow(projected.backupProfile).aliases.push("mutated-backup");
+
+      const fresh = yield* engine.snapshot("semanticRows", semanticQuery);
+      expectSemanticProjection(fresh.rows[0], "row-1", 1);
+      expect(source.profile.aliases).toStrictEqual(["alias-1"]);
+      expect(Option.getOrThrow(source.backupProfile).aliases).toStrictEqual(["backup-alias-1"]);
+    }),
+  );
+
+  it.effect("isolates subscription snapshots plus insert and update delta rows", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeSemanticEngine();
+      yield* engine.publish("semanticRows", semanticRow("row-1", 1));
+
+      const firstSubscription = yield* engine.subscribe("semanticRows", semanticQuery);
+      const secondSubscription = yield* engine.subscribe("semanticRows", semanticQuery);
+      const readFirst = yield* makeEventReader(firstSubscription);
+      const readSecond = yield* makeEventReader(secondSubscription);
+      const firstSnapshot = firstEvent(yield* readFirst(1));
+      const secondSnapshot = firstEvent(yield* readSecond(1));
+      expectSnapshotEvent(firstSnapshot);
+      expectSnapshotEvent(secondSnapshot);
+      let firstState = stateFromSnapshot(firstSnapshot);
+      let secondState = stateFromSnapshot(secondSnapshot);
+
+      const firstInitial = expectSemanticProjection(firstState.rows[0], "row-1", 1);
+      firstInitial.profile.aliases.push("mutated-first-subscriber");
+      expectSemanticProjection(secondState.rows[0], "row-1", 1);
+      expectSemanticProjection(
+        (yield* engine.snapshot("semanticRows", semanticQuery)).rows[0],
+        "row-1",
+        1,
+      );
+
+      yield* engine.publish("semanticRows", semanticRow("row-2", 2));
+      const firstInsert = firstEvent(yield* readFirst(1));
+      expectDeltaEvent(firstInsert);
+      expect(firstInsert.operations.length).toBe(1);
+      expect(firstInsert.operations[0]?.type).toBe("insert");
+      firstState = applyDelta(firstState, firstInsert);
+      const firstInserted = expectSemanticProjection(
+        firstState.rows.find((row) => row.id === "row-2"),
+        "row-2",
+        2,
+      );
+      firstInserted.profile.aliases.push("mutated-insert");
+
+      const secondInsert = firstEvent(yield* readSecond(1));
+      expectDeltaEvent(secondInsert);
+      expect(secondInsert.operations.length).toBe(1);
+      expect(secondInsert.operations[0]?.type).toBe("insert");
+      secondState = applyDelta(secondState, secondInsert);
+      expectSemanticProjection(
+        secondState.rows.find((row) => row.id === "row-2"),
+        "row-2",
+        2,
+      );
+      expectSemanticProjection(
+        (yield* engine.snapshot("semanticRows", semanticQuery)).rows.find(
+          (row) => row.id === "row-2",
+        ),
+        "row-2",
+        2,
+      );
+
+      yield* engine.publish("semanticRows", semanticRow("row-1", 3));
+      const firstUpdate = firstEvent(yield* readFirst(1));
+      expectDeltaEvent(firstUpdate);
+      expect(firstUpdate.operations.length).toBe(1);
+      expect(firstUpdate.operations[0]?.type).toBe("update");
+      firstState = applyDelta(firstState, firstUpdate);
+      const firstUpdated = expectSemanticProjection(
+        firstState.rows.find((row) => row.id === "row-1"),
+        "row-1",
+        3,
+      );
+      firstUpdated.profile.aliases.push("mutated-update");
+
+      const secondUpdate = firstEvent(yield* readSecond(1));
+      expectDeltaEvent(secondUpdate);
+      expect(secondUpdate.operations.length).toBe(1);
+      expect(secondUpdate.operations[0]?.type).toBe("update");
+      secondState = applyDelta(secondState, secondUpdate);
+      expectSemanticProjection(
+        secondState.rows.find((row) => row.id === "row-1"),
+        "row-1",
+        3,
+      );
+      expectSemanticProjection(
+        (yield* engine.snapshot("semanticRows", semanticQuery)).rows.find(
+          (row) => row.id === "row-1",
+        ),
+        "row-1",
+        3,
+      );
+
+      yield* firstSubscription.close();
+      yield* secondSubscription.close();
+    }),
+  );
+
+  it.effect("treats separately instantiated schema-equal rows as no-op publishes", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeSemanticEngine();
+      yield* engine.publish("semanticRows", semanticRow("row-1", 1));
+      const subscription = yield* engine.subscribe("semanticRows", semanticQuery);
+      const read = yield* makeEventReader(subscription);
+      const initial = firstEvent(yield* read(1));
+      expectSnapshotEvent(initial);
+      expect(initial.version).toBe(1);
+
+      yield* engine.publish("semanticRows", semanticRow("row-1", 1));
+
+      const afterEquivalent = yield* engine.snapshot("semanticRows", semanticQuery);
+      const equivalentHealth = yield* engine.health();
+      expect(afterEquivalent.version).toBe(1);
+      expect(equivalentHealth.version).toBe(1);
+      expect(equivalentHealth.queuedEvents).toBe(0);
+
+      yield* engine.publish("semanticRows", semanticRow("row-1", 2));
+      const changed = firstEvent(yield* read(1));
+      expectDeltaEvent(changed);
+      expect(changed.fromVersion).toBe(1);
+      expect(changed.toVersion).toBe(2);
+      expect(changed.operations.length).toBe(1);
+      expect(changed.operations[0]?.type).toBe("update");
+      expectSemanticProjection(
+        (yield* engine.snapshot("semanticRows", semanticQuery)).rows[0],
+        "row-1",
+        2,
+      );
+
+      yield* subscription.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/raw-projection-semantics.test.ts
+++ b/packages/column-live-view-engine/src/raw-projection-semantics.test.ts
@@ -247,6 +247,27 @@ describe("ColumnLiveViewEngine raw projection value semantics", () => {
     }),
   );
 
+  it.effect("does not retain structured publish input references", () =>
+    Effect.gen(function* () {
+      const engine = yield* makeSemanticEngine();
+      const source = semanticRow("row-1", 1);
+      const sourceBackup = Option.getOrThrow(source.backupProfile);
+      yield* engine.publish("semanticRows", source);
+
+      source.profile.aliases.push("mutated-source");
+      sourceBackup.aliases.push("mutated-source-backup");
+
+      const snapshot = yield* engine.snapshot("semanticRows", semanticQuery);
+      const projected = expectSemanticProjection(snapshot.rows[0], "row-1", 1);
+      const projectedBackup = Option.getOrThrow(projected.backupProfile);
+
+      expect(projected.profile === source.profile).toBe(false);
+      expect(projected.profile.aliases === source.profile.aliases).toBe(false);
+      expect(projectedBackup === sourceBackup).toBe(false);
+      expect(projectedBackup.aliases === sourceBackup.aliases).toBe(false);
+    }),
+  );
+
   it.effect("isolates subscription snapshots plus insert and update delta rows", () =>
     Effect.gen(function* () {
       const engine = yield* makeSemanticEngine();

--- a/packages/column-live-view-engine/src/raw-query-compiler-metadata.test.ts
+++ b/packages/column-live-view-engine/src/raw-query-compiler-metadata.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
-import { createColumnLiveViewEngine } from "./index";
+import { createColumnLiveViewEngine, InvalidRowError } from "./index";
 import { rawQueryCompilerMetadata } from "./raw-query-compiler";
 
 describe("Raw query compiler metadata", () => {
-  it.effect("keeps runtime guards for malformed schema field metadata", () =>
+  it.effect("rejects malformed engine schemas while metadata inspection remains defensive", () =>
     Effect.gen(function* () {
       const malformedFieldSchemaConfig = {
         topics: {
@@ -19,50 +19,48 @@ describe("Raw query compiler metadata", () => {
           },
         },
       };
-      // @ts-expect-error invalid configs can still reach runtime through untyped callers.
-      const engine = yield* createColumnLiveViewEngine(malformedFieldSchemaConfig);
-      const query: object = { select: ["id"] };
-
-      const snapshot = yield* engine.snapshot(
-        "loose",
-        // @ts-expect-error hostile untyped runtime query is still handled by runtime guards.
-        query,
+      const configError = yield* Effect.flip(
+        // @ts-expect-error invalid configs can still reach runtime through untyped callers.
+        createColumnLiveViewEngine(malformedFieldSchemaConfig),
       );
 
-      expect(snapshot).toMatchObject({
-        rows: [],
-        totalRows: 0,
+      expect(configError).toBeInstanceOf(InvalidRowError);
+      expect(configError).toMatchObject({
+        _tag: "InvalidRowError",
+        topic: "loose",
+        message: "Topic row schema must be an Effect Schema Struct.",
       });
 
       const metadata = rawQueryCompilerMetadata({
         // @ts-expect-error hostile schema metadata can contain malformed field entries.
         fields: {
           id: "not-a-schema",
+          invalidAst: { ast: "not-an-effect-ast" },
+          plainAst: { ast: Schema.String.ast },
           price: Schema.Number,
         },
       });
-      expect(metadata.fieldOrder).toStrictEqual(["id", "price"]);
+      expect(metadata.fieldOrder).toStrictEqual(["id", "invalidAst", "plainAst", "price"]);
       expect(metadata.fieldNames.has("id")).toBe(true);
+      expect(metadata.exactScalarEqualityFieldNames.has("invalidAst")).toBe(false);
+      expect(metadata.exactScalarEqualityFieldNames.has("plainAst")).toBe(true);
       expect(metadata.numericFieldNames.has("id")).toBe(false);
       expect(metadata.numericFieldNames.has("price")).toBe(true);
 
-      const invalidNumericAggregateQuery: object = {
-        groupBy: ["label"],
-        aggregates: {
-          totalId: { aggFunc: "sum", field: "id" },
-        },
-      };
-      const invalidNumericAggregate = yield* Effect.flip(
-        engine.snapshot(
-          "loose",
-          // @ts-expect-error malformed schema metadata makes the query shape untyped.
-          invalidNumericAggregateQuery,
-        ),
-      );
-      expect(invalidNumericAggregate).toMatchObject({
-        _tag: "InvalidQueryError",
-        topic: "loose",
-        message: "Grouped query aggregate totalId must reference a numeric field.",
+      // @ts-expect-error hostile callers can still pass a non-Struct schema.
+      const nonStructMetadata = rawQueryCompilerMetadata(Schema.String);
+      expect({
+        fields: [...nonStructMetadata.fieldNames],
+        ranges: [...nonStructMetadata.rangeValueKinds],
+        strings: [...nonStructMetadata.stringFieldNames],
+        structured: [...nonStructMetadata.structuredFieldNames],
+        structuredObjects: [...nonStructMetadata.structuredObjectFieldNames],
+      }).toStrictEqual({
+        fields: [],
+        ranges: [],
+        strings: [],
+        structured: [],
+        structuredObjects: [],
       });
     }),
   );

--- a/packages/column-live-view-engine/src/raw-query-decoded-boundary.test.ts
+++ b/packages/column-live-view-engine/src/raw-query-decoded-boundary.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@effect-view-server/config";
+import { Effect, Schema, Stream } from "effect";
+import { InvalidQueryError } from "./index";
+import { createColumnLiveViewEngineInternal } from "./internal";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  amount: Schema.BigIntFromString,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+describe("Raw query decoded value boundary", () => {
+  it.effect("accepts decoded operands and rejects encoded schema representations", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({ topics: viewServer.topics });
+      yield* engine.publishManyDecodedRows("orders", [{ id: "one", amount: 1n }]);
+
+      const subscription = yield* engine.subscribeRuntime("orders", {
+        select: ["id", "amount"],
+        where: { amount: { eq: 1n } },
+      });
+      const events = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+      const encodedError = yield* Effect.flip(
+        engine.subscribeRuntime("orders", {
+          select: ["id"],
+          where: { amount: { eq: "1" } },
+        }),
+      );
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 1,
+          keys: ["one"],
+          rows: [{ id: "one", amount: 1n }],
+          totalRows: 1,
+        },
+      ]);
+      expect(encodedError).toStrictEqual(
+        InvalidQueryError.make({
+          topic: "orders",
+          message: "Raw query where field amount does not satisfy its configured schema.",
+        }),
+      );
+      yield* subscription.close();
+      yield* engine.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/raw-query-decoder.test.ts
+++ b/packages/column-live-view-engine/src/raw-query-decoder.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema, SchemaGetter } from "effect";
+import { decodeRawQuery } from "./raw-query-decoder";
+import { rawQueryCompilerMetadata } from "./raw-query-metadata";
+
+describe("raw query decoder", () => {
+  it.effect("materializes each where operand through its field schema exactly once", () =>
+    Effect.gen(function* () {
+      let encodeCalls = 0;
+      const CountedString = Schema.String.pipe(
+        Schema.decodeTo(Schema.String, {
+          decode: SchemaGetter.transform((value) => value),
+          encode: SchemaGetter.transform((value) => {
+            encodeCalls += 1;
+            return value;
+          }),
+        }),
+      );
+      const Row = Schema.Struct({ value: CountedString });
+
+      const decoded = yield* decodeRawQuery("rows", rawQueryCompilerMetadata(Row), {
+        select: ["value"],
+        where: { value: { eq: "alpha" } },
+      });
+
+      expect(decoded).toStrictEqual({
+        select: ["value"],
+        where: { value: { eq: "alpha" } },
+      });
+      expect(encodeCalls).toBe(1);
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/raw-query-decoder.ts
+++ b/packages/column-live-view-engine/src/raw-query-decoder.ts
@@ -1,7 +1,10 @@
-import { Effect, Schema } from "effect";
+import { Effect, Result, Schema } from "effect";
 import { isBigDecimal } from "effect/BigDecimal";
+import { isRawQueryRangeFilterOperatorKey } from "@effect-view-server/config/internal";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
-import { cloneRecord, isPlainRecord } from "./row-values";
+import { filterOperatorKeys, isDenseArray } from "./raw-query-filter";
+import { materializeRawQueryFilter, RawQuerySchemaValueError } from "./raw-query-value-semantics";
+import { isPlainRecord } from "./row-values";
 
 export class InvalidQueryError extends Schema.TaggedErrorClass<InvalidQueryError>()(
   "InvalidQueryError",
@@ -23,62 +26,10 @@ export type RuntimeRawQuery = {
 };
 
 const rawQueryKeys = new Set(["where", "orderBy", "offset", "limit", "select"]);
-export const filterOperatorKeys = new Set([
-  "eq",
-  "neq",
-  "in",
-  "gt",
-  "gte",
-  "lt",
-  "lte",
-  "startsWith",
-]);
-const rangeFilterOperatorKeys = new Set(["gt", "gte", "lt", "lte"]);
-
-export const isDenseArray = (value: ReadonlyArray<unknown>): boolean => {
-  for (let index = 0; index < value.length; index += 1) {
-    if (!(index in value)) {
-      return false;
-    }
-  }
-  return true;
-};
+export { filterOperatorKeys, isDenseArray } from "./raw-query-filter";
 
 const isValidWindowNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
-
-const isQueryValueSafe = (value: unknown, active: WeakSet<object> = new WeakSet()): boolean => {
-  if (
-    value === null ||
-    value === undefined ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "bigint" ||
-    typeof value === "boolean" ||
-    isBigDecimal(value)
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    if (active.has(value)) {
-      return false;
-    }
-    active.add(value);
-    const safe = isDenseArray(value) && value.every((entry) => isQueryValueSafe(entry, active));
-    active.delete(value);
-    return safe;
-  }
-  if (isPlainRecord(value)) {
-    if (active.has(value)) {
-      return false;
-    }
-    active.add(value);
-    const safe = Object.values(value).every((entry) => isQueryValueSafe(entry, active));
-    active.delete(value);
-    return safe;
-  }
-  return false;
-};
 
 export const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")((
   topic: string,
@@ -113,7 +64,9 @@ export const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")(
       message: "Raw query where must be a plain object.",
     });
   }
+  let normalizedWhere: Record<string, unknown> | undefined;
   if (where !== undefined) {
+    const candidate: Record<string, unknown> = {};
     for (const field of Object.keys(where)) {
       if (!metadata.fieldNames.has(field)) {
         return InvalidQueryError.make({
@@ -121,13 +74,30 @@ export const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")(
           message: `Raw query where contains unknown field: ${field}.`,
         });
       }
-      if (!isQueryValueSafe(where[field])) {
+      const materialized = Result.try(() =>
+        materializeRawQueryFilter(
+          metadata.valueSemantics.field(field),
+          metadata.structuredFieldNames.has(field),
+          where[field],
+        ),
+      );
+      if (Result.isFailure(materialized)) {
         return InvalidQueryError.make({
           topic,
-          message: `Raw query where field ${field} contains unsupported query value.`,
+          message:
+            materialized.failure instanceof RawQuerySchemaValueError
+              ? `Raw query where field ${field} does not satisfy its configured schema.`
+              : `Raw query where field ${field} contains unsupported query value.`,
         });
       }
+      Object.defineProperty(candidate, field, {
+        configurable: true,
+        enumerable: true,
+        value: materialized.success,
+        writable: true,
+      });
     }
+    normalizedWhere = candidate;
   }
 
   const orderBy = query["orderBy"];
@@ -194,17 +164,8 @@ export const decodeRawQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.decode")(
     select: selectedFields,
   };
 
-  if (where !== undefined) {
-    let clonedWhere: Record<string, unknown>;
-    try {
-      clonedWhere = cloneRecord(where);
-    } catch (cause) {
-      return InvalidQueryError.make({
-        topic,
-        message: `Raw query where could not be cloned: ${String(cause)}`,
-      });
-    }
-    decoded.where = clonedWhere;
+  if (normalizedWhere !== undefined) {
+    decoded.where = normalizedWhere;
   }
   if (offset !== undefined) {
     decoded.offset = offset;
@@ -294,7 +255,7 @@ export const validateRuntimeQuery = Effect.fn("ColumnLiveViewEngine.rawQuery.val
         });
       }
       if (
-        keys.some((key) => rangeFilterOperatorKeys.has(key)) &&
+        keys.some(isRawQueryRangeFilterOperatorKey) &&
         (!metadata.numericFieldNames.has(field) || metadata.rangeValueKinds.get(field)?.size !== 1)
       ) {
         return yield* InvalidQueryError.make({

--- a/packages/column-live-view-engine/src/raw-query-evaluation.test.ts
+++ b/packages/column-live-view-engine/src/raw-query-evaluation.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { evaluateRawQuery } from "./active-query";
-import { prepareRawQuery, rawQueryCompilerMetadata } from "./raw-query-compiler";
+import { compareQueryValue, prepareRawQuery, rawQueryCompilerMetadata } from "./raw-query-compiler";
+import { compileRawPredicate } from "./raw-predicate-compiler";
 import { order, Order } from "../test-harness/public-engine";
 
 describe("Raw query evaluation", () => {
@@ -43,4 +44,73 @@ describe("Raw query evaluation", () => {
       expect(evaluation.totalRows).toBe(0);
     }),
   );
+
+  it("does not match scalar union members with structured literal filters", () => {
+    const UnionRow = Schema.Struct({
+      id: Schema.String,
+      value: Schema.Union([
+        Schema.Number,
+        Schema.Struct({
+          eq: Schema.Number,
+          kind: Schema.String,
+        }),
+      ]),
+    });
+    const predicate = compileRawPredicate<typeof UnionRow.Type>(
+      rawQueryCompilerMetadata(UnionRow),
+      {
+        value: {
+          eq: 1,
+          kind: "literal",
+        },
+      },
+    );
+
+    expect([
+      predicate.matches({ id: "scalar", value: 1 }),
+      predicate.matches({ id: "literal", value: { eq: 1, kind: "literal" } }),
+      predicate.matches({ id: "other", value: { eq: 1, kind: "other" } }),
+    ]).toStrictEqual([false, true, false]);
+  });
+
+  it("fails closed when scalar or structured in filters contain invalid schema values", () => {
+    const ScalarRow = Schema.Struct({
+      id: Schema.String,
+      status: Schema.Literals(["open", "closed"]),
+    });
+    const StructuredRow = Schema.Struct({
+      id: Schema.String,
+      profile: Schema.Struct({ code: Schema.String }),
+    });
+    const scalarPredicate = compileRawPredicate<typeof ScalarRow.Type>(
+      rawQueryCompilerMetadata(ScalarRow),
+      {
+        status: { in: ["open", 1] },
+      },
+    );
+    const structuredPredicate = compileRawPredicate<typeof StructuredRow.Type>(
+      rawQueryCompilerMetadata(StructuredRow),
+      {
+        profile: { in: [{ code: "alpha" }, "alpha"] },
+      },
+    );
+
+    expect({
+      scalar: scalarPredicate.matches({ id: "scalar", status: "open" }),
+      structured: structuredPredicate.matches({ id: "structured", profile: { code: "alpha" } }),
+    }).toStrictEqual({
+      scalar: false,
+      structured: false,
+    });
+  });
+
+  it("orders array and object fallback values by their stable query ranks", () => {
+    expect({
+      arrayBeforeObject: compareQueryValue([], {}),
+      objectAfterArray: compareQueryValue({}, []),
+    }).toStrictEqual({
+      arrayBeforeObject: -1,
+      objectAfterArray: 1,
+    });
+  });
 });

--- a/packages/column-live-view-engine/src/raw-query-filter.ts
+++ b/packages/column-live-view-engine/src/raw-query-filter.ts
@@ -1,0 +1,27 @@
+import {
+  isRawQueryFilterOperatorKey,
+  rawQueryFilterOperatorKeys,
+} from "@effect-view-server/config/internal";
+import { isBigDecimal } from "effect/BigDecimal";
+import { isPlainRecord } from "./row-values";
+
+export const filterOperatorKeys = rawQueryFilterOperatorKeys;
+
+export const isDenseArray = (value: ReadonlyArray<unknown>): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    if (!(index in value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const isOperatorFilterObject = (
+  filter: unknown,
+): filter is Readonly<Record<string, unknown>> => {
+  if (!isPlainRecord(filter) || isBigDecimal(filter)) {
+    return false;
+  }
+  const keys = Object.keys(filter);
+  return keys.length > 0 && keys.every(isRawQueryFilterOperatorKey);
+};

--- a/packages/column-live-view-engine/src/raw-query-metadata.ts
+++ b/packages/column-live-view-engine/src/raw-query-metadata.ts
@@ -1,8 +1,12 @@
 import { viewServerSchemaFieldMetadata } from "@effect-view-server/config";
 import { Schema, SchemaAST } from "effect";
 import { isRecord } from "./row-values";
+import {
+  makeTopicRowValueSemantics,
+  type TopicRowValueSemantics,
+} from "./topic-row-value-semantics";
 
-type SchemaWithFields = Schema.Codec<object, unknown, never, unknown> & {
+type SchemaWithFields = Schema.Codec<object, unknown, never, never> & {
   readonly fields: Record<string, unknown>;
 };
 
@@ -19,11 +23,13 @@ export type RawQueryCompilerMetadata = {
   readonly numberFieldNames: ReadonlySet<string>;
   readonly bigintFieldNames: ReadonlySet<string>;
   readonly bigDecimalFieldNames: ReadonlySet<string>;
+  readonly exactScalarEqualityFieldNames: ReadonlySet<string>;
   readonly rangeValueKinds: ReadonlyMap<string, ReadonlySet<RangeValueKind>>;
+  readonly valueSemantics: TopicRowValueSemantics;
 };
 
 const isSchemaWithFields = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): schema is SchemaWithFields => "fields" in schema && isRecord(schema.fields);
 
 const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
@@ -38,6 +44,22 @@ const isBigDecimalAst = (ast: SchemaAST.AST): boolean =>
   SchemaAST.isDeclaration(ast) &&
   isRecord(ast.annotations?.["typeConstructor"]) &&
   ast.annotations["typeConstructor"]["_tag"] === "effect/BigDecimal";
+
+const builtInBigDecimalEquivalence = SchemaAST.resolve(Schema.BigDecimal.ast)?.["toEquivalence"];
+
+const astHasExactScalarEquality = (ast: SchemaAST.AST): boolean => {
+  const equivalence = SchemaAST.resolve(ast)?.["toEquivalence"];
+  if (equivalence !== undefined) {
+    return isBigDecimalAst(ast) && equivalence === builtInBigDecimalEquivalence;
+  }
+  if (SchemaAST.isUnion(ast)) {
+    return ast.types.length > 0 && ast.types.every((member) => astHasExactScalarEquality(member));
+  }
+  if (SchemaAST.isSuspend(ast)) {
+    return false;
+  }
+  return !SchemaAST.isArrays(ast) && !SchemaAST.isObjects(ast);
+};
 
 const rangeValueKindsAst = (ast: SchemaAST.AST): ReadonlySet<RangeValueKind> => {
   if (SchemaAST.isNumber(ast)) {
@@ -88,16 +110,16 @@ const isPureBigDecimalAst = (ast: SchemaAST.AST): boolean => {
 };
 
 const schemaFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> =>
   isSchemaWithFields(schema) ? new Set(Object.keys(schema.fields)) : new Set();
 
 const schemaFieldOrder = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlyArray<string> => (isSchemaWithFields(schema) ? Object.keys(schema.fields) : []);
 
 const schemaFieldMetadata = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlyMap<string, ReturnType<typeof viewServerSchemaFieldMetadata>> => {
   if (!isSchemaWithFields(schema)) {
     return new Map();
@@ -111,7 +133,7 @@ const schemaFieldMetadata = (
 };
 
 const schemaNumericFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -128,7 +150,7 @@ const schemaNumericFieldNames = (
 };
 
 const schemaNumberFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -146,7 +168,7 @@ const schemaNumberFieldNames = (
 };
 
 const schemaBigintFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -162,7 +184,7 @@ const schemaBigintFieldNames = (
 };
 
 const schemaBigDecimalFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -179,8 +201,25 @@ const schemaBigDecimalFieldNames = (
   return fields;
 };
 
+const schemaExactScalarEqualityFieldNames = (
+  schema: Schema.Codec<object, unknown, never, never>,
+): ReadonlySet<string> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Set();
+  }
+
+  const fields = new Set<string>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    const ast = schemaAst(fieldSchema);
+    if (ast !== undefined && astHasExactScalarEquality(ast)) {
+      fields.add(field);
+    }
+  }
+  return fields;
+};
+
 const schemaRangeValueKinds = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlyMap<string, ReadonlySet<RangeValueKind>> => {
   if (!isSchemaWithFields(schema)) {
     return new Map();
@@ -201,7 +240,7 @@ const schemaRangeValueKinds = (
 };
 
 const schemaStringFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -217,7 +256,7 @@ const schemaStringFieldNames = (
 };
 
 const schemaStructuredFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -233,7 +272,7 @@ const schemaStructuredFieldNames = (
 };
 
 const schemaStructuredObjectFieldNames = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): ReadonlySet<string> => {
   if (!isSchemaWithFields(schema)) {
     return new Set();
@@ -249,7 +288,7 @@ const schemaStructuredObjectFieldNames = (
 };
 
 export const rawQueryCompilerMetadata = (
-  schema: Schema.Codec<object, unknown, never, unknown>,
+  schema: Schema.Codec<object, unknown, never, never>,
 ): RawQueryCompilerMetadata => ({
   fieldNames: schemaFieldNames(schema),
   fieldOrder: schemaFieldOrder(schema),
@@ -261,5 +300,7 @@ export const rawQueryCompilerMetadata = (
   numberFieldNames: schemaNumberFieldNames(schema),
   bigintFieldNames: schemaBigintFieldNames(schema),
   bigDecimalFieldNames: schemaBigDecimalFieldNames(schema),
+  exactScalarEqualityFieldNames: schemaExactScalarEqualityFieldNames(schema),
   rangeValueKinds: schemaRangeValueKinds(schema),
+  valueSemantics: makeTopicRowValueSemantics(schema),
 });

--- a/packages/column-live-view-engine/src/raw-query-plan.ts
+++ b/packages/column-live-view-engine/src/raw-query-plan.ts
@@ -3,9 +3,11 @@ import { compareQueryValue, stableQueryValueString } from "./query-value";
 import { compileRawPredicate, type CompiledRawPredicate } from "./raw-predicate-compiler";
 import type { RuntimeRawQuery } from "./raw-query-decoder";
 import type { RawQueryCompilerMetadata } from "./raw-query-metadata";
+import { canonicalRawQueryFilterKey } from "./raw-query-value-semantics";
 import type { TopicRawOrderByPlan, TopicRawWindowScanPlan } from "./raw-window-scan";
 import type { TopicRowEntry } from "./row-scan";
-import { cloneUnknown, trustedFieldValue } from "./row-values";
+import { rawQueryResultSemantics, type QueryResultSemantics } from "./query-result-semantics";
+import { trustedFieldValue } from "./row-values";
 
 type RowObject = object;
 
@@ -23,9 +25,10 @@ export type RawQueryPlan<Row extends RowObject, ResultRow extends RowObject> = {
   readonly selectedFields: ReadonlyArray<string>;
   readonly predicate: CompiledRawPredicate<Row>;
   readonly orderBy: ReadonlyArray<TopicRawOrderByPlan>;
-  readonly storageOrderBy: ReadonlyArray<TopicRawOrderByPlan>;
+  readonly storageOrderBy?: ReadonlyArray<TopicRawOrderByPlan>;
   readonly compare: (left: TopicRowEntry<Row>, right: TopicRowEntry<Row>) => number;
   readonly project: (row: Row) => ResultRow;
+  readonly resultSemantics: QueryResultSemantics;
   readonly window: RawQueryPlanWindow;
 };
 
@@ -34,12 +37,28 @@ type RawRowOrderColumn<Row extends RowObject> = {
   readonly direction: "asc" | "desc";
 };
 
-const rawQueryShapeCacheKey = (query: RuntimeRawQuery): string => {
+const rawQueryShapeCacheKey = (
+  metadata: RawQueryCompilerMetadata,
+  query: RuntimeRawQuery,
+): string => {
   const orderBy: ReadonlyArray<readonly [string, "asc" | "desc"]> =
     query.orderBy === undefined ? [] : query.orderBy.map((entry) => [entry.field, entry.direction]);
+  const where =
+    query.where === undefined
+      ? []
+      : Object.entries(query.where)
+          .toSorted(([left], [right]) => Number(left > right) - Number(left < right))
+          .map(([field, filter]) => [
+            field,
+            canonicalRawQueryFilterKey(
+              metadata.valueSemantics.field(field),
+              metadata.structuredFieldNames.has(field),
+              filter,
+            ),
+          ]);
   const token: QueryCacheToken = [
     "raw",
-    query.where === undefined ? "" : stableQueryValueString(query.where),
+    stableQueryValueString(where),
     stableQueryValueString(orderBy),
   ];
   return JSON.stringify(token);
@@ -65,12 +84,6 @@ export const rawQueryPlanWindow = (
 
 const rawQueryPlanWindowFromQuery = (query: RuntimeRawQuery): RawQueryPlanWindow =>
   rawQueryPlanWindow(query.offset ?? 0, query.limit);
-
-const compareRowFieldValues = <Row extends RowObject>(
-  left: Row,
-  right: Row,
-  field: string,
-): number => compareQueryValue(trustedFieldValue(left, field), trustedFieldValue(right, field));
 
 const compareStringRowFieldValues = <Row extends RowObject>(
   left: Row,
@@ -133,19 +146,39 @@ const rawRowOrderColumnComparator = <Row extends RowObject>(
   metadata: RawQueryCompilerMetadata,
   field: string,
 ): ((left: Row, right: Row) => number) => {
-  if (metadata.stringFieldNames.has(field)) {
+  const exactScalarEquality = metadata.exactScalarEqualityFieldNames.has(field);
+  if (exactScalarEquality && metadata.stringFieldNames.has(field)) {
     return (left, right) => compareStringRowFieldValues(left, right, field);
   }
-  if (metadata.numberFieldNames.has(field)) {
+  if (exactScalarEquality && metadata.numberFieldNames.has(field)) {
     return (left, right) => compareNumberRowFieldValues(left, right, field);
   }
-  if (metadata.bigintFieldNames.has(field)) {
+  if (exactScalarEquality && metadata.bigintFieldNames.has(field)) {
     return (left, right) => compareBigintRowFieldValues(left, right, field);
   }
-  if (metadata.bigDecimalFieldNames.has(field)) {
+  if (exactScalarEquality && metadata.bigDecimalFieldNames.has(field)) {
     return (left, right) => compareBigDecimalRowFieldValues(left, right, field);
   }
-  return (left, right) => compareRowFieldValues(left, right, field);
+  const compare = metadata.valueSemantics.field(field).compare;
+  return (left, right) => compare(trustedFieldValue(left, field), trustedFieldValue(right, field));
+};
+
+const storageOrderBy = (
+  metadata: RawQueryCompilerMetadata,
+  orderBy: ReadonlyArray<TopicRawOrderByPlan>,
+): ReadonlyArray<TopicRawOrderByPlan> | undefined => {
+  for (const order of orderBy) {
+    if (
+      !metadata.exactScalarEqualityFieldNames.has(order.field) ||
+      (!metadata.stringFieldNames.has(order.field) &&
+        !metadata.numberFieldNames.has(order.field) &&
+        !metadata.bigintFieldNames.has(order.field) &&
+        !metadata.bigDecimalFieldNames.has(order.field))
+    ) {
+      return undefined;
+    }
+  }
+  return orderBy;
 };
 
 const compiledRawRowOrder = <Row extends RowObject>(
@@ -171,20 +204,15 @@ const compareRows = <Row extends RowObject>(
   return Number(left.key > right.key) - Number(left.key < right.key);
 };
 
-const projectRow = (row: RowObject, select: ReadonlyArray<string>): RowObject => {
-  const projected: Record<string, unknown> = {};
-  for (const field of select) {
-    projected[field] = cloneUnknown(trustedFieldValue(row, field));
-  }
-  return projected;
-};
+const projectRow = (row: RowObject, semantics: QueryResultSemantics): RowObject =>
+  semantics.projectRow(row);
 
 function projectCompiledRow<ResultRow extends RowObject>(
   row: RowObject,
-  select: ReadonlyArray<string>,
+  semantics: QueryResultSemantics,
 ): ResultRow;
-function projectCompiledRow(row: RowObject, select: ReadonlyArray<string>): RowObject {
-  return projectRow(row, select);
+function projectCompiledRow(row: RowObject, semantics: QueryResultSemantics): RowObject {
+  return projectRow(row, semantics);
 }
 
 export const makeRawQueryPlan = <Row extends RowObject, ResultRow extends RowObject>(
@@ -194,15 +222,18 @@ export const makeRawQueryPlan = <Row extends RowObject, ResultRow extends RowObj
   const orderBy = query.orderBy ?? [];
   const rowOrderBy = compiledRawRowOrder<Row>(metadata, orderBy);
   const selectedFields = [...query.select];
+  const resultSemantics = rawQueryResultSemantics(metadata.valueSemantics, selectedFields);
   const predicate = compileRawPredicate<Row>(metadata, query.where);
+  const storageOrder = storageOrderBy(metadata, orderBy);
   return {
-    queryCacheKey: rawQueryShapeCacheKey(query),
+    queryCacheKey: rawQueryShapeCacheKey(metadata, query),
     selectedFields,
     predicate,
     orderBy,
-    storageOrderBy: orderBy,
+    ...(storageOrder === undefined ? {} : { storageOrderBy: storageOrder }),
     compare: (left, right) => compareRows(left, right, rowOrderBy),
-    project: (row) => projectCompiledRow(row, selectedFields),
+    project: (row) => projectCompiledRow(row, resultSemantics),
+    resultSemantics,
     window: rawQueryPlanWindowFromQuery(query),
   };
 };
@@ -213,7 +244,7 @@ export const rawQueryWindowScanPlan = <Row extends RowObject, ResultRow extends 
 ): TopicRawWindowScanPlan<Row> => ({
   predicate: plan.predicate.plan,
   orderBy: plan.orderBy,
-  storageOrderBy: plan.storageOrderBy,
+  ...(plan.storageOrderBy === undefined ? {} : { storageOrderBy: plan.storageOrderBy }),
   matches: plan.predicate.matches,
   compare: plan.compare,
   offset: window.offset,

--- a/packages/column-live-view-engine/src/raw-query-value-semantics.ts
+++ b/packages/column-live-view-engine/src/raw-query-value-semantics.ts
@@ -61,14 +61,6 @@ const materializeSchemaQueryValue = (
   value: unknown,
   schemaRequired = false,
 ): unknown => {
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.getPrototypeOf(value) === null
-  ) {
-    return unsupportedQueryValue();
-  }
   const materialized = materializedValue(semantics, value);
   if (Result.isSuccess(materialized)) {
     return materialized.success;

--- a/packages/column-live-view-engine/src/raw-query-value-semantics.ts
+++ b/packages/column-live-view-engine/src/raw-query-value-semantics.ts
@@ -1,0 +1,201 @@
+import { Result } from "effect";
+import { isBigDecimal } from "effect/BigDecimal";
+import { stableQueryValueString } from "./query-value";
+import { isDenseArray, isOperatorFilterObject } from "./raw-query-filter";
+import { cloneUnknown, isPlainRecord } from "./row-values";
+import type { SchemaValueSemantics } from "./topic-row-value-semantics";
+
+export class RawQuerySchemaValueError extends Error {}
+
+const isQueryValueSafe = (value: unknown, active: WeakSet<object> = new WeakSet()): boolean => {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    typeof value === "boolean" ||
+    isBigDecimal(value)
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    if (active.has(value)) {
+      return false;
+    }
+    active.add(value);
+    const safe = isDenseArray(value) && value.every((entry) => isQueryValueSafe(entry, active));
+    active.delete(value);
+    return safe;
+  }
+  if (isPlainRecord(value)) {
+    if (active.has(value)) {
+      return false;
+    }
+    active.add(value);
+    const safe = Object.values(value).every((entry) => isQueryValueSafe(entry, active));
+    active.delete(value);
+    return safe;
+  }
+  return false;
+};
+
+const unsupportedQueryValue = (): never => {
+  throw new TypeError("Unsupported raw query value.");
+};
+
+const invalidSchemaQueryValue = (): never => {
+  throw new RawQuerySchemaValueError("Raw query value does not satisfy its configured schema.");
+};
+
+const cloneSafeQueryValue = (value: unknown): unknown =>
+  isQueryValueSafe(value) ? cloneUnknown(value) : unsupportedQueryValue();
+
+const materializedValue = (
+  semantics: SchemaValueSemantics,
+  value: unknown,
+): Result.Result<unknown, unknown> => Result.try(() => semantics.materialize(value));
+
+const materializeSchemaQueryValue = (
+  semantics: SchemaValueSemantics,
+  value: unknown,
+  schemaRequired = false,
+): unknown => {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === null
+  ) {
+    return unsupportedQueryValue();
+  }
+  const materialized = materializedValue(semantics, value);
+  if (Result.isSuccess(materialized)) {
+    return materialized.success;
+  }
+  if (!isQueryValueSafe(value)) {
+    return unsupportedQueryValue();
+  }
+  const encoded = Result.try(() => semantics.decodeEncoded(value));
+  return Result.isSuccess(encoded) || schemaRequired
+    ? invalidSchemaQueryValue()
+    : cloneSafeQueryValue(value);
+};
+
+const setFilterValue = (
+  filter: Record<string, unknown>,
+  operator: string,
+  value: unknown,
+): void => {
+  Object.defineProperty(filter, operator, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const materializeOperatorFilter = (
+  semantics: SchemaValueSemantics,
+  filter: Readonly<Record<string, unknown>>,
+): Record<string, unknown> => {
+  const materialized: Record<string, unknown> = {};
+  for (const [operator, value] of Object.entries(filter)) {
+    if (operator === "in" && Array.isArray(value)) {
+      if (!isDenseArray(value)) {
+        return unsupportedQueryValue();
+      }
+      setFilterValue(
+        materialized,
+        operator,
+        value.map((entry) => materializeSchemaQueryValue(semantics, entry)),
+      );
+    } else {
+      setFilterValue(materialized, operator, materializeSchemaQueryValue(semantics, value));
+    }
+  }
+  return materialized;
+};
+
+export const materializeRawQueryFilter = (
+  semantics: SchemaValueSemantics,
+  structuredField: boolean,
+  filter: unknown,
+): unknown => {
+  if (isOperatorFilterObject(filter)) {
+    if (structuredField) {
+      const literal = materializedValue(semantics, filter);
+      if (Result.isSuccess(literal)) {
+        return literal.success;
+      }
+    }
+    return materializeOperatorFilter(semantics, filter);
+  }
+  if (!structuredField && isPlainRecord(filter)) {
+    return cloneSafeQueryValue(filter);
+  }
+  return materializeSchemaQueryValue(semantics, filter, structuredField);
+};
+
+type CanonicalOperandToken = readonly ["schema" | "generic", string];
+
+const canonicalOperandToken = (
+  semantics: SchemaValueSemantics,
+  value: unknown,
+): CanonicalOperandToken => {
+  const canonical = Result.try(() => semantics.canonicalKey(value));
+  return Result.isSuccess(canonical)
+    ? ["schema", canonical.success]
+    : ["generic", stableQueryValueString(value)];
+};
+
+export const canonicalRawQueryFilterKey = (
+  semantics: SchemaValueSemantics,
+  structuredField: boolean,
+  filter: unknown,
+): string => {
+  if (!isOperatorFilterObject(filter)) {
+    return JSON.stringify(["literal", canonicalOperandToken(semantics, filter)]);
+  }
+  if (structuredField) {
+    const literal = Result.try(() => semantics.canonicalKey(filter));
+    if (Result.isSuccess(literal)) {
+      return JSON.stringify(["literal", ["schema", literal.success]]);
+    }
+  }
+  const operators = Object.entries(filter)
+    .toSorted(([left], [right]) => Number(left > right) - Number(left < right))
+    .map(([operator, value]) => {
+      if (operator === "in" && Array.isArray(value)) {
+        return [operator, value.map((entry) => canonicalOperandToken(semantics, entry))] as const;
+      }
+      if (operator === "startsWith") {
+        return [operator, ["generic", stableQueryValueString(value)]] as const;
+      }
+      return [operator, canonicalOperandToken(semantics, value)] as const;
+    });
+  return JSON.stringify(["operators", operators]);
+};
+
+export type CompiledSchemaEquality = {
+  readonly valid: boolean;
+  readonly matches: (value: unknown) => boolean;
+};
+
+export const compileSchemaEquality = (
+  semantics: SchemaValueSemantics,
+  operand: unknown,
+): CompiledSchemaEquality => {
+  const materialized = materializedValue(semantics, operand);
+  if (Result.isFailure(materialized)) {
+    return {
+      valid: false,
+      matches: () => false,
+    };
+  }
+  const expected = materialized.success;
+  return {
+    valid: true,
+    matches: (value) => semantics.equivalent(value, expected),
+  };
+};

--- a/packages/column-live-view-engine/src/raw-snapshots.test.ts
+++ b/packages/column-live-view-engine/src/raw-snapshots.test.ts
@@ -119,7 +119,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         {
           active: false,
           id: "kept",
-          price: fromStringUnsafe("2.50"),
+          price: fromStringUnsafe("2.5"),
           quantity: 2n,
           symbol: "MSFT",
         },
@@ -1381,7 +1381,7 @@ describe("ColumnLiveViewEngine raw snapshots", () => {
         });
 
         expect(projected.rows).toStrictEqual([
-          { id: "missing-note", note: undefined },
+          { id: "missing-note" },
           { id: "own-note", note: "polluted" },
         ]);
         expect(rowIds(polluted.rows)).toStrictEqual(["own-note"]);

--- a/packages/column-live-view-engine/src/root-class-row.test.ts
+++ b/packages/column-live-view-engine/src/root-class-row.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import { createColumnLiveViewEngine } from "./index";
+import { createColumnLiveViewEngineInternal } from "./internal";
+
+class RootClassOrder extends Schema.Class<RootClassOrder>("RootClassOrder")({
+  id: Schema.String,
+  quantity: Schema.BigInt,
+  status: Schema.String,
+}) {}
+viewSchema.admitClass(RootClassOrder);
+
+const rootClassViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: RootClassOrder,
+      key: "id",
+    },
+  },
+});
+
+describe("ColumnLiveViewEngine root Class rows", () => {
+  it.effect("publishes, replaces, and patches public root Class rows", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngine({
+        topics: rootClassViewServer.topics,
+      });
+
+      yield* engine.publish(
+        "orders",
+        new RootClassOrder({ id: "a", quantity: 1n, status: "published" }),
+      );
+      yield* engine.publishMany("orders", [
+        new RootClassOrder({ id: "b", quantity: 2n, status: "published-many" }),
+        new RootClassOrder({ id: "c", quantity: 3n, status: "published-many" }),
+      ]);
+      yield* engine.publish(
+        "orders",
+        new RootClassOrder({ id: "a", quantity: 10n, status: "replaced" }),
+      );
+      yield* engine.patch("orders", "b", {
+        quantity: 20n,
+        status: "patched",
+      });
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "quantity", "status"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [
+          { id: "a", quantity: 10n, status: "replaced" },
+          { id: "b", quantity: 20n, status: "patched" },
+          { id: "c", quantity: 3n, status: "published-many" },
+        ],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 3,
+        version: 4,
+      });
+      yield* engine.close();
+    }),
+  );
+
+  it.effect("reconstructs root Class rows after decoded patches", () =>
+    Effect.gen(function* () {
+      const engine = yield* createColumnLiveViewEngineInternal({
+        topics: rootClassViewServer.topics,
+      });
+
+      yield* engine.publishManyDecodedRows("orders", [
+        new RootClassOrder({ id: "decoded", quantity: 41n, status: "published" }),
+      ]);
+      yield* engine.patchDecodedFields("orders", "decoded", {
+        quantity: 42n,
+        status: "patched",
+      });
+      const snapshot = yield* engine.snapshot("orders", {
+        select: ["id", "quantity", "status"],
+        limit: 10,
+      });
+
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "decoded", quantity: 42n, status: "patched" }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 2,
+      });
+      yield* engine.close();
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/row-scan.ts
+++ b/packages/column-live-view-engine/src/row-scan.ts
@@ -1,4 +1,4 @@
-import { fieldValue, valuesEqual } from "./row-values";
+import { fieldValue } from "./row-values";
 
 type RowObject = object;
 
@@ -41,10 +41,15 @@ export const topicRowChangedFieldsFromRows = (
   previous: RowObject,
   next: RowObject,
   fields: Iterable<string>,
+  equivalent: (field: string, left: unknown, right: unknown) => boolean,
 ): TopicRowChangedFields | undefined => {
   const changedFields = new Set<string>();
   for (const field of fields) {
-    if (!valuesEqual(fieldValue(previous, field), fieldValue(next, field))) {
+    if (
+      Object.prototype.propertyIsEnumerable.call(previous, field) !==
+        Object.prototype.propertyIsEnumerable.call(next, field) ||
+      !equivalent(field, fieldValue(previous, field), fieldValue(next, field))
+    ) {
       changedFields.add(field);
     }
   }

--- a/packages/column-live-view-engine/src/row-values.test.ts
+++ b/packages/column-live-view-engine/src/row-values.test.ts
@@ -3,9 +3,7 @@ import { fromStringUnsafe } from "effect/BigDecimal";
 import { stableQueryValueString } from "./raw-query-compiler";
 import {
   cloneRecord,
-  cloneRow,
   fieldValue,
-  rowsEqual,
   scalarEqualityKey,
   trustedFieldValue,
   valuesEqual,
@@ -18,7 +16,7 @@ describe("Row value semantics", () => {
     expect(scalarEqualityKey(false)).toBe("boolean:false");
     expect(scalarEqualityKey(true)).toBe("boolean:true");
     expect(scalarEqualityKey(1n)).toBe("bigint:1");
-    expect(scalarEqualityKey(-0)).toBe("number:-0");
+    expect(scalarEqualityKey(-0)).toBe("number:0");
     expect(scalarEqualityKey(Number.NaN)).toBe("number:NaN");
     expect(scalarEqualityKey(Number.POSITIVE_INFINITY)).toBe("number:Infinity");
     expect(scalarEqualityKey(fromStringUnsafe("1.0"))).toBe("bigDecimal:1");
@@ -141,33 +139,23 @@ describe("Row value semantics", () => {
     expect(stableQueryValueString(left)).not.toBe(stableQueryValueString(right));
   });
 
-  it("treats rows with different selected column counts as different", () => {
-    expect(rowsEqual({ id: "1" }, { id: "1", note: "new" })).toBe(false);
-  });
-
-  it("treats identical row references as equal without structural comparison", () => {
-    let getterReads = 0;
-    const row = {
-      id: "1",
-      get status() {
-        getterReads += 1;
-        return "open";
-      },
-    };
-
-    expect(rowsEqual(row, row)).toBe(true);
-    expect(getterReads).toBe(0);
-  });
-
-  it("does not structurally compare map and set values on row hot paths", () => {
+  it("does not structurally compare map and set values", () => {
     expect(valuesEqual(new Map([["venue", "xnys"]]), new Map([["venue", "xnys"]]))).toBe(false);
     expect(valuesEqual(new Set(["xnys"]), new Set(["xnys"]))).toBe(false);
-    expect(
-      rowsEqual(
-        { id: "1", payload: new Map([["venue", "xnys"]]) },
-        { id: "1", payload: new Map([["venue", "xnys"]]) },
-      ),
-    ).toBe(false);
+    expect(cloneRecord({ payload: new Map([["venue", "xnys"]]) })).toStrictEqual({
+      payload: new Map([["venue", "xnys"]]),
+    });
+  });
+
+  it("compares array and plain-record values structurally", () => {
+    expect(valuesEqual([1, { nested: "same" }], [1, { nested: "same" }])).toBe(true);
+    expect(valuesEqual([1], [1, 2])).toBe(false);
+    expect(valuesEqual([1], [2])).toBe(false);
+
+    expect(valuesEqual({ left: 1, right: 2 }, { right: 2, left: 1 })).toBe(true);
+    expect(valuesEqual({ missing: true }, {})).toBe(false);
+    expect(valuesEqual({ changed: 1 }, { changed: 2 })).toBe(false);
+    expect(valuesEqual({}, { extra: true })).toBe(false);
   });
 
   it("ignores inherited row properties", () => {
@@ -175,18 +163,12 @@ describe("Row value semantics", () => {
     inheritedRecord["id"] = "1";
     inheritedRecord["status"] = "open";
 
-    const inheritedRow = Object.create({ inherited: "hidden" });
-    inheritedRow["id"] = "1";
-    inheritedRow["status"] = "open";
-
     expect(cloneRecord(inheritedRecord)).toStrictEqual({ id: "1", status: "open" });
-    expect(cloneRow(inheritedRow)).toStrictEqual({ id: "1", status: "open" });
-    expect(fieldValue(inheritedRow, "inherited")).toBeUndefined();
-    expect(trustedFieldValue(inheritedRow, "inherited")).toBe("hidden");
-    expect(rowsEqual(inheritedRow, { id: "1", status: "open" })).toBe(true);
+    expect(fieldValue(inheritedRecord, "inherited")).toBeUndefined();
+    expect(trustedFieldValue(inheritedRecord, "inherited")).toBe("hidden");
   });
 
-  it("preserves own __proto__ data fields while cloning rows and records", () => {
+  it("preserves own __proto__ data fields while cloning records", () => {
     const dangerousRecord = { id: "1" };
     Object.defineProperty(dangerousRecord, "__proto__", {
       configurable: true,
@@ -195,20 +177,9 @@ describe("Row value semantics", () => {
       writable: true,
     });
 
-    const dangerousRow = { id: "1" };
-    Object.defineProperty(dangerousRow, "__proto__", {
-      configurable: true,
-      enumerable: true,
-      value: "visible-row-data",
-      writable: true,
-    });
-
     const clonedRecord = cloneRecord(dangerousRecord);
-    const clonedRow = cloneRow(dangerousRow);
 
     expect(clonedRecord).toStrictEqual(dangerousRecord);
-    expect(clonedRow).toStrictEqual(dangerousRow);
     expect(Object.hasOwn(clonedRecord, "__proto__")).toBe(true);
-    expect(Object.hasOwn(clonedRow, "__proto__")).toBe(true);
   });
 });

--- a/packages/column-live-view-engine/src/row-values.ts
+++ b/packages/column-live-view-engine/src/row-values.ts
@@ -56,17 +56,6 @@ export const cloneRecord = (value: Record<string, unknown>): Record<string, unkn
   return cloned;
 };
 
-export function cloneRow<Row extends RowObject>(row: Row): Row;
-export function cloneRow(row: RowObject): RowObject {
-  const cloned: Record<string, unknown> = {};
-  for (const key in row) {
-    if (Object.hasOwn(row, key)) {
-      setClonedField(cloned, key, cloneUnknown(Reflect.get(row, key)));
-    }
-  }
-  return cloned;
-}
-
 export const fieldValue = (row: RowObject, field: string): unknown => {
   if (!Object.hasOwn(row, field)) {
     return undefined;
@@ -118,27 +107,10 @@ export function scalarEqualityKey(value: unknown): string | undefined {
     return `bigint:${value.toString()}`;
   }
   if (typeof value === "number") {
-    return `number:${Object.is(value, -0) ? "-0" : value.toString()}`;
+    return `number:${value.toString()}`;
   }
   if (isBigDecimal(value)) {
     return `bigDecimal:${formatBigDecimal(normalize(value))}`;
   }
   return undefined;
 }
-
-export const rowsEqual = <Row extends RowObject>(left: Row, right: Row): boolean => {
-  if (Object.is(left, right)) {
-    return true;
-  }
-  const rightKeys = new Set(Object.keys(right));
-  const leftKeys = Object.keys(left);
-  if (leftKeys.length !== rightKeys.size) {
-    return false;
-  }
-  for (const key of leftKeys) {
-    if (!rightKeys.delete(key) || !valuesEqual(Reflect.get(left, key), fieldValue(right, key))) {
-      return false;
-    }
-  }
-  return true;
-};

--- a/packages/column-live-view-engine/src/subscription-lifecycle.test.ts
+++ b/packages/column-live-view-engine/src/subscription-lifecycle.test.ts
@@ -18,6 +18,7 @@ import {
 import { prepareRawQuery, rawQueryCompilerMetadata } from "./raw-query-compiler";
 import { prepareGroupedQuery } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
+import { makeQueryResultSemantics } from "./query-result-semantics";
 import {
   acquireTopicStoreSubscription,
   closeBackpressuredTopicStoreSubscription,
@@ -35,6 +36,8 @@ import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-s
 import { expectDefined } from "../test-harness/events";
 import { order, Order } from "../test-harness/public-engine";
 import { registerTestTopicStoreSubscriber } from "../test-harness/topic-store";
+
+const emptyResultSemantics = makeQueryResultSemantics([]);
 
 describe("Subscription lifecycle ownership", () => {
   it.effect("only closes acquired subscriptions for interrupted exits", () =>
@@ -351,8 +354,11 @@ describe("Subscription lifecycle ownership", () => {
           aggregates: { rowCount: { aggFunc: "count" } },
         },
       );
-      const execution = yield* acquireMaterializedQueryExecution(readModel, "journal-bounds", () =>
-        makeIncrementalGroupedQueryExecution(readModel, compiled, () => {}),
+      const execution = yield* acquireMaterializedQueryExecution(
+        readModel,
+        "journal-bounds",
+        compiled.plan.resultSemantics,
+        () => makeIncrementalGroupedQueryExecution(readModel, compiled, () => {}),
       );
       expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
 
@@ -407,11 +413,17 @@ describe("Subscription lifecycle ownership", () => {
           aggregates: { rowCount: { aggFunc: "count" } },
         },
       );
-      yield* acquireMaterializedQueryExecution(storage.readModel, "overflow-journal", () =>
-        makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
+      yield* acquireMaterializedQueryExecution(
+        storage.readModel,
+        "overflow-journal",
+        compiled.plan.resultSemantics,
+        () => makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
       );
-      yield* acquireMaterializedQueryExecution(storage.readModel, "overflow-journal-second", () =>
-        makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
+      yield* acquireMaterializedQueryExecution(
+        storage.readModel,
+        "overflow-journal-second",
+        compiled.plan.resultSemantics,
+        () => makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
       );
       yield* releaseMaterializedQueryExecution(storage.readModel, "overflow-journal-second");
       expect(storage.readModel.changesSince(storage.version)).toStrictEqual([]);
@@ -481,8 +493,11 @@ describe("Subscription lifecycle ownership", () => {
         ),
       );
       fallbackStorage.advanceVersion();
-      yield* acquireMaterializedQueryExecution(fallbackStorage.readModel, "fallback-clear", () =>
-        makeIncrementalGroupedQueryExecution(fallbackStorage.readModel, compiled, () => {}),
+      yield* acquireMaterializedQueryExecution(
+        fallbackStorage.readModel,
+        "fallback-clear",
+        compiled.plan.resultSemantics,
+        () => makeIncrementalGroupedQueryExecution(fallbackStorage.readModel, compiled, () => {}),
       );
       yield* clearStoreRawQueryExecutions(fallbackStorage.readModel);
       expect(yield* activeStoreRawQueryExecutionCount(fallbackStorage.readModel)).toBe(0);
@@ -508,6 +523,7 @@ describe("Subscription lifecycle ownership", () => {
       const execution = yield* acquireMaterializedQueryExecution(
         storage.readModel,
         "demoted-grouped-journal",
+        compiled.plan.resultSemantics,
         (releaseRetainedChanges) =>
           makeIncrementalGroupedQueryExecution(
             storage.readModel,
@@ -720,6 +736,7 @@ describe("Subscription lifecycle ownership", () => {
       const execution = yield* acquireMaterializedQueryExecution(
         readModel,
         "empty-materialized",
+        emptyResultSemantics,
         makeExecution,
       );
       const cursor = execution.createCursor();
@@ -727,7 +744,12 @@ describe("Subscription lifecycle ownership", () => {
 
       expect(Option.isNone(unchanged)).toBe(true);
       expect(evaluationCount).toBe(1);
-      yield* acquireMaterializedQueryExecution(readModel, "second-materialized", makeExecution);
+      yield* acquireMaterializedQueryExecution(
+        readModel,
+        "second-materialized",
+        emptyResultSemantics,
+        makeExecution,
+      );
       expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(2);
       yield* releaseMaterializedQueryExecution(readModel, "empty-materialized");
       expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);

--- a/packages/column-live-view-engine/src/topic-column-vector.ts
+++ b/packages/column-live-view-engine/src/topic-column-vector.ts
@@ -299,9 +299,7 @@ export const columnScalarEqualityKey = (
   }
   if (column.kind === "number") {
     const value = column.numberAt(slot);
-    return value === undefined
-      ? undefined
-      : `number:${Object.is(value, -0) ? "-0" : value.toString()}`;
+    return value === undefined ? undefined : `number:${value.toString()}`;
   }
   if (column.kind === "bigint") {
     const value = column.bigintAt(slot);

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-index.test.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-index.test.ts
@@ -1102,42 +1102,45 @@ describe("Topic predicate candidate index", () => {
     }),
   );
 
-  it.effect("keeps broad exact scalar predicates correct without row callbacks", () =>
-    Effect.gen(function* () {
-      const SkewedRow = Schema.Struct({
-        id: Schema.String,
-        status: Schema.String,
-      });
-      const rowCount = 20_000;
-      const skippedSlots = new Set(Array.from({ length: 4_096 }, (_value, index) => index * 2));
-      const rows = Array.from({ length: rowCount }, (_value, index) => ({
-        id: `row-${index.toString().padStart(5, "0")}`,
-        status: skippedSlots.has(index) ? "skip" : "match",
-      }));
-      const store = new TopicStore("skewed", SkewedRow, "id", () => {});
-      yield* publishTopicStoreRows(store, rows, (topic, message) =>
-        InvalidRowError.make({ topic, message }),
-      );
+  it.effect(
+    "keeps broad exact scalar predicates correct without row callbacks",
+    () =>
+      Effect.gen(function* () {
+        const SkewedRow = Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+        });
+        const rowCount = 20_000;
+        const skippedSlots = new Set(Array.from({ length: 4_096 }, (_value, index) => index * 2));
+        const rows = Array.from({ length: rowCount }, (_value, index) => ({
+          id: `row-${index.toString().padStart(5, "0")}`,
+          status: skippedSlots.has(index) ? "skip" : "match",
+        }));
+        const store = new TopicStore("skewed", SkewedRow, "id", () => {});
+        yield* publishTopicStoreRows(store, rows, (topic, message) =>
+          InvalidRowError.make({ topic, message }),
+        );
 
-      const readModel = topicStoreReadModel(store);
-      const fallbackResult = readModel.scanRawWindow({
-        predicate: {
-          filters: [{ field: "status", operator: "eq", value: "match" }],
-          callbackRequired: false,
-          callbackSkippable: true,
-        },
-        orderBy: [],
-        matches: () => {
-          throw new Error("complete skewed predicates should not call row callbacks");
-        },
-        compare: (left, right) => left.key.localeCompare(right.key),
-        offset: 0,
-        limit: 0,
-      });
+        const readModel = topicStoreReadModel(store);
+        const fallbackResult = readModel.scanRawWindow({
+          predicate: {
+            filters: [{ field: "status", operator: "eq", value: "match" }],
+            callbackRequired: false,
+            callbackSkippable: true,
+          },
+          orderBy: [],
+          matches: () => {
+            throw new Error("complete skewed predicates should not call row callbacks");
+          },
+          compare: (left, right) => left.key.localeCompare(right.key),
+          offset: 0,
+          limit: 0,
+        });
 
-      expect(fallbackResult.keys).toStrictEqual([]);
-      expect(fallbackResult.totalRows).toBe(rowCount - skippedSlots.size);
-    }),
+        expect(fallbackResult.keys).toStrictEqual([]);
+        expect(fallbackResult.totalRows).toBe(rowCount - skippedSlots.size);
+      }),
+    10_000,
   );
 
   it("does not touch non-candidate row entries for exact scalar and range scans", () => {

--- a/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
+++ b/packages/column-live-view-engine/src/topic-raw-ordered-window-index.ts
@@ -189,7 +189,7 @@ export const compiledRawStorageOrder = (
   const orderColumns: Array<RawStorageOrderColumn> = [];
   for (const order of storageOrderBy) {
     const column = state.columns.get(order.field);
-    if (column === undefined) {
+    if (column === undefined || column.kind === "generic") {
       return undefined;
     }
     orderColumns.push({
@@ -218,7 +218,7 @@ export const compareSlotsByStorageOrder = (
 };
 
 const rawStorageOrderColumnComparator = (
-  column: TopicColumnValues,
+  column: Exclude<TopicColumnValues, { readonly kind: "generic" }>,
 ): ((left: number, right: number) => number) => {
   if (column.kind === "string") {
     return (left, right) => compareStringColumnSlots(column, left, right);
@@ -229,10 +229,7 @@ const rawStorageOrderColumnComparator = (
   if (column.kind === "bigint") {
     return (left, right) => compareBigIntColumnSlots(column, left, right);
   }
-  if (column.kind === "bigDecimal") {
-    return (left, right) => compareBigDecimalColumnSlots(column, left, right);
-  }
-  return (left, right) => compareQueryValue(columnValue(column, left), columnValue(column, right));
+  return (left, right) => compareBigDecimalColumnSlots(column, left, right);
 };
 
 const compareStringColumnSlots = (

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -1,6 +1,9 @@
-import { Effect, Schema } from "effect";
+import type { RowSchema } from "@effect-view-server/config";
+import { validateDecodedRow } from "@effect-view-server/config/internal";
+import { Effect } from "effect";
 import { topicRowChangedFieldsFromRows, type TopicRowChangedFields } from "./row-scan";
-import { cloneRow, fieldValue, isPlainRecord } from "./row-values";
+import { fieldValue, isPlainRecord } from "./row-values";
+import type { TopicRowValueSemantics } from "./topic-row-value-semantics";
 
 type RowObject = object;
 
@@ -16,29 +19,16 @@ export type PreparedTopicRow = {
 export type TopicRowPreparationContext = {
   readonly fieldNames: ReadonlySet<string>;
   readonly keyField: string;
-  readonly schema: Schema.Codec<object, unknown, never, unknown>;
+  readonly schema: RowSchema;
+  readonly semantics: TopicRowValueSemantics;
   readonly topic: string;
 };
-
-const decodeTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decode")(function* <Error>(
-  context: TopicRowPreparationContext,
-  row: RowObject,
-  invalidRow: InvalidRowErrorFactory<Error>,
-) {
-  return yield* Effect.try({
-    try: () => {
-      const decoded = Schema.decodeUnknownSync(context.schema)(row);
-      return normalizedDecodedTopicRow(context, decoded);
-    },
-    catch: (cause) => invalidRow(context.topic, String(cause)),
-  });
-});
 
 const normalizedDecodedTopicRow = (
   context: TopicRowPreparationContext,
   decoded: RowObject,
 ): RowObject => {
-  const cloned = cloneRow(decoded);
+  const cloned = context.semantics.materializeRow(decoded);
   for (const field of context.fieldNames) {
     if (!Object.hasOwn(cloned, field)) {
       Object.defineProperty(cloned, field, {
@@ -71,13 +61,10 @@ const validateDecodedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decoded
     row: RowObject,
     invalidRow: InvalidRowErrorFactory<Error>,
   ) {
-    return yield* Effect.try({
-      try: () => {
-        const decoded = Schema.decodeUnknownSync(Schema.toType(context.schema))(row);
-        return normalizedDecodedTopicRow(context, decoded);
-      },
-      catch: (cause) => invalidRow(context.topic, String(cause)),
-    });
+    const decoded = yield* validateDecodedRow(context.schema, row).pipe(
+      Effect.mapError((cause) => invalidRow(context.topic, String(cause))),
+    );
+    return yield* normalizeDecodedTopicRow(context, decoded, invalidRow);
   },
 );
 
@@ -95,30 +82,56 @@ const topicRowKey = Effect.fn("ColumnLiveViewEngine.topicRow.key")(function* <Er
   return key;
 });
 
-const validateTopicPatchKeys = Effect.fn("ColumnLiveViewEngine.topicRow.patchKeys.validate")(
-  function* <Error>(
-    context: TopicRowPreparationContext,
-    patch: unknown,
-    invalidRow: InvalidRowErrorFactory<Error>,
-  ) {
-    if (!isPlainRecord(patch)) {
-      return yield* Effect.fail(invalidRow(context.topic, "Patch must be a plain object."));
+const inspectTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.inspect")(function* <
+  Error,
+>(context: TopicRowPreparationContext, patch: unknown, invalidRow: InvalidRowErrorFactory<Error>) {
+  const record = yield* Effect.try({
+    try: () => (isPlainRecord(patch) ? patch : undefined),
+    catch: () => invalidRow(context.topic, "Could not inspect patch object."),
+  });
+  if (record === undefined) {
+    return yield* Effect.fail(invalidRow(context.topic, "Patch must be a plain object."));
+  }
+  const keys = yield* Effect.try({
+    try: () => Reflect.ownKeys(record),
+    catch: () => invalidRow(context.topic, "Could not inspect patch fields."),
+  });
+  const inspected: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (typeof key !== "string" || !context.fieldNames.has(key)) {
+      return yield* Effect.fail(
+        invalidRow(context.topic, `Patch contains unknown field: ${String(key)}.`),
+      );
     }
-    for (const key of Reflect.ownKeys(patch)) {
-      if (typeof key !== "string" || !context.fieldNames.has(key)) {
-        return yield* Effect.fail(
-          invalidRow(context.topic, `Patch contains unknown field: ${String(key)}.`),
-        );
-      }
+    const descriptor = yield* Effect.try({
+      try: () => Object.getOwnPropertyDescriptor(record, key),
+      catch: () => invalidRow(context.topic, `Could not inspect patch field: ${key}.`),
+    });
+    if (descriptor === undefined || !("value" in descriptor)) {
+      return yield* Effect.fail(
+        invalidRow(context.topic, `Patch field must be a data property: ${key}.`),
+      );
     }
-  },
-);
+    if (descriptor.enumerable !== true) {
+      return yield* Effect.fail(
+        invalidRow(context.topic, `Patch field must be enumerable: ${key}.`),
+      );
+    }
+    Object.defineProperty(inspected, key, {
+      configurable: true,
+      enumerable: true,
+      value: descriptor.value,
+      writable: true,
+    });
+  }
+  return inspected;
+});
 
 export const prepareTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.prepare")(function* <
   Error,
   Row extends RowObject,
 >(context: TopicRowPreparationContext, row: Row, invalidRow: InvalidRowErrorFactory<Error>) {
-  const decoded = yield* decodeTopicRow(context, row, invalidRow);
+  const decoded = yield* validateDecodedTopicRow(context, row, invalidRow);
   const key = yield* topicRowKey(context, decoded, invalidRow);
   return {
     key,
@@ -135,7 +148,7 @@ export const prepareTopicRowWithStorageKey = Effect.fn(
   storageKey: string,
   invalidRow: InvalidRowErrorFactory<Error>,
 ) {
-  const decoded = yield* decodeTopicRow(context, row, invalidRow);
+  const decoded = yield* validateDecodedTopicRow(context, row, invalidRow);
   yield* topicRowKey(context, decoded, invalidRow);
   return {
     key: storageKey,
@@ -186,11 +199,11 @@ const preparePatchedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.patch.pr
     invalidRow: InvalidRowErrorFactory<Error>,
     preparePatchedRow: (row: RowObject) => Effect.Effect<RowObject, Error>,
   ) {
-    yield* validateTopicPatchKeys(context, patch, invalidRow);
+    const inspectedPatch = yield* inspectTopicPatch(context, patch, invalidRow);
     if (current === undefined) {
       return yield* Effect.fail(invalidRow(context.topic, `Cannot patch missing key: ${key}`));
     }
-    const decoded = yield* preparePatchedRow({ ...current, ...patch });
+    const decoded = yield* preparePatchedRow({ ...current, ...inspectedPatch });
     const decodedKey = yield* topicRowKey(context, decoded, invalidRow);
     if (decodedKey !== key) {
       return yield* Effect.fail(invalidRow(context.topic, "Patch must not change the row key."));
@@ -200,6 +213,7 @@ const preparePatchedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.patch.pr
       current,
       decoded,
       decodedFieldNames,
+      (field, left, right) => context.semantics.equivalentField(field, left, right),
     );
     if (topicRowChangedFields === undefined) {
       return {
@@ -226,7 +240,7 @@ export const prepareTopicPatch = Effect.fn("ColumnLiveViewEngine.topicRow.patch.
     invalidRow: InvalidRowErrorFactory<Error>,
   ) {
     return yield* preparePatchedTopicRow(context, key, current, patch, invalidRow, (row) =>
-      decodeTopicRow(context, row, invalidRow),
+      validateDecodedTopicRow(context, row, invalidRow),
     );
   },
 );

--- a/packages/column-live-view-engine/src/topic-row-preparation.ts
+++ b/packages/column-live-view-engine/src/topic-row-preparation.ts
@@ -24,14 +24,13 @@ export type TopicRowPreparationContext = {
   readonly topic: string;
 };
 
-const normalizedDecodedTopicRow = (
+const completeDecodedTopicRow = (
   context: TopicRowPreparationContext,
-  decoded: RowObject,
+  row: RowObject,
 ): RowObject => {
-  const cloned = context.semantics.materializeRow(decoded);
   for (const field of context.fieldNames) {
-    if (!Object.hasOwn(cloned, field)) {
-      Object.defineProperty(cloned, field, {
+    if (!Object.hasOwn(row, field)) {
+      Object.defineProperty(row, field, {
         configurable: true,
         enumerable: false,
         value: undefined,
@@ -39,7 +38,14 @@ const normalizedDecodedTopicRow = (
       });
     }
   }
-  return cloned;
+  return row;
+};
+
+const normalizedDecodedTopicRow = (
+  context: TopicRowPreparationContext,
+  decoded: RowObject,
+): RowObject => {
+  return completeDecodedTopicRow(context, context.semantics.materializeRow(decoded));
 };
 
 const normalizeDecodedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decoded.normalize")(
@@ -64,7 +70,11 @@ const validateDecodedTopicRow = Effect.fn("ColumnLiveViewEngine.topicRow.decoded
     const decoded = yield* validateDecodedRow(context.schema, row).pipe(
       Effect.mapError((cause) => invalidRow(context.topic, String(cause))),
     );
-    return yield* normalizeDecodedTopicRow(context, decoded, invalidRow);
+    return yield* Effect.try({
+      try: () =>
+        completeDecodedTopicRow(context, context.semantics.materializeValidatedRowFields(decoded)),
+      catch: (cause) => invalidRow(context.topic, String(cause)),
+    });
   },
 );
 

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -1,4 +1,5 @@
-import { Effect, Schema } from "effect";
+import type { RowSchema } from "@effect-view-server/config";
+import { Effect } from "effect";
 import { createActiveQueryRegistry, type ActiveQueryStoreState } from "./active-query";
 import type {
   TopicRowChange,
@@ -16,7 +17,7 @@ import type {
 import type { TopicRawPredicatePlan } from "./raw-predicate-plan";
 import type { OrderedSlotIndex, RawStorageOrderColumn } from "./topic-ordered-window";
 import { rawQueryCompilerMetadata, type RawQueryCompilerMetadata } from "./raw-query-compiler";
-import { cloneUnknown, rowsEqual, trustedFieldValue } from "./row-values";
+import { trustedFieldValue } from "./row-values";
 import {
   columnValue,
   createTopicColumnValues,
@@ -56,13 +57,13 @@ import {
   compareSlotsByStorageOrder,
   compiledRawStorageOrder,
 } from "./topic-raw-ordered-window-index";
+import type { TopicRowValueSemantics } from "./topic-row-value-semantics";
 
 type RowObject = object;
 
 type RawProjectionColumn = {
   readonly column: MutableTopicColumnValues;
   readonly field: string;
-  readonly shouldClone: boolean;
 };
 
 type AppendBatchReservation = {
@@ -81,6 +82,7 @@ const noopAppendBatchReservation: AppendBatchReservation = {
 export class TopicRowStorage {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
   readonly readModel: ActiveQueryStoreState;
+  readonly valueSemantics: TopicRowValueSemantics;
 
   private readonly slots: Array<TopicRowEntry<object>> = [];
   private readonly keyToSlot = new Map<string, number>();
@@ -109,12 +111,13 @@ export class TopicRowStorage {
 
   constructor(
     readonly topic: string,
-    schema: Schema.Codec<object, unknown, never, unknown>,
+    schema: RowSchema,
     keyField: string,
     rowChangeJournalLimits?: TopicRowChangeJournalLimits,
   ) {
     this.rowChangeJournal = new TopicRowChangeJournal<object>(rowChangeJournalLimits);
     this.rawQueryMetadata = rawQueryCompilerMetadata(schema);
+    this.valueSemantics = this.rawQueryMetadata.valueSemantics;
     this.rawWindowScanState = {
       columns: this.columns,
       orderedSlotIndexes: this.orderedSlotIndexes,
@@ -127,6 +130,7 @@ export class TopicRowStorage {
       fieldNames: this.rawQueryMetadata.fieldNames,
       keyField,
       schema,
+      semantics: this.valueSemantics,
       topic,
     };
     for (const field of this.rawQueryMetadata.fieldNames) {
@@ -293,9 +297,18 @@ export class TopicRowStorage {
 
   private projectRawRow(slot: number, selectedFields: ReadonlyArray<string>): RowObject {
     const projected: Record<string, unknown> = {};
+    const row = this.slots[slot]!.row;
     for (const projection of this.rawProjectionPlan(selectedFields)) {
+      if (!Object.prototype.propertyIsEnumerable.call(row, projection.field)) {
+        continue;
+      }
       const value = columnValue(projection.column, slot);
-      projected[projection.field] = projection.shouldClone ? cloneUnknown(value) : value;
+      Object.defineProperty(projected, projection.field, {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+      });
     }
     return projected;
   }
@@ -425,7 +438,6 @@ export class TopicRowStorage {
       return {
         column,
         field,
-        shouldClone: column.kind === "generic",
       };
     });
     this.rawProjectionPlans.set(selectedFields, plan);
@@ -583,7 +595,7 @@ export class TopicRowStorage {
     slot: number,
   ): PreparedTopicRowReplacement | undefined {
     const previous = this.slots[slot]!.row;
-    if (rowsEqual(previous, prepared.row)) {
+    if (this.valueSemantics.equivalentRows(previous, prepared.row)) {
       return undefined;
     }
     if (prepared.source === "row") {
@@ -597,6 +609,7 @@ export class TopicRowStorage {
         previous,
         prepared.row,
         this.rawQueryMetadata.fieldNames,
+        (field, left, right) => this.valueSemantics.equivalentField(field, left, right),
       ),
       previous,
     };

--- a/packages/column-live-view-engine/src/topic-row-value-semantics.test.ts
+++ b/packages/column-live-view-engine/src/topic-row-value-semantics.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+import { makeTopicRowValueSemantics } from "./topic-row-value-semantics";
+
+describe("Topic Row value semantics", () => {
+  it("rejects an unknown field requested outside validated query preparation", () => {
+    const semantics = makeTopicRowValueSemantics(
+      Schema.Struct({
+        id: Schema.String,
+      }),
+    );
+
+    expect(() => semantics.field("missing")).toThrowError("Unknown Topic Row field: missing.");
+  });
+
+  it("keeps malformed non-Struct schema metadata defensive", () => {
+    // @ts-expect-error hostile callers can still pass a non-Struct schema.
+    const semantics = makeTopicRowValueSemantics(Schema.String);
+
+    expect(semantics.fieldNames).toStrictEqual([]);
+    expect(() => semantics.field("missing")).toThrowError("Unknown Topic Row field: missing.");
+  });
+
+  it("reads an accessor field descriptor once before rejecting it", () => {
+    const semantics = makeTopicRowValueSemantics(
+      Schema.Struct({
+        id: Schema.String,
+      }),
+    );
+    let descriptorReads = 0;
+    const accessorRow = {};
+    Object.defineProperty(accessorRow, "id", {
+      enumerable: true,
+      get() {
+        return "order-1";
+      },
+    });
+    const row = new Proxy(accessorRow, {
+      getOwnPropertyDescriptor(target, property) {
+        if (property === "id") {
+          descriptorReads += 1;
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    expect(() => semantics.materializeRow(row)).toThrowError(
+      "Topic Row field id must be an own data property.",
+    );
+    expect(descriptorReads).toBe(1);
+  });
+});

--- a/packages/column-live-view-engine/src/topic-row-value-semantics.ts
+++ b/packages/column-live-view-engine/src/topic-row-value-semantics.ts
@@ -1,0 +1,189 @@
+import { schemaAstChildren } from "@effect-view-server/config/internal";
+import { makeSchemaJsonIdentity } from "@effect-view-server/effect-utils";
+import { Schema, SchemaAST } from "effect";
+import { isBigDecimal } from "effect/BigDecimal";
+import { compareQueryValue } from "./query-value";
+
+type RowObject = object;
+type ValueSchema = Schema.Codec<unknown, unknown, never, never>;
+type TopicRowSchema = Schema.Codec<object, unknown, never, never>;
+
+export type SchemaValueSemantics = {
+  readonly canonicalKey: (value: unknown) => string;
+  readonly compare: (left: unknown, right: unknown) => number;
+  readonly decodeEncoded: (value: unknown) => unknown;
+  readonly equivalent: (left: unknown, right: unknown) => boolean;
+  readonly materialize: (value: unknown) => unknown;
+};
+
+export type TopicRowValueSemantics = {
+  readonly equivalentField: (field: string, left: unknown, right: unknown) => boolean;
+  readonly equivalentRows: (left: RowObject, right: RowObject) => boolean;
+  readonly field: (field: string) => SchemaValueSemantics;
+  readonly fieldNames: ReadonlyArray<string>;
+  readonly materializeRow: (row: RowObject) => RowObject;
+};
+
+type SchemaWithFields = TopicRowSchema & {
+  readonly fields: Record<string, unknown>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isSchemaWithFields = (schema: TopicRowSchema): schema is SchemaWithFields =>
+  "fields" in schema && isRecord(schema.fields);
+
+const isValueSchema = (value: unknown): value is ValueSchema => Schema.isSchema(value);
+
+const scalarComparable = (value: unknown): boolean =>
+  value === null ||
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "bigint" ||
+  typeof value === "boolean" ||
+  value === undefined ||
+  isBigDecimal(value);
+
+const unorderedEffectCollectionTags = new Set(["effect/HashMap", "effect/HashSet"]);
+
+const schemaContainsUnorderedEffectCollection = (
+  ast: SchemaAST.AST,
+  seen: Set<SchemaAST.AST>,
+): boolean => {
+  if (seen.has(ast)) {
+    return false;
+  }
+  seen.add(ast);
+  if (SchemaAST.isDeclaration(ast)) {
+    const typeConstructor = ast.annotations?.["typeConstructor"];
+    const tag = Reflect.get(Object(typeConstructor), "_tag");
+    if (typeof tag === "string" && unorderedEffectCollectionTags.has(tag)) {
+      return true;
+    }
+  }
+  return schemaAstChildren(ast).some((child) =>
+    schemaContainsUnorderedEffectCollection(child, seen),
+  );
+};
+
+export const makeSchemaValueSemantics = (schema: ValueSchema): SchemaValueSemantics => {
+  const identity = makeSchemaJsonIdentity(schema);
+  const canonicalObjectKeys = new WeakMap<object, string>();
+
+  const canonicalKey = (value: unknown): string => {
+    if ((typeof value === "object" && value !== null) || typeof value === "function") {
+      const cached = canonicalObjectKeys.get(value);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const key = identity.canonicalKey(value);
+      canonicalObjectKeys.set(value, key);
+      return key;
+    }
+    return identity.canonicalKey(value);
+  };
+
+  const schemaEquivalent = Schema.toEquivalence(schema);
+  const equivalent = schemaContainsUnorderedEffectCollection(schema.ast, new Set())
+    ? (left: unknown, right: unknown): boolean => canonicalKey(left) === canonicalKey(right)
+    : schemaEquivalent;
+
+  return {
+    canonicalKey,
+    compare: (left, right) => {
+      if (scalarComparable(left) && scalarComparable(right)) {
+        return compareQueryValue(left, right);
+      }
+      const leftKey = canonicalKey(left);
+      const rightKey = canonicalKey(right);
+      return Number(leftKey > rightKey) - Number(leftKey < rightKey);
+    },
+    decodeEncoded: identity.decodeEncoded,
+    equivalent,
+    materialize: identity.materializeDecoded,
+  };
+};
+
+type TopicRowSchemaSemantics = {
+  readonly materialize: (row: RowObject) => RowObject;
+};
+
+const makeTopicRowSchemaSemantics = (schema: TopicRowSchema): TopicRowSchemaSemantics => {
+  const identity = makeSchemaJsonIdentity<RowObject>(schema);
+  return {
+    materialize: identity.materializeDecoded,
+  };
+};
+
+const unknownValueSemantics = makeSchemaValueSemantics(Schema.Unknown);
+
+const schemaFieldSemantics = (
+  schema: TopicRowSchema,
+): ReadonlyMap<string, SchemaValueSemantics> => {
+  if (!isSchemaWithFields(schema)) {
+    return new Map();
+  }
+  const fields = new Map<string, SchemaValueSemantics>();
+  for (const [field, fieldSchema] of Object.entries(schema.fields)) {
+    fields.set(
+      field,
+      isValueSchema(fieldSchema) ? makeSchemaValueSemantics(fieldSchema) : unknownValueSemantics,
+    );
+  }
+  return fields;
+};
+
+const validateRowFieldDescriptors = (row: RowObject, fieldNames: ReadonlyArray<string>): void => {
+  for (const field of fieldNames) {
+    const descriptor = Object.getOwnPropertyDescriptor(row, field);
+    if (descriptor === undefined) {
+      continue;
+    }
+    if (!("value" in descriptor)) {
+      throw new TypeError(`Topic Row field ${field} must be an own data property.`);
+    }
+  }
+};
+
+export const makeTopicRowValueSemantics = (schema: TopicRowSchema): TopicRowValueSemantics => {
+  const fields = schemaFieldSemantics(schema);
+  const fieldNames = [...fields.keys()];
+  let cachedRowSemantics: TopicRowSchemaSemantics | undefined;
+  const rowSemantics = (): TopicRowSchemaSemantics => {
+    cachedRowSemantics ??= makeTopicRowSchemaSemantics(schema);
+    return cachedRowSemantics;
+  };
+  const field = (name: string): SchemaValueSemantics => {
+    const semantics = fields.get(name);
+    if (semantics === undefined) {
+      throw new TypeError(`Unknown Topic Row field: ${name}.`);
+    }
+    return semantics;
+  };
+
+  return {
+    equivalentField: (name, left, right) => field(name).equivalent(left, right),
+    equivalentRows: (left, right) => {
+      for (const name of fieldNames) {
+        const leftHasField = Object.prototype.propertyIsEnumerable.call(left, name);
+        if (leftHasField !== Object.prototype.propertyIsEnumerable.call(right, name)) {
+          return false;
+        }
+        if (
+          leftHasField &&
+          !field(name).equivalent(Reflect.get(left, name), Reflect.get(right, name))
+        ) {
+          return false;
+        }
+      }
+      return true;
+    },
+    field,
+    fieldNames,
+    materializeRow: (row) => {
+      validateRowFieldDescriptors(row, fieldNames);
+      return rowSemantics().materialize(row);
+    },
+  };
+};

--- a/packages/column-live-view-engine/src/topic-row-value-semantics.ts
+++ b/packages/column-live-view-engine/src/topic-row-value-semantics.ts
@@ -22,6 +22,7 @@ export type TopicRowValueSemantics = {
   readonly field: (field: string) => SchemaValueSemantics;
   readonly fieldNames: ReadonlyArray<string>;
   readonly materializeRow: (row: RowObject) => RowObject;
+  readonly materializeValidatedRowFields: (row: RowObject) => RowObject;
 };
 
 type SchemaWithFields = TopicRowSchema & {
@@ -44,6 +45,14 @@ const scalarComparable = (value: unknown): boolean =>
   typeof value === "boolean" ||
   value === undefined ||
   isBigDecimal(value);
+
+const isBorrowableImmutablePrimitive = (value: unknown): boolean =>
+  value === null ||
+  value === undefined ||
+  typeof value === "string" ||
+  (typeof value === "number" && !Object.is(value, -0)) ||
+  typeof value === "bigint" ||
+  typeof value === "boolean";
 
 const unorderedEffectCollectionTags = new Set(["effect/HashMap", "effect/HashSet"]);
 
@@ -184,6 +193,25 @@ export const makeTopicRowValueSemantics = (schema: TopicRowSchema): TopicRowValu
     materializeRow: (row) => {
       validateRowFieldDescriptors(row, fieldNames);
       return rowSemantics().materialize(row);
+    },
+    materializeValidatedRowFields: (row) => {
+      validateRowFieldDescriptors(row, fieldNames);
+      for (const name of fieldNames) {
+        if (!Object.prototype.propertyIsEnumerable.call(row, name)) {
+          continue;
+        }
+        const value = Reflect.get(row, name);
+        if (isBorrowableImmutablePrimitive(value)) {
+          continue;
+        }
+        Object.defineProperty(row, name, {
+          configurable: true,
+          enumerable: true,
+          value: field(name).materialize(value),
+          writable: true,
+        });
+      }
+      return row;
     },
   };
 };

--- a/packages/column-live-view-engine/src/topic-slot-predicate.ts
+++ b/packages/column-live-view-engine/src/topic-slot-predicate.ts
@@ -63,7 +63,7 @@ const slotFilterMatcher = (
         return (slot) => column.stringAt(slot) === filter.value;
       }
       if (column.kind === "number" && typeof filter.value === "number") {
-        return (slot) => Object.is(column.numberAt(slot), filter.value);
+        return (slot) => column.numberAt(slot) === filter.value;
       }
       if (column.kind === "bigint" && typeof filter.value === "bigint") {
         return (slot) => column.bigintAt(slot) === filter.value;
@@ -88,7 +88,7 @@ const slotFilterMatcher = (
         if (column.kind === "number" && typeof filter.value === "number") {
           return (slot) => {
             const value = column.numberAt(slot);
-            return value !== undefined && !Object.is(value, filter.value);
+            return value !== undefined && value !== filter.value;
           };
         }
         if (column.kind === "bigint" && typeof filter.value === "bigint") {

--- a/packages/column-live-view-engine/src/topic-store-plan-semantics.test.ts
+++ b/packages/column-live-view-engine/src/topic-store-plan-semantics.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Equivalence, Schema } from "effect";
+import { evaluateRawQuery } from "./active-query";
+import { InvalidRowError } from "./index";
+import { prepareRawQuery, rawQueryCompilerMetadata } from "./raw-query-compiler";
+import { publishTopicStoreRows, TopicStore } from "./topic-store";
+import { topicStoreReadModel } from "./topic-store-state";
+import { position, Position } from "../test-harness/public-engine";
+
+describe("Topic Store plan semantics", () => {
+  it.effect("rejects generic storage-order hints and uses the plan comparator", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore("positions", Position, "id", () => {});
+      yield* publishTopicStoreRows(
+        store,
+        [position("1", "aaa", 1n, "1", false), position("2", "bbb", 2n, "2", true)],
+        (topic, message) => InvalidRowError.make({ topic, message }),
+      );
+
+      const result = topicStoreReadModel(store).scanRawWindow({
+        predicate: {
+          filters: [],
+          callbackRequired: false,
+        },
+        orderBy: [{ field: "active", direction: "asc" }],
+        storageOrderBy: [{ field: "active", direction: "asc" }],
+        matches: () => true,
+        compare: (left, right) => right.key.localeCompare(left.key),
+        offset: 0,
+        limit: undefined,
+      });
+
+      expect(result.keys).toStrictEqual(["2", "1"]);
+    }),
+  );
+
+  it.effect("keeps unproven scalar equivalence callback-only at the storage seam", () =>
+    Effect.gen(function* () {
+      const CaseInsensitiveString = Schema.String.pipe(
+        Schema.overrideToEquivalence(() =>
+          Equivalence.make((left, right) => left.toLowerCase() === right.toLowerCase()),
+        ),
+      );
+      const CaseInsensitiveRows = Schema.Struct({
+        id: Schema.String,
+        label: CaseInsensitiveString,
+        suspendedLabel: Schema.suspend(() => Schema.String),
+      });
+      const compiled = yield* prepareRawQuery<object, object>(
+        "caseInsensitiveRows",
+        rawQueryCompilerMetadata(CaseInsensitiveRows),
+        {
+          select: ["id"],
+          where: {
+            label: { eq: "alpha" },
+          },
+          orderBy: [{ field: "label", direction: "asc" }],
+        },
+      );
+
+      const evaluation = evaluateRawQuery(
+        {
+          scanRawWindow: (plan) => {
+            expect(plan.predicate).toStrictEqual({
+              filters: [],
+              callbackRequired: true,
+              callbackSkippable: false,
+            });
+            expect(Object.hasOwn(plan, "storageOrderBy")).toBe(false);
+            expect(plan.matches({ id: "upper", label: "ALPHA" })).toBe(true);
+            expect(plan.matches({ id: "other", label: "beta" })).toBe(false);
+            return {
+              keys: [],
+              window: [],
+              totalRows: 0,
+            };
+          },
+          version: () => 19,
+        },
+        compiled,
+      );
+
+      expect(evaluation).toStrictEqual({
+        keys: [],
+        rows: [],
+        window: [],
+        totalRows: 0,
+        version: 19,
+      });
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/topic-store-query-execution.test.ts
+++ b/packages/column-live-view-engine/src/topic-store-query-execution.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
-import { fromStringUnsafe } from "effect/BigDecimal";
+import { format, fromStringUnsafe, isBigDecimal } from "effect/BigDecimal";
 import { InvalidRowError } from "./index";
 import { TopicRowStorage } from "./topic-row-storage";
 import { evaluateRawQuery } from "./active-query";
@@ -497,7 +497,19 @@ describe("Topic Store query execution", () => {
       const positionEvaluation = evaluateRawQuery(
         {
           scanRawWindow: (plan) => {
-            expect(plan.predicate).toStrictEqual({
+            expect({
+              ...plan.predicate,
+              filters: plan.predicate.filters.map((filter) =>
+                filter.operator === "in"
+                  ? {
+                      ...filter,
+                      values: filter.values.map((value) =>
+                        isBigDecimal(value) ? format(value) : value,
+                      ),
+                    }
+                  : filter,
+              ),
+            }).toStrictEqual({
               filters: [
                 {
                   field: "active",
@@ -514,7 +526,7 @@ describe("Topic Store query execution", () => {
                 {
                   field: "price",
                   operator: "in",
-                  values: [matchedPrice],
+                  values: ["1"],
                   valueKeys: new Set(["bigDecimal:1"]),
                 },
               ],

--- a/packages/column-live-view-engine/src/topic-store-query.ts
+++ b/packages/column-live-view-engine/src/topic-store-query.ts
@@ -78,6 +78,7 @@ export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
   return yield* acquireMaterializedQueryExecution(
     readModel,
     compiled.cacheKey,
+    compiled.plan.resultSemantics,
     (releaseRetainedChanges) =>
       makeIncrementalGroupedQueryExecution(
         readModel,

--- a/packages/column-live-view-engine/src/topic-store-state.ts
+++ b/packages/column-live-view-engine/src/topic-store-state.ts
@@ -1,4 +1,5 @@
-import { Effect, Schema, Semaphore } from "effect";
+import type { RowSchema } from "@effect-view-server/config";
+import { Effect, Semaphore } from "effect";
 import {
   activeStoreQueryExecutionCounts,
   clearStoreRawQueryExecutions,
@@ -35,7 +36,7 @@ export class TopicStore {
 
   constructor(
     readonly topic: string,
-    schema: Schema.Codec<object, unknown, never, unknown>,
+    schema: RowSchema,
     keyField: string,
     onCommit: () => void,
     mutationsAllowed: () => boolean = () => true,

--- a/packages/column-live-view-engine/test-harness/public-engine.ts
+++ b/packages/column-live-view-engine/test-harness/public-engine.ts
@@ -1,7 +1,11 @@
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
-import { createColumnLiveViewEngine, type ColumnLiveViewEngine } from "../src/index";
+import {
+  createColumnLiveViewEngine,
+  type ColumnLiveViewEngine,
+  type InvalidRowError,
+} from "../src/index";
 
 export const Order = Schema.Struct({
   id: Schema.String,
@@ -131,7 +135,7 @@ export const instrument = (
   tags: [...tags],
 });
 
-export const makeEngine = (): Effect.Effect<Engine> =>
+export const makeEngine = (): Effect.Effect<Engine, InvalidRowError> =>
   createColumnLiveViewEngine({ topics: viewServer.topics });
 
 export const withObjectPrototypeValue = <Value, Error, Requirements>(

--- a/packages/config/src/config-atomic-ownership.test.ts
+++ b/packages/config/src/config-atomic-ownership.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+import { snapshotViewServerTopics } from "./config-ownership";
+import { defineViewServerConfig } from "./index";
+
+describe("View Server config atomic ownership", () => {
+  it("snapshots changing topic definitions once before validating the owned graph", () => {
+    const SafeRow = Schema.Struct({ id: Schema.String, value: Schema.String });
+    const UnsupportedRow = Schema.Struct({ id: Schema.String, value: Schema.Date });
+    const reads = {
+      topic: 0,
+      schema: 0,
+      key: 0,
+    };
+    const definition = {
+      get schema() {
+        reads.schema += 1;
+        return reads.schema === 1 ? SafeRow : UnsupportedRow;
+      },
+      get key(): "id" {
+        reads.key += 1;
+        if (reads.key > 1) {
+          throw new Error("topic key was read after ownership capture");
+        }
+        return "id";
+      },
+    };
+    const unsafeDefinition = {
+      schema: UnsupportedRow,
+      key: "id" as const,
+    };
+    const topics = new Proxy(
+      { orders: definition },
+      {
+        get: (target, property, receiver) => {
+          if (property !== "orders") {
+            return Reflect.get(target, property, receiver);
+          }
+          reads.topic += 1;
+          return reads.topic === 1 ? definition : unsafeDefinition;
+        },
+      },
+    );
+
+    const config = defineViewServerConfig({ topics });
+
+    expect(reads).toStrictEqual({
+      topic: 1,
+      schema: 1,
+      key: 1,
+    });
+    expect({
+      key: config.topics.orders.key,
+      schemaField: config.topics.orders.schema.fields.value,
+    }).toStrictEqual({
+      key: "id",
+      schemaField: Schema.String,
+    });
+  });
+
+  it("captures source definitions and nested ownership arrays exactly once", () => {
+    const Row = Schema.Struct({ id: Schema.String });
+    let sourceReads = 0;
+    let regionsReads = 0;
+    const safeSource = {
+      topic: "safe-source",
+      get regions() {
+        regionsReads += 1;
+        return regionsReads === 1 ? ["usa"] : ["london"];
+      },
+    };
+    const unsafeSource = { topic: "unsafe-source", regions: ["london"] };
+    const definition = {
+      schema: Row,
+      key: "id",
+      get kafkaSource() {
+        sourceReads += 1;
+        return sourceReads === 1 ? safeSource : unsafeSource;
+      },
+    };
+
+    const topics = snapshotViewServerTopics({ orders: definition });
+
+    expect({
+      sourceReads,
+      regionsReads,
+      topic: topics.orders.kafkaSource?.topic,
+      regions: topics.orders.kafkaSource?.regions,
+      sourceFrozen: Object.isFrozen(topics.orders.kafkaSource),
+      regionsFrozen: Object.isFrozen(topics.orders.kafkaSource?.regions),
+    }).toStrictEqual({
+      sourceReads: 1,
+      regionsReads: 1,
+      topic: "safe-source",
+      regions: ["usa"],
+      sourceFrozen: true,
+      regionsFrozen: true,
+    });
+  });
+
+  it("preserves non-enumerable and primitive source declarations for structural consumers", () => {
+    const Row = Schema.Struct({ id: Schema.String });
+    const malformedGrpcSource = { kind: "grpc", lifecycle: "wat" };
+    const malformedOrders = {
+      schema: Row,
+      key: "id" as const,
+    };
+    const primitiveOrders = {
+      schema: Row,
+      key: "id" as const,
+    };
+    Object.defineProperty(malformedOrders, "grpcSource", {
+      value: malformedGrpcSource,
+    });
+    Object.defineProperty(primitiveOrders, "grpcSource", {
+      value: "not-a-source",
+    });
+
+    const topics = snapshotViewServerTopics({ malformedOrders, primitiveOrders });
+
+    expect({
+      malformed: Reflect.get(topics.malformedOrders, "grpcSource"),
+      malformedFrozen: Object.isFrozen(Reflect.get(topics.malformedOrders, "grpcSource")),
+      malformedOwn: Object.hasOwn(topics.malformedOrders, "grpcSource"),
+      primitive: Reflect.get(topics.primitiveOrders, "grpcSource"),
+      primitiveOwn: Object.hasOwn(topics.primitiveOrders, "grpcSource"),
+    }).toStrictEqual({
+      malformed: malformedGrpcSource,
+      malformedFrozen: true,
+      malformedOwn: true,
+      primitive: "not-a-source",
+      primitiveOwn: true,
+    });
+  });
+});

--- a/packages/config/src/config-atomic-ownership.test.ts
+++ b/packages/config/src/config-atomic-ownership.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Schema } from "effect";
 import { snapshotViewServerTopics } from "./config-ownership";
-import { defineViewServerConfig } from "./index";
+import { defineViewServerConfig, grpc } from "./index";
+import { ordersService } from "../test-harness/protobuf";
 
 describe("View Server config atomic ownership", () => {
   it("snapshots changing topic definitions once before validating the owned graph", () => {
@@ -95,6 +96,39 @@ describe("View Server config atomic ownership", () => {
       regions: ["usa"],
       sourceFrozen: true,
       regionsFrozen: true,
+    });
+  });
+
+  it("captures and freezes each gRPC client definition", () => {
+    const client = grpc.connectClient({
+      service: ordersService,
+      baseUrl: "https://captured.example.test",
+    });
+    const clients = { orders: client };
+    const config = defineViewServerConfig({ grpc: { clients }, topics: {} });
+
+    expect(Reflect.set(client, "baseUrl", "https://mutated.example.test")).toBe(true);
+    expect(
+      Reflect.set(
+        clients,
+        "orders",
+        grpc.connectClient({
+          service: ordersService,
+          baseUrl: "https://replaced.example.test",
+        }),
+      ),
+    ).toBe(true);
+
+    expect({
+      baseUrl: config.grpc?.clients.orders.baseUrl,
+      clientCaptured: config.grpc?.clients.orders === client,
+      clientFrozen: Object.isFrozen(config.grpc?.clients.orders),
+      clientsFrozen: Object.isFrozen(config.grpc?.clients),
+    }).toStrictEqual({
+      baseUrl: "https://captured.example.test",
+      clientCaptured: false,
+      clientFrozen: true,
+      clientsFrozen: true,
     });
   });
 

--- a/packages/config/src/config-ownership.ts
+++ b/packages/config/src/config-ownership.ts
@@ -11,6 +11,8 @@ type TopicRegistry = Record<
   }
 >;
 
+type GrpcClientRegistry = Record<string, object>;
+
 const schemaSnapshots = new WeakMap<RowSchema, RowSchema>();
 
 export function snapshotViewServerRowSchema<const S extends RowSchema>(schema: S): S;
@@ -93,6 +95,22 @@ const snapshotOwnProperties = (value: object): { [key: PropertyKey]: unknown } =
   }
   return copied;
 };
+
+export function snapshotViewServerGrpcClients<const Clients extends GrpcClientRegistry>(
+  clients: Clients,
+): Clients;
+export function snapshotViewServerGrpcClients(clients: GrpcClientRegistry): GrpcClientRegistry {
+  const snapshot: GrpcClientRegistry = {};
+  for (const clientName of Object.keys(clients)) {
+    Object.defineProperty(snapshot, clientName, {
+      configurable: false,
+      enumerable: true,
+      value: Object.freeze(snapshotOwnProperties(clients[clientName]!)),
+      writable: false,
+    });
+  }
+  return Object.freeze(snapshot);
+}
 
 const snapshotSource = (source: unknown): unknown => {
   if (typeof source !== "object" || source === null) {

--- a/packages/config/src/config-ownership.ts
+++ b/packages/config/src/config-ownership.ts
@@ -1,0 +1,145 @@
+import { Schema, SchemaAST } from "effect";
+import type { RowSchema } from "./topic-contract";
+
+type TopicRegistry = Record<
+  string,
+  {
+    readonly schema: RowSchema;
+    readonly key: string;
+    readonly kafkaSource?: object | undefined;
+    readonly grpcSource?: object | undefined;
+  }
+>;
+
+const schemaSnapshots = new WeakMap<RowSchema, RowSchema>();
+
+export function snapshotViewServerRowSchema<const S extends RowSchema>(schema: S): S;
+export function snapshotViewServerRowSchema(schema: RowSchema): RowSchema {
+  const cached = schemaSnapshots.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const fields = Object.freeze({ ...schema.fields });
+  const ast = schema.ast;
+  const snapshot = new Proxy(schema, {
+    get: (target, property) => {
+      if (property === "fields") {
+        return fields;
+      }
+      if (property === "ast") {
+        return ast;
+      }
+      return Reflect.get(target, property, target);
+    },
+    set: () => false,
+    defineProperty: () => false,
+    deleteProperty: () => false,
+    setPrototypeOf: () => false,
+    preventExtensions: () => false,
+  });
+  schemaSnapshots.set(schema, snapshot);
+  schemaSnapshots.set(snapshot, snapshot);
+  return snapshot;
+}
+
+export const viewServerRowSchemasShareOrigin = (left: RowSchema, right: RowSchema): boolean =>
+  snapshotViewServerRowSchema(left) === snapshotViewServerRowSchema(right);
+
+const rowSchemaObjectsAst = (schema: RowSchema): SchemaAST.Objects | undefined => {
+  if (SchemaAST.isObjects(schema.ast)) {
+    return schema.ast;
+  }
+  if (SchemaAST.isDeclaration(schema.ast) && schema.ast.typeParameters.length === 1) {
+    const parameter = schema.ast.typeParameters[0];
+    return parameter !== undefined && SchemaAST.isObjects(parameter) ? parameter : undefined;
+  }
+  return undefined;
+};
+
+export const viewServerRowSchemaFieldsMatchAst = (schema: RowSchema): boolean => {
+  const objects = rowSchemaObjectsAst(schema);
+  if (objects === undefined || objects.indexSignatures.length > 0) {
+    return false;
+  }
+  const astFields = new Map<string, SchemaAST.AST>();
+  for (const property of objects.propertySignatures) {
+    if (typeof property.name !== "string" || astFields.has(property.name)) {
+      return false;
+    }
+    astFields.set(property.name, property.type);
+  }
+  const fieldNames = Object.keys(schema.fields);
+  if (fieldNames.length !== astFields.size) {
+    return false;
+  }
+  for (const field of fieldNames) {
+    const fieldSchema = schema.fields[field];
+    if (!Schema.isSchema(fieldSchema) || fieldSchema.ast !== astFields.get(field)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const snapshotOwnProperties = (value: object): { [key: PropertyKey]: unknown } => {
+  const copied: { [key: PropertyKey]: unknown } = {};
+  for (const property of Reflect.ownKeys(value)) {
+    Object.defineProperty(copied, property, {
+      configurable: true,
+      enumerable: true,
+      value: Reflect.get(value, property, value),
+      writable: true,
+    });
+  }
+  return copied;
+};
+
+const snapshotSource = (source: unknown): unknown => {
+  if (typeof source !== "object" || source === null) {
+    return source;
+  }
+  const copied = snapshotOwnProperties(source);
+  const routeBy = Object.hasOwn(copied, "routeBy") ? Reflect.get(copied, "routeBy") : undefined;
+  const regions = Object.hasOwn(copied, "regions") ? Reflect.get(copied, "regions") : undefined;
+  return Object.freeze({
+    ...copied,
+    ...(Array.isArray(routeBy) ? { routeBy: Object.freeze([...routeBy]) } : {}),
+    ...(Array.isArray(regions) ? { regions: Object.freeze([...regions]) } : {}),
+  });
+};
+
+const snapshotTopicDefinition = (definition: TopicRegistry[string]) => {
+  const copied = snapshotOwnProperties(definition);
+  const schema = copied["schema"];
+  const kafkaSource = copied["kafkaSource"];
+  const grpcSource = copied["grpcSource"];
+  return Object.freeze({
+    ...copied,
+    ...(isViewServerRowSchema(schema) ? { schema: snapshotViewServerRowSchema(schema) } : {}),
+    ...(!Object.hasOwn(copied, "kafkaSource") || kafkaSource === undefined
+      ? {}
+      : { kafkaSource: snapshotSource(kafkaSource) }),
+    ...(!Object.hasOwn(copied, "grpcSource") || grpcSource === undefined
+      ? {}
+      : { grpcSource: snapshotSource(grpcSource) }),
+  });
+};
+
+export function snapshotViewServerTopics<const Topics extends TopicRegistry>(
+  topics: Topics,
+): Topics;
+export function snapshotViewServerTopics(topics: TopicRegistry): TopicRegistry {
+  const snapshot: TopicRegistry = Object.create(null);
+  for (const topic of Object.keys(topics)) {
+    Object.defineProperty(snapshot, topic, {
+      configurable: false,
+      enumerable: true,
+      value: snapshotTopicDefinition(topics[topic]!),
+      writable: false,
+    });
+  }
+  return Object.freeze(snapshot);
+}
+
+export const isViewServerRowSchema = (schema: unknown): schema is RowSchema =>
+  Schema.isSchema(schema) && "fields" in schema;

--- a/packages/config/src/decoded-row-validation.test.ts
+++ b/packages/config/src/decoded-row-validation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { validateDecodedRow } from "./decoded-row-validation";
+import { viewSchema } from "./view-schema";
+
+const DecodedRow = Schema.Struct({
+  id: Schema.String,
+  amount: Schema.BigIntFromString,
+});
+
+const NestedDecodedRow = Schema.Struct({
+  id: Schema.String,
+  nested: Schema.Struct({
+    amount: Schema.BigIntFromString,
+  }),
+});
+
+class ConstructorNormalizedRow extends Schema.Class<ConstructorNormalizedRow>(
+  "ConstructorNormalizedRow",
+)({
+  id: Schema.String,
+  amount: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(ConstructorNormalizedRow);
+const constructorNormalizedRowMakeEffect =
+  ConstructorNormalizedRow.makeEffect.bind(ConstructorNormalizedRow);
+const makeConstructorNormalizedRow: typeof ConstructorNormalizedRow.makeEffect = (input, options) =>
+  constructorNormalizedRowMakeEffect(input, options).pipe(
+    Effect.map(
+      (row) => new ConstructorNormalizedRow({ id: row.id.toUpperCase(), amount: row.amount }),
+    ),
+  );
+Object.defineProperty(ConstructorNormalizedRow, "makeEffect", {
+  value: makeConstructorNormalizedRow,
+});
+
+describe("decoded row validation", () => {
+  it.effect("validates an owned data-property snapshot", () =>
+    Effect.gen(function* () {
+      const first = yield* validateDecodedRow(DecodedRow, { id: "first", amount: 1n });
+      const second = yield* validateDecodedRow(DecodedRow, { id: "second", amount: 2n });
+
+      expect({ first, second }).toStrictEqual({
+        first: { id: "first", amount: 1n },
+        second: { id: "second", amount: 2n },
+      });
+    }),
+  );
+
+  it.effect("preserves root Class constructor normalization", () =>
+    Effect.gen(function* () {
+      const validated = yield* validateDecodedRow(ConstructorNormalizedRow, {
+        id: "normalized",
+        amount: 1n,
+      });
+
+      expect(validated).toBeInstanceOf(ConstructorNormalizedRow);
+      expect(validated).toStrictEqual(
+        new ConstructorNormalizedRow({ id: "NORMALIZED", amount: 1n }),
+      );
+    }),
+  );
+
+  it.effect("reads a nested stateful accessor once before reconstructing an owned graph", () =>
+    Effect.gen(function* () {
+      let accessorReads = 0;
+      const nested = {
+        get amount() {
+          accessorReads += 1;
+          return accessorReads === 1 ? 1n : 2n;
+        },
+      };
+
+      const validated = yield* validateDecodedRow(NestedDecodedRow, {
+        id: "nested",
+        nested,
+      });
+
+      expect(accessorReads).toBe(1);
+      expect(validated).toStrictEqual({ id: "nested", nested: { amount: 1n } });
+      expect(validated.nested === nested).toBe(false);
+    }),
+  );
+
+  it.effect("rejects excess properties inside nested decoded values", () =>
+    Effect.gen(function* () {
+      const error = yield* validateDecodedRow(NestedDecodedRow, {
+        id: "nested",
+        nested: { amount: 1n, extra: true },
+      }).pipe(Effect.flip);
+
+      expect(String(error)).toBe(
+        'SchemaError(Unexpected key with value true\n  at ["nested"]["extra"])',
+      );
+    }),
+  );
+
+  it.effect("rejects hostile descriptors without reading a stateful accessor", () =>
+    Effect.gen(function* () {
+      let accessorReads = 0;
+      const accessorRow = { id: "accessor" };
+      Object.defineProperty(accessorRow, "amount", {
+        enumerable: true,
+        get() {
+          accessorReads += 1;
+          return accessorReads === 1 ? 1n : 2n;
+        },
+      });
+      const nonEnumerableRow = { id: "non-enumerable" };
+      Object.defineProperty(nonEnumerableRow, "amount", {
+        enumerable: false,
+        value: 1n,
+      });
+      const symbol = Symbol("unknown");
+      const ownKeysFailure = new Proxy(
+        {},
+        {
+          ownKeys: () => {
+            throw new Error("ownKeys exploded");
+          },
+        },
+      );
+      const descriptorFailure = new Proxy(
+        {},
+        {
+          ownKeys: () => ["id"],
+          getOwnPropertyDescriptor: () => {
+            throw new Error("descriptor exploded");
+          },
+        },
+      );
+      const missingDescriptor = new Proxy(
+        {},
+        {
+          ownKeys: () => ["id"],
+          getOwnPropertyDescriptor: () => undefined,
+        },
+      );
+
+      const errors = yield* Effect.forEach(
+        [
+          null,
+          ownKeysFailure,
+          { [symbol]: 1 },
+          { unknown: 1 },
+          descriptorFailure,
+          missingDescriptor,
+          accessorRow,
+          nonEnumerableRow,
+        ],
+        (row) => validateDecodedRow(DecodedRow, row).pipe(Effect.flip),
+      );
+
+      expect(accessorReads).toBe(0);
+      expect(errors.map(String)).toStrictEqual([
+        "DecodedRowSnapshotError: Decoded row must be an object.",
+        "DecodedRowSnapshotError: Could not inspect decoded row fields.",
+        "DecodedRowSnapshotError: Decoded row contains unknown field: Symbol(unknown).",
+        "DecodedRowSnapshotError: Decoded row contains unknown field: unknown.",
+        "DecodedRowSnapshotError: Could not inspect decoded row field: id.",
+        "DecodedRowSnapshotError: Decoded row field must be a data property: id.",
+        "DecodedRowSnapshotError: Decoded row field must be a data property: amount.",
+        "DecodedRowSnapshotError: Decoded row field must be enumerable: amount.",
+      ]);
+    }),
+  );
+});

--- a/packages/config/src/decoded-row-validation.ts
+++ b/packages/config/src/decoded-row-validation.ts
@@ -1,0 +1,66 @@
+import { Effect, Result, Schema } from "effect";
+import type { RowSchema } from "./query-core";
+
+const decodedRowMakeOptions = {
+  parseOptions: { onExcessProperty: "error" },
+} as const;
+
+class DecodedRowSnapshotError extends Schema.TaggedErrorClass<DecodedRowSnapshotError>()(
+  "DecodedRowSnapshotError",
+  { message: Schema.String },
+) {}
+
+const decodedRowSnapshotError = (message: string): DecodedRowSnapshotError =>
+  DecodedRowSnapshotError.make({ message });
+
+const snapshotDecodedRow = (
+  schema: RowSchema,
+  row: unknown,
+): Result.Result<Record<string, unknown>, DecodedRowSnapshotError> => {
+  if (typeof row !== "object" || row === null) {
+    return Result.fail(decodedRowSnapshotError("Decoded row must be an object."));
+  }
+  const keys = Result.try({
+    try: () => Reflect.ownKeys(row),
+    catch: () => decodedRowSnapshotError("Could not inspect decoded row fields."),
+  });
+  if (Result.isFailure(keys)) {
+    return Result.fail(keys.failure);
+  }
+  const snapshot: Record<string, unknown> = {};
+  for (const key of keys.success) {
+    if (typeof key !== "string" || !Object.hasOwn(schema.fields, key)) {
+      return Result.fail(
+        decodedRowSnapshotError(`Decoded row contains unknown field: ${String(key)}.`),
+      );
+    }
+    const descriptor = Result.try({
+      try: () => Object.getOwnPropertyDescriptor(row, key),
+      catch: () => decodedRowSnapshotError(`Could not inspect decoded row field: ${key}.`),
+    });
+    if (Result.isFailure(descriptor)) {
+      return Result.fail(descriptor.failure);
+    }
+    if (descriptor.success === undefined || !("value" in descriptor.success)) {
+      return Result.fail(
+        decodedRowSnapshotError(`Decoded row field must be a data property: ${key}.`),
+      );
+    }
+    if (descriptor.success.enumerable !== true) {
+      return Result.fail(decodedRowSnapshotError(`Decoded row field must be enumerable: ${key}.`));
+    }
+    Object.defineProperty(snapshot, key, {
+      configurable: true,
+      enumerable: true,
+      value: descriptor.success.value,
+      writable: true,
+    });
+  }
+  return Result.succeed(snapshot);
+};
+
+export const validateDecodedRow = <S extends RowSchema>(schema: S, row: unknown) => {
+  return Effect.fromResult(snapshotDecodedRow(schema, row)).pipe(
+    Effect.flatMap((snapshot) => schema.makeEffect(snapshot, decodedRowMakeOptions)),
+  );
+};

--- a/packages/config/src/grpc-contract.ts
+++ b/packages/config/src/grpc-contract.ts
@@ -20,6 +20,7 @@ import type {
   TopicLeasedSourceDefinition,
   TopicMaterializedSourceDefinition,
 } from "./source-contract";
+import { isViewServerRowSchema } from "./config-ownership";
 
 const GrpcTopicSourceTypeId: unique symbol = Symbol("@effect-view-server/config/GrpcTopicSource");
 const GrpcTopicSourceClientsTypeId: unique symbol = Symbol(
@@ -511,9 +512,9 @@ export const grpcTopicSourceDefinitionKey = (source: object): string | undefined
   return typeof key === "string" ? key : undefined;
 };
 
-export const grpcTopicSourceDefinitionSchema = (source: object): object | undefined => {
+export const grpcTopicSourceDefinitionSchema = (source: object): RowSchema | undefined => {
   const schema = Reflect.get(source, GrpcTopicSourceSchemaTypeId);
-  return typeof schema === "object" && schema !== null ? schema : undefined;
+  return isViewServerRowSchema(schema) ? schema : undefined;
 };
 
 export type GrpcTopicSourceHelper<Clients extends GrpcRuntimeClients> = {

--- a/packages/config/src/grpc-source-contract.test-d.ts
+++ b/packages/config/src/grpc-source-contract.test-d.ts
@@ -12,6 +12,8 @@ import { ordersService, tradesOnlyService } from "../test-harness/protobuf";
 import type { OrdersValueMessage, TradesValueMessage } from "../test-harness/protobuf";
 import { Order, Position, Trade } from "../test-harness/schemas";
 
+const openOrderStatus: (typeof Order.Type)["status"] = "open";
+
 describe("gRPC source generic contracts", () => {
   it("types gRPC clients and feed mapping contracts", () => {
     defineViewServerConfig({
@@ -278,7 +280,7 @@ describe("gRPC source generic contracts", () => {
       map: () => ({
         id: "customer-1",
         customerId: "customer-1",
-        status: "open",
+        status: openOrderStatus,
         price: 10,
         region: "usa",
         updatedAt: 1,
@@ -378,7 +380,7 @@ describe("gRPC source generic contracts", () => {
       map: () => ({
         id: "customer-1",
         customerId: "customer-1",
-        status: "open",
+        status: openOrderStatus,
         price: 10,
         region: "usa",
         updatedAt: 1,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,12 @@ import {
   type RuntimeOptionsDefinition,
 } from "./kafka-contract";
 import { grpcTopicSourceDefinitionKey, grpcTopicSourceDefinitionSchema } from "./grpc-contract";
+import {
+  isViewServerRowSchema,
+  snapshotViewServerTopics,
+  viewServerRowSchemaFieldsMatchAst,
+  viewServerRowSchemasShareOrigin,
+} from "./config-ownership";
 import type {
   GrpcLeasedTopicSourceDefinition,
   GrpcMaterializedTopicSource,
@@ -27,6 +33,8 @@ import type {
   TopicDefinitions,
 } from "./topic-contract";
 import { viewServerUnsupportedRuntimeFieldDomain } from "./schema-field-metadata";
+import { Schema } from "effect";
+export { viewSchema } from "./view-schema";
 
 export type {
   Aggregate,
@@ -618,7 +626,11 @@ const validateConcreteGrpcBinding = (
   }
   const sourceSchema = grpcTopicSourceDefinitionSchema(source);
   const topicSchema = Reflect.get(topicDefinition, "schema");
-  if (sourceSchema !== undefined && sourceSchema !== topicSchema) {
+  if (
+    sourceSchema !== undefined &&
+    (!isViewServerRowSchema(topicSchema) ||
+      !viewServerRowSchemasShareOrigin(sourceSchema, topicSchema))
+  ) {
     throw new Error(
       `View Server topic ${topic} declares grpcSource for a different schema than the topic schema.`,
     );
@@ -658,25 +670,52 @@ export function defineViewServerConfig(
   },
   ..._validation: ReadonlyArray<unknown>
 ) {
-  for (const topic of Object.keys(input.topics)) {
+  const topics = snapshotViewServerTopics(input.topics);
+  const inputKafka = input.kafka;
+  const kafka = inputKafka === undefined ? undefined : Object.freeze({ ...inputKafka });
+  const inputGrpc = input.grpc;
+  const grpc =
+    inputGrpc === undefined
+      ? undefined
+      : Object.freeze({
+          clients: Object.freeze({ ...inputGrpc.clients }),
+        });
+
+  for (const topic of Object.keys(topics)) {
     if (viewServerTopicNameIsReserved(topic)) {
       throw new Error(`View Server topic name is reserved for system health streams: ${topic}`);
     }
-    const schema = input.topics[topic]!.schema;
+    const schema = topics[topic]!.schema;
+    if (!isViewServerRowSchema(schema)) {
+      throw new Error(`View Server topic ${topic} row schema must be an Effect Schema Struct.`);
+    }
     for (const field of Object.keys(schema.fields)) {
       if (field === "__proto__" || field === "prototype" || field === "constructor") {
         throw new Error(`View Server topic ${topic} uses a reserved row field name: ${field}`);
       }
-      const unsupportedRuntimeDomain = viewServerUnsupportedRuntimeFieldDomain(
-        schema.fields[field],
-      );
+      const fieldSchema = schema.fields[field];
+      if (!Schema.isSchema(fieldSchema)) {
+        throw new Error(`View Server topic ${topic} field ${field} must be an Effect Schema.`);
+      }
+      const unsupportedRuntimeDomain = viewServerUnsupportedRuntimeFieldDomain(fieldSchema);
       if (unsupportedRuntimeDomain !== undefined) {
         throw new Error(
           `View Server topic ${topic} field ${field} uses unsupported runtime domain: ${unsupportedRuntimeDomain}`,
         );
       }
     }
-    const topicDefinition = input.topics[topic]!;
+    const unsupportedRowRuntimeDomain = viewServerUnsupportedRuntimeFieldDomain(schema);
+    if (unsupportedRowRuntimeDomain !== undefined) {
+      throw new Error(
+        `View Server topic ${topic} row schema uses unsupported runtime domain: ${unsupportedRowRuntimeDomain}`,
+      );
+    }
+    if (!viewServerRowSchemaFieldsMatchAst(schema)) {
+      throw new Error(
+        `View Server topic ${topic} exposed row fields do not match the row schema AST.`,
+      );
+    }
+    const topicDefinition = topics[topic]!;
     if (Object.prototype.hasOwnProperty.call(topicDefinition, "source")) {
       throw new Error(
         `View Server topic ${topic} cannot declare source; use kafkaSource or grpcSource.`,
@@ -694,14 +733,14 @@ export function defineViewServerConfig(
         `View Server topic ${topic} cannot declare more than one source owner: kafkaSource, grpcSource.`,
       );
     }
-    validateConcreteGrpcBinding(topic, topicDefinition, input.grpc?.clients);
+    validateConcreteGrpcBinding(topic, topicDefinition, grpc?.clients);
   }
-  const config = {
-    ...(input.kafka === undefined ? {} : { kafka: input.kafka }),
-    ...(input.grpc === undefined ? {} : { grpc: input.grpc }),
-    topics: input.topics,
+  const config = Object.freeze({
+    ...(kafka === undefined ? {} : { kafka }),
+    ...(grpc === undefined ? {} : { grpc }),
+    topics,
     defineRuntimeOptions: <const Options extends RuntimeOptionsCandidate>(options: Options) =>
       options,
-  };
+  });
   return config;
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { grpcTopicSourceDefinitionKey, grpcTopicSourceDefinitionSchema } from "./grpc-contract";
 import {
   isViewServerRowSchema,
+  snapshotViewServerGrpcClients,
   snapshotViewServerTopics,
   viewServerRowSchemaFieldsMatchAst,
   viewServerRowSchemasShareOrigin,
@@ -678,7 +679,7 @@ export function defineViewServerConfig(
     inputGrpc === undefined
       ? undefined
       : Object.freeze({
-          clients: Object.freeze({ ...inputGrpc.clients }),
+          clients: snapshotViewServerGrpcClients(inputGrpc.clients),
         });
 
   for (const topic of Object.keys(topics)) {

--- a/packages/config/src/internal.ts
+++ b/packages/config/src/internal.ts
@@ -7,6 +7,8 @@ import {
 } from "./kafka-contract";
 import type { RowSchema } from "./topic-contract";
 
+export { validateDecodedRow } from "./decoded-row-validation";
+
 type KafkaSourceTopicRegistry = Record<
   string,
   {
@@ -35,3 +37,16 @@ export type {
 } from "./kafka-contract";
 
 export { grpcSourceMarkers } from "./grpc-contract";
+export {
+  isRawQueryFilterOperatorKey,
+  isRawQueryRangeFilterOperatorKey,
+  rawQueryFilterOperatorKeys,
+  rawQueryRangeFilterOperatorKeys,
+} from "./raw-query-filter-operators";
+export { schemaAstChildren } from "./schema-ast-children";
+export {
+  snapshotViewServerRowSchema,
+  snapshotViewServerTopics,
+  viewServerRowSchemaFieldsMatchAst,
+  viewServerRowSchemasShareOrigin,
+} from "./config-ownership";

--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -2,6 +2,7 @@ import { fromBinary } from "@bufbuild/protobuf";
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 import { Effect, Schema } from "effect";
 import type { Config } from "effect";
+import { validateDecodedRow } from "./decoded-row-validation";
 import type { RowSchema, TopicRow } from "./topic-contract";
 
 export type RuntimeValue<A> = A | Config.Config<A>;
@@ -762,19 +763,45 @@ const mapKafkaRowKey = (map: () => string): Effect.Effect<string, KafkaMappingEr
     ),
   );
 
-const kafkaMappedRowParseOptions = { onExcessProperty: "error" } as const;
-
 const validateKafkaMappedRow = <
   Topics extends KafkaTopicSchemaRegistry,
   ViewTopic extends Extract<keyof Topics, string>,
 >(
   schema: KafkaTopicSchemaValue<Topics, ViewTopic>,
-  row: KafkaTopicSchemaValue<Topics, ViewTopic>["Type"],
+  row: unknown,
+  rowKeyField: string,
+  rowKey: string,
 ): Effect.Effect<KafkaTopicSchemaValue<Topics, ViewTopic>["Type"], KafkaMappingError> =>
-  Schema.encodeUnknownEffect(schema)(row, kafkaMappedRowParseOptions).pipe(
+  validateDecodedRow(schema, row).pipe(
     Effect.mapError((cause) => kafkaMappingError("Kafka mapped row failed topic schema", cause)),
-    Effect.as(row),
+    Effect.tap((decoded) => validateKafkaMappedRowKey(decoded, rowKeyField, rowKey)),
   );
+
+const validateKafkaMappedRowKey = Effect.fn("ViewServerConfig.kafka.mappedRowKey.validate")(
+  function* (row: object, rowKeyField: string, rowKey: string) {
+    const descriptor = yield* Effect.try({
+      try: () => Object.getOwnPropertyDescriptor(row, rowKeyField),
+      catch: (cause) => kafkaMappingError("Kafka mapped row key could not be inspected", cause),
+    });
+    if (descriptor === undefined || !("value" in descriptor) || descriptor.enumerable !== true) {
+      return yield* Effect.fail(
+        kafkaMappingError("Kafka mapped row key must be an enumerable own data property", {
+          rowKey,
+          rowKeyField,
+        }),
+      );
+    }
+    if (descriptor.value !== rowKey) {
+      return yield* Effect.fail(
+        kafkaMappingError("Kafka mapped row changed the configured row key", {
+          decodedRowKey: descriptor.value,
+          rowKey,
+          rowKeyField,
+        }),
+      );
+    }
+  },
+);
 
 const validateKafkaMappedRowDoesNotProvideRowKey = (
   rowKeyField: string,
@@ -1297,7 +1324,7 @@ const makeKafkaResolvedSourceTopicWithKey = <
         ...mappedRowWithoutKey,
         [input.rowKeyField]: rowKey,
       };
-      const row = yield* validateKafkaMappedRow(input.schema, mappedRow);
+      const row = yield* validateKafkaMappedRow(input.schema, mappedRow, input.rowKeyField, rowKey);
       const decoded: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
         row,
         rowKey,
@@ -1371,7 +1398,7 @@ const makeKafkaResolvedSourceTopicWithoutKey = <
         ...mappedRowWithoutKey,
         [input.rowKeyField]: rowKey,
       };
-      const row = yield* validateKafkaMappedRow(input.schema, mappedRow);
+      const row = yield* validateKafkaMappedRow(input.schema, mappedRow, input.rowKeyField, rowKey);
       const decoded: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
         row,
         rowKey,

--- a/packages/config/src/kafka-decoded-row-validation.test.ts
+++ b/packages/config/src/kafka-decoded-row-validation.test.ts
@@ -1,0 +1,370 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { defineViewServerConfig, kafka, kafkaErrorIsMapping, viewSchema } from "./index";
+import { decodeKafkaTopicMessage } from "./kafka-contract";
+import { makeKafkaSourceTopicsForConfig } from "./internal";
+import { kafkaRegions, kafkaTestMetadata, textEncoder } from "../test-harness/kafka";
+
+const IncomingQuantity = Schema.Struct({
+  quantity: Schema.BigIntFromString,
+});
+
+class RootClassKafkaRow extends Schema.Class<RootClassKafkaRow>("RootClassKafkaRow")({
+  id: Schema.String,
+  quantity: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(RootClassKafkaRow);
+
+class NormalizingKafkaKeyRow extends Schema.Class<NormalizingKafkaKeyRow>("NormalizingKafkaKeyRow")(
+  {
+    id: Schema.String,
+    quantity: Schema.BigIntFromString,
+  },
+) {}
+viewSchema.admitClass(NormalizingKafkaKeyRow);
+const normalizingKafkaKeyRowMakeEffect =
+  NormalizingKafkaKeyRow.makeEffect.bind(NormalizingKafkaKeyRow);
+const makeNormalizingKafkaKeyRow: typeof NormalizingKafkaKeyRow.makeEffect = (input, options) =>
+  normalizingKafkaKeyRowMakeEffect(input, options).pipe(
+    Effect.map(
+      (row) => new NormalizingKafkaKeyRow({ id: row.id.toUpperCase(), quantity: row.quantity }),
+    ),
+  );
+Object.defineProperty(NormalizingKafkaKeyRow, "makeEffect", {
+  value: makeNormalizingKafkaKeyRow,
+});
+
+class ThrowingKafkaKeyRow extends Schema.Class<ThrowingKafkaKeyRow>("ThrowingKafkaKeyRow")({
+  id: Schema.String,
+  quantity: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(ThrowingKafkaKeyRow);
+const throwingKafkaKeyRowMakeEffect = ThrowingKafkaKeyRow.makeEffect.bind(ThrowingKafkaKeyRow);
+const makeThrowingKafkaKeyRow: typeof ThrowingKafkaKeyRow.makeEffect = (input, options) =>
+  throwingKafkaKeyRowMakeEffect(input, options).pipe(
+    Effect.map(
+      (row) =>
+        new Proxy(row, {
+          getOwnPropertyDescriptor: (target, property) => {
+            if (property === "id") {
+              throw new Error("key descriptor exploded");
+            }
+            return Reflect.getOwnPropertyDescriptor(target, property);
+          },
+        }),
+    ),
+  );
+Object.defineProperty(ThrowingKafkaKeyRow, "makeEffect", {
+  value: makeThrowingKafkaKeyRow,
+});
+
+let accessorKeyReads = 0;
+class AccessorKafkaKeyRow extends Schema.Class<AccessorKafkaKeyRow>("AccessorKafkaKeyRow")({
+  id: Schema.String,
+  quantity: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(AccessorKafkaKeyRow);
+const accessorKafkaKeyRowMakeEffect = AccessorKafkaKeyRow.makeEffect.bind(AccessorKafkaKeyRow);
+const makeAccessorKafkaKeyRow: typeof AccessorKafkaKeyRow.makeEffect = (input, options) =>
+  accessorKafkaKeyRowMakeEffect(input, options).pipe(
+    Effect.map(
+      (row) =>
+        new Proxy(row, {
+          getOwnPropertyDescriptor: (target, property) =>
+            property === "id"
+              ? {
+                  configurable: true,
+                  enumerable: true,
+                  get: () => {
+                    accessorKeyReads += 1;
+                    return "quantity-1";
+                  },
+                }
+              : Reflect.getOwnPropertyDescriptor(target, property),
+        }),
+    ),
+  );
+Object.defineProperty(AccessorKafkaKeyRow, "makeEffect", {
+  value: makeAccessorKafkaKeyRow,
+});
+
+class MissingKafkaKeyRow extends Schema.Class<MissingKafkaKeyRow>("MissingKafkaKeyRow")({
+  id: Schema.String,
+  quantity: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(MissingKafkaKeyRow);
+const missingKafkaKeyRowMakeEffect = MissingKafkaKeyRow.makeEffect.bind(MissingKafkaKeyRow);
+const makeMissingKafkaKeyRow: typeof MissingKafkaKeyRow.makeEffect = (input, options) =>
+  missingKafkaKeyRowMakeEffect(input, options).pipe(
+    Effect.map(
+      (row) =>
+        new Proxy(row, {
+          getOwnPropertyDescriptor: (target, property) =>
+            property === "id" ? undefined : Reflect.getOwnPropertyDescriptor(target, property),
+        }),
+    ),
+  );
+Object.defineProperty(MissingKafkaKeyRow, "makeEffect", {
+  value: makeMissingKafkaKeyRow,
+});
+
+class HiddenKafkaKeyRow extends Schema.Class<HiddenKafkaKeyRow>("HiddenKafkaKeyRow")({
+  id: Schema.String,
+  quantity: Schema.BigIntFromString,
+}) {}
+viewSchema.admitClass(HiddenKafkaKeyRow);
+const hiddenKafkaKeyRowMakeEffect = HiddenKafkaKeyRow.makeEffect.bind(HiddenKafkaKeyRow);
+const makeHiddenKafkaKeyRow: typeof HiddenKafkaKeyRow.makeEffect = (input, options) =>
+  hiddenKafkaKeyRowMakeEffect(input, options).pipe(
+    Effect.map(
+      (row) =>
+        new Proxy(row, {
+          getOwnPropertyDescriptor: (target, property) => {
+            const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+            return property === "id" && descriptor !== undefined
+              ? { ...descriptor, enumerable: false }
+              : descriptor;
+          },
+        }),
+    ),
+  );
+Object.defineProperty(HiddenKafkaKeyRow, "makeEffect", {
+  value: makeHiddenKafkaKeyRow,
+});
+
+describe("Kafka decoded row validation", () => {
+  it.effect("accepts a plain decoded mapper row for an admitted root Class topic", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          quantities: {
+            schema: RootClassKafkaRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "quantities-source",
+              regions: ["usa"],
+              value: kafka.json(() => Schema.toCodecJson(IncomingQuantity)),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({ quantity: value.quantity }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      const decoded = yield* decodeKafkaTopicMessage(source, {
+        keyBytes: textEncoder.encode("quantity-1"),
+        valueBytes: textEncoder.encode('{"quantity":"42"}'),
+        region: "usa",
+        metadata: kafkaTestMetadata("usa"),
+        rowKeyField: "id",
+        schema: RootClassKafkaRow,
+        viewServerTopic: "quantities",
+      });
+
+      expect(decoded).toStrictEqual({
+        row: new RootClassKafkaRow({ id: "quantity-1", quantity: 42n }),
+        rowKey: "quantity-1",
+        viewServerTopic: "quantities",
+      });
+    }),
+  );
+
+  it.effect("rejects root Class normalization that changes the configured Kafka row key", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          quantities: {
+            schema: NormalizingKafkaKeyRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "quantities-source",
+              regions: ["usa"],
+              value: kafka.json(() => Schema.toCodecJson(IncomingQuantity)),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({ quantity: value.quantity }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      const error = yield* Effect.flip(
+        decodeKafkaTopicMessage(source, {
+          keyBytes: textEncoder.encode("quantity-1"),
+          valueBytes: textEncoder.encode('{"quantity":"42"}'),
+          region: "usa",
+          metadata: kafkaTestMetadata("usa"),
+          rowKeyField: "id",
+          schema: NormalizingKafkaKeyRow,
+          viewServerTopic: "quantities",
+        }),
+      );
+
+      expect(kafkaErrorIsMapping(error)).toBe(true);
+      expect(Reflect.get(Object(error), "message")).toBe(
+        "Kafka mapped row changed the configured row key",
+      );
+    }),
+  );
+
+  it.effect("returns a mapping error when the constructed Kafka row key cannot be read", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          quantities: {
+            schema: ThrowingKafkaKeyRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "quantities-source",
+              regions: ["usa"],
+              value: kafka.json(() => Schema.toCodecJson(IncomingQuantity)),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({ quantity: value.quantity }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      const error = yield* Effect.flip(
+        decodeKafkaTopicMessage(source, {
+          keyBytes: textEncoder.encode("quantity-1"),
+          valueBytes: textEncoder.encode('{"quantity":"42"}'),
+          region: "usa",
+          metadata: kafkaTestMetadata("usa"),
+          rowKeyField: "id",
+          schema: ThrowingKafkaKeyRow,
+          viewServerTopic: "quantities",
+        }),
+      );
+
+      expect(kafkaErrorIsMapping(error)).toBe(true);
+      expect(Reflect.get(Object(error), "message")).toBe(
+        "Kafka mapped row key could not be inspected",
+      );
+    }),
+  );
+
+  it.effect("rejects an accessor Kafka row key without invoking its getter", () =>
+    Effect.gen(function* () {
+      accessorKeyReads = 0;
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          quantities: {
+            schema: AccessorKafkaKeyRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "quantities-source",
+              regions: ["usa"],
+              value: kafka.json(() => Schema.toCodecJson(IncomingQuantity)),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({ quantity: value.quantity }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      const error = yield* Effect.flip(
+        decodeKafkaTopicMessage(source, {
+          keyBytes: textEncoder.encode("quantity-1"),
+          valueBytes: textEncoder.encode('{"quantity":"42"}'),
+          region: "usa",
+          metadata: kafkaTestMetadata("usa"),
+          rowKeyField: "id",
+          schema: AccessorKafkaKeyRow,
+          viewServerTopic: "quantities",
+        }),
+      );
+
+      expect(accessorKeyReads).toBe(0);
+      expect(kafkaErrorIsMapping(error)).toBe(true);
+      expect(Reflect.get(Object(error), "message")).toBe(
+        "Kafka mapped row key must be an enumerable own data property",
+      );
+    }),
+  );
+
+  it.effect("rejects a missing own Kafka row key", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          quantities: {
+            schema: MissingKafkaKeyRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "quantities-source",
+              regions: ["usa"],
+              value: kafka.json(() => Schema.toCodecJson(IncomingQuantity)),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({ quantity: value.quantity }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      const error = yield* Effect.flip(
+        decodeKafkaTopicMessage(source, {
+          keyBytes: textEncoder.encode("quantity-1"),
+          valueBytes: textEncoder.encode('{"quantity":"42"}'),
+          region: "usa",
+          metadata: kafkaTestMetadata("usa"),
+          rowKeyField: "id",
+          schema: MissingKafkaKeyRow,
+          viewServerTopic: "quantities",
+        }),
+      );
+
+      expect(kafkaErrorIsMapping(error)).toBe(true);
+      expect(Reflect.get(Object(error), "message")).toBe(
+        "Kafka mapped row key must be an enumerable own data property",
+      );
+    }),
+  );
+
+  it.effect("rejects a non-enumerable own Kafka row key", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          quantities: {
+            schema: HiddenKafkaKeyRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "quantities-source",
+              regions: ["usa"],
+              value: kafka.json(() => Schema.toCodecJson(IncomingQuantity)),
+              rowKey: ({ key }) => key,
+              map: ({ value }) => ({ quantity: value.quantity }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      const error = yield* Effect.flip(
+        decodeKafkaTopicMessage(source, {
+          keyBytes: textEncoder.encode("quantity-1"),
+          valueBytes: textEncoder.encode('{"quantity":"42"}'),
+          region: "usa",
+          metadata: kafkaTestMetadata("usa"),
+          rowKeyField: "id",
+          schema: HiddenKafkaKeyRow,
+          viewServerTopic: "quantities",
+        }),
+      );
+
+      expect(kafkaErrorIsMapping(error)).toBe(true);
+      expect(Reflect.get(Object(error), "message")).toBe(
+        "Kafka mapped row key must be an enumerable own data property",
+      );
+    }),
+  );
+});

--- a/packages/config/src/kafka-source-contract.test.ts
+++ b/packages/config/src/kafka-source-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { create, toBinary } from "@bufbuild/protobuf";
-import { Effect, Schema, SchemaGetter } from "effect";
+import { Effect, Schema } from "effect";
 import { defineViewServerConfig, kafka, kafkaErrorIsMapping } from "./index";
 import { decodeKafkaTopicMessage, isKafkaResolvedSourceTopicDefinition } from "./kafka-contract";
 import { isKafkaTopicSourceDefinition, makeKafkaSourceTopicsForConfig } from "./internal";
@@ -322,29 +322,30 @@ describe("Kafka source contracts", () => {
         message: "Failed to map Kafka payload",
       });
 
+      const nonStringRowKeySource = kafka.source({
+        topic: "orders-non-string-row-key-source",
+        regions: ["usa"],
+        value: ordersValueKafkaCodec,
+        rowKey: ({ key }) => key,
+        map: ({ value, region }) => ({
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region,
+          updatedAt: value.updatedAt,
+        }),
+      });
+      forceKafkaSourceRowKeyForRuntimeGuard(nonStringRowKeySource, () => 123);
       const nonStringRowKeyViewServer = defineViewServerConfig({
         kafka: kafkaRegions,
         topics: {
           orders: {
             schema: Order,
             key: "id",
-            kafkaSource: kafka.source({
-              topic: "orders-non-string-row-key-source",
-              regions: ["usa"],
-              value: ordersValueKafkaCodec,
-              rowKey: ({ key }) => key,
-              map: ({ value, region }) => ({
-                customerId: value.customerId,
-                status: value.status,
-                price: value.price,
-                region,
-                updatedAt: value.updatedAt,
-              }),
-            }),
+            kafkaSource: nonStringRowKeySource,
           },
         },
       });
-      forceKafkaSourceRowKeyForRuntimeGuard(nonStringRowKeyViewServer, () => 123);
       const nonStringRowKeySourceTopic =
         makeKafkaSourceTopicsForConfig(nonStringRowKeyViewServer)[0]!;
       const nonStringRowKeyFailure = yield* Effect.flip(
@@ -368,34 +369,35 @@ describe("Kafka source contracts", () => {
       );
       expect(kafkaErrorIsMapping(nonStringRowKeyFailure)).toBe(true);
 
+      const schemaInvalidMappedRowSource = kafka.source({
+        topic: "orders-schema-invalid-mapped-row-source",
+        regions: ["usa"],
+        value: ordersValueKafkaCodec,
+        rowKey: ({ key }) => key,
+        map: ({ value, region }) => ({
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region,
+          updatedAt: value.updatedAt,
+        }),
+      });
+      forceKafkaSourceMapForRuntimeGuard(schemaInvalidMappedRowSource, () => ({
+        customerId: "customer-schema-invalid-mapped-row",
+        price: 1,
+        region: "usa",
+        updatedAt: 1,
+      }));
       const schemaInvalidMappedRowViewServer = defineViewServerConfig({
         kafka: kafkaRegions,
         topics: {
           orders: {
             schema: Order,
             key: "id",
-            kafkaSource: kafka.source({
-              topic: "orders-schema-invalid-mapped-row-source",
-              regions: ["usa"],
-              value: ordersValueKafkaCodec,
-              rowKey: ({ key }) => key,
-              map: ({ value, region }) => ({
-                customerId: value.customerId,
-                status: value.status,
-                price: value.price,
-                region,
-                updatedAt: value.updatedAt,
-              }),
-            }),
+            kafkaSource: schemaInvalidMappedRowSource,
           },
         },
       });
-      forceKafkaSourceMapForRuntimeGuard(schemaInvalidMappedRowViewServer, () => ({
-        customerId: "customer-schema-invalid-mapped-row",
-        price: 1,
-        region: "usa",
-        updatedAt: 1,
-      }));
       const schemaInvalidMappedRowSourceTopic = makeKafkaSourceTopicsForConfig(
         schemaInvalidMappedRowViewServer,
       )[0]!;
@@ -426,35 +428,36 @@ describe("Kafka source contracts", () => {
         message: "Kafka mapped row failed topic schema",
       });
 
-      const invalidMappedRowViewServer = defineViewServerConfig({
-        kafka: kafkaRegions,
-        topics: {
-          orders: {
-            schema: Order,
-            key: "id",
-            kafkaSource: kafka.source({
-              topic: "orders-invalid-mapped-row-source",
-              regions: ["usa"],
-              value: ordersValueKafkaCodec,
-              rowKey: ({ key }) => key,
-              map: ({ value, region }) => ({
-                customerId: value.customerId,
-                status: value.status,
-                price: value.price,
-                region,
-                updatedAt: value.updatedAt,
-              }),
-            }),
-          },
-        },
+      const invalidMappedRowSource = kafka.source({
+        topic: "orders-invalid-mapped-row-source",
+        regions: ["usa"],
+        value: ordersValueKafkaCodec,
+        rowKey: ({ key }) => key,
+        map: ({ value, region }) => ({
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region,
+          updatedAt: value.updatedAt,
+        }),
       });
-      forceKafkaSourceMapForRuntimeGuard(invalidMappedRowViewServer, () => ({
+      forceKafkaSourceMapForRuntimeGuard(invalidMappedRowSource, () => ({
         id: "order-invalid-mapped-row",
         customerId: "customer-invalid-mapped-row",
         price: 1,
         region: "usa",
         updatedAt: 1,
       }));
+      const invalidMappedRowViewServer = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          orders: {
+            schema: Order,
+            key: "id",
+            kafkaSource: invalidMappedRowSource,
+          },
+        },
+      });
       const invalidMappedRowSourceTopic = makeKafkaSourceTopicsForConfig(
         invalidMappedRowViewServer,
       )[0]!;
@@ -485,14 +488,7 @@ describe("Kafka source contracts", () => {
         message: "Kafka mapped row must not include the configured row key field",
       });
 
-      const KeyTransformId = Schema.String.pipe(
-        Schema.decodeTo(Schema.String, {
-          decode: SchemaGetter.transform((value) => `decoded-${value}`),
-          encode: SchemaGetter.transform((value) =>
-            value.startsWith("decoded-") ? value.slice("decoded-".length) : value,
-          ),
-        }),
-      );
+      const KeyTransformId = Schema.StringFromUriComponent;
       const KeyTransformOrder = Schema.Struct({
         id: KeyTransformId,
         customerId: Schema.String,
@@ -826,7 +822,7 @@ describe("Kafka source contracts", () => {
       "View Server topic orders has an invalid Kafka source.",
     );
 
-    const erasedPrimitiveSourceViewServer = defineViewServerConfig({
+    const erasedPrimitiveSourceViewServer = {
       kafka: kafkaRegions,
       topics: {
         orders: {
@@ -848,7 +844,7 @@ describe("Kafka source contracts", () => {
           }),
         },
       },
-    });
+    };
     Object.defineProperty(erasedPrimitiveSourceViewServer.topics.orders, "kafkaSource", {
       value: "not-a-source",
     });

--- a/packages/config/src/query-core.ts
+++ b/packages/config/src/query-core.ts
@@ -7,11 +7,9 @@ export type SortDirection = "asc" | "desc";
 
 export type SchemaType<S> = Schema.Schema.Type<S>;
 export type RowSchema = Schema.Codec<object, unknown, never, never> & {
-  readonly fields: Readonly<
-    Record<string, Schema.Codec<unknown, unknown, never, never> | undefined>
-  >;
+  readonly fields: Readonly<Record<string, Schema.Codec<unknown, unknown, never, never>>>;
 };
-export type RowFromSchema<S extends RowSchema> = S["Type"];
+export type RowFromSchema<S extends RowSchema> = Schema.Struct.Type<S["fields"]>;
 
 export type StringFieldKey<Row> = Extract<
   {

--- a/packages/config/src/raw-query-filter-operators.test.ts
+++ b/packages/config/src/raw-query-filter-operators.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  isRawQueryFilterOperatorKey,
+  isRawQueryRangeFilterOperatorKey,
+  rawQueryFilterOperatorKeys,
+  rawQueryRangeFilterOperatorKeys,
+} from "./raw-query-filter-operators";
+
+describe("raw query filter operators", () => {
+  it("owns the exact operator grammar and rejects unknown keys", () => {
+    expect([...rawQueryFilterOperatorKeys]).toStrictEqual([
+      "eq",
+      "neq",
+      "in",
+      "gt",
+      "gte",
+      "lt",
+      "lte",
+      "startsWith",
+    ]);
+    for (const operator of rawQueryFilterOperatorKeys) {
+      expect(isRawQueryFilterOperatorKey(operator)).toBe(true);
+    }
+    expect(isRawQueryFilterOperatorKey("contains")).toBe(false);
+    expect([...rawQueryRangeFilterOperatorKeys]).toStrictEqual(["gt", "gte", "lt", "lte"]);
+    for (const operator of rawQueryRangeFilterOperatorKeys) {
+      expect(isRawQueryRangeFilterOperatorKey(operator)).toBe(true);
+    }
+    expect(isRawQueryRangeFilterOperatorKey("eq")).toBe(false);
+  });
+});

--- a/packages/config/src/raw-query-filter-operators.ts
+++ b/packages/config/src/raw-query-filter-operators.ts
@@ -1,0 +1,26 @@
+const rawQueryFilterOperatorKeyValues = [
+  "eq",
+  "neq",
+  "in",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "startsWith",
+] as const;
+
+const rawQueryRangeFilterOperatorKeyValues = ["gt", "gte", "lt", "lte"] as const;
+
+export const rawQueryFilterOperatorKeys: ReadonlySet<string> = new Set(
+  rawQueryFilterOperatorKeyValues,
+);
+
+export const isRawQueryFilterOperatorKey = (key: string): boolean =>
+  rawQueryFilterOperatorKeys.has(key);
+
+export const rawQueryRangeFilterOperatorKeys: ReadonlySet<string> = new Set(
+  rawQueryRangeFilterOperatorKeyValues,
+);
+
+export const isRawQueryRangeFilterOperatorKey = (key: string): boolean =>
+  rawQueryRangeFilterOperatorKeys.has(key);

--- a/packages/config/src/schema-admission.test.ts
+++ b/packages/config/src/schema-admission.test.ts
@@ -1,0 +1,852 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, Equivalence, Schema, SchemaGetter } from "effect";
+import {
+  defineViewServerConfig,
+  viewSchema,
+  viewServerUnsupportedRuntimeFieldDomain,
+} from "./index";
+
+import { StructuredProfile } from "../test-harness/schemas";
+
+describe("Topic schema admission", () => {
+  it("classifies supported and unsupported runtime value domains", () => {
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Date)).toBe("Date");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeUtc)).toBe("DateTimeUtc");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeUtcFromString)).toBe(
+      "DateTimeUtc",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeZoned)).toBe("DateTimeZoned");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeZonedFromString)).toBe(
+      "DateTimeZoned",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Duration)).toBe("Duration");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Error())).toBe("Error");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Error({ includeStack: true }))).toBe(
+      "ErrorWithStack",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Error({ excludeCause: true }))).toBe(
+      "ErrorWithoutCause",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Error({ includeStack: true, excludeCause: true }),
+      ),
+    ).toBe("ErrorWithStackWithoutCause");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Symbol)).toBe("Symbol");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZone)).toBe("TimeZone");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneFromString)).toBe("TimeZone");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneNamed)).toBe("TimeZoneNamed");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneNamedFromString)).toBe(
+      "TimeZoneNamed",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneOffset)).toBe("TimeZoneOffset");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Trim)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8Array)).toBe("Uint8Array");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromBase64)).toBe("Uint8Array");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromBase64Url)).toBe(
+      "Uint8Array",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromHex)).toBe("Uint8Array");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.suspend(() => Schema.Date))).toBe("Date");
+    const recursiveSuspend: Schema.Schema<string> = Schema.suspend(() => recursiveSuspend);
+    expect(viewServerUnsupportedRuntimeFieldDomain(recursiveSuspend)).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([recursiveSuspend, Schema.String])),
+    ).toBe("ambiguous JSON codec union");
+    type RecursiveNode = {
+      readonly child: RecursiveNode | null;
+    };
+    const RecursiveNode: Schema.Codec<RecursiveNode, unknown, never, never> = Schema.suspend(() =>
+      Schema.Struct({ child: Schema.NullOr(RecursiveNode) }),
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(RecursiveNode)).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.decodeTo(Schema.Duration, {
+            decode: SchemaGetter.transform(() => Duration.millis(1)),
+            encode: SchemaGetter.transform(() => "1"),
+          }),
+        ),
+      ),
+    ).toBe("Duration");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.encodeTo(Schema.Duration, {
+            decode: SchemaGetter.transform(() => "1"),
+            encode: SchemaGetter.transform(() => Duration.millis(1)),
+          }),
+        ),
+      ),
+    ).toBe("Duration");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Array(Schema.RegExp))).toBe("RegExp");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Tuple([Schema.RegExp]))).toBe("RegExp");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Date]),
+      ),
+    ).toBe("Date");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.Symbol, Schema.String)),
+    ).toBe("Symbol");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.String, Schema.String)),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.String, Schema.URL))).toBe(
+      "URL",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.BigInt, Schema.Number])),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.BigDecimal, Schema.Number])),
+    ).toBe("mixed numeric domain: bigDecimal, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Literal(1), Schema.Literal(2n)]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.String, Schema.File])),
+    ).toBe("File");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.decodeTo(Schema.Union([Schema.Number, Schema.BigInt]), {
+            decode: SchemaGetter.transform(() => 1n),
+            encode: SchemaGetter.transform(() => "1"),
+          }),
+        ),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(
+          Schema.encodeTo(Schema.Union([Schema.Number, Schema.BigInt]), {
+            decode: SchemaGetter.transform(() => "1"),
+            encode: SchemaGetter.transform(() => 1n),
+          }),
+        ),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          nested: Schema.Struct({
+            href: Schema.URL,
+          }),
+        }),
+      ),
+    ).toBe("URL");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Option(Schema.Date))).toBe("Date");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Option(Schema.Union([Schema.Number, Schema.BigInt])),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.Option(Schema.String))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Redacted(Schema.Duration))).toBe(
+      "Duration",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          nested: Schema.Struct({
+            amount: Schema.Union([Schema.Number, Schema.BigInt]),
+          }),
+        }),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Record(Schema.String, Schema.Union([Schema.Number, Schema.BigInt])),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Tuple([Schema.Union([Schema.Number, Schema.BigInt])]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [
+          Schema.Union([Schema.Number, Schema.BigInt]),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.String,
+          Schema.Struct({
+            amount: Schema.Union([Schema.Number, Schema.BigInt]),
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Array(Schema.Number), Schema.Array(Schema.BigInt)]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Tuple([Schema.BigInt])]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Array(Schema.Number), Schema.Tuple([Schema.BigInt])]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Struct({
+            amount: Schema.BigInt,
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            payload: Schema.Array(Schema.Number),
+          }),
+          Schema.Struct({
+            payload: Schema.Tuple([Schema.BigInt]),
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Record(Schema.String, Schema.Number),
+          Schema.Struct({
+            amount: Schema.BigInt,
+          }),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Record(Schema.String, Schema.BigInt),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Array(Schema.BigInt)]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]),
+          Schema.Tuple([Schema.BigInt]),
+        ]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]),
+          Schema.Tuple([Schema.String, Schema.BigInt]),
+        ]),
+      ),
+    ).toBe("mixed numeric domain: bigint, number");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Number, Schema.Array(Schema.BigInt)]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Record(Schema.String, Schema.BigInt)]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Tuple([Schema.BigInt]),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            amount: Schema.Number,
+          }),
+          Schema.Array(Schema.BigInt),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            price: Schema.Number,
+          }),
+          Schema.Struct({
+            quantity: Schema.BigInt,
+          }),
+        ]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          quantity: Schema.BigInt,
+          price: Schema.Number,
+        }),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.String]),
+      ),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Struct({ id: Schema.String }))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain({})).toBe(undefined);
+  });
+
+  it("validates the complete row schema, not only its fields", () => {
+    const Row = Schema.Struct({
+      id: Schema.String,
+      status: Schema.String,
+    });
+    const EquivalentRow = Row.pipe(
+      Schema.overrideToEquivalence(() =>
+        Equivalence.make((left, right) => left.id === right.id && left.status === right.status),
+      ),
+    );
+    const LossyRow = Object.assign(
+      Row.pipe(
+        Schema.decodeTo(Row, {
+          decode: SchemaGetter.transform((value) => value),
+          encode: SchemaGetter.transform((value) => ({ ...value, status: "same" })),
+        }),
+      ),
+      { fields: Row.fields },
+    );
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(EquivalentRow)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(LossyRow)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          equivalent: {
+            schema: EquivalentRow,
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic equivalent row schema uses unsupported runtime domain: custom equivalence without canonical identity witness",
+    );
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          lossy: {
+            schema: LossyRow,
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic lossy row schema uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+    );
+  });
+
+  it("rejects safe exposed fields that diverge from the row schema AST", () => {
+    const DivergentRow = Schema.Struct({
+      id: Schema.String,
+      value: Schema.String,
+    });
+    expect(Reflect.set(DivergentRow.fields, "value", Schema.Number)).toBe(true);
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          divergent: {
+            schema: DivergentRow,
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic divergent exposed row fields do not match the row schema AST.");
+  });
+
+  it("admits passthrough optional defaults and rejects omit or lossy optional encodings", () => {
+    const PassthroughDefault = Schema.String.pipe(
+      Schema.withDecodingDefaultKey(Effect.succeed("open")),
+    );
+    const OmittedDefault = Schema.String.pipe(
+      Schema.withDecodingDefaultKey(Effect.succeed("open"), { encodingStrategy: "omit" }),
+    );
+    const LossyOptional = Schema.optionalKey(Schema.String).pipe(
+      Schema.decodeTo(Schema.String, {
+        decode: SchemaGetter.withDefault(Effect.succeed("open")),
+        encode: SchemaGetter.omit(),
+      }),
+    );
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(PassthroughDefault)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(OmittedDefault)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(LossyOptional)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          defaults: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              passthrough: PassthroughDefault,
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          omitted: {
+            schema: Schema.Struct({ id: Schema.String, value: OmittedDefault }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic omitted field value uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+    );
+  });
+
+  it("rejects malformed row and field schemas from untyped callers", () => {
+    const InvalidFieldRow = Schema.Struct({
+      id: Schema.String,
+      value: Schema.String,
+    });
+    Object.defineProperty(InvalidFieldRow.fields, "value", {
+      configurable: true,
+      enumerable: true,
+      value: {},
+      writable: true,
+    });
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          invalidRow: {
+            // @ts-expect-error Runtime admission protects untyped callers that do not provide a Struct.
+            schema: {},
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic invalidRow row schema must be an Effect Schema Struct.");
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          invalidField: {
+            schema: InvalidFieldRow,
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic invalidField field value must be an Effect Schema.");
+  });
+
+  it("rejects canonical JSON codecs that cannot preserve semantic identity", () => {
+    // @ts-expect-error Runtime admission also protects untyped JavaScript callers.
+    const UndefinedLiteral = Schema.Literal(undefined);
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(UndefinedLiteral)).toBe(
+      "non-JSON literal: undefined",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Null, Schema.Undefined])),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.String, Schema.BigInt])),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Struct({
+          nested: Schema.Union([Schema.String, Schema.BigInt]),
+        }),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        viewSchema.Chunk(Schema.Union([Schema.Null, Schema.Undefined])),
+      ),
+    ).toBe("ambiguous JSON codec union");
+
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.String, Schema.Undefined])),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Literal("alpha"), Schema.Literal("beta")]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Boolean, Schema.Number])),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Literal(1), Schema.Number])),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Literal(true), Schema.Boolean])),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.TemplateLiteral(["order-", Schema.String]), Schema.Number]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.TemplateLiteral(["order-", Schema.String]), Schema.Finite]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.ObjectKeyword, Schema.String])),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Unknown, Schema.String])),
+    ).toBe("ambiguous JSON codec union");
+
+    const Status = Schema.Enum({ Alpha: "alpha", Beta: "beta" });
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Literal("gamma"), Status])),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.Literal("alpha"), Status])),
+    ).toBe("ambiguous JSON codec union");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Status, Schema.String]))).toBe(
+      "ambiguous JSON codec union",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.String, Status]))).toBe(
+      "ambiguous JSON codec union",
+    );
+
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.String]), Schema.Tuple([Schema.String, Schema.String])]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.String]), Schema.Tuple([Schema.Number])]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.String]), Schema.Tuple([Schema.Finite])]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.String]), Schema.Tuple([Schema.Literal("alpha")])]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.Tuple([Schema.String]), Schema.Array(Schema.String)]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([viewSchema.Option(Schema.String), Schema.String]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([Schema.String, viewSchema.Option(Schema.String)]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.TaggedStruct("Alpha", {
+            value: Schema.String,
+          }),
+          Schema.TaggedStruct("Beta", {
+            value: Schema.String,
+          }),
+        ]),
+      ),
+    ).toBe(undefined);
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            kind: Schema.optionalKey(Schema.Literal("Alpha")),
+            value: Schema.String,
+          }),
+          Schema.Struct({
+            kind: Schema.Literal("Beta"),
+            value: Schema.String,
+          }),
+        ]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.Union([
+          Schema.Struct({
+            kind: Schema.Literal("Alpha"),
+            value: Schema.String,
+          }),
+          Schema.Struct({
+            kind: Schema.optionalKey(Schema.Literal("Beta")),
+            value: Schema.String,
+          }),
+        ]),
+      ),
+    ).toBe("ambiguous JSON codec union");
+
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.ReadonlyMap(Schema.String, Schema.String)),
+    ).toBe("ReadonlyMap");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.ReadonlySet(Schema.String))).toBe(
+      "ReadonlySet",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(viewSchema.HashMap(Schema.String, Schema.String)),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.HashSet(Schema.String))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.Option(Schema.String))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.Chunk(Schema.String))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.BigDecimal)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(StructuredProfile)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain({ ast: Schema.String.ast })).toBe(undefined);
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          ambiguous: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              value: Schema.Union([Schema.Null, Schema.Undefined]),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic ambiguous field value uses unsupported runtime domain: ambiguous JSON codec union",
+    );
+  });
+
+  it("rejects custom equivalence without a canonical identity witness", () => {
+    const CaseInsensitiveString = Schema.String.pipe(
+      Schema.overrideToEquivalence(() =>
+        Equivalence.make((left, right) => left.toLowerCase() === right.toLowerCase()),
+      ),
+    );
+    const EquivalentScalarUnion = Schema.Union([Schema.String, Schema.Undefined]).pipe(
+      Schema.overrideToEquivalence(() => Equivalence.make((left, right) => left === right)),
+    );
+    const EquivalentSuspendedString = Schema.suspend(() => Schema.String).pipe(
+      Schema.overrideToEquivalence(() => Equivalence.make((left, right) => left === right)),
+    );
+    const EquivalentBigDecimal = Schema.BigDecimal.pipe(
+      Schema.overrideToEquivalence(() => Equivalence.make((left, right) => left === right)),
+    );
+    const EquivalentStruct = Schema.Struct({ value: Schema.String }).pipe(
+      Schema.overrideToEquivalence(() => Equivalence.make((left, right) => left === right)),
+    );
+    const EquivalentClass = StructuredProfile.pipe(
+      Schema.overrideToEquivalence(() => Equivalence.make((left, right) => left === right)),
+    );
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(CaseInsensitiveString)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(EquivalentScalarUnion)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(EquivalentSuspendedString)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(EquivalentBigDecimal)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(EquivalentStruct)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(EquivalentClass)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.BigDecimal)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(StructuredProfile)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.Option(Schema.String))).toBe(
+      undefined,
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.Chunk(Schema.String))).toBe(
+      undefined,
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(viewSchema.HashMap(Schema.String, Schema.String)),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.HashSet(Schema.String))).toBe(
+      undefined,
+    );
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          customEquivalence: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              label: CaseInsensitiveString,
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic customEquivalence field label uses unsupported runtime domain: custom equivalence without canonical identity witness",
+    );
+  });
+
+  it("rejects unrecognized or surrogate-colliding codec transformations", () => {
+    class OpaqueValue {}
+    const Lossy = Schema.String.pipe(
+      Schema.decodeTo(Schema.String, {
+        decode: SchemaGetter.transform((value) => value),
+        encode: SchemaGetter.transform(() => "same"),
+      }),
+    );
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(Lossy)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.StringFromBase64)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.StringFromBase64Url)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.StringFromHex)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        Schema.String.pipe(Schema.withDecodingDefaultKey(Effect.succeed("open"))),
+      ),
+    ).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.instanceOf(OpaqueValue))).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          lossy: {
+            schema: Schema.Struct({ id: Schema.String, value: Lossy }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic lossy field value uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+    );
+  });
+
+  it("rejects topic fields with unsupported runtime value domains", () => {
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          dated: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              createdAt: Schema.Date,
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic dated field createdAt uses unsupported runtime domain: Date");
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          nested: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              metadata: Schema.Struct({
+                latency: Schema.Duration,
+              }),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow("View Server topic nested field metadata uses unsupported runtime domain: Duration");
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          mixedNumeric: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              amount: Schema.Union([Schema.BigInt, Schema.Number]),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic mixedNumeric field amount uses unsupported runtime domain: mixed numeric domain: bigint, number",
+    );
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          nestedMixedNumeric: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              payload: Schema.Struct({
+                amount: Schema.Union([Schema.BigInt, Schema.Number]),
+              }),
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic nestedMixedNumeric field payload uses unsupported runtime domain: mixed numeric domain: bigint, number",
+    );
+  });
+});

--- a/packages/config/src/schema-ast-children.ts
+++ b/packages/config/src/schema-ast-children.ts
@@ -1,0 +1,38 @@
+import { SchemaAST } from "effect";
+
+const schemaClassTypeId = Reflect.get(SchemaAST, "ClassTypeId");
+
+export const schemaAstIsClass = (ast: SchemaAST.AST): boolean =>
+  typeof schemaClassTypeId === "string" &&
+  SchemaAST.isDeclaration(ast) &&
+  ast.annotations?.[schemaClassTypeId] !== undefined;
+
+export const schemaAstChildren = (ast: SchemaAST.AST): ReadonlyArray<SchemaAST.AST> => {
+  const children: Array<SchemaAST.AST> = [];
+  if (SchemaAST.isSuspend(ast)) {
+    children.push(ast.thunk());
+  }
+  if (SchemaAST.isDeclaration(ast)) {
+    children.push(...ast.typeParameters);
+  }
+  if (SchemaAST.isObjects(ast)) {
+    for (const property of ast.propertySignatures) {
+      children.push(property.type);
+    }
+    for (const index of ast.indexSignatures) {
+      children.push(index.parameter, index.type);
+    }
+  }
+  if (SchemaAST.isArrays(ast)) {
+    children.push(...ast.elements, ...ast.rest);
+  }
+  if (SchemaAST.isUnion(ast)) {
+    children.push(...ast.types);
+  }
+  if (ast.encoding !== undefined) {
+    for (const link of ast.encoding) {
+      children.push(link.to);
+    }
+  }
+  return children;
+};

--- a/packages/config/src/schema-canonical-codec.ts
+++ b/packages/config/src/schema-canonical-codec.ts
@@ -1,0 +1,47 @@
+import { Schema, SchemaAST, SchemaGetter } from "effect";
+import { schemaAstChildren } from "./schema-ast-children";
+import { viewSchemaDeclarationAstIsAdmitted } from "./view-schema";
+
+const canonicalEncodingSchemas = [
+  Schema.BigIntFromString,
+  Schema.BooleanFromBit,
+  Schema.FiniteFromString,
+  Schema.NumberFromString,
+  Schema.StringFromUriComponent,
+  Schema.Trim,
+];
+
+const canonicalEncodingTransformations = new Set(
+  canonicalEncodingSchemas.map((schema) => schema.ast.encoding![0]!.transformation),
+);
+
+const isCanonicalDeclaration = (ast: SchemaAST.Declaration): boolean =>
+  viewSchemaDeclarationAstIsAdmitted(ast);
+
+const isCanonicalOptionalEncoding = (link: SchemaAST.Link): boolean =>
+  SchemaAST.isOptional(link.to) &&
+  Reflect.get(link.transformation, "encode") === SchemaGetter.passthrough();
+
+const hasUnrecognizedCanonicalCodec = (ast: SchemaAST.AST, seen: Set<SchemaAST.AST>): boolean => {
+  if (seen.has(ast)) {
+    return false;
+  }
+  seen.add(ast);
+  if (SchemaAST.isDeclaration(ast) && !isCanonicalDeclaration(ast)) {
+    return true;
+  }
+  if (
+    ast.encoding?.some(
+      (link) =>
+        !(SchemaAST.isDeclaration(ast) && isCanonicalDeclaration(ast)) &&
+        !isCanonicalOptionalEncoding(link) &&
+        !canonicalEncodingTransformations.has(link.transformation),
+    ) === true
+  ) {
+    return true;
+  }
+  return schemaAstChildren(ast).some((child) => hasUnrecognizedCanonicalCodec(child, seen));
+};
+
+export const schemaHasUnrecognizedCanonicalCodec = (ast: SchemaAST.AST): boolean =>
+  hasUnrecognizedCanonicalCodec(ast, new Set());

--- a/packages/config/src/schema-config.test.ts
+++ b/packages/config/src/schema-config.test.ts
@@ -1,15 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Duration, Schema, SchemaGetter } from "effect";
-import {
-  defineViewServerConfig,
-  kafka,
-  viewServerSchemaFieldMetadata,
-  viewServerUnsupportedRuntimeFieldDomain,
-} from "./index";
+import { Schema, SchemaAST } from "effect";
+import { defineViewServerConfig, kafka, viewSchema, viewServerSchemaFieldMetadata } from "./index";
+import { snapshotViewServerTopics, viewServerRowSchemaFieldsMatchAst } from "./config-ownership";
 import { isKafkaTopicSourceDefinition, makeKafkaSourceTopicsForConfig } from "./internal";
 
 import { viewServer } from "../test-harness/live-query";
-import { Order } from "../test-harness/schemas";
+import { Order, StructuredProfile } from "../test-harness/schemas";
 
 describe("Topic schema configuration", () => {
   it("derives schema field metadata for query validation", () => {
@@ -169,6 +165,13 @@ describe("Topic schema configuration", () => {
       isStructured: true,
       isStructuredObject: true,
     });
+    expect(viewServerSchemaFieldMetadata(StructuredProfile)).toStrictEqual({
+      isNumeric: false,
+      isPureBigInt: false,
+      isString: false,
+      isStructured: true,
+      isStructuredObject: true,
+    });
     expect(viewServerSchemaFieldMetadata(Schema.Array(Schema.String))).toStrictEqual({
       isNumeric: false,
       isPureBigInt: false,
@@ -176,373 +179,138 @@ describe("Topic schema configuration", () => {
       isStructured: true,
       isStructuredObject: false,
     });
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Date)).toBe("Date");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeUtc)).toBe("DateTimeUtc");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeUtcFromString)).toBe(
-      "DateTimeUtc",
-    );
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeZoned)).toBe("DateTimeZoned");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.DateTimeZonedFromString)).toBe(
-      "DateTimeZoned",
-    );
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Duration)).toBe("Duration");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Error())).toBe("Error");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Error({ includeStack: true }))).toBe(
-      "ErrorWithStack",
-    );
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Error({ excludeCause: true }))).toBe(
-      "ErrorWithoutCause",
-    );
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Error({ includeStack: true, excludeCause: true }),
-      ),
-    ).toBe("ErrorWithStackWithoutCause");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Symbol)).toBe("Symbol");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZone)).toBe("TimeZone");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneFromString)).toBe("TimeZone");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneNamed)).toBe("TimeZoneNamed");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneNamedFromString)).toBe(
-      "TimeZoneNamed",
-    );
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.TimeZoneOffset)).toBe("TimeZoneOffset");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Trim)).toBe(undefined);
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8Array)).toBe("Uint8Array");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromBase64)).toBe("Uint8Array");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromBase64Url)).toBe(
-      "Uint8Array",
-    );
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Uint8ArrayFromHex)).toBe("Uint8Array");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.suspend(() => Schema.Date))).toBe("Date");
-    const recursiveSuspend: Schema.Schema<string> = Schema.suspend(() => recursiveSuspend);
-    expect(viewServerUnsupportedRuntimeFieldDomain(recursiveSuspend)).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.String.pipe(
-          Schema.decodeTo(Schema.Duration, {
-            decode: SchemaGetter.transform(() => Duration.millis(1)),
-            encode: SchemaGetter.transform(() => "1"),
-          }),
-        ),
-      ),
-    ).toBe("Duration");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.String.pipe(
-          Schema.encodeTo(Schema.Duration, {
-            decode: SchemaGetter.transform(() => "1"),
-            encode: SchemaGetter.transform(() => Duration.millis(1)),
-          }),
-        ),
-      ),
-    ).toBe("Duration");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Array(Schema.RegExp))).toBe("RegExp");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Tuple([Schema.RegExp]))).toBe("RegExp");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Date]),
-      ),
-    ).toBe("Date");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.Symbol, Schema.String)),
-    ).toBe("Symbol");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.String, Schema.String)),
-    ).toBe(undefined);
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Record(Schema.String, Schema.URL))).toBe(
-      "URL",
-    );
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.BigInt, Schema.Number])),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.BigDecimal, Schema.Number])),
-    ).toBe("mixed numeric domain: bigDecimal, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Literal(1), Schema.Literal(2n)]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(Schema.Union([Schema.String, Schema.File])),
-    ).toBe("File");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.String.pipe(
-          Schema.decodeTo(Schema.Union([Schema.Number, Schema.BigInt]), {
-            decode: SchemaGetter.transform(() => 1n),
-            encode: SchemaGetter.transform(() => "1"),
-          }),
-        ),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.String.pipe(
-          Schema.encodeTo(Schema.Union([Schema.Number, Schema.BigInt]), {
-            decode: SchemaGetter.transform(() => "1"),
-            encode: SchemaGetter.transform(() => 1n),
-          }),
-        ),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Struct({
-          nested: Schema.Struct({
-            href: Schema.URL,
-          }),
-        }),
-      ),
-    ).toBe("URL");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Option(Schema.Date))).toBe("Date");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Option(Schema.Union([Schema.Number, Schema.BigInt])),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Option(Schema.String))).toBe(undefined);
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Redacted(Schema.Duration))).toBe(
-      "Duration",
-    );
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Struct({
-          nested: Schema.Struct({
-            amount: Schema.Union([Schema.Number, Schema.BigInt]),
-          }),
-        }),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Record(Schema.String, Schema.Union([Schema.Number, Schema.BigInt])),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Tuple([Schema.Union([Schema.Number, Schema.BigInt])]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [
-          Schema.Union([Schema.Number, Schema.BigInt]),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.String,
-          Schema.Struct({
-            amount: Schema.Union([Schema.Number, Schema.BigInt]),
-          }),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Array(Schema.Number), Schema.Array(Schema.BigInt)]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Tuple([Schema.BigInt])]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Array(Schema.Number), Schema.Tuple([Schema.BigInt])]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Struct({
-            amount: Schema.Number,
-          }),
-          Schema.Struct({
-            amount: Schema.BigInt,
-          }),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Struct({
-            payload: Schema.Array(Schema.Number),
-          }),
-          Schema.Struct({
-            payload: Schema.Tuple([Schema.BigInt]),
-          }),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Record(Schema.String, Schema.Number),
-          Schema.Struct({
-            amount: Schema.BigInt,
-          }),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Struct({
-            amount: Schema.Number,
-          }),
-          Schema.Record(Schema.String, Schema.BigInt),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Array(Schema.BigInt)]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]),
-          Schema.Tuple([Schema.BigInt]),
-        ]),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]),
-          Schema.Tuple([Schema.String, Schema.BigInt]),
-        ]),
-      ),
-    ).toBe("mixed numeric domain: bigint, number");
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Number, Schema.Array(Schema.BigInt)]),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([Schema.Tuple([Schema.Number]), Schema.Record(Schema.String, Schema.BigInt)]),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Struct({
-            amount: Schema.Number,
-          }),
-          Schema.Tuple([Schema.BigInt]),
-        ]),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Struct({
-            amount: Schema.Number,
-          }),
-          Schema.Array(Schema.BigInt),
-        ]),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Union([
-          Schema.Struct({
-            price: Schema.Number,
-          }),
-          Schema.Struct({
-            quantity: Schema.BigInt,
-          }),
-        ]),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.Struct({
-          quantity: Schema.BigInt,
-          price: Schema.Number,
-        }),
-      ),
-    ).toBe(undefined);
-    expect(
-      viewServerUnsupportedRuntimeFieldDomain(
-        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.String]),
-      ),
-    ).toBe(undefined);
-    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Struct({ id: Schema.String }))).toBe(
-      undefined,
-    );
-    expect(viewServerUnsupportedRuntimeFieldDomain({})).toBe(undefined);
   });
 
-  it("rejects topic fields with unsupported runtime value domains", () => {
-    expect(() =>
-      defineViewServerConfig({
-        topics: {
-          dated: {
-            schema: Schema.Struct({
-              id: Schema.String,
-              createdAt: Schema.Date,
-            }),
-            key: "id",
-          },
-        },
-      }),
-    ).toThrow("View Server topic dated field createdAt uses unsupported runtime domain: Date");
-    expect(() =>
-      defineViewServerConfig({
-        topics: {
-          nested: {
-            schema: Schema.Struct({
-              id: Schema.String,
-              metadata: Schema.Struct({
-                latency: Schema.Duration,
-              }),
-            }),
-            key: "id",
-          },
-        },
-      }),
-    ).toThrow("View Server topic nested field metadata uses unsupported runtime domain: Duration");
-    expect(() =>
-      defineViewServerConfig({
-        topics: {
-          mixedNumeric: {
-            schema: Schema.Struct({
-              id: Schema.String,
-              amount: Schema.Union([Schema.BigInt, Schema.Number]),
-            }),
-            key: "id",
-          },
-        },
-      }),
-    ).toThrow(
-      "View Server topic mixedNumeric field amount uses unsupported runtime domain: mixed numeric domain: bigint, number",
+  it("snapshots caller-owned config state while preserving Class construction", () => {
+    class OwnedProfile extends Schema.Class<OwnedProfile>("OwnedProfile")({
+      id: Schema.String,
+      code: Schema.String,
+    }) {}
+    viewSchema.admitClass(OwnedProfile);
+
+    const topic: {
+      schema: typeof OwnedProfile;
+      key: "id" | "code";
+    } = {
+      schema: OwnedProfile,
+      key: "id",
+    };
+    const topics = { profiles: topic };
+    const input = { topics };
+    const originalAst = OwnedProfile.ast;
+    const originalFields = OwnedProfile.fields;
+    const config = defineViewServerConfig(input);
+    const made = config.topics.profiles.schema.make({ id: "made", code: "alpha" });
+    const constructed = new config.topics.profiles.schema({
+      id: "constructed",
+      code: "beta",
+    });
+
+    expect(made).toBeInstanceOf(OwnedProfile);
+    expect(constructed).toBeInstanceOf(OwnedProfile);
+    expect(Object.isFrozen(config)).toBe(true);
+    expect(Object.isFrozen(config.topics)).toBe(true);
+    expect(Object.isFrozen(config.topics.profiles)).toBe(true);
+    expect(Object.isFrozen(config.topics.profiles.schema.fields)).toBe(true);
+    expect(Object.isFrozen(input)).toBe(false);
+    expect(Object.isFrozen(topics)).toBe(false);
+    expect(Object.isFrozen(topic)).toBe(false);
+    expect(Object.isFrozen(OwnedProfile)).toBe(false);
+    expect(Object.isFrozen(originalFields)).toBe(false);
+
+    const regions = ["usa"];
+    const routeBy = ["id"];
+    const sourceTopics = {
+      profiles: {
+        schema: OwnedProfile,
+        key: "id",
+        kafkaSource: { regions },
+        grpcSource: { routeBy },
+      },
+    };
+    const sourceSnapshot = snapshotViewServerTopics(sourceTopics);
+
+    expect(Object.isFrozen(sourceSnapshot.profiles.kafkaSource)).toBe(true);
+    expect(Object.isFrozen(sourceSnapshot.profiles.kafkaSource.regions)).toBe(true);
+    expect(Object.isFrozen(sourceSnapshot.profiles.grpcSource)).toBe(true);
+    expect(Object.isFrozen(sourceSnapshot.profiles.grpcSource.routeBy)).toBe(true);
+    expect(Object.isFrozen(sourceTopics.profiles.kafkaSource)).toBe(false);
+    expect(Object.isFrozen(sourceTopics.profiles.grpcSource)).toBe(false);
+    expect(Object.isFrozen(regions)).toBe(false);
+    expect(Object.isFrozen(routeBy)).toBe(false);
+
+    topic.key = "code";
+    Object.defineProperty(topics, "secondary", {
+      configurable: true,
+      enumerable: true,
+      value: { schema: OwnedProfile, key: "id" },
+    });
+    Object.defineProperty(OwnedProfile, "ast", {
+      configurable: true,
+      value: Schema.Struct({ id: Schema.String, code: Schema.Number }).ast,
+    });
+    Object.defineProperty(originalFields, "code", {
+      configurable: true,
+      enumerable: true,
+      value: Schema.Number,
+      writable: true,
+    });
+    regions.push("london");
+    routeBy.push("code");
+
+    expect(config.topics.profiles.key).toBe("id");
+    expect(Object.keys(config.topics)).toStrictEqual(["profiles"]);
+    expect(config.topics.profiles.schema.ast).toBe(originalAst);
+    expect(config.topics.profiles.schema.fields.code).toBe(Schema.String);
+    expect(sourceSnapshot.profiles.kafkaSource.regions).toStrictEqual(["usa"]);
+    expect(sourceSnapshot.profiles.grpcSource.routeBy).toStrictEqual(["id"]);
+    expect(Reflect.set(config.topics.profiles.schema, "extra", true)).toBe(false);
+    expect(Reflect.defineProperty(config.topics.profiles.schema, "extra", { value: true })).toBe(
+      false,
     );
-    expect(() =>
-      defineViewServerConfig({
-        topics: {
-          nestedMixedNumeric: {
-            schema: Schema.Struct({
-              id: Schema.String,
-              payload: Schema.Struct({
-                amount: Schema.Union([Schema.BigInt, Schema.Number]),
-              }),
-            }),
-            key: "id",
-          },
-        },
-      }),
-    ).toThrow(
-      "View Server topic nestedMixedNumeric field payload uses unsupported runtime domain: mixed numeric domain: bigint, number",
+    expect(Reflect.deleteProperty(config.topics.profiles.schema, "fields")).toBe(false);
+    expect(Reflect.setPrototypeOf(config.topics.profiles.schema, OwnedProfile)).toBe(false);
+    expect(Reflect.preventExtensions(config.topics.profiles.schema)).toBe(false);
+    expect(config.topics.profiles.schema.make({ id: "isolated", code: "gamma" })).toBeInstanceOf(
+      OwnedProfile,
     );
+  });
+
+  it("defensively rejects malformed row field and AST relationships", () => {
+    const plainAst = Schema.String.ast;
+    const indexedAst = Schema.Record(Schema.String, Schema.String).ast;
+    const symbolAst = new SchemaAST.Objects(
+      [new SchemaAST.PropertySignature(Symbol.for("field"), Schema.String.ast)],
+      [],
+    );
+    const duplicateProperties = [new SchemaAST.PropertySignature("id", Schema.String.ast)];
+    const duplicateAst = new SchemaAST.Objects(duplicateProperties, []);
+    duplicateProperties.push(new SchemaAST.PropertySignature("id", Schema.String.ast));
+    class Profile extends Schema.Class<Profile>("MalformedProfile")({
+      id: Schema.String,
+    }) {}
+    viewSchema.admitClass(Profile);
+    const missingTypeParameter = new Proxy(Profile.ast, {
+      get(target, property) {
+        return property === "typeParameters" ? [undefined] : Reflect.get(target, property, target);
+      },
+    });
+    const missingField = Schema.Struct({ id: Schema.String });
+    expect(Reflect.deleteProperty(missingField.fields, "id")).toBe(true);
+
+    expect([
+      // @ts-expect-error hostile callers can supply non-Schema row metadata.
+      viewServerRowSchemaFieldsMatchAst({ ast: plainAst, fields: {} }),
+      // @ts-expect-error hostile callers can supply indexed row metadata.
+      viewServerRowSchemaFieldsMatchAst({ ast: indexedAst, fields: {} }),
+      // @ts-expect-error hostile callers can supply symbol field metadata.
+      viewServerRowSchemaFieldsMatchAst({ ast: symbolAst, fields: {} }),
+      // @ts-expect-error hostile callers can supply duplicate AST fields.
+      viewServerRowSchemaFieldsMatchAst({ ast: duplicateAst, fields: { id: Schema.String } }),
+      // @ts-expect-error hostile callers can supply malformed declarations.
+      viewServerRowSchemaFieldsMatchAst({ ast: missingTypeParameter, fields: {} }),
+      viewServerRowSchemaFieldsMatchAst(missingField),
+    ]).toStrictEqual([false, false, false, false, false, false]);
   });
 
   it("does not expose executable React or runtime placeholders from config", () => {

--- a/packages/config/src/schema-custom-equivalence.ts
+++ b/packages/config/src/schema-custom-equivalence.ts
@@ -1,0 +1,21 @@
+import { SchemaAST } from "effect";
+import { schemaAstChildren } from "./schema-ast-children";
+import { viewSchemaDeclarationAstIsAdmitted } from "./view-schema";
+
+const hasCustomEquivalence = (ast: SchemaAST.AST, seen: Set<SchemaAST.AST>): boolean => {
+  if (seen.has(ast)) {
+    return false;
+  }
+  seen.add(ast);
+  const equivalence = SchemaAST.resolve(ast)?.["toEquivalence"];
+  if (
+    equivalence !== undefined &&
+    !(SchemaAST.isDeclaration(ast) && viewSchemaDeclarationAstIsAdmitted(ast))
+  ) {
+    return true;
+  }
+  return schemaAstChildren(ast).some((child) => hasCustomEquivalence(child, seen));
+};
+
+export const schemaHasCustomEquivalence = (ast: SchemaAST.AST): boolean =>
+  hasCustomEquivalence(ast, new Set());

--- a/packages/config/src/schema-field-metadata.ts
+++ b/packages/config/src/schema-field-metadata.ts
@@ -1,4 +1,8 @@
 import { Schema, SchemaAST } from "effect";
+import { schemaHasUnrecognizedCanonicalCodec } from "./schema-canonical-codec";
+import { schemaAstIsClass } from "./schema-ast-children";
+import { schemaHasCustomEquivalence } from "./schema-custom-equivalence";
+import { schemaHasAmbiguousJsonUnion } from "./schema-json-injectivity";
 
 export type ViewServerSchemaFieldMetadata = {
   readonly isNumeric: boolean;
@@ -31,10 +35,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const schemaAst = (schema: unknown): SchemaAST.AST | undefined => {
-  if (!isRecord(schema)) {
+  if ((typeof schema !== "object" || schema === null) && typeof schema !== "function") {
     return undefined;
   }
-  const ast = schema["ast"];
+  const ast = Reflect.get(schema, "ast");
   return SchemaAST.isAST(ast) ? ast : undefined;
 };
 
@@ -86,6 +90,15 @@ const unsupportedRuntimeDeclarationName = (ast: SchemaAST.AST): string | undefin
   }
   if (!SchemaAST.isDeclaration(ast)) {
     return undefined;
+  }
+  const typeConstructor = ast.annotations?.["typeConstructor"];
+  if (isRecord(typeConstructor)) {
+    if (typeConstructor["_tag"] === "ReadonlyMap") {
+      return "ReadonlyMap";
+    }
+    if (typeConstructor["_tag"] === "ReadonlySet") {
+      return "ReadonlySet";
+    }
   }
   const run = Reflect.get(ast, "run");
   const link = declarationLink(ast);
@@ -210,8 +223,13 @@ const collectNumericRuntimeDomainsByPath = (
     }
   }
   if (SchemaAST.isDeclaration(ast)) {
-    for (const typeParameter of ast.typeParameters) {
-      collectNumericRuntimeDomainsByPath(typeParameter, path, entries, active);
+    for (const [index, typeParameter] of ast.typeParameters.entries()) {
+      collectNumericRuntimeDomainsByPath(
+        typeParameter,
+        [...path, ["index", index]],
+        entries,
+        active,
+      );
     }
   }
   if (SchemaAST.isObjects(ast)) {
@@ -278,14 +296,19 @@ const isStringAst = (ast: SchemaAST.AST): boolean => {
 };
 
 const isStructuredAst = (ast: SchemaAST.AST): boolean => {
-  if (SchemaAST.isObjects(ast) || SchemaAST.isArrays(ast) || SchemaAST.isObjectKeyword(ast)) {
+  if (
+    SchemaAST.isObjects(ast) ||
+    SchemaAST.isArrays(ast) ||
+    SchemaAST.isObjectKeyword(ast) ||
+    schemaAstIsClass(ast)
+  ) {
     return true;
   }
   return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isStructuredAst);
 };
 
 const isStructuredObjectAst = (ast: SchemaAST.AST): boolean => {
-  if (SchemaAST.isObjects(ast) || SchemaAST.isObjectKeyword(ast)) {
+  if (SchemaAST.isObjects(ast) || SchemaAST.isObjectKeyword(ast) || schemaAstIsClass(ast)) {
     return true;
   }
   return SchemaAST.isUnion(ast) && ast.types.length > 0 && ast.types.every(isStructuredObjectAst);
@@ -323,6 +346,9 @@ const unsupportedRuntimeDomainAst = (
     return undefined;
   }
   seen.add(ast);
+  if (SchemaAST.isLiteral(ast) && Reflect.get(ast, "literal") === undefined) {
+    return "non-JSON literal: undefined";
+  }
   const unsupportedDeclaration = unsupportedRuntimeDeclarationName(ast);
   if (unsupportedDeclaration !== undefined) {
     return unsupportedDeclaration;
@@ -394,5 +420,22 @@ export const viewServerUnsupportedRuntimeFieldDomain = (schema: unknown): string
   if (ast === undefined) {
     return undefined;
   }
-  return unsupportedRuntimeDomainAst(ast, new Set()) ?? nestedMixedNumericRuntimeDomainAst(ast);
+  const unsupported =
+    unsupportedRuntimeDomainAst(ast, new Set()) ?? nestedMixedNumericRuntimeDomainAst(ast);
+  if (unsupported !== undefined) {
+    return unsupported;
+  }
+  if (schemaHasCustomEquivalence(ast)) {
+    return "custom equivalence without canonical identity witness";
+  }
+  if (schemaHasUnrecognizedCanonicalCodec(ast)) {
+    return "custom codec transformation without canonical identity witness";
+  }
+  if (Schema.isSchema(schema)) {
+    const jsonCodec = Schema.toCodecJson(schema);
+    if (schemaHasAmbiguousJsonUnion(jsonCodec.ast)) {
+      return "ambiguous JSON codec union";
+    }
+  }
+  return undefined;
 };

--- a/packages/config/src/schema-json-injectivity.ts
+++ b/packages/config/src/schema-json-injectivity.ts
@@ -1,0 +1,153 @@
+import { Array as Arr, SchemaAST } from "effect";
+import { schemaAstChildren } from "./schema-ast-children";
+
+const jsonNull = 1;
+const jsonString = 2;
+const jsonNumber = 4;
+const jsonBoolean = 8;
+const jsonArray = 16;
+const jsonObject = 32;
+const jsonAny = jsonNull | jsonString | jsonNumber | jsonBoolean | jsonArray | jsonObject;
+const nullAstTags = new Set(["Null", "Undefined", "Void"]);
+const stringAstTags = new Set(["String", "TemplateLiteral", "BigInt"]);
+
+const literalToken = (value: SchemaAST.LiteralValue): string => JSON.stringify(value);
+
+const literalShape = (value: SchemaAST.LiteralValue): number => {
+  if (typeof value === "number") {
+    return jsonNumber;
+  }
+  return typeof value === "boolean" ? jsonBoolean : jsonString;
+};
+
+const encodedShape = (ast: SchemaAST.AST, seen: Set<SchemaAST.AST> = new Set()): number => {
+  if (seen.has(ast)) {
+    return jsonAny;
+  }
+  if (SchemaAST.isSuspend(ast)) {
+    seen.add(ast);
+    return encodedShape(ast.thunk(), seen);
+  }
+  if (nullAstTags.has(ast._tag)) {
+    return jsonNull;
+  }
+  if (stringAstTags.has(ast._tag)) {
+    return jsonString;
+  }
+  if (SchemaAST.isNumber(ast)) {
+    return jsonNumber;
+  }
+  if (SchemaAST.isBoolean(ast)) {
+    return jsonBoolean;
+  }
+  if (SchemaAST.isArrays(ast)) {
+    return jsonArray;
+  }
+  if (SchemaAST.isObjects(ast)) {
+    return jsonObject;
+  }
+  return jsonAny;
+};
+
+const literalMayOverlap = (literal: SchemaAST.LiteralValue, ast: SchemaAST.AST): boolean => {
+  if (SchemaAST.isLiteral(ast)) {
+    return literalToken(literal) === literalToken(ast.literal);
+  }
+  if (SchemaAST.isEnum(ast)) {
+    return ast.enums.some(([, value]) => literalToken(literal) === literalToken(value));
+  }
+  return (literalShape(literal) & encodedShape(ast)) !== 0;
+};
+
+const fixedArrayElements = (ast: SchemaAST.Arrays): ReadonlyArray<SchemaAST.AST> | undefined =>
+  ast.rest.length === 0 && !ast.elements.some(SchemaAST.isOptional) ? ast.elements : undefined;
+
+const encodedArraysMayOverlap = (left: SchemaAST.Arrays, right: SchemaAST.Arrays): boolean => {
+  const leftElements = fixedArrayElements(left);
+  const rightElements = fixedArrayElements(right);
+  if (leftElements === undefined || rightElements === undefined) {
+    return true;
+  }
+  if (leftElements.length !== rightElements.length) {
+    return false;
+  }
+  return Arr.zip(leftElements, rightElements).every(([leftElement, rightElement]) =>
+    encodedAstsMayOverlap(leftElement, rightElement),
+  );
+};
+
+const encodedObjectsMayOverlap = (left: SchemaAST.Objects, right: SchemaAST.Objects): boolean => {
+  for (const leftProperty of left.propertySignatures) {
+    if (SchemaAST.isOptional(leftProperty.type)) {
+      continue;
+    }
+    const rightProperty = right.propertySignatures.find(
+      (candidate) => candidate.name === leftProperty.name && !SchemaAST.isOptional(candidate.type),
+    );
+    if (
+      rightProperty !== undefined &&
+      !encodedAstsMayOverlap(leftProperty.type, rightProperty.type)
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
+function encodedAstsMayOverlap(leftInput: SchemaAST.AST, rightInput: SchemaAST.AST): boolean {
+  const left = SchemaAST.toEncoded(leftInput);
+  const right = SchemaAST.toEncoded(rightInput);
+  if (SchemaAST.isUnion(left)) {
+    return left.types.some((member) => encodedAstsMayOverlap(member, right));
+  }
+  if (SchemaAST.isUnion(right)) {
+    return right.types.some((member) => encodedAstsMayOverlap(left, member));
+  }
+  if (SchemaAST.isLiteral(left)) {
+    return literalMayOverlap(left.literal, right);
+  }
+  if (SchemaAST.isLiteral(right)) {
+    return literalMayOverlap(right.literal, left);
+  }
+  if (SchemaAST.isEnum(left)) {
+    return left.enums.some(([, value]) => literalMayOverlap(value, right));
+  }
+  if (SchemaAST.isEnum(right)) {
+    return right.enums.some(([, value]) => literalMayOverlap(value, left));
+  }
+  if ((encodedShape(left) & encodedShape(right)) === 0) {
+    return false;
+  }
+  if (SchemaAST.isArrays(left) && SchemaAST.isArrays(right)) {
+    return encodedArraysMayOverlap(left, right);
+  }
+  if (SchemaAST.isObjects(left) && SchemaAST.isObjects(right)) {
+    return encodedObjectsMayOverlap(left, right);
+  }
+  return true;
+}
+
+const unionHasOverlappingEncodings = (ast: SchemaAST.Union): boolean => {
+  for (const [leftIndex, left] of ast.types.entries()) {
+    for (const right of ast.types.slice(leftIndex + 1)) {
+      if (encodedAstsMayOverlap(left, right)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const hasAmbiguousJsonUnion = (ast: SchemaAST.AST, seen: Set<SchemaAST.AST>): boolean => {
+  if (seen.has(ast)) {
+    return false;
+  }
+  seen.add(ast);
+  return (
+    (SchemaAST.isUnion(ast) && unionHasOverlappingEncodings(ast)) ||
+    schemaAstChildren(ast).some((child) => hasAmbiguousJsonUnion(child, seen))
+  );
+};
+
+export const schemaHasAmbiguousJsonUnion = (ast: SchemaAST.AST): boolean =>
+  hasAmbiguousJsonUnion(ast, new Set());

--- a/packages/config/src/source-ownership.test.ts
+++ b/packages/config/src/source-ownership.test.ts
@@ -26,16 +26,18 @@ describe("Topic source ownership", () => {
   });
 
   it("ignores inherited Kafka source topic entries during config derivation", () => {
-    const viewServer = defineViewServerConfig({
-      kafka: kafkaRegions,
-      topics: {
-        orders: {
-          schema: Order,
-          key: "id",
-        },
+    const topics: {
+      orders: {
+        schema: typeof Order;
+        key: "id";
+      };
+    } = {
+      orders: {
+        schema: Order,
+        key: "id",
       },
-    });
-    Object.setPrototypeOf(viewServer.topics, {
+    };
+    Object.setPrototypeOf(topics, {
       ghost: {
         schema: Order,
         key: "id",
@@ -55,40 +57,40 @@ describe("Topic source ownership", () => {
         }),
       },
     });
+    expect(makeKafkaSourceTopicsForConfig({ topics })).toStrictEqual([]);
+    const viewServer = defineViewServerConfig({
+      kafka: kafkaRegions,
+      topics,
+    });
 
     expect(makeKafkaSourceTopicsForConfig(viewServer)).toStrictEqual([]);
   });
 
   it("ignores non-object topic entries during config derivation", () => {
-    const viewServer = defineViewServerConfig({
-      kafka: kafkaRegions,
-      topics: {
-        orders: {
-          schema: Order,
-          key: "id",
-        },
+    const topics = {
+      orders: {
+        schema: Order,
+        key: "id",
       },
-    });
-    Object.defineProperty(viewServer.topics, "ghost", {
+    };
+    Object.defineProperty(topics, "ghost", {
       configurable: true,
       enumerable: true,
       value: undefined,
     });
 
-    expect(makeKafkaSourceTopicsForConfig(viewServer)).toStrictEqual([]);
+    expect(makeKafkaSourceTopicsForConfig({ topics })).toStrictEqual([]);
   });
 
   it("ignores inherited Kafka source properties during config derivation", () => {
-    const viewServer = defineViewServerConfig({
-      kafka: kafkaRegions,
-      topics: {
-        orders: {
-          schema: Order,
-          key: "id",
-        },
-      },
-    });
-    Object.setPrototypeOf(viewServer.topics.orders, {
+    const orders: {
+      schema: typeof Order;
+      key: "id";
+    } = {
+      schema: Order,
+      key: "id",
+    };
+    Object.setPrototypeOf(orders, {
       kafkaSource: kafka.source({
         topic: "orders-source",
         regions: ["usa"],
@@ -103,6 +105,10 @@ describe("Topic source ownership", () => {
           updatedAt: value.updatedAt,
         }),
       }),
+    });
+    const viewServer = defineViewServerConfig({
+      kafka: kafkaRegions,
+      topics: { orders },
     });
 
     expect(makeKafkaSourceTopicsForConfig(viewServer)).toStrictEqual([]);

--- a/packages/config/src/view-schema-admission.test.ts
+++ b/packages/config/src/view-schema-admission.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+import { StructuredProfile } from "../test-harness/schemas";
+import {
+  defineViewServerConfig,
+  viewSchema,
+  viewServerUnsupportedRuntimeFieldDomain,
+} from "./index";
+
+describe("viewSchema admission", () => {
+  it("admits only declarations created or explicitly admitted through viewSchema", () => {
+    class RawProfile extends Schema.Class<RawProfile>("RawProfile")({
+      code: Schema.String,
+    }) {}
+
+    const registeredOption = viewSchema.Option(Schema.String);
+    const registeredChunk = viewSchema.Chunk(Schema.String);
+    const registeredHashMap = viewSchema.HashMap(Schema.String, Schema.BigInt);
+    const registeredNumberBigIntMap = viewSchema.HashMap(Schema.Number, Schema.BigInt);
+    const registeredHashSet = viewSchema.HashSet(Schema.String);
+    const registeredNested = viewSchema.Option(
+      viewSchema.HashMap(Schema.Number, viewSchema.Chunk(Schema.BigInt)),
+    );
+    const rebuiltOption = registeredOption.annotate({ title: "RebuiltOption" });
+    const rebuiltClass = StructuredProfile.annotate({ title: "RebuiltStructuredProfile" });
+    const forgedOption = Schema.declare((input): input is string => typeof input === "string", {
+      typeConstructor: { _tag: "effect/Option" },
+    });
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(viewSchema.BigDecimal)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(registeredOption)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(registeredChunk)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(registeredHashMap)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(registeredNumberBigIntMap)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(registeredHashSet)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(registeredNested)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(StructuredProfile)).toBe(undefined);
+    expect(viewSchema.admitClass(StructuredProfile)).toBe(StructuredProfile);
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Option(Schema.String))).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.Chunk(Schema.String))).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(Schema.HashMap(Schema.String, Schema.BigInt)),
+    ).toBe("custom equivalence without canonical identity witness");
+    expect(viewServerUnsupportedRuntimeFieldDomain(Schema.HashSet(Schema.String))).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(RawProfile)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(rebuiltOption)).toBe(
+      "custom equivalence without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(rebuiltClass)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(viewServerUnsupportedRuntimeFieldDomain(forgedOption)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(viewSchema.Option(Schema.Option(Schema.String))),
+    ).toBe("custom equivalence without canonical identity witness");
+    expect(
+      viewServerUnsupportedRuntimeFieldDomain(
+        viewSchema.HashMap(Schema.String, Schema.HashSet(Schema.String)),
+      ),
+    ).toBe("custom equivalence without canonical identity witness");
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          rawClass: {
+            schema: RawProfile,
+            key: "code",
+          },
+        },
+      }),
+    ).toThrow(
+      "View Server topic rawClass row schema uses unsupported runtime domain: custom codec transformation without canonical identity witness",
+    );
+
+    expect(() =>
+      defineViewServerConfig({
+        topics: {
+          accepted: {
+            schema: Schema.Struct({
+              id: Schema.String,
+              decimal: viewSchema.BigDecimal,
+              option: registeredOption,
+              chunk: registeredChunk,
+              hashMap: registeredNumberBigIntMap,
+              hashSet: registeredHashSet,
+              nested: registeredNested,
+              profile: StructuredProfile,
+            }),
+            key: "id",
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("admits concrete classes independently of reuse and schema inspection order", () => {
+    class FirstProfile extends Schema.Class<FirstProfile>("FirstProfile")({
+      id: Schema.String,
+    }) {}
+    class SecondProfile extends Schema.Class<SecondProfile>("SecondProfile")({
+      id: Schema.String,
+    }) {}
+
+    expect(viewServerUnsupportedRuntimeFieldDomain(FirstProfile)).toBe(
+      "custom codec transformation without canonical identity witness",
+    );
+    expect(FirstProfile.ast).toBe(FirstProfile.ast);
+    expect(viewSchema.admitClass(FirstProfile)).toBe(FirstProfile);
+    expect(viewSchema.admitClass(FirstProfile)).toBe(FirstProfile);
+    expect(viewSchema.admitClass(SecondProfile)).toBe(SecondProfile);
+    expect(viewServerUnsupportedRuntimeFieldDomain(FirstProfile)).toBe(undefined);
+    expect(viewServerUnsupportedRuntimeFieldDomain(SecondProfile)).toBe(undefined);
+
+    expect(() =>
+      Reflect.apply(viewSchema.admitClass, undefined, [Schema.Struct({ id: Schema.String })]),
+    ).toThrow("viewSchema.admitClass requires a concrete Effect Schema.Class.");
+  });
+});

--- a/packages/config/src/view-schema-contract.test-d.ts
+++ b/packages/config/src/view-schema-contract.test-d.ts
@@ -1,0 +1,107 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import { Schema } from "effect";
+import type * as EffectChunk from "effect/Chunk";
+import type * as EffectHashMap from "effect/HashMap";
+import type * as EffectHashSet from "effect/HashSet";
+import * as EffectOption from "effect/Option";
+import { defineViewServerConfig, viewSchema } from "./index";
+
+const OptionNumber = viewSchema.Option(Schema.NumberFromString);
+const ChunkNumber = viewSchema.Chunk(Schema.NumberFromString);
+const NumberBigIntMap = viewSchema.HashMap(Schema.NumberFromString, Schema.BigIntFromString);
+const StringSet = viewSchema.HashSet(Schema.String);
+const Nested = viewSchema.Option(
+  viewSchema.HashMap(Schema.String, viewSchema.Chunk(Schema.BigIntFromString)),
+);
+
+class Profile extends Schema.Class<Profile>("Profile")({
+  id: Schema.String,
+  score: Schema.NumberFromString,
+  backup: viewSchema.Option(Schema.String),
+}) {
+  upperId(): string {
+    return this.id.toUpperCase();
+  }
+}
+const admittedProfile = viewSchema.admitClass(Profile);
+const AnnotatedProfile = Profile.annotate({ title: "AnnotatedProfile" });
+
+class SecondaryProfile extends Schema.Class<SecondaryProfile>("SecondaryProfile")(
+  { id: Schema.String },
+  { title: "Secondary profile" },
+) {}
+const admittedSecondaryProfile = viewSchema.admitClass(SecondaryProfile);
+
+const profileConfig = defineViewServerConfig({
+  topics: {
+    profiles: {
+      schema: Profile,
+      key: "id",
+    },
+  },
+});
+
+describe("viewSchema public type contracts", () => {
+  it("preserves declaration Type and Encoded parameters", () => {
+    expectTypeOf<typeof OptionNumber.Type>().toEqualTypeOf<EffectOption.Option<number>>();
+    expectTypeOf<typeof OptionNumber.Encoded>().toEqualTypeOf<EffectOption.Option<string>>();
+    expectTypeOf<typeof ChunkNumber.Type>().toEqualTypeOf<EffectChunk.Chunk<number>>();
+    expectTypeOf<typeof ChunkNumber.Encoded>().toEqualTypeOf<EffectChunk.Chunk<string>>();
+    expectTypeOf<typeof NumberBigIntMap.Type>().toEqualTypeOf<
+      EffectHashMap.HashMap<number, bigint>
+    >();
+    expectTypeOf<typeof NumberBigIntMap.Encoded>().toEqualTypeOf<
+      EffectHashMap.HashMap<string, string>
+    >();
+    expectTypeOf<typeof StringSet.Type>().toEqualTypeOf<EffectHashSet.HashSet<string>>();
+    expectTypeOf<typeof StringSet.Encoded>().toEqualTypeOf<EffectHashSet.HashSet<string>>();
+    expectTypeOf<typeof Nested.Type>().toEqualTypeOf<
+      EffectOption.Option<EffectHashMap.HashMap<string, EffectChunk.Chunk<bigint>>>
+    >();
+    expectTypeOf<typeof Nested.Encoded>().toEqualTypeOf<
+      EffectOption.Option<EffectHashMap.HashMap<string, EffectChunk.Chunk<string>>>
+    >();
+  });
+
+  it("preserves Class construction, methods, and config inference", () => {
+    const made = Profile.make({
+      id: "profile-1",
+      score: 42,
+      backup: EffectOption.none(),
+    });
+    const constructed = new Profile({
+      id: "profile-2",
+      score: 43,
+      backup: EffectOption.some("profile-1"),
+    });
+
+    expectTypeOf(made).toEqualTypeOf<Profile>();
+    expectTypeOf(constructed).toEqualTypeOf<Profile>();
+    expectTypeOf(made.upperId()).toEqualTypeOf<string>();
+    expectTypeOf(admittedProfile).toEqualTypeOf<typeof Profile>();
+    expectTypeOf(admittedSecondaryProfile).toEqualTypeOf<typeof SecondaryProfile>();
+    expectTypeOf<typeof Profile.Type>().toEqualTypeOf<Profile>();
+    expectTypeOf<typeof Profile.Encoded>().toEqualTypeOf<{
+      readonly id: string;
+      readonly score: string;
+      readonly backup: EffectOption.Option<string>;
+    }>();
+    expectTypeOf(profileConfig.topics.profiles.schema).toEqualTypeOf<typeof Profile>();
+    expectTypeOf<typeof profileConfig.topics.profiles.schema.Type>().toEqualTypeOf<Profile>();
+  });
+
+  it("reports misuse without requiring consumer casts", () => {
+    // @ts-expect-error admitClass requires a concrete Effect Schema.Class.
+    viewSchema.admitClass(Schema.Struct({ id: Schema.String }));
+    // @ts-expect-error declarations without Class fields are not concrete Schema classes.
+    viewSchema.admitClass(Schema.Option(Schema.String));
+    // @ts-expect-error Class annotation rebuilds do not retain the concrete Class field Interface.
+    viewSchema.admitClass(AnnotatedProfile);
+    // @ts-expect-error admitClass requires an Effect Schema value.
+    viewSchema.admitClass({ identifier: "NotASchema" });
+    // @ts-expect-error viewSchema.Option requires an Effect Schema.
+    viewSchema.Option("not-a-schema");
+    // @ts-expect-error viewSchema.HashMap requires key and value schemas.
+    viewSchema.HashMap(Schema.String);
+  });
+});

--- a/packages/config/src/view-schema.ts
+++ b/packages/config/src/view-schema.ts
@@ -1,0 +1,48 @@
+import { Schema, SchemaAST } from "effect";
+import { schemaAstIsClass } from "./schema-ast-children";
+
+const admittedDeclarationAsts = new WeakSet<SchemaAST.Declaration>([Schema.BigDecimal.ast]);
+
+const registerDeclaration = <
+  S extends Schema.Constraint & {
+    readonly ast: SchemaAST.Declaration;
+  },
+>(
+  schema: S,
+): S => {
+  admittedDeclarationAsts.add(schema.ast);
+  return schema;
+};
+
+export const viewSchemaDeclarationAstIsAdmitted = (ast: SchemaAST.Declaration): boolean =>
+  admittedDeclarationAsts.has(ast);
+
+type ConcreteSchemaClass = Schema.Constraint & {
+  readonly ast: SchemaAST.Declaration;
+  readonly fields: Schema.Struct.Fields;
+  readonly identifier: string;
+};
+
+const admitClass = <Class extends ConcreteSchemaClass>(schemaClass: Class): Class => {
+  const ast = schemaClass.ast;
+  if (!schemaAstIsClass(ast)) {
+    throw new TypeError("viewSchema.admitClass requires a concrete Effect Schema.Class.");
+  }
+  admittedDeclarationAsts.add(ast);
+  return schemaClass;
+};
+
+export const viewSchema = Object.freeze({
+  BigDecimal: Schema.BigDecimal,
+  Option: <A extends Schema.Constraint>(value: A): Schema.Option<A> =>
+    registerDeclaration(Schema.Option(value)),
+  Chunk: <Value extends Schema.Constraint>(value: Value): Schema.Chunk<Value> =>
+    registerDeclaration(Schema.Chunk(value)),
+  HashMap: <Key extends Schema.Constraint, Value extends Schema.Constraint>(
+    key: Key,
+    value: Value,
+  ): Schema.HashMap<Key, Value> => registerDeclaration(Schema.HashMap(key, value)),
+  HashSet: <Value extends Schema.Constraint>(value: Value): Schema.HashSet<Value> =>
+    registerDeclaration(Schema.HashSet(value)),
+  admitClass,
+});

--- a/packages/config/test-harness/kafka.ts
+++ b/packages/config/test-harness/kafka.ts
@@ -21,29 +21,15 @@ export const kafkaTestMetadata = <const Region extends "usa" | "london">(
   headers: {},
 });
 
-export type RuntimeGuardKafkaSourceViewServer = {
-  readonly topics: {
-    readonly orders: {
-      readonly kafkaSource: object;
-    };
-  };
-};
-
-export const forceKafkaSourceRowKeyForRuntimeGuard = (
-  viewServer: RuntimeGuardKafkaSourceViewServer,
-  rowKey: () => unknown,
-) => {
-  Object.defineProperty(viewServer.topics.orders.kafkaSource, "rowKey", {
+export const forceKafkaSourceRowKeyForRuntimeGuard = (source: object, rowKey: () => unknown) => {
+  Object.defineProperty(source, "rowKey", {
     configurable: true,
     value: rowKey,
   });
 };
 
-export const forceKafkaSourceMapForRuntimeGuard = (
-  viewServer: RuntimeGuardKafkaSourceViewServer,
-  map: () => unknown,
-) => {
-  Object.defineProperty(viewServer.topics.orders.kafkaSource, "map", {
+export const forceKafkaSourceMapForRuntimeGuard = (source: object, map: () => unknown) => {
+  Object.defineProperty(source, "map", {
     configurable: true,
     value: map,
   });

--- a/packages/config/test-harness/schemas.ts
+++ b/packages/config/test-harness/schemas.ts
@@ -1,4 +1,10 @@
 import { Schema } from "effect";
+import { viewSchema } from "../src/index";
+
+export class StructuredProfile extends Schema.Class<StructuredProfile>("StructuredProfile")({
+  code: Schema.String,
+}) {}
+viewSchema.admitClass(StructuredProfile);
 
 export const Order = Schema.Struct({
   id: Schema.String,

--- a/packages/effect-utils/src/grouped-key-identity.test.ts
+++ b/packages/effect-utils/src/grouped-key-identity.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "@effect/vitest";
+import { HashMap, HashSet, Schema } from "effect";
+import { compileGroupedKeyIdentity, type GroupedKeyIdentityField } from "./grouped-key-identity";
+import { makeSchemaJsonIdentity } from "./schema-json-identity";
+
+const GroupedKeyRow = Schema.Struct({
+  text: Schema.String,
+  amount: Schema.Number,
+  nested: Schema.Struct({ desk: Schema.String }),
+  maybe: Schema.optionalKey(Schema.Union([Schema.String, Schema.Undefined])),
+  hashMap: Schema.HashMap(Schema.String, Schema.String),
+  hashSet: Schema.HashSet(Schema.String),
+});
+
+const groupedKeyFields: ReadonlyArray<GroupedKeyIdentityField> = [
+  { field: "text", canonicalKey: makeSchemaJsonIdentity(GroupedKeyRow.fields.text).canonicalKey },
+  {
+    field: "amount",
+    canonicalKey: makeSchemaJsonIdentity(GroupedKeyRow.fields.amount).canonicalKey,
+  },
+  {
+    field: "nested",
+    canonicalKey: makeSchemaJsonIdentity(GroupedKeyRow.fields.nested).canonicalKey,
+  },
+  {
+    field: "maybe",
+    canonicalKey: makeSchemaJsonIdentity(GroupedKeyRow.fields.maybe).canonicalKey,
+  },
+  {
+    field: "hashMap",
+    canonicalKey: makeSchemaJsonIdentity(GroupedKeyRow.fields.hashMap).canonicalKey,
+  },
+  {
+    field: "hashSet",
+    canonicalKey: makeSchemaJsonIdentity(GroupedKeyRow.fields.hashSet).canonicalKey,
+  },
+];
+
+const throwingIdentity = compileGroupedKeyIdentity<object>(groupedKeyFields, "throw");
+const optionalIdentity = compileGroupedKeyIdentity<object>(groupedKeyFields, "undefined");
+
+const missingPresenceKey = JSON.stringify(["missing"]);
+const presentPresenceKey = (canonicalKey: string): string =>
+  JSON.stringify(["present", canonicalKey]);
+const groupedKey = (
+  entries: ReadonlyArray<readonly [field: string, presenceKey: string]>,
+): string => JSON.stringify(entries);
+
+const collisionLeft = "8ocpIaaa";
+const collisionRight = "GpcpIaaa";
+
+const semanticRow = (amount: number, reverse: boolean) => ({
+  text: "route",
+  amount,
+  nested: { desk: "equities" },
+  hashMap: reverse
+    ? HashMap.make([collisionRight, "right"], [collisionLeft, "left"])
+    : HashMap.make([collisionLeft, "left"], [collisionRight, "right"]),
+  hashSet: reverse
+    ? HashSet.make(collisionRight, collisionLeft)
+    : HashSet.make(collisionLeft, collisionRight),
+});
+
+const expectedSemanticKey = (amount: string, maybePresenceKey: string): string =>
+  groupedKey([
+    ["text", presentPresenceKey('"route"')],
+    ["amount", presentPresenceKey(amount)],
+    ["nested", presentPresenceKey('{"desk":"equities"}')],
+    ["maybe", maybePresenceKey],
+    ["hashMap", presentPresenceKey(`[["${collisionLeft}","left"],["${collisionRight}","right"]]`)],
+    ["hashSet", presentPresenceKey(`["${collisionLeft}","${collisionRight}"]`)],
+  ]);
+
+describe("grouped key identity", () => {
+  it("shares exact multi-field composition and semantic partitions across failure adapters", () => {
+    const negativeZero = semanticRow(-0, false);
+    const equivalent = semanticRow(0, true);
+    const expected = expectedSemanticKey("0", missingPresenceKey);
+
+    expect(throwingIdentity.key(negativeZero)).toBe(expected);
+    expect(optionalIdentity.key(negativeZero)).toBe(expected);
+    expect(throwingIdentity.key(equivalent)).toBe(expected);
+    expect(optionalIdentity.key(equivalent)).toBe(throwingIdentity.key(equivalent));
+  });
+
+  it("distinguishes missing from present undefined with the same exact framing", () => {
+    const missing = semanticRow(1, false);
+    const present = { ...missing, maybe: undefined };
+    const missingKey = throwingIdentity.key(missing);
+    const presentKey = throwingIdentity.key(present);
+
+    expect(missingKey).toBe(expectedSemanticKey("1", missingPresenceKey));
+    expect(presentKey).toBe(expectedSemanticKey("1", presentPresenceKey("null")));
+    expect(presentKey).not.toBe(missingKey);
+    expect(optionalIdentity.key(missing)).toBe(missingKey);
+    expect(optionalIdentity.key(present)).toBe(presentKey);
+  });
+
+  it("applies throwing and undefined failure policies to reflection and canonicalization", () => {
+    const hostileRow = new Proxy(semanticRow(1, false), {
+      getOwnPropertyDescriptor() {
+        throw new Error("row reflection failed");
+      },
+    });
+    const invalidRow = {
+      ...semanticRow(1, false),
+      text: 1,
+    };
+
+    expect(() => throwingIdentity.key(hostileRow)).toThrow("row reflection failed");
+    expect(optionalIdentity.key(hostileRow)).toBeUndefined();
+    expect(() => throwingIdentity.key(invalidRow)).toThrow();
+    expect(optionalIdentity.key(invalidRow)).toBeUndefined();
+  });
+});

--- a/packages/effect-utils/src/grouped-key-identity.ts
+++ b/packages/effect-utils/src/grouped-key-identity.ts
@@ -1,0 +1,73 @@
+import {
+  missingSchemaValuePresenceToken,
+  presentSchemaValuePresenceToken,
+  schemaValuePresenceKey,
+} from "./schema-value-presence";
+
+export type GroupedKeyIdentityField = {
+  readonly field: string;
+  readonly canonicalKey: (value: unknown) => string;
+};
+
+export type CompiledGroupedKeyIdentity<Row extends object, Key extends string | undefined> = {
+  readonly key: (row: Row) => Key;
+};
+
+type CompiledGroupedKeyFrame = GroupedKeyIdentityField & {
+  readonly prefix: string;
+};
+
+const missingGroupedValueKey = schemaValuePresenceKey(missingSchemaValuePresenceToken);
+
+const compileGroupedKeyFrames = (
+  fields: ReadonlyArray<GroupedKeyIdentityField>,
+): ReadonlyArray<CompiledGroupedKeyFrame> =>
+  fields.map((field) => ({
+    ...field,
+    prefix: `[${JSON.stringify(field.field)},`,
+  }));
+
+const groupedKeyFromRow = <Row extends object>(
+  fields: ReadonlyArray<CompiledGroupedKeyFrame>,
+  row: Row,
+): string => {
+  const tokens: Array<string> = [];
+  for (const field of fields) {
+    const presenceKey = Object.prototype.propertyIsEnumerable.call(row, field.field)
+      ? schemaValuePresenceKey(
+          presentSchemaValuePresenceToken(field.canonicalKey(Reflect.get(row, field.field))),
+        )
+      : missingGroupedValueKey;
+    tokens.push(`${field.prefix}${JSON.stringify(presenceKey)}]`);
+  }
+  return `[${tokens.join(",")}]`;
+};
+
+export function compileGroupedKeyIdentity<Row extends object>(
+  fields: ReadonlyArray<GroupedKeyIdentityField>,
+  failureMode: "throw",
+): CompiledGroupedKeyIdentity<Row, string>;
+export function compileGroupedKeyIdentity<Row extends object>(
+  fields: ReadonlyArray<GroupedKeyIdentityField>,
+  failureMode: "undefined",
+): CompiledGroupedKeyIdentity<Row, string | undefined>;
+export function compileGroupedKeyIdentity<Row extends object>(
+  fields: ReadonlyArray<GroupedKeyIdentityField>,
+  failureMode: "throw" | "undefined",
+): CompiledGroupedKeyIdentity<Row, string | undefined> {
+  const compiled = compileGroupedKeyFrames(fields);
+  if (failureMode === "throw") {
+    return {
+      key: (row) => groupedKeyFromRow(compiled, row),
+    };
+  }
+  return {
+    key: (row) => {
+      try {
+        return groupedKeyFromRow(compiled, row);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}

--- a/packages/effect-utils/src/index.ts
+++ b/packages/effect-utils/src/index.ts
@@ -1,5 +1,23 @@
 import { Cause, Effect, Exit } from "effect";
 
+export {
+  materializeStrictJson,
+  StrictJsonMaterializationError,
+  type StrictJsonMaterializationReason,
+} from "./strict-json-materialization";
+export { makeSchemaJsonIdentity, type SchemaJsonIdentity } from "./schema-json-identity";
+export {
+  compileGroupedKeyIdentity,
+  type CompiledGroupedKeyIdentity,
+  type GroupedKeyIdentityField,
+} from "./grouped-key-identity";
+export {
+  missingSchemaValuePresenceToken,
+  presentSchemaValuePresenceToken,
+  schemaValuePresenceKey,
+  type SchemaValuePresenceToken,
+} from "./schema-value-presence";
+
 const isNonTypedFailureReason = <E>(
   reason: Cause.Reason<E>,
 ): reason is Cause.Die | Cause.Interrupt =>

--- a/packages/effect-utils/src/schema-json-identity.test.ts
+++ b/packages/effect-utils/src/schema-json-identity.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Chunk, HashMap, HashSet, Option, Schema } from "effect";
+import { makeSchemaJsonIdentity, makeSchemaJsonNormalizer } from "./schema-json-identity";
+
+const collisionLeft = "8ocpIaaa";
+const collisionRight = "GpcpIaaa";
+
+class Profile extends Schema.Class<Profile>("Profile")({
+  name: Schema.String,
+}) {}
+
+describe("Schema JSON identity", () => {
+  it("canonicalizes collision-node HashMap and HashSet values independent of insertion order", () => {
+    const mapIdentity = makeSchemaJsonIdentity(Schema.HashMap(Schema.String, Schema.String));
+    const setIdentity = makeSchemaJsonIdentity(Schema.HashSet(Schema.String));
+    const leftMap = HashMap.make([collisionLeft, "left"], [collisionRight, "right"]);
+    const rightMap = HashMap.make([collisionRight, "right"], [collisionLeft, "left"]);
+    const leftSet = HashSet.make(collisionLeft, collisionRight);
+    const rightSet = HashSet.make(collisionRight, collisionLeft);
+
+    expect(mapIdentity.canonicalKey(leftMap)).toBe(mapIdentity.canonicalKey(rightMap));
+    expect(setIdentity.canonicalKey(leftSet)).toBe(setIdentity.canonicalKey(rightSet));
+    expect(mapIdentity.canonicalJson(leftMap)).toStrictEqual(mapIdentity.canonicalJson(rightMap));
+    expect(setIdentity.canonicalJson(leftSet)).toStrictEqual(setIdentity.canonicalJson(rightSet));
+  });
+
+  it("normalizes nested unordered values without changing ordered collections", () => {
+    const Nested = Schema.Struct({
+      values: Schema.Array(
+        Schema.Option(Schema.HashMap(Schema.String, Schema.HashSet(Schema.String))),
+      ),
+      ordered: Schema.Chunk(Schema.String),
+    });
+    const identity = makeSchemaJsonIdentity(Nested);
+    const left = {
+      values: [
+        Option.some(
+          HashMap.make(
+            [collisionLeft, HashSet.make(collisionLeft, collisionRight)],
+            [collisionRight, HashSet.make(collisionRight, collisionLeft)],
+          ),
+        ),
+      ],
+      ordered: Chunk.make("first", "second"),
+    };
+    const equivalent = {
+      ordered: Chunk.make("first", "second"),
+      values: [
+        Option.some(
+          HashMap.make(
+            [collisionRight, HashSet.make(collisionLeft, collisionRight)],
+            [collisionLeft, HashSet.make(collisionRight, collisionLeft)],
+          ),
+        ),
+      ],
+    };
+    const reordered = {
+      ...equivalent,
+      ordered: Chunk.make("second", "first"),
+    };
+
+    expect(identity.canonicalKey(left)).toBe(identity.canonicalKey(equivalent));
+    expect(identity.canonicalKey(left)).not.toBe(identity.canonicalKey(reordered));
+  });
+
+  it("uses the canonical class codec for separately instantiated values", () => {
+    const identity = makeSchemaJsonIdentity(Profile);
+
+    expect(identity.canonicalKey(Profile.make({ name: "Ada" }))).toBe(
+      identity.canonicalKey(Profile.make({ name: "Ada" })),
+    );
+  });
+
+  it("keeps decoded ownership materialization separate from encoded decoding", () => {
+    const profileIdentity = makeSchemaJsonIdentity(Profile);
+    const profile = Profile.make({ name: "Ada" });
+    const materializedProfile = profileIdentity.materializeDecoded(profile);
+    const bigintIdentity = makeSchemaJsonIdentity(Schema.BigInt);
+
+    expect(materializedProfile).toStrictEqual(profile);
+    expect(materializedProfile).not.toBe(profile);
+    expect(() => bigintIdentity.materializeDecoded("9007199254740993")).toThrow();
+    expect(bigintIdentity.decodeEncoded("9007199254740993")).toBe(9007199254740993n);
+  });
+
+  it("selects the matching tagged-union branch before normalizing nested values", () => {
+    const Tagged = Schema.Union([
+      Schema.Struct({
+        kind: Schema.Literal("Map"),
+        value: Schema.HashMap(Schema.String, Schema.String),
+      }),
+      Schema.Struct({
+        kind: Schema.Literal("Array"),
+        value: Schema.Array(Schema.String),
+      }),
+    ]);
+    const identity = makeSchemaJsonIdentity(Tagged);
+
+    expect(
+      identity.canonicalKey({ kind: "Array", value: [collisionRight, collisionLeft] }),
+    ).not.toBe(identity.canonicalKey({ kind: "Array", value: [collisionLeft, collisionRight] }));
+  });
+
+  it("normalizes record index values and preserves own __proto__ data", () => {
+    const identity = makeSchemaJsonIdentity(
+      Schema.Record(Schema.String, Schema.HashSet(Schema.String)),
+    );
+    const left: Record<string, HashSet.HashSet<string>> = {};
+    const right: Record<string, HashSet.HashSet<string>> = {};
+    Object.defineProperty(left, "__proto__", {
+      enumerable: true,
+      value: HashSet.make(collisionLeft, collisionRight),
+    });
+    Object.defineProperty(right, "__proto__", {
+      enumerable: true,
+      value: HashSet.make(collisionRight, collisionLeft),
+    });
+
+    expect(identity.canonicalKey(left)).toBe(identity.canonicalKey(right));
+  });
+
+  it("rejects encoded values that are not strict JSON", () => {
+    const identity = makeSchemaJsonIdentity(Schema.Unknown);
+
+    expect(() => identity.canonicalKey(new Map([["key", "value"]]))).toThrow(
+      "Expected a plain data record or dense array",
+    );
+  });
+
+  it("keeps the encoded normalizer total for non-matching JSON shapes", () => {
+    const objectNormalizer = makeSchemaJsonNormalizer(
+      Schema.toCodecJson(Schema.Struct({ value: Schema.String })).ast,
+    );
+    const arrayNormalizer = makeSchemaJsonNormalizer(
+      Schema.toCodecJson(Schema.Array(Schema.String)).ast,
+    );
+    const mapNormalizer = makeSchemaJsonNormalizer(
+      Schema.toCodecJson(Schema.HashMap(Schema.String, Schema.String)).ast,
+    );
+    const unionNormalizer = makeSchemaJsonNormalizer(
+      Schema.toCodecJson(Schema.Union([Schema.String, Schema.Number])).ast,
+    );
+
+    expect(objectNormalizer("value")).toBe("value");
+    expect(objectNormalizer({ other: "value" })).toStrictEqual({ other: "value" });
+    expect(arrayNormalizer("value")).toBe("value");
+    expect(mapNormalizer("value")).toBe("value");
+    expect(unionNormalizer(false)).toBe(false);
+  });
+
+  it("normalizes suspended schemas and fixed, rest, and trailing tuple elements", () => {
+    const Suspended = Schema.suspend(() =>
+      Schema.Struct({ values: Schema.HashSet(Schema.String) }),
+    );
+    const suspendedNormalizer = makeSchemaJsonNormalizer(Schema.toCodecJson(Suspended).ast);
+    const tupleNormalizer = makeSchemaJsonNormalizer(
+      Schema.toCodecJson(
+        Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.String, Schema.Number]),
+      ).ast,
+    );
+
+    expect(suspendedNormalizer({ values: [collisionRight, collisionLeft] })).toStrictEqual({
+      values: [collisionLeft, collisionRight],
+    });
+    expect(suspendedNormalizer({ values: [collisionRight, collisionLeft] })).toStrictEqual({
+      values: [collisionLeft, collisionRight],
+    });
+    expect(tupleNormalizer(["head", "rest", 1])).toStrictEqual(["head", "rest", 1]);
+    expect(tupleNormalizer(["head", "rest", "extra", 1])).toStrictEqual([
+      "head",
+      "rest",
+      "extra",
+      1,
+    ]);
+    expect(
+      makeSchemaJsonNormalizer(Schema.Tuple([Schema.String]).ast)(["head", "extra"]),
+    ).toStrictEqual(["head", "extra"]);
+  });
+});

--- a/packages/effect-utils/src/schema-json-identity.test.ts
+++ b/packages/effect-utils/src/schema-json-identity.test.ts
@@ -10,6 +10,15 @@ class Profile extends Schema.Class<Profile>("Profile")({
 }) {}
 
 describe("Schema JSON identity", () => {
+  it("keeps the direct string key path byte-identical and validates invalid inputs", () => {
+    const identity = makeSchemaJsonIdentity(Schema.String);
+
+    expect(identity.canonicalKey('route\\"north')).toBe('"route\\\\\\"north"');
+    expect(identity.canonicalJson('route\\"north')).toBe('route\\"north');
+    expect(() => identity.canonicalKey(1)).toThrow();
+    expect(() => makeSchemaJsonIdentity(Schema.NonEmptyString).canonicalKey("")).toThrow();
+  });
+
   it("canonicalizes collision-node HashMap and HashSet values independent of insertion order", () => {
     const mapIdentity = makeSchemaJsonIdentity(Schema.HashMap(Schema.String, Schema.String));
     const setIdentity = makeSchemaJsonIdentity(Schema.HashSet(Schema.String));

--- a/packages/effect-utils/src/schema-json-identity.ts
+++ b/packages/effect-utils/src/schema-json-identity.ts
@@ -185,6 +185,15 @@ export const makeSchemaJsonIdentity = <Type>(
   const normalize = makeSchemaJsonNormalizer(codec.ast);
   const strictEncoded = (value: unknown): Schema.Json => strictJson(encode(value));
   const canonicalJson = (value: unknown): Schema.Json => normalize(strictEncoded(value));
+  const canonicalKey =
+    SchemaAST.isString(codec.ast) &&
+    codec.ast.encoding === undefined &&
+    (codec.ast.checks?.length ?? 0) === 0
+      ? (value: unknown): string =>
+          typeof value === "string"
+            ? canonicalJsonString(value)
+            : canonicalJsonString(canonicalJson(value))
+      : (value: unknown): string => canonicalJsonString(canonicalJson(value));
   const materializeDecoded = (value: unknown): Type => decode(strictEncoded(value));
   const decodeEncoded = (value: unknown): Type => {
     const decoded = decode(strictJson(value));
@@ -192,7 +201,7 @@ export const makeSchemaJsonIdentity = <Type>(
   };
   return {
     canonicalJson,
-    canonicalKey: (value) => canonicalJsonString(canonicalJson(value)),
+    canonicalKey,
     decodeEncoded,
     materializeDecoded,
   };

--- a/packages/effect-utils/src/schema-json-identity.ts
+++ b/packages/effect-utils/src/schema-json-identity.ts
@@ -1,0 +1,199 @@
+import { Result, Schema, SchemaAST } from "effect";
+import { materializeStrictJson } from "./strict-json-materialization";
+
+type ValueSchema<Type = unknown> = Schema.Codec<Type, unknown, never, never>;
+type JsonNormalizer = (value: Schema.Json) => Schema.Json;
+
+export type SchemaJsonIdentity<Type = unknown> = {
+  readonly canonicalJson: (value: unknown) => Schema.Json;
+  readonly canonicalKey: (value: unknown) => string;
+  readonly decodeEncoded: (value: unknown) => Type;
+  readonly materializeDecoded: (value: unknown) => Type;
+};
+
+const typeConstructorTag = (ast: SchemaAST.AST): unknown => {
+  if (!SchemaAST.isDeclaration(ast)) {
+    return undefined;
+  }
+  const typeConstructor = ast.annotations?.["typeConstructor"];
+  return typeof typeConstructor === "object" && typeConstructor !== null
+    ? Reflect.get(typeConstructor, "_tag")
+    : undefined;
+};
+
+const compareStrings = (left: string, right: string): number =>
+  Number(left > right) - Number(left < right);
+
+const isJsonArray = (value: Schema.Json): value is Schema.JsonArray => Array.isArray(value);
+
+const isJsonObject = (value: Schema.Json): value is Schema.JsonObject =>
+  value !== null && typeof value === "object" && !isJsonArray(value);
+
+const canonicalJsonString = (value: Schema.Json): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (isJsonObject(value)) {
+    return `{${Object.keys(value)
+      .toSorted(compareStrings)
+      .map((key) => `${JSON.stringify(key)}:${canonicalJsonString(value[key]!)}`)
+      .join(",")}}`;
+  }
+  return `[${value.map(canonicalJsonString).join(",")}]`;
+};
+
+const defineJsonProperty = (
+  output: Record<string, Schema.Json>,
+  key: string,
+  value: Schema.Json,
+): void => {
+  Object.defineProperty(output, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+export const makeSchemaJsonNormalizer = (root: SchemaAST.AST): JsonNormalizer => {
+  const compiled = new Map<SchemaAST.AST, JsonNormalizer>();
+
+  const compile = (ast: SchemaAST.AST): JsonNormalizer => {
+    const cached = compiled.get(ast);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let implementation: JsonNormalizer = (value) => value;
+    const normalizer: JsonNormalizer = (value) => implementation(value);
+    compiled.set(ast, normalizer);
+
+    if (SchemaAST.isSuspend(ast)) {
+      let suspended: JsonNormalizer | undefined;
+      implementation = (value) => {
+        suspended ??= compile(ast.thunk());
+        return suspended(value);
+      };
+      return normalizer;
+    }
+
+    if (ast.encoding !== undefined && ast.encoding.length > 0) {
+      const encoded = compile(ast.encoding[ast.encoding.length - 1]!.to);
+      const tag = typeConstructorTag(ast);
+      if (tag === "effect/HashMap" || tag === "effect/HashSet") {
+        implementation = (value) => {
+          const normalized = encoded(value);
+          return isJsonArray(normalized)
+            ? normalized.toSorted((left, right) =>
+                compareStrings(canonicalJsonString(left), canonicalJsonString(right)),
+              )
+            : normalized;
+        };
+      } else {
+        implementation = encoded;
+      }
+      return normalizer;
+    }
+
+    if (SchemaAST.isUnion(ast)) {
+      const members = ast.types.map((member) => ({
+        is: Schema.is(
+          Schema.make<Schema.Codec<unknown, unknown, never, never>>(SchemaAST.toEncoded(member)),
+        ),
+        normalize: compile(member),
+      }));
+      implementation = (value) =>
+        members.find((member) => member.is(value))?.normalize(value) ?? value;
+      return normalizer;
+    }
+
+    if (SchemaAST.isObjects(ast)) {
+      const properties = new Map(
+        ast.propertySignatures
+          .filter((property) => typeof property.name === "string")
+          .map((property) => [property.name, compile(property.type)] as const),
+      );
+      const indexes = ast.indexSignatures.map((index) => ({
+        accepts: Schema.is(
+          Schema.make<Schema.Codec<unknown, unknown, never, never>>(
+            SchemaAST.toEncoded(index.parameter),
+          ),
+        ),
+        normalize: compile(index.type),
+      }));
+      implementation = (value) => {
+        if (!isJsonObject(value)) {
+          return value;
+        }
+        const output: Record<string, Schema.Json> = {};
+        for (const key of Object.keys(value)) {
+          const property = properties.get(key);
+          const index = indexes.find((candidate) => candidate.accepts(key));
+          const fieldValue = value[key]!;
+          defineJsonProperty(
+            output,
+            key,
+            property?.(fieldValue) ?? index?.normalize(fieldValue) ?? fieldValue,
+          );
+        }
+        return output;
+      };
+      return normalizer;
+    }
+
+    if (SchemaAST.isArrays(ast)) {
+      const elements = ast.elements.map(compile);
+      const rest = ast.rest.map(compile);
+      implementation = (value) => {
+        if (!isJsonArray(value)) {
+          return value;
+        }
+        const [head, ...tail] = rest;
+        const tailThreshold = value.length - tail.length;
+        return value.map((entry, index) => {
+          const item =
+            index < elements.length
+              ? elements[index]
+              : index >= tailThreshold
+                ? tail[index - tailThreshold]
+                : head;
+          return item?.(entry) ?? entry;
+        });
+      };
+    }
+
+    return normalizer;
+  };
+
+  return compile(root);
+};
+
+const strictJson = (value: unknown): Schema.Json => {
+  const materialized = materializeStrictJson(value);
+  if (Result.isFailure(materialized)) {
+    throw materialized.failure;
+  }
+  return materialized.success;
+};
+
+export const makeSchemaJsonIdentity = <Type>(
+  schema: ValueSchema<Type>,
+): SchemaJsonIdentity<Type> => {
+  const codec = Schema.toCodecJson(schema);
+  const decode = Schema.decodeUnknownSync(codec);
+  const encode = Schema.encodeUnknownSync(codec);
+  const normalize = makeSchemaJsonNormalizer(codec.ast);
+  const strictEncoded = (value: unknown): Schema.Json => strictJson(encode(value));
+  const canonicalJson = (value: unknown): Schema.Json => normalize(strictEncoded(value));
+  const materializeDecoded = (value: unknown): Type => decode(strictEncoded(value));
+  const decodeEncoded = (value: unknown): Type => {
+    const decoded = decode(strictJson(value));
+    return materializeDecoded(decoded);
+  };
+  return {
+    canonicalJson,
+    canonicalKey: (value) => canonicalJsonString(canonicalJson(value)),
+    decodeEncoded,
+    materializeDecoded,
+  };
+};

--- a/packages/effect-utils/src/schema-value-presence.test.ts
+++ b/packages/effect-utils/src/schema-value-presence.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  missingSchemaValuePresenceToken,
+  presentSchemaValuePresenceToken,
+  schemaValuePresenceKey,
+} from "./schema-value-presence";
+
+describe("Schema value presence", () => {
+  it("frames missing and present canonical values without token collisions", () => {
+    expect(schemaValuePresenceKey(missingSchemaValuePresenceToken)).toBe('["missing"]');
+    expect(schemaValuePresenceKey(presentSchemaValuePresenceToken('["missing"]'))).toBe(
+      '["present","[\\"missing\\"]"]',
+    );
+  });
+});

--- a/packages/effect-utils/src/schema-value-presence.ts
+++ b/packages/effect-utils/src/schema-value-presence.ts
@@ -1,0 +1,13 @@
+export type SchemaValuePresenceToken =
+  | readonly ["missing"]
+  | readonly ["present", canonicalKey: string];
+
+export const missingSchemaValuePresenceToken: SchemaValuePresenceToken = Object.freeze(["missing"]);
+
+export const presentSchemaValuePresenceToken = (canonicalKey: string): SchemaValuePresenceToken => [
+  "present",
+  canonicalKey,
+];
+
+export const schemaValuePresenceKey = (token: SchemaValuePresenceToken): string =>
+  JSON.stringify(token);

--- a/packages/effect-utils/src/strict-json-materialization.test.ts
+++ b/packages/effect-utils/src/strict-json-materialization.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Option, Result, type Schema } from "effect";
+import {
+  materializeStrictJson,
+  type StrictJsonMaterializationError,
+  type StrictJsonMaterializationReason,
+} from "./index";
+
+const successValue = (
+  result: Result.Result<Schema.Json, StrictJsonMaterializationError>,
+): Schema.Json => Option.getOrThrow(Result.getSuccess(result));
+
+const expectFailure = (
+  value: unknown,
+  expected: {
+    readonly path: string;
+    readonly reason: StrictJsonMaterializationReason;
+    readonly message: string;
+  },
+): void => {
+  const error = Option.getOrThrow(Result.getFailure(materializeStrictJson(value)));
+
+  expect({
+    _tag: error._tag,
+    path: error.path,
+    reason: error.reason,
+    message: error.message,
+  }).toStrictEqual({
+    _tag: "StrictJsonMaterializationError",
+    ...expected,
+  });
+};
+
+describe("materializeStrictJson", () => {
+  it("materializes JSON primitives and normalizes negative zero", () => {
+    expect(successValue(materializeStrictJson(null))).toBe(null);
+    expect(successValue(materializeStrictJson("value"))).toBe("value");
+    expect(successValue(materializeStrictJson(true))).toBe(true);
+    expect(successValue(materializeStrictJson(42))).toBe(42);
+
+    const zero = successValue(materializeStrictJson(-0));
+    expect(zero).toBe(0);
+    expect(Object.is(zero, -0)).toBe(false);
+  });
+
+  it("recursively materializes fresh dense arrays and plain records", () => {
+    const nested = { enabled: true };
+    const input = { rows: [nested, { enabled: false }] };
+    const output = successValue(materializeStrictJson(input));
+
+    expect(output).toStrictEqual({ rows: [{ enabled: true }, { enabled: false }] });
+    expect(output).not.toBe(input);
+
+    const outputRows = Object.getOwnPropertyDescriptor(output, "rows")?.value;
+    expect(outputRows).not.toBe(input.rows);
+    expect(Object.getOwnPropertyDescriptor(outputRows, "0")?.value).not.toBe(nested);
+  });
+
+  it("accepts null-prototype records and returns fresh plain data", () => {
+    const input = Object.setPrototypeOf({ value: { nested: true } }, null);
+    const output = successValue(materializeStrictJson(input));
+
+    expect(output).toStrictEqual({ value: { nested: true } });
+    expect(output).not.toBe(input);
+    expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+  });
+
+  it("preserves an own __proto__ data key without changing the output prototype", () => {
+    const input = { safe: true };
+    Object.defineProperty(input, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      value: { polluted: false },
+      writable: true,
+    });
+
+    const output = successValue(materializeStrictJson(input));
+
+    expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+    expect(Object.hasOwn(Object(output), "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(output, "__proto__")?.value).toStrictEqual({
+      polluted: false,
+    });
+  });
+
+  it("allows shared acyclic aliases while materializing each branch independently", () => {
+    const shared = { value: 1 };
+    const output = successValue(materializeStrictJson({ left: shared, right: shared }));
+    const left = Object.getOwnPropertyDescriptor(output, "left")?.value;
+    const right = Object.getOwnPropertyDescriptor(output, "right")?.value;
+
+    expect(left).toStrictEqual({ value: 1 });
+    expect(right).toStrictEqual({ value: 1 });
+    expect(left).not.toBe(shared);
+    expect(right).not.toBe(shared);
+    expect(left).not.toBe(right);
+  });
+
+  it.each([
+    [undefined, "undefined"],
+    [1n, "bigint"],
+    [Symbol("value"), "symbol"],
+    [() => "value", "function"],
+  ])("rejects unsupported %s values", (value, valueType) => {
+    expectFailure(value, {
+      path: "$",
+      reason: "unsupported-type",
+      message: `Unsupported JSON value type "${valueType}" at $.`,
+    });
+  });
+
+  it("reports the exact nested path for unsupported values", () => {
+    expectFailure(
+      { payload: { "unsafe key": undefined } },
+      {
+        path: '$.payload["unsafe key"]',
+        reason: "unsupported-type",
+        message: 'Unsupported JSON value type "undefined" at $.payload["unsafe key"].',
+      },
+    );
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects non-finite numbers",
+    (value) => {
+      expectFailure(
+        { value },
+        {
+          path: "$.value",
+          reason: "non-finite-number",
+          message: "Expected a finite JSON number at $.value.",
+        },
+      );
+    },
+  );
+
+  it.each([new Map([["value", 1]]), new Set([1]), new Date(0)])(
+    "rejects built-in objects with semantic prototypes",
+    (value) => {
+      expectFailure(value, {
+        path: "$",
+        reason: "unsupported-prototype",
+        message: "Expected a plain data record or dense array at $.",
+      });
+    },
+  );
+
+  it("rejects custom class instances", () => {
+    class Box {
+      readonly value = 1;
+    }
+
+    expectFailure(
+      { payload: new Box() },
+      {
+        path: "$.payload",
+        reason: "unsupported-prototype",
+        message: "Expected a plain data record or dense array at $.payload.",
+      },
+    );
+  });
+
+  it("rejects arrays with a replaced prototype", () => {
+    const value = Object.setPrototypeOf([1, 2], null);
+
+    expectFailure(value, {
+      path: "$",
+      reason: "unsupported-prototype",
+      message: "Expected a plain data record or dense array at $.",
+    });
+  });
+
+  it("rejects active record cycles but not completed aliases", () => {
+    type RecursiveRecord = { self?: RecursiveRecord };
+    const value: RecursiveRecord = {};
+    value.self = value;
+
+    expectFailure(value, {
+      path: "$.self",
+      reason: "cyclic-reference",
+      message: "Cyclic reference detected at $.self.",
+    });
+  });
+
+  it("rejects active array cycles", () => {
+    const value: Array<unknown> = [];
+    value.push(value);
+
+    expectFailure(value, {
+      path: "$[0]",
+      reason: "cyclic-reference",
+      message: "Cyclic reference detected at $[0].",
+    });
+  });
+
+  it("rejects sparse arrays", () => {
+    const value: Array<unknown> = [];
+    value.length = 3;
+    value[1] = "present";
+
+    expectFailure(
+      { payload: value },
+      {
+        path: "$.payload[0]",
+        reason: "sparse-array",
+        message: "Sparse arrays are not valid JSON data at $.payload[0].",
+      },
+    );
+  });
+
+  it.each(["extra", "-1", "4294967295", "01"])("rejects the extra array property %s", (key) => {
+    const value = [1, 2];
+    Object.defineProperty(value, key, {
+      configurable: true,
+      enumerable: true,
+      value: 2,
+    });
+
+    const path = key === "extra" ? "$.extra" : `$["${key}"]`;
+    expectFailure(value, {
+      path,
+      reason: "extra-array-property",
+      message: `Unexpected array property at ${path}.`,
+    });
+  });
+
+  it("reports the first trailing sparse-array index", () => {
+    const value = ["first", "second"];
+    value.length = 3;
+
+    expectFailure(value, {
+      path: "$[2]",
+      reason: "sparse-array",
+      message: "Sparse arrays are not valid JSON data at $[2].",
+    });
+  });
+
+  it("sanitizes array length reflection failures", () => {
+    const value = new Proxy([1], {
+      get: (target, key, receiver) => {
+        if (key === "length") {
+          throw new Error("native length detail");
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+
+    expectFailure(value, {
+      path: "$.length",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $.length.",
+    });
+  });
+
+  it("rejects invalid reflected array lengths", () => {
+    const value = new Proxy([], {
+      get: (target, key, receiver) =>
+        key === "length" ? "invalid" : Reflect.get(target, key, receiver),
+    });
+
+    expectFailure(value, {
+      path: "$.length",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $.length.",
+    });
+  });
+
+  it("sanitizes array element descriptor reflection failures", () => {
+    const value = new Proxy([1], {
+      getOwnPropertyDescriptor: (target, key) => {
+        if (key === "0") {
+          throw new Error("native element descriptor detail");
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+
+    expectFailure(value, {
+      path: "$[0]",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $[0].",
+    });
+  });
+
+  it("rejects array properties even when they are non-enumerable", () => {
+    const value = [1];
+    Object.defineProperty(value, "extra", {
+      configurable: true,
+      enumerable: false,
+      value: 2,
+    });
+
+    expectFailure(value, {
+      path: "$.extra",
+      reason: "extra-array-property",
+      message: "Unexpected array property at $.extra.",
+    });
+  });
+
+  it("rejects symbol-keyed record properties", () => {
+    const key = Symbol("secret");
+    const value = { safe: true };
+    Object.defineProperty(value, key, {
+      configurable: true,
+      enumerable: true,
+      value: "hidden",
+    });
+
+    expectFailure(value, {
+      path: "$[Symbol(secret)]",
+      reason: "symbol-key",
+      message: "Symbol-keyed properties are not valid JSON data at $[Symbol(secret)].",
+    });
+  });
+
+  it("rejects symbol-keyed array properties", () => {
+    const key = Symbol();
+    const value = [1];
+    Object.defineProperty(value, key, {
+      configurable: true,
+      enumerable: true,
+      value: "hidden",
+    });
+
+    expectFailure(value, {
+      path: "$[Symbol()]",
+      reason: "symbol-key",
+      message: "Symbol-keyed properties are not valid JSON data at $[Symbol()].",
+    });
+  });
+
+  it("rejects non-enumerable record properties", () => {
+    const value = { visible: true };
+    Object.defineProperty(value, "hidden", {
+      configurable: true,
+      enumerable: false,
+      value: 1,
+    });
+
+    expectFailure(value, {
+      path: "$.hidden",
+      reason: "non-enumerable-property",
+      message: "Expected an enumerable data property at $.hidden.",
+    });
+  });
+
+  it("rejects non-enumerable array elements", () => {
+    const value = [1];
+    Object.defineProperty(value, "0", {
+      configurable: true,
+      enumerable: false,
+      value: 1,
+      writable: true,
+    });
+
+    expectFailure(value, {
+      path: "$[0]",
+      reason: "non-enumerable-property",
+      message: "Expected an enumerable data property at $[0].",
+    });
+  });
+
+  it("rejects accessors without invoking them", () => {
+    const value = { safe: true };
+    Object.defineProperty(value, "danger", {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        throw new Error("getter must not run");
+      },
+    });
+
+    expectFailure(value, {
+      path: "$.danger",
+      reason: "accessor-property",
+      message: "Accessor properties are not valid JSON data at $.danger.",
+    });
+  });
+
+  it("rejects array accessors without invoking them", () => {
+    const value = [1];
+    Object.defineProperty(value, "0", {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        throw new Error("getter must not run");
+      },
+    });
+
+    expectFailure(value, {
+      path: "$[0]",
+      reason: "accessor-property",
+      message: "Accessor properties are not valid JSON data at $[0].",
+    });
+  });
+
+  it("sanitizes revoked proxy failures", () => {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+
+    expectFailure(
+      { payload: revoked.proxy },
+      {
+        path: "$.payload",
+        reason: "reflection-failure",
+        message: "Could not inspect JSON value at $.payload.",
+      },
+    );
+  });
+
+  it("sanitizes getPrototypeOf reflection failures", () => {
+    const value = new Proxy(
+      {},
+      {
+        getPrototypeOf: () => {
+          throw new Error("native prototype detail");
+        },
+      },
+    );
+
+    expectFailure(value, {
+      path: "$",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $.",
+    });
+  });
+
+  it("sanitizes ownKeys reflection failures", () => {
+    const value = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error("native ownKeys detail");
+        },
+      },
+    );
+
+    expectFailure(value, {
+      path: "$",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $.",
+    });
+  });
+
+  it("sanitizes property descriptor reflection failures", () => {
+    const value = new Proxy(
+      { field: 1 },
+      {
+        getOwnPropertyDescriptor: () => {
+          throw new Error("native descriptor detail");
+        },
+      },
+    );
+
+    expectFailure(value, {
+      path: "$.field",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $.field.",
+    });
+  });
+
+  it("rejects unstable reflection when an own key has no descriptor", () => {
+    const value = new Proxy(
+      {},
+      {
+        ownKeys: () => ["ghost"],
+      },
+    );
+
+    expectFailure(value, {
+      path: "$.ghost",
+      reason: "reflection-failure",
+      message: "Could not inspect JSON value at $.ghost.",
+    });
+  });
+});

--- a/packages/effect-utils/src/strict-json-materialization.ts
+++ b/packages/effect-utils/src/strict-json-materialization.ts
@@ -1,0 +1,325 @@
+import { Result, Schema } from "effect";
+
+const StrictJsonMaterializationReasonSchema = Schema.Literals([
+  "unsupported-type",
+  "non-finite-number",
+  "unsupported-prototype",
+  "cyclic-reference",
+  "sparse-array",
+  "extra-array-property",
+  "symbol-key",
+  "non-enumerable-property",
+  "accessor-property",
+  "reflection-failure",
+]);
+
+export type StrictJsonMaterializationReason = typeof StrictJsonMaterializationReasonSchema.Type;
+
+export class StrictJsonMaterializationError extends Schema.TaggedErrorClass<StrictJsonMaterializationError>()(
+  "StrictJsonMaterializationError",
+  {
+    path: Schema.String,
+    reason: StrictJsonMaterializationReasonSchema,
+    message: Schema.String,
+  },
+) {}
+
+type StrictJsonResult = Result.Result<Schema.Json, StrictJsonMaterializationError>;
+
+const simplePathKey = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+const appendPropertyPath = (path: string, key: string): string =>
+  simplePathKey.test(key) ? `${path}.${key}` : `${path}[${JSON.stringify(key)}]`;
+
+const appendSymbolPath = (path: string, key: symbol): string => `${path}[${String(key)}]`;
+
+const unsupportedType = (path: string, valueType: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "unsupported-type",
+      message: `Unsupported JSON value type "${valueType}" at ${path}.`,
+    }),
+  );
+
+const nonFiniteNumber = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "non-finite-number",
+      message: `Expected a finite JSON number at ${path}.`,
+    }),
+  );
+
+const unsupportedPrototype = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "unsupported-prototype",
+      message: `Expected a plain data record or dense array at ${path}.`,
+    }),
+  );
+
+const cyclicReference = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "cyclic-reference",
+      message: `Cyclic reference detected at ${path}.`,
+    }),
+  );
+
+const sparseArray = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "sparse-array",
+      message: `Sparse arrays are not valid JSON data at ${path}.`,
+    }),
+  );
+
+const extraArrayProperty = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "extra-array-property",
+      message: `Unexpected array property at ${path}.`,
+    }),
+  );
+
+const symbolKey = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "symbol-key",
+      message: `Symbol-keyed properties are not valid JSON data at ${path}.`,
+    }),
+  );
+
+const nonEnumerableProperty = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "non-enumerable-property",
+      message: `Expected an enumerable data property at ${path}.`,
+    }),
+  );
+
+const accessorProperty = (path: string): StrictJsonResult =>
+  Result.fail(
+    StrictJsonMaterializationError.make({
+      path,
+      reason: "accessor-property",
+      message: `Accessor properties are not valid JSON data at ${path}.`,
+    }),
+  );
+
+const reflectionFailureError = (path: string): StrictJsonMaterializationError =>
+  StrictJsonMaterializationError.make({
+    path,
+    reason: "reflection-failure",
+    message: `Could not inspect JSON value at ${path}.`,
+  });
+
+const reflectionFailure = (path: string): StrictJsonResult =>
+  Result.fail(reflectionFailureError(path));
+
+const inspect = <A>(path: string, operation: () => A) =>
+  Result.try({
+    try: operation,
+    catch: () => reflectionFailureError(path),
+  });
+
+const isArrayIndex = (key: string, length: number): boolean => {
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < length && String(index) === key;
+};
+
+const materializeDataProperty = (
+  descriptor: PropertyDescriptor | undefined,
+  path: string,
+  active: WeakSet<object>,
+): StrictJsonResult => {
+  if (descriptor === undefined) {
+    return reflectionFailure(path);
+  }
+  if (descriptor.enumerable !== true) {
+    return nonEnumerableProperty(path);
+  }
+  if (!("value" in descriptor)) {
+    return accessorProperty(path);
+  }
+
+  const value: unknown = descriptor.value;
+  return materialize(value, path, active);
+};
+
+const materializeArray = (
+  value: object,
+  path: string,
+  keys: ReadonlyArray<string | symbol>,
+  active: WeakSet<object>,
+): StrictJsonResult => {
+  const lengthPath = appendPropertyPath(path, "length");
+  const lengthResult = inspect(lengthPath, () => Reflect.get(value, "length"));
+  if (Result.isFailure(lengthResult)) {
+    return Result.fail(lengthResult.failure);
+  }
+
+  const lengthValue: unknown = lengthResult.success;
+  if (typeof lengthValue !== "number") {
+    return reflectionFailure(lengthPath);
+  }
+
+  const indices: Array<number> = [];
+  for (const key of keys) {
+    if (typeof key === "symbol") {
+      return symbolKey(appendSymbolPath(path, key));
+    }
+    if (key === "length") {
+      continue;
+    }
+    if (!isArrayIndex(key, lengthValue)) {
+      return extraArrayProperty(appendPropertyPath(path, key));
+    }
+    indices.push(Number(key));
+  }
+
+  indices.sort((left, right) => left - right);
+  let expectedIndex = 0;
+  for (const index of indices) {
+    if (index !== expectedIndex) {
+      return sparseArray(`${path}[${expectedIndex}]`);
+    }
+    expectedIndex += 1;
+  }
+  if (expectedIndex !== lengthValue) {
+    return sparseArray(`${path}[${expectedIndex}]`);
+  }
+
+  const output: Array<Schema.Json> = [];
+  for (let index = 0; index < lengthValue; index += 1) {
+    const itemPath = `${path}[${index}]`;
+    const descriptorResult = inspect(itemPath, () =>
+      Object.getOwnPropertyDescriptor(value, String(index)),
+    );
+    if (Result.isFailure(descriptorResult)) {
+      return Result.fail(descriptorResult.failure);
+    }
+
+    const itemResult = materializeDataProperty(descriptorResult.success, itemPath, active);
+    if (Result.isFailure(itemResult)) {
+      return itemResult;
+    }
+    output.push(itemResult.success);
+  }
+
+  return Result.succeed(output);
+};
+
+const materializeRecord = (
+  value: object,
+  path: string,
+  keys: ReadonlyArray<string | symbol>,
+  active: WeakSet<object>,
+): StrictJsonResult => {
+  const output: Record<string, Schema.Json> = {};
+
+  for (const key of keys) {
+    if (typeof key === "symbol") {
+      return symbolKey(appendSymbolPath(path, key));
+    }
+
+    const propertyPath = appendPropertyPath(path, key);
+    const descriptorResult = inspect(propertyPath, () =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (Result.isFailure(descriptorResult)) {
+      return Result.fail(descriptorResult.failure);
+    }
+
+    const propertyResult = materializeDataProperty(descriptorResult.success, propertyPath, active);
+    if (Result.isFailure(propertyResult)) {
+      return propertyResult;
+    }
+
+    Object.defineProperty(output, key, {
+      configurable: true,
+      enumerable: true,
+      value: propertyResult.success,
+      writable: true,
+    });
+  }
+
+  return Result.succeed(output);
+};
+
+const materializeObject = (
+  value: object,
+  path: string,
+  active: WeakSet<object>,
+): StrictJsonResult => {
+  if (active.has(value)) {
+    return cyclicReference(path);
+  }
+  active.add(value);
+
+  const finish = (result: StrictJsonResult): StrictJsonResult => {
+    active.delete(value);
+    return result;
+  };
+
+  const isArrayResult = inspect(path, () => Array.isArray(value));
+  if (Result.isFailure(isArrayResult)) {
+    return finish(Result.fail(isArrayResult.failure));
+  }
+
+  const prototypeResult = inspect(path, () => Object.getPrototypeOf(value));
+  if (Result.isFailure(prototypeResult)) {
+    return finish(Result.fail(prototypeResult.failure));
+  }
+
+  const isArray = isArrayResult.success;
+  const prototype = prototypeResult.success;
+  if (
+    (isArray && prototype !== Array.prototype) ||
+    (!isArray && prototype !== Object.prototype && prototype !== null)
+  ) {
+    return finish(unsupportedPrototype(path));
+  }
+
+  const keysResult = inspect(path, () => Reflect.ownKeys(value));
+  if (Result.isFailure(keysResult)) {
+    return finish(Result.fail(keysResult.failure));
+  }
+
+  return finish(
+    isArray
+      ? materializeArray(value, path, keysResult.success, active)
+      : materializeRecord(value, path, keysResult.success, active),
+  );
+};
+
+const materialize = (value: unknown, path: string, active: WeakSet<object>): StrictJsonResult => {
+  if (value === null) {
+    return Result.succeed(null);
+  }
+
+  if (typeof value === "string" || typeof value === "boolean") {
+    return Result.succeed(value);
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value)
+      ? Result.succeed(Object.is(value, -0) ? 0 : value)
+      : nonFiniteNumber(path);
+  }
+  if (typeof value === "object") {
+    return materializeObject(value, path, active);
+  }
+  return unsupportedType(path, typeof value);
+};
+
+export const materializeStrictJson = (
+  value: unknown,
+): Result.Result<Schema.Json, StrictJsonMaterializationError> =>
+  materialize(value, "$", new WeakSet());

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -10,10 +10,27 @@ import { createViewServerReact } from "effect-view-server/react";
 import { runViewServerRuntime } from "effect-view-server/runtime";
 ```
 
+Topic schemas that use Effect `Option`, `Chunk`, `HashMap`, or `HashSet` values
+use the corresponding `viewSchema` factory from `effect-view-server/config`.
+`viewSchema.BigDecimal` is the admitted `Schema.BigDecimal` declaration, so
+either spelling is valid. Admit each concrete schema class explicitly after
+definition:
+
+```ts
+import { viewSchema } from "effect-view-server/config";
+import { Schema } from "effect";
+
+class Profile extends Schema.Class<Profile>("Profile")({ id: Schema.String }) {}
+viewSchema.admitClass(Profile);
+```
+
+Class methods remain domain behavior and are not exposed as Topic Row columns.
+
 React applications should install the package and compatible peer dependencies:
 
 ```sh
 npm install effect-view-server effect react react-dom @effect/atom-react
 ```
 
-See the repository README and examples for Kafka, gRPC, TCP publishing, in-memory testing, and React usage.
+See the repository README and Public API guide for schema admission, Kafka,
+gRPC, TCP publishing, in-memory testing, and React usage.

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -1,14 +1,19 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
-import { defineViewServerConfig, kafka as kafkaFromConfig } from "effect-view-server/config";
+import {
+  defineViewServerConfig,
+  kafka as kafkaFromConfig,
+  viewSchema,
+} from "effect-view-server/config";
 import { decodeKafkaCodec as decodeKafkaCodecFromConfig } from "effect-view-server/config";
 import { decodeKafkaCodec, kafka } from "effect-view-server/config/kafka";
-import type { KafkaCodecType, LiveQueryResult } from "effect-view-server/config";
+import type { KafkaCodecType, LiveQueryResult, RowFromSchema } from "effect-view-server/config";
 import { createViewServerReact } from "effect-view-server/react";
 import { createInMemoryViewServerReact } from "effect-view-server/react/testing";
 import { runViewServerRuntime } from "effect-view-server/runtime";
 import { createViewServerWebSocketServer } from "effect-view-server/server";
 import { createInMemoryViewServer } from "effect-view-server/in-memory";
 import { Schema } from "effect";
+import type * as EffectOption from "effect/Option";
 import type { ViewServerLiveClient } from "effect-view-server/client";
 
 const Order = Schema.Struct({
@@ -32,6 +37,29 @@ const react = createViewServerReact(viewServer);
 const kafkaOrderCodec = kafka.json(() => Schema.toCodecJson(Order));
 const kafkaOrderCodecFromConfig = kafkaFromConfig.json(() => Schema.toCodecJson(Order));
 
+class PublicProfile extends Schema.Class<PublicProfile>("PublicProfile")({
+  id: Schema.String,
+  score: Schema.NumberFromString,
+  backup: viewSchema.Option(Schema.String),
+  nickname: Schema.optionalKey(Schema.String),
+}) {
+  upperId(): string {
+    return this.id.toUpperCase();
+  }
+}
+viewSchema.admitClass(PublicProfile);
+
+const publicProfileViewServer = defineViewServerConfig({
+  topics: {
+    profiles: {
+      schema: PublicProfile,
+      key: "id",
+    },
+  },
+});
+const publicProfileReact = createViewServerReact(publicProfileViewServer);
+const publicProfileInMemory = createInMemoryViewServer(publicProfileViewServer);
+
 describe("public effect-view-server subpath type contracts", () => {
   it("rejects bare root package imports", () => {
     // @ts-expect-error effect-view-server intentionally has no root export.
@@ -47,6 +75,23 @@ describe("public effect-view-server subpath type contracts", () => {
     expectTypeOf(createInMemoryViewServer).not.toBeAny();
     expectTypeOf(decodeKafkaCodec).not.toBeAny();
     expectTypeOf(decodeKafkaCodecFromConfig).not.toBeAny();
+    expectTypeOf(viewSchema).not.toBeAny();
+    expectTypeOf<typeof PublicProfile.Type>().toEqualTypeOf<PublicProfile>();
+    expectTypeOf<typeof PublicProfile.Encoded>().toEqualTypeOf<{
+      readonly id: string;
+      readonly score: string;
+      readonly backup: EffectOption.Option<string>;
+      readonly nickname?: string;
+    }>();
+    expectTypeOf<RowFromSchema<typeof PublicProfile>>().toEqualTypeOf<{
+      readonly id: string;
+      readonly score: number;
+      readonly backup: EffectOption.Option<string>;
+      readonly nickname?: string;
+    }>();
+    expectTypeOf(publicProfileViewServer.topics.profiles.schema).toEqualTypeOf<
+      typeof PublicProfile
+    >();
     expectTypeOf<KafkaCodecType<typeof kafkaOrderCodec>>().toEqualTypeOf<typeof Order.Type>();
     expectTypeOf<KafkaCodecType<typeof kafkaOrderCodecFromConfig>>().toEqualTypeOf<
       typeof Order.Type
@@ -73,6 +118,18 @@ describe("public effect-view-server subpath type contracts", () => {
         readonly price: number;
       }>
     >();
+
+    const profileResult = publicProfileReact.useLiveQuery("profiles", {
+      select: ["id", "score"],
+      where: { score: { gte: 10 } },
+      orderBy: [{ field: "score", direction: "desc" }],
+    });
+    expectTypeOf(profileResult).toEqualTypeOf<
+      LiveQueryResult<{
+        readonly id: string;
+        readonly score: number;
+      }>
+    >();
   });
 
   it("rejects invalid query and config contracts through public subpaths", () => {
@@ -86,6 +143,16 @@ describe("public effect-view-server subpath type contracts", () => {
     };
     // @ts-expect-error projected fields must be topic field names.
     react.useLiveQuery("orders", unknownProjectedFieldQuery);
+
+    const encodedProfileScoreQuery = {
+      select: ["id"],
+      where: { score: { gte: "10" } },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly score: { readonly gte: "10" } };
+    };
+    // @ts-expect-error transformed query operands must use the decoded number type.
+    publicProfileReact.useLiveQuery("profiles", encodedProfileScoreQuery);
 
     const stringRangeFilterQuery = {
       select: ["id"],
@@ -115,10 +182,82 @@ describe("public effect-view-server subpath type contracts", () => {
       },
     });
 
+    // @ts-expect-error Schema.Class methods are not Topic Row key fields.
+    defineViewServerConfig({
+      topics: {
+        invalidProfiles: {
+          schema: PublicProfile,
+          key: "upperId",
+        },
+      },
+    });
+
     // @ts-expect-error public config/kafka rejects raw Row Schemas
     kafka.json(Order);
     // @ts-expect-error public config rejects direct canonical codecs
     kafkaFromConfig.json(Schema.toCodecJson(Order));
+
+    const methodSelectQuery = {
+      select: ["upperId"],
+    } satisfies { readonly select: readonly ["upperId"] };
+    // @ts-expect-error Schema.Class methods are not Topic Row select fields.
+    publicProfileReact.useLiveQuery("profiles", methodSelectQuery);
+
+    const methodWhereQuery = {
+      select: ["id"],
+      where: { upperId: { eq: () => "PROFILE" } },
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: { readonly upperId: { readonly eq: () => string } };
+    };
+    // @ts-expect-error Schema.Class methods are not Topic Row where fields.
+    publicProfileReact.useLiveQuery("profiles", methodWhereQuery);
+
+    const methodOrderQuery = {
+      select: ["id"],
+      orderBy: [{ field: "upperId", direction: "asc" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly orderBy: readonly [{ readonly field: "upperId"; readonly direction: "asc" }];
+    };
+    // @ts-expect-error Schema.Class methods are not Topic Row orderBy fields.
+    publicProfileReact.useLiveQuery("profiles", methodOrderQuery);
+
+    const methodGroupQuery = {
+      groupBy: ["upperId"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+    } satisfies {
+      readonly groupBy: readonly ["upperId"];
+      readonly aggregates: { readonly rowCount: { readonly aggFunc: "count" } };
+    };
+    // @ts-expect-error Schema.Class methods are not Topic Row groupBy fields.
+    publicProfileReact.useLiveQuery("profiles", methodGroupQuery);
+
+    const methodAggregateQuery = {
+      groupBy: ["id"],
+      aggregates: {
+        distinctMethods: { aggFunc: "countDistinct", field: "upperId" },
+      },
+    } satisfies {
+      readonly groupBy: readonly ["id"];
+      readonly aggregates: {
+        readonly distinctMethods: {
+          readonly aggFunc: "countDistinct";
+          readonly field: "upperId";
+        };
+      };
+    };
+    // @ts-expect-error Schema.Class methods are not Topic Row aggregate fields.
+    publicProfileReact.useLiveQuery("profiles", methodAggregateQuery);
+
+    const methodPatch = { upperId: () => "PROFILE" };
+    const invalidMethodPatch = publicProfileInMemory.client.patch(
+      "profiles",
+      "profile-1",
+      // @ts-expect-error Schema.Class methods are not Topic Row patch fields.
+      methodPatch,
+    );
+    expectTypeOf(invalidMethodPatch).not.toBeAny();
   });
 
   it("preserves public in-memory client and React testing provider types", () => {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@effect-view-server/config": "workspace:*",
+    "@effect-view-server/effect-utils": "workspace:*",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/protocol/src/grouped-live-wire.test.ts
+++ b/packages/protocol/src/grouped-live-wire.test.ts
@@ -241,7 +241,41 @@ describe("Grouped live wire codec", () => {
           totalRows: 1,
         }),
       );
-      expect(invalidMinSnapshot.message).toMatch(/Invalid field minPrice/);
+      expect(invalidMinSnapshot).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        topic: "orders",
+        message:
+          "Invalid field minPrice: aggregate min cannot be undefined because price is required.",
+      });
+      const invalidMinEnvelope = yield* Effect.flip(
+        viewServerDecodeLiveEvent(viewServer, "orders", encodedGrouped, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-undefined-envelope",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: "2" },
+              totalPrice: { _viewServerAggregate: "bigdecimal", value: "21" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "10.5" },
+              minPrice: { _viewServerAggregate: "undefined" },
+              maxPrice: { _viewServerAggregate: "json", value: 11 },
+              distinctPrice: { _viewServerAggregate: "bigint", value: "2" },
+            },
+          ],
+          totalRows: 1,
+        }),
+      );
+      expect(invalidMinEnvelope).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        topic: "orders",
+        message:
+          "Invalid field minPrice: aggregate min cannot be undefined because price is required.",
+      });
 
       const optionalMinQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
         groupBy: ["id"],
@@ -272,7 +306,7 @@ describe("Grouped live wire codec", () => {
         rows: [
           {
             id: "a",
-            minUnset: { _viewServerAggregate: "json", value: null },
+            minUnset: { _viewServerAggregate: "undefined" },
           },
         ],
         totalRows: 1,

--- a/packages/protocol/src/invalid-grouped-row-wire.test.ts
+++ b/packages/protocol/src/invalid-grouped-row-wire.test.ts
@@ -444,6 +444,22 @@ describe("Invalid grouped row wire inputs", () => {
         },
       });
 
+      const invalidEncodedMin = yield* Effect.flip(
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedMinQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-min",
+          version: 1,
+          keys: ["a"],
+          rows: [{ id: "a", minPrice: "not-a-number" }],
+          totalRows: 1,
+        }),
+      );
+
+      expect(invalidEncodedMin.message).toBe(
+        'Invalid field minPrice: Expected number, got "not-a-number"',
+      );
+
       const wrongJsonEnvelope = yield* Effect.flip(
         viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
           viewServer,

--- a/packages/protocol/src/invalid-query-wire.test.ts
+++ b/packages/protocol/src/invalid-query-wire.test.ts
@@ -10,7 +10,7 @@ import {
   viewServerEncodeRawQuery,
 } from "./index";
 
-import { viewServer } from "../test-harness/protocol";
+import { BadJsonField, viewServer } from "../test-harness/protocol";
 
 describe("Invalid query wire inputs", () => {
   it.effect("rejects invalid topics, query shapes, and filters", () =>
@@ -485,15 +485,39 @@ describe("Invalid query wire inputs", () => {
 
       expect(invalidRangeOperator.message).toBe("Filter id does not support range operators");
 
+      const hostileFilterSchema = Schema.Struct({ id: Schema.String });
+      const hostileFilterViewServer = defineViewServerConfig({
+        topics: {
+          badjson: {
+            schema: hostileFilterSchema,
+            key: "id",
+          },
+        },
+      });
+      Object.defineProperty(hostileFilterSchema.fields, "id", {
+        configurable: true,
+        enumerable: true,
+        value: BadJsonField,
+        writable: true,
+      });
+      const unsafeHostileFilterViewServer = {
+        ...hostileFilterViewServer,
+        topics: {
+          badjson: {
+            ...hostileFilterViewServer.topics.badjson,
+            schema: hostileFilterSchema,
+          },
+        },
+      };
       const nonJsonFilter = yield* Effect.flip(
-        viewServerEncodeRawQuery(viewServer, "badjson", {
+        viewServerEncodeRawQuery(unsafeHostileFilterViewServer, "badjson", {
           select: ["id"],
           where: { id: { eq: "x" } },
         }),
       );
 
       expect(nonJsonFilter.message).toBe(
-        "Filter id is not JSON-safe: Expected JSON value, got Symbol(not-json)",
+        'Filter id is not JSON-safe: Unsupported JSON value type "symbol" at $.',
       );
 
       const badDecodedField = yield* Effect.flip(

--- a/packages/protocol/src/invalid-raw-row-wire.test.ts
+++ b/packages/protocol/src/invalid-raw-row-wire.test.ts
@@ -152,8 +152,32 @@ describe("Invalid raw row wire inputs", () => {
         'Invalid field price: Expected "Infinity" | "-Infinity" | "NaN", got "nope"',
       );
 
+      const hostileRowSchema = Schema.Struct({ id: Schema.String });
+      const hostileRowViewServer = defineViewServerConfig({
+        topics: {
+          badjson: {
+            schema: hostileRowSchema,
+            key: "id",
+          },
+        },
+      });
+      Object.defineProperty(hostileRowSchema.fields, "id", {
+        configurable: true,
+        enumerable: true,
+        value: BadJsonField,
+        writable: true,
+      });
+      const unsafeHostileRowViewServer = {
+        ...hostileRowViewServer,
+        topics: {
+          badjson: {
+            ...hostileRowViewServer.topics.badjson,
+            schema: hostileRowSchema,
+          },
+        },
+      };
       const nonJsonRow = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "badjson", idQuery, {
+        viewServerEncodeLiveEvent(unsafeHostileRowViewServer, "badjson", idQuery, {
           type: "snapshot",
           topic: "badjson",
           queryId: "query-0",
@@ -165,12 +189,12 @@ describe("Invalid raw row wire inputs", () => {
       );
 
       expect(nonJsonRow.message).toBe(
-        "Field id is not JSON-safe: Expected JSON value, got Symbol(not-json)",
+        'Field id is not JSON-safe: Unsupported JSON value type "symbol" at $.',
       );
 
       const BadJsonAggregateRow = Schema.Struct({
         id: Schema.String,
-        value: BadJsonField,
+        value: Schema.Number,
       });
 
       const badJsonAggregateViewServer = defineViewServerConfig({
@@ -192,10 +216,25 @@ describe("Invalid raw row wire inputs", () => {
           },
         },
       );
+      Object.defineProperty(BadJsonAggregateRow.fields, "value", {
+        configurable: true,
+        enumerable: true,
+        value: BadJsonField,
+        writable: true,
+      });
+      const unsafeBadJsonAggregateViewServer = {
+        ...badJsonAggregateViewServer,
+        topics: {
+          badAggregate: {
+            ...badJsonAggregateViewServer.topics.badAggregate,
+            schema: BadJsonAggregateRow,
+          },
+        },
+      };
 
       const nonJsonAggregate = yield* Effect.flip(
         viewServerEncodeLiveEvent(
-          badJsonAggregateViewServer,
+          unsafeBadJsonAggregateViewServer,
           "badAggregate",
           badJsonAggregateQuery,
           {
@@ -213,7 +252,7 @@ describe("Invalid raw row wire inputs", () => {
       expect(nonJsonAggregate.code).toBe("InvalidRow");
 
       expect(nonJsonAggregate.message).toBe(
-        "Field badValue is not JSON-safe: Expected JSON value, got Symbol(not-json)",
+        'Field badValue is not JSON-safe: Unsupported JSON value type "symbol" at $.',
       );
     }),
   );

--- a/packages/protocol/src/opaque-row-wire.test.ts
+++ b/packages/protocol/src/opaque-row-wire.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import {
+  viewServerDecodeLiveEvent,
+  viewServerEncodeGroupedQuery,
+  viewServerEncodeLiveEvent,
+} from "./index";
+
+const OpaqueRow = Schema.Struct({
+  id: Schema.String,
+  payload: Schema.ObjectKeyword,
+});
+
+const opaqueViewServer = defineViewServerConfig({
+  topics: {
+    opaque: {
+      schema: OpaqueRow,
+      key: "id",
+    },
+  },
+});
+
+const rawQuery = { select: ["id", "payload"] };
+
+const expectedOpaqueValueError = {
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidRow",
+  message: "Field payload is not JSON-safe: Expected a plain data record or dense array at $.",
+  topic: "opaque",
+} as const;
+
+describe("Opaque row wire values", () => {
+  it.effect("rejects opaque Map values in raw Snapshots and insert/update Deltas", () =>
+    Effect.gen(function* () {
+      const payload = new Map([["venue", "xnys"]]);
+      const snapshotError = yield* Effect.flip(
+        viewServerEncodeLiveEvent(opaqueViewServer, "opaque", rawQuery, {
+          type: "snapshot",
+          topic: "opaque",
+          queryId: "opaque-snapshot",
+          version: 1,
+          keys: ["1"],
+          rows: [{ id: "1", payload }],
+          totalRows: 1,
+        }),
+      );
+      expect(snapshotError).toStrictEqual(expectedOpaqueValueError);
+
+      const insertError = yield* Effect.flip(
+        viewServerEncodeLiveEvent(opaqueViewServer, "opaque", rawQuery, {
+          type: "delta",
+          topic: "opaque",
+          queryId: "opaque-insert",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "insert", key: "1", row: { id: "1", payload }, index: 0 }],
+          totalRows: 1,
+        }),
+      );
+      expect(insertError).toStrictEqual(expectedOpaqueValueError);
+
+      const updateError = yield* Effect.flip(
+        viewServerEncodeLiveEvent(opaqueViewServer, "opaque", rawQuery, {
+          type: "delta",
+          topic: "opaque",
+          queryId: "opaque-update",
+          fromVersion: 2,
+          toVersion: 3,
+          operations: [{ type: "update", key: "1", row: { id: "1", payload }, index: 0 }],
+          totalRows: 1,
+        }),
+      );
+      expect(updateError).toStrictEqual(expectedOpaqueValueError);
+    }),
+  );
+
+  it.effect("rejects hostile opaque Map values supplied directly to decode", () =>
+    Effect.gen(function* () {
+      const hostileEvent = {
+        type: "snapshot",
+        topic: "opaque",
+        queryId: "hostile-direct-decode",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", payload: new Map([["venue", "xnys"]]) }],
+        totalRows: 1,
+      };
+      const error = yield* Effect.flip(
+        viewServerDecodeLiveEvent<typeof opaqueViewServer.topics, "opaque", typeof OpaqueRow.Type>(
+          opaqueViewServer,
+          "opaque",
+          rawQuery,
+          // @ts-expect-error hostile callers can bypass the public JSON wire type.
+          hostileEvent,
+        ),
+      );
+
+      expect(error).toStrictEqual({
+        ...expectedOpaqueValueError,
+        message:
+          "Invalid row for topic opaque: Expected a plain data record or dense array at $.payload.",
+      });
+    }),
+  );
+
+  it.effect("rejects opaque Map aggregate values in grouped Snapshots and update Deltas", () =>
+    Effect.gen(function* () {
+      const groupedQuery = yield* viewServerEncodeGroupedQuery(opaqueViewServer, "opaque", {
+        groupBy: ["id"],
+        aggregates: {
+          firstPayload: { aggFunc: "min", field: "payload" },
+        },
+      });
+      const row = {
+        id: "1",
+        firstPayload: new Map([["venue", "xnys"]]),
+      };
+      const groupedError = {
+        ...expectedOpaqueValueError,
+        message:
+          "Field firstPayload is not JSON-safe: Expected a plain data record or dense array at $.",
+      };
+
+      const snapshotError = yield* Effect.flip(
+        viewServerEncodeLiveEvent(opaqueViewServer, "opaque", groupedQuery, {
+          type: "snapshot",
+          topic: "opaque",
+          queryId: "opaque-grouped-snapshot",
+          version: 1,
+          keys: ["1"],
+          rows: [row],
+          totalRows: 1,
+        }),
+      );
+      expect(snapshotError).toStrictEqual(groupedError);
+
+      const updateError = yield* Effect.flip(
+        viewServerEncodeLiveEvent(opaqueViewServer, "opaque", groupedQuery, {
+          type: "delta",
+          topic: "opaque",
+          queryId: "opaque-grouped-update",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [{ type: "update", key: "1", row, index: 0 }],
+          totalRows: 1,
+        }),
+      );
+      expect(updateError).toStrictEqual(groupedError);
+
+      const hostileGroupedEvent = {
+        type: "snapshot",
+        topic: "opaque",
+        queryId: "opaque-grouped-direct-decode",
+        version: 1,
+        keys: ["1"],
+        rows: [
+          {
+            id: "1",
+            firstPayload: {
+              _viewServerAggregate: "json",
+              value: new Map([["venue", "xnys"]]),
+            },
+          },
+        ],
+        totalRows: 1,
+      };
+      const directDecodeError = yield* Effect.flip(
+        viewServerDecodeLiveEvent<
+          typeof opaqueViewServer.topics,
+          "opaque",
+          { readonly id: string; readonly firstPayload: object }
+        >(
+          opaqueViewServer,
+          "opaque",
+          groupedQuery,
+          // @ts-expect-error hostile callers can bypass the public JSON wire type.
+          hostileGroupedEvent,
+        ),
+      );
+      expect(directDecodeError).toStrictEqual({
+        ...expectedOpaqueValueError,
+        message:
+          "Invalid grouped row for topic opaque: Expected a plain data record or dense array at $.firstPayload.value.",
+      });
+    }),
+  );
+
+  it.effect("round-trips plain JSON objects accepted by an opaque field schema", () =>
+    Effect.gen(function* () {
+      const encoded = yield* viewServerEncodeLiveEvent(opaqueViewServer, "opaque", rawQuery, {
+        type: "snapshot",
+        topic: "opaque",
+        queryId: "plain-object",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", payload: { venue: "xnys", nested: [1, true, null] } }],
+        totalRows: 1,
+      });
+      expect(encoded).toStrictEqual({
+        type: "snapshot",
+        topic: "opaque",
+        queryId: "plain-object",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", payload: { venue: "xnys", nested: [1, true, null] } }],
+        totalRows: 1,
+      });
+
+      const decoded = yield* viewServerDecodeLiveEvent<
+        typeof opaqueViewServer.topics,
+        "opaque",
+        typeof OpaqueRow.Type
+      >(opaqueViewServer, "opaque", rawQuery, encoded);
+      expect(decoded).toStrictEqual(encoded);
+    }),
+  );
+});

--- a/packages/protocol/src/protocol-aggregate-row-codec.ts
+++ b/packages/protocol/src/protocol-aggregate-row-codec.ts
@@ -1,9 +1,9 @@
 import type { TopicDefinitions, ViewServerRuntimeError } from "@effect-view-server/config";
 import { viewServerSchemaFieldMetadata } from "@effect-view-server/config";
-import { Effect, Schema } from "effect";
+import { Effect, Schema, SchemaAST } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import {
-  decodeContextualJsonFieldValue,
+  decodeMaterializedJsonFieldValue,
   encodeContextualJsonFieldValue,
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
@@ -24,26 +24,42 @@ const isBigIntFieldSchema = (schema: JsonFieldSchema): boolean =>
 
 const bigintPattern = /^-?\d+$/;
 
-type AggregateEnvelope =
-  | {
-      readonly _viewServerAggregate: "bigint";
-      readonly value: string;
-    }
-  | {
-      readonly _viewServerAggregate: "bigdecimal";
-      readonly value: string;
-    }
-  | {
-      readonly _viewServerAggregate: "json";
-      readonly value: Schema.Json;
-    };
+type BigIntAggregateEnvelope = {
+  readonly _viewServerAggregate: "bigint";
+  readonly value: string;
+};
 
-const isAggregateEnvelope = (value: unknown): value is AggregateEnvelope =>
+type BigDecimalAggregateEnvelope = {
+  readonly _viewServerAggregate: "bigdecimal";
+  readonly value: string;
+};
+
+type JsonAggregateEnvelope<Value> = {
+  readonly _viewServerAggregate: "json";
+  readonly value: Value;
+};
+
+type UndefinedAggregateEnvelope = {
+  readonly _viewServerAggregate: "undefined";
+};
+
+type AggregateEnvelope =
+  | BigIntAggregateEnvelope
+  | BigDecimalAggregateEnvelope
+  | JsonAggregateEnvelope<Schema.Json>
+  | UndefinedAggregateEnvelope;
+
+const isUndefinedAggregateEnvelope = (value: Schema.Json): value is UndefinedAggregateEnvelope =>
   isRecord(value) &&
-  ((value["_viewServerAggregate"] === "bigint" && typeof value["value"] === "string") ||
-    (value["_viewServerAggregate"] === "bigdecimal" && typeof value["value"] === "string") ||
-    (value["_viewServerAggregate"] === "json" &&
-      Schema.decodeUnknownOption(Schema.Json)(value["value"])._tag === "Some"));
+  value["_viewServerAggregate"] === "undefined" &&
+  !Object.hasOwn(value, "value");
+
+const isAggregateEnvelope = (value: Schema.Json): value is AggregateEnvelope =>
+  isUndefinedAggregateEnvelope(value) ||
+  (isRecord(value) &&
+    ((value["_viewServerAggregate"] === "bigint" && typeof value["value"] === "string") ||
+      (value["_viewServerAggregate"] === "bigdecimal" && typeof value["value"] === "string") ||
+      (value["_viewServerAggregate"] === "json" && Object.hasOwn(value, "value"))));
 
 const encodeJsonAggregateEnvelope = (value: Schema.Json): AggregateEnvelope => ({
   _viewServerAggregate: "json",
@@ -60,8 +76,12 @@ const encodeBigDecimalAggregateEnvelope = (value: BigDecimal.BigDecimal): Aggreg
   value: BigDecimal.format(value),
 });
 
+const encodeUndefinedAggregateEnvelope = (): AggregateEnvelope => ({
+  _viewServerAggregate: "undefined",
+});
+
 const decodeAggregateEnvelope = Effect.fn("ViewServerProtocol.row.aggregate.envelope.decode")(
-  function* (topic: string, field: string, value: unknown) {
+  function* (topic: string, field: string, value: Schema.Json) {
     if (!isAggregateEnvelope(value)) {
       return yield* Effect.fail(
         invalidRow(topic, `Aggregate ${field} must be a View Server aggregate envelope.`),
@@ -92,7 +112,7 @@ const encodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.b
 );
 
 const decodeBigIntAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.bigint.decode")(
-  function* (topic: string, field: string, value: unknown) {
+  function* (topic: string, field: string, value: Schema.Json) {
     const envelope = yield* decodeAggregateEnvelope(topic, field, value);
     if (envelope._viewServerAggregate !== "bigint" || !bigintPattern.test(envelope.value)) {
       return yield* Effect.fail(invalidRow(topic, `Aggregate ${field} must be a bigint envelope.`));
@@ -112,7 +132,7 @@ const encodeBigDecimalAggregateValue = Effect.fn(
 
 const decodeBigDecimalAggregateValue = Effect.fn(
   "ViewServerProtocol.row.aggregate.bigDecimal.decode",
-)(function* (topic: string, field: string, value: unknown) {
+)(function* (topic: string, field: string, value: Schema.Json) {
   const envelope = yield* decodeAggregateEnvelope(topic, field, value);
   if (envelope._viewServerAggregate !== "bigdecimal") {
     return yield* Effect.fail(
@@ -134,16 +154,15 @@ const encodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.jso
 );
 
 const decodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.json.decode")(
-  function* (topic: string, field: string, schema: JsonFieldSchema, value: unknown) {
+  function* (topic: string, field: string, schema: JsonFieldSchema, value: Schema.Json) {
     const envelope = yield* decodeAggregateEnvelope(topic, field, value);
     if (envelope._viewServerAggregate !== "json") {
       return yield* Effect.fail(
         invalidRow(topic, `Aggregate ${field} must be a JSON aggregate envelope.`),
       );
     }
-    return yield* decodeContextualJsonFieldValue(schema, envelope.value, {
-      invalid: (message) => invalidRow(topic, message),
-      invalidMessage: (message) => `Invalid field ${field}: ${message}`,
+    return yield* decodeMaterializedJsonFieldValue(schema, envelope.value, {
+      invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
     });
   },
 );
@@ -160,6 +179,29 @@ const aggregateFieldSchema = Effect.fn("ViewServerProtocol.row.aggregate.fieldSc
   return fieldSchema;
 });
 
+const undefinedAggregateFieldAcceptance = new WeakMap<JsonFieldSchema, boolean>();
+
+const fieldSchemaAllowsUndefinedAggregate = (schema: JsonFieldSchema): boolean => {
+  const cached = undefinedAggregateFieldAcceptance.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const accepted = SchemaAST.isOptional(schema.ast) || Schema.is(schema)(undefined);
+  undefinedAggregateFieldAcceptance.set(schema, accepted);
+  return accepted;
+};
+
+const invalidUndefinedAggregate = (
+  topic: string,
+  field: string,
+  aggregateFunction: "min" | "max",
+  aggregateField: string,
+): ViewServerRuntimeError =>
+  invalidRow(
+    topic,
+    `Invalid field ${field}: aggregate ${aggregateFunction} cannot be undefined because ${aggregateField} is required.`,
+  );
+
 export const encodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.encode")(function* <
   const Topics extends TopicDefinitions,
 >(
@@ -173,6 +215,14 @@ export const encodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.
     return yield* encodeBigIntAggregateValue(topic, field, value);
   }
   const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
+  if ((aggregate.aggFunc === "min" || aggregate.aggFunc === "max") && value === undefined) {
+    if (!fieldSchemaAllowsUndefinedAggregate(fieldSchema)) {
+      return yield* Effect.fail(
+        invalidUndefinedAggregate(topic, field, aggregate.aggFunc, aggregate.field),
+      );
+    }
+    return encodeUndefinedAggregateEnvelope();
+  }
   if (aggregate.aggFunc === "avg") {
     return yield* encodeBigDecimalAggregateValue(topic, field, value);
   }
@@ -192,12 +242,23 @@ export const decodeAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.
   topic: Extract<keyof Topics, string>,
   field: string,
   aggregate: ViewServerWireAggregate,
-  value: unknown,
+  value: Schema.Json,
 ) {
   if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
     return yield* decodeBigIntAggregateValue(topic, field, value);
   }
   const fieldSchema = yield* aggregateFieldSchema(config, topic, aggregate.field);
+  if (
+    (aggregate.aggFunc === "min" || aggregate.aggFunc === "max") &&
+    isUndefinedAggregateEnvelope(value)
+  ) {
+    if (!fieldSchemaAllowsUndefinedAggregate(fieldSchema)) {
+      return yield* Effect.fail(
+        invalidUndefinedAggregate(topic, field, aggregate.aggFunc, aggregate.field),
+      );
+    }
+    return undefined;
+  }
   if (aggregate.aggFunc === "avg") {
     return yield* decodeBigDecimalAggregateValue(topic, field, value);
   }

--- a/packages/protocol/src/protocol-field-filter-codec.ts
+++ b/packages/protocol/src/protocol-field-filter-codec.ts
@@ -2,6 +2,11 @@ import {
   viewServerSchemaFieldMetadata,
   type ViewServerRuntimeError,
 } from "@effect-view-server/config";
+import {
+  isRawQueryFilterOperatorKey,
+  isRawQueryRangeFilterOperatorKey,
+  rawQueryFilterOperatorKeys,
+} from "@effect-view-server/config/internal";
 import { Effect, Schema } from "effect";
 import {
   decodeTopicNamedJsonFieldValue,
@@ -9,18 +14,7 @@ import {
   type JsonFieldSchema,
 } from "./protocol-json-field-codec";
 
-export const filterOperatorKeys = new Set([
-  "eq",
-  "neq",
-  "in",
-  "gt",
-  "gte",
-  "lt",
-  "lte",
-  "startsWith",
-]);
-
-const rangeFilterOperatorKeys = new Set(["gt", "gte", "lt", "lte"]);
+export const filterOperatorKeys = rawQueryFilterOperatorKeys;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -28,7 +22,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 export const isFilterObject = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) &&
   Object.keys(value).length > 0 &&
-  Object.keys(value).every((key) => filterOperatorKeys.has(key));
+  Object.keys(value).every(isRawQueryFilterOperatorKey);
 
 const invalidQuery = (topic: string, message: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",
@@ -79,7 +73,7 @@ const validateOperatorFilterValue = Effect.fn("ViewServerProtocol.filter.operato
     if (keys.includes("startsWith") && !metadata.isString) {
       return yield* Effect.fail(invalidQuery(topic, `Filter ${field} does not support startsWith`));
     }
-    if (keys.some((key) => rangeFilterOperatorKeys.has(key)) && !metadata.isNumeric) {
+    if (keys.some(isRawQueryRangeFilterOperatorKey) && !metadata.isNumeric) {
       return yield* Effect.fail(
         invalidQuery(topic, `Filter ${field} does not support range operators`),
       );

--- a/packages/protocol/src/protocol-filter-operator-ownership.test.ts
+++ b/packages/protocol/src/protocol-filter-operator-ownership.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "@effect/vitest";
+import { rawQueryFilterOperatorKeys } from "@effect-view-server/config/internal";
+import { filterOperatorKeys, isFilterObject } from "./protocol-field-filter-codec";
+
+describe("protocol filter operator ownership", () => {
+  it("uses the canonical raw query operator grammar by identity", () => {
+    expect(filterOperatorKeys).toBe(rawQueryFilterOperatorKeys);
+    expect(isFilterObject({ eq: "open", lt: 10 })).toBe(true);
+    expect(isFilterObject({ contains: "open" })).toBe(false);
+  });
+});

--- a/packages/protocol/src/protocol-json-field-codec.ts
+++ b/packages/protocol/src/protocol-json-field-codec.ts
@@ -1,4 +1,5 @@
-import { Effect, Schema } from "effect";
+import { materializeStrictJson } from "@effect-view-server/effect-utils";
+import { Effect, Result, Schema } from "effect";
 
 export type JsonFieldSchema = Schema.Codec<unknown, unknown, never, never>;
 
@@ -36,27 +37,72 @@ type TopicNamedJsonFieldEncodeContext<E> = TopicNamedJsonFieldCodecContext<E> & 
   readonly notJsonSafePrefix: string;
 };
 
+type CompiledJsonFieldCodec<Row> = {
+  readonly decode: (value: unknown) => Effect.Effect<Row, Schema.SchemaError>;
+  readonly encode: (value: unknown) => Effect.Effect<Schema.Json, Schema.SchemaError>;
+};
+
+const compiledJsonFieldCodecCache = new WeakMap<JsonFieldSchema, CompiledJsonFieldCodec<unknown>>();
+
+function compiledJsonFieldCodec<Row>(
+  schema: Schema.Codec<Row, unknown, never, never>,
+): CompiledJsonFieldCodec<Row>;
+function compiledJsonFieldCodec(schema: JsonFieldSchema): CompiledJsonFieldCodec<unknown> {
+  const cached = compiledJsonFieldCodecCache.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const codec = Schema.toCodecJson(schema);
+  const compiled: CompiledJsonFieldCodec<unknown> = {
+    decode: Schema.decodeUnknownEffect(codec),
+    encode: Schema.encodeUnknownEffect(codec),
+  };
+  compiledJsonFieldCodecCache.set(schema, compiled);
+  return compiled;
+}
+
+export const materializeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.materialize")(
+  function* <E>(value: unknown, invalid: (message: string) => E) {
+    return yield* Result.match(materializeStrictJson(value), {
+      onSuccess: Effect.succeed,
+      onFailure: (error) => Effect.fail(invalid(error.message)),
+    });
+  },
+);
+
 export const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.encode")(function* <E>(
   schema: JsonFieldSchema,
   value: unknown,
   errors: JsonFieldCodecErrors<E>,
 ) {
-  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) => errors.invalid(error.message)),
-  );
-  return yield* Schema.decodeUnknownEffect(Schema.Json)(encoded).pipe(
-    Effect.mapError((error) => errors.notJsonSafe(error.message)),
-  );
+  const encoded = yield* compiledJsonFieldCodec(schema)
+    .encode(value)
+    .pipe(Effect.mapError((error) => errors.invalid(error.message)));
+  return yield* materializeJsonFieldValue(encoded, errors.notJsonSafe);
 });
 
-export const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.decode")(function* <E>(
-  schema: JsonFieldSchema,
+export const decodeMaterializedJsonFieldValue = Effect.fn(
+  "ViewServerProtocol.jsonField.decodeMaterialized",
+)(function* <Row, E>(
+  schema: Schema.Codec<Row, unknown, never, never>,
+  value: Schema.Json,
+  errors: Pick<JsonFieldCodecErrors<E>, "invalid">,
+) {
+  return yield* compiledJsonFieldCodec(schema)
+    .decode(value)
+    .pipe(Effect.mapError((error) => errors.invalid(error.message)));
+});
+
+export const decodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.decode")(function* <
+  Row,
+  E,
+>(
+  schema: Schema.Codec<Row, unknown, never, never>,
   value: unknown,
   errors: Pick<JsonFieldCodecErrors<E>, "invalid">,
 ) {
-  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(value).pipe(
-    Effect.mapError((error) => errors.invalid(error.message)),
-  );
+  const materialized = yield* materializeJsonFieldValue(value, errors.invalid);
+  return yield* decodeMaterializedJsonFieldValue(schema, materialized, errors);
 });
 
 export const encodeContextualJsonFieldValue = Effect.fn(
@@ -70,7 +116,11 @@ export const encodeContextualJsonFieldValue = Effect.fn(
 
 export const decodeContextualJsonFieldValue = Effect.fn(
   "ViewServerProtocol.jsonField.contextual.decode",
-)(function* <E>(schema: JsonFieldSchema, value: unknown, context: JsonFieldCodecContext<E>) {
+)(function* <Row, E>(
+  schema: Schema.Codec<Row, unknown, never, never>,
+  value: unknown,
+  context: JsonFieldCodecContext<E>,
+) {
   return yield* decodeJsonFieldValue(schema, value, {
     invalid: (message) => context.invalid(context.invalidMessage(message)),
   });
@@ -92,8 +142,8 @@ export const encodeNamedJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField
 );
 
 export const decodeNamedJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.named.decode")(
-  function* <E>(
-    schema: JsonFieldSchema,
+  function* <Row, E>(
+    schema: Schema.Codec<Row, unknown, never, never>,
     value: unknown,
     { field, invalid, invalidPrefix }: NamedJsonFieldCodecContext<E>,
   ) {
@@ -123,10 +173,10 @@ export const encodeTopicNamedJsonFieldValue = Effect.fn(
 
 export const decodeTopicNamedJsonFieldValue = Effect.fn(
   "ViewServerProtocol.jsonField.topicNamed.decode",
-)(function* <E>(
+)(function* <Row, E>(
   topic: string,
   field: string,
-  schema: JsonFieldSchema,
+  schema: Schema.Codec<Row, unknown, never, never>,
   value: unknown,
   context: TopicNamedJsonFieldCodecContext<E>,
 ) {

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -1,10 +1,13 @@
 import type { TopicDefinitions, ViewServerRuntimeError } from "@effect-view-server/config";
-import { Effect, Schema } from "effect";
+import { Effect, Schema, SchemaAST } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
 import {
-  decodeTopicNamedJsonFieldValue,
+  decodeJsonFieldValue,
+  decodeMaterializedJsonFieldValue,
+  encodeJsonFieldValue,
   encodeTopicNamedJsonFieldValue,
+  materializeJsonFieldValue,
 } from "./protocol-json-field-codec";
 import type { ViewServerEventGroupedQuery, ViewServerEventQuery } from "./protocol-query-schema";
 
@@ -21,6 +24,98 @@ const rowJsonFieldContext = {
   notJsonSafePrefix: "Field",
 };
 
+const defineEnumerableOwn = <Value>(
+  target: Record<string, Value>,
+  key: string,
+  value: Value,
+): void => {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const rowFieldIsOptional = (schema: Schema.Codec<unknown, unknown, never, never>): boolean =>
+  SchemaAST.isOptional(schema.ast);
+
+type RowKind = "row" | "grouped row";
+
+type InspectedRow = {
+  readonly entries: ReadonlyArray<readonly [field: string, value: unknown]>;
+  readonly fields: ReadonlySet<string>;
+};
+
+const rowKindTitle = (kind: RowKind): "Row" | "Grouped row" =>
+  kind === "row" ? "Row" : "Grouped row";
+
+const inspectRow = Effect.fn("ViewServerProtocol.row.inspect")(function* (
+  topic: string,
+  kind: RowKind,
+  row: object,
+): Effect.fn.Return<InspectedRow, ViewServerRuntimeError> {
+  const keys = yield* Effect.try({
+    try: () => Reflect.ownKeys(row),
+    catch: () => invalidRow(topic, `Could not inspect ${kind} for topic ${topic}`),
+  });
+  const entries: Array<readonly [field: string, value: unknown]> = [];
+  const fields = new Set<string>();
+  for (const key of keys) {
+    if (typeof key === "symbol") {
+      return yield* Effect.fail(
+        invalidRow(topic, `Unexpected ${kind} symbol field for topic ${topic}: ${String(key)}`),
+      );
+    }
+    const descriptor = yield* Effect.try({
+      try: () => Object.getOwnPropertyDescriptor(row, key),
+      catch: () => invalidRow(topic, `Could not inspect ${kind} field for topic ${topic}: ${key}`),
+    });
+    if (descriptor === undefined) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Could not inspect ${kind} field for topic ${topic}: ${key}`),
+      );
+    }
+    if (descriptor.enumerable !== true) {
+      return yield* Effect.fail(
+        invalidRow(
+          topic,
+          `${rowKindTitle(kind)} field for topic ${topic} must be enumerable: ${key}`,
+        ),
+      );
+    }
+    if (!("value" in descriptor)) {
+      return yield* Effect.fail(
+        invalidRow(
+          topic,
+          `${rowKindTitle(kind)} field for topic ${topic} must be a data property: ${key}`,
+        ),
+      );
+    }
+    fields.add(key);
+    entries.push([key, descriptor.value]);
+  }
+  return { entries, fields };
+});
+
+const isViewServerWireRow = Schema.is(ViewServerWireRowSchema);
+
+const materializeWireRow = Effect.fn("ViewServerProtocol.row.materializeWire")(function* (
+  topic: string,
+  kind: RowKind,
+  row: ViewServerWireRow,
+) {
+  const materialized = yield* materializeJsonFieldValue(row, (message) =>
+    invalidRow(topic, `Invalid ${kind} for topic ${topic}: ${message}`),
+  );
+  if (!isViewServerWireRow(materialized)) {
+    return yield* Effect.fail(
+      invalidRow(topic, `Invalid ${kind} for topic ${topic}: Expected a JSON object.`),
+    );
+  }
+  return materialized;
+});
+
 export const isViewServerEventGroupedQuery = (
   query: ViewServerEventQuery,
 ): query is ViewServerEventGroupedQuery => "groupBy" in query;
@@ -35,27 +130,30 @@ export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.enco
 ) {
   const topicSchema = config.topics[topic]!.schema;
   const output: Record<string, Schema.Json> = {};
+  const inspected = yield* inspectRow(topic, "row", row);
   for (const field of selectedFields) {
-    if (!Object.hasOwn(row, field)) {
+    const fieldSchema = topicSchema.fields[field]!;
+    if (!inspected.fields.has(field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing row field for topic ${topic}: ${field}`),
       );
     }
   }
-  for (const [field, value] of Object.entries(row)) {
+  for (const [field, value] of inspected.entries) {
     if (!selectedFields.has(field)) {
       return yield* Effect.fail(
         invalidRow(topic, `Unexpected row field for topic ${topic}: ${field}`),
       );
     }
     const fieldSchema = topicSchema.fields[field]!;
-    output[field] = yield* encodeTopicNamedJsonFieldValue(
+    const encoded = yield* encodeTopicNamedJsonFieldValue(
       topic,
       field,
       fieldSchema,
       value,
       rowJsonFieldContext,
     );
+    defineEnumerableOwn(output, field, encoded);
   }
   return output;
 });
@@ -70,27 +168,26 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
   row: ViewServerWireRow,
 ) {
   const output: Record<string, unknown> = {};
+  const materialized = yield* materializeWireRow(topic, "row", row);
   for (const field of selectedFields) {
-    if (!Object.hasOwn(row, field)) {
+    const fieldSchema = config.topics[topic]!.schema.fields[field]!;
+    if (!Object.hasOwn(materialized, field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing row field for topic ${topic}: ${field}`),
       );
     }
   }
-  for (const [field, value] of Object.entries(row)) {
+  for (const [field, value] of Object.entries(materialized)) {
     if (!selectedFields.has(field)) {
       return yield* Effect.fail(
         invalidRow(topic, `Unexpected row field for topic ${topic}: ${field}`),
       );
     }
     const fieldSchema = config.topics[topic]!.schema.fields[field]!;
-    output[field] = yield* decodeTopicNamedJsonFieldValue(
-      topic,
-      field,
-      fieldSchema,
-      value,
-      rowJsonFieldContext,
-    );
+    const decoded = yield* decodeMaterializedJsonFieldValue(fieldSchema, value, {
+      invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+    });
+    defineEnumerableOwn(output, field, decoded);
   }
   return output;
 });
@@ -107,30 +204,33 @@ export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode
   const groupFields = new Set<string>(query.groupBy);
   const aggregateAliases = new Set<string>(Object.keys(query.aggregates));
   const output: Record<string, Schema.Json> = {};
+  const inspected = yield* inspectRow(topic, "grouped row", row);
   for (const field of groupFields) {
-    if (!Object.hasOwn(row, field)) {
+    const fieldSchema = topicSchema.fields[field]!;
+    if (!inspected.fields.has(field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
       );
     }
   }
   for (const alias of aggregateAliases) {
-    if (!Object.hasOwn(row, alias)) {
+    if (!inspected.fields.has(alias)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
       );
     }
   }
-  for (const [field, value] of Object.entries(row)) {
+  for (const [field, value] of inspected.entries) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
-      output[field] = yield* encodeTopicNamedJsonFieldValue(
+      const encoded = yield* encodeTopicNamedJsonFieldValue(
         topic,
         field,
         fieldSchema,
         value,
         rowJsonFieldContext,
       );
+      defineEnumerableOwn(output, field, encoded);
     } else if (aggregateAliases.has(field)) {
       const aggregate = query.aggregates[field];
       if (aggregate === undefined) {
@@ -138,7 +238,8 @@ export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode
           invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
         );
       }
-      output[field] = yield* encodeAggregateValue(config, topic, field, aggregate, value);
+      const encoded = yield* encodeAggregateValue(config, topic, field, aggregate, value);
+      defineEnumerableOwn(output, field, encoded);
     } else {
       return yield* Effect.fail(
         invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
@@ -161,30 +262,29 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   const groupFields = new Set<string>(query.groupBy);
   const aggregateAliases = new Set<string>(Object.keys(query.aggregates));
   const output: Record<string, unknown> = {};
+  const materialized = yield* materializeWireRow(topic, "grouped row", row);
   for (const field of groupFields) {
-    if (!Object.hasOwn(row, field)) {
+    const fieldSchema = topicSchema.fields[field]!;
+    if (!Object.hasOwn(materialized, field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
       );
     }
   }
   for (const alias of aggregateAliases) {
-    if (!Object.hasOwn(row, alias)) {
+    if (!Object.hasOwn(materialized, alias)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
       );
     }
   }
-  for (const [field, value] of Object.entries(row)) {
+  for (const [field, value] of Object.entries(materialized)) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
-      output[field] = yield* decodeTopicNamedJsonFieldValue(
-        topic,
-        field,
-        fieldSchema,
-        value,
-        rowJsonFieldContext,
-      );
+      const decoded = yield* decodeMaterializedJsonFieldValue(fieldSchema, value, {
+        invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+      });
+      defineEnumerableOwn(output, field, decoded);
     } else if (aggregateAliases.has(field)) {
       const aggregate = query.aggregates[field];
       if (aggregate === undefined) {
@@ -192,7 +292,8 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
           invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
         );
       }
-      output[field] = yield* decodeAggregateValue(config, topic, field, aggregate, value);
+      const decoded = yield* decodeAggregateValue(config, topic, field, aggregate, value);
+      defineEnumerableOwn(output, field, decoded);
     } else {
       return yield* Effect.fail(
         invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
@@ -207,10 +308,13 @@ export const encodeSystemRow = Effect.fn("ViewServerProtocol.system.row.encode")
   schema: Schema.Codec<Row, unknown, never, never>,
   row: Row,
 ) {
-  const encoded = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(schema))(row).pipe(
+  const encoded = yield* encodeJsonFieldValue(schema, row, {
+    invalid: (message) => invalidRow(topic, `Invalid system row: ${message}`),
+    notJsonSafe: (message) => invalidRow(topic, `System row is not JSON-safe: ${message}`),
+  });
+  return yield* Schema.decodeUnknownEffect(ViewServerWireRowSchema)(encoded).pipe(
     Effect.mapError((error) => invalidRow(topic, `Invalid system row: ${error.message}`)),
   );
-  return yield* Schema.decodeUnknownEffect(ViewServerWireRowSchema)(encoded).pipe(Effect.orDie);
 });
 
 export const decodeSystemRow = Effect.fn("ViewServerProtocol.system.row.decode")(function* <Row>(
@@ -218,7 +322,7 @@ export const decodeSystemRow = Effect.fn("ViewServerProtocol.system.row.decode")
   schema: Schema.Codec<Row, unknown, never, never>,
   row: ViewServerWireRow,
 ) {
-  return yield* Schema.decodeUnknownEffect(Schema.toCodecJson(schema))(row).pipe(
-    Effect.mapError((error) => invalidRow(topic, `Invalid system row: ${error.message}`)),
-  );
+  return yield* decodeJsonFieldValue(schema, row, {
+    invalid: (message) => invalidRow(topic, `Invalid system row: ${message}`),
+  });
 });

--- a/packages/protocol/src/row-reflection-boundary.test.ts
+++ b/packages/protocol/src/row-reflection-boundary.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import {
+  decodeGroupedRow,
+  decodeProjectedRow,
+  encodeGroupedRow,
+  encodeProjectedRow,
+} from "./protocol-row-codec";
+
+import { viewServer } from "../test-harness/protocol";
+
+const invalidRow = (message: string) => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidRow",
+  message,
+  topic: "orders",
+});
+
+const selectedId = new Set(["id"]);
+
+const groupedQuery = {
+  groupBy: ["id"],
+  aggregates: {
+    rowCount: { aggFunc: "count" },
+  },
+} as const;
+
+describe("Protocol row reflection boundaries", () => {
+  it.effect(
+    "rejects non-enumerable and accessor raw encode fields without invoking accessors",
+    () =>
+      Effect.gen(function* () {
+        const nonEnumerableRow = {};
+        Object.defineProperty(nonEnumerableRow, "id", {
+          enumerable: false,
+          value: "a",
+        });
+
+        const nonEnumerableError = yield* Effect.flip(
+          encodeProjectedRow(viewServer, "orders", selectedId, nonEnumerableRow),
+        );
+        expect(nonEnumerableError).toStrictEqual(
+          invalidRow("Row field for topic orders must be enumerable: id"),
+        );
+
+        const accessorRow = {};
+        Object.defineProperty(accessorRow, "id", {
+          enumerable: true,
+          get: () => {
+            throw new Error("The row getter must not be invoked.");
+          },
+        });
+
+        const accessorError = yield* Effect.flip(
+          encodeProjectedRow(viewServer, "orders", selectedId, accessorRow),
+        );
+        expect(accessorError).toStrictEqual(
+          invalidRow("Row field for topic orders must be a data property: id"),
+        );
+      }),
+  );
+
+  it.effect("rejects raw encode symbol fields and hostile reflection", () =>
+    Effect.gen(function* () {
+      const symbolRow = { id: "a" };
+      Object.defineProperty(symbolRow, Symbol("secret"), {
+        enumerable: true,
+        value: "hidden",
+      });
+
+      const symbolError = yield* Effect.flip(
+        encodeProjectedRow(viewServer, "orders", selectedId, symbolRow),
+      );
+      expect(symbolError).toStrictEqual(
+        invalidRow("Unexpected row symbol field for topic orders: Symbol(secret)"),
+      );
+
+      const ownKeysFailure = new Proxy(
+        { id: "a" },
+        {
+          ownKeys: () => {
+            throw new Error("ownKeys failed");
+          },
+        },
+      );
+      const ownKeysError = yield* Effect.flip(
+        encodeProjectedRow(viewServer, "orders", selectedId, ownKeysFailure),
+      );
+      expect(ownKeysError).toStrictEqual(invalidRow("Could not inspect row for topic orders"));
+
+      const descriptorFailure = new Proxy(
+        {},
+        {
+          getOwnPropertyDescriptor: () => {
+            throw new Error("descriptor failed");
+          },
+          ownKeys: () => ["id"],
+        },
+      );
+      const descriptorError = yield* Effect.flip(
+        encodeProjectedRow(viewServer, "orders", selectedId, descriptorFailure),
+      );
+      expect(descriptorError).toStrictEqual(
+        invalidRow("Could not inspect row field for topic orders: id"),
+      );
+
+      const missingDescriptor = new Proxy(
+        {},
+        {
+          getOwnPropertyDescriptor: () => undefined,
+          ownKeys: () => ["id"],
+        },
+      );
+      const missingDescriptorError = yield* Effect.flip(
+        encodeProjectedRow(viewServer, "orders", selectedId, missingDescriptor),
+      );
+      expect(missingDescriptorError).toStrictEqual(
+        invalidRow("Could not inspect row field for topic orders: id"),
+      );
+    }),
+  );
+
+  it.effect("rejects non-data grouped encode fields and symbol extras", () =>
+    Effect.gen(function* () {
+      const nonEnumerableRow = { rowCount: 1n };
+      Object.defineProperty(nonEnumerableRow, "id", {
+        enumerable: false,
+        value: "a",
+      });
+      const nonEnumerableError = yield* Effect.flip(
+        encodeGroupedRow(viewServer, "orders", groupedQuery, nonEnumerableRow),
+      );
+      expect(nonEnumerableError).toStrictEqual(
+        invalidRow("Grouped row field for topic orders must be enumerable: id"),
+      );
+
+      const accessorRow = { id: "a" };
+      Object.defineProperty(accessorRow, "rowCount", {
+        enumerable: true,
+        get: () => {
+          throw new Error("The aggregate getter must not be invoked.");
+        },
+      });
+      const accessorError = yield* Effect.flip(
+        encodeGroupedRow(viewServer, "orders", groupedQuery, accessorRow),
+      );
+      expect(accessorError).toStrictEqual(
+        invalidRow("Grouped row field for topic orders must be a data property: rowCount"),
+      );
+
+      const symbolRow = { id: "a", rowCount: 1n };
+      Object.defineProperty(symbolRow, Symbol("secret"), {
+        enumerable: true,
+        value: "hidden",
+      });
+      const symbolError = yield* Effect.flip(
+        encodeGroupedRow(viewServer, "orders", groupedQuery, symbolRow),
+      );
+      expect(symbolError).toStrictEqual(
+        invalidRow("Unexpected grouped row symbol field for topic orders: Symbol(secret)"),
+      );
+    }),
+  );
+
+  it.effect("strictly materializes raw and grouped wire rows before decoding fields", () =>
+    Effect.gen(function* () {
+      const nonEnumerableWireRow = {};
+      Object.defineProperty(nonEnumerableWireRow, "id", {
+        enumerable: false,
+        value: "a",
+      });
+      const rawError = yield* Effect.flip(
+        decodeProjectedRow(viewServer, "orders", selectedId, nonEnumerableWireRow),
+      );
+      expect(rawError).toStrictEqual(
+        invalidRow("Invalid row for topic orders: Expected an enumerable data property at $.id."),
+      );
+
+      const accessorWireRow = {
+        id: "a",
+        get rowCount(): never {
+          throw new Error("The aggregate wire getter must not be invoked.");
+        },
+      };
+      const groupedError = yield* Effect.flip(
+        decodeGroupedRow(viewServer, "orders", groupedQuery, accessorWireRow),
+      );
+      expect(groupedError).toStrictEqual(
+        invalidRow(
+          "Invalid grouped row for topic orders: Accessor properties are not valid JSON data at $.rowCount.",
+        ),
+      );
+
+      const symbolWireRow = { id: "a" };
+      Object.defineProperty(symbolWireRow, Symbol("secret"), {
+        enumerable: true,
+        value: "hidden",
+      });
+      const symbolError = yield* Effect.flip(
+        decodeProjectedRow(viewServer, "orders", selectedId, symbolWireRow),
+      );
+      expect(symbolError).toStrictEqual(
+        invalidRow(
+          "Invalid row for topic orders: Symbol-keyed properties are not valid JSON data at $[Symbol(secret)].",
+        ),
+      );
+
+      const hostileWireRow = new Proxy(
+        { id: "a", rowCount: { _viewServerAggregate: "bigint", value: "1" } },
+        {
+          ownKeys: () => {
+            throw new Error("wire ownKeys failed");
+          },
+        },
+      );
+      const reflectionError = yield* Effect.flip(
+        decodeGroupedRow(viewServer, "orders", groupedQuery, hostileWireRow),
+      );
+      expect(reflectionError).toStrictEqual(
+        invalidRow("Invalid grouped row for topic orders: Could not inspect JSON value at $."),
+      );
+
+      const nonObjectError = yield* Effect.flip(
+        decodeProjectedRow(
+          viewServer,
+          "orders",
+          selectedId,
+          // @ts-expect-error hostile callers can bypass the public wire-row object type.
+          ["a"],
+        ),
+      );
+      expect(nonObjectError).toStrictEqual(
+        invalidRow("Invalid row for topic orders: Expected a JSON object."),
+      );
+    }),
+  );
+});

--- a/packages/protocol/src/schema-value-wire.test.ts
+++ b/packages/protocol/src/schema-value-wire.test.ts
@@ -1,0 +1,529 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import * as BigDecimal from "effect/BigDecimal";
+import * as HashMap from "effect/HashMap";
+import * as Option from "effect/Option";
+import { Effect, Schema } from "effect";
+import {
+  ViewServerWireEventSchema,
+  viewServerDecodeLiveEvent,
+  viewServerDecodeRawQuery,
+  viewServerEncodeGroupedQuery,
+  viewServerEncodeLiveEvent,
+  viewServerEncodeRawQuery,
+} from "./index";
+import type { ViewServerProtocolEvent } from "./protocol-event-codec";
+
+class Venue extends Schema.Class<Venue>("Venue")({
+  code: Schema.String,
+}) {}
+viewSchema.admitClass(Venue);
+
+const SemanticRow = Schema.Struct({
+  id: Schema.String,
+  venue: Venue,
+  optionalQuantity: viewSchema.Option(Schema.BigInt),
+  tags: viewSchema.Chunk(Schema.String),
+  quantities: viewSchema.HashMap(Schema.String, Schema.BigInt),
+  amount: Schema.BigDecimal,
+  note: Schema.optionalKey(Schema.String),
+});
+
+const semanticViewServer = defineViewServerConfig({
+  topics: {
+    semantic: {
+      schema: SemanticRow,
+      key: "id",
+    },
+  },
+});
+
+const semanticWireRow = {
+  id: "1",
+  venue: { code: "XNYS" },
+  optionalQuantity: { _tag: "Some", value: "9007199254740993" },
+  tags: ["live", "typed"],
+  quantities: [["desk-a", "9007199254740995"]],
+  amount: "1234567890.123456789",
+};
+
+const summarizeSemanticRow = (row: typeof SemanticRow.Type) => ({
+  id: row.id,
+  venue: row.venue.code,
+  venueIsClass: row.venue instanceof Venue,
+  optionalQuantity: Option.getOrNull(row.optionalQuantity),
+  tags: Array.from(row.tags),
+  quantities: HashMap.toEntries(row.quantities),
+  amount: BigDecimal.format(row.amount),
+  hasNote: Object.hasOwn(row, "note"),
+});
+
+const semanticRowSummary = {
+  id: "1",
+  venue: "XNYS",
+  venueIsClass: true,
+  optionalQuantity: 9007199254740993n,
+  tags: ["live", "typed"],
+  quantities: [["desk-a", 9007199254740995n]],
+  amount: "1234567890.123456789",
+  hasNote: false,
+};
+
+const decodeTransportedEvent = Effect.fn("ViewServerProtocol.test.transport")(function* (
+  value: unknown,
+) {
+  const jsonText = yield* Schema.encodeUnknownEffect(Schema.UnknownFromJsonString)(value);
+  const parsed = yield* Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)(jsonText);
+  return yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(parsed);
+});
+
+const requireSnapshotEvent = Effect.fn("ViewServerProtocol.test.requireSnapshot")(function* <Row>(
+  event: ViewServerProtocolEvent<Row>,
+) {
+  if (event.type !== "snapshot") {
+    return yield* Effect.die("Expected a Snapshot event.");
+  }
+  return event;
+});
+
+const requireDeltaEvent = Effect.fn("ViewServerProtocol.test.requireDelta")(function* <Row>(
+  event: ViewServerProtocolEvent<Row>,
+) {
+  if (event.type !== "delta") {
+    return yield* Effect.die("Expected a Delta event.");
+  }
+  return event;
+});
+
+describe("Schema value wire semantics", () => {
+  it.effect("round-trips Schema.Class equality filters through canonical JSON", () =>
+    Effect.gen(function* () {
+      const venue = Venue.make({ code: "XNYS" });
+      const encoded = yield* viewServerEncodeRawQuery(semanticViewServer, "semantic", {
+        select: ["id"],
+        where: {
+          venue: { eq: venue },
+        },
+      });
+      expect(encoded).toStrictEqual({
+        select: ["id"],
+        where: {
+          venue: { eq: { code: "XNYS" } },
+        },
+      });
+
+      const jsonText = yield* Schema.encodeUnknownEffect(Schema.UnknownFromJsonString)(encoded);
+      const transported = yield* Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)(jsonText);
+      const decoded = yield* viewServerDecodeRawQuery(semanticViewServer, "semantic", transported);
+      const decodedVenue = Reflect.get(Object(decoded.where?.["venue"]), "eq");
+
+      expect(decoded.where).toStrictEqual({
+        venue: { eq: venue },
+      });
+      expect(decodedVenue).toBeInstanceOf(Venue);
+    }),
+  );
+
+  it.effect(
+    "round-trips canonical values and omitted optional fields in raw Snapshot and Delta",
+    () =>
+      Effect.gen(function* () {
+        const row = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(SemanticRow))(
+          semanticWireRow,
+        );
+        const query = {
+          select: ["id", "venue", "optionalQuantity", "tags", "quantities", "amount", "note"],
+        };
+        const snapshot = yield* viewServerEncodeLiveEvent(semanticViewServer, "semantic", query, {
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-snapshot",
+          version: 1,
+          keys: ["1"],
+          rows: [row],
+          totalRows: 1,
+        });
+        expect(snapshot).toStrictEqual({
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-snapshot",
+          version: 1,
+          keys: ["1"],
+          rows: [semanticWireRow],
+          totalRows: 1,
+        });
+
+        const transportedSnapshot = yield* decodeTransportedEvent(snapshot);
+        const decodedSnapshot = yield* viewServerDecodeLiveEvent<
+          typeof semanticViewServer.topics,
+          "semantic",
+          typeof SemanticRow.Type
+        >(semanticViewServer, "semantic", query, transportedSnapshot);
+        const decodedSnapshotEvent = yield* requireSnapshotEvent(decodedSnapshot);
+        const summarizedSnapshot = {
+          ...decodedSnapshotEvent,
+          rows: decodedSnapshotEvent.rows.map(summarizeSemanticRow),
+        };
+        expect(summarizedSnapshot).toStrictEqual({
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-snapshot",
+          version: 1,
+          keys: ["1"],
+          rows: [semanticRowSummary],
+          totalRows: 1,
+        });
+
+        const delta = yield* viewServerEncodeLiveEvent(semanticViewServer, "semantic", query, {
+          type: "delta",
+          topic: "semantic",
+          queryId: "semantic-delta",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            { type: "insert", key: "1", row, index: 0 },
+            { type: "update", key: "1", row, index: 0 },
+          ],
+          totalRows: 1,
+        });
+        expect(delta).toStrictEqual({
+          type: "delta",
+          topic: "semantic",
+          queryId: "semantic-delta",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            { type: "insert", key: "1", row: semanticWireRow, index: 0 },
+            { type: "update", key: "1", row: semanticWireRow, index: 0 },
+          ],
+          totalRows: 1,
+        });
+
+        const transportedDelta = yield* decodeTransportedEvent(delta);
+        const decodedDelta = yield* viewServerDecodeLiveEvent<
+          typeof semanticViewServer.topics,
+          "semantic",
+          typeof SemanticRow.Type
+        >(semanticViewServer, "semantic", query, transportedDelta);
+        const decodedDeltaEvent = yield* requireDeltaEvent(decodedDelta);
+        const summarizedDelta = {
+          ...decodedDeltaEvent,
+          operations: decodedDeltaEvent.operations.map((operation) =>
+            operation.type === "insert" || operation.type === "update"
+              ? { ...operation, row: summarizeSemanticRow(operation.row) }
+              : operation,
+          ),
+        };
+        expect(summarizedDelta).toStrictEqual({
+          type: "delta",
+          topic: "semantic",
+          queryId: "semantic-delta",
+          fromVersion: 1,
+          toVersion: 2,
+          operations: [
+            { type: "insert", key: "1", row: semanticRowSummary, index: 0 },
+            { type: "update", key: "1", row: semanticRowSummary, index: 0 },
+          ],
+          totalRows: 1,
+        });
+
+        expect(summarizeSemanticRow(row)).toStrictEqual(semanticRowSummary);
+      }),
+  );
+
+  it.effect("round-trips Schema.Class group fields in grouped Snapshot and update Delta rows", () =>
+    Effect.gen(function* () {
+      const venue = Venue.make({ code: "XNYS" });
+      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+        groupBy: ["venue"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      });
+      const groupedRow = { venue, rowCount: 1n };
+      const groupedWireRow = {
+        venue: { code: "XNYS" },
+        rowCount: { _viewServerAggregate: "bigint", value: "1" },
+      };
+      const snapshot = yield* viewServerEncodeLiveEvent(
+        semanticViewServer,
+        "semantic",
+        groupedQuery,
+        {
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-grouped-snapshot",
+          version: 1,
+          keys: ["venue-xnys"],
+          rows: [groupedRow],
+          totalRows: 1,
+        },
+      );
+      expect(snapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-grouped-snapshot",
+        version: 1,
+        keys: ["venue-xnys"],
+        rows: [groupedWireRow],
+        totalRows: 1,
+      });
+
+      const decodedSnapshot = yield* viewServerDecodeLiveEvent<
+        typeof semanticViewServer.topics,
+        "semantic",
+        typeof groupedRow
+      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(snapshot));
+      expect(decodedSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-grouped-snapshot",
+        version: 1,
+        keys: ["venue-xnys"],
+        rows: [groupedRow],
+        totalRows: 1,
+      });
+
+      const delta = yield* viewServerEncodeLiveEvent(semanticViewServer, "semantic", groupedQuery, {
+        type: "delta",
+        topic: "semantic",
+        queryId: "semantic-grouped-delta",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "update", key: "venue-xnys", row: groupedRow, index: 0 }],
+        totalRows: 1,
+      });
+      expect(delta).toStrictEqual({
+        type: "delta",
+        topic: "semantic",
+        queryId: "semantic-grouped-delta",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "update", key: "venue-xnys", row: groupedWireRow, index: 0 }],
+        totalRows: 1,
+      });
+
+      const decodedDelta = yield* viewServerDecodeLiveEvent<
+        typeof semanticViewServer.topics,
+        "semantic",
+        typeof groupedRow
+      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(delta));
+      expect(decodedDelta).toStrictEqual({
+        type: "delta",
+        topic: "semantic",
+        queryId: "semantic-grouped-delta",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "update", key: "venue-xnys", row: groupedRow, index: 0 }],
+        totalRows: 1,
+      });
+    }),
+  );
+
+  it.effect("round-trips Schema.Class min and max aggregate envelopes", () =>
+    Effect.gen(function* () {
+      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+        groupBy: ["id"],
+        aggregates: {
+          firstVenue: { aggFunc: "min", field: "venue" },
+          lastVenue: { aggFunc: "max", field: "venue" },
+        },
+      });
+      const groupedRow = {
+        id: "1",
+        firstVenue: Venue.make({ code: "XNYS" }),
+        lastVenue: Venue.make({ code: "XNAS" }),
+      };
+      const encoded = yield* viewServerEncodeLiveEvent(
+        semanticViewServer,
+        "semantic",
+        groupedQuery,
+        {
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-class-aggregates",
+          version: 1,
+          keys: ["1"],
+          rows: [groupedRow],
+          totalRows: 1,
+        },
+      );
+      expect(encoded).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-class-aggregates",
+        version: 1,
+        keys: ["1"],
+        rows: [
+          {
+            id: "1",
+            firstVenue: { _viewServerAggregate: "json", value: { code: "XNYS" } },
+            lastVenue: { _viewServerAggregate: "json", value: { code: "XNAS" } },
+          },
+        ],
+        totalRows: 1,
+      });
+
+      const decoded = yield* viewServerDecodeLiveEvent<
+        typeof semanticViewServer.topics,
+        "semantic",
+        typeof groupedRow
+      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(encoded));
+      const snapshot = yield* requireSnapshotEvent(decoded);
+      expect(snapshot.rows[0]?.firstVenue).toBeInstanceOf(Venue);
+      expect(snapshot.rows[0]?.lastVenue).toBeInstanceOf(Venue);
+      expect(snapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-class-aggregates",
+        version: 1,
+        keys: ["1"],
+        rows: [groupedRow],
+        totalRows: 1,
+      });
+    }),
+  );
+
+  it.effect("round-trips all-missing optional min and max values in Snapshot and Delta", () =>
+    Effect.gen(function* () {
+      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+        groupBy: ["id"],
+        aggregates: {
+          firstNote: { aggFunc: "min", field: "note" },
+          lastNote: { aggFunc: "max", field: "note" },
+        },
+      });
+      const groupedRow = {
+        id: "1",
+        firstNote: undefined,
+        lastNote: undefined,
+      };
+      const wireRow = {
+        id: "1",
+        firstNote: { _viewServerAggregate: "undefined" },
+        lastNote: { _viewServerAggregate: "undefined" },
+      };
+      const snapshot = yield* viewServerEncodeLiveEvent(
+        semanticViewServer,
+        "semantic",
+        groupedQuery,
+        {
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-optional-extrema-snapshot",
+          version: 1,
+          keys: ["1"],
+          rows: [groupedRow],
+          totalRows: 1,
+        },
+      );
+      expect(snapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-optional-extrema-snapshot",
+        version: 1,
+        keys: ["1"],
+        rows: [wireRow],
+        totalRows: 1,
+      });
+      const decodedSnapshot = yield* viewServerDecodeLiveEvent<
+        typeof semanticViewServer.topics,
+        "semantic",
+        typeof groupedRow
+      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(snapshot));
+      expect(decodedSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-optional-extrema-snapshot",
+        version: 1,
+        keys: ["1"],
+        rows: [groupedRow],
+        totalRows: 1,
+      });
+
+      const delta = yield* viewServerEncodeLiveEvent(semanticViewServer, "semantic", groupedQuery, {
+        type: "delta",
+        topic: "semantic",
+        queryId: "semantic-optional-extrema-delta",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "update", key: "1", row: groupedRow, index: 0 }],
+        totalRows: 1,
+      });
+      expect(delta).toStrictEqual({
+        type: "delta",
+        topic: "semantic",
+        queryId: "semantic-optional-extrema-delta",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "update", key: "1", row: wireRow, index: 0 }],
+        totalRows: 1,
+      });
+      const decodedDelta = yield* viewServerDecodeLiveEvent<
+        typeof semanticViewServer.topics,
+        "semantic",
+        typeof groupedRow
+      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(delta));
+      expect(decodedDelta).toStrictEqual({
+        type: "delta",
+        topic: "semantic",
+        queryId: "semantic-optional-extrema-delta",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [{ type: "update", key: "1", row: groupedRow, index: 0 }],
+        totalRows: 1,
+      });
+    }),
+  );
+
+  it.effect("round-trips an omitted optional grouped field", () =>
+    Effect.gen(function* () {
+      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+        groupBy: ["note"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+      });
+      const groupedRow = { rowCount: 1n };
+      const snapshot = yield* viewServerEncodeLiveEvent(
+        semanticViewServer,
+        "semantic",
+        groupedQuery,
+        {
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-optional-group",
+          version: 1,
+          keys: ["missing-note"],
+          rows: [groupedRow],
+          totalRows: 1,
+        },
+      );
+
+      expect(snapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-optional-group",
+        version: 1,
+        keys: ["missing-note"],
+        rows: [{ rowCount: { _viewServerAggregate: "bigint", value: "1" } }],
+        totalRows: 1,
+      });
+
+      const decoded = yield* viewServerDecodeLiveEvent<
+        typeof semanticViewServer.topics,
+        "semantic",
+        typeof groupedRow
+      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(snapshot));
+      expect(decoded).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-optional-group",
+        version: 1,
+        keys: ["missing-note"],
+        rows: [groupedRow],
+        totalRows: 1,
+      });
+    }),
+  );
+});

--- a/packages/protocol/src/system-row-strict-json.test.ts
+++ b/packages/protocol/src/system-row-strict-json.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { decodeSystemLiveEvent, encodeSystemLiveEvent } from "./protocol-event-codec";
+
+const SystemRow = Schema.Struct({
+  id: Schema.String,
+  payload: Schema.ObjectKeyword,
+});
+
+const expectedSystemMapError = {
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidRow",
+  message: "System row is not JSON-safe: Expected a plain data record or dense array at $.payload.",
+  topic: "system",
+} as const;
+
+describe("System row strict JSON boundary", () => {
+  it.effect("rejects opaque values during system-row encoding and hostile direct decoding", () =>
+    Effect.gen(function* () {
+      const encodeError = yield* Effect.flip(
+        encodeSystemLiveEvent("system", SystemRow, {
+          type: "snapshot",
+          topic: "system",
+          queryId: "system-encode",
+          version: 1,
+          keys: ["1"],
+          rows: [{ id: "1", payload: new Map([["venue", "xnys"]]) }],
+          totalRows: 1,
+        }),
+      );
+      expect(encodeError).toStrictEqual(expectedSystemMapError);
+
+      const hostileEvent = {
+        type: "snapshot",
+        topic: "system",
+        queryId: "system-decode",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", payload: new Map([["venue", "xnys"]]) }],
+        totalRows: 1,
+      };
+      const decodeError = yield* Effect.flip(
+        decodeSystemLiveEvent(
+          "system",
+          SystemRow,
+          // @ts-expect-error hostile callers can bypass the public JSON wire type.
+          hostileEvent,
+        ),
+      );
+      expect(decodeError).toStrictEqual({
+        ...expectedSystemMapError,
+        message: "Invalid system row: Expected a plain data record or dense array at $.payload.",
+      });
+    }),
+  );
+
+  it.effect("round-trips plain system rows and rejects non-record schema encodings", () =>
+    Effect.gen(function* () {
+      const event = {
+        type: "snapshot",
+        topic: "system",
+        queryId: "system-plain",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", payload: { venue: "xnys" } }],
+        totalRows: 1,
+      } as const;
+      const encoded = yield* encodeSystemLiveEvent("system", SystemRow, event);
+      expect(encoded).toStrictEqual(event);
+      expect(yield* decodeSystemLiveEvent("system", SystemRow, encoded)).toStrictEqual(event);
+
+      const nonRecordError = yield* Effect.flip(
+        encodeSystemLiveEvent("system", Schema.String, {
+          type: "snapshot",
+          topic: "system",
+          queryId: "system-non-record",
+          version: 1,
+          keys: ["1"],
+          rows: ["not-a-row"],
+          totalRows: 1,
+        }),
+      );
+      expect(nonRecordError).toMatchObject({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        message: expect.stringContaining("Invalid system row"),
+        topic: "system",
+      });
+    }),
+  );
+});

--- a/packages/protocol/test-harness/protocol.ts
+++ b/packages/protocol/test-harness/protocol.ts
@@ -26,7 +26,7 @@ export const BadJsonField = Schema.String.pipe(
 );
 
 export const BadJsonRow = Schema.Struct({
-  id: BadJsonField,
+  id: Schema.String,
 });
 
 export const viewServer = defineViewServerConfig({

--- a/packages/runtime-core/src/internal.ts
+++ b/packages/runtime-core/src/internal.ts
@@ -29,6 +29,7 @@ import type {
 } from "./public-client";
 import { makeRuntimeCoreClient } from "./runtime-client";
 import type { ViewServerRuntimeCoreInternalClient } from "./runtime-client";
+import { engineErrorToRuntimeError } from "./runtime-error";
 import type { ViewServerRuntimeCoreInstance } from "./index";
 export {
   collectSourceOwnershipConflicts,
@@ -110,7 +111,9 @@ export const makeViewServerRuntimeCoreInternal: <const Topics extends DecodableT
         : { subscriptionQueueCapacity: input.subscriptionQueueCapacity }),
       topics: config.topics,
     };
-    const engine = yield* createColumnLiveViewEngineInternal<Topics>(engineConfig);
+    const engine = yield* createColumnLiveViewEngineInternal<Topics>(engineConfig).pipe(
+      Effect.mapError(engineErrorToRuntimeError),
+    );
     const engineHealth = yield* engine.health();
     const runtimeStartedAtMillis = yield* Clock.currentTimeMillis;
     const runtimeStartedAtNanos = yield* Clock.currentTimeNanos;

--- a/packages/runtime-core/src/source-binding-resolution.test.ts
+++ b/packages/runtime-core/src/source-binding-resolution.test.ts
@@ -97,17 +97,21 @@ describe("source binding resolution", () => {
   });
 
   it("keeps malformed gRPC source metadata local to the binding", () => {
+    const malformedOrders: {
+      schema: typeof Row;
+      key: "id";
+    } = {
+      schema: Row,
+      key: "id",
+    };
+    const malformedSource = { kind: "grpc", lifecycle: "wat" };
+    Object.defineProperty(malformedOrders, "grpcSource", {
+      value: malformedSource,
+    });
     const malformedViewServer = defineViewServerConfig({
       topics: {
-        malformedOrders: {
-          schema: Row,
-          key: "id",
-        },
+        malformedOrders,
       },
-    });
-    const malformedSource = { kind: "grpc", lifecycle: "wat" };
-    Object.defineProperty(malformedViewServer.topics.malformedOrders, "grpcSource", {
-      value: malformedSource,
     });
 
     expect(
@@ -128,71 +132,35 @@ describe("source binding resolution", () => {
   });
 
   it("classifies hostile gRPC source shapes without caller reflection", () => {
-    const hostileViewServer = defineViewServerConfig({
-      topics: {
-        incompleteConcreteLeased: {
-          schema: Row,
-          key: "id",
-        },
-        incompleteConcreteMaterialized: {
-          schema: Row,
-          key: "id",
-        },
-        invalidKind: {
-          schema: Row,
-          key: "id",
-        },
-        invalidLeasedRouteBy: {
-          schema: Row,
-          key: "id",
-        },
-        invalidLifecycle: {
-          schema: Row,
-          key: "id",
-        },
-        materializedExtraKey: {
-          schema: Row,
-          key: "id",
-        },
-        materializedWrongTag: {
-          schema: Row,
-          key: "id",
-        },
-        nonStringLeasedRouteBy: {
-          schema: Row,
-          key: "id",
-        },
-        primitiveSource: {
-          schema: Row,
-          key: "id",
-        },
-        validConcreteLeased: {
-          schema: Row,
-          key: "id",
-        },
-        validConcreteMaterialized: {
-          schema: Row,
-          key: "id",
-        },
-        leasedExtraKey: {
-          schema: Row,
-          key: "id",
-        },
-        leasedWrongTag: {
-          schema: Row,
-          key: "id",
-        },
-        releaseIsNotCallable: {
-          schema: Row,
-          key: "id",
-        },
-      },
+    const topicDefinition = (): {
+      schema: typeof Row;
+      key: "id";
+    } => ({
+      schema: Row,
+      key: "id",
     });
+    const topicDefinitions = () => ({
+      incompleteConcreteLeased: topicDefinition(),
+      incompleteConcreteMaterialized: topicDefinition(),
+      invalidKind: topicDefinition(),
+      invalidLeasedRouteBy: topicDefinition(),
+      invalidLifecycle: topicDefinition(),
+      materializedExtraKey: topicDefinition(),
+      materializedWrongTag: topicDefinition(),
+      nonStringLeasedRouteBy: topicDefinition(),
+      primitiveSource: topicDefinition(),
+      validConcreteLeased: topicDefinition(),
+      validConcreteMaterialized: topicDefinition(),
+      leasedExtraKey: topicDefinition(),
+      leasedWrongTag: topicDefinition(),
+      releaseIsNotCallable: topicDefinition(),
+    });
+    const hostileTopics = topicDefinitions();
     const request = () => undefined;
     const acquire = () => undefined;
     const release = () => undefined;
     const map = () => undefined;
-    Object.defineProperty(hostileViewServer.topics.incompleteConcreteLeased, "grpcSource", {
+    Object.defineProperty(hostileTopics.incompleteConcreteLeased, "grpcSource", {
       value: {
         _tag: "GrpcLeasedTopicSource",
         kind: "grpc",
@@ -201,7 +169,7 @@ describe("source binding resolution", () => {
         client: "orders",
       },
     });
-    Object.defineProperty(hostileViewServer.topics.incompleteConcreteMaterialized, "grpcSource", {
+    Object.defineProperty(hostileTopics.incompleteConcreteMaterialized, "grpcSource", {
       value: {
         _tag: "GrpcMaterializedTopicSource",
         kind: "grpc",
@@ -209,10 +177,10 @@ describe("source binding resolution", () => {
         client: "orders",
       },
     });
-    Object.defineProperty(hostileViewServer.topics.invalidKind, "grpcSource", {
+    Object.defineProperty(hostileTopics.invalidKind, "grpcSource", {
       value: { kind: "not-grpc", lifecycle: "leased" },
     });
-    Object.defineProperty(hostileViewServer.topics.invalidLeasedRouteBy, "grpcSource", {
+    Object.defineProperty(hostileTopics.invalidLeasedRouteBy, "grpcSource", {
       value: {
         _tag: "GrpcLeasedTopicSource",
         kind: "grpc",
@@ -220,10 +188,10 @@ describe("source binding resolution", () => {
         routeBy: [],
       },
     });
-    Object.defineProperty(hostileViewServer.topics.invalidLifecycle, "grpcSource", {
+    Object.defineProperty(hostileTopics.invalidLifecycle, "grpcSource", {
       value: { kind: "grpc", lifecycle: "wat" },
     });
-    Object.defineProperty(hostileViewServer.topics.materializedExtraKey, "grpcSource", {
+    Object.defineProperty(hostileTopics.materializedExtraKey, "grpcSource", {
       value: {
         _tag: "GrpcMaterializedTopicSource",
         extra: true,
@@ -231,10 +199,10 @@ describe("source binding resolution", () => {
         lifecycle: "materialized",
       },
     });
-    Object.defineProperty(hostileViewServer.topics.materializedWrongTag, "grpcSource", {
+    Object.defineProperty(hostileTopics.materializedWrongTag, "grpcSource", {
       value: { _tag: "Wrong", kind: "grpc", lifecycle: "materialized" },
     });
-    Object.defineProperty(hostileViewServer.topics.nonStringLeasedRouteBy, "grpcSource", {
+    Object.defineProperty(hostileTopics.nonStringLeasedRouteBy, "grpcSource", {
       value: {
         _tag: "GrpcLeasedTopicSource",
         kind: "grpc",
@@ -242,10 +210,10 @@ describe("source binding resolution", () => {
         routeBy: ["region", 1],
       },
     });
-    Object.defineProperty(hostileViewServer.topics.primitiveSource, "grpcSource", {
+    Object.defineProperty(hostileTopics.primitiveSource, "grpcSource", {
       value: "not-an-object",
     });
-    Object.defineProperty(hostileViewServer.topics.validConcreteLeased, "grpcSource", {
+    Object.defineProperty(hostileTopics.validConcreteLeased, "grpcSource", {
       value: {
         _tag: "GrpcLeasedTopicSource",
         kind: "grpc",
@@ -259,7 +227,7 @@ describe("source binding resolution", () => {
         map,
       },
     });
-    Object.defineProperty(hostileViewServer.topics.validConcreteMaterialized, "grpcSource", {
+    Object.defineProperty(hostileTopics.validConcreteMaterialized, "grpcSource", {
       value: {
         _tag: "GrpcMaterializedTopicSource",
         kind: "grpc",
@@ -271,7 +239,7 @@ describe("source binding resolution", () => {
         map,
       },
     });
-    Object.defineProperty(hostileViewServer.topics.leasedExtraKey, "grpcSource", {
+    Object.defineProperty(hostileTopics.leasedExtraKey, "grpcSource", {
       value: {
         _tag: "GrpcLeasedTopicSource",
         extra: true,
@@ -280,7 +248,7 @@ describe("source binding resolution", () => {
         routeBy: ["region"],
       },
     });
-    Object.defineProperty(hostileViewServer.topics.leasedWrongTag, "grpcSource", {
+    Object.defineProperty(hostileTopics.leasedWrongTag, "grpcSource", {
       value: {
         _tag: "Wrong",
         kind: "grpc",
@@ -288,7 +256,7 @@ describe("source binding resolution", () => {
         routeBy: ["region"],
       },
     });
-    Object.defineProperty(hostileViewServer.topics.releaseIsNotCallable, "grpcSource", {
+    Object.defineProperty(hostileTopics.releaseIsNotCallable, "grpcSource", {
       value: {
         _tag: "GrpcMaterializedTopicSource",
         kind: "grpc",
@@ -301,13 +269,24 @@ describe("source binding resolution", () => {
         map,
       },
     });
-    Object.defineProperty(hostileViewServer.topics, "primitiveTopic", {
+    const hostileViewServer = defineViewServerConfig({
+      topics: topicDefinitions(),
+    });
+    const hostileTopicsWithPrimitive = {
+      ...hostileTopics,
+    };
+    Object.defineProperty(hostileTopicsWithPrimitive, "primitiveTopic", {
       enumerable: true,
       value: null,
     });
 
     expect(
-      [...makeTopicSourceBindings(hostileViewServer)].map(([topic, binding]) => ({
+      [
+        ...makeTopicSourceBindings({
+          ...hostileViewServer,
+          topics: hostileTopicsWithPrimitive,
+        }),
+      ].map(([topic, binding]) => ({
         grpcMetadataTag: binding.grpcMetadata._tag,
         owners: binding.owners,
         topic,

--- a/packages/runtime-core/src/source-ownership-policy.test.ts
+++ b/packages/runtime-core/src/source-ownership-policy.test.ts
@@ -253,20 +253,24 @@ describe("SourceOwnershipPolicy", () => {
 
   it.effect("preserves leased runtime protection for invalid declared leased metadata", () =>
     Effect.gen(function* () {
-      const malformedLeasedViewServer = defineViewServerConfig({
-        topics: {
-          malformedLeasedOrders: {
-            schema: Row,
-            key: "id",
-          },
-        },
-      });
-      Object.defineProperty(malformedLeasedViewServer.topics.malformedLeasedOrders, "grpcSource", {
+      const malformedLeasedOrders: {
+        schema: typeof Row;
+        key: "id";
+      } = {
+        schema: Row,
+        key: "id",
+      };
+      Object.defineProperty(malformedLeasedOrders, "grpcSource", {
         value: {
           _tag: "GrpcLeasedTopicSource",
           kind: "grpc",
           lifecycle: "leased",
           routeBy: [],
+        },
+      });
+      const malformedLeasedViewServer = defineViewServerConfig({
+        topics: {
+          malformedLeasedOrders,
         },
       });
       const policy = makeSourceOwnershipPolicy(malformedLeasedViewServer);
@@ -294,48 +298,57 @@ describe("SourceOwnershipPolicy", () => {
   );
 
   it("classifies malformed and conflicting source declarations without caller reflection", () => {
+    const topicDefinition = (): {
+      schema: typeof Row;
+      key: "id";
+    } => ({
+      schema: Row,
+      key: "id",
+    });
+    const malformedGrpcOrders = topicDefinition();
+    const primitiveGrpcOrders = topicDefinition();
+    const multiOwnedOrders = {
+      ...topicDefinition(),
+      kafkaSource: kafka.source({
+        topic: "multi-owned-orders-source",
+        regions: ["usa"],
+        value: kafka.json(() => Schema.toCodecJson(Row)),
+        key: kafka.stringKey(),
+        rowKey: ({ key }) => key,
+        map: ({ value }) => ({
+          price: value.price,
+          region: value.region,
+          status: value.status,
+        }),
+      }),
+    };
+    Object.defineProperty(malformedGrpcOrders, "grpcSource", {
+      value: { kind: "grpc", lifecycle: "wat" },
+    });
+    Object.defineProperty(primitiveGrpcOrders, "grpcSource", {
+      value: "not-a-grpc-source",
+    });
+    Object.defineProperty(multiOwnedOrders, "grpcSource", {
+      value: grpcSourceMarkers.materialized(),
+    });
     const malformedViewServer = defineViewServerConfig({
       kafka: {
         usa: "localhost:9092",
       },
       topics: {
-        malformedGrpcOrders: {
-          schema: Row,
-          key: "id",
-        },
-        primitiveGrpcOrders: {
-          schema: Row,
-          key: "id",
-        },
-        multiOwnedOrders: {
-          schema: Row,
-          key: "id",
-          kafkaSource: kafka.source({
-            topic: "multi-owned-orders-source",
-            regions: ["usa"],
-            value: kafka.json(() => Schema.toCodecJson(Row)),
-            key: kafka.stringKey(),
-            rowKey: ({ key }) => key,
-            map: ({ value }) => ({
-              price: value.price,
-              region: value.region,
-              status: value.status,
-            }),
-          }),
-        },
+        malformedGrpcOrders,
+        primitiveGrpcOrders,
       },
     });
-    Object.defineProperty(malformedViewServer.topics.malformedGrpcOrders, "grpcSource", {
-      value: { kind: "grpc", lifecycle: "wat" },
-    });
-    Object.defineProperty(malformedViewServer.topics.primitiveGrpcOrders, "grpcSource", {
-      value: "not-a-grpc-source",
-    });
-    Object.defineProperty(malformedViewServer.topics.multiOwnedOrders, "grpcSource", {
-      value: grpcSourceMarkers.materialized(),
+    // Config admission rejects dual owners, while the policy still defends its structural seam.
+    const policy = makeSourceOwnershipPolicy({
+      topics: {
+        ...malformedViewServer.topics,
+        multiOwnedOrders,
+      },
     });
 
-    expect([...makeSourceOwnershipPolicy(malformedViewServer).topics]).toStrictEqual([
+    expect([...policy.topics]).toStrictEqual([
       [
         "malformedGrpcOrders",
         {

--- a/packages/runtime/src/grpc-decoded-row-validation.test.ts
+++ b/packages/runtime/src/grpc-decoded-row-validation.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import { Effect, Schedule, Schema } from "effect";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+import { grpcClients, grpcOrderValue, grpcTopicSources } from "../test-harness/grpc-config";
+import {
+  captureLeasedGrpcDegradation,
+  longRunningGrpcStream,
+  makeLeasedGrpcHealth,
+} from "../test-harness/grpc-leased";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+import {
+  makeMaterializedGrpcRuntimeHarness,
+  readGrpcHealthOverlayNow,
+} from "../test-harness/grpc-runtime";
+
+class GrpcDecodedRow extends Schema.Class<GrpcDecodedRow>("GrpcDecodedRow")({
+  id: Schema.String,
+  amount: Schema.BigIntFromString,
+  region: Schema.String,
+}) {}
+viewSchema.admitClass(GrpcDecodedRow);
+
+const rowsQuery = () => ({
+  select: ["id", "amount", "region"] as const,
+  orderBy: [{ field: "id", direction: "asc" }] as const,
+  limit: 10,
+});
+
+const leasedRowsQuery = (region: string) => ({
+  ...rowsQuery(),
+  where: { region: { eq: region } },
+});
+
+describe("gRPC decoded row validation", () => {
+  it.live("accepts a decoded materialized mapper row for a root Class topic", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          rows: grpcTopicSources.materialized({
+            schema: GrpcDecodedRow,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            request: () => ({ orderId: "all" }),
+            acquire: () => longRunningGrpcStream([grpcOrderValue("materialized", 42)]),
+            map: ({ value }) => ({
+              id: value.customerId,
+              amount: BigInt(value.price),
+              region: "global",
+            }),
+          }),
+        },
+      });
+      const harness = yield* makeMaterializedGrpcRuntimeHarness({ config });
+
+      const snapshot = yield* harness.runtimeCore.client.snapshot("rows", rowsQuery()).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (current) => current.totalRows === 1,
+        }),
+      );
+
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "materialized", amount: 42n, region: "global" }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
+      yield* harness.close;
+    }),
+  );
+
+  it.live("rejects an encoded materialized mapper row", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          rows: grpcTopicSources.materialized({
+            schema: GrpcDecodedRow,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            request: () => ({ orderId: "all" }),
+            acquire: () => longRunningGrpcStream([grpcOrderValue("materialized-encoded", 42)]),
+            map: ({ value }) => ({
+              id: value.customerId,
+              // @ts-expect-error gRPC mappers return the decoded bigint, not its wire encoding
+              amount: String(value.price),
+              region: "global",
+            }),
+          }),
+        },
+      });
+      const harness = yield* makeMaterializedGrpcRuntimeHarness({ config });
+
+      const degraded = yield* readGrpcHealthOverlayNow(
+        harness.runtimeCore.client,
+        harness.health,
+      ).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (health) => health.grpc?.feeds.rows?.materialized["rows"]?.status === "degraded",
+        }),
+      );
+      const snapshot = yield* harness.runtimeCore.client.snapshot("rows", rowsQuery());
+
+      expect(degraded.grpc?.feeds.rows?.materialized["rows"]?.mappingFailuresPerSecond).toBe(1);
+      expect(snapshot).toStrictEqual({
+        rows: [],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 0,
+        version: 0,
+      });
+      yield* harness.close;
+    }),
+  );
+
+  it.live("rejects a stateful materialized mapper accessor without reading it", () =>
+    Effect.gen(function* () {
+      let accessorReads = 0;
+      const config = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          rows: grpcTopicSources.materialized({
+            schema: GrpcDecodedRow,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            request: () => ({ orderId: "all" }),
+            acquire: () => longRunningGrpcStream([grpcOrderValue("materialized-accessor", 42)]),
+            map: ({ value }) => ({
+              id: value.customerId,
+              get amount() {
+                accessorReads += 1;
+                return accessorReads === 1 ? 1n : 2n;
+              },
+              region: "global",
+            }),
+          }),
+        },
+      });
+      const harness = yield* makeMaterializedGrpcRuntimeHarness({ config });
+
+      const degraded = yield* readGrpcHealthOverlayNow(
+        harness.runtimeCore.client,
+        harness.health,
+      ).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (health) => health.grpc?.feeds.rows?.materialized["rows"]?.status === "degraded",
+        }),
+      );
+
+      expect(accessorReads).toBe(0);
+      expect(degraded.grpc?.feeds.rows?.materialized["rows"]?.mappingFailuresPerSecond).toBe(1);
+      yield* harness.close;
+    }),
+  );
+
+  it.live("accepts a decoded leased mapper row for a root Class topic", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          rows: grpcTopicSources.leased({
+            schema: GrpcDecodedRow,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            routeBy: ["region"],
+            request: ({ region }) => ({ orderId: region }),
+            acquire: () => longRunningGrpcStream([grpcOrderValue("leased", 42)]),
+            map: ({ value, route }) => ({
+              id: value.customerId,
+              amount: BigInt(value.price),
+              region: route.region,
+            }),
+          }),
+        },
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(config);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(config, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        config,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("rows", leasedRowsQuery("usa"));
+
+      const snapshot = yield* runtimeCore.internalClient
+        .snapshot("rows", leasedRowsQuery("usa"))
+        .pipe(
+          Effect.repeat({
+            schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+            until: (current) => current.totalRows === 1,
+          }),
+        );
+
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "leased", amount: 42n, region: "usa" }],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 1,
+        version: 1,
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("rejects an encoded leased mapper row", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          rows: grpcTopicSources.leased({
+            schema: GrpcDecodedRow,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            routeBy: ["region"],
+            request: ({ region }) => ({ orderId: region }),
+            acquire: () => longRunningGrpcStream([grpcOrderValue("leased-encoded", 42)]),
+            map: ({ value, route }) => ({
+              id: value.customerId,
+              // @ts-expect-error gRPC mappers return the decoded bigint, not its wire encoding
+              amount: String(value.price),
+              region: route.region,
+            }),
+          }),
+        },
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(config);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(config, {});
+      const degradationMessages: Array<string> = [];
+      const health = captureLeasedGrpcDegradation(
+        makeLeasedGrpcHealth(grpcOptions),
+        degradationMessages,
+      );
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        config,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribe("rows", leasedRowsQuery("usa"));
+
+      yield* Effect.gen(function* () {
+        return health.healthOverlay(yield* runtimeCore.client.health(), 3_000);
+      }).pipe(
+        Effect.repeat({
+          schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+          until: (current) =>
+            degradationMessages.length === 1 &&
+            Object.keys(current.grpc?.feeds.rows?.leased ?? {}).length === 0,
+        }),
+      );
+      const snapshot = yield* runtimeCore.internalClient.snapshot("rows", leasedRowsQuery("usa"));
+
+      expect(degradationMessages).toStrictEqual([
+        "gRPC leased feed rows failed: ViewServerGrpcIngressError: gRPC leased feed mapping produced an invalid row for rows",
+      ]);
+      expect(snapshot).toStrictEqual({
+        rows: [],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 0,
+        version: 0,
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-grouped-public-key.test.ts
+++ b/packages/runtime/src/grpc-grouped-public-key.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "@effect/vitest";
+import { viewSchema } from "@effect-view-server/config";
+import { HashMap, HashSet, Schema } from "effect";
+import { compileGrpcGroupedPublicKey } from "./grpc-grouped-public-key";
+
+const GroupedKeyRow = Schema.Struct({
+  text: Schema.String,
+  amount: Schema.Number,
+  active: Schema.Boolean,
+  none: Schema.Null,
+  nested: Schema.Struct({ desk: Schema.String }),
+  maybe: Schema.optionalKey(Schema.Union([Schema.String, Schema.Undefined])),
+  maybeArray: Schema.optionalKey(Schema.Array(Schema.String)),
+  opaque: Schema.Unknown,
+  hashMap: viewSchema.HashMap(Schema.String, Schema.String),
+  hashSet: viewSchema.HashSet(Schema.String),
+});
+
+const missingPresenceKey = JSON.stringify(["missing"]);
+
+const presentPresenceKey = (canonicalKey: string): string =>
+  JSON.stringify(["present", canonicalKey]);
+
+const groupedPublicKey = (
+  entries: ReadonlyArray<readonly [field: string, presenceKey: string]>,
+): string => JSON.stringify(entries);
+
+describe("leased gRPC grouped public keys", () => {
+  it("compiles canonical field codecs once and distinguishes missing from present undefined", () => {
+    const key = compileGrpcGroupedPublicKey(GroupedKeyRow, [
+      "text",
+      "amount",
+      "active",
+      "none",
+      "nested",
+      "maybe",
+    ]);
+
+    expect(
+      key?.key({
+        text: "route",
+        amount: -0,
+        active: false,
+        none: null,
+        nested: { desk: "equities" },
+      }),
+    ).toBe(
+      groupedPublicKey([
+        ["text", presentPresenceKey('"route"')],
+        ["amount", presentPresenceKey("0")],
+        ["active", presentPresenceKey("false")],
+        ["none", presentPresenceKey("null")],
+        ["nested", presentPresenceKey('{"desk":"equities"}')],
+        ["maybe", missingPresenceKey],
+      ]),
+    );
+    expect(
+      key?.key({
+        text: "route",
+        amount: 1,
+        active: true,
+        none: null,
+        nested: { desk: "equities" },
+        maybe: undefined,
+      }),
+    ).toBe(
+      groupedPublicKey([
+        ["text", presentPresenceKey('"route"')],
+        ["amount", presentPresenceKey("1")],
+        ["active", presentPresenceKey("true")],
+        ["none", presentPresenceKey("null")],
+        ["nested", presentPresenceKey('{"desk":"equities"}')],
+        ["maybe", presentPresenceKey("null")],
+      ]),
+    );
+  });
+
+  it('keeps a missing value distinct from a present ["missing"] value', () => {
+    const key = compileGrpcGroupedPublicKey(GroupedKeyRow, ["maybeArray"]);
+    const missingKey = key?.key({});
+    const presentKey = key?.key({ maybeArray: ["missing"] });
+
+    expect(missingKey).toBe(groupedPublicKey([["maybeArray", missingPresenceKey]]));
+    expect(presentKey).toBe(groupedPublicKey([["maybeArray", presentPresenceKey('["missing"]')]]));
+    expect(presentKey).not.toBe(missingKey);
+  });
+
+  it("rejects missing schemas and synchronous codec compilation failures", () => {
+    const hostileField = new Proxy(Schema.String, {
+      get(target, property, receiver) {
+        if (property === "ast") {
+          throw new Error("codec compilation failed");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const hostileSchema = new Proxy(Schema.Struct({ value: Schema.String }), {
+      get(target, property, receiver) {
+        if (property === "fields") {
+          return { value: hostileField };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(compileGrpcGroupedPublicKey(GroupedKeyRow, ["missing"])).toBeUndefined();
+    expect(compileGrpcGroupedPublicKey(hostileSchema, ["value"])).toBeUndefined();
+  });
+
+  it("returns no key for codec, strict materialization, or row reflection failures", () => {
+    const stringKey = compileGrpcGroupedPublicKey(GroupedKeyRow, ["text"]);
+    const opaqueKey = compileGrpcGroupedPublicKey(GroupedKeyRow, ["opaque"]);
+    const hostileRow = new Proxy(
+      { text: "route" },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("row reflection failed");
+        },
+      },
+    );
+
+    expect(stringKey?.key({ text: 1 })).toBeUndefined();
+    expect(opaqueKey?.key({ opaque: new Map([["desk", "equities"]]) })).toBeUndefined();
+    expect(stringKey?.key(hostileRow)).toBeUndefined();
+  });
+
+  it("derives one public key for equivalent collision-node HashMap and HashSet values", () => {
+    const key = compileGrpcGroupedPublicKey(GroupedKeyRow, ["hashMap", "hashSet"]);
+    const collisionLeft = "8ocpIaaa";
+    const collisionRight = "GpcpIaaa";
+
+    expect(
+      key?.key({
+        hashMap: HashMap.make([collisionLeft, "left"], [collisionRight, "right"]),
+        hashSet: HashSet.make(collisionLeft, collisionRight),
+      }),
+    ).toBe(
+      key?.key({
+        hashMap: HashMap.make([collisionRight, "right"], [collisionLeft, "left"]),
+        hashSet: HashSet.make(collisionRight, collisionLeft),
+      }),
+    );
+  });
+});

--- a/packages/runtime/src/grpc-grouped-public-key.ts
+++ b/packages/runtime/src/grpc-grouped-public-key.ts
@@ -1,0 +1,44 @@
+import type { RowSchema } from "@effect-view-server/config";
+import {
+  compileGroupedKeyIdentity,
+  makeSchemaJsonIdentity,
+  type GroupedKeyIdentityField,
+} from "@effect-view-server/effect-utils";
+import { Result } from "effect";
+
+export type GrpcGroupedPublicKey = {
+  readonly key: (row: object) => string | undefined;
+};
+
+const compileGroupedKeyFields = (
+  schema: RowSchema,
+  groupBy: ReadonlyArray<string>,
+): ReadonlyArray<GroupedKeyIdentityField> | undefined => {
+  const fields: Array<GroupedKeyIdentityField> = [];
+  for (const field of groupBy) {
+    const fieldSchema = schema.fields[field];
+    if (fieldSchema === undefined) {
+      return undefined;
+    }
+    const compiled = Result.try(() => {
+      const identity = makeSchemaJsonIdentity(fieldSchema);
+      return {
+        field,
+        canonicalKey: identity.canonicalKey,
+      } satisfies GroupedKeyIdentityField;
+    });
+    if (Result.isFailure(compiled)) {
+      return undefined;
+    }
+    fields.push(compiled.success);
+  }
+  return fields;
+};
+
+export const compileGrpcGroupedPublicKey = (
+  schema: RowSchema,
+  groupBy: ReadonlyArray<string>,
+): GrpcGroupedPublicKey | undefined => {
+  const fields = compileGroupedKeyFields(schema, groupBy);
+  return fields === undefined ? undefined : compileGroupedKeyIdentity(fields, "undefined");
+};

--- a/packages/runtime/src/grpc-ingress.ts
+++ b/packages/runtime/src/grpc-ingress.ts
@@ -1,7 +1,8 @@
 import { type GrpcRuntimeClients, type ViewServerTopicConfig } from "@effect-view-server/config";
+import { validateDecodedRow } from "@effect-view-server/config/internal";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
 import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
-import { Cause, Clock, Effect, Exit, Fiber, Option, Schema, Scope, Stream } from "effect";
+import { Cause, Clock, Effect, Exit, Fiber, Option, Scope, Stream } from "effect";
 import type { ViewServerGrpcHealthLedger } from "./grpc-health";
 import {
   callMaterializedGrpcSourceAcquire,
@@ -227,7 +228,7 @@ const mapMaterializedValue = Effect.fn("ViewServerRuntime.grpc.materialized.map"
         topic: feed.topic,
       }),
   });
-  const decodedRow = yield* Schema.decodeUnknownEffect(topicDefinition.schema)(row).pipe(
+  const decodedRow = yield* validateDecodedRow(topicDefinition.schema, row).pipe(
     Effect.mapError((cause) =>
       grpcIngressError({
         message: `gRPC feed mapping produced an invalid row for ${feedName}`,

--- a/packages/runtime/src/grpc-lease-manager-cleanup.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-cleanup.test.ts
@@ -19,6 +19,27 @@ import {
 
 import type { GrpcOrderValueMessage } from "../test-harness/grpc-config";
 
+const cloneWithMutableOrdersGrpcSource = <
+  const Config extends {
+    readonly topics: {
+      readonly orders: {
+        readonly grpcSource: object;
+      };
+    };
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: {
+    ...config.topics,
+    orders: {
+      ...config.topics.orders,
+      grpcSource: { ...config.topics.orders.grpcSource },
+    },
+  },
+});
+
 describe("gRPC lease manager cleanup", () => {
   it.live(
     "rolls back a failed leased acquire when release defects and allows a fresh acquire",
@@ -91,9 +112,8 @@ describe("gRPC lease manager cleanup", () => {
           releaseCountAfterFreshClose,
           failedLeaseKeys: Object.keys(afterFailedAcquire.grpc?.feeds.orders?.leased ?? {}),
           freshSubscriberCount:
-            afterFreshAcquire.grpc?.feeds.orders?.leased[
-              "orders/orders/leased/region=string%3A3%3Ausa"
-            ]?.subscriberCount,
+            afterFreshAcquire.grpc?.feeds.orders?.leased["orders/orders/leased/region=%22usa%22"]
+              ?.subscriberCount,
           freshCloseSucceeded: Exit.isSuccess(freshCloseExit),
           managerCloseSucceeded: Exit.isSuccess(managerCloseExit),
         }).toStrictEqual({
@@ -114,12 +134,14 @@ describe("gRPC lease manager cleanup", () => {
     () =>
       Effect.gen(function* () {
         let released = 0;
-        const localViewServer = grpcLeasedViewServer({
-          streamForRegion: () => Stream.never,
-          release: Effect.sync(() => {
-            released += 1;
+        const localViewServer = cloneWithMutableOrdersGrpcSource(
+          grpcLeasedViewServer({
+            streamForRegion: () => Stream.never,
+            release: Effect.sync(() => {
+              released += 1;
+            }),
           }),
-        });
+        );
         Object.defineProperty(localViewServer.topics.orders.grpcSource, "request", {
           value: ({ region }: { readonly region: string }) => {
             Object.defineProperty(localViewServer.topics, "orders", {
@@ -173,12 +195,14 @@ describe("gRPC lease manager cleanup", () => {
     () =>
       Effect.gen(function* () {
         let released = 0;
-        const localViewServer = grpcLeasedViewServer({
-          streamForRegion: () => Stream.never,
-          release: Effect.sync(() => {
-            released += 1;
+        const localViewServer = cloneWithMutableOrdersGrpcSource(
+          grpcLeasedViewServer({
+            streamForRegion: () => Stream.never,
+            release: Effect.sync(() => {
+              released += 1;
+            }),
           }),
-        });
+        );
         Object.defineProperty(localViewServer.topics.orders.grpcSource, "request", {
           value: ({ region }: { readonly region: string }) => {
             Object.defineProperty(localViewServer.topics, "orders", {
@@ -229,10 +253,12 @@ describe("gRPC lease manager cleanup", () => {
 
   it.live("marks leased gRPC cleanup degraded when runtime topic disappears before close", () =>
     Effect.gen(function* () {
-      const localViewServer = grpcLeasedViewServer({
-        streamForRegion: (region) =>
-          longRunningGrpcStream([grpcOrderValue(`${region}-order-1`, 10)]),
-      });
+      const localViewServer = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: (region) =>
+            longRunningGrpcStream([grpcOrderValue(`${region}-order-1`, 10)]),
+        }),
+      );
       const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
       const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
@@ -256,7 +282,7 @@ describe("gRPC lease manager cleanup", () => {
       const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
 
       expect(
-        currentHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+        currentHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
           ?.lastError,
       ).toBe("gRPC leased feed row cleanup failed for orders");
       yield* manager.close;
@@ -409,14 +435,14 @@ describe("gRPC lease manager cleanup", () => {
       expect({
         released,
         leasedFeed:
-          idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"],
+          idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"],
       }).toStrictEqual({
         released: 1,
         leasedFeed: {
           status: "degraded",
           lifecycle: "leased",
           feedName: "orders",
-          feedKey: "orders/orders/leased/region=string%3A3%3Ausa",
+          feedKey: "orders/orders/leased/region=%22usa%22",
           topic: "orders",
           subscriberCount: 0,
           rowCount: 1,
@@ -427,7 +453,7 @@ describe("gRPC lease manager cleanup", () => {
           publishFailuresPerSecond: 0,
           reconnects: 0,
           lastMessageAt:
-            idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+            idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
               ?.lastMessageAt,
           lastError: "gRPC leased feed row cleanup failed for orders",
         },
@@ -476,14 +502,14 @@ describe("gRPC lease manager cleanup", () => {
       expect({
         released,
         leasedFeed:
-          idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"],
+          idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"],
       }).toStrictEqual({
         released: 1,
         leasedFeed: {
           status: "degraded",
           lifecycle: "leased",
           feedName: "orders",
-          feedKey: "orders/orders/leased/region=string%3A3%3Ausa",
+          feedKey: "orders/orders/leased/region=%22usa%22",
           topic: "orders",
           subscriberCount: 0,
           rowCount: 1,
@@ -494,7 +520,7 @@ describe("gRPC lease manager cleanup", () => {
           publishFailuresPerSecond: 0,
           reconnects: 0,
           lastMessageAt:
-            idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+            idleHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
               ?.lastMessageAt,
           lastError: "gRPC leased feed row cleanup failed for orders",
         },
@@ -507,10 +533,12 @@ describe("gRPC lease manager cleanup", () => {
   it.live("cleans a leased gRPC feed when mapped rows have a non-string row key", () =>
     Effect.gen(function* () {
       const firstValue = yield* Deferred.make<GrpcOrderValueMessage>();
-      const localViewServer = grpcLeasedViewServer({
-        streamForRegion: () =>
-          Stream.fromEffect(Deferred.await(firstValue)).pipe(Stream.concat(Stream.never)),
-      });
+      const localViewServer = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: () =>
+            Stream.fromEffect(Deferred.await(firstValue)).pipe(Stream.concat(Stream.never)),
+        }),
+      );
       const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
       const degradationMessages: Array<string> = [];
@@ -727,10 +755,12 @@ describe("gRPC lease manager cleanup", () => {
 
   it.live("closes leased gRPC feeds when release callback returns a non-Effect", () =>
     Effect.gen(function* () {
-      const feed = grpcLeasedViewServer({
-        streamForRegion: (region) =>
-          longRunningGrpcStream([grpcOrderValue(`${region}-order-1`, 10)]),
-      });
+      const feed = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: (region) =>
+            longRunningGrpcStream([grpcOrderValue(`${region}-order-1`, 10)]),
+        }),
+      );
       Object.defineProperty(feed.topics.orders.grpcSource, "release", {
         value: () => "not-an-effect",
       });
@@ -1123,13 +1153,12 @@ describe("gRPC lease manager cleanup", () => {
         Effect.repeat({
           schedule: Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
           until: (currentHealth) =>
-            currentHealth.grpc?.feeds["orders"]?.leased[
-              "orders/orders/leased/region=string%3A3%3Ausa"
-            ]?.rowCount === 1,
+            currentHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
+              ?.rowCount === 1,
         }),
       );
       expect(
-        degradedHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+        degradedHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
           ?.lastError,
       ).toContain("gRPC leased feed row cleanup failed for orders");
 

--- a/packages/runtime/src/grpc-lease-manager-grouped-public-keys.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-grouped-public-keys.test.ts
@@ -1,0 +1,652 @@
+import { describe, expect, it } from "@effect/vitest";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import type { ViewServerRuntimeCoreInternalLiveClient } from "@effect-view-server/runtime-core/internal";
+import { Deferred, Effect, Fiber, Queue, Stream } from "effect";
+import { makeViewServerGrpcHealthLedger } from "./grpc-health";
+import type { GrpcGroupedKeyRetentionView } from "./grpc-grouped-key-translations";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+import { makeDefaultGrpcClient } from "./grpc-source-lifecycle";
+
+import { grpcOrderValue } from "../test-harness/grpc-config";
+import { grpcGroupedKeyEncodingLeasedViewServer } from "../test-harness/grpc-grouped";
+import {
+  grpcLeasedViewServer,
+  leasedGrpcViewServer,
+  longRunningGrpcStream,
+  makeLeasedGrpcHealth,
+  routeEncodingValues,
+} from "../test-harness/grpc-leased";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+
+const presentGroupedFieldKey = (field: string, canonicalKey: string): string =>
+  JSON.stringify([[field, JSON.stringify(["present", canonicalKey])]]);
+
+const groupedPublicKey = (
+  fields: ReadonlyArray<readonly [field: string, canonicalKey: string]>,
+): string =>
+  JSON.stringify(
+    fields.map(([field, canonicalKey]) => [field, JSON.stringify(["present", canonicalKey])]),
+  );
+
+describe("gRPC lease manager grouped public-key translation and retention", () => {
+  it.live("externalizes grouped leased gRPC keys that include the topic key field", () =>
+    Effect.gen(function* () {
+      const feed = grpcLeasedViewServer({
+        streamForRegion: (region) =>
+          longRunningGrpcStream([
+            grpcOrderValue(`${region}-order-1`, 10),
+            grpcOrderValue(`${region}-order-2`, 20),
+          ]),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const first = yield* manager.liveClient.subscribe("orders", {
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const firstEventQueue = yield* Queue.unbounded<unknown>();
+      const firstEventsFiber = yield* first.events.pipe(
+        Stream.runForEach((event) => Queue.offer(firstEventQueue, event)),
+        Effect.forkChild,
+      );
+      const firstSnapshot = yield* Queue.take(firstEventQueue);
+      const firstDelta = yield* Queue.take(firstEventQueue);
+      const second = yield* manager.liveClient.subscribe("orders", {
+        groupBy: ["id"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const secondEvents = yield* second.events.pipe(Stream.take(1), Stream.runCollect);
+      const firstPublicGroupKey = presentGroupedFieldKey("id", '"usa:usa-order-1"');
+      const secondPublicGroupKey = presentGroupedFieldKey("id", '"usa:usa-order-2"');
+
+      expect(firstSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-0",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
+      });
+      expect(firstDelta).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "insert",
+            key: firstPublicGroupKey,
+            row: {
+              id: "usa:usa-order-1",
+              rowCount: 1n,
+            },
+            index: 0,
+          },
+          {
+            type: "insert",
+            key: secondPublicGroupKey,
+            row: {
+              id: "usa:usa-order-2",
+              rowCount: 1n,
+            },
+            index: 1,
+          },
+        ],
+        totalRows: 2,
+      });
+      expect(secondEvents[0]).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-1",
+        version: 1,
+        keys: [firstPublicGroupKey, secondPublicGroupKey],
+        rows: [
+          {
+            id: "usa:usa-order-1",
+            rowCount: 1n,
+          },
+          {
+            id: "usa:usa-order-2",
+            rowCount: 1n,
+          },
+        ],
+        totalRows: 2,
+      });
+
+      yield* first.close();
+      yield* second.close();
+      yield* Fiber.interrupt(firstEventsFiber);
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("externalizes grouped leased gRPC route values with public grouped keys", () =>
+    Effect.gen(function* () {
+      const feed = grpcGroupedKeyEncodingLeasedViewServer({
+        acquire: () =>
+          Stream.make(
+            grpcOrderValue("route-encoding-1", 10),
+            grpcOrderValue("route-encoding-2", 20),
+            grpcOrderValue("route-encoding-3", 30),
+          ),
+        map: (value) => ({
+          id: value.customerId,
+          ...routeEncodingValues,
+          meta: {
+            desk: value.price === 30 ? "credit" : value.price === 20 ? "rates" : "equities",
+          },
+          tags:
+            value.price === 30
+              ? ["unsupported"]
+              : value.price === 20
+                ? ["slow", "shared"]
+                : routeEncodingValues.tags,
+          weird: null,
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
+        clients: {
+          orders: "https://orders.example.test",
+        },
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: [
+          "amount",
+          "count",
+          "disabled",
+          "flag",
+          "none",
+          "plainScore",
+          "score",
+          "text",
+          "weird",
+          "meta",
+          "tags",
+        ],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          text: { eq: routeEncodingValues.text },
+        },
+        limit: 10,
+      });
+      const deltaEvents = yield* subscription.events.pipe(
+        Stream.filter((event) => event.type === "delta"),
+        Stream.take(4),
+        Stream.runCollect,
+      );
+      const commonGroupedKeyFields = [
+        ["amount", '"123.45"'],
+        ["count", '"9007199254740993"'],
+        ["disabled", "false"],
+        ["flag", "true"],
+        ["none", "null"],
+        ["plainScore", "42"],
+        ["score", "0"],
+        ["text", '"route"'],
+        ["weird", "null"],
+      ] satisfies ReadonlyArray<readonly [string, string]>;
+      const publicGroupedKeyOne = groupedPublicKey([
+        ...commonGroupedKeyFields,
+        ["meta", '{"desk":"equities"}'],
+        ["tags", '["fast","shared"]'],
+      ]);
+      const publicGroupedKeyTwo = groupedPublicKey([
+        ...commonGroupedKeyFields,
+        ["meta", '{"desk":"rates"}'],
+        ["tags", '["slow","shared"]'],
+      ]);
+      const publicGroupedKeyThree = groupedPublicKey([
+        ...commonGroupedKeyFields,
+        ["meta", '{"desk":"credit"}'],
+        ["tags", '["unsupported"]'],
+      ]);
+
+      expect(deltaEvents[0]).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "insert",
+            key: publicGroupedKeyThree,
+            row: {
+              amount: routeEncodingValues.amount,
+              count: routeEncodingValues.count,
+              disabled: routeEncodingValues.disabled,
+              flag: routeEncodingValues.flag,
+              none: routeEncodingValues.none,
+              plainScore: routeEncodingValues.plainScore,
+              score: 0,
+              text: routeEncodingValues.text,
+              weird: null,
+              meta: {
+                desk: "credit",
+              },
+              tags: ["unsupported"],
+              rowCount: 1n,
+            },
+            index: 0,
+          },
+          {
+            type: "insert",
+            key: publicGroupedKeyOne,
+            row: {
+              amount: routeEncodingValues.amount,
+              count: routeEncodingValues.count,
+              disabled: routeEncodingValues.disabled,
+              flag: routeEncodingValues.flag,
+              none: routeEncodingValues.none,
+              plainScore: routeEncodingValues.plainScore,
+              score: 0,
+              text: routeEncodingValues.text,
+              weird: null,
+              meta: routeEncodingValues.meta,
+              tags: routeEncodingValues.tags,
+              rowCount: 1n,
+            },
+            index: 1,
+          },
+          {
+            type: "insert",
+            key: publicGroupedKeyTwo,
+            row: {
+              amount: routeEncodingValues.amount,
+              count: routeEncodingValues.count,
+              disabled: routeEncodingValues.disabled,
+              flag: routeEncodingValues.flag,
+              none: routeEncodingValues.none,
+              plainScore: routeEncodingValues.plainScore,
+              score: 0,
+              text: routeEncodingValues.text,
+              weird: null,
+              meta: {
+                desk: "rates",
+              },
+              tags: ["slow", "shared"],
+              rowCount: 1n,
+            },
+            index: 2,
+          },
+        ],
+        totalRows: 3,
+      });
+      expect(deltaEvents[1]).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          {
+            type: "remove",
+            key: publicGroupedKeyOne,
+          },
+        ],
+        totalRows: 2,
+      });
+      expect(deltaEvents[2]).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 2,
+        toVersion: 3,
+        operations: [
+          {
+            type: "remove",
+            key: publicGroupedKeyTwo,
+          },
+        ],
+        totalRows: 1,
+      });
+      expect(deltaEvents[3]).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: publicGroupedKeyThree,
+          },
+        ],
+        totalRows: 0,
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("bounds grouped-key translations to each leased subscription lifetime", () =>
+    Effect.gen(function* () {
+      const churnRows = Array.from({ length: 64 }, (_, index) => ({
+        customerId: `customer-${index}`,
+        rowCount: 1n,
+      }));
+      const churnInternalKeys = churnRows.map((_row, index) => `customer-internal-${index}`);
+      const removalOperations: ReadonlyArray<{ readonly type: "remove"; readonly key: string }> =
+        churnInternalKeys.slice(1).map((key) => ({ type: "remove", key }));
+      const replacementRows = [
+        { customerId: "replacement-a", rowCount: 1n },
+        { customerId: "replacement-b", rowCount: 1n },
+      ];
+      const replacementInternalKeys = ["replacement-internal-a", "replacement-internal-b"];
+      const customerSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "customer-groups",
+        version: 0,
+        keys: churnInternalKeys,
+        rows: churnRows,
+        totalRows: churnRows.length,
+      } as const;
+      const customerRemovalDelta = {
+        type: "delta",
+        topic: "orders",
+        queryId: "customer-groups",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: removalOperations,
+        totalRows: 1,
+      } as const;
+      const customerReplacementSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "customer-groups",
+        version: 2,
+        keys: replacementInternalKeys,
+        rows: replacementRows,
+        totalRows: replacementRows.length,
+      } as const;
+      const statusSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "status-groups",
+        version: 0,
+        keys: ["status-internal-open"],
+        rows: [{ status: "open", rowCount: 64n }],
+        totalRows: 1,
+      } as const;
+      const statusMoveDelta = {
+        type: "delta",
+        topic: "orders",
+        queryId: "status-groups",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "update",
+            key: "status-internal-open",
+            row: { status: "open", rowCount: 65n },
+            index: 0,
+          },
+          {
+            type: "move",
+            key: "status-internal-open",
+            fromIndex: 0,
+            toIndex: 0,
+          },
+        ],
+        totalRows: 1,
+      } as const;
+      const publicGroupedStringKey = (field: string, value: string): string =>
+        presentGroupedFieldKey(field, JSON.stringify(value));
+      const releaseCustomerRemovals = yield* Deferred.make<void>();
+      const releaseCustomerReplacement = yield* Deferred.make<void>();
+      const releaseStatusMove = yield* Deferred.make<void>();
+      const retentionViews: Array<GrpcGroupedKeyRetentionView> = [];
+      const feed = grpcLeasedViewServer({
+        streamForRegion: () => Stream.never,
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+
+      yield* Effect.acquireUseRelease(
+        makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {}),
+        (runtimeCore) => {
+          let subscriptionIndex = 0;
+          const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+            typeof leasedGrpcViewServer.topics
+          > = {
+            ...runtimeCore.internalLiveClient,
+            subscribeRuntimeObservedInternal: (_topic, _query, observer) => {
+              if (subscriptionIndex === 0) {
+                subscriptionIndex += 1;
+                return observer.onQueryRegistered(customerSnapshot.queryId).pipe(
+                  Effect.as({
+                    events: Stream.make(customerSnapshot).pipe(
+                      Stream.concat(
+                        Stream.fromEffect(
+                          Deferred.await(releaseCustomerRemovals).pipe(
+                            Effect.as(customerRemovalDelta),
+                          ),
+                        ),
+                      ),
+                      Stream.concat(
+                        Stream.fromEffect(
+                          Deferred.await(releaseCustomerReplacement).pipe(
+                            Effect.as(customerReplacementSnapshot),
+                          ),
+                        ),
+                      ),
+                      Stream.concat(Stream.never),
+                    ),
+                    close: () => Effect.void,
+                  }),
+                );
+              }
+              subscriptionIndex += 1;
+              return observer.onQueryRegistered(statusSnapshot.queryId).pipe(
+                Effect.as({
+                  events: Stream.make(statusSnapshot).pipe(
+                    Stream.concat(
+                      Stream.fromEffect(
+                        Deferred.await(releaseStatusMove).pipe(Effect.as(statusMoveDelta)),
+                      ),
+                    ),
+                    Stream.concat(Stream.never),
+                  ),
+                  close: () => Effect.void,
+                }),
+              );
+            },
+          };
+          const health = makeLeasedGrpcHealth(grpcOptions);
+          return Effect.acquireUseRelease(
+            makeViewServerGrpcLeaseManager(
+              grpcOptions.sourceConfig,
+              runtimeCore.internalClient,
+              runtimeCore.liveClient,
+              fakeInternalLiveClient,
+              Effect.void,
+              grpcOptions,
+              health,
+              makeDefaultGrpcClient,
+              (retention) => {
+                retentionViews.push(retention);
+              },
+            ),
+            (manager) =>
+              Effect.acquireUseRelease(
+                manager.liveClient.subscribeRuntime("orders", {
+                  groupBy: ["customerId"],
+                  aggregates: {
+                    rowCount: { aggFunc: "count" },
+                  },
+                  where: {
+                    region: { eq: "usa" },
+                  },
+                  limit: 100,
+                }),
+                (customerSubscription) =>
+                  Effect.acquireUseRelease(
+                    manager.liveClient.subscribeRuntime("orders", {
+                      groupBy: ["status"],
+                      aggregates: {
+                        rowCount: { aggFunc: "count" },
+                      },
+                      where: {
+                        region: { eq: "usa" },
+                      },
+                      limit: 10,
+                    }),
+                    (statusSubscription) =>
+                      Effect.gen(function* () {
+                        const customerRetention = yield* Effect.fromNullishOr(retentionViews[0]);
+                        const statusRetention = yield* Effect.fromNullishOr(retentionViews[1]);
+                        const customerEventQueue = yield* Queue.unbounded<unknown>();
+                        const customerEventsFiber = yield* customerSubscription.events.pipe(
+                          Stream.runForEach((event) => Queue.offer(customerEventQueue, event)),
+                          Effect.forkChild({ startImmediately: true }),
+                        );
+                        const customerSnapshotEvent = yield* Queue.take(customerEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(customerRetention.retainedEntryCount()).toBe(64);
+
+                        yield* Deferred.succeed(releaseCustomerRemovals, undefined);
+                        const customerRemovalEvent = yield* Queue.take(customerEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(customerRetention.retainedEntryCount()).toBe(1);
+
+                        yield* Deferred.succeed(releaseCustomerReplacement, undefined);
+                        const customerReplacementEvent = yield* Queue.take(customerEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(customerRetention.retainedEntryCount()).toBe(2);
+                        const customerEvents = [
+                          customerSnapshotEvent,
+                          customerRemovalEvent,
+                          customerReplacementEvent,
+                        ];
+                        const statusEventQueue = yield* Queue.unbounded<unknown>();
+                        const statusEventsFiber = yield* statusSubscription.events.pipe(
+                          Stream.runForEach((event) => Queue.offer(statusEventQueue, event)),
+                          Effect.forkChild({ startImmediately: true }),
+                        );
+                        const statusSnapshotEvent = yield* Queue.take(statusEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        expect(statusRetention.retainedEntryCount()).toBe(1);
+
+                        yield* customerSubscription.close();
+                        yield* Fiber.interrupt(customerEventsFiber);
+                        expect(customerRetention.retainedEntryCount()).toBe(0);
+                        yield* Deferred.succeed(releaseStatusMove, undefined);
+                        const statusMoveEvent = yield* Queue.take(statusEventQueue).pipe(
+                          Effect.timeout("1 second"),
+                        );
+                        const statusEvents = [statusSnapshotEvent, statusMoveEvent];
+
+                        expect(customerEvents).toStrictEqual([
+                          {
+                            ...customerSnapshot,
+                            keys: churnRows.map((row) =>
+                              publicGroupedStringKey("customerId", row.customerId),
+                            ),
+                          },
+                          {
+                            ...customerRemovalDelta,
+                            operations: churnRows.slice(1).map((row) => ({
+                              type: "remove",
+                              key: publicGroupedStringKey("customerId", row.customerId),
+                            })),
+                          },
+                          {
+                            ...customerReplacementSnapshot,
+                            keys: replacementRows.map((row) =>
+                              publicGroupedStringKey("customerId", row.customerId),
+                            ),
+                          },
+                        ]);
+                        expect(statusEvents).toStrictEqual([
+                          {
+                            ...statusSnapshot,
+                            keys: [publicGroupedStringKey("status", "open")],
+                          },
+                          {
+                            ...statusMoveDelta,
+                            operations: [
+                              {
+                                ...statusMoveDelta.operations[0],
+                                key: publicGroupedStringKey("status", "open"),
+                              },
+                              {
+                                ...statusMoveDelta.operations[1],
+                                key: publicGroupedStringKey("status", "open"),
+                              },
+                            ],
+                          },
+                        ]);
+                        yield* manager.close;
+                        expect(statusRetention.retainedEntryCount()).toBe(0);
+                        expect(customerRetention.retainedEntryCount()).toBe(0);
+                        yield* manager.close;
+                        expect(statusRetention.retainedEntryCount()).toBe(0);
+                        yield* Fiber.interrupt(statusEventsFiber);
+                      }).pipe(
+                        Effect.ensuring(
+                          Deferred.succeed(releaseCustomerRemovals, undefined).pipe(
+                            Effect.andThen(Deferred.succeed(releaseCustomerReplacement, undefined)),
+                            Effect.andThen(Deferred.succeed(releaseStatusMove, undefined)),
+                          ),
+                        ),
+                      ),
+                    (subscription) => subscription.close(),
+                  ),
+                (subscription) => subscription.close(),
+              ),
+            (manager) => manager.close,
+          );
+        },
+        (runtimeCore) => runtimeCore.close,
+      );
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-lease-manager-grouped-query.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-grouped-query.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "@effect/vitest";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import { Effect, Fiber, Queue, Stream } from "effect";
+import * as BigDecimal from "effect/BigDecimal";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+
+import { grpcOrderValue } from "../test-harness/grpc-config";
+import {
+  grpcLeasedViewServer,
+  longRunningGrpcStream,
+  makeLeasedGrpcHealth,
+} from "../test-harness/grpc-leased";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+
+const presentGroupedFieldKey = (field: string, canonicalKey: string): string =>
+  JSON.stringify([[field, JSON.stringify(["present", canonicalKey])]]);
+
+describe("gRPC lease manager grouped query behavior", () => {
+  it.live("shares leased gRPC feeds while applying grouped queries locally", () =>
+    Effect.gen(function* () {
+      let acquired = 0;
+      const feed = grpcLeasedViewServer({
+        acquired: () => {
+          acquired += 1;
+        },
+        streamForRegion: (region) =>
+          longRunningGrpcStream([
+            grpcOrderValue(`${region}-order-1`, 10),
+            grpcOrderValue(`${region}-order-2`, 20),
+          ]),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const first = yield* manager.liveClient.subscribe("orders", {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        orderBy: [{ field: "status", direction: "asc" }],
+        limit: 10,
+      });
+      const firstEventQueue = yield* Queue.unbounded<unknown>();
+      const firstEventsFiber = yield* first.events.pipe(
+        Stream.runForEach((event) => Queue.offer(firstEventQueue, event)),
+        Effect.forkChild,
+      );
+      const firstSnapshot = yield* Queue.take(firstEventQueue);
+      const firstDelta = yield* Queue.take(firstEventQueue);
+      const openStatusGroupKey = presentGroupedFieldKey("status", '"open"');
+      const second = yield* manager.liveClient.subscribe("orders", {
+        groupBy: ["status"],
+        aggregates: {
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+        limit: 10,
+      });
+      const secondEvents = yield* second.events.pipe(Stream.take(1), Stream.runCollect);
+
+      expect(acquired).toBe(1);
+      expect(firstSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-0",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
+      });
+      expect(firstDelta).toStrictEqual({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-0",
+        fromVersion: 0,
+        toVersion: 1,
+        operations: [
+          {
+            type: "insert",
+            key: openStatusGroupKey,
+            row: {
+              status: "open",
+              rowCount: 2n,
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 1,
+      });
+      expect(secondEvents[0]).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-1",
+        version: 1,
+        keys: [openStatusGroupKey],
+        rows: [
+          {
+            status: "open",
+            totalPrice: BigDecimal.fromStringUnsafe("30"),
+          },
+        ],
+        totalRows: 1,
+      });
+      yield* first.close();
+      yield* second.close();
+      yield* Fiber.interrupt(firstEventsFiber);
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-lease-manager-grouped-semantic-identity.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-grouped-semantic-identity.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect, it } from "@effect/vitest";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import type { ViewServerRuntimeCoreInternalLiveClient } from "@effect-view-server/runtime-core/internal";
+import { Effect, Fiber, Queue, Stream } from "effect";
+import { makeViewServerGrpcHealthLedger } from "./grpc-health";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+
+import { grpcOrderValue } from "../test-harness/grpc-config";
+import {
+  grpcGroupedKeyEncodingLeasedViewServer,
+  grpcSemanticGroupedKeyLeasedViewServer,
+  semanticGroupedKeyValues,
+} from "../test-harness/grpc-grouped";
+import {
+  grpcLeasedViewServer,
+  leasedGrpcViewServer,
+  longRunningGrpcStream,
+  makeLeasedGrpcHealth,
+  routeEncodingValues,
+} from "../test-harness/grpc-leased";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+
+const groupedPublicKey = (
+  fields: ReadonlyArray<readonly [field: string, canonicalKey: string]>,
+): string =>
+  JSON.stringify(
+    fields.map(([field, canonicalKey]) => [field, JSON.stringify(["present", canonicalKey])]),
+  );
+
+const semanticGroupedPublicKey = groupedPublicKey([
+  ["semanticClass", '{"value":"class-value"}'],
+  ["semanticOption", '{"_tag":"Some","value":"option-value"}'],
+  ["semanticChunk", '["chunk-a","chunk-b"]'],
+  ["semanticHashMap", '[["alpha","one"],["beta","two"]]'],
+  ["semanticPlain", '"plain-value"'],
+]);
+
+const semanticGroupedPlainValue = "plain-value";
+
+const missingOptionalGroupedPublicKey = JSON.stringify([
+  ["optionalValue", JSON.stringify(["missing"])],
+]);
+
+const presentUndefinedGroupedPublicKey = JSON.stringify([
+  ["optionalValue", JSON.stringify(["present", "null"])],
+]);
+
+describe("gRPC lease manager semantic route and grouped identity", () => {
+  it.live("externalizes semantic grouped keys in leased gRPC delta events", () =>
+    Effect.gen(function* () {
+      const semanticValues = semanticGroupedKeyValues();
+      const feed = grpcSemanticGroupedKeyLeasedViewServer({
+        acquire: () => longRunningGrpcStream([grpcOrderValue("route-encoding-1", 10)]),
+        map: (value) => ({
+          id: value.customerId,
+          text: routeEncodingValues.text,
+          ...semanticValues,
+          semanticPlain: semanticGroupedPlainValue,
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
+        clients: {
+          orders: "https://orders.example.test",
+        },
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: [
+          "semanticClass",
+          "semanticOption",
+          "semanticChunk",
+          "semanticHashMap",
+          "semanticPlain",
+        ],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          text: { eq: routeEncodingValues.text },
+        },
+        limit: 10,
+      });
+      const events = yield* subscription.events.pipe(Stream.take(2), Stream.runCollect);
+
+      expect(events).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 0,
+          toVersion: 1,
+          operations: [
+            {
+              type: "insert",
+              key: semanticGroupedPublicKey,
+              row: {
+                ...semanticValues,
+                rowCount: 1n,
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        },
+      ]);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("externalizes semantic grouped keys in leased gRPC snapshots", () =>
+    Effect.gen(function* () {
+      const semanticValues = semanticGroupedKeyValues();
+      const feed = grpcSemanticGroupedKeyLeasedViewServer({
+        acquire: () => longRunningGrpcStream([grpcOrderValue("route-encoding-1", 10)]),
+        map: (value) => ({
+          id: value.customerId,
+          text: routeEncodingValues.text,
+          ...semanticValues,
+          semanticPlain: semanticGroupedPlainValue,
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
+        clients: {
+          orders: "https://orders.example.test",
+        },
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const rawSubscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        select: [
+          "id",
+          "semanticClass",
+          "semanticOption",
+          "semanticChunk",
+          "semanticHashMap",
+          "semanticPlain",
+        ],
+        where: {
+          text: { eq: routeEncodingValues.text },
+        },
+        limit: 10,
+      });
+      const rawEventQueue = yield* Queue.unbounded<unknown>();
+      const rawEventsFiber = yield* rawSubscription.events.pipe(
+        Stream.runForEach((event) => Queue.offer(rawEventQueue, event)),
+        Effect.forkChild,
+      );
+      const rawSnapshot = yield* Queue.take(rawEventQueue);
+      const rawDelta = yield* Queue.take(rawEventQueue);
+      const groupedSubscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: [
+          "semanticClass",
+          "semanticOption",
+          "semanticChunk",
+          "semanticHashMap",
+          "semanticPlain",
+        ],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          text: { eq: routeEncodingValues.text },
+        },
+        limit: 10,
+      });
+      const groupedEvents = yield* groupedSubscription.events.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+      );
+
+      expect([rawSnapshot, rawDelta]).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 0,
+          toVersion: 1,
+          operations: [
+            {
+              type: "insert",
+              key: "route-encoding-1",
+              row: {
+                id: "route-encoding-1",
+                ...semanticValues,
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        },
+      ]);
+      expect(groupedEvents).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-1",
+          version: 1,
+          keys: [semanticGroupedPublicKey],
+          rows: [
+            {
+              ...semanticValues,
+              rowCount: 1n,
+            },
+          ],
+          totalRows: 1,
+        },
+      ]);
+      yield* rawSubscription.close();
+      yield* groupedSubscription.close();
+      yield* Fiber.interrupt(rawEventsFiber);
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("keeps missing and present undefined leased gRPC grouped keys distinct", () =>
+    Effect.gen(function* () {
+      const semanticValues = semanticGroupedKeyValues();
+      const feed = grpcSemanticGroupedKeyLeasedViewServer({
+        acquire: () =>
+          longRunningGrpcStream([
+            grpcOrderValue("missing-optional", 10),
+            grpcOrderValue("present-undefined", 20),
+          ]),
+        map: (value) =>
+          value.price === 10
+            ? {
+                id: value.customerId,
+                text: routeEncodingValues.text,
+                ...semanticValues,
+                semanticPlain: semanticGroupedPlainValue,
+              }
+            : {
+                id: value.customerId,
+                text: routeEncodingValues.text,
+                ...semanticValues,
+                semanticPlain: semanticGroupedPlainValue,
+                optionalValue: undefined,
+              },
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
+        clients: {
+          orders: "https://orders.example.test",
+        },
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["optionalValue"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          text: { eq: routeEncodingValues.text },
+        },
+        limit: 10,
+      });
+      const events = yield* subscription.events.pipe(Stream.take(2), Stream.runCollect);
+
+      expect(events).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 0,
+          toVersion: 1,
+          operations: [
+            {
+              type: "insert",
+              key: missingOptionalGroupedPublicKey,
+              row: {
+                rowCount: 1n,
+              },
+              index: 0,
+            },
+            {
+              type: "insert",
+              key: presentUndefinedGroupedPublicKey,
+              row: {
+                optionalValue: undefined,
+                rowCount: 1n,
+              },
+              index: 1,
+            },
+          ],
+          totalRows: 2,
+        },
+      ]);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("turns grouped row reflection failures into the stable public-key error status", () =>
+    Effect.gen(function* () {
+      const hostileGroupedRow = new Proxy(
+        {
+          customerId: "customer-1",
+          rowCount: 1n,
+        },
+        {
+          getOwnPropertyDescriptor() {
+            throw new Error("grouped row reflection failed");
+          },
+        },
+      );
+      const internalSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "hostile-grouped-row",
+        version: 0,
+        keys: ["internal-group"],
+        rows: [hostileGroupedRow],
+        totalRows: 1,
+      } as const;
+      const feed = grpcLeasedViewServer({
+        streamForRegion: () => Stream.never,
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof leasedGrpcViewServer.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(internalSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(internalSnapshot),
+              close: () => Effect.void,
+            }),
+          ),
+      };
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["customerId"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: "usa" },
+        },
+        limit: 10,
+      });
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+
+      expect(events).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "hostile-grouped-row",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "Leased gRPC grouped key value cannot be encoded as a stable public key",
+        },
+      ]);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("turns non-materializable canonical grouped values into the stable error status", () =>
+    Effect.gen(function* () {
+      const internalSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "non-materializable-grouped-value",
+        version: 0,
+        keys: ["internal-group"],
+        rows: [{ weird: new Map([["desk", "equities"]]), rowCount: 1n }],
+        totalRows: 1,
+      } as const;
+      const feed = grpcGroupedKeyEncodingLeasedViewServer({
+        acquire: () => Stream.never,
+        map: () => ({
+          id: "unused",
+          ...routeEncodingValues,
+        }),
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+        typeof grpcOptions.sourceConfig.topics
+      > = {
+        ...runtimeCore.internalLiveClient,
+        subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+          observer.onQueryRegistered(internalSnapshot.queryId).pipe(
+            Effect.as({
+              events: Stream.make(internalSnapshot),
+              close: () => Effect.void,
+            }),
+          ),
+      };
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        fakeInternalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        groupBy: ["weird"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          text: { eq: routeEncodingValues.text },
+        },
+        limit: 10,
+      });
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+
+      expect(events).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "non-materializable-grouped-value",
+          status: "error",
+          code: "RuntimeUnavailable",
+          message: "Leased gRPC grouped key value cannot be encoded as a stable public key",
+        },
+      ]);
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-lease-manager-large-grouped-snapshot.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-large-grouped-snapshot.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "@effect/vitest";
+import type { ViewServerLiveEvent } from "@effect-view-server/client";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import type { ViewServerRuntimeCoreInternalLiveClient } from "@effect-view-server/runtime-core/internal";
+import { Effect, Stream } from "effect";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+
+import {
+  grpcLeasedViewServer,
+  leasedGrpcViewServer,
+  makeLeasedGrpcHealth,
+} from "../test-harness/grpc-leased";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+
+const presentGroupedFieldKey = (field: string, canonicalKey: string): string =>
+  JSON.stringify([[field, JSON.stringify(["present", canonicalKey])]]);
+
+describe("gRPC lease manager large grouped snapshots", () => {
+  it.live("externalizes a 200,000-row grouped snapshot without caller-side spread limits", () =>
+    Effect.gen(function* () {
+      const cardinality = 200_000;
+      const midpoint = Math.floor(cardinality / 2);
+      const internalKeys = Array.from(
+        { length: cardinality },
+        (_value, index) => "customer-internal-" + index,
+      );
+      const rows = Array.from({ length: cardinality }, (_value, index) => ({
+        customerId: "customer-" + index,
+        rowCount: 1n,
+      }));
+      const internalSnapshot = {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "large-customer-groups",
+        version: 0,
+        keys: internalKeys,
+        rows,
+        totalRows: cardinality,
+      } as const;
+      const publicGroupedCustomerKey = (customerId: string): string =>
+        presentGroupedFieldKey("customerId", JSON.stringify(customerId));
+      const feed = grpcLeasedViewServer({
+        streamForRegion: () => Stream.never,
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+
+      yield* Effect.acquireUseRelease(
+        makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {}),
+        (runtimeCore) => {
+          const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
+            typeof leasedGrpcViewServer.topics
+          > = {
+            ...runtimeCore.internalLiveClient,
+            subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
+              observer.onQueryRegistered(internalSnapshot.queryId).pipe(
+                Effect.as({
+                  events: Stream.make(internalSnapshot).pipe(Stream.concat(Stream.never)),
+                  close: () => Effect.void,
+                }),
+              ),
+          };
+          const health = makeLeasedGrpcHealth(grpcOptions);
+
+          return Effect.acquireUseRelease(
+            makeViewServerGrpcLeaseManager(
+              grpcOptions.sourceConfig,
+              runtimeCore.internalClient,
+              runtimeCore.liveClient,
+              fakeInternalLiveClient,
+              Effect.void,
+              grpcOptions,
+              health,
+            ),
+            (manager) =>
+              Effect.acquireUseRelease(
+                manager.liveClient.subscribeRuntime("orders", {
+                  groupBy: ["customerId"],
+                  aggregates: {
+                    rowCount: { aggFunc: "count" },
+                  },
+                  where: {
+                    region: { eq: "usa" },
+                  },
+                  limit: cardinality,
+                }),
+                (subscription) =>
+                  Effect.gen(function* () {
+                    const firstEventOption = yield* Stream.runHead(subscription.events);
+                    const firstEvent: ViewServerLiveEvent<object> =
+                      yield* Effect.fromOption(firstEventOption);
+                    const snapshot = yield* Effect.succeed(firstEvent).pipe(
+                      Effect.filterOrFail(
+                        (
+                          event,
+                        ): event is Extract<typeof firstEvent, { readonly type: "snapshot" }> =>
+                          event.type === "snapshot",
+                      ),
+                    );
+
+                    expect(snapshot.keys.length).toBe(cardinality);
+                    expect(snapshot.keys[0]).toBe(publicGroupedCustomerKey("customer-0"));
+                    expect(snapshot.keys[cardinality - 1]).toBe(
+                      publicGroupedCustomerKey("customer-" + (cardinality - 1)),
+                    );
+                    expect(snapshot.rows.length).toBe(cardinality);
+                    expect([
+                      snapshot.rows[0],
+                      snapshot.rows[midpoint],
+                      snapshot.rows[cardinality - 1],
+                    ]).toStrictEqual([
+                      { customerId: "customer-0", rowCount: 1n },
+                      { customerId: "customer-" + midpoint, rowCount: 1n },
+                      { customerId: "customer-" + (cardinality - 1), rowCount: 1n },
+                    ]);
+                    expect(snapshot.totalRows).toBe(cardinality);
+                  }),
+                (subscription) => subscription.close(),
+              ),
+            (manager) => manager.close,
+          );
+        },
+        (runtimeCore) => runtimeCore.close,
+      );
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-lease-manager-lifecycle.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-lifecycle.test.ts
@@ -214,7 +214,7 @@ describe("gRPC lease manager lifecycle", () => {
           until: (currentHealth) =>
             currentHealth.engine.topics.orders.activeSubscriptions === 1 &&
             currentHealth.engine.topics.orders.backpressureEvents === 1 &&
-            currentHealth.grpc?.feeds.orders?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+            currentHealth.grpc?.feeds.orders?.leased["orders/orders/leased/region=%22usa%22"]
               ?.subscriberCount === 1,
         }),
         Effect.timeout("1 second"),
@@ -255,7 +255,7 @@ describe("gRPC lease manager lifecycle", () => {
         activeSubscriptions: isolatedHealth.engine.topics.orders.activeSubscriptions,
         retainedRows: isolatedHealth.engine.topics.orders.rowCount,
         subscriberCount:
-          isolatedHealth.grpc?.feeds.orders?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+          isolatedHealth.grpc?.feeds.orders?.leased["orders/orders/leased/region=%22usa%22"]
             ?.subscriberCount,
         releaseCount,
         upstreamFinalizedWithPeerActive,
@@ -2528,7 +2528,7 @@ describe("gRPC lease manager lifecycle", () => {
         secondSubscribeError,
         released,
         subscriberCount:
-          activeHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+          activeHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
             ?.subscriberCount,
       }).toStrictEqual({
         secondSubscribeError: subscriptionFailure,
@@ -2605,7 +2605,7 @@ describe("gRPC lease manager lifecycle", () => {
       expect({
         released,
         subscriberCount:
-          activeHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+          activeHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
             ?.subscriberCount,
       }).toStrictEqual({
         released: 0,

--- a/packages/runtime/src/grpc-lease-manager-query.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-query.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from "@effect/vitest";
-import type { ViewServerLiveEvent } from "@effect-view-server/client";
 import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
 import type { ViewServerRuntimeCoreInternalLiveClient } from "@effect-view-server/runtime-core/internal";
-import { Clock, Deferred, Effect, Fiber, Queue, Schedule, Stream } from "effect";
-import * as BigDecimal from "effect/BigDecimal";
+import { Clock, Effect, Fiber, HashMap, Option, Queue, Schedule, Stream } from "effect";
 import { makeViewServerGrpcHealthLedger } from "./grpc-health";
-import type { GrpcGroupedKeyRetentionView } from "./grpc-grouped-key-translations";
 import { makeDefaultRuntimeDependencies } from "./internal";
 import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
-import { makeDefaultGrpcClient } from "./grpc-source-lifecycle";
 import { resolveViewServerRuntimeOptions } from "./runtime-options";
 import { makeLeasedGrpcRuntimeHarness } from "../test-harness/grpc-runtime";
 
@@ -18,17 +14,18 @@ import {
   resolveLeasedGrpcRuntimeOptions,
 } from "../test-harness/grpc-materialized";
 import {
-  grpcGroupedKeyEncodingLeasedViewServer,
   grpcKeyLeasedViewServer,
   grpcLeasedViewServer,
   grpcLeasedViewServerFromCallbacks,
   grpcPublicKeyLeasedViewServer,
   grpcRouteEncodingLeasedViewServer,
+  grpcSemanticRouteLeasedViewServer,
   leasedGrpcViewServer,
   leasedOrdersQuery,
   longRunningGrpcStream,
   makeLeasedGrpcHealth,
   routeEncodingValues,
+  SemanticRouteClass,
   waitForLeasedGrpcSnapshotRows,
 } from "../test-harness/grpc-leased";
 
@@ -108,15 +105,15 @@ describe("gRPC lease manager query translation", () => {
         },
       ]);
       expect(Object.keys(readyHealth.grpc?.feeds["orders"]?.leased ?? {})).toStrictEqual([
-        "orders/orders/leased/region=string%3A3%3Ausa",
+        "orders/orders/leased/region=%22usa%22",
       ]);
       expect(
-        readyHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"],
+        readyHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"],
       ).toStrictEqual({
         status: "ready",
         lifecycle: "leased",
         feedName: "orders",
-        feedKey: "orders/orders/leased/region=string%3A3%3Ausa",
+        feedKey: "orders/orders/leased/region=%22usa%22",
         topic: "orders",
         subscriberCount: 1,
         rowCount: 2,
@@ -127,7 +124,7 @@ describe("gRPC lease manager query translation", () => {
         publishFailuresPerSecond: 0,
         reconnects: 0,
         lastMessageAt:
-          readyHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+          readyHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
             ?.lastMessageAt,
         lastError: null,
       });
@@ -175,13 +172,12 @@ describe("gRPC lease manager query translation", () => {
       expect(acquired).toBe(1);
       expect(released).toBe(1);
       expect(
-        sharedHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=string%3A3%3Ausa"]
+        sharedHealth.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
           ?.subscriberCount,
       ).toBe(2);
       expect(
-        afterFirstClose.grpc?.feeds["orders"]?.leased[
-          "orders/orders/leased/region=string%3A3%3Ausa"
-        ]?.subscriberCount,
+        afterFirstClose.grpc?.feeds["orders"]?.leased["orders/orders/leased/region=%22usa%22"]
+          ?.subscriberCount,
       ).toBe(1);
       yield* harness.close;
     }),
@@ -290,236 +286,6 @@ describe("gRPC lease manager query translation", () => {
       });
       yield* subscription.close();
       yield* harness.close;
-    }),
-  );
-
-  it.live("shares leased gRPC feeds while applying grouped queries locally", () =>
-    Effect.gen(function* () {
-      let acquired = 0;
-      const feed = grpcLeasedViewServer({
-        acquired: () => {
-          acquired += 1;
-        },
-        streamForRegion: (region) =>
-          longRunningGrpcStream([
-            grpcOrderValue(`${region}-order-1`, 10),
-            grpcOrderValue(`${region}-order-2`, 20),
-          ]),
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const first = yield* manager.liveClient.subscribe("orders", {
-        groupBy: ["status"],
-        aggregates: {
-          rowCount: { aggFunc: "count" },
-        },
-        where: {
-          region: { eq: "usa" },
-        },
-        orderBy: [{ field: "status", direction: "asc" }],
-        limit: 10,
-      });
-      const firstEventQueue = yield* Queue.unbounded<unknown>();
-      const firstEventsFiber = yield* first.events.pipe(
-        Stream.runForEach((event) => Queue.offer(firstEventQueue, event)),
-        Effect.forkChild,
-      );
-      const firstSnapshot = yield* Queue.take(firstEventQueue);
-      const firstDelta = yield* Queue.take(firstEventQueue);
-      const openStatusGroupKey = '["array",[["array",[["string","status"],["string","open"]]]]]';
-      const second = yield* manager.liveClient.subscribe("orders", {
-        groupBy: ["status"],
-        aggregates: {
-          totalPrice: { aggFunc: "sum", field: "price" },
-        },
-        where: {
-          region: { eq: "usa" },
-        },
-        orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
-        limit: 10,
-      });
-      const secondEvents = yield* second.events.pipe(Stream.take(1), Stream.runCollect);
-
-      expect(acquired).toBe(1);
-      expect(firstSnapshot).toStrictEqual({
-        type: "snapshot",
-        topic: "orders",
-        queryId: "query-0",
-        version: 0,
-        keys: [],
-        rows: [],
-        totalRows: 0,
-      });
-      expect(firstDelta).toStrictEqual({
-        type: "delta",
-        topic: "orders",
-        queryId: "query-0",
-        fromVersion: 0,
-        toVersion: 1,
-        operations: [
-          {
-            type: "insert",
-            key: openStatusGroupKey,
-            row: {
-              status: "open",
-              rowCount: 2n,
-            },
-            index: 0,
-          },
-        ],
-        totalRows: 1,
-      });
-      expect(secondEvents[0]).toStrictEqual({
-        type: "snapshot",
-        topic: "orders",
-        queryId: "query-1",
-        version: 1,
-        keys: [openStatusGroupKey],
-        rows: [
-          {
-            status: "open",
-            totalPrice: BigDecimal.fromStringUnsafe("30"),
-          },
-        ],
-        totalRows: 1,
-      });
-      yield* first.close();
-      yield* second.close();
-      yield* Fiber.interrupt(firstEventsFiber);
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("externalizes grouped leased gRPC keys that include the topic key field", () =>
-    Effect.gen(function* () {
-      const feed = grpcLeasedViewServer({
-        streamForRegion: (region) =>
-          longRunningGrpcStream([
-            grpcOrderValue(`${region}-order-1`, 10),
-            grpcOrderValue(`${region}-order-2`, 20),
-          ]),
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const first = yield* manager.liveClient.subscribe("orders", {
-        groupBy: ["id"],
-        aggregates: {
-          rowCount: { aggFunc: "count" },
-        },
-        where: {
-          region: { eq: "usa" },
-        },
-        orderBy: [{ field: "id", direction: "asc" }],
-        limit: 10,
-      });
-      const firstEventQueue = yield* Queue.unbounded<unknown>();
-      const firstEventsFiber = yield* first.events.pipe(
-        Stream.runForEach((event) => Queue.offer(firstEventQueue, event)),
-        Effect.forkChild,
-      );
-      const firstSnapshot = yield* Queue.take(firstEventQueue);
-      const firstDelta = yield* Queue.take(firstEventQueue);
-      const second = yield* manager.liveClient.subscribe("orders", {
-        groupBy: ["id"],
-        aggregates: {
-          rowCount: { aggFunc: "count" },
-        },
-        where: {
-          region: { eq: "usa" },
-        },
-        orderBy: [{ field: "id", direction: "asc" }],
-        limit: 10,
-      });
-      const secondEvents = yield* second.events.pipe(Stream.take(1), Stream.runCollect);
-      const firstPublicGroupKey =
-        '["array",[["array",[["string","id"],["string","usa:usa-order-1"]]]]]';
-      const secondPublicGroupKey =
-        '["array",[["array",[["string","id"],["string","usa:usa-order-2"]]]]]';
-
-      expect(firstSnapshot).toStrictEqual({
-        type: "snapshot",
-        topic: "orders",
-        queryId: "query-0",
-        version: 0,
-        keys: [],
-        rows: [],
-        totalRows: 0,
-      });
-      expect(firstDelta).toStrictEqual({
-        type: "delta",
-        topic: "orders",
-        queryId: "query-0",
-        fromVersion: 0,
-        toVersion: 1,
-        operations: [
-          {
-            type: "insert",
-            key: firstPublicGroupKey,
-            row: {
-              id: "usa:usa-order-1",
-              rowCount: 1n,
-            },
-            index: 0,
-          },
-          {
-            type: "insert",
-            key: secondPublicGroupKey,
-            row: {
-              id: "usa:usa-order-2",
-              rowCount: 1n,
-            },
-            index: 1,
-          },
-        ],
-        totalRows: 2,
-      });
-      expect(secondEvents[0]).toStrictEqual({
-        type: "snapshot",
-        topic: "orders",
-        queryId: "query-1",
-        version: 1,
-        keys: [firstPublicGroupKey, secondPublicGroupKey],
-        rows: [
-          {
-            id: "usa:usa-order-1",
-            rowCount: 1n,
-          },
-          {
-            id: "usa:usa-order-2",
-            rowCount: 1n,
-          },
-        ],
-        totalRows: 2,
-      });
-
-      yield* first.close();
-      yield* second.close();
-      yield* Fiber.interrupt(firstEventsFiber);
-      yield* manager.close;
-      yield* runtimeCore.close;
     }),
   );
 
@@ -632,7 +398,7 @@ describe("gRPC lease manager query translation", () => {
       const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
 
       expect(Object.keys(currentHealth.grpc?.feeds["orders"]?.leased ?? {})).toStrictEqual([
-        "orders/orders/leased/amount=bigDecimal%3A6%3A123.45&count=bigint%3A16%3A9007199254740993&disabled=boolean%3A5%3Afalse&flag=boolean%3A4%3Atrue&meta=object%3A28%3A6%3A%22desk%2217%3Astring%3A8%3Aequities&none=null%3A4%3Anull&plainScore=number%3A2%3A42&score=number%3A2%3A-0&tags=array%3A34%3A13%3Astring%3A4%3Afast15%3Astring%3A6%3Ashared&text=string%3A5%3Aroute&weird=object%3A53%3A7%3A%22alpha%2214%3Astring%3A5%3Afirst8%3A%22stable%2214%3Astring%3A5%3Aroute",
+        "orders/orders/leased/amount=%22123.45%22&count=%229007199254740993%22&disabled=false&flag=true&meta=%7B%22desk%22%3A%22equities%22%7D&none=null&plainScore=42&score=0&tags=%5B%22fast%22%2C%22shared%22%5D&text=%22route%22&weird=%7B%22alpha%22%3A%22first%22%2C%22stable%22%3A%22route%22%7D",
       ]);
       yield* subscription.close();
       yield* manager.close;
@@ -640,653 +406,74 @@ describe("gRPC lease manager query translation", () => {
     }),
   );
 
-  it.live("externalizes grouped leased gRPC route values with public grouped keys", () =>
-    Effect.gen(function* () {
-      const feed = grpcGroupedKeyEncodingLeasedViewServer({
-        acquire: () =>
-          Stream.make(
-            grpcOrderValue("route-encoding-1", 10),
-            grpcOrderValue("route-encoding-2", 20),
-            grpcOrderValue("route-encoding-3", 30),
-          ),
-        map: (value) => ({
-          id: value.customerId,
-          ...routeEncodingValues,
-          meta: {
-            desk: value.price === 30 ? "credit" : value.price === 20 ? "rates" : "equities",
+  it.live(
+    "shares semantic Class, Option, and collision-node HashMap routes by schema identity",
+    () =>
+      Effect.gen(function* () {
+        const feed = grpcSemanticRouteLeasedViewServer();
+        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+        const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
+          clients: {
+            orders: "https://orders.example.test",
           },
-          tags:
-            value.price === 30
-              ? ["unsupported"]
-              : value.price === 20
-                ? ["slow", "shared"]
-                : routeEncodingValues.tags,
-          weird: undefined,
-        }),
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
-        clients: {
-          orders: "https://orders.example.test",
-        },
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
-        groupBy: [
-          "amount",
-          "count",
-          "disabled",
-          "flag",
-          "none",
-          "plainScore",
-          "score",
-          "text",
-          "weird",
-          "meta",
-          "tags",
-        ],
-        aggregates: {
-          rowCount: { aggFunc: "count" },
-        },
-        where: {
-          text: { eq: routeEncodingValues.text },
-        },
-        limit: 10,
-      });
-      const deltaEvents = yield* subscription.events.pipe(
-        Stream.filter((event) => event.type === "delta"),
-        Stream.take(4),
-        Stream.runCollect,
-      );
-      const publicGroupedKeyOne =
-        '["array",[["array",[["string","amount"],["bigDecimal","123.45"]]],["array",[["string","count"],["bigint","9007199254740993"]]],["array",[["string","disabled"],["boolean",false]]],["array",[["string","flag"],["boolean",true]]],["array",[["string","none"],["null"]]],["array",[["string","plainScore"],["number","42"]]],["array",[["string","score"],["number","-0"]]],["array",[["string","text"],["string","route"]]],["array",[["string","weird"],["undefined"]]],["array",[["string","meta"],["canonical","object:28:6:\\"desk\\"17:string:8:equities"]]],["array",[["string","tags"],["canonical","array:34:13:string:4:fast15:string:6:shared"]]]]]';
-      const publicGroupedKeyTwo =
-        '["array",[["array",[["string","amount"],["bigDecimal","123.45"]]],["array",[["string","count"],["bigint","9007199254740993"]]],["array",[["string","disabled"],["boolean",false]]],["array",[["string","flag"],["boolean",true]]],["array",[["string","none"],["null"]]],["array",[["string","plainScore"],["number","42"]]],["array",[["string","score"],["number","-0"]]],["array",[["string","text"],["string","route"]]],["array",[["string","weird"],["undefined"]]],["array",[["string","meta"],["canonical","object:25:6:\\"desk\\"14:string:5:rates"]]],["array",[["string","tags"],["canonical","array:34:13:string:4:slow15:string:6:shared"]]]]]';
-      const publicGroupedKeyThree =
-        '["array",[["array",[["string","amount"],["bigDecimal","123.45"]]],["array",[["string","count"],["bigint","9007199254740993"]]],["array",[["string","disabled"],["boolean",false]]],["array",[["string","flag"],["boolean",true]]],["array",[["string","none"],["null"]]],["array",[["string","plainScore"],["number","42"]]],["array",[["string","score"],["number","-0"]]],["array",[["string","text"],["string","route"]]],["array",[["string","weird"],["undefined"]]],["array",[["string","meta"],["canonical","object:26:6:\\"desk\\"15:string:6:credit"]]],["array",[["string","tags"],["canonical","array:24:21:string:11:unsupported"]]]]]';
-
-      expect(deltaEvents[0]).toStrictEqual({
-        type: "delta",
-        topic: "orders",
-        queryId: "query-0",
-        fromVersion: 0,
-        toVersion: 1,
-        operations: [
-          {
-            type: "insert",
-            key: publicGroupedKeyThree,
-            row: {
-              amount: routeEncodingValues.amount,
-              count: routeEncodingValues.count,
-              disabled: routeEncodingValues.disabled,
-              flag: routeEncodingValues.flag,
-              none: routeEncodingValues.none,
-              plainScore: routeEncodingValues.plainScore,
-              score: routeEncodingValues.score,
-              text: routeEncodingValues.text,
-              weird: undefined,
-              meta: {
-                desk: "credit",
-              },
-              tags: ["unsupported"],
-              rowCount: 1n,
-            },
-            index: 0,
+          feeds: {},
+        });
+        const manager = yield* makeViewServerGrpcLeaseManager(
+          grpcOptions.sourceConfig,
+          runtimeCore.internalClient,
+          runtimeCore.liveClient,
+          runtimeCore.internalLiveClient,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+        const collisionLeft = "8ocpIaaa";
+        const collisionRight = "GpcpIaaa";
+        const firstRouteOption = yield* Effect.succeed(Option.some("route")).pipe(
+          Effect.filterOrFail(Option.isSome),
+        );
+        const equivalentRouteOption = yield* Effect.succeed(Option.some("route")).pipe(
+          Effect.filterOrFail(Option.isSome),
+        );
+        const firstRoute = {
+          routeClass: SemanticRouteClass.make({ value: "route" }),
+          routeOption: firstRouteOption,
+          routeHashMap: HashMap.make([collisionLeft, "left"], [collisionRight, "right"]),
+        };
+        const equivalentRoute = {
+          routeClass: SemanticRouteClass.make({ value: "route" }),
+          routeOption: equivalentRouteOption,
+          routeHashMap: HashMap.make([collisionRight, "right"], [collisionLeft, "left"]),
+        };
+        const first = yield* manager.liveClient.subscribeRuntime("orders", {
+          select: ["id"],
+          where: {
+            routeClass: { eq: firstRoute.routeClass },
+            routeOption: { eq: firstRoute.routeOption },
+            routeHashMap: { eq: firstRoute.routeHashMap },
           },
-          {
-            type: "insert",
-            key: publicGroupedKeyOne,
-            row: {
-              amount: routeEncodingValues.amount,
-              count: routeEncodingValues.count,
-              disabled: routeEncodingValues.disabled,
-              flag: routeEncodingValues.flag,
-              none: routeEncodingValues.none,
-              plainScore: routeEncodingValues.plainScore,
-              score: routeEncodingValues.score,
-              text: routeEncodingValues.text,
-              weird: undefined,
-              meta: routeEncodingValues.meta,
-              tags: routeEncodingValues.tags,
-              rowCount: 1n,
-            },
-            index: 1,
+          limit: 10,
+        });
+        const second = yield* manager.liveClient.subscribeRuntime("orders", {
+          select: ["id"],
+          where: {
+            routeClass: { eq: equivalentRoute.routeClass },
+            routeOption: { eq: equivalentRoute.routeOption },
+            routeHashMap: { eq: equivalentRoute.routeHashMap },
           },
-          {
-            type: "insert",
-            key: publicGroupedKeyTwo,
-            row: {
-              amount: routeEncodingValues.amount,
-              count: routeEncodingValues.count,
-              disabled: routeEncodingValues.disabled,
-              flag: routeEncodingValues.flag,
-              none: routeEncodingValues.none,
-              plainScore: routeEncodingValues.plainScore,
-              score: routeEncodingValues.score,
-              text: routeEncodingValues.text,
-              weird: undefined,
-              meta: {
-                desk: "rates",
-              },
-              tags: ["slow", "shared"],
-              rowCount: 1n,
-            },
-            index: 2,
-          },
-        ],
-        totalRows: 3,
-      });
-      expect(deltaEvents[1]).toStrictEqual({
-        type: "delta",
-        topic: "orders",
-        queryId: "query-0",
-        fromVersion: 1,
-        toVersion: 2,
-        operations: [
-          {
-            type: "remove",
-            key: publicGroupedKeyOne,
-          },
-        ],
-        totalRows: 2,
-      });
-      expect(deltaEvents[2]).toStrictEqual({
-        type: "delta",
-        topic: "orders",
-        queryId: "query-0",
-        fromVersion: 2,
-        toVersion: 3,
-        operations: [
-          {
-            type: "remove",
-            key: publicGroupedKeyTwo,
-          },
-        ],
-        totalRows: 1,
-      });
-      expect(deltaEvents[3]).toStrictEqual({
-        type: "delta",
-        topic: "orders",
-        queryId: "query-0",
-        fromVersion: 3,
-        toVersion: 4,
-        operations: [
-          {
-            type: "remove",
-            key: publicGroupedKeyThree,
-          },
-        ],
-        totalRows: 0,
-      });
-      yield* subscription.close();
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
+          limit: 10,
+        });
+        const currentHealth = health.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+        const feedKeys = Object.keys(currentHealth.grpc?.feeds["orders"]?.leased ?? {});
 
-  it.live("bounds grouped-key translations to each leased subscription lifetime", () =>
-    Effect.gen(function* () {
-      const churnRows = Array.from({ length: 64 }, (_, index) => ({
-        customerId: `customer-${index}`,
-        rowCount: 1n,
-      }));
-      const churnInternalKeys = churnRows.map((_row, index) => `customer-internal-${index}`);
-      const removalOperations: ReadonlyArray<{ readonly type: "remove"; readonly key: string }> =
-        churnInternalKeys.slice(1).map((key) => ({ type: "remove", key }));
-      const replacementRows = [
-        { customerId: "replacement-a", rowCount: 1n },
-        { customerId: "replacement-b", rowCount: 1n },
-      ];
-      const replacementInternalKeys = ["replacement-internal-a", "replacement-internal-b"];
-      const customerSnapshot = {
-        type: "snapshot",
-        topic: "orders",
-        queryId: "customer-groups",
-        version: 0,
-        keys: churnInternalKeys,
-        rows: churnRows,
-        totalRows: churnRows.length,
-      } as const;
-      const customerRemovalDelta = {
-        type: "delta",
-        topic: "orders",
-        queryId: "customer-groups",
-        fromVersion: 0,
-        toVersion: 1,
-        operations: removalOperations,
-        totalRows: 1,
-      } as const;
-      const customerReplacementSnapshot = {
-        type: "snapshot",
-        topic: "orders",
-        queryId: "customer-groups",
-        version: 2,
-        keys: replacementInternalKeys,
-        rows: replacementRows,
-        totalRows: replacementRows.length,
-      } as const;
-      const statusSnapshot = {
-        type: "snapshot",
-        topic: "orders",
-        queryId: "status-groups",
-        version: 0,
-        keys: ["status-internal-open"],
-        rows: [{ status: "open", rowCount: 64n }],
-        totalRows: 1,
-      } as const;
-      const statusMoveDelta = {
-        type: "delta",
-        topic: "orders",
-        queryId: "status-groups",
-        fromVersion: 0,
-        toVersion: 1,
-        operations: [
-          {
-            type: "update",
-            key: "status-internal-open",
-            row: { status: "open", rowCount: 65n },
-            index: 0,
-          },
-          {
-            type: "move",
-            key: "status-internal-open",
-            fromIndex: 0,
-            toIndex: 0,
-          },
-        ],
-        totalRows: 1,
-      } as const;
-      const publicGroupedStringKey = (field: string, value: string): string => {
-        const fieldToken = `["array",[["string",${JSON.stringify(field)}],["string",${JSON.stringify(value)}]]]`;
-        return `["array",[${fieldToken}]]`;
-      };
-      const releaseCustomerRemovals = yield* Deferred.make<void>();
-      const releaseCustomerReplacement = yield* Deferred.make<void>();
-      const releaseStatusMove = yield* Deferred.make<void>();
-      const retentionViews: Array<GrpcGroupedKeyRetentionView> = [];
-      const feed = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-
-      yield* Effect.acquireUseRelease(
-        makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {}),
-        (runtimeCore) => {
-          let subscriptionIndex = 0;
-          const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
-            typeof leasedGrpcViewServer.topics
-          > = {
-            ...runtimeCore.internalLiveClient,
-            subscribeRuntimeObservedInternal: (_topic, _query, observer) => {
-              if (subscriptionIndex === 0) {
-                subscriptionIndex += 1;
-                return observer.onQueryRegistered(customerSnapshot.queryId).pipe(
-                  Effect.as({
-                    events: Stream.make(customerSnapshot).pipe(
-                      Stream.concat(
-                        Stream.fromEffect(
-                          Deferred.await(releaseCustomerRemovals).pipe(
-                            Effect.as(customerRemovalDelta),
-                          ),
-                        ),
-                      ),
-                      Stream.concat(
-                        Stream.fromEffect(
-                          Deferred.await(releaseCustomerReplacement).pipe(
-                            Effect.as(customerReplacementSnapshot),
-                          ),
-                        ),
-                      ),
-                      Stream.concat(Stream.never),
-                    ),
-                    close: () => Effect.void,
-                  }),
-                );
-              }
-              subscriptionIndex += 1;
-              return observer.onQueryRegistered(statusSnapshot.queryId).pipe(
-                Effect.as({
-                  events: Stream.make(statusSnapshot).pipe(
-                    Stream.concat(
-                      Stream.fromEffect(
-                        Deferred.await(releaseStatusMove).pipe(Effect.as(statusMoveDelta)),
-                      ),
-                    ),
-                    Stream.concat(Stream.never),
-                  ),
-                  close: () => Effect.void,
-                }),
-              );
-            },
-          };
-          const health = makeLeasedGrpcHealth(grpcOptions);
-          return Effect.acquireUseRelease(
-            makeViewServerGrpcLeaseManager(
-              grpcOptions.sourceConfig,
-              runtimeCore.internalClient,
-              runtimeCore.liveClient,
-              fakeInternalLiveClient,
-              Effect.void,
-              grpcOptions,
-              health,
-              makeDefaultGrpcClient,
-              (retention) => {
-                retentionViews.push(retention);
-              },
-            ),
-            (manager) =>
-              Effect.acquireUseRelease(
-                manager.liveClient.subscribeRuntime("orders", {
-                  groupBy: ["customerId"],
-                  aggregates: {
-                    rowCount: { aggFunc: "count" },
-                  },
-                  where: {
-                    region: { eq: "usa" },
-                  },
-                  limit: 100,
-                }),
-                (customerSubscription) =>
-                  Effect.acquireUseRelease(
-                    manager.liveClient.subscribeRuntime("orders", {
-                      groupBy: ["status"],
-                      aggregates: {
-                        rowCount: { aggFunc: "count" },
-                      },
-                      where: {
-                        region: { eq: "usa" },
-                      },
-                      limit: 10,
-                    }),
-                    (statusSubscription) =>
-                      Effect.gen(function* () {
-                        const customerRetention = yield* Effect.fromNullishOr(retentionViews[0]);
-                        const statusRetention = yield* Effect.fromNullishOr(retentionViews[1]);
-                        const customerEventQueue = yield* Queue.unbounded<unknown>();
-                        const customerEventsFiber = yield* customerSubscription.events.pipe(
-                          Stream.runForEach((event) => Queue.offer(customerEventQueue, event)),
-                          Effect.forkChild({ startImmediately: true }),
-                        );
-                        const customerSnapshotEvent = yield* Queue.take(customerEventQueue).pipe(
-                          Effect.timeout("1 second"),
-                        );
-                        expect(customerRetention.retainedEntryCount()).toBe(64);
-
-                        yield* Deferred.succeed(releaseCustomerRemovals, undefined);
-                        const customerRemovalEvent = yield* Queue.take(customerEventQueue).pipe(
-                          Effect.timeout("1 second"),
-                        );
-                        expect(customerRetention.retainedEntryCount()).toBe(1);
-
-                        yield* Deferred.succeed(releaseCustomerReplacement, undefined);
-                        const customerReplacementEvent = yield* Queue.take(customerEventQueue).pipe(
-                          Effect.timeout("1 second"),
-                        );
-                        expect(customerRetention.retainedEntryCount()).toBe(2);
-                        const customerEvents = [
-                          customerSnapshotEvent,
-                          customerRemovalEvent,
-                          customerReplacementEvent,
-                        ];
-                        const statusEventQueue = yield* Queue.unbounded<unknown>();
-                        const statusEventsFiber = yield* statusSubscription.events.pipe(
-                          Stream.runForEach((event) => Queue.offer(statusEventQueue, event)),
-                          Effect.forkChild({ startImmediately: true }),
-                        );
-                        const statusSnapshotEvent = yield* Queue.take(statusEventQueue).pipe(
-                          Effect.timeout("1 second"),
-                        );
-                        expect(statusRetention.retainedEntryCount()).toBe(1);
-
-                        yield* customerSubscription.close();
-                        yield* Fiber.interrupt(customerEventsFiber);
-                        expect(customerRetention.retainedEntryCount()).toBe(0);
-                        yield* Deferred.succeed(releaseStatusMove, undefined);
-                        const statusMoveEvent = yield* Queue.take(statusEventQueue).pipe(
-                          Effect.timeout("1 second"),
-                        );
-                        const statusEvents = [statusSnapshotEvent, statusMoveEvent];
-
-                        expect(customerEvents).toStrictEqual([
-                          {
-                            ...customerSnapshot,
-                            keys: churnRows.map((row) =>
-                              publicGroupedStringKey("customerId", row.customerId),
-                            ),
-                          },
-                          {
-                            ...customerRemovalDelta,
-                            operations: churnRows.slice(1).map((row) => ({
-                              type: "remove",
-                              key: publicGroupedStringKey("customerId", row.customerId),
-                            })),
-                          },
-                          {
-                            ...customerReplacementSnapshot,
-                            keys: replacementRows.map((row) =>
-                              publicGroupedStringKey("customerId", row.customerId),
-                            ),
-                          },
-                        ]);
-                        expect(statusEvents).toStrictEqual([
-                          {
-                            ...statusSnapshot,
-                            keys: [publicGroupedStringKey("status", "open")],
-                          },
-                          {
-                            ...statusMoveDelta,
-                            operations: [
-                              {
-                                ...statusMoveDelta.operations[0],
-                                key: publicGroupedStringKey("status", "open"),
-                              },
-                              {
-                                ...statusMoveDelta.operations[1],
-                                key: publicGroupedStringKey("status", "open"),
-                              },
-                            ],
-                          },
-                        ]);
-                        yield* manager.close;
-                        expect(statusRetention.retainedEntryCount()).toBe(0);
-                        expect(customerRetention.retainedEntryCount()).toBe(0);
-                        yield* manager.close;
-                        expect(statusRetention.retainedEntryCount()).toBe(0);
-                        yield* Fiber.interrupt(statusEventsFiber);
-                      }).pipe(
-                        Effect.ensuring(
-                          Deferred.succeed(releaseCustomerRemovals, undefined).pipe(
-                            Effect.andThen(Deferred.succeed(releaseCustomerReplacement, undefined)),
-                            Effect.andThen(Deferred.succeed(releaseStatusMove, undefined)),
-                          ),
-                        ),
-                      ),
-                    (subscription) => subscription.close(),
-                  ),
-                (subscription) => subscription.close(),
-              ),
-            (manager) => manager.close,
-          );
-        },
-        (runtimeCore) => runtimeCore.close,
-      );
-    }),
-  );
-
-  it.live("fails grouped leased gRPC event streams for non-canonical public key values", () =>
-    Effect.gen(function* () {
-      const feed = grpcGroupedKeyEncodingLeasedViewServer({
-        acquire: () => longRunningGrpcStream([grpcOrderValue("route-encoding-1", 10)]),
-        map: (value) => ({
-          id: value.customerId,
-          ...routeEncodingValues,
-          weird: new Uint8Array([1]),
-        }),
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
-        clients: {
-          orders: "https://orders.example.test",
-        },
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
-        groupBy: ["weird"],
-        aggregates: {
-          rowCount: { aggFunc: "count" },
-        },
-        where: {
-          text: { eq: routeEncodingValues.text },
-        },
-        limit: 10,
-      });
-      const events = yield* subscription.events.pipe(Stream.runCollect);
-
-      expect(events).toStrictEqual([
-        {
-          type: "snapshot",
-          topic: "orders",
-          queryId: "query-0",
-          version: 0,
-          keys: [],
-          rows: [],
-          totalRows: 0,
-        },
-        {
-          type: "status",
-          topic: "orders",
-          queryId: "query-0",
-          status: "error",
-          code: "RuntimeUnavailable",
-          message: "Leased gRPC grouped key value cannot be encoded as a stable public key",
-        },
-      ]);
-      yield* subscription.close();
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("fails grouped leased gRPC snapshots for non-canonical public key values", () =>
-    Effect.gen(function* () {
-      const feed = grpcGroupedKeyEncodingLeasedViewServer({
-        acquire: () => longRunningGrpcStream([grpcOrderValue("route-encoding-1", 10)]),
-        map: (value) => ({
-          id: value.customerId,
-          ...routeEncodingValues,
-          weird: new Uint8Array([1]),
-        }),
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeViewServerGrpcHealthLedger<typeof grpcOptions.sourceConfig.topics>({
-        clients: {
-          orders: "https://orders.example.test",
-        },
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-      const rawSubscription = yield* manager.liveClient.subscribeRuntime("orders", {
-        select: ["id", "weird"],
-        where: {
-          text: { eq: routeEncodingValues.text },
-        },
-        limit: 10,
-      });
-      const rawEventQueue = yield* Queue.unbounded<unknown>();
-      const rawEventsFiber = yield* rawSubscription.events.pipe(
-        Stream.runForEach((event) => Queue.offer(rawEventQueue, event)),
-        Effect.forkChild,
-      );
-      const rawSnapshot = yield* Queue.take(rawEventQueue);
-      const rawDelta = yield* Queue.take(rawEventQueue);
-      const groupedSubscription = yield* manager.liveClient.subscribeRuntime("orders", {
-        groupBy: ["weird"],
-        aggregates: {
-          rowCount: { aggFunc: "count" },
-        },
-        where: {
-          text: { eq: routeEncodingValues.text },
-        },
-        limit: 10,
-      });
-      const groupedEvents = yield* groupedSubscription.events.pipe(Stream.runCollect);
-
-      expect([rawSnapshot, rawDelta]).toStrictEqual([
-        {
-          type: "snapshot",
-          topic: "orders",
-          queryId: "query-0",
-          version: 0,
-          keys: [],
-          rows: [],
-          totalRows: 0,
-        },
-        {
-          type: "delta",
-          topic: "orders",
-          queryId: "query-0",
-          fromVersion: 0,
-          toVersion: 1,
-          operations: [
-            {
-              type: "insert",
-              key: "route-encoding-1",
-              row: {
-                id: "route-encoding-1",
-                weird: new Uint8Array([1]),
-              },
-              index: 0,
-            },
-          ],
-          totalRows: 1,
-        },
-      ]);
-      expect(groupedEvents).toStrictEqual([
-        {
-          type: "status",
-          topic: "orders",
-          queryId: "query-1",
-          status: "error",
-          code: "RuntimeUnavailable",
-          message: "Leased gRPC grouped key value cannot be encoded as a stable public key",
-        },
-      ]);
-      yield* rawSubscription.close();
-      yield* groupedSubscription.close();
-      yield* Fiber.interrupt(rawEventsFiber);
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
+        expect(feedKeys).toHaveLength(1);
+        expect(currentHealth.grpc?.feeds["orders"]?.leased[feedKeys[0]!]?.subscriberCount).toBe(2);
+        yield* first.close();
+        yield* second.close();
+        yield* manager.close;
+        yield* runtimeCore.close;
+      }),
   );
 
   it.live("rejects non-canonical leased gRPC route values instead of sharing a fallback key", () =>
@@ -1362,14 +549,14 @@ describe("gRPC lease manager query translation", () => {
           code: "InvalidQuery",
           topic: "orders",
           message:
-            "Leased topic orders route field weird value cannot be used as a stable leased gRPC route key.",
+            "Leased topic orders route field weird value does not match the topic schema or cannot be used as a stable leased gRPC route key.",
         },
         objectError: {
           _tag: "ViewServerRuntimeError",
           code: "InvalidQuery",
           topic: "orders",
           message:
-            "Leased topic orders route field weird value cannot be used as a stable leased gRPC route key.",
+            "Leased topic orders route field weird value does not match the topic schema or cannot be used as a stable leased gRPC route key.",
         },
         leasedFeeds: [],
       });
@@ -1429,8 +616,8 @@ describe("gRPC lease manager query translation", () => {
         },
       ]);
       expect(Object.keys(routeHealth.grpc?.feeds["orders"]?.leased ?? {})).toStrictEqual([
-        "orders/orders/leased/region=string%3A3%3Ausa",
-        "orders/orders/leased/region=string%3A2%3Aeu",
+        "orders/orders/leased/region=%22usa%22",
+        "orders/orders/leased/region=%22eu%22",
       ]);
       yield* usa.close();
       yield* eu.close();
@@ -1855,7 +1042,7 @@ describe("gRPC lease manager query translation", () => {
     }),
   );
 
-  it.live("keeps non-string leased row-key predicates unchanged in internal runtime queries", () =>
+  it.live("captures leased row-key predicates before caller mutation", () =>
     Effect.gen(function* () {
       const feed = grpcLeasedViewServer({
         streamForRegion: () => Stream.never,
@@ -1963,7 +1150,7 @@ describe("gRPC lease manager query translation", () => {
           status: "ready",
           code: "Ready",
           message:
-            '{"select":["id","price"],"where":{"region":{"eq":"usa"},"id":{"eq":123}},"limit":10}',
+            '{"select":["id","price"],"where":{"region":{"eq":"usa"},"id":{"eq":"usa:order-1"}},"limit":10}',
         },
       ]);
       yield* subscription.close();
@@ -2404,117 +1591,6 @@ describe("gRPC lease manager query translation", () => {
       yield* subscription.close();
       yield* manager.close;
       yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("externalizes a 200,000-row grouped snapshot without caller-side spread limits", () =>
-    Effect.gen(function* () {
-      const cardinality = 200_000;
-      const midpoint = Math.floor(cardinality / 2);
-      const internalKeys = Array.from(
-        { length: cardinality },
-        (_value, index) => "customer-internal-" + index,
-      );
-      const rows = Array.from({ length: cardinality }, (_value, index) => ({
-        customerId: "customer-" + index,
-        rowCount: 1n,
-      }));
-      const internalSnapshot = {
-        type: "snapshot",
-        topic: "orders",
-        queryId: "large-customer-groups",
-        version: 0,
-        keys: internalKeys,
-        rows,
-        totalRows: cardinality,
-      } as const;
-      const publicGroupedCustomerKey = (customerId: string): string => {
-        const fieldToken =
-          '["array",[["string","customerId"],["string",' + JSON.stringify(customerId) + "]]]";
-        return '["array",[' + fieldToken + "]]";
-      };
-      const feed = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-
-      yield* Effect.acquireUseRelease(
-        makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {}),
-        (runtimeCore) => {
-          const fakeInternalLiveClient: ViewServerRuntimeCoreInternalLiveClient<
-            typeof leasedGrpcViewServer.topics
-          > = {
-            ...runtimeCore.internalLiveClient,
-            subscribeRuntimeObservedInternal: (_topic, _query, observer) =>
-              observer.onQueryRegistered(internalSnapshot.queryId).pipe(
-                Effect.as({
-                  events: Stream.make(internalSnapshot).pipe(Stream.concat(Stream.never)),
-                  close: () => Effect.void,
-                }),
-              ),
-          };
-          const health = makeLeasedGrpcHealth(grpcOptions);
-
-          return Effect.acquireUseRelease(
-            makeViewServerGrpcLeaseManager(
-              grpcOptions.sourceConfig,
-              runtimeCore.internalClient,
-              runtimeCore.liveClient,
-              fakeInternalLiveClient,
-              Effect.void,
-              grpcOptions,
-              health,
-            ),
-            (manager) =>
-              Effect.acquireUseRelease(
-                manager.liveClient.subscribeRuntime("orders", {
-                  groupBy: ["customerId"],
-                  aggregates: {
-                    rowCount: { aggFunc: "count" },
-                  },
-                  where: {
-                    region: { eq: "usa" },
-                  },
-                  limit: cardinality,
-                }),
-                (subscription) =>
-                  Effect.gen(function* () {
-                    const firstEventOption = yield* Stream.runHead(subscription.events);
-                    const firstEvent: ViewServerLiveEvent<object> =
-                      yield* Effect.fromOption(firstEventOption);
-                    const snapshot = yield* Effect.succeed(firstEvent).pipe(
-                      Effect.filterOrFail(
-                        (
-                          event,
-                        ): event is Extract<typeof firstEvent, { readonly type: "snapshot" }> =>
-                          event.type === "snapshot",
-                      ),
-                    );
-
-                    expect(snapshot.keys.length).toBe(cardinality);
-                    expect(snapshot.keys[0]).toBe(publicGroupedCustomerKey("customer-0"));
-                    expect(snapshot.keys[cardinality - 1]).toBe(
-                      publicGroupedCustomerKey("customer-" + (cardinality - 1)),
-                    );
-                    expect(snapshot.rows.length).toBe(cardinality);
-                    expect([
-                      snapshot.rows[0],
-                      snapshot.rows[midpoint],
-                      snapshot.rows[cardinality - 1],
-                    ]).toStrictEqual([
-                      { customerId: "customer-0", rowCount: 1n },
-                      { customerId: "customer-" + midpoint, rowCount: 1n },
-                      { customerId: "customer-" + (cardinality - 1), rowCount: 1n },
-                    ]);
-                    expect(snapshot.totalRows).toBe(cardinality);
-                  }),
-                (subscription) => subscription.close(),
-              ),
-            (manager) => manager.close,
-          );
-        },
-        (runtimeCore) => runtimeCore.close,
-      );
     }),
   );
 });

--- a/packages/runtime/src/grpc-lease-manager-route-ownership.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-route-ownership.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@effect-view-server/config";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import { Effect, Schema, Stream } from "effect";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+
+import { grpcClients, grpcOrderValue, grpcTopicSources } from "../test-harness/grpc-config";
+import { makeLeasedGrpcHealth } from "../test-harness/grpc-leased";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+
+type RouteView = {
+  readonly region: {
+    readonly name: string;
+  };
+};
+
+type RouteOwnershipGroupedQuery = {
+  groupBy: ["region"];
+  aggregates: {
+    rowCount: {
+      aggFunc: "count";
+    };
+  };
+  where: {
+    region: {
+      eq: {
+        name: string;
+      };
+    };
+  };
+  orderBy: [
+    {
+      aggregate: "rowCount";
+      direction: "desc";
+    },
+  ];
+  limit: 10;
+};
+
+type RouteOwnershipRawQuery = {
+  readonly select: readonly ["id"];
+  readonly where: {
+    readonly region: {
+      readonly eq: {
+        readonly name: string;
+      };
+    };
+  };
+};
+
+const RouteOwnershipOrder = Schema.Struct({
+  id: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literals(["open", "closed", "cancelled"]),
+  price: Schema.Number,
+  region: Schema.Struct({
+    name: Schema.Trim,
+  }),
+  updatedAt: Schema.Number,
+});
+
+const routeGroupKey = JSON.stringify([
+  ["region", JSON.stringify(["present", JSON.stringify({ name: "usa" })])],
+]);
+
+describe("gRPC lease manager route ownership", () => {
+  it.live("owns the query and gives every source callback a fresh schema-materialized route", () =>
+    Effect.gen(function* () {
+      const queryRoute = { name: "usa" };
+      const query: RouteOwnershipGroupedQuery = {
+        groupBy: ["region"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
+        where: {
+          region: { eq: queryRoute },
+        },
+        orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+        limit: 10,
+      };
+      const requestRoutes: Array<RouteView> = [];
+      const acquireRoutes: Array<RouteView> = [];
+      const mapRoutes: Array<RouteView> = [];
+      const releaseRoutes: Array<RouteView> = [];
+      const requestRegionNames: Array<string> = [];
+      const acquireRegionNames: Array<string> = [];
+      const mapRegionNames: Array<string> = [];
+      const releaseRegionNames: Array<string> = [];
+
+      const localViewServer = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          orders: grpcTopicSources.leased({
+            schema: RouteOwnershipOrder,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            routeBy: ["region"],
+            request: (route) => {
+              requestRoutes.push(route);
+              requestRegionNames.push(route.region.name);
+              Reflect.set(route.region, "name", "request-route-mutation");
+              Reflect.set(query.where.region.eq, "name", "request-query-mutation");
+              Reflect.set(query.groupBy, 0, "customerId");
+              Reflect.set(query.aggregates.rowCount, "aggFunc", "sum");
+              Reflect.set(query.aggregates.rowCount, "field", "price");
+              Reflect.set(query.orderBy[0], "aggregate", "changedTotal");
+              return { orderId: "owned-route" };
+            },
+            acquire: ({ route }) => {
+              acquireRoutes.push(route);
+              acquireRegionNames.push(route.region.name);
+              Reflect.set(route.region, "name", "acquire-route-mutation");
+              return Stream.make(grpcOrderValue("order-1", 10), grpcOrderValue("order-2", 20)).pipe(
+                Stream.concat(Stream.never),
+              );
+            },
+            release: ({ route }) => {
+              releaseRoutes.push(route);
+              releaseRegionNames.push(route.region.name);
+              Reflect.set(route.region, "name", "release-route-mutation");
+              return Effect.void;
+            },
+            map: ({ value, route }) => {
+              mapRoutes.push(route);
+              const regionName = route.region.name;
+              mapRegionNames.push(regionName);
+              Reflect.set(route.region, "name", "map-route-mutation");
+              return {
+                id: `${regionName}:${value.customerId}`,
+                customerId: value.customerId,
+                status: value.status,
+                price: value.price,
+                region: { name: regionName },
+                updatedAt: value.updatedAt,
+              };
+            },
+          }),
+        },
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const accessorQuery: RouteOwnershipRawQuery = {
+        select: ["id"],
+        where: {
+          region: { eq: { name: "usa" } },
+        },
+      };
+      Object.defineProperty(accessorQuery, "select", {
+        enumerable: true,
+        get: () => ["id"],
+      });
+      const publicSnapshotError = yield* manager.liveClient
+        .subscribe("orders", accessorQuery)
+        .pipe(Effect.flip);
+      const runtimeSnapshotError = yield* manager.liveClient
+        .subscribeRuntime("orders", accessorQuery)
+        .pipe(Effect.flip);
+      const expectedSnapshotError = {
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message:
+          "Leased gRPC query could not be snapshotted before acquisition: TypeError: Leased gRPC query fields must be own data properties.",
+      };
+      expect(publicSnapshotError).toStrictEqual(expectedSnapshotError);
+      expect(runtimeSnapshotError).toStrictEqual(expectedSnapshotError);
+
+      const encodedRouteError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          groupBy: ["region"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          where: {
+            region: { eq: { name: "  usa  " } },
+          },
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+      expect(encodedRouteError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message:
+          "Leased topic orders route field region value does not match the topic schema or cannot be used as a stable leased gRPC route key.",
+      });
+
+      const invalidRouteValue = { name: "invalid" };
+      Reflect.set(invalidRouteValue, "name", 123);
+      const invalidRouteError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          groupBy: ["region"],
+          aggregates: {
+            rowCount: { aggFunc: "count" },
+          },
+          where: {
+            region: { eq: invalidRouteValue },
+          },
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+      expect(invalidRouteError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message:
+          "Leased topic orders route field region value does not match the topic schema or cannot be used as a stable leased gRPC route key.",
+      });
+
+      const subscriptionEffect = manager.liveClient.subscribe("orders", query);
+      Reflect.set(queryRoute, "name", "caller-after-subscribe-call");
+      Reflect.set(query.groupBy, 0, "status");
+      Reflect.set(query.aggregates.rowCount, "aggFunc", "sum");
+      Reflect.set(query.aggregates.rowCount, "field", "price");
+      Reflect.set(query.orderBy[0], "aggregate", "callerTotal");
+      const subscription = yield* subscriptionEffect;
+      Reflect.set(queryRoute, "name", "caller-after-subscription-acquire");
+      Reflect.set(query.groupBy, 0, "customerId");
+      Reflect.set(query.aggregates.rowCount, "aggFunc", "avg");
+      Reflect.set(query.orderBy[0], "aggregate", "afterAcquireTotal");
+      const events = yield* subscription.events.pipe(Stream.take(2), Stream.runCollect);
+
+      expect(events).toStrictEqual([
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+        {
+          type: "delta",
+          topic: "orders",
+          queryId: "query-0",
+          fromVersion: 0,
+          toVersion: 1,
+          operations: [
+            {
+              type: "insert",
+              key: routeGroupKey,
+              row: {
+                region: { name: "usa" },
+                rowCount: 2n,
+              },
+              index: 0,
+            },
+          ],
+          totalRows: 1,
+        },
+      ]);
+
+      yield* subscription.close();
+
+      expect({
+        requestRegionNames,
+        acquireRegionNames,
+        mapRegionNames,
+        releaseRegionNames,
+      }).toStrictEqual({
+        requestRegionNames: ["usa"],
+        acquireRegionNames: ["usa"],
+        mapRegionNames: ["usa", "usa"],
+        releaseRegionNames: ["usa"],
+      });
+      expect(requestRoutes).toHaveLength(1);
+      expect(acquireRoutes).toHaveLength(1);
+      expect(mapRoutes).toHaveLength(2);
+      expect(releaseRoutes).toHaveLength(1);
+      expect(requestRoutes[0]?.region).not.toBe(queryRoute);
+      expect(requestRoutes[0]).not.toBe(acquireRoutes[0]);
+      expect(requestRoutes[0]?.region).not.toBe(acquireRoutes[0]?.region);
+      expect(acquireRoutes[0]).not.toBe(mapRoutes[0]);
+      expect(acquireRoutes[0]?.region).not.toBe(mapRoutes[0]?.region);
+      expect(mapRoutes[0]).not.toBe(mapRoutes[1]);
+      expect(mapRoutes[0]?.region).not.toBe(mapRoutes[1]?.region);
+      expect(releaseRoutes[0]).not.toBe(requestRoutes[0]);
+      expect(releaseRoutes[0]).not.toBe(acquireRoutes[0]);
+      expect(releaseRoutes[0]).not.toBe(mapRoutes[0]);
+      expect(releaseRoutes[0]).not.toBe(mapRoutes[1]);
+      expect(releaseRoutes[0]?.region).not.toBe(mapRoutes[1]?.region);
+
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-lease-manager-route-validation.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-route-validation.test.ts
@@ -1,0 +1,600 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig } from "@effect-view-server/config";
+import { grpcSourceMarkers } from "@effect-view-server/config/internal";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import { Cause, Effect, Exit, Fiber, Queue, Schema, Stream } from "effect";
+import { makeViewServerGrpcHealthLedger } from "./grpc-health";
+import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
+import { resolveViewServerRuntimeOptions } from "./runtime-options";
+
+import {
+  grpcClients,
+  grpcOrderValue,
+  grpcTopicSources,
+  type GrpcOrderValueMessage,
+} from "../test-harness/grpc-config";
+import { resolveLeasedGrpcRuntimeOptions } from "../test-harness/grpc-materialized";
+import {
+  grpcLeasedViewServer,
+  leasedOrdersQuery,
+  makeLeasedGrpcHealth,
+} from "../test-harness/grpc-leased";
+
+const cloneWithMutableOrdersGrpcSource = <
+  const Config extends {
+    readonly topics: {
+      readonly orders: {
+        readonly grpcSource: object;
+      };
+    };
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: {
+    ...config.topics,
+    orders: {
+      ...config.topics.orders,
+      grpcSource: { ...config.topics.orders.grpcSource },
+    },
+  },
+});
+
+describe("gRPC lease manager route validation", () => {
+  it.live("rejects leased gRPC subscriptions without exact route equality", () =>
+    Effect.gen(function* () {
+      const feed = grpcLeasedViewServer({
+        streamForRegion: () => Stream.never,
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const error = yield* Effect.flip(
+        manager.liveClient.subscribeRuntime("orders", {
+          select: ["id"],
+          where: {
+            region: { startsWith: "u" },
+          },
+          limit: 10,
+        }),
+      );
+
+      expect(error).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        topic: "orders",
+        message: "Leased topic orders route field region must use an exact eq filter.",
+      });
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("maps leased gRPC acquisition topic metadata failures to runtime unavailable", () =>
+    Effect.gen(function* () {
+      const localViewServer = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: () => Stream.never,
+        }),
+      );
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {},
+      });
+      Reflect.deleteProperty(localViewServer.topics, "orders");
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const error = yield* manager.liveClient
+        .subscribeRuntime("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.flip);
+
+      expect(error).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "RuntimeUnavailable",
+        topic: "orders",
+        message: "gRPC leased feed orders references unknown topic orders",
+      });
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("accepts decoded transform schema values for leased gRPC routes", () =>
+    Effect.gen(function* () {
+      const BigIntRouteOrder = Schema.Struct({
+        id: Schema.String,
+        accountId: Schema.BigIntFromString,
+        customerId: Schema.String,
+        price: Schema.Number,
+      });
+      let acquiredRoute: bigint | null = null;
+      const localViewServer = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          orders: grpcTopicSources.leased({
+            schema: BigIntRouteOrder,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            routeBy: ["accountId"],
+            request: ({ accountId }) => ({ orderId: accountId.toString() }),
+            acquire: ({ route }) => {
+              acquiredRoute = route.accountId;
+              return Stream.never;
+            },
+            map: ({ value, route }) => ({
+              id: `${route.accountId}:${value.customerId}`,
+              accountId: route.accountId,
+              customerId: value.customerId,
+              price: value.price,
+            }),
+          }),
+        },
+      });
+      const grpcOptions = yield* resolveViewServerRuntimeOptions(localViewServer).pipe(
+        Effect.flatMap((options) => Effect.fromNullishOr(options.grpcOptions)),
+      );
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        select: ["id", "accountId", "customerId"],
+        where: {
+          accountId: { eq: 7n },
+        },
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+      const snapshot = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+      const encodedRouteError = yield* Effect.flip(
+        manager.liveClient.subscribeRuntime("orders", {
+          select: ["id", "accountId"],
+          where: {
+            // @ts-expect-error Runtime validation also protects untyped encoded route values.
+            accountId: { eq: "7" },
+          },
+          limit: 10,
+        }),
+      );
+
+      expect({
+        acquiredRoute,
+        encodedRouteError,
+        snapshot,
+      }).toStrictEqual({
+        acquiredRoute: 7n,
+        encodedRouteError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message:
+            "Leased topic orders route field accountId value does not match the topic schema or cannot be used as a stable leased gRPC route key.",
+        },
+        snapshot: [
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+        ],
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("captures decoded leased gRPC route values before subscribeRuntime returns", () =>
+    Effect.gen(function* () {
+      let acquiredRegion: string | null = null;
+      const feed = grpcLeasedViewServer({
+        acquired: (region) => {
+          acquiredRegion = region;
+        },
+        streamForRegion: () => Stream.never,
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        grpcOptions.sourceConfig,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      const delayedRuntimeQuery = leasedOrdersQuery("usa");
+      const subscribeRuntimeEffect = manager.liveClient.subscribeRuntime(
+        "orders",
+        delayedRuntimeQuery,
+      );
+      Object.defineProperty(delayedRuntimeQuery.where.region, "eq", {
+        value: 123,
+      });
+
+      const subscription = yield* subscribeRuntimeEffect;
+      const events = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
+
+      expect({ acquiredRegion, events }).toStrictEqual({
+        acquiredRegion: "usa",
+        events: [
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+        ],
+      });
+      yield* subscription.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("fails a leased gRPC feed when a mapped route value has no canonical identity", () =>
+    Effect.gen(function* () {
+      const UnknownRouteOrder = Schema.Struct({
+        id: Schema.String,
+        route: Schema.Unknown,
+      });
+      const upstream = yield* Queue.unbounded<GrpcOrderValueMessage>();
+      const localViewServer = defineViewServerConfig({
+        grpc: { clients: grpcClients },
+        topics: {
+          orders: grpcTopicSources.leased({
+            schema: UnknownRouteOrder,
+            key: "id",
+            client: "orders",
+            method: "streamOrders",
+            routeBy: ["route"],
+            request: () => ({ orderId: "stable-route" }),
+            acquire: () => Stream.fromQueue(upstream),
+            map: ({ value }) => ({
+              id: value.customerId,
+              route: new Map([["key", "value"]]),
+            }),
+          }),
+        },
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
+        select: ["id", "route"],
+        where: {
+          route: { eq: "stable-route" },
+        },
+        limit: 10,
+      });
+      const eventQueue = yield* Queue.unbounded<unknown>();
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.runForEach((event) => Queue.offer(eventQueue, event)),
+        Effect.forkChild,
+      );
+      const initial = yield* Queue.take(eventQueue);
+      yield* Queue.offer(upstream, grpcOrderValue("bad-route", 10));
+      const terminal = yield* Queue.take(eventQueue);
+
+      expect(initial).toStrictEqual({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-0",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
+      });
+      expect(terminal).toStrictEqual({
+        type: "status",
+        topic: "orders",
+        queryId: "query-0",
+        status: "error",
+        code: "RuntimeUnavailable",
+        message: "gRPC leased upstream failed.",
+      });
+      yield* subscription.close();
+      yield* Fiber.interrupt(eventsFiber);
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("rejects leased gRPC route extraction when query shape or route schema is invalid", () =>
+    Effect.gen(function* () {
+      const localViewServer = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: () => Stream.never,
+        }),
+      );
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
+      const missingRouteFieldFeed = yield* Effect.fromNullishOr(grpcOptions.feeds["orders"]);
+      Object.defineProperty(localViewServer.topics.orders.grpcSource, "routeBy", {
+        value: ["missing"],
+      });
+      Object.defineProperty(missingRouteFieldFeed, "routeBy", {
+        value: ["missing"],
+      });
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const missingWhereError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          select: ["id"],
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+      const missingFieldQuery = leasedOrdersQuery("usa");
+      Object.defineProperty(missingFieldQuery.where, "missing", {
+        enumerable: true,
+        value: { eq: "usa" },
+      });
+      const missingFieldError = yield* manager.liveClient
+        .subscribeRuntime("orders", missingFieldQuery)
+        .pipe(Effect.flip);
+
+      expect({
+        missingWhereError,
+        missingFieldError,
+      }).toStrictEqual({
+        missingWhereError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message: "Leased topic orders requires exact equality filters for route fields: missing.",
+        },
+        missingFieldError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message: "Leased topic orders route field missing is not in the topic schema.",
+        },
+      });
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("rejects leased gRPC route extraction when topic source metadata is corrupted", () =>
+    Effect.gen(function* () {
+      const localViewServer = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: () => Stream.never,
+        }),
+      );
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
+      Object.defineProperty(localViewServer.topics.orders, "source", {
+        value: grpcSourceMarkers.materialized(),
+      });
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+
+      const missingWhereError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          select: ["id"],
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+      const nonExactRouteError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          select: ["id"],
+          where: {
+            region: { startsWith: "u" },
+          },
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+
+      expect({
+        missingWhereError,
+        nonExactRouteError,
+      }).toStrictEqual({
+        missingWhereError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message: "Leased topic orders requires exact equality filters for route fields: region.",
+        },
+        nonExactRouteError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message: "Leased topic orders route field region must use an exact eq filter.",
+        },
+      });
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live("rejects leased gRPC route extraction when route validation metadata disappears", () =>
+    Effect.gen(function* () {
+      const localViewServer = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServer({
+          streamForRegion: () => Stream.never,
+        }),
+      );
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
+      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
+        clients: grpcOptions.clientBaseUrls,
+        feeds: {},
+      });
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        localViewServer,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        health,
+      );
+      Object.defineProperty(localViewServer.topics.orders, "grpcSource", {
+        value: undefined,
+      });
+
+      const missingWhereError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          select: ["id"],
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+      const nonExactRouteError = yield* manager.liveClient
+        .subscribeRuntime("orders", {
+          select: ["id"],
+          where: {
+            region: "usa",
+          },
+          limit: 10,
+        })
+        .pipe(Effect.flip);
+
+      expect({
+        missingWhereError,
+        nonExactRouteError,
+      }).toStrictEqual({
+        missingWhereError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message: "Leased topic orders requires exact equality filters for route fields: region.",
+        },
+        nonExactRouteError: {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidQuery",
+          topic: "orders",
+          message: "Leased topic orders route field region must use an exact eq filter.",
+        },
+      });
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.live(
+    "fails leased gRPC subscription when feed route metadata changes during acquisition",
+    () =>
+      Effect.gen(function* () {
+        const feed = grpcLeasedViewServer({
+          streamForRegion: () => Stream.empty,
+        });
+        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+        const resolvedFeed = yield* Effect.fromNullishOr(grpcOptions.feeds["orders"]);
+        let routeByReads = 0;
+        Object.defineProperty(resolvedFeed, "routeBy", {
+          get: () => {
+            routeByReads += 1;
+            return routeByReads <= 2 ? ["region"] : ["region", "status"];
+          },
+        });
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
+        const health = makeLeasedGrpcHealth(grpcOptions);
+        const manager = yield* makeViewServerGrpcLeaseManager(
+          grpcOptions.sourceConfig,
+          runtimeCore.internalClient,
+          runtimeCore.liveClient,
+          runtimeCore.internalLiveClient,
+          Effect.void,
+          grpcOptions,
+          health,
+        );
+
+        const exit = yield* Effect.exit(
+          manager.liveClient.subscribe("orders", leasedOrdersQuery("usa")),
+        );
+
+        expect({
+          error: Exit.isFailure(exit)
+            ? exit.cause.reasons.find(Cause.isFailReason)?.error
+            : undefined,
+          routeByReads,
+        }).toStrictEqual({
+          error: {
+            _tag: "ViewServerRuntimeError",
+            code: "RuntimeUnavailable",
+            topic: "orders",
+            message: "Leased gRPC route is missing configured field status",
+          },
+          routeByReads: 3,
+        });
+        yield* manager.close;
+        yield* runtimeCore.close;
+      }),
+  );
+});

--- a/packages/runtime/src/grpc-lease-manager-validation.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-validation.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
-import { grpcSourceMarkers } from "@effect-view-server/config/internal";
 import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
-import { Cause, Effect, Exit, Schema, Stream } from "effect";
+import { Effect, Stream } from "effect";
 import { makeViewServerGrpcHealthLedger } from "./grpc-health";
 import { makeViewServerGrpcLeaseManager } from "./grpc-lease-manager";
 import { resolveViewServerRuntimeOptions } from "./runtime-options";
@@ -22,444 +21,28 @@ import {
   makeLeasedGrpcHealth,
 } from "../test-harness/grpc-leased";
 
+const cloneWithMutableOrdersGrpcSource = <
+  const Config extends {
+    readonly topics: {
+      readonly orders: {
+        readonly grpcSource: object;
+      };
+    };
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: {
+    ...config.topics,
+    orders: {
+      ...config.topics.orders,
+      grpcSource: { ...config.topics.orders.grpcSource },
+    },
+  },
+});
+
 describe("gRPC lease manager validation", () => {
-  it.live("rejects leased gRPC subscriptions without exact route equality", () =>
-    Effect.gen(function* () {
-      const feed = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const error = yield* Effect.flip(
-        manager.liveClient.subscribeRuntime("orders", {
-          select: ["id"],
-          where: {
-            region: { startsWith: "u" },
-          },
-          limit: 10,
-        }),
-      );
-
-      expect(error).toStrictEqual({
-        _tag: "ViewServerRuntimeError",
-        code: "InvalidQuery",
-        topic: "orders",
-        message: "Leased topic orders route field region must use an exact eq filter.",
-      });
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("maps leased gRPC acquisition topic metadata failures to runtime unavailable", () =>
-    Effect.gen(function* () {
-      const localViewServer = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
-      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
-        clients: grpcOptions.clientBaseUrls,
-        feeds: {},
-      });
-      Reflect.deleteProperty(localViewServer.topics, "orders");
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        localViewServer,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const error = yield* manager.liveClient
-        .subscribeRuntime("orders", leasedOrdersQuery("usa"))
-        .pipe(Effect.flip);
-
-      expect(error).toStrictEqual({
-        _tag: "ViewServerRuntimeError",
-        code: "RuntimeUnavailable",
-        topic: "orders",
-        message: "gRPC leased feed orders references unknown topic orders",
-      });
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("accepts decoded transform schema values for leased gRPC routes", () =>
-    Effect.gen(function* () {
-      const BigIntRouteOrder = Schema.Struct({
-        id: Schema.String,
-        accountId: Schema.BigIntFromString,
-        customerId: Schema.String,
-        price: Schema.Number,
-      });
-      let acquiredRoute: bigint | null = null;
-      const localViewServer = defineViewServerConfig({
-        grpc: { clients: grpcClients },
-        topics: {
-          orders: grpcTopicSources.leased({
-            schema: BigIntRouteOrder,
-            key: "id",
-            client: "orders",
-            method: "streamOrders",
-            routeBy: ["accountId"],
-            request: ({ accountId }) => ({ orderId: accountId.toString() }),
-            acquire: ({ route }) => {
-              acquiredRoute = route.accountId;
-              return Stream.never;
-            },
-            map: ({ value, route }) => ({
-              id: `${route.accountId}:${value.customerId}`,
-              accountId: route.accountId,
-              customerId: value.customerId,
-              price: value.price,
-            }),
-          }),
-        },
-      });
-      const grpcOptions = yield* resolveViewServerRuntimeOptions(localViewServer).pipe(
-        Effect.flatMap((options) => Effect.fromNullishOr(options.grpcOptions)),
-      );
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
-      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
-        clients: grpcOptions.clientBaseUrls,
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        localViewServer,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const subscription = yield* manager.liveClient.subscribeRuntime("orders", {
-        select: ["id", "accountId", "customerId"],
-        where: {
-          accountId: { eq: 7n },
-        },
-        orderBy: [{ field: "id", direction: "asc" }],
-        limit: 10,
-      });
-      const snapshot = yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
-
-      expect({
-        acquiredRoute,
-        snapshot,
-      }).toStrictEqual({
-        acquiredRoute: 7n,
-        snapshot: [
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "query-0",
-            version: 0,
-            keys: [],
-            rows: [],
-            totalRows: 0,
-          },
-        ],
-      });
-      yield* subscription.close();
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("rejects decoded leased gRPC route values that fail topic schema validation", () =>
-    Effect.gen(function* () {
-      const feed = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-      const health = makeLeasedGrpcHealth(grpcOptions);
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        grpcOptions.sourceConfig,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-      const delayedRuntimeQuery = leasedOrdersQuery("usa");
-      const subscribeRuntimeEffect = manager.liveClient.subscribeRuntime(
-        "orders",
-        delayedRuntimeQuery,
-      );
-      Object.defineProperty(delayedRuntimeQuery.where.region, "eq", {
-        value: 123,
-      });
-
-      const error = yield* Effect.flip(subscribeRuntimeEffect);
-
-      expect(error).toStrictEqual({
-        _tag: "ViewServerRuntimeError",
-        code: "InvalidQuery",
-        topic: "orders",
-        message: "Leased topic orders route field region value does not match the topic schema.",
-      });
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("rejects leased gRPC route extraction when query shape or route schema is invalid", () =>
-    Effect.gen(function* () {
-      const localViewServer = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
-      const missingRouteFieldFeed = yield* Effect.fromNullishOr(grpcOptions.feeds["orders"]);
-      Object.defineProperty(localViewServer.topics.orders.grpcSource, "routeBy", {
-        value: ["missing"],
-      });
-      Object.defineProperty(missingRouteFieldFeed, "routeBy", {
-        value: ["missing"],
-      });
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
-      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
-        clients: grpcOptions.clientBaseUrls,
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        localViewServer,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const missingWhereError = yield* manager.liveClient
-        .subscribeRuntime("orders", {
-          select: ["id"],
-          limit: 10,
-        })
-        .pipe(Effect.flip);
-      const missingFieldQuery = leasedOrdersQuery("usa");
-      Object.defineProperty(missingFieldQuery.where, "missing", {
-        value: { eq: "usa" },
-      });
-      const missingFieldError = yield* manager.liveClient
-        .subscribeRuntime("orders", missingFieldQuery)
-        .pipe(Effect.flip);
-
-      expect({
-        missingWhereError,
-        missingFieldError,
-      }).toStrictEqual({
-        missingWhereError: {
-          _tag: "ViewServerRuntimeError",
-          code: "InvalidQuery",
-          topic: "orders",
-          message: "Leased topic orders requires exact equality filters for route fields: missing.",
-        },
-        missingFieldError: {
-          _tag: "ViewServerRuntimeError",
-          code: "InvalidQuery",
-          topic: "orders",
-          message: "Leased topic orders route field missing is not in the topic schema.",
-        },
-      });
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("rejects leased gRPC route extraction when topic source metadata is corrupted", () =>
-    Effect.gen(function* () {
-      const localViewServer = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
-      Object.defineProperty(localViewServer.topics.orders, "source", {
-        value: grpcSourceMarkers.materialized(),
-      });
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
-      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
-        clients: grpcOptions.clientBaseUrls,
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        localViewServer,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-
-      const missingWhereError = yield* manager.liveClient
-        .subscribeRuntime("orders", {
-          select: ["id"],
-          limit: 10,
-        })
-        .pipe(Effect.flip);
-      const nonExactRouteError = yield* manager.liveClient
-        .subscribeRuntime("orders", {
-          select: ["id"],
-          where: {
-            region: { startsWith: "u" },
-          },
-          limit: 10,
-        })
-        .pipe(Effect.flip);
-
-      expect({
-        missingWhereError,
-        nonExactRouteError,
-      }).toStrictEqual({
-        missingWhereError: {
-          _tag: "ViewServerRuntimeError",
-          code: "InvalidQuery",
-          topic: "orders",
-          message: "Leased topic orders requires exact equality filters for route fields: region.",
-        },
-        nonExactRouteError: {
-          _tag: "ViewServerRuntimeError",
-          code: "InvalidQuery",
-          topic: "orders",
-          message: "Leased topic orders route field region must use an exact eq filter.",
-        },
-      });
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live("rejects leased gRPC route extraction when route validation metadata disappears", () =>
-    Effect.gen(function* () {
-      const localViewServer = grpcLeasedViewServer({
-        streamForRegion: () => Stream.never,
-      });
-      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(localViewServer);
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});
-      const health = makeViewServerGrpcHealthLedger<typeof localViewServer.topics>({
-        clients: grpcOptions.clientBaseUrls,
-        feeds: {},
-      });
-      const manager = yield* makeViewServerGrpcLeaseManager(
-        localViewServer,
-        runtimeCore.internalClient,
-        runtimeCore.liveClient,
-        runtimeCore.internalLiveClient,
-        Effect.void,
-        grpcOptions,
-        health,
-      );
-      Object.defineProperty(localViewServer.topics.orders, "grpcSource", {
-        value: undefined,
-      });
-
-      const missingWhereError = yield* manager.liveClient
-        .subscribeRuntime("orders", {
-          select: ["id"],
-          limit: 10,
-        })
-        .pipe(Effect.flip);
-      const nonExactRouteError = yield* manager.liveClient
-        .subscribeRuntime("orders", {
-          select: ["id"],
-          where: {
-            region: "usa",
-          },
-          limit: 10,
-        })
-        .pipe(Effect.flip);
-
-      expect({
-        missingWhereError,
-        nonExactRouteError,
-      }).toStrictEqual({
-        missingWhereError: {
-          _tag: "ViewServerRuntimeError",
-          code: "InvalidQuery",
-          topic: "orders",
-          message: "Leased topic orders requires exact equality filters for route fields: region.",
-        },
-        nonExactRouteError: {
-          _tag: "ViewServerRuntimeError",
-          code: "InvalidQuery",
-          topic: "orders",
-          message: "Leased topic orders route field region must use an exact eq filter.",
-        },
-      });
-      yield* manager.close;
-      yield* runtimeCore.close;
-    }),
-  );
-
-  it.live(
-    "fails leased gRPC subscription when feed route metadata changes during acquisition",
-    () =>
-      Effect.gen(function* () {
-        const feed = grpcLeasedViewServer({
-          streamForRegion: () => Stream.empty,
-        });
-        const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
-        const resolvedFeed = yield* Effect.fromNullishOr(grpcOptions.feeds["orders"]);
-        let routeByReads = 0;
-        Object.defineProperty(resolvedFeed, "routeBy", {
-          get: () => {
-            routeByReads += 1;
-            return routeByReads <= 2 ? ["region"] : ["region", "status"];
-          },
-        });
-        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(grpcOptions.sourceConfig, {});
-        const health = makeLeasedGrpcHealth(grpcOptions);
-        const manager = yield* makeViewServerGrpcLeaseManager(
-          grpcOptions.sourceConfig,
-          runtimeCore.internalClient,
-          runtimeCore.liveClient,
-          runtimeCore.internalLiveClient,
-          Effect.void,
-          grpcOptions,
-          health,
-        );
-
-        const exit = yield* Effect.exit(
-          manager.liveClient.subscribe("orders", leasedOrdersQuery("usa")),
-        );
-
-        expect({
-          error: Exit.isFailure(exit)
-            ? exit.cause.reasons.find(Cause.isFailReason)?.error
-            : undefined,
-          routeByReads,
-        }).toStrictEqual({
-          error: {
-            _tag: "ViewServerRuntimeError",
-            code: "RuntimeUnavailable",
-            topic: "orders",
-            message: "Leased gRPC route is missing configured field status",
-          },
-          routeByReads: 3,
-        });
-        yield* manager.close;
-        yield* runtimeCore.close;
-      }),
-  );
-
   it.live("fails leased gRPC subscription when acquire fails before returning a stream", () =>
     Effect.gen(function* () {
       let released = 0;
@@ -591,22 +174,24 @@ describe("gRPC lease manager validation", () => {
   it.live("fails leased gRPC subscription when acquire does not return a Stream", () =>
     Effect.gen(function* () {
       let released = 0;
-      const feed = grpcLeasedViewServerFromCallbacks({
-        request: ({ region }) => ({ orderId: region }),
-        acquire: () => Stream.never,
-        release: () =>
-          Effect.sync(() => {
-            released += 1;
+      const feed = cloneWithMutableOrdersGrpcSource(
+        grpcLeasedViewServerFromCallbacks({
+          request: ({ region }) => ({ orderId: region }),
+          acquire: () => Stream.never,
+          release: () =>
+            Effect.sync(() => {
+              released += 1;
+            }),
+          map: ({ value, route }) => ({
+            id: `${route.region}:${value.customerId}`,
+            customerId: value.customerId,
+            status: value.status,
+            price: value.price,
+            region: route.region,
+            updatedAt: value.updatedAt,
           }),
-        map: ({ value, route }) => ({
-          id: `${route.region}:${value.customerId}`,
-          customerId: value.customerId,
-          status: value.status,
-          price: value.price,
-          region: route.region,
-          updatedAt: value.updatedAt,
         }),
-      });
+      );
       Object.defineProperty(feed.topics.orders.grpcSource, "acquire", {
         value: () => "not-a-stream",
       });

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -13,9 +13,12 @@ import type {
   ViewServerTransportError,
 } from "@effect-view-server/config";
 import { validateLiveQuerySourceRoute } from "@effect-view-server/config";
+import { validateDecodedRow } from "@effect-view-server/config/internal";
 import {
   ignoreLoggedTypedFailuresPreserveNonTypedFailures,
+  makeSchemaJsonIdentity,
   runAllFinalizers,
+  type SchemaJsonIdentity,
 } from "@effect-view-server/effect-utils";
 import type {
   ViewServerLiveEvent,
@@ -29,18 +32,19 @@ import {
   Effect,
   Exit,
   Option,
+  Result,
   Schema,
   Scope,
   Semaphore,
   Stream,
 } from "effect";
-import * as BigDecimal from "effect/BigDecimal";
 import type { ViewServerGrpcHealthLedger } from "./grpc-health";
 import {
   makeGrpcGroupedKeyTranslations,
   type GrpcGroupedKeyTranslations,
   type GrpcGroupedKeyRetentionObserver,
 } from "./grpc-grouped-key-translations";
+import { compileGrpcGroupedPublicKey } from "./grpc-grouped-public-key";
 import {
   callLeasedGrpcSourceAcquire,
   callLeasedGrpcSourceRelease,
@@ -55,6 +59,7 @@ import {
 } from "./grpc-source-lifecycle";
 import type { ResolvedViewServerGrpcRuntimeOptions } from "./runtime-options";
 import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+import { snapshotLeasedGrpcQuery } from "./grpc-leased-query-snapshot";
 import {
   makeSourceOwnershipPolicy,
   type ViewServerRuntimeCoreInternalClient,
@@ -86,17 +91,28 @@ type RuntimeTopicDefinition = {
   readonly key: string;
 };
 
-type CanonicalRouteValue =
-  | BigDecimal.BigDecimal
-  | bigint
-  | string
-  | number
-  | boolean
-  | null
-  | ReadonlyArray<CanonicalRouteValue>
-  | { readonly [key: string]: CanonicalRouteValue };
+type LeasedFeedRoute = Readonly<Record<string, unknown>>;
 
-type LeasedFeedRoute = Readonly<Record<string, CanonicalRouteValue>>;
+type LeasedRouteFieldIdentity = {
+  readonly canonicalKey: string;
+  readonly identity: SchemaJsonIdentity;
+};
+
+type ExtractedLeasedFeedRoute = {
+  readonly values: LeasedFeedRoute;
+  readonly fields: ReadonlyMap<string, LeasedRouteFieldIdentity>;
+};
+
+const materializeLeasedRouteView = (
+  route: LeasedFeedRoute,
+  fields: ReadonlyMap<string, LeasedRouteFieldIdentity>,
+): LeasedFeedRoute => {
+  const view: Record<string, unknown> = Object.create(null);
+  for (const [field, routeField] of fields) {
+    view[field] = routeField.identity.materializeDecoded(route[field]);
+  }
+  return view;
+};
 
 type LeasedFeedRuntimeInput = ViewServerGrpcSourceInput<LeasedFeedRoute>;
 
@@ -143,6 +159,7 @@ type LeaseRowOwner = {
 type ActiveLease = LeaseRowOwner & {
   readonly feedKey: string;
   readonly route: LeasedFeedRoute;
+  readonly routeFields: ReadonlyMap<string, LeasedRouteFieldIdentity>;
   readonly scope: Scope.Scope;
   readonly publicToInternalKeys: Map<string, string>;
   readonly cleanupRows: Effect.Effect<void, ViewServerGrpcIngressError, never>;
@@ -225,42 +242,6 @@ const grpcLeaseError = (input: {
 const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const isPlainRouteRecord = (value: unknown): value is Readonly<Record<string, unknown>> => {
-  if (!isRecord(value)) {
-    return false;
-  }
-  const prototype = Object.getPrototypeOf(value);
-  return (
-    (prototype === null || prototype === Object.prototype) &&
-    Object.getOwnPropertySymbols(value).length === 0 &&
-    Object.getOwnPropertyNames(value).length === Object.keys(value).length
-  );
-};
-
-const isCanonicalRouteValue = (value: unknown): value is CanonicalRouteValue => {
-  if (BigDecimal.isBigDecimal(value)) {
-    return true;
-  }
-  if (
-    typeof value === "bigint" ||
-    typeof value === "string" ||
-    typeof value === "boolean" ||
-    value === null
-  ) {
-    return true;
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value);
-  }
-  if (Array.isArray(value)) {
-    return value.every(isCanonicalRouteValue);
-  }
-  if (isPlainRouteRecord(value)) {
-    return Object.keys(value).every((key) => isCanonicalRouteValue(value[key]));
-  }
-  return false;
-};
-
 const exactEqValue = (value: unknown): Option.Option<unknown> => {
   if (!isRecord(value) || Object.keys(value).length !== 1 || !Object.hasOwn(value, "eq")) {
     return Option.none();
@@ -297,7 +278,8 @@ const extractRoute = Effect.fn("ViewServerRuntime.grpc.leased.route.extract")(fu
     );
   }
   const topicDefinition = yield* topicDefinitionFor(config, topic, feed.topic);
-  const route: Record<string, CanonicalRouteValue> = Object.create(null);
+  const route: Record<string, unknown> = Object.create(null);
+  const fields = new Map<string, LeasedRouteFieldIdentity>();
   for (const field of feed.routeBy) {
     const value = exactEqValue(query["where"][field]);
     if (Option.isNone(value)) {
@@ -319,96 +301,52 @@ const extractRoute = Effect.fn("ViewServerRuntime.grpc.leased.route.extract")(fu
         }),
       );
     }
-    yield* Schema.encodeUnknownEffect(fieldSchema)(value.value).pipe(
-      Effect.mapError(() =>
+    const identity = makeSchemaJsonIdentity(fieldSchema);
+    const routeField = yield* Effect.try({
+      try: () => {
+        const routeValue = identity.materializeDecoded(value.value);
+        return {
+          canonicalKey: identity.canonicalKey(routeValue),
+          routeValue,
+        };
+      },
+      catch: () =>
         runtimeError({
           code: "InvalidQuery",
           topic,
-          message: `Leased topic ${topic} route field ${field} value does not match the topic schema.`,
+          message: `Leased topic ${topic} route field ${field} value does not match the topic schema or cannot be used as a stable leased gRPC route key.`,
         }),
-      ),
-      Effect.asVoid,
-    );
-    const routeValue = value.value;
-    if (!isCanonicalRouteValue(routeValue)) {
-      return yield* Effect.fail(
-        runtimeError({
-          code: "InvalidQuery",
-          topic,
-          message: `Leased topic ${topic} route field ${field} value cannot be used as a stable leased gRPC route key.`,
-        }),
-      );
-    }
-    route[field] = routeValue;
+    });
+    route[field] = routeField.routeValue;
+    fields.set(field, { canonicalKey: routeField.canonicalKey, identity });
   }
-  return route;
+  return {
+    values: route,
+    fields,
+  } satisfies ExtractedLeasedFeedRoute;
 });
-
-const encodeFrame = (tag: string, payload: string): string => `${tag}:${payload.length}:${payload}`;
-
-const isCanonicalRouteArray = (
-  value: CanonicalRouteValue,
-): value is ReadonlyArray<CanonicalRouteValue> => Array.isArray(value);
-
-const encodeRouteRecord = (value: Readonly<Record<string, CanonicalRouteValue>>): string => {
-  const entries: Array<string> = [];
-  for (const [key, routeValue] of Object.entries(value).sort(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    const encodedValue = encodeRouteValue(routeValue);
-    const encodedKey = JSON.stringify(key);
-    entries.push(`${encodedKey.length}:${encodedKey}${encodedValue.length}:${encodedValue}`);
-  }
-  return entries.join("");
-};
-
-const encodeRouteValue = (value: CanonicalRouteValue): string => {
-  if (BigDecimal.isBigDecimal(value)) {
-    return encodeFrame("bigDecimal", BigDecimal.format(BigDecimal.normalize(value)));
-  }
-  if (typeof value === "bigint") {
-    return encodeFrame("bigint", value.toString());
-  }
-  if (typeof value === "string") {
-    return encodeFrame("string", value);
-  }
-  if (typeof value === "number") {
-    return encodeFrame("number", Object.is(value, -0) ? "-0" : value.toString());
-  }
-  if (typeof value === "boolean") {
-    return encodeFrame("boolean", value ? "true" : "false");
-  }
-  if (value === null) {
-    return encodeFrame("null", "null");
-  }
-  if (isCanonicalRouteArray(value)) {
-    const entries: Array<string> = [];
-    for (const entry of value) {
-      const encodedEntry = encodeRouteValue(entry);
-      entries.push(`${encodedEntry.length}:${encodedEntry}`);
-    }
-    return encodeFrame("array", entries.join(""));
-  }
-  return encodeFrame("object", encodeRouteRecord(value));
-};
 
 const routeFeedKey = Effect.fn("ViewServerRuntime.grpc.leased.route.feedKey")(function* <
   Topic extends string,
->(topic: Topic, feedName: string, feed: RuntimeLeasedFeedDefinition, route: LeasedFeedRoute) {
+>(
+  topic: Topic,
+  feedName: string,
+  feed: RuntimeLeasedFeedDefinition,
+  route: ExtractedLeasedFeedRoute,
+) {
   const parts: Array<string> = [];
   for (const field of feed.routeBy) {
-    const routeValue = route[field];
-    if (routeValue === undefined) {
+    const routeField = route.fields.get(field);
+    if (routeField === undefined) {
       return yield* grpcLeaseError({
         message: `Leased gRPC route is missing configured field ${field}`,
-        cause: route,
+        cause: route.values,
         phase: "request",
         feedName,
         topic,
       });
     }
-    const encodedValue = encodeRouteValue(routeValue);
-    parts.push(`${encodeURIComponent(field)}=${encodeURIComponent(encodedValue)}`);
+    parts.push(`${encodeURIComponent(field)}=${encodeURIComponent(routeField.canonicalKey)}`);
   }
   return `${topic}/${feedName}/leased/${parts.join("&")}`;
 });
@@ -504,7 +442,7 @@ const mapLeasedValue = Effect.fn("ViewServerRuntime.grpc.leased.map")(function* 
         topic: feed.topic,
       }),
   });
-  const decoded = yield* Schema.decodeUnknownEffect(topicDefinition.schema)(row).pipe(
+  const decoded = yield* validateDecodedRow(topicDefinition.schema, row).pipe(
     Effect.mapError((cause) =>
       grpcLeaseError({
         message: `gRPC leased feed mapping produced an invalid row for ${feedName}`,
@@ -540,13 +478,6 @@ const rowKey = <const Topics extends ViewServerRuntimeTopicDefinitions>(
     });
   });
 
-const topicKeyField = Effect.fn("ViewServerRuntime.grpc.leased.topicKeyField")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(config: ViewServerTopicConfig<Topics>, topic: string, feedName: string) {
-  const topicDefinition = yield* topicDefinitionFor(config, topic, feedName);
-  return topicDefinition.key;
-});
-
 type LeasedRowWithStorageKey = {
   readonly storageKey: string;
   readonly row: object;
@@ -567,14 +498,25 @@ const internalizeLeasedRow = Effect.fn("ViewServerRuntime.grpc.leased.row.intern
 
 const validateLeasedRowRoute = Effect.fn("ViewServerRuntime.grpc.leased.row.validateRoute")(
   function* (lease: ActiveLease, route: LeasedFeedRoute, row: object) {
-    for (const field of lease.feed.routeBy) {
+    for (const [field, routeField] of lease.routeFields) {
       const routeValue = route[field];
       const rowValue = Reflect.get(row, field);
-      if (
-        routeValue === undefined ||
-        !isCanonicalRouteValue(rowValue) ||
-        encodeRouteValue(rowValue) !== encodeRouteValue(routeValue)
-      ) {
+      const rowCanonicalKey = yield* Effect.try({
+        try: () => routeField.identity.canonicalKey(rowValue),
+        catch: () =>
+          grpcLeaseError({
+            message: `gRPC leased feed ${lease.feedName} mapped row field ${field} outside the acquired route.`,
+            cause: {
+              field,
+              rowValue,
+              routeValue,
+            },
+            phase: "mapping",
+            feedName: lease.feedName,
+            topic: lease.feed.topic,
+          }),
+      });
+      if (rowCanonicalKey !== routeField.canonicalKey) {
         return yield* grpcLeaseError({
           message: `gRPC leased feed ${lease.feedName} mapped row field ${field} outside the acquired route.`,
           cause: {
@@ -615,57 +557,6 @@ const isGroupedRuntimeQuery = (query: unknown): query is Pick<GroupedQuery<objec
 const groupedKeyEncodingErrorPrefix =
   "Leased gRPC grouped key value cannot be encoded as a stable public key";
 
-const stableGroupedKeyValueTokenString = (value: unknown): string | undefined => {
-  if (BigDecimal.isBigDecimal(value)) {
-    return `["bigDecimal",${JSON.stringify(BigDecimal.format(BigDecimal.normalize(value)))}]`;
-  }
-  if (value === null) {
-    return `["null"]`;
-  }
-  if (typeof value === "bigint") {
-    return `["bigint",${JSON.stringify(value.toString())}]`;
-  }
-  if (typeof value === "number") {
-    return `["number",${JSON.stringify(Object.is(value, -0) ? "-0" : String(value))}]`;
-  }
-  if (typeof value === "string") {
-    return `["string",${JSON.stringify(value)}]`;
-  }
-  if (typeof value === "boolean") {
-    return `["boolean",${value ? "true" : "false"}]`;
-  }
-  if (value === undefined) {
-    return `["undefined"]`;
-  }
-  if (isCanonicalRouteValue(value)) {
-    return `["canonical",${JSON.stringify(encodeRouteValue(value))}]`;
-  }
-  return undefined;
-};
-
-const stableGroupedKeyFieldTokenString = (field: string, value: unknown): string | undefined => {
-  const valueToken = stableGroupedKeyValueTokenString(value);
-  if (valueToken === undefined) {
-    return undefined;
-  }
-  return `["array",[["string",${JSON.stringify(field)}],${valueToken}]]`;
-};
-
-const groupedKeyFromExternalizedRow = (
-  query: Pick<GroupedQuery<object>, "groupBy">,
-  row: object,
-): string | undefined => {
-  const tokens: Array<string> = [];
-  for (const field of query.groupBy) {
-    const token = stableGroupedKeyFieldTokenString(field, Reflect.get(row, field));
-    if (token === undefined) {
-      return undefined;
-    }
-    tokens.push(token);
-  }
-  return `["array",[${tokens.join(",")}]]`;
-};
-
 const groupedKeyEncodingErrorStatus = (lease: ActiveLease, queryId: string): StatusEvent => ({
   type: "status",
   topic: lease.feed.topic,
@@ -705,17 +596,6 @@ const makeLeaseTerminalRegistration = Effect.fn(
     queryId,
   } satisfies LeaseTerminalRegistration;
 });
-
-const internalizeLeasedQuery = <Query extends Readonly<Record<string, unknown>>>(
-  query: Query,
-): Query => {
-  const currentWhere: Record<string, unknown> = Object(query["where"]);
-  const where: Record<string, unknown> = { ...currentWhere };
-  return {
-    ...query,
-    where,
-  };
-};
 
 const notifyLeaseSubscribers = Effect.fn("ViewServerRuntime.grpc.leased.subscribers.notify")(
   function* (lease: ActiveLease, message: string) {
@@ -885,12 +765,17 @@ const publishLeasedBatch = Effect.fn("ViewServerRuntime.grpc.leased.publishBatch
   requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
   health: ViewServerGrpcHealthLedger<Topics>,
   lease: ActiveLease,
-  route: LeasedFeedRoute,
   values: ReadonlyArray<unknown>,
 ) {
   const rows = yield* Effect.forEach(values, (value) =>
-    mapLeasedValue(config, lease.feedName, lease.feed, route, value).pipe(
-      Effect.flatMap((row) => validateLeasedRowRoute(lease, route, row)),
+    mapLeasedValue(
+      config,
+      lease.feedName,
+      lease.feed,
+      materializeLeasedRouteView(lease.route, lease.routeFields),
+      value,
+    ).pipe(
+      Effect.flatMap((row) => validateLeasedRowRoute(lease, lease.route, row)),
       Effect.tapError((error) =>
         Clock.currentTimeMillis.pipe(
           Effect.flatMap((nowMillis) =>
@@ -941,16 +826,35 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
   health: ViewServerGrpcHealthLedger<Topics>,
   lease: ActiveLease,
   lock: Semaphore.Semaphore,
-  route: LeasedFeedRoute,
-  input: LeasedFeedRuntimeInput,
+  grpcClient: unknown,
+  request: unknown,
 ) {
   const releaseResources = (yield* Effect.cached(
-    ignoreGrpcFeedReleaseFailure(callFeedRelease(lease.feedName, lease.feed, input)).pipe(
+    Effect.suspend(() =>
+      callFeedRelease(
+        lease.feedName,
+        lease.feed,
+        makeGrpcSourceInput(
+          grpcClient,
+          request,
+          materializeLeasedRouteView(lease.route, lease.routeFields),
+        ),
+      ),
+    ).pipe(
+      ignoreGrpcFeedReleaseFailure,
       Effect.withSpan("ViewServerRuntime.grpc.leased.resources.release"),
     ),
   )).pipe(Effect.uninterruptible);
   yield* Scope.addFinalizer(lease.scope, releaseResources);
-  const stream = yield* callFeedAcquire(lease.feedName, lease.feed, input);
+  const stream = yield* callFeedAcquire(
+    lease.feedName,
+    lease.feed,
+    makeGrpcSourceInput(
+      grpcClient,
+      request,
+      materializeLeasedRouteView(lease.route, lease.routeFields),
+    ),
+  );
   const degradeInactiveLease = (input: {
     readonly publicMessage: string;
     readonly healthMessage: string;
@@ -988,7 +892,7 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
     ),
     Stream.groupedWithin(grpcMessageBatchSize, grpcMessageBatchFlushInterval),
     Stream.runForEach((values) =>
-      publishLeasedBatch(config, runtimeClient, requestHealthRefresh, health, lease, route, values),
+      publishLeasedBatch(config, runtimeClient, requestHealthRefresh, health, lease, values),
     ),
     Effect.exit,
     Effect.flatMap((exit) => {
@@ -1091,6 +995,30 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
   const subscriptionScope = yield* Scope.make("parallel");
   let closed = false;
 
+  const captureLeasedQuery = <
+    const Topic extends Extract<keyof Topics, string>,
+    Query extends Readonly<Record<string, unknown>>,
+  >(
+    topic: Topic,
+    query: Query,
+  ) =>
+    Result.try(() => {
+      if (!feedsByTopic.has(topic)) {
+        return query;
+      }
+      const topicDefinition = config.topics[topic];
+      return topicDefinition === undefined
+        ? query
+        : snapshotLeasedGrpcQuery(topicDefinition.schema, query);
+    });
+
+  const leasedQuerySnapshotError = (topic: string, cause: unknown): ViewServerRuntimeError =>
+    runtimeError({
+      code: "InvalidQuery",
+      topic,
+      message: `Leased gRPC query could not be snapshotted before acquisition: ${String(cause)}`,
+    });
+
   const acquireLease = Effect.fn("ViewServerRuntime.grpc.leased.acquireLease")(function* <
     const Topic extends Extract<keyof Topics, string>,
   >(topic: Topic, query: unknown) {
@@ -1108,8 +1036,9 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       return Option.none<AcquiredLease>();
     }
     const [feedName, feed] = configuredFeed;
-    const route = yield* extractRoute(config, topic, feed, query);
-    const feedKey = yield* routeFeedKey(topic, feedName, feed, route).pipe(
+    const extractedRoute = yield* extractRoute(config, topic, feed, query);
+    const route = extractedRoute.values;
+    const feedKey = yield* routeFeedKey(topic, feedName, feed, extractedRoute).pipe(
       Effect.mapError((error) =>
         runtimeError({
           code: "RuntimeUnavailable",
@@ -1192,7 +1121,11 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         }),
       ),
     );
-    const request = yield* callFeedRequest(feedName, feed, route).pipe(
+    const request = yield* callFeedRequest(
+      feedName,
+      feed,
+      materializeLeasedRouteView(route, extractedRoute.fields),
+    ).pipe(
       Effect.mapError((error) =>
         runtimeError({
           code: "RuntimeUnavailable",
@@ -1214,6 +1147,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       ...rowOwner,
       feedKey,
       route,
+      routeFields: extractedRoute.fields,
       scope,
       publicToInternalKeys: new Map<string, string>(),
       cleanupRows,
@@ -1225,7 +1159,6 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         leases.set(feedKey, lease);
-        const input: LeasedFeedRuntimeInput = makeGrpcSourceInput(grpcClient, request, route);
         const startedAt = yield* Clock.currentTimeMillis;
         yield* health.clientConnected(feed.client, startedAt);
         yield* health.leasedFeedStarting({
@@ -1245,8 +1178,8 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
             health,
             lease,
             lock,
-            route,
-            input,
+            grpcClient,
+            request,
           ),
         ).pipe(Effect.exit);
         if (Exit.isFailure(startExit)) {
@@ -1342,6 +1275,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     readonly lease: ActiveLease;
     readonly keyField: string;
     readonly query: unknown;
+    readonly schema: RowSchema;
     readonly terminalSignal: Deferred.Deferred<LeaseTerminal>;
     readonly terminalRegistration: LeaseTerminalRegistration;
   }): Effect.Effect<ViewServerLiveSubscription<Row>, never, never> =>
@@ -1349,10 +1283,10 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       const groupedQuery = isGroupedRuntimeQuery(input.query) ? input.query : undefined;
       let groupedKeyTranslations: GrpcGroupedKeyTranslations<Row> | undefined;
       if (groupedQuery !== undefined) {
+        const groupedPublicKey = compileGrpcGroupedPublicKey(input.schema, groupedQuery.groupBy);
         const externalizeRow = (row: Row): Row =>
           externalizeLeasedRow(input.lease, input.keyField, row);
-        const publicKeyFromRow = (row: Row): string | undefined =>
-          groupedKeyFromExternalizedRow(groupedQuery, row);
+        const publicKeyFromRow = (row: Row): string | undefined => groupedPublicKey?.key(row);
         groupedKeyTranslations =
           groupedKeyRetentionObserver === undefined
             ? makeGrpcGroupedKeyTranslations({ externalizeRow, publicKeyFromRow })
@@ -1502,19 +1436,28 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
     ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
     ViewServerRuntimeError | ViewServerTransportError
   > {
+    const capturedQuery = captureLeasedQuery(topic, query);
     return Effect.gen(function* () {
+      if (Result.isFailure(capturedQuery)) {
+        return yield* Effect.fail(leasedQuerySnapshotError(topic, capturedQuery.failure));
+      }
+      const ownedQuery = capturedQuery.success;
       const lease = yield* lock
-        .withPermit(acquireLease(topic, query))
+        .withPermit(acquireLease(topic, ownedQuery))
         .pipe(
           Effect.catchCause((cause) => Effect.failCause(normalizeAcquireLeaseCause(topic)(cause))),
         );
       if (Option.isNone(lease)) {
-        return yield* internalLiveClient.subscribeInternal<Topic, Query>(topic, query);
+        return yield* internalLiveClient.subscribeInternal<Topic, Query>(topic, ownedQuery);
       }
       const acquired = lease.value;
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const keyField = yield* topicKeyField(config, topic, acquired.lease.feedName).pipe(
+          const topicDefinition = yield* topicDefinitionFor(
+            config,
+            topic,
+            acquired.lease.feedName,
+          ).pipe(
             Effect.mapError((error) =>
               runtimeError({
                 code: "RuntimeUnavailable",
@@ -1523,22 +1466,22 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
               }),
             ),
           );
-          const internalQuery = internalizeLeasedQuery(query);
           const terminalRegistration = yield* makeLeaseTerminalRegistration(
             acquired.terminalSignal,
           );
           const subscription = yield* restore(
             internalLiveClient.subscribeObservedInternal<Topic, Query>(
               topic,
-              internalQuery,
+              ownedQuery,
               terminalRegistration.observer,
             ),
           );
           return yield* withLeaseClose({
             subscription,
             lease: acquired.lease,
-            keyField,
-            query,
+            keyField: topicDefinition.key,
+            query: ownedQuery,
+            schema: topicDefinition.schema,
             terminalSignal: acquired.terminalSignal,
             terminalRegistration,
           });
@@ -1550,20 +1493,29 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
   const subscribeRuntime: ViewServerRuntimeLiveClient<Topics>["subscribeRuntime"] = (
     topic,
     query,
-  ) =>
-    Effect.gen(function* () {
+  ) => {
+    const capturedQuery = captureLeasedQuery(topic, query);
+    return Effect.gen(function* () {
+      if (Result.isFailure(capturedQuery)) {
+        return yield* Effect.fail(leasedQuerySnapshotError(topic, capturedQuery.failure));
+      }
+      const ownedQuery = capturedQuery.success;
       const lease = yield* lock
-        .withPermit(acquireLease(topic, query))
+        .withPermit(acquireLease(topic, ownedQuery))
         .pipe(
           Effect.catchCause((cause) => Effect.failCause(normalizeAcquireLeaseCause(topic)(cause))),
         );
       if (Option.isNone(lease)) {
-        return yield* internalLiveClient.subscribeRuntimeInternal(topic, query);
+        return yield* internalLiveClient.subscribeRuntimeInternal(topic, ownedQuery);
       }
       const acquired = lease.value;
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const keyField = yield* topicKeyField(config, topic, acquired.lease.feedName).pipe(
+          const topicDefinition = yield* topicDefinitionFor(
+            config,
+            topic,
+            acquired.lease.feedName,
+          ).pipe(
             Effect.mapError((error) =>
               runtimeError({
                 code: "RuntimeUnavailable",
@@ -1572,28 +1524,29 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
               }),
             ),
           );
-          const internalQuery = internalizeLeasedQuery(query);
           const terminalRegistration = yield* makeLeaseTerminalRegistration(
             acquired.terminalSignal,
           );
           const subscription = yield* restore(
             internalLiveClient.subscribeRuntimeObservedInternal(
               topic,
-              internalQuery,
+              ownedQuery,
               terminalRegistration.observer,
             ),
           );
           return yield* withLeaseClose({
             subscription,
             lease: acquired.lease,
-            keyField,
-            query,
+            keyField: topicDefinition.key,
+            query: ownedQuery,
+            schema: topicDefinition.schema,
             terminalSignal: acquired.terminalSignal,
             terminalRegistration,
           });
         }),
       ).pipe(Effect.onError(() => releaseAcquiredLease(acquired)));
     });
+  };
 
   const snapshot: ViewServerRuntimeClient<Topics>["snapshot"] = (topic, query) =>
     sourceOwnership

--- a/packages/runtime/src/grpc-leased-query-snapshot.test.ts
+++ b/packages/runtime/src/grpc-leased-query-snapshot.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
+import { snapshotLeasedGrpcQuery } from "./grpc-leased-query-snapshot";
+
+const SnapshotRow = Schema.Struct({
+  id: Schema.String,
+  label: Schema.String,
+  route: Schema.Struct({
+    desk: Schema.Trim,
+  }),
+  rank: Schema.Number,
+  score: Schema.Number,
+});
+
+describe("leased gRPC query snapshots", () => {
+  it("owns nested query arrays, filters, aggregate definitions, and opaque values", () => {
+    const orderByEntry = { aggregate: "total", direction: "desc" };
+    const query = {
+      select: ["id"],
+      where: {
+        route: { eq: { desk: "equities" } },
+        rank: { eq: "not-a-number" },
+        score: { in: [1, 2] },
+        label: { startsWith: "e" },
+        missing: { custom: { enabled: true } },
+      },
+      groupBy: ["route"],
+      aggregates: {
+        total: { aggFunc: "sum", field: "score" },
+      },
+      orderBy: [orderByEntry],
+      metadata: new Date(0),
+    };
+
+    const snapshot = snapshotLeasedGrpcQuery(SnapshotRow, query);
+
+    query.select.push("label");
+    Reflect.set(query.where.route.eq, "desk", "changed");
+    query.where.score.in.push(3);
+    Reflect.set(query.where.missing.custom, "enabled", false);
+    query.groupBy.push("label");
+    Reflect.set(query.aggregates.total, "field", "missing");
+    Reflect.set(orderByEntry, "direction", "asc");
+    query.metadata.setUTCFullYear(2020);
+
+    expect(snapshot).toStrictEqual({
+      select: ["id"],
+      where: {
+        route: { eq: { desk: "equities" } },
+        rank: { eq: "not-a-number" },
+        score: { in: [1, 2] },
+        label: { startsWith: "e" },
+        missing: { custom: { enabled: true } },
+      },
+      groupBy: ["route"],
+      aggregates: {
+        total: { aggFunc: "sum", field: "score" },
+      },
+      orderBy: [{ aggregate: "total", direction: "desc" }],
+      metadata: new Date(0),
+    });
+    expect(snapshot.where.route.eq).not.toBe(query.where.route.eq);
+    expect(snapshot.where.score.in).not.toBe(query.where.score.in);
+    expect(snapshot.metadata).not.toBe(query.metadata);
+  });
+
+  it("snapshots non-record where values without consulting row fields", () => {
+    const query = {
+      select: ["id"],
+      where: null,
+    };
+
+    expect(snapshotLeasedGrpcQuery(SnapshotRow, query)).toStrictEqual(query);
+  });
+
+  it("owns decoded direct field literals without decoding encoded query forms", () => {
+    const labelFilter = { custom: { prefix: "e" } };
+    const nullPrototype: Record<string, unknown> = { enabled: true };
+    Object.setPrototypeOf(nullPrototype, null);
+    const query = {
+      select: ["id"],
+      where: {
+        route: { desk: "  equities  " },
+        rank: 1,
+        score: "not-a-number",
+        label: labelFilter,
+      },
+      extension: nullPrototype,
+    };
+
+    const snapshot = snapshotLeasedGrpcQuery(SnapshotRow, query);
+    Reflect.set(labelFilter.custom, "prefix", "changed");
+    Reflect.set(nullPrototype, "enabled", false);
+
+    expect(snapshot).toStrictEqual({
+      select: ["id"],
+      where: {
+        route: { desk: "  equities  " },
+        rank: 1,
+        score: "not-a-number",
+        label: { custom: { prefix: "e" } },
+      },
+      extension: { enabled: true },
+    });
+  });
+
+  it("rejects cyclic query values", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        extension: cyclic,
+      }),
+    ).toThrow("Leased gRPC query contains a cycle.");
+  });
+
+  it("rejects cyclic query arrays", () => {
+    const cyclic: Array<unknown> = [];
+    cyclic.push(cyclic);
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        extension: cyclic,
+      }),
+    ).toThrow("Leased gRPC query contains a cycle.");
+  });
+
+  it("rejects cyclic schema-field objects and arrays", () => {
+    const cyclicRoute: Record<string, unknown> = {};
+    cyclicRoute["desk"] = cyclicRoute;
+    const cyclicScores: Array<unknown> = [];
+    cyclicScores.push(cyclicScores);
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        where: { route: cyclicRoute },
+      }),
+    ).toThrow("Leased gRPC query contains a cycle.");
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        where: { score: { in: cyclicScores } },
+      }),
+    ).toThrow("Leased gRPC query contains a cycle.");
+  });
+
+  it("rejects accessor-backed top-level query fields", () => {
+    const query: Record<string, unknown> = {
+      select: ["id"],
+    };
+    Object.defineProperty(query, "where", {
+      enumerable: true,
+      get: () => ({ route: { eq: { desk: "equities" } } }),
+    });
+
+    expect(() => snapshotLeasedGrpcQuery(SnapshotRow, query)).toThrow(
+      "Leased gRPC query fields must be own data properties.",
+    );
+  });
+
+  it("rejects accessor-backed nested query fields", () => {
+    const extension: Record<string, unknown> = {};
+    Object.defineProperty(extension, "value", {
+      enumerable: true,
+      get: () => "computed",
+    });
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        extension,
+      }),
+    ).toThrow("Leased gRPC query fields must be own data properties.");
+  });
+
+  it("rejects accessor-backed where fields and operators without invoking them", () => {
+    let whereReads = 0;
+    const where: Record<string, unknown> = {};
+    Object.defineProperty(where, "score", {
+      enumerable: true,
+      get: () => {
+        whereReads += 1;
+        return { eq: 1 };
+      },
+    });
+    let operatorReads = 0;
+    const operator: Record<string, unknown> = {};
+    Object.defineProperty(operator, "eq", {
+      enumerable: true,
+      get: () => {
+        operatorReads += 1;
+        return 1;
+      },
+    });
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        where,
+      }),
+    ).toThrow("Leased gRPC query fields must be own data properties.");
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        where: { score: operator },
+      }),
+    ).toThrow("Leased gRPC query fields must be own data properties.");
+    expect({ operatorReads, whereReads }).toStrictEqual({
+      operatorReads: 0,
+      whereReads: 0,
+    });
+  });
+
+  it("rejects accessor-backed decoded field literals without invoking them", () => {
+    let fieldReads = 0;
+    const route: Record<string, unknown> = {};
+    Object.defineProperty(route, "desk", {
+      enumerable: true,
+      get: () => {
+        fieldReads += 1;
+        return "equities";
+      },
+    });
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: ["id"],
+        where: { route },
+      }),
+    ).toThrow("Leased gRPC query fields must be own data properties.");
+    expect(fieldReads).toBe(0);
+  });
+
+  it("rejects accessor-backed and sparse query array entries without invoking them", () => {
+    let accessorReads = 0;
+    const accessorArray: Array<unknown> = [undefined];
+    Object.defineProperty(accessorArray, "0", {
+      enumerable: true,
+      get: () => {
+        accessorReads += 1;
+        return 1;
+      },
+    });
+    const sparseArray: Array<unknown> = [];
+    sparseArray.length = 1;
+
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        select: accessorArray,
+      }),
+    ).toThrow("Leased gRPC query array entries must be own data properties.");
+    expect(() =>
+      snapshotLeasedGrpcQuery(SnapshotRow, {
+        where: { score: { in: sparseArray } },
+      }),
+    ).toThrow("Leased gRPC query array entries must be own data properties.");
+    expect(accessorReads).toBe(0);
+  });
+
+  it("captures proxied array length without invoking its get trap", () => {
+    let lengthReads = 0;
+    const select = new Proxy(["id"], {
+      get: (target, property, receiver) => {
+        if (property === "length") {
+          lengthReads += 1;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(snapshotLeasedGrpcQuery(SnapshotRow, { select })).toStrictEqual({
+      select: ["id"],
+    });
+    expect(lengthReads).toBe(0);
+  });
+
+  it("ignores non-enumerable query metadata and rejects enumerable symbols", () => {
+    const hiddenQuery: Record<string, unknown> = {
+      select: ["id"],
+    };
+    Object.defineProperty(hiddenQuery, "hidden", {
+      enumerable: false,
+      value: true,
+    });
+    const symbolicQuery: Record<string, unknown> = {
+      select: ["id"],
+    };
+    Object.defineProperty(symbolicQuery, Symbol("hidden"), {
+      enumerable: true,
+      value: true,
+    });
+
+    expect(snapshotLeasedGrpcQuery(SnapshotRow, hiddenQuery)).toStrictEqual({
+      select: ["id"],
+    });
+    expect(() => snapshotLeasedGrpcQuery(SnapshotRow, symbolicQuery)).toThrow(
+      "Leased gRPC query fields must be own data properties.",
+    );
+  });
+
+  it("rejects query properties that disappear during descriptor capture", () => {
+    const query = new Proxy(
+      { select: ["id"] },
+      {
+        getOwnPropertyDescriptor: () => undefined,
+      },
+    );
+
+    expect(() => snapshotLeasedGrpcQuery(SnapshotRow, query)).toThrow(
+      "Leased gRPC query fields could not be inspected.",
+    );
+  });
+
+  it("does not re-enumerate a caller proxy after capturing its data properties", () => {
+    const injectedRoute = { desk: "equities" };
+    let ownKeysReads = 0;
+    const query = new Proxy(
+      {
+        select: ["id"],
+      },
+      {
+        ownKeys: (target) => {
+          ownKeysReads += 1;
+          return ownKeysReads === 1 ? Reflect.ownKeys(target) : ["select", "where"];
+        },
+        getOwnPropertyDescriptor: (target, property) =>
+          property === "where"
+            ? {
+                configurable: true,
+                enumerable: true,
+                value: { route: { eq: injectedRoute } },
+                writable: true,
+              }
+            : Reflect.getOwnPropertyDescriptor(target, property),
+        get: (target, property, receiver) =>
+          property === "where"
+            ? { route: { eq: injectedRoute } }
+            : Reflect.get(target, property, receiver),
+      },
+    );
+
+    const snapshot = snapshotLeasedGrpcQuery(SnapshotRow, query);
+    Reflect.set(injectedRoute, "desk", "changed");
+
+    expect(ownKeysReads).toBe(1);
+    expect(snapshot).toStrictEqual({ select: ["id"] });
+  });
+});

--- a/packages/runtime/src/grpc-leased-query-snapshot.ts
+++ b/packages/runtime/src/grpc-leased-query-snapshot.ts
@@ -1,0 +1,207 @@
+import type { RowSchema } from "@effect-view-server/config";
+import { isRawQueryFilterOperatorKey } from "@effect-view-server/config/internal";
+import { makeSchemaJsonIdentity, type SchemaJsonIdentity } from "@effect-view-server/effect-utils";
+import { Result, Schema } from "effect";
+
+type QueryRecord = Readonly<Record<string, unknown>>;
+type RowFieldSchema = Schema.Codec<unknown, unknown, never, never>;
+
+const isRowFieldSchema = (value: unknown): value is RowFieldSchema => Schema.isSchema(value);
+
+const isPlainRecord = (value: unknown): value is QueryRecord => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
+
+const defineSnapshotProperty = (
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void => {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const ownEnumerableDataProperties = (
+  value: QueryRecord,
+): ReadonlyArray<readonly [string, unknown]> => {
+  const entries: Array<readonly [string, unknown]> = [];
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined) {
+      throw new TypeError("Leased gRPC query fields could not be inspected.");
+    }
+    if (!descriptor.enumerable) {
+      continue;
+    }
+    if (typeof key !== "string" || !("value" in descriptor)) {
+      throw new TypeError("Leased gRPC query fields must be own data properties.");
+    }
+    entries.push([key, descriptor.value]);
+  }
+  return entries;
+};
+
+const snapshotArrayValues = (
+  value: ReadonlyArray<unknown>,
+  snapshotEntry: (entry: unknown) => unknown,
+): ReadonlyArray<unknown> => {
+  const snapshot: Array<unknown> = [];
+  const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length")!;
+  const length: number = lengthDescriptor.value;
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (descriptor === undefined || !("value" in descriptor)) {
+      throw new TypeError("Leased gRPC query array entries must be own data properties.");
+    }
+    snapshot.push(snapshotEntry(descriptor.value));
+  }
+  return snapshot;
+};
+
+const snapshotSchemaValueInput = (value: unknown, active: WeakSet<object>): unknown => {
+  if (Array.isArray(value)) {
+    if (active.has(value)) {
+      throw new TypeError("Leased gRPC query contains a cycle.");
+    }
+    active.add(value);
+    const snapshot = snapshotArrayValues(value, (entry) => snapshotSchemaValueInput(entry, active));
+    active.delete(value);
+    return snapshot;
+  }
+  if (isPlainRecord(value)) {
+    if (active.has(value)) {
+      throw new TypeError("Leased gRPC query contains a cycle.");
+    }
+    active.add(value);
+    const snapshot: Record<string, unknown> = {};
+    for (const [key, entry] of ownEnumerableDataProperties(value)) {
+      defineSnapshotProperty(snapshot, key, snapshotSchemaValueInput(entry, active));
+    }
+    active.delete(value);
+    return snapshot;
+  }
+  return value;
+};
+
+const snapshotQueryValue = (value: unknown, active: WeakSet<object>): unknown => {
+  if (Array.isArray(value)) {
+    if (active.has(value)) {
+      throw new TypeError("Leased gRPC query contains a cycle.");
+    }
+    active.add(value);
+    const snapshot = snapshotArrayValues(value, (entry) => snapshotQueryValue(entry, active));
+    active.delete(value);
+    return snapshot;
+  }
+  if (isPlainRecord(value)) {
+    if (active.has(value)) {
+      throw new TypeError("Leased gRPC query contains a cycle.");
+    }
+    active.add(value);
+    const snapshot: Record<string, unknown> = {};
+    for (const [key, entry] of ownEnumerableDataProperties(value)) {
+      defineSnapshotProperty(snapshot, key, snapshotQueryValue(entry, active));
+    }
+    active.delete(value);
+    return snapshot;
+  }
+  if (typeof value === "object" && value !== null) {
+    return structuredClone(value);
+  }
+  return value;
+};
+
+const snapshotWithFieldSchema = (
+  identity: SchemaJsonIdentity,
+  value: unknown,
+  active: WeakSet<object>,
+): unknown => {
+  const owned = snapshotSchemaValueInput(value, active);
+  const materialized = Result.try(() => identity.materializeDecoded(owned));
+  return Result.isSuccess(materialized) ? materialized.success : snapshotQueryValue(owned, active);
+};
+
+const snapshotOperatorFilter = (
+  identity: SchemaJsonIdentity,
+  entries: ReadonlyArray<readonly [string, unknown]>,
+  active: WeakSet<object>,
+): Record<string, unknown> => {
+  const snapshot: Record<string, unknown> = {};
+  for (const [operator, value] of entries) {
+    if (operator === "in" && Array.isArray(value)) {
+      defineSnapshotProperty(
+        snapshot,
+        operator,
+        snapshotArrayValues(value, (entry) => snapshotWithFieldSchema(identity, entry, active)),
+      );
+    } else if (operator === "startsWith" || !isRawQueryFilterOperatorKey(operator)) {
+      defineSnapshotProperty(snapshot, operator, snapshotQueryValue(value, active));
+    } else {
+      defineSnapshotProperty(snapshot, operator, snapshotWithFieldSchema(identity, value, active));
+    }
+  }
+  return snapshot;
+};
+
+const snapshotWhereFilter = (
+  fieldSchema: RowFieldSchema,
+  filter: unknown,
+  active: WeakSet<object>,
+): unknown => {
+  const identity = makeSchemaJsonIdentity(fieldSchema);
+  const owned = snapshotSchemaValueInput(filter, active);
+  const literal = Result.try(() => identity.materializeDecoded(owned));
+  if (Result.isSuccess(literal)) {
+    return literal.success;
+  }
+  if (isPlainRecord(owned)) {
+    const entries = ownEnumerableDataProperties(owned);
+    if (entries.some(([operator]) => isRawQueryFilterOperatorKey(operator))) {
+      return snapshotOperatorFilter(identity, entries, active);
+    }
+  }
+  return snapshotQueryValue(owned, active);
+};
+
+const snapshotWhere = (schema: RowSchema, where: unknown, active: WeakSet<object>): unknown => {
+  if (!isPlainRecord(where)) {
+    return snapshotQueryValue(where, active);
+  }
+  const snapshot: Record<string, unknown> = {};
+  for (const [field, filter] of ownEnumerableDataProperties(where)) {
+    const fieldSchema = schema.fields[field];
+    defineSnapshotProperty(
+      snapshot,
+      field,
+      !isRowFieldSchema(fieldSchema)
+        ? snapshotQueryValue(filter, active)
+        : snapshotWhereFilter(fieldSchema, filter, active),
+    );
+  }
+  return snapshot;
+};
+
+export function snapshotLeasedGrpcQuery<Query extends QueryRecord>(
+  schema: RowSchema,
+  query: Query,
+): Query;
+export function snapshotLeasedGrpcQuery(schema: RowSchema, query: QueryRecord): QueryRecord {
+  const active = new WeakSet<object>();
+  const snapshot: Record<string, unknown> = {};
+  for (const [key, value] of ownEnumerableDataProperties(query)) {
+    defineSnapshotProperty(
+      snapshot,
+      key,
+      key === "where" ? snapshotWhere(schema, value, active) : snapshotQueryValue(value, active),
+    );
+  }
+  return snapshot;
+}

--- a/packages/runtime/src/grpc-materialized-ingress.test.ts
+++ b/packages/runtime/src/grpc-materialized-ingress.test.ts
@@ -46,6 +46,38 @@ import {
 
 import type { GrpcOrderValueMessage, GrpcTopics } from "../test-harness/grpc-config";
 
+const cloneWithMutableTopics = <
+  const Config extends {
+    readonly topics: object;
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: { ...config.topics },
+});
+
+const cloneWithMutableOrdersGrpcSource = <
+  const Config extends {
+    readonly topics: {
+      readonly orders: {
+        readonly grpcSource: object;
+      };
+    };
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: {
+    ...config.topics,
+    orders: {
+      ...config.topics.orders,
+      grpcSource: { ...config.topics.orders.grpcSource },
+    },
+  },
+});
+
 describe("Materialized gRPC ingress", () => {
   it.live(
     "delivers terminal status when a leased gRPC stream completes before publishing rows",
@@ -1395,7 +1427,7 @@ describe("Materialized gRPC ingress", () => {
 
   it.live("marks materialized gRPC feed degraded when acquire does not return a Stream", () =>
     Effect.gen(function* () {
-      const feed = grpcMaterializedViewServer(Stream.never);
+      const feed = cloneWithMutableOrdersGrpcSource(grpcMaterializedViewServer(Stream.never));
       Object.defineProperty(feed.topics.orders.grpcSource, "acquire", {
         value: () => "not-a-stream",
       });
@@ -1474,19 +1506,21 @@ describe("Materialized gRPC ingress", () => {
 
   it.live("marks materialized gRPC feed degraded when release does not return an Effect", () =>
     Effect.gen(function* () {
-      const feed = grpcMaterializedViewServerFromCallbacks({
-        request: () => ({ orderId: "all-orders" }),
-        acquire: () => Stream.empty,
-        release: () => Effect.void,
-        map: ({ value }) => ({
-          id: value.customerId,
-          customerId: value.customerId,
-          status: value.status,
-          price: value.price,
-          region: "usa",
-          updatedAt: value.updatedAt,
+      const feed = cloneWithMutableOrdersGrpcSource(
+        grpcMaterializedViewServerFromCallbacks({
+          request: () => ({ orderId: "all-orders" }),
+          acquire: () => Stream.empty,
+          release: () => Effect.void,
+          map: ({ value }) => ({
+            id: value.customerId,
+            customerId: value.customerId,
+            status: value.status,
+            price: value.price,
+            region: "usa",
+            updatedAt: value.updatedAt,
+          }),
         }),
-      });
+      );
       Object.defineProperty(feed.topics.orders.grpcSource, "release", {
         value: () => "not-an-effect",
       });
@@ -1824,8 +1858,10 @@ describe("Materialized gRPC ingress", () => {
     "marks materialized gRPC feed degraded when topic metadata disappears before mapping",
     () =>
       Effect.gen(function* () {
-        const localViewServer = grpcMaterializedViewServer(
-          longRunningGrpcStream([grpcOrderValue("order-without-topic", 10)]),
+        const localViewServer = cloneWithMutableTopics(
+          grpcMaterializedViewServer(
+            longRunningGrpcStream([grpcOrderValue("order-without-topic", 10)]),
+          ),
         );
         const grpcOptions = yield* resolveGrpcRuntimeOptions(localViewServer);
         const runtimeCore = yield* makeViewServerRuntimeCoreInternal(localViewServer, {});

--- a/packages/runtime/src/grpc-source-validation.test.ts
+++ b/packages/runtime/src/grpc-source-validation.test.ts
@@ -21,10 +21,42 @@ import {
 } from "../test-harness/grpc-materialized";
 import { grpcLeasedViewServer, leasedGrpcViewServer } from "../test-harness/grpc-leased";
 
+const cloneWithMutableTopics = <
+  const Config extends {
+    readonly topics: object;
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: { ...config.topics },
+});
+
+const cloneWithMutableOrdersGrpcSource = <
+  const Config extends {
+    readonly topics: {
+      readonly orders: {
+        readonly grpcSource: object;
+      };
+    };
+  },
+>(
+  config: Config,
+) => ({
+  ...config,
+  topics: {
+    ...config.topics,
+    orders: {
+      ...config.topics.orders,
+      grpcSource: { ...config.topics.orders.grpcSource },
+    },
+  },
+});
+
 describe("Runtime source composition and options", () => {
   it.live("rejects topic-owned gRPC feeds without config-owned clients", () =>
     Effect.gen(function* () {
-      const config = grpcMaterializedViewServer(Stream.never);
+      const config = { ...grpcMaterializedViewServer(Stream.never) };
       Reflect.deleteProperty(config, "grpc");
       const error = yield* resolveViewServerRuntimeOptions(config).pipe(Effect.flip);
       const grpcError = yield* Schema.decodeUnknownEffect(ViewServerGrpcIngressError)(error);
@@ -46,71 +78,77 @@ describe("Runtime source composition and options", () => {
 
   it.live("rejects malformed topic-owned gRPC bindings during runtime option derivation", () =>
     Effect.gen(function* () {
-      const invalidLifecycleViewServer = defineViewServerConfig({
-        grpc: {
-          clients: grpcClients,
-        },
-        topics: {
-          orders: grpcTopicSources.materialized({
-            schema: GrpcOrder,
-            key: "id",
-            client: "orders",
-            method: "streamOrders",
-            request: () => ({ orderId: "all" }),
-            acquire: () => Stream.never,
-            map: ({ value }) => ({
-              id: value.customerId,
-              customerId: value.customerId,
-              status: value.status,
-              price: value.price,
-              region: "usa",
-              updatedAt: value.updatedAt,
+      const invalidLifecycleViewServer = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          grpc: {
+            clients: grpcClients,
+          },
+          topics: {
+            orders: grpcTopicSources.materialized({
+              schema: GrpcOrder,
+              key: "id",
+              client: "orders",
+              method: "streamOrders",
+              request: () => ({ orderId: "all" }),
+              acquire: () => Stream.never,
+              map: ({ value }) => ({
+                id: value.customerId,
+                customerId: value.customerId,
+                status: value.status,
+                price: value.price,
+                region: "usa",
+                updatedAt: value.updatedAt,
+              }),
             }),
-          }),
-        },
-      });
+          },
+        }),
+      );
       Object.defineProperty(invalidLifecycleViewServer.topics.orders.grpcSource, "lifecycle", {
         value: "invalid-lifecycle",
       });
-      const invalidRouteByViewServer = defineViewServerConfig({
-        grpc: {
-          clients: grpcClients,
-        },
-        topics: {
-          orders: grpcTopicSources.leased({
-            schema: GrpcOrder,
-            key: "id",
-            client: "orders",
-            method: "streamOrders",
-            routeBy: ["region"],
-            request: ({ region }) => ({ orderId: region }),
-            acquire: () => Stream.never,
-            map: ({ value, route }) => ({
-              id: `${route.region}:${value.customerId}`,
-              customerId: value.customerId,
-              status: value.status,
-              price: value.price,
-              region: route.region,
-              updatedAt: value.updatedAt,
+      const invalidRouteByViewServer = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          grpc: {
+            clients: grpcClients,
+          },
+          topics: {
+            orders: grpcTopicSources.leased({
+              schema: GrpcOrder,
+              key: "id",
+              client: "orders",
+              method: "streamOrders",
+              routeBy: ["region"],
+              request: ({ region }) => ({ orderId: region }),
+              acquire: () => Stream.never,
+              map: ({ value, route }) => ({
+                id: `${route.region}:${value.customerId}`,
+                customerId: value.customerId,
+                status: value.status,
+                price: value.price,
+                region: route.region,
+                updatedAt: value.updatedAt,
+              }),
             }),
-          }),
-        },
-      });
+          },
+        }),
+      );
       Object.defineProperty(invalidRouteByViewServer.topics.orders.grpcSource, "routeBy", {
         value: [],
       });
-      const partialConcreteBindingViewServer = defineViewServerConfig({
-        grpc: {
-          clients: grpcClients,
-        },
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const partialConcreteBindingViewServer = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          grpc: {
+            clients: grpcClients,
           },
-        },
-      });
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
+          },
+        }),
+      );
       Object.defineProperty(partialConcreteBindingViewServer.topics.orders.grpcSource, "client", {
         enumerable: true,
         value: "orders",
@@ -203,7 +241,7 @@ describe("Runtime source composition and options", () => {
 
   it.live("rejects resolved gRPC feeds that reference non-server-streaming methods", () =>
     Effect.gen(function* () {
-      const config = grpcMaterializedViewServer(Stream.never);
+      const config = cloneWithMutableOrdersGrpcSource(grpcMaterializedViewServer(Stream.never));
       Object.defineProperty(config.topics.orders.grpcSource, "method", {
         enumerable: true,
         value: "getOrder",
@@ -353,8 +391,12 @@ describe("Runtime source composition and options", () => {
 
   it.live("rejects resolved gRPC feeds that reference missing clients or methods", () =>
     Effect.gen(function* () {
-      const missingClientConfig = grpcMaterializedViewServer(Stream.never);
-      const missingMethodConfig = grpcMaterializedViewServer(Stream.never);
+      const missingClientConfig = cloneWithMutableOrdersGrpcSource(
+        grpcMaterializedViewServer(Stream.never),
+      );
+      const missingMethodConfig = cloneWithMutableOrdersGrpcSource(
+        grpcMaterializedViewServer(Stream.never),
+      );
       Object.defineProperty(missingClientConfig.topics.orders.grpcSource, "client", {
         value: "missing",
       });
@@ -430,7 +472,8 @@ describe("Runtime source composition and options", () => {
         });
       const localViewServer = makeLocalViewServer();
       const invalidFeedRouteByViewServer = makeLocalViewServer();
-      const invalidSourceRouteByViewServer = makeLocalViewServer();
+      const invalidSourceRouteByViewServer =
+        cloneWithMutableOrdersGrpcSource(makeLocalViewServer());
       const resolvedGrpcOptions = yield* resolveGrpcRuntimeOptions(localViewServer);
       const invalidFeedRouteByOptions = yield* resolveGrpcRuntimeOptions(
         invalidFeedRouteByViewServer,
@@ -477,114 +520,132 @@ describe("Runtime source composition and options", () => {
 
   it.live("rejects gRPC feeds when topic source metadata is malformed", () =>
     Effect.gen(function* () {
-      const nullTopicConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const nullTopicConfig = cloneWithMutableTopics(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(nullTopicConfig.topics, "orders", { value: null });
-      const nonGrpcKindConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const nonGrpcKindConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(nonGrpcKindConfig.topics.orders.grpcSource, "kind", {
         value: "not-grpc",
       });
-      const invalidLifecycleConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const invalidLifecycleConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(invalidLifecycleConfig.topics.orders.grpcSource, "lifecycle", {
         value: "invalid-lifecycle",
       });
-      const rawGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const rawGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(rawGrpcSourceConfig.topics.orders, "grpcSource", {
         value: {
           kind: "grpc",
           lifecycle: "materialized",
         },
       });
-      const mismatchedGrpcSourceTagConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const mismatchedGrpcSourceTagConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(mismatchedGrpcSourceTagConfig.topics.orders.grpcSource, "_tag", {
         value: "GrpcLeasedTopicSource",
       });
-      const mismatchedGrpcLeasedSourceTagConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.leased({
-              routeBy: ["region"],
-            }),
+      const mismatchedGrpcLeasedSourceTagConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.leased({
+                routeBy: ["region"],
+              }),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(mismatchedGrpcLeasedSourceTagConfig.topics.orders.grpcSource, "_tag", {
         value: "GrpcMaterializedTopicSource",
       });
-      const malformedGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const malformedGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(malformedGrpcSourceConfig.topics.orders, "grpcSource", {
         value: "not-grpc",
       });
-      const extraGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const extraGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(extraGrpcSourceConfig.topics.orders.grpcSource, "extra", {
         value: true,
       });
-      const materializedRouteByGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.materialized(),
+      const materializedRouteByGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.materialized(),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(
         materializedRouteByGrpcSourceConfig.topics.orders.grpcSource,
         "routeBy",
@@ -592,31 +653,35 @@ describe("Runtime source composition and options", () => {
           value: ["region"],
         },
       );
-      const emptyRouteByGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.leased({
-              routeBy: ["region"],
-            }),
+      const emptyRouteByGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.leased({
+                routeBy: ["region"],
+              }),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(emptyRouteByGrpcSourceConfig.topics.orders.grpcSource, "routeBy", {
         value: [],
       });
-      const partialLeasedGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.leased({
-              routeBy: ["region"],
-            }),
+      const partialLeasedGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.leased({
+                routeBy: ["region"],
+              }),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(partialLeasedGrpcSourceConfig.topics.orders.grpcSource, "client", {
         enumerable: true,
         value: "orders",
@@ -625,17 +690,19 @@ describe("Runtime source composition and options", () => {
         enumerable: true,
         value: "streamOrders",
       });
-      const extraLeasedGrpcSourceConfig = defineViewServerConfig({
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-            grpcSource: grpcSourceMarkers.leased({
-              routeBy: ["region"],
-            }),
+      const extraLeasedGrpcSourceConfig = cloneWithMutableOrdersGrpcSource(
+        defineViewServerConfig({
+          topics: {
+            orders: {
+              schema: GrpcOrder,
+              key: "id",
+              grpcSource: grpcSourceMarkers.leased({
+                routeBy: ["region"],
+              }),
+            },
           },
-        },
-      });
+        }),
+      );
       Object.defineProperty(extraLeasedGrpcSourceConfig.topics.orders.grpcSource, "extra", {
         value: true,
       });

--- a/packages/runtime/src/kafka-microbatch-recovery.internal.test.ts
+++ b/packages/runtime/src/kafka-microbatch-recovery.internal.test.ts
@@ -537,11 +537,16 @@ describe("Kafka microbatch failure recovery internals", () => {
             ),
           ),
       };
-      Reflect.deleteProperty(multiSourceViewServer.topics, "payments");
+      const missingPaymentsTopics = { ...multiSourceViewServer.topics };
+      Reflect.deleteProperty(missingPaymentsTopics, "payments");
+      const missingPaymentsViewServer = {
+        ...multiSourceViewServer,
+        topics: missingPaymentsTopics,
+      };
 
       const error = yield* Effect.flip(
         processKafkaMessageBatch(
-          multiSourceViewServer,
+          missingPaymentsViewServer,
           batchingClient,
           runtimeCore.requestHealthRefresh,
           multiSourceKafkaOptions,
@@ -688,11 +693,16 @@ describe("Kafka microbatch failure recovery internals", () => {
             operations.push(`publishMany:${topic}:${rows.length}`);
           }).pipe(Effect.andThen(Effect.fail(runtimeUnavailable))),
       };
-      Reflect.deleteProperty(multiSourceViewServer.topics, "payments");
+      const missingPaymentsTopics = { ...multiSourceViewServer.topics };
+      Reflect.deleteProperty(missingPaymentsTopics, "payments");
+      const missingPaymentsViewServer = {
+        ...multiSourceViewServer,
+        topics: missingPaymentsTopics,
+      };
 
       const exit = yield* Effect.exit(
         processKafkaMessageBatch(
-          multiSourceViewServer,
+          missingPaymentsViewServer,
           publishManyFailingClient,
           runtimeCore.requestHealthRefresh,
           multiSourceKafkaOptions,

--- a/packages/runtime/src/kafka-source-contract.internal.test.ts
+++ b/packages/runtime/src/kafka-source-contract.internal.test.ts
@@ -64,10 +64,15 @@ describe("Kafka source mapping contracts", () => {
         },
       });
 
-      Reflect.deleteProperty(corruptedViewServer.topics, "ghost");
+      const missingGhostTopics = { ...corruptedViewServer.topics };
+      Reflect.deleteProperty(missingGhostTopics, "ghost");
+      const missingGhostViewServer = {
+        ...corruptedViewServer,
+        topics: missingGhostTopics,
+      };
       const error = yield* Effect.flip(
         processKafkaMessage(
-          corruptedViewServer,
+          missingGhostViewServer,
           runtimeCore.internalClient,
           runtimeCore.requestHealthRefresh,
           kafkaOptions,
@@ -545,16 +550,26 @@ describe("Kafka source mapping contracts", () => {
           },
         },
       });
-      Object.defineProperty(kafkaBackedViewServer.topics.orders.kafkaSource, "map", {
-        value: () => invalidOrder,
-      });
-      const resolved = yield* resolveViewServerRuntimeOptions(kafkaBackedViewServer, {
+      const invalidMappingViewServer = {
+        ...kafkaBackedViewServer,
+        topics: {
+          ...kafkaBackedViewServer.topics,
+          orders: {
+            ...kafkaBackedViewServer.topics.orders,
+            kafkaSource: {
+              ...kafkaBackedViewServer.topics.orders.kafkaSource,
+              map: () => invalidOrder,
+            },
+          },
+        },
+      };
+      const resolved = yield* resolveViewServerRuntimeOptions(invalidMappingViewServer, {
         kafka: {
           consumerGroupId: "view-server-direct-invalid-mapped-row",
         },
       });
       const kafkaOptions = Option.getOrThrow(Option.fromNullishOr(resolved.kafkaOptions));
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(kafkaBackedViewServer, {});
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(invalidMappingViewServer, {});
       const health = makeViewServerKafkaHealthLedger<typeof kafkaBackedViewServer.topics>({
         regions: kafkaOptions.regions,
         startFrom: kafkaOptions.consume,
@@ -568,7 +583,7 @@ describe("Kafka source mapping contracts", () => {
 
       const error = yield* Effect.flip(
         processKafkaMessage(
-          kafkaBackedViewServer,
+          invalidMappingViewServer,
           runtimeCore.internalClient,
           runtimeCore.requestHealthRefresh,
           kafkaOptions,

--- a/packages/runtime/src/runtime-kafka-options.test.ts
+++ b/packages/runtime/src/runtime-kafka-options.test.ts
@@ -173,7 +173,7 @@ describe("Runtime Kafka options and health", () => {
           },
         },
       });
-      const extraKeyKafkaBackedViewServer = defineViewServerConfig({
+      const validKafkaBackedViewServer = defineViewServerConfig({
         kafka: regions,
         topics: {
           orders: {
@@ -192,9 +192,19 @@ describe("Runtime Kafka options and health", () => {
           },
         },
       });
-      Object.defineProperty(extraKeyKafkaBackedViewServer.topics.orders.kafkaSource, "extra", {
-        value: true,
-      });
+      const extraKeyKafkaBackedViewServer = {
+        ...validKafkaBackedViewServer,
+        topics: {
+          ...validKafkaBackedViewServer.topics,
+          orders: {
+            ...validKafkaBackedViewServer.topics.orders,
+            kafkaSource: {
+              ...validKafkaBackedViewServer.topics.orders.kafkaSource,
+              extra: true,
+            },
+          },
+        },
+      };
 
       const error = yield* Effect.flip(
         resolveViewServerRuntimeOptions(malformedKafkaBackedViewServer, {

--- a/packages/runtime/src/runtime-source-options.test.ts
+++ b/packages/runtime/src/runtime-source-options.test.ts
@@ -264,18 +264,11 @@ describe("Runtime source composition and options", () => {
 
   it.live("ignores inherited topic-owned gRPC bindings during runtime option derivation", () =>
     Effect.gen(function* () {
-      const viewServerWithInheritedSource = defineViewServerConfig({
-        grpc: {
-          clients: grpcClients,
-        },
-        topics: {
-          orders: {
-            schema: GrpcOrder,
-            key: "id",
-          },
-        },
-      });
-      Object.setPrototypeOf(viewServerWithInheritedSource.topics.orders, {
+      const inheritedOrders = {
+        schema: GrpcOrder,
+        key: "id" as const,
+      };
+      Object.setPrototypeOf(inheritedOrders, {
         grpcSource: grpcTopicSources.materialized({
           schema: GrpcOrder,
           key: "id",
@@ -292,6 +285,14 @@ describe("Runtime source composition and options", () => {
             updatedAt: value.updatedAt,
           }),
         }).grpcSource,
+      });
+      const viewServerWithInheritedSource = defineViewServerConfig({
+        grpc: {
+          clients: grpcClients,
+        },
+        topics: {
+          orders: inheritedOrders,
+        },
       });
 
       const options = yield* resolveViewServerRuntimeOptions(viewServerWithInheritedSource);

--- a/packages/runtime/src/tcp-publish-command.ts
+++ b/packages/runtime/src/tcp-publish-command.ts
@@ -319,10 +319,9 @@ const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(functi
       }
     }
   }
-  return yield* Schema.decodeUnknownEffect(Schema.toType(topicDefinition.schema))(
-    decodedRow,
-    strictParseOptions,
-  ).pipe(Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)));
+  return yield* topicDefinition.schema
+    .makeEffect(decodedRow)
+    .pipe(Effect.mapError((cause) => tcpDecodeSchemaError(topic, "row", cause)));
 });
 
 const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(function* <

--- a/packages/runtime/src/tcp-publish-interface.test.ts
+++ b/packages/runtime/src/tcp-publish-interface.test.ts
@@ -194,12 +194,12 @@ describe("TCP publish Interface", () => {
       const publishResponse = yield* sendTcpPublishCommand(tcpUrl, {
         op: "publish",
         topic: "orders",
-        row: { id: "a", price: 10 },
+        row: { id: "%61", price: 10 },
       });
       const patchResponse = yield* sendTcpPublishCommand(tcpUrl, {
         op: "patch",
         topic: "orders",
-        key: "a",
+        key: "%61",
         patch: { price: 20 },
       });
       const patchedSnapshot = yield* runtime.client.snapshot("orders", {
@@ -209,7 +209,7 @@ describe("TCP publish Interface", () => {
       const deleteResponse = yield* sendTcpPublishCommand(tcpUrl, {
         op: "delete",
         topic: "orders",
-        key: "a",
+        key: "%61",
       });
       const deletedSnapshot = yield* runtime.client.snapshot("orders", {
         select: ["id", "price"],
@@ -219,7 +219,7 @@ describe("TCP publish Interface", () => {
       expect(publishResponse).toStrictEqual({ ok: true });
       expect(patchResponse).toStrictEqual({ ok: true });
       expect(patchedSnapshot).toStrictEqual({
-        rows: [{ id: "decoded-a", price: 20 }],
+        rows: [{ id: "a", price: 20 }],
         totalRows: 1,
         version: 2,
         status: "ready",
@@ -923,7 +923,7 @@ describe("TCP publish Interface", () => {
               },
             },
             id: "a",
-            amount: BigDecimal.fromStringUnsafe("678.90"),
+            amount: BigDecimal.fromStringUnsafe("678.9"),
             fills: [
               {
                 encodedQuantity: 3003n,
@@ -1013,7 +1013,7 @@ describe("TCP publish Interface", () => {
             ],
             meta: {
               encodedQuantity: 1005n,
-              runtimeAmount: BigDecimal.fromStringUnsafe("55.50"),
+              runtimeAmount: BigDecimal.fromStringUnsafe("55.5"),
               runtimeQuantity: 11005n,
             },
             nullableMeta: null,

--- a/packages/runtime/src/tcp-publish-root-class.test.ts
+++ b/packages/runtime/src/tcp-publish-root-class.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "@effect/vitest";
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { Effect, Schema } from "effect";
+import { sendTcpPublishCommand } from "../test-harness/runtime";
+import { makeViewServerRuntime } from "./index";
+
+class RootClassTcpOrder extends Schema.Class<RootClassTcpOrder>("RootClassTcpOrder")({
+  id: Schema.String,
+  quantity: Schema.BigInt,
+  status: Schema.String,
+}) {}
+viewSchema.admitClass(RootClassTcpOrder);
+
+const rootClassTcpViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: RootClassTcpOrder,
+      key: "id",
+    },
+  },
+});
+
+describe("TCP publish root Class rows", () => {
+  it.live("publishes, publishes many, and patches through the TCP command path", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeViewServerRuntime(rootClassTcpViewServer, {
+        host: "127.0.0.1",
+        tcpPublishPort: 0,
+        websocketPort: 0,
+      });
+      const tcpUrl = yield* Effect.fromNullishOr(runtime.tcpPublishUrl);
+
+      const responses = [
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publish",
+          topic: "orders",
+          row: { id: "a", quantity: "1", status: "published" },
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "publishMany",
+          topic: "orders",
+          rows: [
+            { id: "b", quantity: "2", status: "published-many" },
+            { id: "c", quantity: "3", status: "published-many" },
+          ],
+        }),
+        yield* sendTcpPublishCommand(tcpUrl, {
+          op: "patch",
+          topic: "orders",
+          key: "a",
+          patch: { quantity: "10", status: "patched" },
+        }),
+      ];
+      const snapshot = yield* runtime.client.snapshot("orders", {
+        select: ["id", "quantity", "status"],
+        orderBy: [{ field: "id", direction: "asc" }],
+        limit: 10,
+      });
+
+      expect(responses).toStrictEqual([{ ok: true }, { ok: true }, { ok: true }]);
+      expect(snapshot).toStrictEqual({
+        rows: [
+          { id: "a", quantity: 10n, status: "patched" },
+          { id: "b", quantity: 2n, status: "published-many" },
+          { id: "c", quantity: 3n, status: "published-many" },
+        ],
+        status: "ready",
+        statusCode: "Ready",
+        totalRows: 3,
+        version: 3,
+      });
+      yield* runtime.close;
+    }),
+  );
+});

--- a/packages/runtime/test-harness/grpc-grouped.ts
+++ b/packages/runtime/test-harness/grpc-grouped.ts
@@ -1,0 +1,73 @@
+import { defineViewServerConfig, viewSchema } from "@effect-view-server/config";
+import { Chunk, HashMap, Option, Schema, Stream } from "effect";
+
+import { grpcClients, type GrpcOrderValueMessage, grpcTopicSources } from "./grpc-config";
+import { RouteEncodingOrder } from "./grpc-leased";
+
+export class SemanticGroupedKeyClass extends Schema.Class<SemanticGroupedKeyClass>(
+  "SemanticGroupedKeyClass",
+)({
+  value: Schema.String,
+}) {}
+viewSchema.admitClass(SemanticGroupedKeyClass);
+
+const SemanticGroupedPlainValue = Schema.StringFromUriComponent;
+
+export const SemanticGroupedKeyOrder = Schema.Struct({
+  id: Schema.String,
+  text: Schema.String,
+  semanticClass: SemanticGroupedKeyClass,
+  semanticOption: viewSchema.Option(Schema.String),
+  semanticChunk: viewSchema.Chunk(Schema.String),
+  semanticHashMap: viewSchema.HashMap(Schema.String, Schema.String),
+  semanticPlain: SemanticGroupedPlainValue,
+  optionalValue: Schema.optionalKey(Schema.Union([Schema.String, Schema.Undefined])),
+});
+
+export const semanticGroupedKeyValues = () => ({
+  semanticClass: SemanticGroupedKeyClass.make({ value: "class-value" }),
+  semanticOption: Option.some("option-value"),
+  semanticChunk: Chunk.make("chunk-a", "chunk-b"),
+  semanticHashMap: HashMap.make(["alpha", "one"], ["beta", "two"]),
+  semanticPlain: "plain-value",
+});
+
+export const grpcGroupedKeyEncodingLeasedViewServer = (input: {
+  readonly acquire: () => Stream.Stream<GrpcOrderValueMessage, unknown, never>;
+  readonly map: (value: GrpcOrderValueMessage) => typeof RouteEncodingOrder.Type;
+}) =>
+  defineViewServerConfig({
+    grpc: { clients: grpcClients },
+    topics: {
+      orders: grpcTopicSources.leased({
+        schema: RouteEncodingOrder,
+        key: "id",
+        client: "orders",
+        method: "streamOrders",
+        routeBy: ["text"],
+        request: ({ text }) => ({ orderId: text }),
+        acquire: input.acquire,
+        map: ({ value }) => input.map(value),
+      }),
+    },
+  });
+
+export const grpcSemanticGroupedKeyLeasedViewServer = (input: {
+  readonly acquire: () => Stream.Stream<GrpcOrderValueMessage, unknown, never>;
+  readonly map: (value: GrpcOrderValueMessage) => typeof SemanticGroupedKeyOrder.Type;
+}) =>
+  defineViewServerConfig({
+    grpc: { clients: grpcClients },
+    topics: {
+      orders: grpcTopicSources.leased({
+        schema: SemanticGroupedKeyOrder,
+        key: "id",
+        client: "orders",
+        method: "streamOrders",
+        routeBy: ["text"],
+        request: ({ text }) => ({ orderId: text }),
+        acquire: input.acquire,
+        map: ({ value }) => input.map(value),
+      }),
+    },
+  });

--- a/packages/runtime/test-harness/grpc-leased.ts
+++ b/packages/runtime/test-harness/grpc-leased.ts
@@ -1,6 +1,10 @@
-import { defineViewServerConfig, type ViewServerRuntimeClient } from "@effect-view-server/config";
+import {
+  defineViewServerConfig,
+  type ViewServerRuntimeClient,
+  viewSchema,
+} from "@effect-view-server/config";
 import { grpcSourceMarkers } from "@effect-view-server/config/internal";
-import { Effect, Schedule, Schema, Stream } from "effect";
+import { Effect, HashMap, Option, Schedule, Schema, Stream } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import { type ViewServerGrpcHealthLedger } from "../src/grpc-health";
 import type { ViewServerRuntimeTopicDefinitions } from "../src/runtime-types";
@@ -48,6 +52,11 @@ export const RouteEncodingOrder = Schema.Struct({
   }),
   weird: Schema.Unknown,
 });
+
+export class SemanticRouteClass extends Schema.Class<SemanticRouteClass>("SemanticRouteClass")({
+  value: Schema.String,
+}) {}
+viewSchema.admitClass(SemanticRouteClass);
 
 export const grpcLeasedViewServer = (input: {
   readonly streamForRegion: (
@@ -218,22 +227,31 @@ export const grpcRouteEncodingLeasedViewServer = () =>
     },
   });
 
-export const grpcGroupedKeyEncodingLeasedViewServer = (input: {
-  readonly acquire: () => Stream.Stream<GrpcOrderValueMessage, unknown, never>;
-  readonly map: (value: GrpcOrderValueMessage) => typeof RouteEncodingOrder.Type;
-}) =>
+export const SemanticRouteOrder = Schema.Struct({
+  id: Schema.String,
+  routeClass: SemanticRouteClass,
+  routeOption: viewSchema.Option(Schema.String),
+  routeHashMap: viewSchema.HashMap(Schema.String, Schema.String),
+});
+
+export const grpcSemanticRouteLeasedViewServer = () =>
   defineViewServerConfig({
     grpc: { clients: grpcClients },
     topics: {
       orders: grpcTopicSources.leased({
-        schema: RouteEncodingOrder,
+        schema: SemanticRouteOrder,
         key: "id",
         client: "orders",
         method: "streamOrders",
-        routeBy: ["text"],
-        request: ({ text }) => ({ orderId: text }),
-        acquire: input.acquire,
-        map: ({ value }) => input.map(value),
+        routeBy: ["routeClass", "routeOption", "routeHashMap"],
+        request: () => ({ orderId: "semantic-route" }),
+        acquire: () => Stream.never,
+        map: () => ({
+          id: "semantic-route",
+          routeClass: SemanticRouteClass.make({ value: "route" }),
+          routeOption: Option.none(),
+          routeHashMap: HashMap.empty(),
+        }),
       }),
     },
   });

--- a/packages/runtime/test-harness/tcp-publish.ts
+++ b/packages/runtime/test-harness/tcp-publish.ts
@@ -1,5 +1,5 @@
 import { defineViewServerConfig } from "@effect-view-server/config";
-import { Effect, Schema, SchemaGetter } from "effect";
+import { Effect, Schema } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 
 export const NestedTcpOrder = Schema.Struct({
@@ -32,14 +32,7 @@ export const transformTcpViewServer = defineViewServerConfig({
   },
 });
 
-export const KeyTransformTcpId = Schema.String.pipe(
-  Schema.decodeTo(Schema.String, {
-    decode: SchemaGetter.transform((value) => `decoded-${value}`),
-    encode: SchemaGetter.transform((value) =>
-      value.startsWith("decoded-") ? value.slice("decoded-".length) : value,
-    ),
-  }),
-);
+export const KeyTransformTcpId = Schema.StringFromUriComponent;
 
 export const KeyTransformTcpOrder = Schema.Struct({
   id: KeyTransformTcpId,

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -113,7 +113,7 @@ const BadJsonField = Schema.String.pipe(
 );
 
 const BadJsonRow = Schema.Struct({
-  id: BadJsonField,
+  id: Schema.String,
 });
 
 const viewServer = defineViewServerConfig({
@@ -133,7 +133,7 @@ const viewServer = defineViewServerConfig({
   },
 });
 
-const edgeViewServer = defineViewServerConfig({
+const safeEdgeViewServer = defineViewServerConfig({
   topics: {
     badjson: {
       schema: BadJsonRow,
@@ -141,6 +141,21 @@ const edgeViewServer = defineViewServerConfig({
     },
   },
 });
+Object.defineProperty(BadJsonRow.fields, "id", {
+  configurable: true,
+  enumerable: true,
+  value: BadJsonField,
+  writable: true,
+});
+const edgeViewServer = {
+  ...safeEdgeViewServer,
+  topics: {
+    badjson: {
+      ...safeEdgeViewServer.topics.badjson,
+      schema: BadJsonRow,
+    },
+  },
+};
 
 const createServerTestRuntime = <
   const Topics extends TopicDefinitions,
@@ -1802,7 +1817,7 @@ describe("@effect-view-server/server", () => {
 
   it.live("rejects non-json schema encodings during server event encoding", () =>
     Effect.gen(function* () {
-      const inMemory = createServerTestRuntime(edgeViewServer);
+      const inMemory = createServerTestRuntime(safeEdgeViewServer);
       const event: ViewServerLiveEvent<object> = {
         type: "snapshot",
         topic: "badjson",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,6 +811,9 @@ importers:
       '@effect-view-server/config':
         specifier: workspace:*
         version: link:../config
+      '@effect-view-server/effect-utils':
+        specifier: workspace:*
+        version: link:../effect-utils
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.91
@@ -993,6 +996,9 @@ importers:
       '@effect-view-server/config':
         specifier: workspace:*
         version: link:../config
+      '@effect-view-server/effect-utils':
+        specifier: workspace:*
+        version: link:../effect-utils
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.91

--- a/scripts/package-surface-policy.ts
+++ b/scripts/package-surface-policy.ts
@@ -123,8 +123,13 @@ export const packageSurfacePolicy = {
     },
     {
       architecture: {
-        allowedWorkspaceSpecifiers: ["@effect-view-server/config"],
-        message: "The engine must stay transport/runtime independent.",
+        allowedWorkspaceSpecifiers: [
+          "@effect-view-server/config",
+          "@effect-view-server/config/internal",
+          "@effect-view-server/effect-utils",
+        ],
+        message:
+          "The engine may use neutral Effect utilities but must stay transport/runtime independent.",
         relativeOverrides: [],
       },
       directory: "column-live-view-engine",
@@ -273,8 +278,12 @@ export const packageSurfacePolicy = {
     },
     {
       architecture: {
-        allowedWorkspaceSpecifiers: ["@effect-view-server/config"],
-        message: "Protocol may depend on config contracts only.",
+        allowedWorkspaceSpecifiers: [
+          "@effect-view-server/config",
+          "@effect-view-server/config/internal",
+          "@effect-view-server/effect-utils",
+        ],
+        message: "Protocol may depend on config contracts and neutral Effect utilities only.",
         relativeOverrides: [],
       },
       directory: "protocol",


### PR DESCRIPTION
## Summary

- preserve schema-decoded values, exact optional-field presence, and consumer isolation across raw/grouped snapshots and deltas
- compile schema-aware ownership, equivalence, ordering, filter, aggregate, and canonical identity semantics once per configured topic/query plan
- add explicit `viewSchema` admission for supported Effect declarations and concrete `Schema.Class` values, with type-level migration coverage
- keep the same semantics across in-memory, Effect RPC WebSocket/NDJSON, gRPC leased/materialized, Kafka, and TCP boundaries
- document the contract in ADR 0003 and the public migration guide; include a major changeset

## Validation

- `vp check` — pass on the final commit (767 formatting files, 471 lint/type files)
- exact 100% coverage — config (23 files / 70 tests) and column-live-view-engine (44 files / 329 tests), including the final HashSet runtime-type matrix
- focused runtime, protocol, client, TCP, gRPC, Kafka, and public type tests — pass
- strict Effect diagnostics — pass across packages/examples in the full readiness/gRPC gate
- `vp run -w grpc:gate` — pass, including materialized and leased baselines
- `vp run -w bench:baseline:smoke` — pass (19/19), no baseline update
- `vp run -w bench:baseline:raw-read-write` — pass, no baseline update
- three independent final reviews (Effect, Vitest/type/coverage, architecture/thermo-nuclear) — zero blocking and zero non-blocking findings

The final all-in-one `ready` retry after test/documentation-only refinements hit a Vite+ process/IPC crash (`tsgolint` SIGSEGV, then shared-memory creation failure). `vp env doctor`, the exact standalone failed task, final `vp check`, and changed-package exact coverage all passed; the earlier full readiness run on the implementation state passed inside `grpc:gate`. GitHub CI will re-run in a clean environment.

Closes #324
