### PR TITLE
Resolve Kafka Source declarations into a validated decoder contract

### DIFF
--- a/packages/config/src/kafka-contract.ts
+++ b/packages/config/src/kafka-contract.ts
@@ -3,6 +3,7 @@ import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 import { Effect, Schema } from "effect";
 import type { Config } from "effect";
 import { validateDecodedRow } from "./decoded-row-validation";
+import { resolveKafkaSourceFormat } from "./kafka-source-format";
 import type { RowSchema, TopicRow } from "./topic-contract";
 
 export type RuntimeValue<A> = A | Config.Config<A>;
@@ -68,7 +69,6 @@ type RejectAnyReturn<Mapper extends (...args: ReadonlyArray<never>) => unknown> 
 const KafkaCodecValueTypeId = Symbol("@effect-view-server/config/KafkaCodecValue");
 const KafkaCodecErrorTypeId = Symbol("@effect-view-server/config/KafkaCodecError");
 const KafkaCodecDecodeTypeId = Symbol("@effect-view-server/config/KafkaCodecDecode");
-const KafkaTopicDecodeTypeId = Symbol("@effect-view-server/config/KafkaTopicDecode");
 const KafkaResolvedSourceTopicTypeId = Symbol(
   "@effect-view-server/config/KafkaResolvedSourceTopic",
 );
@@ -217,7 +217,7 @@ type KafkaTopicSourceDecoder<
   Region extends string,
   E,
 > = {
-  readonly [KafkaTopicDecodeTypeId]: {
+  readonly decode: {
     bivarianceHack(
       input: KafkaTopicSourceDecodeInput<Topics, ViewTopic, Region>,
     ): Effect.Effect<KafkaDecodedTopicSourceResult<Topics, ViewTopic>, E>;
@@ -742,9 +742,6 @@ export type KafkaResolvedSourceTopicDefinition<
   readonly viewServerTopic: ViewTopic;
 };
 
-const decodeKafkaStringKey = (input: KafkaCodecDecodeInput): string =>
-  utf8Decoder.decode(input.bytes);
-
 const mapKafkaPayload = <A>(map: () => A): Effect.Effect<A, KafkaMappingError> =>
   Effect.try({
     try: map,
@@ -872,7 +869,7 @@ const decodeKafkaTopicMessageEffect: (
       }),
     );
   }
-  const decoded = yield* topic[KafkaTopicDecodeTypeId]({
+  const decoded = yield* topic.decode({
     keyBytes: input.keyBytes,
     valueBytes: input.valueBytes,
     region: input.region,
@@ -1280,59 +1277,73 @@ const makeKafkaResolvedSourceTopicWithKey = <
     TopicRegions,
     Mapping
   >,
-): KafkaResolvedSourceTopicDefinition<Topics, Regions, ViewTopic, TopicRegions> => ({
-  ...topic,
-  [KafkaResolvedSourceTopicTypeId]: true,
-  viewServerTopic,
-  [KafkaTopicDecodeTypeId]: (input) =>
-    Effect.gen(function* () {
-      const key = yield* decodeKafkaCodec(topic.key, {
-        bytes: input.keyBytes,
-        metadata: input.metadata,
-      });
-      const rowKey = yield* mapKafkaRowKey(() =>
-        topic.rowKey({
-          key,
-          region: input.region,
+): KafkaResolvedSourceTopicDefinition<Topics, Regions, ViewTopic, TopicRegions> => {
+  const keyDecoder = resolveKafkaSourceFormat(topic.key, topic.key[KafkaCodecDecodeTypeId]);
+  const valueDecoder = resolveKafkaSourceFormat(topic.value, topic.value[KafkaCodecDecodeTypeId]);
+  const sourceTopic = topic.topic;
+  const sourceRegions = topic.regions;
+  const sourceRowKey = topic.rowKey;
+  const map = topic.map;
+  return {
+    [KafkaResolvedSourceTopicTypeId]: true,
+    topic: sourceTopic,
+    regions: sourceRegions,
+    viewServerTopic,
+    decode: (input) =>
+      Effect.gen(function* () {
+        const key = yield* keyDecoder.decode({
+          bytes: input.keyBytes,
           metadata: input.metadata,
-        }),
-      );
-      if (input.valueBytes === null) {
-        const tombstone: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
+        });
+        const rowKey = yield* mapKafkaRowKey(() =>
+          sourceRowKey({
+            key,
+            region: input.region,
+            metadata: input.metadata,
+          }),
+        );
+        if (input.valueBytes === null) {
+          const tombstone: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
+            rowKey,
+            tombstone: true,
+            viewServerTopic,
+          };
+          return tombstone;
+        }
+        const value = yield* valueDecoder.decode({
+          bytes: input.valueBytes,
+          metadata: input.metadata,
+        });
+        const mappedRowWithoutKey = yield* mapKafkaPayload(() =>
+          map({
+            key,
+            value,
+            region: input.region,
+            rowKey,
+            schema: input.schema,
+            metadata: input.metadata,
+          }),
+        );
+        yield* validateKafkaMappedRowDoesNotProvideRowKey(input.rowKeyField, mappedRowWithoutKey);
+        const mappedRow = {
+          ...mappedRowWithoutKey,
+          [input.rowKeyField]: rowKey,
+        };
+        const row = yield* validateKafkaMappedRow(
+          input.schema,
+          mappedRow,
+          input.rowKeyField,
           rowKey,
-          tombstone: true,
+        );
+        const decoded: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
+          row,
+          rowKey,
           viewServerTopic,
         };
-        return tombstone;
-      }
-      const value = yield* decodeKafkaCodec(topic.value, {
-        bytes: input.valueBytes,
-        metadata: input.metadata,
-      });
-      const mappedRowWithoutKey = yield* mapKafkaPayload(() =>
-        topic.map({
-          key,
-          value,
-          region: input.region,
-          rowKey,
-          schema: input.schema,
-          metadata: input.metadata,
-        }),
-      );
-      yield* validateKafkaMappedRowDoesNotProvideRowKey(input.rowKeyField, mappedRowWithoutKey);
-      const mappedRow = {
-        ...mappedRowWithoutKey,
-        [input.rowKeyField]: rowKey,
-      };
-      const row = yield* validateKafkaMappedRow(input.schema, mappedRow, input.rowKeyField, rowKey);
-      const decoded: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
-        row,
-        rowKey,
-        viewServerTopic,
-      };
-      return decoded;
-    }),
-});
+        return decoded;
+      }),
+  };
+};
 
 const makeKafkaResolvedSourceTopicWithoutKey = <
   Topics extends KafkaTopicSchemaRegistry,
