### PR TITLE
Enforce exact all-source coverage for the leased gRPC React example

### DIFF
--- a/examples/grpc-leased-react/package.json
+++ b/examples/grpc-leased-react/package.json
@@ -13,7 +13,7 @@
     "runtime": "vp run -t effect-view-server#build && vp exec tsx src/runtime.ts",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
   },
   "dependencies": {
     "@bufbuild/protobuf": "2.12.0",
@@ -38,6 +38,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
     "playwright": "1.60.0",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/examples/grpc-leased-react/src/runtime.browser.test.tsx
+++ b/examples/grpc-leased-react/src/runtime.browser.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import { Effect } from "effect";
+import { viewServer } from "./view-server.config";
+
+describe("leased gRPC React example runtime", () => {
+  it("composes the topic-owned config with the runtime options", async () => {
+    const runtimeProgram = Effect.void;
+    const runMain = vi.fn();
+    const runViewServerRuntime = vi.fn(() => runtimeProgram);
+    vi.doMock("@effect/platform-node", () => ({
+      NodeRuntime: { runMain },
+    }));
+    vi.doMock("effect-view-server/runtime", () => ({
+      runViewServerRuntime,
+    }));
+
+    await import("./runtime");
+
+    expect(runViewServerRuntime.mock.calls).toStrictEqual([
+      [
+        viewServer,
+        {
+          websocketPort: 8080,
+        },
+      ],
+    ]);
+    expect(runMain.mock.calls).toStrictEqual([[runtimeProgram]]);
+  });
+});

--- a/examples/grpc-leased-react/src/view-server.config.browser.test.tsx
+++ b/examples/grpc-leased-react/src/view-server.config.browser.test.tsx
@@ -1,0 +1,128 @@
+import type { Client } from "@connectrpc/connect";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Stream } from "effect";
+import { ordersService, orderRouteSchema, orderValueSchema } from "./grpc-descriptors";
+import { Order, viewServer } from "./view-server.config";
+
+const client = {
+  streamOrders: async function* streamOrders() {},
+} satisfies Client<typeof ordersService>;
+
+describe("leased gRPC React example topic-owned source", () => {
+  it.effect("constructs descriptors and maps the leased route stream", () =>
+    Effect.gen(function* () {
+      const source = viewServer.topics.orders.grpcSource;
+      const route = {
+        strategyId: "strategy-alpha",
+        region: "usa",
+      };
+      const request = source.request(route);
+      const sourceInput = {
+        client,
+        request,
+        route,
+        session: {
+          id: null,
+          forwardedHeaders: {},
+          systemHeaders: {},
+        },
+      };
+      const values = yield* source.acquire(sourceInput).pipe(Stream.take(2), Stream.runCollect);
+      const release = source.release ?? (() => Effect.fail("Expected leased source release"));
+      yield* release(sourceInput);
+      const rows = Array.from(values, (value) =>
+        source.map({
+          value,
+          route,
+          schema: Order,
+        }),
+      );
+
+      expect({
+        descriptors: {
+          valueTypeName: orderValueSchema.typeName,
+          valueFields: orderValueSchema.fields.map((field) => ({
+            name: field.name,
+            localName: field.localName,
+          })),
+          routeTypeName: orderRouteSchema.typeName,
+          routeFields: orderRouteSchema.fields.map((field) => ({
+            name: field.name,
+            localName: field.localName,
+          })),
+          serviceTypeName: ordersService.typeName,
+          method: {
+            name: ordersService.method.streamOrders.name,
+            localName: ordersService.method.streamOrders.localName,
+            methodKind: ordersService.method.streamOrders.methodKind,
+            input: ordersService.method.streamOrders.input.typeName,
+            output: ordersService.method.streamOrders.output.typeName,
+          },
+        },
+        source: {
+          lifecycle: source.lifecycle,
+          routeBy: source.routeBy,
+          client: source.client,
+          method: source.method,
+          request,
+          hasRelease: source.release !== undefined,
+        },
+        rows,
+      }).toStrictEqual({
+        descriptors: {
+          valueTypeName: "viewserver.example.OrderValue",
+          valueFields: [
+            { name: "customer_id", localName: "customerId" },
+            { name: "status", localName: "status" },
+            { name: "price", localName: "price" },
+            { name: "updated_at", localName: "updatedAt" },
+          ],
+          routeTypeName: "viewserver.example.OrderRoute",
+          routeFields: [
+            { name: "strategy_id", localName: "strategyId" },
+            { name: "region", localName: "region" },
+          ],
+          serviceTypeName: "viewserver.example.OrdersService",
+          method: {
+            name: "StreamOrders",
+            localName: "streamOrders",
+            methodKind: "server_streaming",
+            input: "viewserver.example.OrderRoute",
+            output: "viewserver.example.OrderValue",
+          },
+        },
+        source: {
+          lifecycle: "leased",
+          routeBy: ["strategyId", "region"],
+          client: "orders",
+          method: "streamOrders",
+          request: {
+            strategyId: "strategy-alpha",
+            region: "usa",
+          },
+          hasRelease: true,
+        },
+        rows: [
+          {
+            id: "strategy-alpha:usa:customer-strategy-alpha",
+            customerId: "customer-strategy-alpha",
+            status: "open",
+            price: 10,
+            region: "usa",
+            strategyId: "strategy-alpha",
+            updatedAt: 1,
+          },
+          {
+            id: "strategy-alpha:usa:customer-usa",
+            customerId: "customer-usa",
+            status: "open",
+            price: 20,
+            region: "usa",
+            strategyId: "strategy-alpha",
+            updatedAt: 2,
+          },
+        ],
+      });
+    }),
+  );
+});

--- a/examples/grpc-leased-react/vite.config.ts
+++ b/examples/grpc-leased-react/vite.config.ts
@@ -7,4 +7,13 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
+  enforceAllSourceCoverage: true,
+  optimizeDepsInclude: [
+    "@effect/platform-node",
+    "effect/unstable/http",
+    "effect/unstable/socket/Socket",
+    "effect-view-server > @connectrpc/connect",
+    "effect-view-server > @connectrpc/connect-node",
+    "effect-view-server > @platformatic/kafka",
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(playwright@1.60.0)(vitest@4.1.9)
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       playwright:
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
Closes #333

Summary:
- enable exact all-source Istanbul coverage for the leased gRPC React example
- cover protobuf descriptor construction and the complete topic-owned leased source lifecycle
- verify runtime composition while retaining visible behavior and type-test coverage across Chromium, Firefox, and WebKit

Validation:
- vp run @effect-view-server/example-grpc-leased-react#test
- vp check
- vp run -w check:effect
- vp run -w ready
- Effect review: 0 blocking, 0 non-blocking
- Vitest review: 0 blocking, 0 non-blocking
- architecture review: 0 blocking, 0 non-blocking