### PR TITLE
Enforce exact all-source coverage for the combined-sources React example

### DIFF
--- a/examples/combined-sources-react/package.json
+++ b/examples/combined-sources-react/package.json
@@ -13,7 +13,7 @@
     "runtime": "vp run -t effect-view-server#build && vp exec tsx src/runtime.ts",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --coverage --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
   },
   "dependencies": {
     "@bufbuild/protobuf": "2.12.0",
@@ -39,6 +39,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
     "playwright": "1.60.0",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/examples/combined-sources-react/src/runtime.browser.test.tsx
+++ b/examples/combined-sources-react/src/runtime.browser.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import { Effect } from "effect";
+import { viewServer } from "./view-server.config";
+
+describe("combined-sources React example runtime", () => {
+  it("composes the topic-owned config with the Kafka runtime options", async () => {
+    const runtimeProgram = Effect.void;
+    const runMain = vi.fn();
+    const runViewServerRuntime = vi.fn(() => runtimeProgram);
+    vi.doMock("@effect/platform-node", () => ({
+      NodeRuntime: { runMain },
+    }));
+    vi.doMock("effect-view-server/runtime", () => ({
+      runViewServerRuntime,
+    }));
+
+    await import("./runtime");
+
+    expect(runViewServerRuntime.mock.calls).toStrictEqual([
+      [
+        viewServer,
+        {
+          websocketPort: 8080,
+          kafka: {
+            consumerGroupId: "view-server-example-combined-sources-react",
+            startFrom: "latest",
+          },
+        },
+      ],
+    ]);
+    expect(runMain.mock.calls).toStrictEqual([[runtimeProgram]]);
+  });
+});

--- a/examples/combined-sources-react/src/view-server.config.browser.test.tsx
+++ b/examples/combined-sources-react/src/view-server.config.browser.test.tsx
@@ -1,0 +1,216 @@
+import type { Client } from "@connectrpc/connect";
+import { describe, expect, it } from "@effect/vitest";
+import { decodeKafkaCodec, type KafkaMessageMetadata } from "effect-view-server/config";
+import { Effect, Stream } from "effect";
+import { combinedService } from "./grpc-descriptors";
+import { Order, Strategy, viewServer } from "./view-server.config";
+
+const client = {
+  streamOrders: async function* streamOrders() {},
+  streamStrategies: async function* streamStrategies() {},
+} satisfies Client<typeof combinedService>;
+
+const textEncoder = new TextEncoder();
+
+describe("combined-sources React example topic-owned sources", () => {
+  it.effect("maps leased, materialized, and Kafka source values", () =>
+    Effect.gen(function* () {
+      const session = {
+        id: null,
+        forwardedHeaders: {},
+        systemHeaders: {},
+      };
+
+      const orderSource = viewServer.topics.orders.grpcSource;
+      const orderRoute = {
+        strategyId: "strategy-alpha",
+        region: "usa",
+      };
+      const orderRequest = orderSource.request(orderRoute);
+      const orderValues = yield* orderSource
+        .acquire({
+          client,
+          request: orderRequest,
+          route: orderRoute,
+          session,
+        })
+        .pipe(Stream.take(1), Stream.runCollect);
+      const orderRows = Array.from(orderValues, (value) =>
+        orderSource.map({
+          value,
+          route: orderRoute,
+          schema: Order,
+        }),
+      );
+
+      const strategySource = viewServer.topics.strategies.grpcSource;
+      const strategyRequest = strategySource.request();
+      const strategyValues = yield* strategySource
+        .acquire({
+          client,
+          request: strategyRequest,
+          route: undefined,
+          session,
+        })
+        .pipe(Stream.take(1), Stream.runCollect);
+      const strategyRows = Array.from(strategyValues, (value) =>
+        strategySource.map({
+          value,
+          route: undefined,
+          schema: Strategy,
+        }),
+      );
+
+      const tradeSource = viewServer.topics.trades.kafkaSource;
+      const tradeMetadata = {
+        sourceTopic: tradeSource.topic,
+        sourceRegion: "london",
+        partition: 0,
+        offset: "1",
+        timestamp: null,
+        headers: {},
+      } satisfies KafkaMessageMetadata<"london">;
+      const tradeKey = yield* decodeKafkaCodec(tradeSource.key, {
+        bytes: textEncoder.encode("trade-combined-config"),
+        metadata: tradeMetadata,
+      });
+      const tradeValue = yield* decodeKafkaCodec(tradeSource.value, {
+        bytes: textEncoder.encode('{"symbol":"EFFECT","side":"buy","quantity":7,"updatedAt":2}'),
+        metadata: tradeMetadata,
+      });
+      const tradeRowKey = tradeSource.rowKey({
+        key: tradeKey,
+        region: "london",
+        metadata: tradeMetadata,
+      });
+      const tradeRow = tradeSource.map({
+        key: tradeKey,
+        value: tradeValue,
+        region: "london",
+        rowKey: tradeRowKey,
+        metadata: tradeMetadata,
+      });
+
+      expect({
+        descriptors: {
+          serviceTypeName: combinedService.typeName,
+          orders: {
+            name: combinedService.method.streamOrders.name,
+            localName: combinedService.method.streamOrders.localName,
+            methodKind: combinedService.method.streamOrders.methodKind,
+            input: combinedService.method.streamOrders.input.typeName,
+            output: combinedService.method.streamOrders.output.typeName,
+          },
+          strategies: {
+            name: combinedService.method.streamStrategies.name,
+            localName: combinedService.method.streamStrategies.localName,
+            methodKind: combinedService.method.streamStrategies.methodKind,
+            input: combinedService.method.streamStrategies.input.typeName,
+            output: combinedService.method.streamStrategies.output.typeName,
+          },
+        },
+        sources: {
+          orders: {
+            lifecycle: orderSource.lifecycle,
+            routeBy: orderSource.routeBy,
+            client: orderSource.client,
+            method: orderSource.method,
+            request: orderRequest,
+          },
+          strategies: {
+            lifecycle: strategySource.lifecycle,
+            client: strategySource.client,
+            method: strategySource.method,
+            request: strategyRequest,
+          },
+          trades: {
+            topic: tradeSource.topic,
+            regions: tradeSource.regions,
+            keyFormat: tradeSource.key.format,
+            valueFormat: tradeSource.value.format,
+          },
+        },
+        rows: {
+          orders: orderRows,
+          strategies: strategyRows,
+          trades: [{ id: tradeRowKey, ...tradeRow }],
+        },
+      }).toStrictEqual({
+        descriptors: {
+          serviceTypeName: "viewserver.combined.CombinedService",
+          orders: {
+            name: "StreamOrders",
+            localName: "streamOrders",
+            methodKind: "server_streaming",
+            input: "viewserver.combined.OrderRoute",
+            output: "viewserver.combined.OrderValue",
+          },
+          strategies: {
+            name: "StreamStrategies",
+            localName: "streamStrategies",
+            methodKind: "server_streaming",
+            input: "viewserver.combined.StrategyRequest",
+            output: "viewserver.combined.StrategyValue",
+          },
+        },
+        sources: {
+          orders: {
+            lifecycle: "leased",
+            routeBy: ["strategyId", "region"],
+            client: "orders",
+            method: "streamOrders",
+            request: {
+              strategyId: "strategy-alpha",
+              region: "usa",
+            },
+          },
+          strategies: {
+            lifecycle: "materialized",
+            client: "strategies",
+            method: "streamStrategies",
+            request: { universe: "global" },
+          },
+          trades: {
+            topic: "view-server-example-trades",
+            regions: ["usa", "london"],
+            keyFormat: "string",
+            valueFormat: "json",
+          },
+        },
+        rows: {
+          orders: [
+            {
+              id: "strategy-alpha:usa:customer-strategy-alpha",
+              customerId: "customer-strategy-alpha",
+              status: "open",
+              price: 15,
+              region: "usa",
+              strategyId: "strategy-alpha",
+              updatedAt: 1,
+            },
+          ],
+          strategies: [
+            {
+              id: "strategy-alpha:usa",
+              strategyId: "strategy-alpha",
+              region: "usa",
+              status: "active",
+              notional: 100,
+              updatedAt: 1,
+            },
+          ],
+          trades: [
+            {
+              id: "trade-combined-config",
+              symbol: "EFFECT",
+              side: "buy",
+              quantity: 7,
+              region: "london",
+              updatedAt: 2,
+            },
+          ],
+        },
+      });
+    }),
+  );
+});

--- a/examples/combined-sources-react/vite.config.ts
+++ b/examples/combined-sources-react/vite.config.ts
@@ -7,4 +7,13 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
+  enforceAllSourceCoverage: true,
+  optimizeDepsInclude: [
+    "@effect/platform-node",
+    "@platformatic/kafka",
+    "effect/unstable/http",
+    "effect/unstable/socket/Socket",
+    "effect-view-server > @connectrpc/connect",
+    "effect-view-server > @connectrpc/connect-node",
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(playwright@1.60.0)(vitest@4.1.9)
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       playwright:
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
Closes #334

## Summary
- enable Istanbul all-source coverage for the combined-sources React example
- cover runtime composition plus topic-owned leased gRPC, materialized gRPC, and Kafka sources
- preserve exact visible behavior across Chromium, Firefox, and WebKit

## Validation
- vp run @effect-view-server/example-combined-sources-react#test
- vp check
- vp run -w check:effect
- vp run -w ready
- independent Effect, Vitest, and architecture reviews: 0 blocking, 0 non-blocking