@@ -1354,59 +1365,77 @@ const makeKafkaResolvedSourceTopicWithoutKey = <
     TopicRegions,
     Mapping
   >,
-): KafkaResolvedSourceTopicDefinition<Topics, Regions, ViewTopic, TopicRegions> => ({
-  ...topic,
-  [KafkaResolvedSourceTopicTypeId]: true,
-  viewServerTopic,
-  [KafkaTopicDecodeTypeId]: (input) =>
-    Effect.gen(function* () {
-      const key = decodeKafkaStringKey({
-        bytes: input.keyBytes,
-        metadata: input.metadata,
-      });
-      const rowKey = yield* mapKafkaRowKey(() =>
-        topic.rowKey({
-          key,
-          region: input.region,
+): KafkaResolvedSourceTopicDefinition<Topics, Regions, ViewTopic, TopicRegions> => {
+  const implicitKeyCodec = kafka.stringKey();
+  const keyDecoder = resolveKafkaSourceFormat(
+    implicitKeyCodec,
+    implicitKeyCodec[KafkaCodecDecodeTypeId],
+  );
+  const valueDecoder = resolveKafkaSourceFormat(topic.value, topic.value[KafkaCodecDecodeTypeId]);
+  const sourceTopic = topic.topic;
+  const sourceRegions = topic.regions;
+  const sourceRowKey = topic.rowKey;
+  const map = topic.map;
+  return {
+    [KafkaResolvedSourceTopicTypeId]: true,
+    topic: sourceTopic,
+    regions: sourceRegions,
+    viewServerTopic,
+    decode: (input) =>
+      Effect.gen(function* () {
+        const key = yield* keyDecoder.decode({
+          bytes: input.keyBytes,
           metadata: input.metadata,
-        }),
-      );
-      if (input.valueBytes === null) {
-        const tombstone: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
+        });
+        const rowKey = yield* mapKafkaRowKey(() =>
+          sourceRowKey({
+            key,
+            region: input.region,
+            metadata: input.metadata,
+          }),
+        );
+        if (input.valueBytes === null) {
+          const tombstone: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
+            rowKey,
+            tombstone: true,
+            viewServerTopic,
+          };
+          return tombstone;
+        }
+        const value = yield* valueDecoder.decode({
+          bytes: input.valueBytes,
+          metadata: input.metadata,
+        });
+        const mappedRowWithoutKey = yield* mapKafkaPayload(() =>
+          map({
+            key,
+            value,
+            region: input.region,
+            rowKey,
+            schema: input.schema,
+            metadata: input.metadata,
+          }),
+        );
+        yield* validateKafkaMappedRowDoesNotProvideRowKey(input.rowKeyField, mappedRowWithoutKey);
+        const mappedRow = {
+          ...mappedRowWithoutKey,
+          [input.rowKeyField]: rowKey,
+        };
+        const row = yield* validateKafkaMappedRow(
+          input.schema,
+          mappedRow,
+          input.rowKeyField,
           rowKey,
-          tombstone: true,
+        );
+        const decoded: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
+          row,
+          rowKey,
           viewServerTopic,
         };
-        return tombstone;
-      }
-      const value = yield* decodeKafkaCodec(topic.value, {
-        bytes: input.valueBytes,
-        metadata: input.metadata,
-      });
-      const mappedRowWithoutKey = yield* mapKafkaPayload(() =>
-        topic.map({
-          key,
-          value,
-          region: input.region,
-          rowKey,
-          schema: input.schema,
-          metadata: input.metadata,
-        }),
-      );
-      yield* validateKafkaMappedRowDoesNotProvideRowKey(input.rowKeyField, mappedRowWithoutKey);
-      const mappedRow = {
-        ...mappedRowWithoutKey,
-        [input.rowKeyField]: rowKey,
-      };
-      const row = yield* validateKafkaMappedRow(input.schema, mappedRow, input.rowKeyField, rowKey);
-      const decoded: KafkaDecodedTopicSourceMessage<Topics, ViewTopic> = {
-        row,
-        rowKey,
-        viewServerTopic,
-      };
-      return decoded;
-    }),
-});
+        return decoded;
+      }),
+  };
+};
 
 const makeKafkaResolvedSourceTopic = <
   Topics extends KafkaTopicSchemaRegistry,

