### PR TITLE
Make WebSocket lifecycle tests event-driven

### DIFF
--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   Clock,
   Context,
+  Deferred,
   Effect,
   Fiber,
   Layer,
@@ -16,6 +17,7 @@ import {
   Schema,
   SchemaGetter,
   Stream,
+  SubscriptionRef,
   type Duration,
 } from "effect";
 import { HttpRouter, HttpServer } from "effect/unstable/http";
@@ -257,6 +259,17 @@ const trustedEvent = (event: ViewServerWireEvent) =>
     Effect.mapError(invalidTrustedEvent),
   );
 
+const awaitSubscriptionCount = Effect.fn(
+  "ViewServerClient.remote.testServer.awaitSubscriptionCount",
+)(function* (ref: SubscriptionRef.SubscriptionRef<number>, expected: number) {
+  yield* SubscriptionRef.changes(ref).pipe(
+    Stream.filter((count) => count === expected),
+    Stream.take(1),
+    Stream.runDrain,
+    Effect.timeout("1 second"),
+  );
+});
+
 const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(function* () {
   const path = "/rpc";
   const events = yield* Queue.unbounded<ViewServerTrustedWireEvent>();
@@ -264,7 +277,7 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
   const healthTopicEvents = yield* Queue.unbounded<ViewServerTrustedWireEvent>();
   let lastSubscribeQuery: unknown = undefined;
   let rows: ReadonlyArray<typeof ViewServerWireRowSchema.Type> = [];
-  let activeSubscriptions = 0;
+  const activeSubscriptions = yield* SubscriptionRef.make(0);
   let healthRequests = 0;
   let healthOverride: ViewServerWireHealth | undefined = undefined;
   let healthDelay: Duration.Input = "0 millis";
@@ -282,7 +295,8 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
           Effect.gen(function* () {
             healthRequests += 1;
             yield* Effect.sleep(healthDelay);
-            return healthOverride ?? health(rows.length, activeSubscriptions);
+            const activeSubscriptionCount = yield* SubscriptionRef.get(activeSubscriptions);
+            return healthOverride ?? health(rows.length, activeSubscriptionCount);
           }),
         "ViewServer.Subscribe": (
           payload,
@@ -293,19 +307,18 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
               return Stream.fail(healthSummaryError);
             }
             return Stream.unwrap(
-              Effect.sync(() => {
-                activeSubscriptions += 1;
-                return Stream.fromEffect(
-                  trustedEvent(snapshotEvent(payload.topic, healthSummaryRows)),
-                ).pipe(
-                  Stream.concat(Stream.fromQueue(healthSummaryEvents)),
-                  Stream.ensuring(
-                    Effect.sync(() => {
-                      activeSubscriptions -= 1;
-                    }),
+              SubscriptionRef.update(activeSubscriptions, (count) => count + 1).pipe(
+                Effect.as(
+                  Stream.fromEffect(
+                    trustedEvent(snapshotEvent(payload.topic, healthSummaryRows)),
+                  ).pipe(
+                    Stream.concat(Stream.fromQueue(healthSummaryEvents)),
+                    Stream.ensuring(
+                      SubscriptionRef.update(activeSubscriptions, (count) => count - 1),
+                    ),
                   ),
-                );
-              }),
+                ),
+              ),
             );
           }
           if (payload.topic === VIEW_SERVER_HEALTH_TOPIC) {
@@ -313,19 +326,18 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
               return Stream.fail(healthTopicError);
             }
             return Stream.unwrap(
-              Effect.sync(() => {
-                activeSubscriptions += 1;
-                return Stream.fromEffect(
-                  trustedEvent(snapshotEvent(payload.topic, healthTopicRows)),
-                ).pipe(
-                  Stream.concat(Stream.fromQueue(healthTopicEvents)),
-                  Stream.ensuring(
-                    Effect.sync(() => {
-                      activeSubscriptions -= 1;
-                    }),
+              SubscriptionRef.update(activeSubscriptions, (count) => count + 1).pipe(
+                Effect.as(
+                  Stream.fromEffect(
+                    trustedEvent(snapshotEvent(payload.topic, healthTopicRows)),
+                  ).pipe(
+                    Stream.concat(Stream.fromQueue(healthTopicEvents)),
+                    Stream.ensuring(
+                      SubscriptionRef.update(activeSubscriptions, (count) => count - 1),
+                    ),
                   ),
-                );
-              }),
+                ),
+              ),
             );
           }
           const limit = readLimit(payload.query);
@@ -375,17 +387,16 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
             });
           }
           return Stream.unwrap(
-            Effect.sync(() => {
-              activeSubscriptions += 1;
-              return Stream.fromEffect(trustedEvent(snapshotEvent(payload.topic, rows))).pipe(
-                Stream.concat(Stream.fromQueue(events)),
-                Stream.ensuring(
-                  Effect.sync(() => {
-                    activeSubscriptions -= 1;
-                  }),
+            SubscriptionRef.update(activeSubscriptions, (count) => count + 1).pipe(
+              Effect.as(
+                Stream.fromEffect(trustedEvent(snapshotEvent(payload.topic, rows))).pipe(
+                  Stream.concat(Stream.fromQueue(events)),
+                  Stream.ensuring(
+                    SubscriptionRef.update(activeSubscriptions, (count) => count - 1),
+                  ),
                 ),
-              );
-            }),
+              ),
+            ),
           );
         },
       }),
