### PR TITLE
Enforce exact all-source coverage for the TCP publisher React example

### DIFF
--- a/examples/tcp-publisher-react/package.json
+++ b/examples/tcp-publisher-react/package.json
@@ -15,7 +15,7 @@
     "publisher:invalid": "vp exec tsx src/tcp-invalid-publisher.ts",
     "build": "vp run -t effect-view-server#build && vp run generate-routes && vp build && vp run clean-routes",
     "preview": "vp preview",
-    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --typecheck.enabled=false && vp test run --browser.enabled=false --typecheck && vp run clean-routes"
+    "test": "vp run -t effect-view-server#build && vp run generate-routes && vp test run --coverage && vp run clean-routes"
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",
@@ -38,6 +38,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:",
     "playwright": "1.60.0",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/examples/tcp-publisher-react/src/entrypoints.test.ts
+++ b/examples/tcp-publisher-react/src/entrypoints.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import { Cause, Effect, Exit, Fiber, Queue } from "effect";
+import { TestClock } from "effect/testing";
+import { TcpPublisherExampleError, type TcpCommand, type TcpPublishResponse } from "./tcp-client";
+import { viewServer } from "./view-server.config";
+
+const loadInvalidPublisher = async (response: TcpPublishResponse) => {
+  vi.resetModules();
+  const programs: Array<Effect.Effect<unknown, TcpPublisherExampleError>> = [];
+  const runMain = vi.fn((program: Effect.Effect<unknown, TcpPublisherExampleError>) => {
+    programs.push(program);
+  });
+  const writeCommand = vi.fn(() => Effect.succeed(response));
+  vi.doMock("@effect/platform-node", () => ({
+    NodeRuntime: { runMain },
+  }));
+  vi.doMock("./tcp-client", () => ({
+    TcpPublisherExampleError,
+    writeCommand,
+  }));
+
+  await import("./tcp-invalid-publisher");
+
+  return {
+    program:
+      programs[0] ?? Effect.die(new Error("The invalid publisher did not register a program.")),
+    runMain,
+    writeCommand,
+  };
+};
+
+const loadPublisher = async (
+  writeCommandImplementation: (command: TcpCommand) => Effect.Effect<TcpPublishResponse, never>,
+) => {
+  vi.resetModules();
+  const programs: Array<Effect.Effect<unknown, TcpPublisherExampleError>> = [];
+  const runMain = vi.fn((program: Effect.Effect<unknown, TcpPublisherExampleError>) => {
+    programs.push(program);
+  });
+  const writeCommand = vi.fn(writeCommandImplementation);
+  vi.doMock("@effect/platform-node", () => ({
+    NodeRuntime: { runMain },
+  }));
+  vi.doMock("./tcp-client", () => ({
+    TcpPublisherExampleError,
+    writeCommand,
+  }));
+
+  await import("./tcp-publisher");
+
+  return {
+    program: programs[0] ?? Effect.die(new Error("The TCP publisher did not register a program.")),
+    runMain,
+    writeCommand,
+  };
+};
+
+describe("TCP publisher example entrypoints", () => {
+  it("composes the View Server config with TCP ingress runtime options", async () => {
+    const runtimeProgram = Effect.void;
+    const runMain = vi.fn();
+    const runViewServerRuntime = vi.fn(() => runtimeProgram);
+    vi.doMock("@effect/platform-node", () => ({
+      NodeRuntime: { runMain },
+    }));
+    vi.doMock("effect-view-server/runtime", () => ({
+      runViewServerRuntime,
+    }));
+
+    await import("./runtime");
+
+    expect(runViewServerRuntime.mock.calls).toStrictEqual([
+      [
+        viewServer,
+        {
+          websocketPort: 8080,
+          tcpPublishHost: "127.0.0.1",
+          tcpPublishPort: 8081,
+        },
+      ],
+    ]);
+    expect(runMain.mock.calls).toStrictEqual([[runtimeProgram]]);
+  });
+
+  it.effect("reports the invalid command's typed rejection", () =>
+    Effect.gen(function* () {
+      const response = {
+        ok: false,
+        error: {
+          _tag: "InvalidRow",
+          message: "The row is invalid.",
+          phase: "row",
+          topic: "orders",
+        },
+      } satisfies TcpPublishResponse;
+      const loaded = yield* Effect.promise(() => loadInvalidPublisher(response));
+
+      yield* loaded.program;
+
+      expect(loaded.writeCommand.mock.calls).toStrictEqual([
+        [
+          {
+            op: "publish",
+            topic: "orders",
+            row: {
+              customerId: "invalid-customer",
+              status: "open",
+              price: "not-a-number",
+              region: "usa",
+              updatedAt: 1,
+            },
+          },
+        ],
+      ]);
+      expect(loaded.runMain.mock.calls).toStrictEqual([[loaded.program]]);
+    }),
+  );
+
+  it.effect("fails if the invalid command unexpectedly succeeds", () =>
+    Effect.gen(function* () {
+      const loaded = yield* Effect.promise(() => loadInvalidPublisher({ ok: true }));
+
+      const error = yield* loaded.program.pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("Invalid TCP publish unexpectedly succeeded.");
+    }),
+  );
+
+  it.effect("publishes an even-timestamped London order", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(2);
+      const commands = yield* Queue.unbounded<TcpCommand>();
+      const response = { ok: true } satisfies TcpPublishResponse;
+      const loaded = yield* Effect.promise(() =>
+        loadPublisher((command) => Queue.offer(commands, command).pipe(Effect.as(response))),
+      );
+      const publisher = yield* loaded.program.pipe(Effect.forkChild({ startImmediately: true }));
+
+      const command = yield* Queue.take(commands);
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(publisher);
+      const exit = yield* Fiber.await(publisher);
+
+      expect(command).toStrictEqual({
+        op: "publish",
+        topic: "orders",
+        row: {
+          id: "tcp-order-2",
+          customerId: "tcp-customer-2",
+          status: "open",
+          price: 10,
+          region: "london",
+          updatedAt: 2,
+        },
+      });
+      expect(loaded.writeCommand.mock.calls).toStrictEqual([[command]]);
+      expect(loaded.runMain.mock.calls).toStrictEqual([[loaded.program]]);
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+    }),
+  );
+
+  it.effect("publishes an odd-timestamped USA order", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(1);
+      const commands = yield* Queue.unbounded<TcpCommand>();
+      const response = { ok: true } satisfies TcpPublishResponse;
+      const loaded = yield* Effect.promise(() =>
+        loadPublisher((command) => Queue.offer(commands, command).pipe(Effect.as(response))),
+      );
+      const publisher = yield* loaded.program.pipe(Effect.forkChild({ startImmediately: true }));
+
+      const command = yield* Queue.take(commands);
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(publisher);
+      const exit = yield* Fiber.await(publisher);
+
+      expect(command).toStrictEqual({
+        op: "publish",
+        topic: "orders",
+        row: {
+          id: "tcp-order-1",
+          customerId: "tcp-customer-1",
+          status: "open",
+          price: 5,
+          region: "usa",
+          updatedAt: 1,
+        },
+      });
+      expect(loaded.writeCommand.mock.calls).toStrictEqual([[command]]);
+      expect(loaded.runMain.mock.calls).toStrictEqual([[loaded.program]]);
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+    }),
+  );
+
+  it.effect("fails the publisher program when TCP ingress rejects a row", () =>
+    Effect.gen(function* () {
+      const response = {
+        ok: false,
+        error: {
+          _tag: "InvalidRow",
+          message: "The row is invalid.",
+          phase: "row",
+          topic: "orders",
+        },
+      } satisfies TcpPublishResponse;
+      const loaded = yield* Effect.promise(() => loadPublisher(() => Effect.succeed(response)));
+
+      const error = yield* loaded.program.pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(TcpPublisherExampleError);
+      expect(error._tag).toBe("TcpPublisherExampleError");
+      expect(error.message).toBe("TCP publish failed: The row is invalid.");
+    }),
+  );
+});