--- a/packages/config/src/kafka-source-format.test-d.ts
+++ b/packages/config/src/kafka-source-format.test-d.ts
@@ -1,0 +1,89 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { kafka } from "./index";
+
+import { ordersValueSchema } from "../test-harness/protobuf";
+import type { OrdersValueMessage } from "../test-harness/protobuf";
+
+const JsonValue = Schema.Struct({ payload: Schema.String });
+
+describe("Kafka source format public types", () => {
+  it("infers every source format through the same source declaration", () => {
+    kafka.source({
+      topic: "bytes-source",
+      regions: ["usa"],
+      value: kafka.bytes(),
+      rowKey: ({ key }) => key,
+      map: ({ value }) => {
+        expectTypeOf(value).toEqualTypeOf<Uint8Array>();
+        return { byteLength: value.byteLength };
+      },
+    });
+
+    kafka.source({
+      topic: "string-source",
+      regions: ["usa"],
+      value: kafka.string(),
+      rowKey: ({ key }) => key,
+      map: ({ value }) => {
+        expectTypeOf(value).toEqualTypeOf<string>();
+        return { value };
+      },
+    });
+
+    kafka.source({
+      topic: "json-source",
+      regions: ["usa"],
+      value: kafka.json(() => Schema.toCodecJson(JsonValue)),
+      rowKey: ({ key }) => key,
+      map: ({ value }) => {
+        expectTypeOf(value).toEqualTypeOf<typeof JsonValue.Type>();
+        return value;
+      },
+    });
+
+    kafka.source({
+      topic: "protobuf-source",
+      regions: ["usa"],
+      value: kafka.protobuf(ordersValueSchema),
+      rowKey: ({ key }) => key,
+      map: ({ value }) => {
+        expectTypeOf(value).toEqualTypeOf<OrdersValueMessage>();
+        return { customerId: value.customerId };
+      },
+    });
+
+    kafka.source({
+      topic: "custom-source",
+      regions: ["usa"],
+      value: kafka.codec({
+        name: "custom",
+        decode: (): Effect.Effect<{ readonly value: string }, never> =>
+          Effect.succeed({ value: "custom" }),
+      }),
+      rowKey: ({ key }) => key,
+      map: ({ value }) => {
+        expectTypeOf(value).toEqualTypeOf<{ readonly value: string }>();
+        return value;
+      },
+    });
+  });
+
+  it("rejects format-specific options on the wrong public factory", () => {
+    // @ts-expect-error bytes codecs do not accept source-format options.
+    kafka.bytes({ encoding: "utf8" });
+
+    // @ts-expect-error string codecs do not accept source-format options.
+    kafka.string({ descriptor: ordersValueSchema });
+
+    // @ts-expect-error protobuf codecs accept one generated message descriptor only.
+    kafka.protobuf(ordersValueSchema, { framing: "delimited" });
+
+    kafka.codec({
+      name: "custom",
+      decode: () => Effect.succeed("value"),
+      // @ts-expect-error custom codecs cannot declare protobuf options.
+      descriptor: ordersValueSchema,
+    });
+  });
+});

