### PR TITLE
Enforce exact all-source coverage for the materialized gRPC React example

### DIFF
--- a/examples/grpc-materialized-react/package.json
+++ b/examples/grpc-materialized-react/package.json
@@ -13,7 +13,7 @@
     "runtime": "vp run -t effect-view-server#build && vp exec tsx src/runtime.ts",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
   },
   "dependencies": {
     "@bufbuild/protobuf": "2.12.0",
@@ -38,6 +38,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
     "playwright": "1.60.0",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/examples/grpc-materialized-react/src/runtime.browser.test.tsx
+++ b/examples/grpc-materialized-react/src/runtime.browser.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import { Effect } from "effect";
+import { viewServer } from "./view-server.config";
+
+describe("materialized gRPC React example runtime", () => {
+  it("composes the topic-owned config with the runtime options", async () => {
+    const runtimeProgram = Effect.void;
+    const runMain = vi.fn();
+    const runViewServerRuntime = vi.fn(() => runtimeProgram);
+    vi.doMock("@effect/platform-node", () => ({
+      NodeRuntime: { runMain },
+    }));
+    vi.doMock("effect-view-server/runtime", () => ({
+      runViewServerRuntime,
+    }));
+
+    await import("./runtime");
+
+    expect(runViewServerRuntime.mock.calls).toStrictEqual([
+      [
+        viewServer,
+        {
+          websocketPort: 8080,
+        },
+      ],
+    ]);
+    expect(runMain.mock.calls).toStrictEqual([[runtimeProgram]]);
+  });
+});

--- a/examples/grpc-materialized-react/src/view-server.config.browser.test.tsx
+++ b/examples/grpc-materialized-react/src/view-server.config.browser.test.tsx
@@ -1,0 +1,112 @@
+import type { Client } from "@connectrpc/connect";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Stream } from "effect";
+import { strategiesService, strategyRequestSchema, strategyValueSchema } from "./grpc-descriptors";
+import { Strategy, viewServer } from "./view-server.config";
+
+const client = {
+  streamStrategies: async function* streamStrategies() {},
+} satisfies Client<typeof strategiesService>;
+
+describe("materialized gRPC React example topic-owned source", () => {
+  it.effect("constructs descriptors and maps the materialized stream", () =>
+    Effect.gen(function* () {
+      const source = viewServer.topics.strategies.grpcSource;
+      const request = source.request();
+      const values = yield* source
+        .acquire({
+          client,
+          request,
+          route: undefined,
+          session: {
+            id: null,
+            forwardedHeaders: {},
+            systemHeaders: {},
+          },
+        })
+        .pipe(Stream.take(2), Stream.runCollect);
+      const rows = Array.from(values, (value) =>
+        source.map({
+          value,
+          route: undefined,
+          schema: Strategy,
+        }),
+      );
+
+      expect({
+        descriptors: {
+          valueTypeName: strategyValueSchema.typeName,
+          valueFields: strategyValueSchema.fields.map((field) => ({
+            name: field.name,
+            localName: field.localName,
+          })),
+          requestTypeName: strategyRequestSchema.typeName,
+          requestFields: strategyRequestSchema.fields.map((field) => ({
+            name: field.name,
+            localName: field.localName,
+          })),
+          serviceTypeName: strategiesService.typeName,
+          method: {
+            name: strategiesService.method.streamStrategies.name,
+            localName: strategiesService.method.streamStrategies.localName,
+            methodKind: strategiesService.method.streamStrategies.methodKind,
+            input: strategiesService.method.streamStrategies.input.typeName,
+            output: strategiesService.method.streamStrategies.output.typeName,
+          },
+        },
+        source: {
+          lifecycle: source.lifecycle,
+          client: source.client,
+          method: source.method,
+          request,
+        },
+        rows,
+      }).toStrictEqual({
+        descriptors: {
+          valueTypeName: "viewserver.example.StrategyValue",
+          valueFields: [
+            { name: "strategy_id", localName: "strategyId" },
+            { name: "region", localName: "region" },
+            { name: "status", localName: "status" },
+            { name: "notional", localName: "notional" },
+            { name: "updated_at", localName: "updatedAt" },
+          ],
+          requestTypeName: "viewserver.example.StrategyRequest",
+          requestFields: [{ name: "universe", localName: "universe" }],
+          serviceTypeName: "viewserver.example.StrategiesService",
+          method: {
+            name: "StreamStrategies",
+            localName: "streamStrategies",
+            methodKind: "server_streaming",
+            input: "viewserver.example.StrategyRequest",
+            output: "viewserver.example.StrategyValue",
+          },
+        },
+        source: {
+          lifecycle: "materialized",
+          client: "strategies",
+          method: "streamStrategies",
+          request: { universe: "global" },
+        },
+        rows: [
+          {
+            id: "strategy-alpha:usa",
+            strategyId: "strategy-alpha",
+            region: "usa",
+            status: "active",
+            notional: 100,
+            updatedAt: 1,
+          },
+          {
+            id: "strategy-beta:london",
+            strategyId: "strategy-beta",
+            region: "london",
+            status: "paused",
+            notional: 75,
+            updatedAt: 2,
+          },
+        ],
+      });
+    }),
+  );
+});

--- a/examples/grpc-materialized-react/vite.config.ts
+++ b/examples/grpc-materialized-react/vite.config.ts
@@ -7,4 +7,13 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
+  enforceAllSourceCoverage: true,
+  optimizeDepsInclude: [
+    "@effect/platform-node",
+    "effect/unstable/http",
+    "effect/unstable/socket/Socket",
+    "effect-view-server > @connectrpc/connect",
+    "effect-view-server > @connectrpc/connect-node",
+    "effect-view-server > @platformatic/kafka",
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(playwright@1.60.0)(vitest@4.1.9)
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       playwright:
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
Closes #332

## Summary
- enable exact Istanbul all-source coverage for the materialized gRPC React example
- cover protobuf descriptor construction and topic-owned materialized source configuration
- verify runtime entrypoint composition and retain real visible browser behavior across Chromium, Firefox, and WebKit
- pin the example optimizer dependencies needed for stable browser coverage

## Validation
- vp run @effect-view-server/example-grpc-materialized-react#test
- vp check
- vp run -w check:effect
- vp run -w ready
- independent Effect review: 0 blocking, 0 non-blocking
- independent Vitest review: 0 blocking, 0 non-blocking
- independent architecture review: 0 blocking, 0 non-blocking