### PR TITLE
test: enforce Kafka example coverage

### DIFF
--- a/examples/kafka-react/package.json
+++ b/examples/kafka-react/package.json
@@ -13,7 +13,7 @@
     "runtime": "vp run -t effect-view-server#build && vp exec tsx src/runtime.ts",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",
@@ -37,6 +37,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
     "playwright": "1.60.0",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/examples/kafka-react/package.json
+++ b/examples/kafka-react/package.json
@@ -13,7 +13,7 @@
     "runtime": "vp run -t effect-view-server#build && vp exec tsx src/runtime.ts",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --globals --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",

--- a/examples/kafka-react/src/runtime.browser.test.tsx
+++ b/examples/kafka-react/src/runtime.browser.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import { Effect } from "effect";
+import { viewServer } from "./view-server.config";
+
+describe("Kafka React example runtime", () => {
+  it("composes the topic-owned config with the Kafka runtime options", async () => {
+    const runtimeProgram = Effect.void;
+    const runMain = vi.fn();
+    const runViewServerRuntime = vi.fn(() => runtimeProgram);
+    vi.doMock("@effect/platform-node", () => ({
+      NodeRuntime: { runMain },
+    }));
+    vi.doMock("effect-view-server/runtime", () => ({
+      runViewServerRuntime,
+    }));
+
+    await import("./runtime");
+
+    expect(runViewServerRuntime.mock.calls).toStrictEqual([
+      [
+        viewServer,
+        {
+          websocketPort: 8080,
+          kafka: {
+            consumerGroupId: "view-server-example-kafka-react",
+            startFrom: "latest",
+          },
+        },
+      ],
+    ]);
+    expect(runMain.mock.calls).toStrictEqual([[runtimeProgram]]);
+  });
+});

--- a/examples/kafka-react/src/view-server.config.browser.test.tsx
+++ b/examples/kafka-react/src/view-server.config.browser.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "@effect/vitest";
+import { decodeKafkaCodec, type KafkaMessageMetadata } from "effect-view-server/config";
+import { Effect } from "effect";
+import { viewServer } from "./view-server.config";
+
+const textEncoder = new TextEncoder();
+
+describe("Kafka React example topic-owned sources", () => {
+  it.effect("decodes, keys, and maps order and trade source messages", () =>
+    Effect.gen(function* () {
+      const orderSource = viewServer.topics.orders.kafkaSource;
+      const orderMetadata = {
+        sourceTopic: orderSource.topic,
+        sourceRegion: "usa",
+        partition: 0,
+        offset: "1",
+        timestamp: null,
+        headers: {},
+      } satisfies KafkaMessageMetadata<"usa">;
+      const orderKey = yield* decodeKafkaCodec(orderSource.key, {
+        bytes: textEncoder.encode("order-kafka-config"),
+        metadata: orderMetadata,
+      });
+      const orderValue = yield* decodeKafkaCodec(orderSource.value, {
+        bytes: textEncoder.encode(
+          '{"customerId":"customer-kafka-config","status":"open","price":42,"updatedAt":1}',
+        ),
+        metadata: orderMetadata,
+      });
+      const orderRowKey = orderSource.rowKey({
+        key: orderKey,
+        region: "usa",
+        metadata: orderMetadata,
+      });
+      const orderRow = orderSource.map({
+        key: orderKey,
+        value: orderValue,
+        region: "usa",
+        rowKey: orderRowKey,
+        metadata: orderMetadata,
+      });
+
+      const tradeSource = viewServer.topics.trades.kafkaSource;
+      const tradeMetadata = {
+        sourceTopic: tradeSource.topic,
+        sourceRegion: "london",
+        partition: 1,
+        offset: "2",
+        timestamp: 1,
+        headers: {},
+      } satisfies KafkaMessageMetadata<"london">;
+      const tradeKey = yield* decodeKafkaCodec(tradeSource.key, {
+        bytes: textEncoder.encode("trade-kafka-config"),
+        metadata: tradeMetadata,
+      });
+      const tradeValue = yield* decodeKafkaCodec(tradeSource.value, {
+        bytes: textEncoder.encode('{"symbol":"EFFECT","side":"buy","quantity":7,"updatedAt":2}'),
+        metadata: tradeMetadata,
+      });
+      const tradeRowKey = tradeSource.rowKey({
+        key: tradeKey,
+        region: "london",
+        metadata: tradeMetadata,
+      });
+      const tradeRow = tradeSource.map({
+        key: tradeKey,
+        value: tradeValue,
+        region: "london",
+        rowKey: tradeRowKey,
+        metadata: tradeMetadata,
+      });
+
+      expect({
+        orders: {
+          source: {
+            topic: orderSource.topic,
+            regions: orderSource.regions,
+            keyFormat: orderSource.key.format,
+            valueFormat: orderSource.value.format,
+          },
+          row: { id: orderRowKey, ...orderRow },
+        },
+        trades: {
+          source: {
+            topic: tradeSource.topic,
+            regions: tradeSource.regions,
+            keyFormat: tradeSource.key.format,
+            valueFormat: tradeSource.value.format,
+          },
+          row: { id: tradeRowKey, ...tradeRow },
+        },
+      }).toStrictEqual({
+        orders: {
+          source: {
+            topic: "view-server-example-orders-usa",
+            regions: ["usa"],
+            keyFormat: "string",
+            valueFormat: "json",
+          },
+          row: {
+            id: "order-kafka-config",
+            customerId: "customer-kafka-config",
+            status: "open",
+            price: 42,
+            region: "usa",
+            updatedAt: 1,
+          },
+        },
+        trades: {
+          source: {
+            topic: "view-server-example-trades-london",
+            regions: ["london"],
+            keyFormat: "string",
+            valueFormat: "json",
+          },
+          row: {
+            id: "trade-kafka-config",
+            symbol: "EFFECT",
+            side: "buy",
+            quantity: 7,
+            region: "london",
+            updatedAt: 2,
+          },
+        },
+      });
+    }),
+  );
+});

