### PR TITLE
Fix TCP publisher client interruption cleanup

### DIFF
--- a/examples/tcp-publisher-react/src/tcp-client.test.ts
+++ b/examples/tcp-publisher-react/src/tcp-client.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Schema } from "effect";
+import { Cause, Deferred, Effect, Exit, Fiber, Schema } from "effect";
+import { TestClock } from "effect/testing";
 import * as Net from "node:net";
-import { writeCommand } from "./tcp-client";
+import { TcpPublisherExampleError, writeCommand } from "./tcp-client";
 
 class TcpClientTestError extends Schema.TaggedErrorClass<TcpClientTestError>()(
   "TcpClientTestError",
@@ -15,41 +16,151 @@ const ListeningAddress = Schema.Struct({
   port: Schema.Number,
 });
 
-const closeServer = (server: Net.Server) =>
-  Effect.tryPromise({
-    try: () =>
-      new Promise<void>((resolve, reject) => {
-        server.close((cause) => (cause === undefined ? resolve() : reject(cause)));
-      }),
-    catch: (cause) =>
-      new TcpClientTestError({
-        cause,
-        message: "Failed to close fragmented acknowledgement TCP server.",
-      }),
-  });
+const closeServer = Effect.fn("TcpPublisherExample.test.closeServer")((server: Net.Server) =>
+  Effect.callback<void, TcpClientTestError>((resume) => {
+    server.close((cause) =>
+      resume(
+        cause === undefined
+          ? Effect.void
+          : Effect.fail(
+              new TcpClientTestError({
+                cause,
+                message: "Failed to close TCP acknowledgement test server.",
+              }),
+            ),
+      ),
+    );
+  }),
+);
 
-const makeFragmentedAcknowledgementServer = Effect.acquireRelease(
-  Effect.tryPromise({
-    try: () =>
-      new Promise<Net.Server>((resolve, reject) => {
+const makeAcknowledgementServer = Effect.fn("TcpPublisherExample.test.makeAcknowledgementServer")(
+  function* () {
+    const connected = yield* Deferred.make<Net.Socket>();
+    const commandReceived = yield* Deferred.make<string>();
+    const peerClosed = yield* Deferred.make<void>();
+    const sockets = new Set<Net.Socket>();
+    let peerCloseCount = 0;
+    const server = yield* Effect.acquireRelease(
+      Effect.callback<Net.Server, TcpClientTestError>((resume) => {
         const server = Net.createServer((socket) => {
-          socket.once("data", () => {
-            socket.write('{"ok":');
-            setTimeout(() => socket.end("true}\n"), 1);
+          let commandBuffer = "";
+          sockets.add(socket);
+          Deferred.doneUnsafe(connected, Effect.succeed(socket));
+
+          const onData = (chunk: Buffer) => {
+            commandBuffer += chunk.toString("utf8");
+            const newlineIndex = commandBuffer.indexOf("\n");
+            if (newlineIndex >= 0) {
+              Deferred.doneUnsafe(
+                commandReceived,
+                Effect.succeed(commandBuffer.slice(0, newlineIndex)),
+              );
+            }
+          };
+          socket.on("data", onData);
+          socket.once("close", () => {
+            socket.off("data", onData);
+            sockets.delete(socket);
+            peerCloseCount += 1;
+            Deferred.doneUnsafe(peerClosed, Effect.void);
           });
         });
-        server.once("error", reject);
+        const fail = (cause: unknown) => {
+          server.removeAllListeners();
+          resume(
+            Effect.fail(
+              new TcpClientTestError({
+                cause,
+                message: "Failed to start TCP acknowledgement test server.",
+              }),
+            ),
+          );
+        };
+        server.once("error", fail);
         server.listen(0, "127.0.0.1", () => {
-          server.off("error", reject);
-          resolve(server);
+          server.off("error", fail);
+          resume(Effect.succeed(server));
+        });
+        return Effect.sync(() => {
+          server.off("error", fail);
+          if (server.listening) {
+            server.close();
+          }
         });
       }),
-    catch: (cause) =>
-      new TcpClientTestError({
-        cause,
-        message: "Failed to start fragmented acknowledgement TCP server.",
-      }),
+      (server) =>
+        Effect.sync(() => {
+          for (const socket of sockets) {
+            socket.destroy();
+          }
+        }).pipe(Effect.andThen(closeServer(server)), Effect.ignore),
+    );
+
+    return {
+      activeSocketCount: () => sockets.size,
+      commandReceived,
+      connected,
+      peerClosed,
+      peerCloseCount: () => peerCloseCount,
+      server,
+    };
+  },
+);
+
+const serverPort = Effect.fn("TcpPublisherExample.test.serverPort")(function* (server: Net.Server) {
+  const address = yield* Schema.decodeUnknownEffect(ListeningAddress)(server.address());
+  return address.port;
+});
+
+const writePeer = Effect.fn("TcpPublisherExample.test.writePeer")(
+  (socket: Net.Socket, chunk: string) =>
+    Effect.callback<void, TcpClientTestError>((resume) => {
+      socket.write(chunk, (cause) =>
+        resume(
+          cause === undefined || cause === null
+            ? Effect.void
+            : Effect.fail(
+                new TcpClientTestError({
+                  cause,
+                  message: "Failed to write TCP acknowledgement test data.",
+                }),
+              ),
+        ),
+      );
+    }),
+);
+
+const endPeer = Effect.fn("TcpPublisherExample.test.endPeer")((socket: Net.Socket, chunk = "") =>
+  Effect.callback<void, TcpClientTestError>((resume) => {
+    socket.end(chunk, () => resume(Effect.void));
   }),
+);
+
+const reserveClosedPort = Effect.acquireUseRelease(
+  Effect.callback<Net.Server, TcpClientTestError>((resume) => {
+    const server = Net.createServer();
+    const fail = (cause: unknown) =>
+      resume(
+        Effect.fail(
+          new TcpClientTestError({
+            cause,
+            message: "Failed to reserve a closed TCP test port.",
+          }),
+        ),
+      );
+    server.once("error", fail);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", fail);
+      resume(Effect.succeed(server));
+    });
+    return Effect.sync(() => {
+      server.off("error", fail);
+      if (server.listening) {
+        server.close();
+      }
+    });
+  }),
+  serverPort,
   (server) => closeServer(server).pipe(Effect.ignore),
 );
 
@@ -57,7 +168,7 @@ const command = {
   op: "publish",
   topic: "orders",
   row: {
-    id: "order-fragmented-ack",
+    id: "order-tcp-client",
     customerId: "customer-1",
     status: "open",
     price: 123,
@@ -67,13 +178,243 @@ const command = {
 } satisfies Parameters<typeof writeCommand>[0];
 
 describe("tcp publisher client", () => {
-  it.effect("buffers newline-delimited TCP acknowledgements split across packets", () =>
+  it.live("buffers newline-delimited acknowledgements split across peer writes", () =>
     Effect.gen(function* () {
-      const server = yield* makeFragmentedAcknowledgementServer;
-      const address = yield* Schema.decodeUnknownEffect(ListeningAddress)(server.address());
-      const response = yield* writeCommand(command, { port: address.port });
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const peer = yield* Deferred.await(acknowledgement.connected).pipe(
+        Effect.timeout("1 second"),
+      );
+      const receivedCommand = yield* Deferred.await(acknowledgement.commandReceived).pipe(
+        Effect.timeout("1 second"),
+      );
 
-      expect(response).toStrictEqual({ ok: true });
+      yield* writePeer(peer, '{"ok":');
+      yield* Effect.sleep("10 millis");
+      expect(commandFiber.pollUnsafe()).toBeUndefined();
+      yield* writePeer(peer, "true}\n");
+
+      const response = yield* Fiber.join(commandFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(acknowledgement.peerClosed).pipe(Effect.timeout("1 second"));
+      expect(receivedCommand).toBe(JSON.stringify(command));
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+        response,
+      }).toStrictEqual({
+        activeSocketCount: 0,
+        peerCloseCount: 1,
+        response: { ok: true },
+      });
+    }),
+  );
+
+  it.live("preserves a typed negative acknowledgement", () =>
+    Effect.gen(function* () {
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const peer = yield* Deferred.await(acknowledgement.connected).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.await(acknowledgement.commandReceived).pipe(Effect.timeout("1 second"));
+      yield* writePeer(
+        peer,
+        `${JSON.stringify({
+          ok: false,
+          error: {
+            _tag: "InvalidRow",
+            message: "The row is invalid.",
+            phase: "row",
+            topic: "orders",
+          },
+        })}\n`,
+      );
+
+      const response = yield* Fiber.join(commandFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(acknowledgement.peerClosed).pipe(Effect.timeout("1 second"));
+      expect(response).toStrictEqual({
+        ok: false,
+        error: {
+          _tag: "InvalidRow",
+          message: "The row is invalid.",
+          phase: "row",
+          topic: "orders",
+        },
+      });
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+      }).toStrictEqual({ activeSocketCount: 0, peerCloseCount: 1 });
+    }),
+  );
+
+  it.live("returns a typed invalid-JSON acknowledgement failure", () =>
+    Effect.gen(function* () {
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.flip,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const peer = yield* Deferred.await(acknowledgement.connected).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.await(acknowledgement.commandReceived).pipe(Effect.timeout("1 second"));
+      yield* writePeer(peer, "not-json\n");
+
+      const error = yield* Fiber.join(commandFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(acknowledgement.peerClosed).pipe(Effect.timeout("1 second"));
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("Invalid TCP publish acknowledgement.");
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+      }).toStrictEqual({ activeSocketCount: 0, peerCloseCount: 1 });
+    }),
+  );
+
+  it.live("returns a typed schema failure for an invalid acknowledgement shape", () =>
+    Effect.gen(function* () {
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.flip,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const peer = yield* Deferred.await(acknowledgement.connected).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.await(acknowledgement.commandReceived).pipe(Effect.timeout("1 second"));
+      yield* writePeer(peer, '{"ok":"yes"}\n');
+
+      const error = yield* Fiber.join(commandFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(acknowledgement.peerClosed).pipe(Effect.timeout("1 second"));
+      expect(Schema.isSchemaError(error)).toBe(true);
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+      }).toStrictEqual({ activeSocketCount: 0, peerCloseCount: 1 });
+    }),
+  );
+
+  it.live("returns a typed failure when the peer closes before acknowledging", () =>
+    Effect.gen(function* () {
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.flip,
+        Effect.forkChild({ startImmediately: true }),
+      );
+      const peer = yield* Deferred.await(acknowledgement.connected).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Deferred.await(acknowledgement.commandReceived).pipe(Effect.timeout("1 second"));
+      yield* endPeer(peer, '{"ok":');
+
+      const error = yield* Fiber.join(commandFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(acknowledgement.peerClosed).pipe(Effect.timeout("1 second"));
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("TCP publisher closed before sending an acknowledgement.");
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+      }).toStrictEqual({ activeSocketCount: 0, peerCloseCount: 1 });
+    }),
+  );
+
+  it.effect("returns a typed failure when the command cannot be encoded", () =>
+    Effect.gen(function* () {
+      const unserializableCommand = { ...command, unsupported: 1n };
+      const error = yield* writeCommand(unserializableCommand, {
+        host: undefined,
+        port: undefined,
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("Failed to encode TCP publish command.");
+    }),
+  );
+
+  it.live("returns a typed transport failure when connection fails", () =>
+    Effect.gen(function* () {
+      const port = yield* reserveClosedPort;
+      const error = yield* writeCommand(command, { host: "127.0.0.1", port }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("TCP publish command failed.");
+    }),
+  );
+
+  it.effect("returns a typed failure for invalid connection options", () =>
+    Effect.gen(function* () {
+      const error = yield* writeCommand(command, { port: -1 }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("TCP publish command failed.");
+    }),
+  );
+
+  it.effect("uses Effect time to own acknowledgement timeout and cleanup", () =>
+    Effect.gen(function* () {
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.flip,
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      yield* Deferred.await(acknowledgement.connected);
+      yield* Deferred.await(acknowledgement.commandReceived);
+      yield* TestClock.adjust("5 seconds");
+      const error = yield* Fiber.join(commandFiber);
+      yield* Deferred.await(acknowledgement.peerClosed);
+
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("Timed out waiting for TCP publish acknowledgement.");
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+      }).toStrictEqual({ activeSocketCount: 0, peerCloseCount: 1 });
+
+      yield* TestClock.adjust("5 seconds");
+      expect(acknowledgement.peerCloseCount()).toBe(1);
+    }),
+  );
+
+  it.live("destroys a withholding peer connection when the command is interrupted", () =>
+    Effect.gen(function* () {
+      const acknowledgement = yield* makeAcknowledgementServer();
+      const port = yield* serverPort(acknowledgement.server);
+      const commandFiber = yield* writeCommand(command, { port }).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      yield* Deferred.await(acknowledgement.connected).pipe(Effect.timeout("1 second"));
+      const receivedCommand = yield* Deferred.await(acknowledgement.commandReceived).pipe(
+        Effect.timeout("1 second"),
+      );
+      yield* Fiber.interrupt(commandFiber).pipe(Effect.timeout("1 second"));
+      const commandExit = yield* Fiber.await(commandFiber).pipe(Effect.timeout("1 second"));
+      yield* Deferred.await(acknowledgement.peerClosed).pipe(Effect.timeout("250 millis"));
+
+      expect(receivedCommand).toBe(JSON.stringify(command));
+      expect(Exit.isFailure(commandExit) && Cause.hasInterruptsOnly(commandExit.cause)).toBe(true);
+      expect({
+        activeSocketCount: acknowledgement.activeSocketCount(),
+        peerCloseCount: acknowledgement.peerCloseCount(),
+      }).toStrictEqual({ activeSocketCount: 0, peerCloseCount: 1 });
     }),
   );
 });

--- a/examples/tcp-publisher-react/src/tcp-client.ts
+++ b/examples/tcp-publisher-react/src/tcp-client.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect";
+import { Deferred, Effect, Schema } from "effect";
 import * as Net from "node:net";
 
 export class TcpPublisherExampleError extends Schema.TaggedErrorClass<TcpPublisherExampleError>()(
@@ -39,6 +39,18 @@ export type WriteCommandOptions = {
   readonly port?: number;
 };
 
+type ResolvedWriteCommandOptions = {
+  readonly host: string;
+  readonly port: number;
+};
+
+const defaultWriteCommandOptions: ResolvedWriteCommandOptions = {
+  host: "127.0.0.1",
+  port: 8081,
+};
+
+const acknowledgementTimeout = "5 seconds";
+
 const TcpPublishResponse = Schema.Union([
   Schema.Struct({
     ok: Schema.Literal(true),
@@ -56,8 +68,10 @@ const TcpPublishResponse = Schema.Union([
 
 export type TcpPublishResponse = typeof TcpPublishResponse.Type;
 
-const parseTcpPublishResponse = (line: string) =>
-  Effect.try({
+const parseTcpPublishResponse = Effect.fn("TcpPublisherExample.parseResponse")(function* (
+  line: string,
+) {
+  const parsed = yield* Effect.try({
     try: () => JSON.parse(line),
     catch: (cause) =>
       new TcpPublisherExampleError({
@@ -65,67 +79,111 @@ const parseTcpPublishResponse = (line: string) =>
         message: "Invalid TCP publish acknowledgement.",
       }),
   });
+  return yield* Schema.decodeUnknownEffect(TcpPublishResponse)(parsed);
+});
 
-export const writeCommand = (
-  command: TcpCommand | InvalidTcpCommand,
-  options: WriteCommandOptions = {},
-) =>
-  Effect.tryPromise({
-    try: () =>
-      new Promise<unknown>((resolve, reject) => {
-        let isSettled = false;
-        let responseBuffer = "";
-        const socket = Net.createConnection({
-          host: options.host ?? "127.0.0.1",
-          port: options.port ?? 8081,
-        });
-        const writeCommand = () => {
-          socket.write(`${JSON.stringify(command)}\n`);
-        };
-        const cleanup = () => {
-          socket.off("data", onData);
-          socket.off("connect", writeCommand);
-          socket.off("error", fail);
-        };
-        const finish = (line: string) => {
-          if (!isSettled) {
-            isSettled = true;
-            cleanup();
-            socket.end();
-            Effect.runPromise(parseTcpPublishResponse(line)).then(resolve, reject);
-          }
-        };
-        const fail = (cause: unknown) => {
-          if (!isSettled) {
-            isSettled = true;
-            cleanup();
-            socket.destroy();
-            reject(cause);
-          }
-        };
-        const onData = (chunk: Buffer) => {
-          responseBuffer += chunk.toString("utf8");
-          const newlineIndex = responseBuffer.indexOf("\n");
-          if (newlineIndex >= 0) {
-            finish(responseBuffer.slice(0, newlineIndex));
-          }
-        };
-        socket.setTimeout(5_000, () =>
-          fail(
-            new TcpPublisherExampleError({
-              message: "Timed out waiting for TCP publish acknowledgement.",
-            }),
+const tcpPublishTransportError = (cause: unknown, message = "TCP publish command failed.") =>
+  new TcpPublisherExampleError({ cause, message });
+
+const createTcpResponseLineHandler = (complete: (line: string) => void) => {
+  let responseBuffer = "";
+  return (chunk: Buffer) => {
+    responseBuffer += chunk.toString("utf8");
+    const newlineIndex = responseBuffer.indexOf("\n");
+    if (newlineIndex >= 0) {
+      complete(responseBuffer.slice(0, newlineIndex));
+    }
+  };
+};
+
+const acquireCommandSocket = Effect.fn("TcpPublisherExample.acquireCommandSocket")(function* (
+  commandLine: string,
+  responseLine: Deferred.Deferred<string, TcpPublisherExampleError>,
+) {
+  return yield* Effect.acquireRelease(
+    Effect.sync(() => {
+      const socket = new Net.Socket();
+      const onConnect = () => {
+        socket.write(commandLine);
+      };
+      const onData = createTcpResponseLineHandler((line) => {
+        Deferred.doneUnsafe(responseLine, Effect.succeed(line));
+      });
+      const onError = (cause: Error) => {
+        Deferred.doneUnsafe(responseLine, Effect.fail(tcpPublishTransportError(cause)));
+      };
+      const onClose = () => {
+        Deferred.doneUnsafe(
+          responseLine,
+          Effect.fail(
+            tcpPublishTransportError(
+              undefined,
+              "TCP publisher closed before sending an acknowledgement.",
+            ),
           ),
         );
-        socket.once("error", fail);
-        socket.once("connect", writeCommand);
-        socket.on("data", onData);
+      };
+
+      socket.once("close", onClose);
+      socket.once("connect", onConnect);
+      socket.on("data", onData);
+      socket.once("error", onError);
+
+      return { socket, onClose, onConnect, onData, onError };
+    }),
+    ({ socket, onClose, onConnect, onData, onError }) =>
+      Effect.sync(() => {
+        socket.off("close", onClose);
+        socket.off("connect", onConnect);
+        socket.off("data", onData);
+        socket.off("error", onError);
+        socket.destroy();
       }),
+  );
+});
+
+export const writeCommand = Effect.fn("TcpPublisherExample.writeCommand")(function* (
+  command: TcpCommand | InvalidTcpCommand,
+  options?: WriteCommandOptions,
+) {
+  const resolvedOptions: ResolvedWriteCommandOptions = {
+    host: options?.host ?? defaultWriteCommandOptions.host,
+    port: options?.port ?? defaultWriteCommandOptions.port,
+  };
+  const commandLine = yield* Effect.try({
+    try: () => `${JSON.stringify(command)}\n`,
     catch: (cause) =>
-      cause instanceof TcpPublisherExampleError
-        ? cause
-        : new TcpPublisherExampleError({
-            cause,
-            message: "TCP publish command failed.",
-          }),
-  }).pipe(Effect.andThen(Schema.decodeUnknownEffect(TcpPublishResponse)));
+      new TcpPublisherExampleError({
+        cause,
+        message: "Failed to encode TCP publish command.",
+      }),
+  });
+  const responseLine = yield* Deferred.make<string, TcpPublisherExampleError>();
+
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const commandSocket = yield* acquireCommandSocket(commandLine, responseLine);
+      yield* Effect.try({
+        try: () => {
+          commandSocket.socket.connect({
+            host: resolvedOptions.host,
+            port: resolvedOptions.port,
+          });
+        },
+        catch: (cause) => tcpPublishTransportError(cause),
+      });
+      const line = yield* Deferred.await(responseLine).pipe(
+        Effect.timeoutOrElse({
+          duration: acknowledgementTimeout,
+          orElse: () =>
+            Effect.fail(
+              new TcpPublisherExampleError({
+                message: "Timed out waiting for TCP publish acknowledgement.",
+              }),
+            ),
+        }),
+      );
+      return yield* parseTcpPublishResponse(line);
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

- replace the TCP example client’s callback-owned Promise, native socket timeout, and nested runtime boundary with an Effect-scoped socket resource
- use a Deferred acknowledgement and Effect-owned timeout so success, failure, timeout, and interruption share one finalizer
- add deterministic coverage for fragmented acknowledgements, typed transport/decode failures, timeout, interruption, and client-initiated exact-once connection cleanup

## Root cause

The previous implementation managed settlement, listeners, socket shutdown, and timeout imperatively inside `Effect.tryPromise`. Interrupting the outer Effect could not cancel that Promise or destroy a withholding peer connection promptly, and acknowledgement parsing crossed a nested `Effect.runPromise` boundary.

## Validation

- focused TCP client suite: 10/10 tests; 100% statements, branches, functions, and lines
- full TCP publisher example task: Chromium, Firefox, and WebKit browser tests; node tests; type tests; no type errors
- `vp check`
- `vp run -w check:effect` (strict; zero diagnostics)
- `vp run -w ready`
- `vp run -w bench:baseline:smoke` (19-task comparison passed)
- two review cycles across Effect, Vitest/type safety, and architecture/maintainability; final result: 0 blocking and 0 non-blocking findings

No changeset is needed because this fixes an example-local client and does not change the published package API.

Closes #327