--- a/packages/config/src/kafka-source-format.test.ts
+++ b/packages/config/src/kafka-source-format.test.ts
@@ -1,0 +1,256 @@
+import { create, toBinary } from "@bufbuild/protobuf";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { decodeKafkaCodec, defineViewServerConfig, kafka } from "./index";
+import type { KafkaCodec } from "./index";
+import { resolveKafkaSourceFormat } from "./kafka-source-format";
+import { decodeKafkaTopicMessage, makeKafkaSourceTopicsForConfig } from "./internal";
+
+import { kafkaRegions, kafkaTestMetadata, textEncoder } from "../test-harness/kafka";
+import { ordersService, ordersValueSchema } from "../test-harness/protobuf";
+
+const textDecoder = new TextDecoder();
+
+const resolveTestSourceFormat = <A, E>(codec: KafkaCodec<A, E>) =>
+  resolveKafkaSourceFormat(codec, (input) => decodeKafkaCodec(codec, input));
+
+const JsonValue = Schema.Struct({
+  payload: Schema.String,
+});
+
+const ResolvedRow = Schema.Struct({
+  id: Schema.String,
+  payload: Schema.String,
+  region: Schema.Literals(["usa", "london"]),
+});
+
+describe("Kafka source format resolution", () => {
+  it.effect("normalizes every Kafka source codec through one decoder contract", () =>
+    Effect.gen(function* () {
+      const bytes = resolveTestSourceFormat(kafka.bytes());
+      const string = resolveTestSourceFormat(kafka.string());
+      const json = resolveTestSourceFormat(kafka.json(() => Schema.toCodecJson(JsonValue)));
+      const protobuf = resolveTestSourceFormat(kafka.protobuf(ordersValueSchema));
+      const custom = resolveTestSourceFormat(
+        kafka.codec({
+          name: "utf8-text",
+          decode: ({ bytes: input }) => Effect.succeed(textDecoder.decode(input)),
+        }),
+      );
+      const metadata = kafkaTestMetadata("usa");
+
+      expect(
+        yield* bytes.decode({
+          bytes: new Uint8Array([1, 2, 3]),
+          metadata,
+        }),
+      ).toStrictEqual(new Uint8Array([1, 2, 3]));
+      expect(
+        yield* string.decode({
+          bytes: textEncoder.encode("string-value"),
+          metadata,
+        }),
+      ).toBe("string-value");
+      expect(
+        yield* json.decode({
+          bytes: textEncoder.encode('{"payload":"json-value"}'),
+          metadata,
+        }),
+      ).toStrictEqual({ payload: "json-value" });
+      const expectedProtobufValue = create(ordersValueSchema, {
+        customerId: "protobuf-value",
+        status: "open",
+        price: 42,
+        updatedAt: 100,
+      });
+      const protobufValue = yield* protobuf.decode({
+        bytes: toBinary(ordersValueSchema, expectedProtobufValue),
+        metadata,
+      });
+      expect(protobufValue).toStrictEqual(expectedProtobufValue);
+      expect(
+        yield* custom.decode({
+          bytes: textEncoder.encode("custom-value"),
+          metadata,
+        }),
+      ).toBe("custom-value");
+      expect(
+        [bytes, string, json, protobuf, custom].map((resolved) =>
+          Object.getOwnPropertyNames(resolved),
+        ),
+      ).toStrictEqual([["decode"], ["decode"], ["decode"], ["decode"], ["decode"]]);
+    }),
+  );
+
+  it("rejects unsupported formats and invalid format option combinations", () => {
+    const unsupported = kafka.string();
+    Object.defineProperty(unsupported, "format", { value: "xml" });
+    expect(() => resolveTestSourceFormat(unsupported)).toThrow(
+      "Unsupported Kafka source codec format: xml.",
+    );
+
+    const stringWithEncoding = kafka.string();
+    Object.defineProperty(stringWithEncoding, "encoding", { value: "utf8" });
+    expect(() => resolveTestSourceFormat(stringWithEncoding)).toThrow(
+      "Kafka string codec cannot declare encoding.",
+    );
+    const invalidSourceConfig = defineViewServerConfig({
+      kafka: kafkaRegions,
+      topics: {
+        invalid: {
+          schema: ResolvedRow,
+          key: "id",
+          kafkaSource: kafka.source({
+            topic: "invalid-source",
+            regions: ["usa"],
+            value: stringWithEncoding,
+            rowKey: ({ key }) => key,
+            map: ({ value, region }) => ({ payload: value, region }),
+          }),
+        },
+      },
+    });
+    expect(() => makeKafkaSourceTopicsForConfig(invalidSourceConfig)).toThrow(
+      "Kafka string codec cannot declare encoding.",
+    );
+
+    const protobufWithoutDescriptor = kafka.protobuf(ordersValueSchema);
+    Reflect.deleteProperty(protobufWithoutDescriptor, "descriptor");
+    expect(() => resolveTestSourceFormat(protobufWithoutDescriptor)).toThrow(
+      "Kafka protobuf codec requires descriptor.",
+    );
+
+    const protobufWithInvalidDescriptor = kafka.protobuf(ordersValueSchema);
+    Object.defineProperty(protobufWithInvalidDescriptor, "descriptor", { value: null });
+    expect(() => resolveTestSourceFormat(protobufWithInvalidDescriptor)).toThrow(
+      "Kafka protobuf codec descriptor must be a message descriptor.",
+    );
+
+    const protobufWithPlainObjectDescriptor = kafka.protobuf(ordersValueSchema);
+    Object.defineProperty(protobufWithPlainObjectDescriptor, "descriptor", { value: {} });
+    expect(() => resolveTestSourceFormat(protobufWithPlainObjectDescriptor)).toThrow(
+      "Kafka protobuf codec descriptor must be a message descriptor.",
+    );
+
+    const protobufWithServiceDescriptor = kafka.protobuf(ordersValueSchema);
+    Object.defineProperty(protobufWithServiceDescriptor, "descriptor", { value: ordersService });
+    expect(() => resolveTestSourceFormat(protobufWithServiceDescriptor)).toThrow(
+      "Kafka protobuf codec descriptor must be a message descriptor.",
+    );
+
+    const protobufWithNullDescriptorMembers = kafka.protobuf(ordersValueSchema);
+    Object.defineProperty(protobufWithNullDescriptorMembers, "descriptor", {
+      value: {
+        kind: "message",
+        typeName: "example.Invalid",
+        name: "Invalid",
+        file: null,
+        fields: [],
+        field: null,
+        members: [],
+      },
+    });
+    expect(() => resolveTestSourceFormat(protobufWithNullDescriptorMembers)).toThrow(
+      "Kafka protobuf codec descriptor must be a message descriptor.",
+    );
+
+    const protobufWithFraming = kafka.protobuf(ordersValueSchema);
+    Object.defineProperty(protobufWithFraming, "framing", { value: "delimited" });
+    expect(() => resolveTestSourceFormat(protobufWithFraming)).toThrow(
+      "Kafka protobuf codec cannot declare framing.",
+    );
+
+    const customWithDescriptor = kafka.codec({
+      name: "custom-with-descriptor",
+      decode: () => Effect.succeed("value"),
+    });
+    Object.defineProperty(customWithDescriptor, "descriptor", { value: ordersValueSchema });
+    expect(() => resolveTestSourceFormat(customWithDescriptor)).toThrow(
+      "Kafka custom codec cannot declare descriptor.",
+    );
+
+    const customWithoutName = kafka.codec({
+      name: "custom-without-name",
+      decode: () => Effect.succeed("value"),
+    });
+    Reflect.deleteProperty(customWithoutName, "name");
+    expect(() => resolveTestSourceFormat(customWithoutName)).toThrow(
+      "Kafka custom codec requires name.",
+    );
+
+    const customWithInvalidName = kafka.codec({
+      name: "custom-with-invalid-name",
+      decode: () => Effect.succeed("value"),
+    });
+    Object.defineProperty(customWithInvalidName, "name", { value: 1 });
+    expect(() => resolveTestSourceFormat(customWithInvalidName)).toThrow(
+      "Kafka custom codec name must be a string.",
+    );
+
+    const customWithoutDecode = kafka.codec({
+      name: "custom-without-decode",
+      decode: () => Effect.succeed("value"),
+    });
+    Reflect.deleteProperty(customWithoutDecode, "decode");
+    expect(() => resolveTestSourceFormat(customWithoutDecode)).toThrow(
+      "Kafka custom codec requires decode.",
+    );
+
+    const customWithInvalidDecode = kafka.codec({
+      name: "custom-with-invalid-decode",
+      decode: () => Effect.succeed("value"),
+    });
+    Object.defineProperty(customWithInvalidDecode, "decode", { value: "invalid" });
+    expect(() => resolveTestSourceFormat(customWithInvalidDecode)).toThrow(
+      "Kafka custom codec decode must be a function.",
+    );
+  });
+
+  it.effect("resolves a source declaration into a decoder-only schema-valid row contract", () =>
+    Effect.gen(function* () {
+      const config = defineViewServerConfig({
+        kafka: kafkaRegions,
+        topics: {
+          resolved: {
+            schema: ResolvedRow,
+            key: "id",
+            kafkaSource: kafka.source({
+              topic: "resolved-source",
+              regions: ["usa"],
+              value: kafka.string(),
+              rowKey: ({ key }) => key,
+              map: ({ value, region }) => ({ payload: value, region }),
+            }),
+          },
+        },
+      });
+      const source = makeKafkaSourceTopicsForConfig(config)[0]!;
+
+      expect(Object.getOwnPropertyNames(source).sort()).toStrictEqual([
+        "decode",
+        "regions",
+        "topic",
+        "viewServerTopic",
+      ]);
+      expect(
+        yield* decodeKafkaTopicMessage(source, {
+          keyBytes: textEncoder.encode("resolved-1"),
+          valueBytes: textEncoder.encode("resolved-value"),
+          region: "usa",
+          metadata: kafkaTestMetadata("usa"),
+          rowKeyField: "id",
+          schema: ResolvedRow,
+          viewServerTopic: "resolved",
+        }),
+      ).toStrictEqual({
+        row: {
+          id: "resolved-1",
+          payload: "resolved-value",
+          region: "usa",
+        },
+        rowKey: "resolved-1",
+        viewServerTopic: "resolved",
+      });
+    }),
+  );
+});