--- a/examples/tcp-publisher-react/vite.config.ts
+++ b/examples/tcp-publisher-react/vite.config.ts
@@ -7,4 +7,7 @@ import { defineTanStackReactExampleConfig } from "../vite.config.shared";
 export default defineTanStackReactExampleConfig({
   plugins: [tailwindcss(), tanstackStart(), viteReact()],
   browserProvider: playwright(),
+  enforceAllSourceCoverage: true,
+  includeNodeTests: true,
+  optimizeDepsInclude: ["@effect/platform-node"],
 });

--- a/examples/vite.config.shared.ts
+++ b/examples/vite.config.shared.ts
@@ -5,6 +5,7 @@ interface TanStackReactExampleConfigOptions {
   readonly plugins: Array<PluginOption>;
   readonly browserProvider: BrowserProviderOption;
   readonly enforceAllSourceCoverage?: boolean;
+  readonly includeNodeTests?: boolean;
   readonly optimizeDepsInclude?: ReadonlyArray<string>;
 }
 
@@ -29,6 +30,7 @@ export const defineTanStackReactExampleConfig = ({
   plugins,
   browserProvider,
   enforceAllSourceCoverage,
+  includeNodeTests,
   optimizeDepsInclude,
 }: TanStackReactExampleConfigOptions) =>
   defineConfig({
@@ -73,6 +75,27 @@ export const defineTanStackReactExampleConfig = ({
           },
         ],
       },
+      ...(includeNodeTests === true
+        ? {
+            projects: [
+              {
+                extends: true,
+                test: {
+                  name: "node",
+                  browser: { enabled: false },
+                  include: ["src/**/*.test.ts"],
+                },
+              },
+              {
+                extends: true,
+                test: {
+                  name: "browser",
+                  typecheck: { enabled: false },
+                },
+              },
+            ],
+          }
+        : {}),
       ...(enforceAllSourceCoverage === true ? { coverage: exactAllSourceCoverage } : {}),
     },
     lint: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(playwright@1.60.0)(vitest@4.1.9)
+      '@vitest/coverage-istanbul':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
       playwright:
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
Closes #335

## Summary
- aggregate Node entrypoint and Chromium, Firefox, and WebKit browser coverage in one Vitest run
- exercise TCP runtime and publisher entrypoints, including typed rejection and deterministic interruption paths
- enforce exact all-source Istanbul coverage for the TCP publisher React example

## Validation
- vp run @effect-view-server/example-tcp-publisher-react#test
- vp check
- vp run -w check:effect
- vp run -w ready
- independent Effect, Vitest, and architecture reviews: 0 blocking, 0 non-blocking