--- a/examples/kafka-react/src/view-server.example.browser.test.tsx
+++ b/examples/kafka-react/src/view-server.example.browser.test.tsx
@@ -24,6 +24,7 @@ describe("Kafka React example", () => {
         }),
       )
       .toBeVisible();
+    await expect.element(screen.getByText("Max Kafka lag: n/a", { exact: true })).toBeVisible();
     await Effect.runPromise(
       inMemoryExample.client.publish("orders", {
         id: "order-kafka-browser",

--- a/examples/kafka-react/src/view-server.example.kafka-lag.browser.test.tsx
+++ b/examples/kafka-react/src/view-server.example.kafka-lag.browser.test.tsx
@@ -1,0 +1,42 @@
+/// <reference types="vitest/globals" />
+
+import { describe, expect, it } from "@effect/vitest";
+import type { ViewServerHealthSummary } from "effect-view-server/config";
+import { createInMemoryViewServerReact } from "effect-view-server/react/testing";
+import { Effect } from "effect";
+import { render } from "vitest-browser-react";
+import { KafkaExampleApp } from "./view-server.example";
+import { viewServerReact } from "./view-server.config";
+
+vi.mock("./view-server.config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./view-server.config")>();
+  const summary = {
+    status: "ready",
+    runtimeStatus: "ready",
+    connectionStatus: "connected",
+    unhealthyTopics: [],
+    updatedAtNanos: 1n,
+    maxKafkaLag: 7n,
+  } satisfies ViewServerHealthSummary<typeof actual.viewServer.topics>;
+  return {
+    ...actual,
+    useViewServerHealthSummary: () => summary,
+  };
+});
+
+describe("Kafka React example health", () => {
+  it("renders a numeric Kafka lag", async () => {
+    const inMemoryExample = createInMemoryViewServerReact(viewServerReact);
+    await Effect.runPromise(inMemoryExample.client.reset());
+
+    const screen = await render(
+      <inMemoryExample.ViewServerInMemoryProvider>
+        <KafkaExampleApp />
+      </inMemoryExample.ViewServerInMemoryProvider>,
+    );
+
+    await expect.element(screen.getByText("Max Kafka lag: 7", { exact: true })).toBeVisible();
+    await screen.unmount();
+    await Effect.runPromise(inMemoryExample.close);
+  });
+});

--- a/examples/kafka-react/vite.config.ts
+++ b/examples/kafka-react/vite.config.ts
@@ -7,4 +7,13 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
+  enforceAllSourceCoverage: true,
+  optimizeDepsInclude: [
+    "@effect/platform-node",
+    "@platformatic/kafka",
+    "effect/unstable/http",
+    "effect/unstable/socket/Socket",
+    "effect-view-server > @connectrpc/connect",
+    "effect-view-server > @connectrpc/connect-node",
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,6 +604,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(playwright@1.60.0)(vitest@4.1.9)
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       playwright:
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
## Summary

- enable shared Istanbul all-source coverage for the Kafka React example
- exercise real topic-owned Kafka codecs, row keys, mappings, and runtime option composition
- preserve Chromium, Firefox, and WebKit coverage while asserting the visible Kafka-lag fallback

## Coverage evidence

The red baseline was 75% statements, 100% branches, 50% functions, and 75% lines. The final package run reports:

- statements: 20/20
- branches: 2/2
- functions: 8/8
- lines: 20/20
- browser executions: 9/9 across Chromium, Firefox, and WebKit

## Validation

- vp run @effect-view-server/example-kafka-react#test
- vp check
- vp run -w check:effect
- vp run -w ready
- independent Effect review: 0 blocking, 0 non-blocking
- independent Vitest/coverage review: 0 blocking, 0 non-blocking
- independent architecture review: 0 blocking, 0 non-blocking

No changeset is needed because this changes private example tests and test configuration only. No performance gate is implicated because no runtime or hot-path production code changed.

Closes #331