### PR TITLE
test: enforce exact SSR example coverage

### DIFF
--- a/examples/in-memory-react/vite.config.ts
+++ b/examples/in-memory-react/vite.config.ts
@@ -7,20 +7,5 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
-  coverage: {
-    provider: "istanbul",
-    include: ["src/**/*.ts", "src/**/*.tsx"],
-    exclude: [
-      "src/router.tsx",
-      "src/routeTree.gen.ts",
-      "src/routes/**/*.tsx",
-      "src/**/*.test.ts",
-      "src/**/*.test.tsx",
-      "src/**/*.test-d.ts",
-    ],
-    reporter: ["text"],
-    thresholds: {
-      "100": true,
-    },
-  },
+  enforceAllSourceCoverage: true,
 });

--- a/examples/ssr-react/package.json
+++ b/examples/ssr-react/package.json
@@ -12,7 +12,7 @@
     "generate-routes": "vp exec tsr generate && vp run clean-routes",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --globals --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
   },
   "dependencies": {
     "@tanstack/react-router": "catalog:",
@@ -34,6 +34,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
     "playwright": "1.60.0",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/examples/ssr-react/src/view-server.example.browser.test.tsx
+++ b/examples/ssr-react/src/view-server.example.browser.test.tsx
@@ -1,11 +1,45 @@
+/// <reference types="vitest/globals" />
+
 import { describe, expect, it } from "@effect/vitest";
 import { createInMemoryViewServerReact } from "effect-view-server/react/testing";
 import { Effect } from "effect";
+import { renderToStaticMarkup } from "react-dom/server";
 import { render } from "vitest-browser-react";
 import { SsrExampleApp } from "./view-server.example";
 import { viewServerReact } from "./view-server.config";
 
+vi.mock("./view-server.config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./view-server.config")>();
+  const { createElement } = await import("react");
+  return {
+    ...actual,
+    ViewServerProvider: function TestViewServerProvider() {
+      return createElement(
+        "section",
+        { "aria-label": "default remote provider" },
+        "Default remote provider selected.",
+      );
+    },
+  };
+});
+
 describe("SSR React example", () => {
+  it("renders the complete live-data placeholder without mounting a browser provider", () => {
+    expect(renderToStaticMarkup(SsrExampleApp())).toBe(
+      '<main class="example-shell"><header><p class="eyebrow">SSR shell</p><h1>TanStack Start shell with client-only live data</h1><p>The page shell is safe to server-render. The View Server WebSocket provider only mounts in the browser.</p></header><section class="panel" aria-label="ssr placeholder"><h2>Live data</h2><p>Live queries hydrate in the browser.</p></section></main>',
+    );
+  });
+
+  it("selects the default remote provider when the wrapper prop is omitted", async () => {
+    const screen = await render(<SsrExampleApp />);
+
+    await screen.getByRole("button", { name: "Connect live data", exact: true }).click();
+    await expect
+      .element(screen.getByRole("region", { name: "default remote provider", exact: true }))
+      .toBeVisible();
+    await screen.unmount();
+  });
+
   it("renders the browser-only live panel with an in-memory provider", async () => {
     const inMemoryExample = createInMemoryViewServerReact(viewServerReact);
     await Effect.runPromise(inMemoryExample.client.reset());

--- a/examples/ssr-react/src/view-server.example.ssr.test.ts
+++ b/examples/ssr-react/src/view-server.example.ssr.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "@effect/vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SsrExampleApp } from "./view-server.example";
+
+describe("SSR React example server rendering", () => {
+  it("renders the complete live-data placeholder in the Node SSR runtime", () => {
+    expect(renderToStaticMarkup(createElement(SsrExampleApp))).toBe(
+      '<main class="example-shell"><header><p class="eyebrow">SSR shell</p><h1>TanStack Start shell with client-only live data</h1><p>The page shell is safe to server-render. The View Server WebSocket provider only mounts in the browser.</p></header><section class="panel" aria-label="ssr placeholder"><h2>Live data</h2><p>Live queries hydrate in the browser.</p></section></main>',
+    );
+  });
+});

--- a/examples/ssr-react/vite.config.ts
+++ b/examples/ssr-react/vite.config.ts
@@ -7,4 +7,6 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
+  enforceAllSourceCoverage: true,
+  optimizeDepsInclude: ["react-dom/server"],
 });

--- a/examples/vite.config.shared.ts
+++ b/examples/vite.config.shared.ts
@@ -4,17 +4,42 @@ import type { BrowserProviderOption } from "vite-plus/test/node";
 interface TanStackReactExampleConfigOptions {
   readonly plugins: Array<PluginOption>;
   readonly browserProvider: BrowserProviderOption;
-  readonly coverage?: NonNullable<TestUserConfig["coverage"]>;
+  readonly enforceAllSourceCoverage?: boolean;
+  readonly optimizeDepsInclude?: ReadonlyArray<string>;
 }
+
+const exactAllSourceCoverage = {
+  provider: "istanbul",
+  include: ["src/**/*.ts", "src/**/*.tsx"],
+  exclude: [
+    "src/router.tsx",
+    "src/routeTree.gen.ts",
+    "src/routes/**/*.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.test-d.ts",
+  ],
+  reporter: ["text"],
+  thresholds: {
+    "100": true,
+  },
+} satisfies NonNullable<TestUserConfig["coverage"]>;
 
 export const defineTanStackReactExampleConfig = ({
   plugins,
   browserProvider,
-  coverage,
+  enforceAllSourceCoverage,
+  optimizeDepsInclude,
 }: TanStackReactExampleConfigOptions) =>
   defineConfig({
     optimizeDeps: {
-      include: ["@effect/vitest", "effect/Array", "react-dom/client", "vitest-browser-react"],
+      include: [
+        "@effect/vitest",
+        "effect/Array",
+        "react-dom/client",
+        "vitest-browser-react",
+        ...(optimizeDepsInclude ?? []),
+      ],
       exclude: ["@tanstack/react-router", "@tanstack/react-start", "@tanstack/router-plugin"],
     },
     plugins,
@@ -48,7 +73,7 @@ export const defineTanStackReactExampleConfig = ({
           },
         ],
       },
-      ...(coverage === undefined ? {} : { coverage }),
+      ...(enforceAllSourceCoverage === true ? { coverage: exactAllSourceCoverage } : {}),
     },
     lint: {
       options: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(playwright@1.60.0)(vitest@4.1.9)
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       playwright:
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
## Summary

- enable Istanbul all-source coverage for the SSR React example
- centralize the accepted exact example coverage policy and reuse it for the in-memory example
- cover SSR placeholder rendering, default provider selection, and real in-memory live behavior
- add a true Node SSR rendering test while retaining Chromium, Firefox, and WebKit

## Red / green evidence

- red baseline: 89.28% statements, 50% branches, 81.81% functions, 92% lines
- green: 28/28 statements, 6/6 branches, 11/11 functions, and 25/25 lines
- browser matrix: 9/9 tests across Chromium, Firefox, and WebKit
- Node SSR and type-test phase: green with no type errors

## Verification

- `vp run @effect-view-server/example-ssr-react#test`
- `vp check`
- strict Effect diagnostics across all 19 projects
- `vp run -w ready` (1,999 tasks, exit 0)
- forbidden-pattern and generated-artifact audits

## Independent reviews

- Effect correctness: 0 blocking, 0 non-blocking
- Vitest/browser/type/coverage: 0 blocking, 0 non-blocking
- architecture/maintainability: 0 blocking, 0 non-blocking

## Release / performance

- no changeset: private example and test configuration only
- no performance benchmark: no runtime hot-path change

Closes #330