--- a/packages/config/src/kafka-source-format.ts
+++ b/packages/config/src/kafka-source-format.ts
@@ -1,0 +1,97 @@
+import type { Effect } from "effect";
+
+import type { KafkaCodec, KafkaCodecDecodeInput, KafkaSourceCodec } from "./kafka-contract";
+
+export type KafkaSourceFormat = KafkaSourceCodec["format"];
+
+export type KafkaResolvedSourceFormat<A, E> = {
+  readonly decode: (input: KafkaCodecDecodeInput) => Effect.Effect<A, E>;
+};
+
+type KafkaSourceFormatDecoder<A, E> = (input: KafkaCodecDecodeInput) => Effect.Effect<A, E>;
+
+const isNonNullObject = (value: unknown): value is object =>
+  typeof value === "object" && value !== null;
+
+const requireCodecOption = (codec: object, format: KafkaSourceFormat, option: string): unknown => {
+  if (!Object.hasOwn(codec, option)) {
+    throw new Error(`Kafka ${format} codec requires ${option}.`);
+  }
+  return Reflect.get(codec, option);
+};
+
+const validateCodecOptions = (
+  codec: object,
+  format: KafkaSourceFormat,
+  allowedOptions: ReadonlyArray<string>,
+): void => {
+  for (const option of Object.getOwnPropertyNames(codec)) {
+    if (!allowedOptions.includes(option)) {
+      throw new Error(`Kafka ${format} codec cannot declare ${option}.`);
+    }
+  }
+};
+
+const validateOptionFreeCodec = (codec: object, format: "bytes" | "string" | "json"): void => {
+  validateCodecOptions(codec, format, ["format"]);
+};
+
+const validateProtobufCodec = (codec: object): void => {
+  validateCodecOptions(codec, "protobuf", ["format", "descriptor"]);
+  const descriptor = requireCodecOption(codec, "protobuf", "descriptor");
+  if (
+    !isNonNullObject(descriptor) ||
+    Reflect.get(descriptor, "kind") !== "message" ||
+    typeof Reflect.get(descriptor, "typeName") !== "string" ||
+    typeof Reflect.get(descriptor, "name") !== "string" ||
+    !isNonNullObject(Reflect.get(descriptor, "file")) ||
+    !Array.isArray(Reflect.get(descriptor, "fields")) ||
+    !isNonNullObject(Reflect.get(descriptor, "field")) ||
+    !Array.isArray(Reflect.get(descriptor, "members"))
+  ) {
+    throw new Error("Kafka protobuf codec descriptor must be a message descriptor.");
+  }
+};
+
+const validateCustomCodec = (codec: object): void => {
+  validateCodecOptions(codec, "custom", ["format", "name", "decode"]);
+  const name = requireCodecOption(codec, "custom", "name");
+  if (typeof name !== "string") {
+    throw new Error("Kafka custom codec name must be a string.");
+  }
+  const decode = requireCodecOption(codec, "custom", "decode");
+  if (typeof decode !== "function") {
+    throw new Error("Kafka custom codec decode must be a function.");
+  }
+};
+
+const makeResolvedSourceFormat = <A, E>(
+  decode: KafkaSourceFormatDecoder<A, E>,
+): KafkaResolvedSourceFormat<A, E> => ({
+  decode,
+});
+
+export const resolveKafkaSourceFormat = <A, E>(
+  codec: KafkaCodec<A, E>,
+  decode: KafkaSourceFormatDecoder<A, E>,
+): KafkaResolvedSourceFormat<A, E> => {
+  switch (codec.format) {
+    case "bytes":
+      validateOptionFreeCodec(codec, "bytes");
+      return makeResolvedSourceFormat(decode);
+    case "string":
+      validateOptionFreeCodec(codec, "string");
+      return makeResolvedSourceFormat(decode);
+    case "json":
+      validateOptionFreeCodec(codec, "json");
+      return makeResolvedSourceFormat(decode);
+    case "protobuf":
+      validateProtobufCodec(codec);
+      return makeResolvedSourceFormat(decode);
+    case "custom":
+      validateCustomCodec(codec);
+      return makeResolvedSourceFormat(decode);
+    default:
+      throw new Error(`Unsupported Kafka source codec format: ${codec.format}.`);
+  }
+};


### PR DESCRIPTION
## Summary
- normalize bytes, string, JSON, protobuf, and custom Kafka codecs behind one decoder-only source-format seam
- validate exact runtime codec options and protobuf message descriptor shape during source resolution
- preserve public inference and rejection coverage while binding decoders once off the ingestion hot path

## Validation
- `vp run -w ready`
- `vp run -w bench:baseline:smoke`
- `vp run -w bench:baseline:kafka-ingest`
- Effect review: 0 blocking, 0 non-blocking
- Vitest review: 0 blocking, 0 non-blocking
- Architecture review: 0 blocking, 0 non-blocking

Closes #336