@@ -414,7 +425,9 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
     return yield* Effect.die(new Error("Expected a TCP test server address."));
   }
   return {
-    activeSubscriptions: () => activeSubscriptions,
+    activeSubscriptions: () => SubscriptionRef.getUnsafe(activeSubscriptions),
+    awaitSubscriptionCount: (expected: number) =>
+      awaitSubscriptionCount(activeSubscriptions, expected),
     close: runtime.disposeEffect,
     emit: (event: ViewServerWireEvent) =>
       Effect.flatMap(trustedEvent(event), (trusted) => Queue.offer(events, trusted)),
@@ -529,7 +542,7 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       expect(server.healthRequests()).toBe(1);
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(1);
       expect(client.health.value.transport.activeSubscriptions).toBe(1);
@@ -543,11 +556,10 @@ describe("remote ViewServer client", () => {
         operations: [{ type: "insert", key: "queued", row: { id: "queued", price: 5 }, index: 0 }],
         totalRows: 1,
       });
-      yield* Effect.sleep("10 millis");
-      expect(server.healthRequests()).toBe(1);
 
       yield* server.emitInsert("orders", order("a", 10));
       const events = yield* Fiber.join(eventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(server.healthRequests()).toBe(1);
       expect(events[0]).toStrictEqual({
         type: "snapshot",
@@ -577,7 +589,6 @@ describe("remote ViewServer client", () => {
         totalRows: 1,
       });
 
-      yield* Effect.sleep("10 millis");
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(0);
       expect(client.health.value.transport.activeSubscriptions).toBe(0);
 
@@ -601,6 +612,7 @@ describe("remote ViewServer client", () => {
           limit: 10,
         });
 
+        yield* server.awaitSubscriptionCount(1);
         yield* server.emitInsert("orders", order("first", 1));
         yield* server.emitInsert("orders", order("second", 2));
         const events = yield* subscription.events.pipe(Stream.takeRight(1), Stream.runCollect);
@@ -615,7 +627,7 @@ describe("remote ViewServer client", () => {
             message: "Remote subscription buffer exceeded capacity with 1 queued event(s).",
           },
         ]);
-        yield* Effect.sleep("10 millis");
+        yield* server.awaitSubscriptionCount(0);
         expect(server.activeSubscriptions()).toBe(0);
 
         yield* client.close;
@@ -635,6 +647,7 @@ describe("remote ViewServer client", () => {
         limit: 10,
       });
 
+      yield* server.awaitSubscriptionCount(1);
       yield* server.emitInsert("orders", order("first", 1));
       yield* server.emitInsert("orders", order("second", 2));
       const events = yield* subscription.events.pipe(Stream.takeRight(1), Stream.runCollect);
@@ -649,7 +662,7 @@ describe("remote ViewServer client", () => {
           message: "Remote subscription buffer exceeded capacity with 1 queued event(s).",
         },
       ]);
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(0);
       expect(server.activeSubscriptions()).toBe(0);
 
       yield* client.close;
@@ -671,6 +684,7 @@ describe("remote ViewServer client", () => {
           limit: 10,
         });
 
+        yield* server.awaitSubscriptionCount(1);
         yield* server.emitInsert("orders", order("first", 1));
         yield* server.emitInsert("orders", order("second", 2));
         const events = yield* subscription.events.pipe(Stream.takeRight(1), Stream.runCollect);
@@ -685,7 +699,7 @@ describe("remote ViewServer client", () => {
             message: "Remote subscription buffer exceeded capacity with 1 queued event(s).",
           },
         ]);
-        yield* Effect.sleep("10 millis");
+        yield* server.awaitSubscriptionCount(0);
         expect(server.activeSubscriptions()).toBe(0);
 
         yield* client.close;
@@ -699,6 +713,7 @@ describe("remote ViewServer client", () => {
       const client = yield* makeViewServerClient(viewServer, {
         url: server.url,
       });
+      // This delay is the scenario under test: event delivery must not wait for a slow health RPC.
       server.setHealthDelay("500 millis");
       const subscription = yield* client.subscribe("orders", {
         select: ["id"],
@@ -719,7 +734,7 @@ describe("remote ViewServer client", () => {
         rows: [],
         totalRows: 0,
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(0);
       expect(server.healthRequests()).toBe(1);
 
       server.setHealthDelay("0 millis");
@@ -737,11 +752,11 @@ describe("remote ViewServer client", () => {
         select: ["id"],
         limit: 10,
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       expect(server.activeSubscriptions()).toBe(1);
 
       yield* subscription.events.pipe(Stream.take(1), Stream.runCollect);
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(0);
 
       expect(server.activeSubscriptions()).toBe(0);
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(0);
@@ -848,12 +863,15 @@ describe("remote ViewServer client", () => {
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
 
       const summarySubscription = yield* client.subscribeHealthSummary();
+      const initialSummaryReceived = yield* Deferred.make<void>();
       const summaryEventsFiber = yield* summarySubscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(initialSummaryReceived, undefined)),
         Stream.take(2),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
+      yield* Deferred.await(initialSummaryReceived).pipe(Effect.timeout("1 second"));
       expect(client.health.value.status).toBe("degraded");
       expect(server.healthRequests()).toBe(1);
       const refreshedHealth = health(0, 0);
@@ -934,7 +952,7 @@ describe("remote ViewServer client", () => {
         totalRows: 1,
       });
       yield* Fiber.join(summaryEventsFiber);
-      yield* Effect.sleep("50 millis");
+      yield* server.awaitSubscriptionCount(0);
       expect(client.health.value.status).toBe("ready");
       expect(client.health.value.version).toBe(0);
       expect(client.health.value.uptimeMs).toBe(0);
@@ -946,12 +964,15 @@ describe("remote ViewServer client", () => {
       yield* summarySubscription.close();
 
       const healthSubscription = yield* client.subscribeHealth();
+      const initialDetailReceived = yield* Deferred.make<void>();
       const detailEventsFiber = yield* healthSubscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(initialDetailReceived, undefined)),
         Stream.take(2),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
+      yield* Deferred.await(initialDetailReceived).pipe(Effect.timeout("1 second"));
       expect(client.health.value.engine.topics.orders.status).toBe("ready");
       yield* server.emitHealthTopic({
         type: "delta",
@@ -976,6 +997,7 @@ describe("remote ViewServer client", () => {
         totalRows: 1,
       });
       yield* Fiber.join(detailEventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(client.health.value.engine.topics.orders.rowCount).toBe(25);
       yield* healthSubscription.close();
 
@@ -1087,13 +1109,13 @@ describe("remote ViewServer client", () => {
         select: ["id"],
         limit: 10,
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       expect(server.activeSubscriptions()).toBe(1);
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(1);
       expect(client.health.value.transport.activeSubscriptions).toBe(1);
 
       yield* client.close;
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(0);
 
       expect(server.activeSubscriptions()).toBe(0);
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(0);
@@ -1127,7 +1149,7 @@ describe("remote ViewServer client", () => {
         select: ["id"],
         limit: 10,
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
 
       expect(client.health.value.engine.topics.orders.activeViews).toBe(7);
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(3);
@@ -1135,6 +1157,7 @@ describe("remote ViewServer client", () => {
       expect(client.health.value.transport.activeSubscriptions).toBe(3);
 
       yield* subscription.close();
+      yield* server.awaitSubscriptionCount(0);
       expect(client.health.value.engine.topics.orders.activeViews).toBe(7);
       expect(client.health.value.engine.topics.orders.activeSubscriptions).toBe(2);
       expect(client.health.value.transport.activeStreams).toBe(2);
@@ -1163,7 +1186,7 @@ describe("remote ViewServer client", () => {
         offset: 1,
         limit: 10,
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       expect(server.lastSubscribeQuery()).toStrictEqual({
         select: ["id", "price"],
         where: {
@@ -1178,6 +1201,7 @@ describe("remote ViewServer client", () => {
         limit: 10,
       });
       yield* richQuery.close();
+      yield* server.awaitSubscriptionCount(0);
 
       const scalarFilter = yield* client.subscribe("orders", {
         select: ["id"],
@@ -1186,7 +1210,7 @@ describe("remote ViewServer client", () => {
         },
         limit: 10,
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       expect(server.lastSubscribeQuery()).toStrictEqual({
         select: ["id"],
         where: {
@@ -1195,15 +1219,17 @@ describe("remote ViewServer client", () => {
         limit: 10,
       });
       yield* scalarFilter.close();
+      yield* server.awaitSubscriptionCount(0);
 
       const noLimit = yield* client.subscribe("orders", {
         select: ["id"],
       });
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       expect(server.lastSubscribeQuery()).toStrictEqual({
         select: ["id"],
       });
       yield* noLimit.close();
+      yield* server.awaitSubscriptionCount(0);
 
       const invalidTopic = yield* Effect.flip(
         // @ts-expect-error hostile callers can still send unknown topics.
@@ -1460,7 +1486,7 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       yield* server.emit({
         type: "snapshot",
         topic: "orders",
@@ -1471,6 +1497,7 @@ describe("remote ViewServer client", () => {
         totalRows: 1,
       });
       const unknownFieldEvents = yield* Fiber.join(unknownFieldEventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(unknownFieldEvents[1]).toStrictEqual({
         type: "status",
         topic: "orders",
@@ -1489,7 +1516,7 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       yield* server.emit({
         type: "snapshot",
         topic: "orders",
@@ -1500,6 +1527,7 @@ describe("remote ViewServer client", () => {
         totalRows: 1,
       });
       const invalidTypeEvents = yield* Fiber.join(invalidTypeEventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(invalidTypeEvents[1]).toStrictEqual({
         type: "status",
         topic: "orders",
@@ -1518,7 +1546,7 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       yield* server.emit({
         type: "snapshot",
         topic: "missing",
@@ -1529,6 +1557,7 @@ describe("remote ViewServer client", () => {
         totalRows: 0,
       });
       const invalidTopicEvents = yield* Fiber.join(invalidTopicEventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(invalidTopicEvents[1]).toStrictEqual({
         type: "status",
         topic: "orders",
@@ -1547,7 +1576,7 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       yield* server.emit({
         type: "snapshot",
         topic: "orders",
@@ -1558,6 +1587,7 @@ describe("remote ViewServer client", () => {
         totalRows: 1,
       });
       const missingFieldEvents = yield* Fiber.join(missingFieldEventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(missingFieldEvents[1]).toStrictEqual({
         type: "status",
         topic: "orders",
@@ -1576,7 +1606,7 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* server.awaitSubscriptionCount(1);
       yield* server.emit({
         type: "status",
         topic: "orders",
@@ -1597,6 +1627,7 @@ describe("remote ViewServer client", () => {
         totalRows: 0,
       });
       const statusAndMoveEvents = yield* Fiber.join(statusAndMoveEventsFiber);
+      yield* server.awaitSubscriptionCount(0);
       expect(statusAndMoveEvents[1]).toStrictEqual({
         type: "status",
         topic: "orders",

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -35,6 +35,7 @@ import {
   SchemaGetter,
   Scope,
   Stream,
+  SubscriptionRef,
 } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
 import { AtomRef } from "effect/unstable/reactivity";
@@ -411,33 +412,72 @@ const openRawWebSocket = Effect.fn("ViewServerServer.test.websocket.raw.open")(f
   );
 });
 
+type ServerTransportLifecycleCounts = {
+  readonly openedClients: number;
+  readonly closedClients: number;
+  readonly openedStreams: number;
+  readonly closedStreams: number;
+};
+
+const awaitServerTransportLifecycleCount = Effect.fn("ViewServerServer.test.transport.awaitCount")(
+  function* (
+    counts: SubscriptionRef.SubscriptionRef<ServerTransportLifecycleCounts>,
+    field: keyof ServerTransportLifecycleCounts,
+    expected: number,
+  ) {
+    yield* SubscriptionRef.changes(counts).pipe(
+      Stream.filter((current) => current[field] === expected),
+      Stream.take(1),
+      Stream.runDrain,
+      Effect.timeout("1 second"),
+    );
+  },
+);
+
+const makeServerTransportLifecycleProbe = Effect.fn("ViewServerServer.test.transport.probe.make")(
+  function* () {
+    const counts = yield* SubscriptionRef.make<ServerTransportLifecycleCounts>({
+      openedClients: 0,
+      closedClients: 0,
+      openedStreams: 0,
+      closedStreams: 0,
+    });
+
+    return {
+      awaitCount: (field: keyof ServerTransportLifecycleCounts, expected: number) =>
+        awaitServerTransportLifecycleCount(counts, field, expected),
+      readCounts: SubscriptionRef.get(counts),
+      transport: {
+        clientOpened: SubscriptionRef.update(counts, (current) => ({
+          ...current,
+          openedClients: current.openedClients + 1,
+        })),
+        clientClosed: SubscriptionRef.update(counts, (current) => ({
+          ...current,
+          closedClients: current.closedClients + 1,
+        })),
+        streamOpened: SubscriptionRef.update(counts, (current) => ({
+          ...current,
+          openedStreams: current.openedStreams + 1,
+        })),
+        streamClosed: SubscriptionRef.update(counts, (current) => ({
+          ...current,
+          closedStreams: current.closedStreams + 1,
+        })),
+      },
+    };
+  },
+);
+
 describe("@effect-view-server/server", () => {
   it.live("serves an in-memory runtime through Effect RPC WebSocket", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
-      let openedClients = 0;
-      let closedClients = 0;
-      let openedStreams = 0;
-      let closedStreams = 0;
-      const clientClosedSignal = yield* Deferred.make<void>();
+      const lifecycle = yield* makeServerTransportLifecycleProbe();
       const server = yield* makeViewServerWebSocketServer(viewServer, {
         liveClient: inMemory.liveClient,
         runtime: inMemory.client,
-        transport: {
-          clientOpened: Effect.sync(() => {
-            openedClients += 1;
-          }),
-          clientClosed: Effect.gen(function* () {
-            closedClients += 1;
-            yield* Deferred.succeed(clientClosedSignal, void 0);
-          }),
-          streamOpened: Effect.sync(() => {
-            openedStreams += 1;
-          }),
-          streamClosed: Effect.sync(() => {
-            closedStreams += 1;
-          }),
-        },
+        transport: lifecycle.transport,
       });
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
       const subscription = yield* client.subscribe("orders", {
@@ -445,12 +485,14 @@ describe("@effect-view-server/server", () => {
         orderBy: [{ field: "price", direction: "asc" }],
         limit: 10,
       });
+      const firstEventSeen = yield* Deferred.make<void>();
       const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(firstEventSeen, undefined)),
         Stream.take(3),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* Deferred.await(firstEventSeen).pipe(Effect.timeout("1 second"));
 
       yield* inMemory.client.publish("orders", order("b", 20));
       yield* inMemory.client.publishMany("orders", [order("a", 10)]);
@@ -505,16 +547,18 @@ describe("@effect-view-server/server", () => {
       yield* inMemory.client.reset();
       expect((yield* inMemory.client.health()).engine.topics.orders.rowCount).toBe(0);
 
-      yield* Effect.sleep("10 millis");
+      yield* lifecycle.awaitCount("closedStreams", 3);
       const afterClose = yield* inMemory.client.health();
       expect(afterClose.engine.topics.orders.activeSubscriptions).toBe(0);
 
       yield* client.close;
-      yield* Deferred.await(clientClosedSignal);
-      expect(openedClients).toBe(1);
-      expect(closedClients).toBe(1);
-      expect(openedStreams).toBe(3);
-      expect(closedStreams).toBe(3);
+      yield* lifecycle.awaitCount("closedClients", 1);
+      expect(yield* lifecycle.readCounts).toStrictEqual({
+        openedClients: 1,
+        closedClients: 1,
+        openedStreams: 3,
+        closedStreams: 3,
+      });
       yield* server.close;
       yield* inMemory.close;
     }),
@@ -1857,9 +1901,11 @@ describe("@effect-view-server/server", () => {
   it.live("round-trips BigInt rows and filters through the RPC NDJSON transport", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
+      const lifecycle = yield* makeServerTransportLifecycleProbe();
       const server = yield* makeViewServerWebSocketServer(viewServer, {
         liveClient: inMemory.liveClient,
         runtime: inMemory.client,
+        transport: lifecycle.transport,
       });
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
       const subscription = yield* client.subscribe("trades", {
@@ -1870,17 +1916,20 @@ describe("@effect-view-server/server", () => {
         orderBy: [{ field: "quantity", direction: "asc" }],
         limit: 10,
       });
+      const firstEventSeen = yield* Deferred.make<void>();
       const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(firstEventSeen, undefined)),
         Stream.take(2),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* Deferred.await(firstEventSeen).pipe(Effect.timeout("1 second"));
 
       yield* inMemory.client.publish("trades", trade("a", 5n));
       yield* inMemory.client.publish("trades", trade("b", 10n));
 
       const events = yield* Fiber.join(eventsFiber);
+      yield* lifecycle.awaitCount("closedStreams", 1);
       expect(events[0]).toStrictEqual({
         type: "snapshot",
         topic: "trades",
@@ -1900,7 +1949,6 @@ describe("@effect-view-server/server", () => {
         totalRows: 1,
       });
 
-      yield* Effect.sleep("10 millis");
       yield* client.close;
       yield* server.close;
       yield* inMemory.close;
@@ -1910,9 +1958,11 @@ describe("@effect-view-server/server", () => {
   it.live("round-trips BigDecimal rows and filters through the RPC NDJSON transport", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
+      const lifecycle = yield* makeServerTransportLifecycleProbe();
       const server = yield* makeViewServerWebSocketServer(viewServer, {
         liveClient: inMemory.liveClient,
         runtime: inMemory.client,
+        transport: lifecycle.transport,
       });
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
       const subscription = yield* client.subscribe("quotes", {
@@ -1923,17 +1973,20 @@ describe("@effect-view-server/server", () => {
         orderBy: [{ field: "price", direction: "asc" }],
         limit: 10,
       });
+      const firstEventSeen = yield* Deferred.make<void>();
       const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(firstEventSeen, undefined)),
         Stream.take(2),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* Deferred.await(firstEventSeen).pipe(Effect.timeout("1 second"));
 
       yield* inMemory.client.publish("quotes", quote("a", "9.99"));
       yield* inMemory.client.publish("quotes", quote("b", "10.50"));
 
       const events = yield* Fiber.join(eventsFiber);
+      yield* lifecycle.awaitCount("closedStreams", 1);
       expect(events[0]).toStrictEqual({
         type: "snapshot",
         topic: "quotes",
@@ -1960,7 +2013,6 @@ describe("@effect-view-server/server", () => {
         totalRows: 1,
       });
 
-      yield* Effect.sleep("10 millis");
       yield* client.close;
       yield* server.close;
       yield* inMemory.close;
@@ -1970,9 +2022,11 @@ describe("@effect-view-server/server", () => {
   it.live("encodes snapshot rows, move/remove deltas, and close statuses", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
+      const lifecycle = yield* makeServerTransportLifecycleProbe();
       const server = yield* makeViewServerWebSocketServer(viewServer, {
         liveClient: inMemory.liveClient,
         runtime: inMemory.client,
+        transport: lifecycle.transport,
       });
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
 
@@ -1982,17 +2036,20 @@ describe("@effect-view-server/server", () => {
         orderBy: [{ field: "price", direction: "asc" }],
         limit: 10,
       });
+      const firstEventSeen = yield* Deferred.make<void>();
       const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(firstEventSeen, undefined)),
         Stream.take(3),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* Deferred.await(firstEventSeen).pipe(Effect.timeout("1 second"));
 
       yield* inMemory.client.patch("orders", "a", { price: 30 });
       yield* inMemory.client.delete("orders", "b");
 
       const events = yield* Fiber.join(eventsFiber);
+      yield* lifecycle.awaitCount("closedStreams", 1);
       expect(events[0]).toStrictEqual({
         type: "snapshot",
         topic: "orders",
@@ -2036,25 +2093,30 @@ describe("@effect-view-server/server", () => {
   it.live("encodes subscription closed status when the runtime closes", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
+      const lifecycle = yield* makeServerTransportLifecycleProbe();
       const server = yield* makeViewServerWebSocketServer(viewServer, {
         liveClient: inMemory.liveClient,
         runtime: inMemory.client,
+        transport: lifecycle.transport,
       });
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
       const subscription = yield* client.subscribe("orders", {
         select: ["id"],
         limit: 10,
       });
+      const firstEventSeen = yield* Deferred.make<void>();
       const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(firstEventSeen, undefined)),
         Stream.take(2),
         Stream.runCollect,
         Effect.forkChild,
       );
-      yield* Effect.sleep("10 millis");
+      yield* Deferred.await(firstEventSeen).pipe(Effect.timeout("1 second"));
 
       yield* inMemory.close;
 
       const events = yield* Fiber.join(eventsFiber);
+      yield* lifecycle.awaitCount("closedStreams", 1);
       expect(events[1]).toStrictEqual({
         type: "status",
         topic: "orders",
@@ -2548,23 +2610,31 @@ describe("@effect-view-server/server", () => {
   it.live("cleans up engine subscribers when the remote websocket disconnects", () =>
     Effect.gen(function* () {
       const inMemory = createServerTestRuntime(viewServer);
+      const lifecycle = yield* makeServerTransportLifecycleProbe();
       const server = yield* makeViewServerWebSocketServer(viewServer, {
         liveClient: inMemory.liveClient,
         runtime: inMemory.client,
+        transport: lifecycle.transport,
       });
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
       const subscription = yield* client.subscribe("orders", {
         select: ["id", "price"],
         limit: 10,
       });
-      const eventsFiber = yield* subscription.events.pipe(Stream.runDrain, Effect.forkChild);
+      const firstEventSeen = yield* Deferred.make<void>();
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap(() => Deferred.succeed(firstEventSeen, undefined)),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
 
-      yield* Effect.sleep("10 millis");
+      yield* Deferred.await(firstEventSeen).pipe(Effect.timeout("1 second"));
       const beforeDisconnect = yield* inMemory.client.health();
       expect(beforeDisconnect.engine.topics.orders.activeSubscriptions).toBe(1);
 
       yield* client.close;
-      yield* Effect.sleep("10 millis");
+      yield* lifecycle.awaitCount("closedStreams", 1);
+      yield* lifecycle.awaitCount("closedClients", 1);
 
       const afterDisconnect = yield* inMemory.client.health();
       expect(afterDisconnect.engine.topics.orders.activeSubscriptions).toBe(0);


### PR DESCRIPTION
Closes #328

## Summary

- replace client-side transport settling sleeps with bounded, replaying subscription-count barriers
- add test-local server lifecycle probes and downstream first-event signals for real WebSocket registration
- await stream and client cleanup convergence while preserving the production Effect RPC WebSocket + NDJSON path

## Validation

- TDD red confirmed before the client lifecycle barrier existed; focused test green after implementation
- client package: 51 tests, exact 100% statements, branches, functions, and lines
- server package: 44 tests, exact 100% statements, branches, functions, and lines
- vp check
- vp run -w check:effect: 0 errors, warnings, or messages across 19 projects
- vp run -w ready
- vp run -w bench:baseline:smoke
- vp run -w bench:baseline:websocket-firehose
- independent Effect, Vitest, and architecture/maintainability reviews: 0 blocking and 0 non-blocking findings each

No changeset: test-only change.