### PR TITLE
Report Kafka lag and ingestion health through an observation Seam

### DIFF
--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -206,15 +206,19 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
       dependencies.makeRuntimeCore(dependencyConfig, runtimeCoreInput),
       (resource) => resource.close,
     );
+    const refreshRuntimeHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
     const kafkaHealthObserver =
       kafkaHealth === undefined
         ? undefined
         : yield* acquireRuntimeResourceUninterruptibly(
             runtimeScope,
-            dependencies.makeKafkaHealthObserver(kafkaHealth, runtimeCore.requestHealthRefresh),
+            dependencies.makeKafkaHealthObserver(
+              kafkaHealth,
+              runtimeCore.requestHealthRefresh,
+              refreshRuntimeHealth,
+            ),
             (resource) => resource.close,
           );
-    const refreshTransportHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
     const grpcLeaseManager =
       grpcOptions === undefined || grpcHealth === undefined
         ? undefined
@@ -242,10 +246,10 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
           liveClient: runtimeLiveClient,
           runtime: runtimeClient,
           transport: {
-            clientOpened: transportHealth.clientOpened.pipe(Effect.andThen(refreshTransportHealth)),
-            clientClosed: transportHealth.clientClosed.pipe(Effect.andThen(refreshTransportHealth)),
-            streamOpened: transportHealth.streamOpened.pipe(Effect.andThen(refreshTransportHealth)),
-            streamClosed: transportHealth.streamClosed.pipe(Effect.andThen(refreshTransportHealth)),
+            clientOpened: transportHealth.clientOpened.pipe(Effect.andThen(refreshRuntimeHealth)),
+            clientClosed: transportHealth.clientClosed.pipe(Effect.andThen(refreshRuntimeHealth)),
+            streamOpened: transportHealth.streamOpened.pipe(Effect.andThen(refreshRuntimeHealth)),
+            streamClosed: transportHealth.streamClosed.pipe(Effect.andThen(refreshRuntimeHealth)),
           },
         },
         resolvedOptions.serverOptions,

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -79,6 +79,18 @@ const acquireRuntimeResource = Effect.fn("ViewServerRuntime.acquireResource")(fu
   );
 });
 
+const acquireRuntimeResourceUninterruptibly = Effect.fn(
+  "ViewServerRuntime.acquireResourceUninterruptibly",
+)(function* <A, E, R>(
+  scope: Scope.Scope,
+  acquire: Effect.Effect<A, E, R>,
+  release: (resource: A) => Effect.Effect<void>,
+) {
+  return yield* Effect.acquireRelease(acquire, release, { interruptible: false }).pipe(
+    Scope.provide(scope),
+  );
+});
+
 type RuntimeCoreOptionsBuilder<Topics extends ViewServerRuntimeTopicDefinitions> = {
   groupedIncrementalAdmissionLimits?: NonNullable<
     ViewServerRuntimeCoreOptionsFor<Topics>["groupedIncrementalAdmissionLimits"]
@@ -194,6 +206,14 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
       dependencies.makeRuntimeCore(dependencyConfig, runtimeCoreInput),
       (resource) => resource.close,
     );
+    const kafkaHealthObserver =
+      kafkaHealth === undefined
+        ? undefined
+        : yield* acquireRuntimeResourceUninterruptibly(
+            runtimeScope,
+            dependencies.makeKafkaHealthObserver(kafkaHealth, runtimeCore.requestHealthRefresh),
+            (resource) => resource.close,
+          );
     const refreshTransportHealth = ignoreRuntimeHealthRefreshFailure(runtimeCore.refreshHealth);
     const grpcLeaseManager =
       grpcOptions === undefined || grpcHealth === undefined
@@ -232,15 +252,14 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
       ),
       (resource) => resource.close,
     );
-    if (kafkaOptions !== undefined && kafkaHealth !== undefined) {
+    if (kafkaOptions !== undefined && kafkaHealthObserver !== undefined) {
       yield* acquireRuntimeResource(
         runtimeScope,
         dependencies.makeKafkaIngress(
           dependencyConfig,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
-          kafkaHealth,
+          kafkaHealthObserver,
         ),
         (resource) => resource.close,
       );

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -212,11 +212,7 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
         ? undefined
         : yield* acquireRuntimeResourceUninterruptibly(
             runtimeScope,
-            dependencies.makeKafkaHealthObserver(
-              kafkaHealth,
-              runtimeCore.requestHealthRefresh,
-              refreshRuntimeHealth,
-            ),
+            dependencies.makeKafkaHealthObserver(kafkaHealth, refreshRuntimeHealth),
             (resource) => resource.close,
           );
     const grpcLeaseManager =

--- a/packages/runtime/src/kafka-consumer-adapter.test.ts
+++ b/packages/runtime/src/kafka-consumer-adapter.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
+import { Consumer } from "@platformatic/kafka";
 import { Buffer } from "node:buffer";
-import { Effect, Exit, Fiber } from "effect";
+import { Effect, Exit, Fiber, Scope } from "effect";
 import {
-  assignedPartitionsForSourceTopic,
+  acquireKafkaRegionResources,
   bootstrapBrokers,
   closeKafkaConsumer,
   closeKafkaConsumerAfterStartFailure,
@@ -18,15 +19,19 @@ import {
   mapKafkaConsumerStartError,
   mapKafkaStreamError,
   messageFromUnknown,
+  registerKafkaConsumerHealthListeners,
   sourceTopicsForRegion,
 } from "./kafka-ingress";
+import { assignedPartitionsForSourceTopic } from "./kafka-health-observation";
 import { acquireKafkaDeliveryResource, makeScopedKafkaDelivery } from "./kafka-delivery";
 import {
   kafkaIngressErrorSourceTopicOrNull,
   kafkaOptions,
+  makeViewServerKafkaHealthLedger,
   ordersSourceTopic,
   regions,
   runtimeUnavailable,
+  type Topics,
   unknownSourceTopic,
 } from "../test-harness/kafka-ingress";
 
@@ -201,6 +206,52 @@ describe("Kafka consumer Adapter", () => {
     });
   });
 
+  it.effect("removes observation listeners without owning lag monitoring or the consumer", () =>
+    Effect.gen(function* () {
+      const health = makeViewServerKafkaHealthLedger<Topics>({
+        regions: kafkaOptions.regions,
+        topics: {
+          [ordersSourceTopic]: {
+            regions: ["local"],
+            viewServerTopic: "orders",
+          },
+        },
+      });
+      const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
+        bootstrapBrokers: ["127.0.0.1:1"],
+        clientId: "view-server-observation-ownership-test",
+        groupId: "view-server-observation-ownership-test",
+      });
+      const closeConsumer = vi.spyOn(consumer, "close").mockImplementation(() => Promise.resolve());
+      const stopLagMonitoring = vi
+        .spyOn(consumer, "stopLagMonitoring")
+        .mockImplementation(() => undefined);
+      const scope = yield* Scope.make("parallel");
+      const registration = yield* registerKafkaConsumerHealthListeners(
+        consumer,
+        health,
+        "local",
+        [ordersSourceTopic],
+        scope,
+      );
+
+      yield* registration.close;
+      yield* Scope.close(scope, Exit.void);
+
+      expect({
+        consumerCloseCalls: closeConsumer.mock.calls.length,
+        stopLagMonitoringCalls: stopLagMonitoring.mock.calls.length,
+      }).toStrictEqual({
+        consumerCloseCalls: 0,
+        stopLagMonitoringCalls: 0,
+      });
+
+      closeConsumer.mockRestore();
+      stopLagMonitoring.mockRestore();
+      yield* Effect.promise(() => Promise.resolve(consumer.close(true)));
+    }),
+  );
+
   it.effect("closes a constructed consumer when consume startup fails or is interrupted", () =>
     Effect.gen(function* () {
       const closeForces: Array<boolean | undefined> = [];
@@ -229,6 +280,142 @@ describe("Kafka consumer Adapter", () => {
         closeForces: [true, true, true],
         failed: true,
         interrupted: true,
+      });
+    }),
+  );
+
+  it.effect("rolls back Region resources when listener registration defects", () =>
+    Effect.gen(function* () {
+      const successfulCleanupOperations: Array<string> = [];
+      const successfulCleanup = yield* Effect.exit(
+        acquireKafkaRegionResources(
+          Effect.sync(() => {
+            successfulCleanupOperations.push("acquire");
+            return "consumer";
+          }),
+          () =>
+            Effect.sync(() => {
+              successfulCleanupOperations.push("register");
+            }).pipe(Effect.andThen(Effect.die(new Error("registration defect")))),
+          () => Effect.void,
+          () =>
+            Effect.sync(() => {
+              successfulCleanupOperations.push("close consumer");
+            }),
+          () => Effect.void,
+        ),
+      );
+      const failedCleanupOperations: Array<string> = [];
+      const failedCleanup = yield* Effect.exit(
+        acquireKafkaRegionResources(
+          Effect.sync(() => {
+            failedCleanupOperations.push("acquire");
+            return "consumer";
+          }),
+          () =>
+            Effect.sync(() => {
+              failedCleanupOperations.push("register");
+            }).pipe(Effect.andThen(Effect.die(new Error("registration defect")))),
+          () => Effect.void,
+          () =>
+            Effect.sync(() => {
+              failedCleanupOperations.push("close consumer");
+            }).pipe(Effect.andThen(Effect.die(new Error("consumer close defect")))),
+          () => Effect.void,
+        ),
+      );
+
+      expect({
+        failedCleanup: Exit.isFailure(failedCleanup),
+        failedCleanupOperations,
+        successfulCleanup: Exit.isFailure(successfulCleanup),
+        successfulCleanupOperations,
+      }).toStrictEqual({
+        failedCleanup: true,
+        failedCleanupOperations: ["acquire", "register", "close consumer"],
+        successfulCleanup: true,
+        successfulCleanupOperations: ["acquire", "register", "close consumer"],
+      });
+    }),
+  );
+
+  it.effect("rolls back listeners and consumer when lag monitoring defects", () =>
+    Effect.gen(function* () {
+      const successfulCleanupOperations: Array<string> = [];
+      const successfulCleanup = yield* Effect.exit(
+        acquireKafkaRegionResources(
+          Effect.sync(() => {
+            successfulCleanupOperations.push("acquire");
+            return "consumer";
+          }),
+          () =>
+            Effect.sync(() => {
+              successfulCleanupOperations.push("register");
+              return "listeners";
+            }),
+          () =>
+            Effect.sync(() => {
+              successfulCleanupOperations.push("start lag");
+            }).pipe(Effect.andThen(Effect.die(new Error("lag monitoring defect")))),
+          () =>
+            Effect.sync(() => {
+              successfulCleanupOperations.push("close consumer");
+            }),
+          () =>
+            Effect.sync(() => {
+              successfulCleanupOperations.push("close listeners");
+            }),
+        ),
+      );
+      const failedCleanupOperations: Array<string> = [];
+      const failedCleanup = yield* Effect.exit(
+        acquireKafkaRegionResources(
+          Effect.sync(() => {
+            failedCleanupOperations.push("acquire");
+            return "consumer";
+          }),
+          () =>
+            Effect.sync(() => {
+              failedCleanupOperations.push("register");
+              return "listeners";
+            }),
+          () =>
+            Effect.sync(() => {
+              failedCleanupOperations.push("start lag");
+            }).pipe(Effect.andThen(Effect.die(new Error("lag monitoring defect")))),
+          () =>
+            Effect.sync(() => {
+              failedCleanupOperations.push("close consumer");
+            }).pipe(Effect.andThen(Effect.die(new Error("consumer close defect")))),
+          () =>
+            Effect.sync(() => {
+              failedCleanupOperations.push("close listeners");
+            }).pipe(Effect.andThen(Effect.die(new Error("listener close defect")))),
+        ),
+      );
+
+      expect({
+        failedCleanup: Exit.isFailure(failedCleanup),
+        failedCleanupOperations,
+        successfulCleanup: Exit.isFailure(successfulCleanup),
+        successfulCleanupOperations,
+      }).toStrictEqual({
+        failedCleanup: true,
+        failedCleanupOperations: [
+          "acquire",
+          "register",
+          "start lag",
+          "close listeners",
+          "close consumer",
+        ],
+        successfulCleanup: true,
+        successfulCleanupOperations: [
+          "acquire",
+          "register",
+          "start lag",
+          "close listeners",
+          "close consumer",
+        ],
       });
     }),
   );

--- a/packages/runtime/src/kafka-delivery-contract.test.ts
+++ b/packages/runtime/src/kafka-delivery-contract.test.ts
@@ -154,11 +154,6 @@ const makeKafkaHealthLedger = () =>
     },
   });
 
-const healthRefresh = (operations: Array<string>) =>
-  Effect.sync(() => {
-    operations.push("health");
-  });
-
 describe("Kafka delivery contract", () => {
   it("plans contiguous upsert runs and tombstone runs without reordering messages", () => {
     const firstUpsert = upsertMessage({
@@ -390,7 +385,6 @@ describe("Kafka delivery contract", () => {
 
       yield* publishAndCommitKafkaDecodedBatch(
         makeDeliveryClient(operations),
-        healthRefresh(operations),
         makeKafkaHealthLedger(),
         "local",
         [firstUpsert, secondUpsert, tombstone, finalUpsert],
@@ -400,13 +394,10 @@ describe("Kafka delivery contract", () => {
         "publish:orders:a,b",
         "commit:1",
         "commit:2",
-        "health",
         "delete:orders:a",
         "commit:3",
-        "health",
         "publish:orders:c",
         "commit:4",
-        "health",
       ]);
     }),
   );
@@ -428,7 +419,6 @@ describe("Kafka delivery contract", () => {
       const exit = yield* Effect.exit(
         publishAndCommitKafkaDecodedBatch(
           makeDeliveryClient(operations, { publishFails: true }),
-          healthRefresh(operations),
           makeKafkaHealthLedger(),
           "local",
           [message],
@@ -436,7 +426,7 @@ describe("Kafka delivery contract", () => {
       );
 
       expect(Exit.isFailure(exit)).toBe(true);
-      expect(operations).toStrictEqual(["publish-fail:orders:a", "health"]);
+      expect(operations).toStrictEqual(["publish-fail:orders:a"]);
     }),
   );
 
@@ -467,7 +457,6 @@ describe("Kafka delivery contract", () => {
       const exit = yield* Effect.exit(
         publishAndCommitKafkaDecodedBatch(
           makeDeliveryClient(operations, { publishFailsForTopic: "trades" }),
-          healthRefresh(operations),
           makeKafkaHealthLedger(),
           "local",
           [ordersMessage, tradesMessage],
@@ -478,9 +467,7 @@ describe("Kafka delivery contract", () => {
       expect(operations).toStrictEqual([
         "publish:orders:a",
         "commit:orders",
-        "health",
         "publish-fail:trades:t1",
-        "health",
       ]);
     }),
   );
@@ -496,14 +483,9 @@ describe("Kafka delivery contract", () => {
         sourceTopic: "orders-source",
       });
 
-      yield* recordAndCommitKeylessKafkaMessage(
-        healthRefresh(operations),
-        makeKafkaHealthLedger(),
-        "local",
-        message,
-      );
+      yield* recordAndCommitKeylessKafkaMessage(makeKafkaHealthLedger(), "local", message);
 
-      expect(operations).toStrictEqual(["health", "commit:5", "health"]);
+      expect(operations).toStrictEqual(["commit:5"]);
     }),
   );
 });

--- a/packages/runtime/src/kafka-delivery-contract.ts
+++ b/packages/runtime/src/kafka-delivery-contract.ts
@@ -1,9 +1,8 @@
 import type { Message } from "@platformatic/kafka";
 import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
 import { Buffer } from "node:buffer";
-import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
 import { Cause, Clock, Effect, Option } from "effect";
-import type { ViewServerKafkaHealthLedger } from "./kafka-health";
+import type { ViewServerKafkaHealthObservation } from "./kafka-health-observation";
 import {
   kafkaFailureCause,
   kafkaIngressFailureCause,
@@ -86,19 +85,9 @@ export type KafkaDeliveryRuntimeClient<Topics extends ViewServerRuntimeTopicDefi
   "delete" | "publishManyDecodedRowsWithStorageKeys"
 >;
 
-export type KafkaDeliveryHealthRefreshRequest = Effect.Effect<void>;
-
 export type KafkaDecodedCommitOptions = {
   readonly preserveLastErrorForSourceTopic: string | undefined;
 };
-
-const ignoreKafkaDeliveryHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
-  "Ignoring Kafka delivery health refresh failure.",
-);
-
-const requestKafkaDeliveryHealthRefresh = (
-  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-) => requestHealthRefresh.pipe(ignoreKafkaDeliveryHealthRefreshFailure);
 
 export const kafkaBatchMessageIsTombstone = <
   const Topics extends ViewServerRuntimeTopicDefinitions,
@@ -173,8 +162,7 @@ export const planKafkaUpsertPublishRuns = <const Topics extends ViewServerRuntim
 
 const publishKafkaRowsForMessages = Effect.fn("ViewServerRuntime.kafka.delivery.publishRows")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
     region: string,
     sourceTopic: string,
     messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
@@ -206,7 +194,6 @@ const publishKafkaRowsForMessages = Effect.fn("ViewServerRuntime.kafka.delivery.
               }),
             { discard: true },
           ).pipe(
-            Effect.andThen(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)),
             Effect.andThen(Effect.failCause(kafkaIngressFailureCause(processingError, cause))),
           );
         },
@@ -219,8 +206,7 @@ const publishKafkaRowsForMessages = Effect.fn("ViewServerRuntime.kafka.delivery.
 export const commitSkippedKafkaMessage = Effect.fn(
   "ViewServerRuntime.kafka.delivery.skipAndCommit",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   sourceTopic: string,
   message: KafkaConsumerMessage,
@@ -251,42 +237,35 @@ export const commitSkippedKafkaMessage = Effect.fn(
           }),
       }),
     ),
-  ).pipe(Effect.ensuring(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)));
+  );
 });
 
 export const recordAndCommitKeylessKafkaMessage = Effect.fn(
   "ViewServerRuntime.kafka.delivery.keylessSkipAndCommit",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   message: KafkaConsumerMessage,
 ) {
   const nowMillis = yield* Clock.currentTimeMillis;
   const sourceTopic = message.topic;
   const messageBytes = (message.value?.byteLength ?? 0) + (message.key?.byteLength ?? 0);
-  yield* health
-    .mappingFailed(sourceTopic, region, {
-      bytes: messageBytes,
-      message: "Kafka source key bytes are required",
-      nowMillis,
-    })
-    .pipe(Effect.andThen(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)));
-  yield* commitSkippedKafkaMessage(requestHealthRefresh, health, region, sourceTopic, message, {
+  yield* health.mappingFailed(sourceTopic, region, {
+    bytes: messageBytes,
+    message: "Kafka source key bytes are required",
     nowMillis,
   });
+  yield* commitSkippedKafkaMessage(health, region, sourceTopic, message, { nowMillis });
 });
 
 const publishKafkaDecodedTombstone = Effect.fn("ViewServerRuntime.kafka.delivery.publishTombstone")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     client: KafkaDeliveryRuntimeClient<Topics>,
-    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
     region: string,
     message: DecodedKafkaBatchTombstoneMessage<Topics>,
   ) {
     yield* publishKafkaRowsForMessages(
-      requestHealthRefresh,
       health,
       region,
       message.sourceTopic,
@@ -299,13 +278,11 @@ const publishKafkaDecodedTombstone = Effect.fn("ViewServerRuntime.kafka.delivery
 const publishKafkaDecodedUpsertRun = Effect.fn("ViewServerRuntime.kafka.delivery.publishUpserts")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     client: KafkaDeliveryRuntimeClient<Topics>,
-    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
     region: string,
     run: KafkaUpsertPublishRun<Topics>,
   ) {
     yield* publishKafkaRowsForMessages(
-      requestHealthRefresh,
       health,
       region,
       run.sourceTopic,
@@ -323,8 +300,7 @@ const publishKafkaDecodedUpsertRun = Effect.fn("ViewServerRuntime.kafka.delivery
 
 export const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.delivery.commit")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-    requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
     region: string,
     messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
     options?: KafkaDecodedCommitOptions,
@@ -358,7 +334,7 @@ export const commitKafkaDecodedBatch = Effect.fn("ViewServerRuntime.kafka.delive
           ),
         );
       }
-    }).pipe(Effect.ensuring(requestKafkaDeliveryHealthRefresh(requestHealthRefresh)));
+    });
   },
 );
 
@@ -366,8 +342,7 @@ export const publishAndCommitKafkaDecodedBatch = Effect.fn(
   "ViewServerRuntime.kafka.delivery.publishAndCommit",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   client: KafkaDeliveryRuntimeClient<Topics>,
-  requestHealthRefresh: KafkaDeliveryHealthRefreshRequest,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   messages: ReadonlyArray<DecodedKafkaBatchMessage<Topics>>,
   options?: KafkaDecodedCommitOptions,
@@ -378,15 +353,8 @@ export const publishAndCommitKafkaDecodedBatch = Effect.fn(
     if (run._tag === "Upserts") {
       const upsertRuns = planKafkaUpsertPublishRuns(run.messages);
       for (const upsertRun of upsertRuns) {
-        yield* publishKafkaDecodedUpsertRun(
-          client,
-          requestHealthRefresh,
-          health,
-          region,
-          upsertRun,
-        );
+        yield* publishKafkaDecodedUpsertRun(client, health, region, upsertRun);
         yield* commitKafkaDecodedBatch(
-          requestHealthRefresh,
           health,
           region,
           upsertRun.rows.map((row) => row.message),
@@ -394,14 +362,8 @@ export const publishAndCommitKafkaDecodedBatch = Effect.fn(
         );
       }
     } else {
-      yield* publishKafkaDecodedTombstone(
-        client,
-        requestHealthRefresh,
-        health,
-        region,
-        run.message,
-      );
-      yield* commitKafkaDecodedBatch(requestHealthRefresh, health, region, [run.message], options);
+      yield* publishKafkaDecodedTombstone(client, health, region, run.message);
+      yield* commitKafkaDecodedBatch(health, region, [run.message], options);
     }
   }
 });

--- a/packages/runtime/src/kafka-delivery-lifecycle.test.ts
+++ b/packages/runtime/src/kafka-delivery-lifecycle.test.ts
@@ -232,6 +232,101 @@ describe("Kafka delivery lifecycle", () => {
     }),
   );
 
+  it.effect("clears Region health after in-flight observations and ordered resource shutdown", () =>
+    Effect.gen(function* () {
+      const operations: Array<string> = [];
+      const workerStarted = yield* Deferred.make<void>();
+      const unblockObservation = yield* Deferred.make<void>();
+
+      const delivery = yield* makeScopedKafkaDelivery((startWorker) =>
+        startWorker(
+          Effect.acquireRelease(Effect.void, () =>
+            Effect.gen(function* () {
+              operations.push("lag:stop");
+              operations.push("listeners:close");
+              operations.push("consumer:close");
+              yield* Deferred.succeed(unblockObservation, undefined);
+            }),
+          ),
+          () =>
+            Deferred.succeed(workerStarted, undefined).pipe(
+              Effect.andThen(
+                Deferred.await(unblockObservation).pipe(
+                  Effect.andThen(
+                    Effect.sync(() => {
+                      operations.push("observation:finished");
+                    }),
+                  ),
+                  Effect.uninterruptible,
+                ),
+              ),
+            ),
+          Effect.sync(() => {
+            operations.push("region:stopped");
+          }),
+        ),
+      );
+
+      yield* Deferred.await(workerStarted);
+      yield* delivery.close;
+
+      expect(operations).toStrictEqual([
+        "lag:stop",
+        "listeners:close",
+        "consumer:close",
+        "observation:finished",
+        "region:stopped",
+      ]);
+    }),
+  );
+
+  it.effect("shares shutdown finalizer defects with delivery close callers", () =>
+    Effect.gen(function* () {
+      const workerStarted = yield* Deferred.make<void>();
+      const delivery = yield* makeScopedKafkaDelivery((startWorker) =>
+        startWorker(
+          Effect.void,
+          () => Deferred.succeed(workerStarted, undefined).pipe(Effect.andThen(Effect.never)),
+          Effect.die(new Error("Region health shutdown defect")),
+        ),
+      );
+
+      yield* Deferred.await(workerStarted);
+      const closeExit = yield* Effect.exit(delivery.close);
+
+      expect(Exit.isFailure(closeExit)).toBe(true);
+    }),
+  );
+
+  it.effect("runs Region health shutdown after a worker resource finalizer defects", () =>
+    Effect.gen(function* () {
+      const workerStarted = yield* Deferred.make<void>();
+      let regionStopped = 0;
+      const delivery = yield* makeScopedKafkaDelivery((startWorker) =>
+        startWorker(
+          Effect.acquireRelease(Effect.void, () =>
+            Effect.die(new Error("consumer cleanup defect")),
+          ),
+          () => Deferred.succeed(workerStarted, undefined).pipe(Effect.andThen(Effect.never)),
+          Effect.sync(() => {
+            regionStopped += 1;
+          }),
+        ),
+      );
+
+      yield* Deferred.await(workerStarted);
+      const closeExit = yield* Effect.exit(delivery.close);
+
+      expect({
+        closeFailed: Exit.isFailure(closeExit),
+        regionStopped,
+      }).toStrictEqual({
+        closeFailed: true,
+        regionStopped: 1,
+      });
+    }),
+  );
+
   it.effect("releases an acquired Region when delivery startup is interrupted", () =>
     Effect.gen(function* () {
       let releaseCount = 0;

--- a/packages/runtime/src/kafka-delivery.ts
+++ b/packages/runtime/src/kafka-delivery.ts
@@ -1,4 +1,5 @@
-import { Deferred, Effect, Exit, Fiber, Scope } from "effect";
+import { runAllFinalizers } from "@effect-view-server/effect-utils";
+import { Deferred, Effect, Exit, Fiber, MutableRef, Scope } from "effect";
 
 export type KafkaDelivery = {
   readonly close: Effect.Effect<void>;
@@ -7,6 +8,7 @@ export type KafkaDelivery = {
 export type StartKafkaDeliveryWorker = <A, E, R, R2>(
   start: Effect.Effect<A, E, R>,
   deliver: (resource: A) => Effect.Effect<void, E, R2>,
+  onShutdown?: Effect.Effect<void>,
 ) => Effect.Effect<void, E, Exclude<R, Scope.Scope> | R2>;
 
 export const acquireKafkaDeliveryResource = Effect.fn(
@@ -25,11 +27,48 @@ const startScopedKafkaDeliveryWorker = Effect.fn("ViewServerRuntime.kafka.delive
     scope: Scope.Scope,
     start: Effect.Effect<A, E, R>,
     deliver: (resource: A) => Effect.Effect<void, E, R2>,
+    onShutdown: Effect.Effect<void>,
   ) {
     yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         const workerScope = yield* Scope.make("parallel");
-        yield* Scope.addFinalizerExit(scope, (exit) => Scope.close(workerScope, exit));
+        const shutdownExit = yield* Deferred.make<Exit.Exit<unknown, unknown>>();
+        const shutdownStarted = MutableRef.make(false);
+        const shutdownCompleted = yield* Deferred.make<Exit.Exit<void, never>>();
+        const awaitShutdownResult = Effect.fn(
+          "ViewServerRuntime.kafka.delivery.awaitShutdownResult",
+        )(function* () {
+          const shutdownResult = yield* Deferred.await(shutdownCompleted);
+          if (Exit.isFailure(shutdownResult)) {
+            return yield* Effect.failCause(shutdownResult.cause);
+          }
+        });
+        const requestWorkerShutdown = (exit: Exit.Exit<unknown, unknown>) =>
+          Deferred.succeed(shutdownExit, exit).pipe(
+            Effect.andThen(
+              Effect.gen(function* () {
+                const isShutdownLeader = yield* Effect.sync(() => {
+                  if (shutdownStarted.current) {
+                    return false;
+                  }
+                  shutdownStarted.current = true;
+                  return true;
+                });
+                if (isShutdownLeader) {
+                  const shutdownResult = yield* Effect.exit(
+                    Deferred.await(shutdownExit).pipe(
+                      Effect.flatMap((shutdownExit) =>
+                        runAllFinalizers([Scope.close(workerScope, shutdownExit), onShutdown]),
+                      ),
+                    ),
+                  );
+                  yield* Deferred.succeed(shutdownCompleted, shutdownResult);
+                }
+                yield* awaitShutdownResult();
+              }).pipe(Effect.uninterruptible),
+            ),
+          );
+        yield* Scope.addFinalizerExit(scope, requestWorkerShutdown);
         const started = yield* Deferred.make<void, E>();
         const worker = yield* Effect.gen(function* () {
           const resource = yield* start;
@@ -41,7 +80,7 @@ const startScopedKafkaDeliveryWorker = Effect.fn("ViewServerRuntime.kafka.delive
           Effect.forkIn(workerScope, { startImmediately: true }),
         );
         yield* Fiber.await(worker).pipe(
-          Effect.flatMap((exit) => Scope.close(workerScope, exit).pipe(Effect.uninterruptible)),
+          Effect.flatMap(requestWorkerShutdown),
           Effect.forkIn(scope, { startImmediately: true }),
         );
         yield* restore(Deferred.await(started));
@@ -55,8 +94,8 @@ export const makeScopedKafkaDelivery = Effect.fn("ViewServerRuntime.kafka.delive
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         const scope = yield* Scope.make("parallel");
-        const startWorker: StartKafkaDeliveryWorker = (workerStart, deliver) =>
-          startScopedKafkaDeliveryWorker(scope, workerStart, deliver);
+        const startWorker: StartKafkaDeliveryWorker = (workerStart, deliver, onShutdown) =>
+          startScopedKafkaDeliveryWorker(scope, workerStart, deliver, onShutdown ?? Effect.void);
         yield* restore(start(startWorker)).pipe(
           Effect.onExit((exit) => (Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)),
         );

--- a/packages/runtime/src/kafka-health-ledger.internal.test.ts
+++ b/packages/runtime/src/kafka-health-ledger.internal.test.ts
@@ -4,11 +4,8 @@ import { makeViewServerRuntimeCoreInternal as makeViewServerRuntimeCore } from "
 import { Buffer } from "node:buffer";
 import { Cause, Deferred, Effect, Exit, Fiber, Logger, References, Scope } from "effect";
 import type { ViewServerKafkaHealthLedger } from "./kafka-health";
-import {
-  recordKafkaAssignments,
-  recordKafkaLag,
-  registerKafkaConsumerHealthListeners,
-} from "./kafka-ingress";
+import { recordKafkaAssignments, recordKafkaLag } from "./kafka-health-observation";
+import { registerKafkaConsumerHealthListeners } from "./kafka-ingress";
 import {
   kafkaOptions,
   makeCapturedLogs,
@@ -245,14 +242,9 @@ describe("Kafka ingress health ledger internals", () => {
             },
           },
         });
-        let healthRefreshRequestCount = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshRequestCount += 1;
-        });
         yield* ledger.regionConnected("local", 1_000);
         yield* recordKafkaAssignments(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           [{ topic: ordersSourceTopic, partitions: [0, 1] }],
@@ -260,7 +252,6 @@ describe("Kafka ingress health ledger internals", () => {
         );
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic, unknownSourceTopic],
           new Map([
@@ -270,8 +261,6 @@ describe("Kafka ingress health ledger internals", () => {
           2_000,
         );
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
-
-        expect(healthRefreshRequestCount).toBe(2);
         expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
           status: "ready",
           sourceTopic: ordersSourceTopic,
@@ -315,14 +304,9 @@ describe("Kafka ingress health ledger internals", () => {
             },
           },
         });
-        let healthRefreshRequestCount = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshRequestCount += 1;
-        });
 
         yield* recordKafkaAssignments(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           [{ topic: ordersSourceTopic, partitions: [0] }],
@@ -330,7 +314,6 @@ describe("Kafka ingress health ledger internals", () => {
         );
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           new Map([[ordersSourceTopic, [5n]]]),
@@ -338,15 +321,12 @@ describe("Kafka ingress health ledger internals", () => {
         );
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           new Map([[ordersSourceTopic, [-1n]]]),
           2_000,
         );
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
-
-        expect(healthRefreshRequestCount).toBe(3);
         expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
           status: "ready",
           sourceTopic: ordersSourceTopic,
@@ -389,14 +369,9 @@ describe("Kafka ingress health ledger internals", () => {
             },
           },
         });
-        let healthRefreshRequestCount = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshRequestCount += 1;
-        });
 
         yield* recordKafkaAssignments(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           [{ topic: ordersSourceTopic, partitions: [0] }],
@@ -404,15 +379,12 @@ describe("Kafka ingress health ledger internals", () => {
         );
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           new Map([[ordersSourceTopic, []]]),
           2_000,
         );
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
-
-        expect(healthRefreshRequestCount).toBe(2);
         expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
           status: "ready",
           sourceTopic: ordersSourceTopic,
@@ -459,15 +431,10 @@ describe("Kafka ingress health ledger internals", () => {
             },
           },
         });
-        let healthRefreshRequestCount = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshRequestCount += 1;
-        });
 
         yield* ledger.regionConnected("local", 1_000);
         yield* recordKafkaAssignments(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic, paymentsSourceTopic],
           [
@@ -478,7 +445,6 @@ describe("Kafka ingress health ledger internals", () => {
         );
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic, paymentsSourceTopic],
           new Map([
@@ -489,15 +455,12 @@ describe("Kafka ingress health ledger internals", () => {
         );
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic, paymentsSourceTopic],
           new Map([[ordersSourceTopic, [1n]]]),
           3_000,
         );
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 3_000);
-
-        expect(healthRefreshRequestCount).toBe(3);
         expect({
           orders: health.kafka?.topics[ordersSourceTopic],
           payments: health.kafka?.topics[paymentsSourceTopic],
@@ -570,15 +533,10 @@ describe("Kafka ingress health ledger internals", () => {
             },
           },
         });
-        let healthRefreshRequestCount = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshRequestCount += 1;
-        });
 
         yield* ledger.regionConnected("local", 1_000);
         yield* recordKafkaAssignments(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           [{ topic: ordersSourceTopic, partitions: [0, 1] }],
@@ -587,15 +545,12 @@ describe("Kafka ingress health ledger internals", () => {
         yield* ledger.regionDisconnected("local", "Kafka consumer left group");
         yield* recordKafkaLag(
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           new Map([[ordersSourceTopic, [8n, -1n, 3n]]]),
           2_000,
         );
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
-
-        expect(healthRefreshRequestCount).toBe(2);
         expect({
           region: health.kafka?.regions["local"],
           topicStatus: health.kafka?.topics[ordersSourceTopic]?.status,
@@ -643,10 +598,6 @@ describe("Kafka ingress health ledger internals", () => {
           },
         },
       });
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-listener-test",
@@ -657,7 +608,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         ledger,
-        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -686,13 +636,7 @@ describe("Kafka ingress health ledger internals", () => {
       const degradedProcessed = yield* listenerRegistration.processed;
       const degradedHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
-      expect({
-        healthRefreshRequestCount,
-        processed: degradedProcessed,
-      }).toStrictEqual({
-        healthRefreshRequestCount: 5,
-        processed: 5,
-      });
+      expect(degradedProcessed).toBe(5);
       expect({
         region: degradedHealth.kafka?.regions["local"],
         topicStatus: degradedHealth.kafka?.topics[ordersSourceTopic]?.status,
@@ -738,13 +682,7 @@ describe("Kafka ingress health ledger internals", () => {
       const recoveredProcessed = yield* listenerRegistration.processed;
       const recoveredHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
-      expect({
-        healthRefreshRequestCount,
-        processed: recoveredProcessed,
-      }).toStrictEqual({
-        healthRefreshRequestCount: 7,
-        processed: 7,
-      });
+      expect(recoveredProcessed).toBe(7);
       expect({
         region: recoveredHealth.kafka?.regions["local"],
         topicStatus: recoveredHealth.kafka?.topics[ordersSourceTopic]?.status,
@@ -800,10 +738,6 @@ describe("Kafka ingress health ledger internals", () => {
           },
         },
       });
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-listener-omitted-lag-test",
@@ -814,7 +748,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         ledger,
-        requestHealthRefresh,
         "local",
         [ordersSourceTopic, paymentsSourceTopic],
         scope,
@@ -845,11 +778,9 @@ describe("Kafka ingress health ledger internals", () => {
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect({
-        healthRefreshRequestCount,
         orders: health.kafka?.topics[ordersSourceTopic]?.regions["local"],
         payments: health.kafka?.topics[paymentsSourceTopic]?.regions["local"],
       }).toStrictEqual({
-        healthRefreshRequestCount: 3,
         orders: {
           connected: true,
           assignedPartitions: 1,
@@ -909,10 +840,6 @@ describe("Kafka ingress health ledger internals", () => {
             },
           },
         });
-        let healthRefreshRequestCount = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshRequestCount += 1;
-        });
         const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
           bootstrapBrokers: ["127.0.0.1:1"],
           clientId: "view-server-listener-rebalance-test",
@@ -923,7 +850,6 @@ describe("Kafka ingress health ledger internals", () => {
         const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
           consumer,
           ledger,
-          requestHealthRefresh,
           "local",
           [ordersSourceTopic],
           scope,
@@ -939,8 +865,6 @@ describe("Kafka ingress health ledger internals", () => {
         });
         yield* Fiber.join(connectedWait);
         const connectedHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
-
-        expect(healthRefreshRequestCount).toBe(1);
         expect({
           region: connectedHealth.kafka?.regions["local"],
           topicRegion: connectedHealth.kafka?.topics[ordersSourceTopic]?.regions["local"],
@@ -979,8 +903,6 @@ describe("Kafka ingress health ledger internals", () => {
         });
         yield* Fiber.join(rebalanceWait);
         const rebalanceHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
-
-        expect(healthRefreshRequestCount).toBe(2);
         expect({
           region: rebalanceHealth.kafka?.regions["local"],
           topicStatus: rebalanceHealth.kafka?.topics[ordersSourceTopic]?.status,
@@ -1023,8 +945,6 @@ describe("Kafka ingress health ledger internals", () => {
         });
         yield* Fiber.join(recoveredWait);
         const recoveredHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
-
-        expect(healthRefreshRequestCount).toBe(3);
         expect({
           region: recoveredHealth.kafka?.regions["local"],
           topicStatus: recoveredHealth.kafka?.topics[ordersSourceTopic]?.status,
@@ -1083,10 +1003,6 @@ describe("Kafka ingress health ledger internals", () => {
             Effect.andThen(ledger.regionDisconnected(region, message, options)),
           ),
       };
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-listener-rebalance-order-test",
@@ -1097,7 +1013,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         delayedDisconnectLedger,
-        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1126,8 +1041,6 @@ describe("Kafka ingress health ledger internals", () => {
       });
       yield* Fiber.join(recoveredWait);
       const recoveredHealth = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
-
-      expect(healthRefreshRequestCount).toBe(3);
       expect({
         region: recoveredHealth.kafka?.regions["local"],
         topicStatus: recoveredHealth.kafka?.topics[ordersSourceTopic]?.status,
@@ -1187,10 +1100,6 @@ describe("Kafka ingress health ledger internals", () => {
             Effect.andThen(ledger.regionDegraded(region, message)),
           ),
       };
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-listener-assignment-snapshot-test",
@@ -1201,7 +1110,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         blockingLedger,
-        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1220,8 +1128,6 @@ describe("Kafka ingress health ledger internals", () => {
       yield* Deferred.succeed(releaseLagError, undefined);
       yield* Fiber.join(processedWait);
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
-
-      expect(healthRefreshRequestCount).toBe(2);
       expect(health.kafka?.topics[ordersSourceTopic]?.regions["local"]).toStrictEqual({
         connected: true,
         assignedPartitions: 2,
@@ -1278,7 +1184,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         failingLedger,
-        runtimeCore.requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1372,7 +1277,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         interruptingLedger,
-        runtimeCore.requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -1465,7 +1369,6 @@ describe("Kafka ingress health ledger internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         blockingLedger,
-        runtimeCore.requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,

--- a/packages/runtime/src/kafka-health-observation.test.ts
+++ b/packages/runtime/src/kafka-health-observation.test.ts
@@ -1,0 +1,464 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Consumer } from "@platformatic/kafka";
+import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
+import { Buffer } from "node:buffer";
+import { Deferred, Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
+import { makeScopedKafkaDelivery } from "./kafka-delivery";
+import { makeViewServerKafkaHealthLedger } from "./kafka-health";
+import {
+  makeViewServerKafkaHealthObserver,
+  recordKafkaAssignments,
+  recordKafkaLag,
+  type ViewServerKafkaHealthObservation,
+} from "./kafka-health-observation";
+import { registerKafkaConsumerHealthListeners } from "./kafka-ingress";
+import {
+  kafkaOptions,
+  nullRecord,
+  ordersSourceTopic,
+  regions,
+  type Topics,
+  viewServer,
+} from "../test-harness/kafka-ingress";
+
+const makeHealthLedger = () =>
+  makeViewServerKafkaHealthLedger<Topics>({
+    regions: kafkaOptions.regions,
+    startFrom: kafkaOptions.consume,
+    topics: {
+      [ordersSourceTopic]: {
+        regions: ["local"],
+        viewServerTopic: "orders",
+      },
+    },
+  });
+
+describe("Kafka health observation", () => {
+  it.effect("refreshes observed delivery health only on the bounded cadence", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const ledger = makeHealthLedger();
+      let refreshes = 0;
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Effect.sync(() => {
+          refreshes += 1;
+        }),
+        "1 second",
+      );
+
+      yield* observer.messageDecoded(ordersSourceTopic, "local", {
+        bytes: 10,
+        committedOffset: "1",
+        nowMillis: 1_000,
+      });
+      yield* observer.messageDecoded(ordersSourceTopic, "local", {
+        bytes: 20,
+        committedOffset: "2",
+        nowMillis: 1_001,
+      });
+      yield* observer.messagePublishFailed(ordersSourceTopic, "local", {
+        bytes: 30,
+        message: "publish failed",
+        nowMillis: 1_002,
+      });
+
+      expect(refreshes).toBe(0);
+      yield* TestClock.adjust("999 millis");
+      expect(refreshes).toBe(0);
+      yield* TestClock.adjust("1 millis");
+      expect(refreshes).toBe(1);
+
+      yield* observer.messageCommitFailed(ordersSourceTopic, "local", {
+        bytes: 40,
+        message: "commit failed",
+        nowMillis: 2_000,
+      });
+      yield* TestClock.adjust("1 second");
+      expect(refreshes).toBe(2);
+
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+      expect({
+        commitFailuresPerSecond:
+          health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.commitFailuresPerSecond,
+        lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+        processingFailuresPerSecond:
+          health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.processingFailuresPerSecond,
+        publishFailuresPerSecond:
+          health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.publishFailuresPerSecond,
+      }).toStrictEqual({
+        commitFailuresPerSecond: 1,
+        lastError: "commit failed",
+        processingFailuresPerSecond: 2,
+        publishFailuresPerSecond: 1,
+      });
+
+      yield* observer.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("joins an in-flight cadence refresh before flushing observer shutdown", () =>
+    Effect.gen(function* () {
+      const ledger = makeHealthLedger();
+      const refreshStarted = yield* Deferred.make<void>();
+      const allowRefresh = yield* Deferred.make<void>();
+      const closeCompleted = yield* Deferred.make<void>();
+      let refreshes = 0;
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Deferred.succeed(refreshStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(allowRefresh)),
+          Effect.andThen(
+            Effect.sync(() => {
+              refreshes += 1;
+            }),
+          ),
+        ),
+        "1 second",
+      );
+
+      yield* observer.regionConnected("local", 1_000);
+      yield* TestClock.adjust("1 second");
+      yield* Deferred.await(refreshStarted);
+      const close = yield* observer.close.pipe(
+        Effect.ensuring(Deferred.succeed(closeCompleted, undefined)),
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Effect.yieldNow;
+
+      expect(yield* Deferred.isDone(closeCompleted)).toBe(false);
+      yield* Deferred.succeed(allowRefresh, undefined);
+      yield* Fiber.join(close);
+      expect(refreshes).toBe(1);
+    }),
+  );
+
+  it.effect("routes assignment and lag observations through the same observer", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const ledger = makeHealthLedger();
+      const observer = yield* makeViewServerKafkaHealthObserver(ledger, Effect.void, "1 second");
+
+      yield* recordKafkaAssignments(
+        observer,
+        "local",
+        [ordersSourceTopic],
+        [{ topic: ordersSourceTopic, partitions: [0, 1] }],
+        1_000,
+      );
+      yield* recordKafkaLag(
+        observer,
+        "local",
+        [ordersSourceTopic],
+        new Map([[ordersSourceTopic, [4n, -1n, 2n]]]),
+        2_000,
+      );
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect(health.kafka?.topics[ordersSourceTopic]?.regions["local"]).toStrictEqual({
+        connected: true,
+        assignedPartitions: 2,
+        messagesPerSecond: 0,
+        bytesPerSecond: 0,
+        decodedMessagesPerSecond: 0,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        commitFailuresPerSecond: 0,
+        processingFailuresPerSecond: 0,
+        lastMessageAt: null,
+        lastCommitAt: null,
+        consumerLagMessages: 6n,
+        lagSampledAt: 2_000,
+        committedOffset: null,
+        lastError: null,
+      });
+
+      yield* observer.close;
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("forwards region, skipped, decode, and mapping outcomes through one observer", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const ledger = makeHealthLedger();
+      let refreshes = 0;
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Effect.sync(() => {
+          refreshes += 1;
+        }),
+        "1 second",
+      );
+
+      yield* observer.regionConnected("local", 900);
+      yield* observer.regionDisconnected("local", "broker disconnected");
+      const disconnected = ledger.healthOverlay(yield* runtimeCore.client.health(), 900);
+      expect(disconnected.kafka?.regions["local"]).toStrictEqual({
+        status: "disconnected",
+        brokers: regions.local,
+        lastConnectedAt: 900,
+        lastError: "broker disconnected",
+      });
+
+      yield* observer.regionDegraded("local", "lag sampling failed");
+      yield* observer.messageSkippedCommitted(ordersSourceTopic, "local", {
+        committedOffset: "7",
+        nowMillis: 1_000,
+      });
+      yield* observer.decodeFailed(ordersSourceTopic, "local", {
+        bytes: 5,
+        message: "decode failed",
+        nowMillis: 1_001,
+      });
+      yield* observer.mappingFailed(ordersSourceTopic, "local", {
+        bytes: 7,
+        message: "mapping failed",
+        nowMillis: 1_002,
+      });
+
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 1_002);
+      expect({
+        committedOffset: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.committedOffset,
+        decodeFailuresPerSecond:
+          health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+        lastCommitAt: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastCommitAt,
+        lastError: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastError,
+        lastMessageAt: health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.lastMessageAt,
+        mappingFailuresPerSecond:
+          health.kafka?.topics[ordersSourceTopic]?.regions["local"]?.mappingFailuresPerSecond,
+        region: health.kafka?.regions["local"],
+      }).toStrictEqual({
+        committedOffset: "7",
+        decodeFailuresPerSecond: 1,
+        lastCommitAt: 1_000,
+        lastError: "mapping failed",
+        lastMessageAt: 1_002,
+        mappingFailuresPerSecond: 1,
+        region: {
+          status: "degraded",
+          brokers: regions.local,
+          lastConnectedAt: 900,
+          lastError: "lag sampling failed",
+        },
+      });
+
+      expect(refreshes).toBe(0);
+      yield* observer.close;
+      expect(refreshes).toBe(1);
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("removes consumer-owned assignment, lag, and rate state when a source stops", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const ledger = makeHealthLedger();
+      let refreshes = 0;
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Effect.sync(() => {
+          refreshes += 1;
+        }),
+        "1 second",
+      );
+
+      yield* recordKafkaAssignments(
+        observer,
+        "local",
+        [ordersSourceTopic],
+        [{ topic: ordersSourceTopic, partitions: [0, 1] }],
+        1_000,
+      );
+      yield* recordKafkaLag(
+        observer,
+        "local",
+        [ordersSourceTopic],
+        new Map([[ordersSourceTopic, [5n, 3n]]]),
+        1_000,
+      );
+      yield* observer.messageDecoded(ordersSourceTopic, "local", {
+        bytes: 10,
+        committedOffset: "2",
+        nowMillis: 1_000,
+      });
+      yield* observer.decodeFailed(ordersSourceTopic, "local", {
+        bytes: 5,
+        message: "decode failed",
+        nowMillis: 1_000,
+      });
+      yield* observer.mappingFailed(ordersSourceTopic, "local", {
+        bytes: 6,
+        message: "mapping failed",
+        nowMillis: 1_000,
+      });
+      yield* observer.messagePublishFailed(ordersSourceTopic, "local", {
+        bytes: 7,
+        message: "publish failed",
+        nowMillis: 1_000,
+      });
+      yield* observer.messageCommitFailed(ordersSourceTopic, "local", {
+        bytes: 8,
+        message: "commit failed",
+        nowMillis: 1_000,
+      });
+      const beforeStop = ledger.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+      expect({
+        decodeFailuresPerSecond:
+          beforeStop.kafka?.topics[ordersSourceTopic]?.regions["local"]?.decodeFailuresPerSecond,
+        mappingFailuresPerSecond:
+          beforeStop.kafka?.topics[ordersSourceTopic]?.regions["local"]?.mappingFailuresPerSecond,
+        processingFailuresPerSecond:
+          beforeStop.kafka?.topics[ordersSourceTopic]?.regions["local"]
+            ?.processingFailuresPerSecond,
+        publishFailuresPerSecond:
+          beforeStop.kafka?.topics[ordersSourceTopic]?.regions["local"]?.publishFailuresPerSecond,
+        commitFailuresPerSecond:
+          beforeStop.kafka?.topics[ordersSourceTopic]?.regions["local"]?.commitFailuresPerSecond,
+      }).toStrictEqual({
+        decodeFailuresPerSecond: 1,
+        mappingFailuresPerSecond: 1,
+        processingFailuresPerSecond: 2,
+        publishFailuresPerSecond: 1,
+        commitFailuresPerSecond: 1,
+      });
+      yield* observer.regionStopped("local");
+      yield* observer.regionStopped("unknown");
+
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 1_000);
+      expect({
+        region: health.kafka?.regions["local"],
+        topic: health.kafka?.topics[ordersSourceTopic],
+      }).toStrictEqual({
+        region: {
+          status: "disconnected",
+          brokers: regions.local,
+          lastConnectedAt: 1_000,
+          lastError: null,
+        },
+        topic: {
+          status: "degraded",
+          sourceTopic: ordersSourceTopic,
+          viewServerTopic: "orders",
+          regions: nullRecord({
+            local: {
+              connected: false,
+              assignedPartitions: 0,
+              messagesPerSecond: 0,
+              bytesPerSecond: 0,
+              decodedMessagesPerSecond: 0,
+              decodeFailuresPerSecond: 0,
+              mappingFailuresPerSecond: 0,
+              publishFailuresPerSecond: 0,
+              commitFailuresPerSecond: 0,
+              processingFailuresPerSecond: 0,
+              lastMessageAt: 1_000,
+              lastCommitAt: 1_000,
+              consumerLagMessages: null,
+              lagSampledAt: null,
+              committedOffset: "2",
+              lastError: "commit failed",
+            },
+          }),
+        },
+      });
+
+      expect(refreshes).toBe(0);
+      yield* observer.close;
+      yield* observer.close;
+      expect(refreshes).toBe(1);
+
+      yield* runtimeCore.close;
+    }),
+  );
+
+  it.effect("clears assignment and lag after an in-flight listener observation finishes", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      const ledger = makeHealthLedger();
+      const assignmentRecorded = yield* Deferred.make<void>();
+      const lagObservationStarted = yield* Deferred.make<void>();
+      const allowLagObservation = yield* Deferred.make<void>();
+      const workerStarted = yield* Deferred.make<void>();
+      const observation = {
+        ...ledger,
+        topicConnected: (sourceTopic, region, assignedPartitions, nowMillis) =>
+          ledger
+            .topicConnected(sourceTopic, region, assignedPartitions, nowMillis)
+            .pipe(Effect.andThen(Deferred.succeed(assignmentRecorded, undefined))),
+        topicLagSampled: (sourceTopic, region, input) =>
+          Deferred.succeed(lagObservationStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(allowLagObservation)),
+            Effect.andThen(ledger.topicLagSampled(sourceTopic, region, input)),
+            Effect.uninterruptible,
+          ),
+      } satisfies ViewServerKafkaHealthObservation<Topics>;
+      const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
+        bootstrapBrokers: ["127.0.0.1:1"],
+        clientId: "view-server-shutdown-observation-test",
+        groupId: "view-server-shutdown-observation-test",
+      });
+
+      const delivery = yield* makeScopedKafkaDelivery((startWorker) =>
+        startWorker(
+          Effect.gen(function* () {
+            const workerScope = yield* Effect.scope;
+            yield* Effect.acquireRelease(
+              registerKafkaConsumerHealthListeners(
+                consumer,
+                observation,
+                "local",
+                [ordersSourceTopic],
+                workerScope,
+              ),
+              (registration) =>
+                registration.close.pipe(
+                  Effect.andThen(Effect.promise(() => Promise.resolve(consumer.close(true)))),
+                  Effect.andThen(Deferred.succeed(allowLagObservation, undefined)),
+                ),
+            );
+          }),
+          () => Deferred.succeed(workerStarted, undefined).pipe(Effect.andThen(Effect.never)),
+          ledger.regionStopped("local"),
+        ),
+      );
+
+      yield* Deferred.await(workerStarted);
+      consumer.emit("consumer:group:join", {
+        groupId: "view-server-shutdown-observation-test",
+        memberId: "member-1",
+        assignments: [{ topic: ordersSourceTopic, partitions: [0, 1] }],
+      });
+      yield* Deferred.await(assignmentRecorded);
+      consumer.emit("consumer:lag", new Map([[ordersSourceTopic, [7n, 5n]]]));
+      yield* Deferred.await(lagObservationStarted);
+
+      yield* delivery.close;
+
+      const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
+      expect(health.kafka?.topics[ordersSourceTopic]?.regions["local"]).toStrictEqual({
+        connected: false,
+        assignedPartitions: 0,
+        messagesPerSecond: 0,
+        bytesPerSecond: 0,
+        decodedMessagesPerSecond: 0,
+        decodeFailuresPerSecond: 0,
+        mappingFailuresPerSecond: 0,
+        publishFailuresPerSecond: 0,
+        commitFailuresPerSecond: 0,
+        processingFailuresPerSecond: 0,
+        lastMessageAt: null,
+        lastCommitAt: null,
+        consumerLagMessages: null,
+        lagSampledAt: null,
+        committedOffset: null,
+        lastError: null,
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
+});

--- a/packages/runtime/src/kafka-health-observation.test.ts
+++ b/packages/runtime/src/kafka-health-observation.test.ts
@@ -38,15 +38,11 @@ describe("Kafka health observation", () => {
   it.effect("awaits an immediate health flush when the observer closes", () =>
     Effect.gen(function* () {
       const ledger = makeHealthLedger();
-      let scheduledRefreshes = 0;
-      let immediateFlushes = 0;
+      let immediateRefreshes = 0;
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
         Effect.sync(() => {
-          scheduledRefreshes += 1;
-        }),
-        Effect.sync(() => {
-          immediateFlushes += 1;
+          immediateRefreshes += 1;
         }),
         "1 minute",
       );
@@ -54,10 +50,7 @@ describe("Kafka health observation", () => {
       yield* observer.regionStopped("local");
       yield* observer.close;
 
-      expect({ immediateFlushes, scheduledRefreshes }).toStrictEqual({
-        immediateFlushes: 1,
-        scheduledRefreshes: 0,
-      });
+      expect(immediateRefreshes).toBe(1);
     }),
   );
 
@@ -71,7 +64,6 @@ describe("Kafka health observation", () => {
         Effect.sync(() => {
           refreshes += 1;
         }),
-        Effect.void,
         "1 second",
       );
 
@@ -126,6 +118,30 @@ describe("Kafka health observation", () => {
     }),
   );
 
+  it.effect("uses the immediate health refresh after the observer cadence", () =>
+    Effect.gen(function* () {
+      const ledger = makeHealthLedger();
+      let immediateRefreshes = 0;
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Effect.sync(() => {
+          immediateRefreshes += 1;
+        }),
+        "1 second",
+      );
+
+      yield* observer.decodeFailed(ordersSourceTopic, "local", {
+        bytes: 5,
+        message: "decode failed",
+        nowMillis: 1_000,
+      });
+      yield* TestClock.adjust("1 second");
+
+      expect(immediateRefreshes).toBe(1);
+      yield* observer.close;
+    }),
+  );
+
   it.effect("joins an in-flight cadence refresh before flushing observer shutdown", () =>
     Effect.gen(function* () {
       const ledger = makeHealthLedger();
@@ -143,7 +159,6 @@ describe("Kafka health observation", () => {
             }),
           ),
         ),
-        Effect.void,
         "1 second",
       );
 
@@ -159,7 +174,7 @@ describe("Kafka health observation", () => {
       expect(yield* Deferred.isDone(closeCompleted)).toBe(false);
       yield* Deferred.succeed(allowRefresh, undefined);
       yield* Fiber.join(close);
-      expect(refreshes).toBe(1);
+      expect(refreshes).toBe(2);
     }),
   );
 
@@ -167,12 +182,7 @@ describe("Kafka health observation", () => {
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
       const ledger = makeHealthLedger();
-      const observer = yield* makeViewServerKafkaHealthObserver(
-        ledger,
-        Effect.void,
-        Effect.void,
-        "1 second",
-      );
+      const observer = yield* makeViewServerKafkaHealthObserver(ledger, Effect.void, "1 second");
 
       yield* recordKafkaAssignments(
         observer,
@@ -221,9 +231,6 @@ describe("Kafka health observation", () => {
       let refreshes = 0;
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
-        Effect.sync(() => {
-          refreshes += 1;
-        }),
         Effect.sync(() => {
           refreshes += 1;
         }),
@@ -296,9 +303,6 @@ describe("Kafka health observation", () => {
       let refreshes = 0;
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
-        Effect.sync(() => {
-          refreshes += 1;
-        }),
         Effect.sync(() => {
           refreshes += 1;
         }),

--- a/packages/runtime/src/kafka-health-observation.test.ts
+++ b/packages/runtime/src/kafka-health-observation.test.ts
@@ -35,6 +35,32 @@ const makeHealthLedger = () =>
   });
 
 describe("Kafka health observation", () => {
+  it.effect("awaits an immediate health flush when the observer closes", () =>
+    Effect.gen(function* () {
+      const ledger = makeHealthLedger();
+      let scheduledRefreshes = 0;
+      let immediateFlushes = 0;
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Effect.sync(() => {
+          scheduledRefreshes += 1;
+        }),
+        Effect.sync(() => {
+          immediateFlushes += 1;
+        }),
+        "1 minute",
+      );
+
+      yield* observer.regionStopped("local");
+      yield* observer.close;
+
+      expect({ immediateFlushes, scheduledRefreshes }).toStrictEqual({
+        immediateFlushes: 1,
+        scheduledRefreshes: 0,
+      });
+    }),
+  );
+
   it.effect("refreshes observed delivery health only on the bounded cadence", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
@@ -45,6 +71,7 @@ describe("Kafka health observation", () => {
         Effect.sync(() => {
           refreshes += 1;
         }),
+        Effect.void,
         "1 second",
       );
 
@@ -116,6 +143,7 @@ describe("Kafka health observation", () => {
             }),
           ),
         ),
+        Effect.void,
         "1 second",
       );
 
@@ -139,7 +167,12 @@ describe("Kafka health observation", () => {
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
       const ledger = makeHealthLedger();
-      const observer = yield* makeViewServerKafkaHealthObserver(ledger, Effect.void, "1 second");
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        Effect.void,
+        Effect.void,
+        "1 second",
+      );
 
       yield* recordKafkaAssignments(
         observer,
@@ -188,6 +221,9 @@ describe("Kafka health observation", () => {
       let refreshes = 0;
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
+        Effect.sync(() => {
+          refreshes += 1;
+        }),
         Effect.sync(() => {
           refreshes += 1;
         }),
@@ -260,6 +296,9 @@ describe("Kafka health observation", () => {
       let refreshes = 0;
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
+        Effect.sync(() => {
+          refreshes += 1;
+        }),
         Effect.sync(() => {
           refreshes += 1;
         }),

--- a/packages/runtime/src/kafka-health-observation.ts
+++ b/packages/runtime/src/kafka-health-observation.ts
@@ -1,0 +1,222 @@
+import type { GroupAssignment, Offsets } from "@platformatic/kafka";
+import { Duration, Effect, Exit, MutableRef, Scope } from "effect";
+import type { ViewServerKafkaHealthLedger } from "./kafka-health";
+import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
+
+export type ViewServerKafkaHealthObservation<Topics extends ViewServerRuntimeTopicDefinitions> =
+  Pick<
+    ViewServerKafkaHealthLedger<Topics>,
+    | "regionConnected"
+    | "regionDisconnected"
+    | "regionDegraded"
+    | "regionRecovered"
+    | "regionStopped"
+    | "topicConnected"
+    | "topicLagSampled"
+    | "messageDecoded"
+    | "messageSkippedCommitted"
+    | "decodeFailed"
+    | "mappingFailed"
+    | "messagePublishFailed"
+    | "messageCommitFailed"
+  >;
+
+export type ViewServerKafkaHealthObserver<Topics extends ViewServerRuntimeTopicDefinitions> =
+  ViewServerKafkaHealthObservation<Topics> & {
+    readonly close: Effect.Effect<void>;
+  };
+
+export const assignedPartitionsForSourceTopic = (
+  assignments: ReadonlyArray<GroupAssignment> | null | undefined,
+  sourceTopic: string,
+): number => {
+  const assignment = assignments?.find((candidate) => candidate.topic === sourceTopic);
+  return assignment?.partitions.length ?? 0;
+};
+
+const consumerLagMessagesFromLag = (lags: ReadonlyArray<bigint>): bigint | null => {
+  let total = 0n;
+  let hasKnownLag = false;
+  for (const lag of lags) {
+    if (lag >= 0n) {
+      hasKnownLag = true;
+      total += lag;
+    }
+  }
+  return hasKnownLag ? total : null;
+};
+
+export const recordKafkaAssignments = Effect.fn(
+  "ViewServerRuntime.kafka.observation.recordAssignments",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  observation: ViewServerKafkaHealthObservation<Topics>,
+  region: string,
+  topics: ReadonlyArray<string>,
+  assignments: ReadonlyArray<GroupAssignment> | null | undefined,
+  nowMillis: number,
+) {
+  yield* observation.regionConnected(region, nowMillis);
+  yield* Effect.forEach(
+    topics,
+    (sourceTopic) =>
+      observation.topicConnected(
+        sourceTopic,
+        region,
+        assignedPartitionsForSourceTopic(assignments, sourceTopic),
+        nowMillis,
+      ),
+    { discard: true },
+  );
+});
+
+export const recordKafkaLag = Effect.fn("ViewServerRuntime.kafka.observation.recordLag")(function* <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+>(
+  observation: ViewServerKafkaHealthObservation<Topics>,
+  region: string,
+  topics: ReadonlyArray<string>,
+  lag: Offsets,
+  nowMillis: number,
+) {
+  yield* observation.regionRecovered(region, nowMillis);
+  yield* Effect.forEach(
+    topics,
+    (sourceTopic) => {
+      const sourceTopicLag = lag.get(sourceTopic);
+      return observation.topicLagSampled(sourceTopic, region, {
+        consumerLagMessages:
+          sourceTopicLag === undefined ? null : consumerLagMessagesFromLag(sourceTopicLag),
+        nowMillis,
+      });
+    },
+    { discard: true },
+  );
+});
+
+export const makeViewServerKafkaHealthObserver = Effect.fn(
+  "ViewServerRuntime.kafka.observation.make",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  health: ViewServerKafkaHealthLedger<Topics>,
+  requestHealthRefresh: Effect.Effect<void>,
+  cadence: Duration.Input = "1 second",
+) {
+  return yield* Effect.uninterruptibleMask(() =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make("parallel");
+      const dirty = MutableRef.make(false);
+      const markDirty = Effect.sync(() => {
+        dirty.current = true;
+      });
+      const observed = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+        effect.pipe(Effect.tap(() => markDirty));
+      const refreshIfDirty = Effect.fn("ViewServerRuntime.kafka.observation.refreshIfDirty")(
+        function* () {
+          const shouldRefresh = yield* Effect.sync(() => {
+            const current = dirty.current;
+            dirty.current = false;
+            return current;
+          });
+          if (shouldRefresh) {
+            yield* requestHealthRefresh;
+          }
+        },
+      );
+      const refreshIfDirtyUninterruptibly = () => refreshIfDirty().pipe(Effect.uninterruptible);
+
+      yield* Effect.forever(
+        Effect.sleep(cadence).pipe(Effect.andThen(refreshIfDirtyUninterruptibly())),
+      ).pipe(Effect.forkIn(scope, { startImmediately: true }));
+
+      const close = (yield* Effect.cached(
+        Scope.close(scope, Exit.void).pipe(Effect.andThen(refreshIfDirtyUninterruptibly())),
+      )).pipe(Effect.uninterruptible);
+
+      return {
+        regionConnected: (region: string, nowMillis: number) =>
+          observed(health.regionConnected(region, nowMillis)),
+        regionDisconnected: (
+          region: string,
+          message: string,
+          options?: {
+            readonly preserveTopicErrors?: boolean;
+          },
+        ) => observed(health.regionDisconnected(region, message, options)),
+        regionDegraded: (region: string, message: string) =>
+          observed(health.regionDegraded(region, message)),
+        regionRecovered: (region: string, nowMillis: number) =>
+          observed(health.regionRecovered(region, nowMillis)),
+        regionStopped: (region: string) => observed(health.regionStopped(region)),
+        topicConnected: (
+          sourceTopic: string,
+          region: string,
+          assignedPartitions: number,
+          nowMillis: number,
+        ) => observed(health.topicConnected(sourceTopic, region, assignedPartitions, nowMillis)),
+        topicLagSampled: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly consumerLagMessages: bigint | null;
+            readonly nowMillis: number;
+          },
+        ) => observed(health.topicLagSampled(sourceTopic, region, input)),
+        messageDecoded: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly bytes: number;
+            readonly committedOffset: string;
+            readonly nowMillis: number;
+            readonly preserveLastError?: boolean;
+          },
+        ) => observed(health.messageDecoded(sourceTopic, region, input)),
+        messageSkippedCommitted: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly committedOffset: string;
+            readonly nowMillis: number;
+          },
+        ) => observed(health.messageSkippedCommitted(sourceTopic, region, input)),
+        decodeFailed: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly bytes: number;
+            readonly message: string;
+            readonly nowMillis: number;
+          },
+        ) => observed(health.decodeFailed(sourceTopic, region, input)),
+        mappingFailed: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly bytes: number;
+            readonly message: string;
+            readonly nowMillis: number;
+          },
+        ) => observed(health.mappingFailed(sourceTopic, region, input)),
+        messagePublishFailed: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly bytes: number;
+            readonly message: string;
+            readonly nowMillis: number;
+          },
+        ) => observed(health.messagePublishFailed(sourceTopic, region, input)),
+        messageCommitFailed: (
+          sourceTopic: string,
+          region: string,
+          input: {
+            readonly bytes: number;
+            readonly message: string;
+            readonly nowMillis: number;
+            readonly recountMessage?: boolean;
+          },
+        ) => observed(health.messageCommitFailed(sourceTopic, region, input)),
+        close,
+      } satisfies ViewServerKafkaHealthObserver<Topics>;
+    }),
+  );
+});

--- a/packages/runtime/src/kafka-health-observation.ts
+++ b/packages/runtime/src/kafka-health-observation.ts
@@ -97,8 +97,7 @@ export const makeViewServerKafkaHealthObserver = Effect.fn(
   "ViewServerRuntime.kafka.observation.make",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   health: ViewServerKafkaHealthLedger<Topics>,
-  requestHealthRefresh: Effect.Effect<void>,
-  flushHealth: Effect.Effect<void>,
+  refreshHealth: Effect.Effect<void>,
   cadence: Duration.Input = "1 second",
 ) {
   return yield* Effect.uninterruptibleMask(() =>
@@ -118,7 +117,7 @@ export const makeViewServerKafkaHealthObserver = Effect.fn(
             return current;
           });
           if (shouldRefresh) {
-            yield* requestHealthRefresh;
+            yield* refreshHealth;
           }
         },
       );
@@ -129,7 +128,7 @@ export const makeViewServerKafkaHealthObserver = Effect.fn(
       ).pipe(Effect.forkIn(scope, { startImmediately: true }));
 
       const close = (yield* Effect.cached(
-        Scope.close(scope, Exit.void).pipe(Effect.andThen(flushHealth)),
+        Scope.close(scope, Exit.void).pipe(Effect.andThen(refreshHealth)),
       )).pipe(Effect.uninterruptible);
 
       return {

--- a/packages/runtime/src/kafka-health-observation.ts
+++ b/packages/runtime/src/kafka-health-observation.ts
@@ -98,6 +98,7 @@ export const makeViewServerKafkaHealthObserver = Effect.fn(
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   health: ViewServerKafkaHealthLedger<Topics>,
   requestHealthRefresh: Effect.Effect<void>,
+  flushHealth: Effect.Effect<void>,
   cadence: Duration.Input = "1 second",
 ) {
   return yield* Effect.uninterruptibleMask(() =>
@@ -128,7 +129,7 @@ export const makeViewServerKafkaHealthObserver = Effect.fn(
       ).pipe(Effect.forkIn(scope, { startImmediately: true }));
 
       const close = (yield* Effect.cached(
-        Scope.close(scope, Exit.void).pipe(Effect.andThen(refreshIfDirtyUninterruptibly())),
+        Scope.close(scope, Exit.void).pipe(Effect.andThen(flushHealth)),
       )).pipe(Effect.uninterruptible);
 
       return {

--- a/packages/runtime/src/kafka-health.ts
+++ b/packages/runtime/src/kafka-health.ts
@@ -77,6 +77,7 @@ export type ViewServerKafkaHealthLedger<Topics extends ViewServerRuntimeTopicDef
   ) => Effect.Effect<void>;
   readonly regionDegraded: (region: string, message: string) => Effect.Effect<void>;
   readonly regionRecovered: (region: string, nowMillis: number) => Effect.Effect<void>;
+  readonly regionStopped: (region: string) => Effect.Effect<void>;
   readonly topicConnected: (
     sourceTopic: string,
     region: string,
@@ -265,6 +266,18 @@ const resetIdleWindow = (region: KafkaTopicRegionLedger, nowMillis: number) => {
   region.publishFailuresPerSecond = publishFailuresPerSecond;
   region.commitFailuresPerSecond = commitFailuresPerSecond;
   region.processingFailuresPerSecond = processingFailuresPerSecond;
+};
+
+const clearRateWindow = (region: KafkaTopicRegionLedger) => {
+  region.messagesPerSecond = 0;
+  region.bytesPerSecond = 0;
+  region.decodedMessagesPerSecond = 0;
+  region.decodeFailuresPerSecond = 0;
+  region.mappingFailuresPerSecond = 0;
+  region.publishFailuresPerSecond = 0;
+  region.commitFailuresPerSecond = 0;
+  region.processingFailuresPerSecond = 0;
+  region.rateBuckets = Array.from({ length: maxKafkaRateBuckets }, () => undefined);
 };
 
 const copyRegionHealth = (region: KafkaRegionLedger): KafkaRegionHealth => ({
@@ -474,6 +487,24 @@ export const makeViewServerKafkaHealthLedger = <
               topicRegion.regionLastError = null;
               refreshTopicStatus(topic);
             }
+          }
+        }
+      }),
+    regionStopped: (region) =>
+      Effect.sync(() => {
+        const regionLedger = regions.get(region);
+        if (regionLedger !== undefined) {
+          regionLedger.status = "disconnected";
+        }
+        for (const topic of topics.values()) {
+          const topicRegion = topic.regions.get(region);
+          if (topicRegion !== undefined) {
+            topicRegion.connected = false;
+            topicRegion.assignedPartitions = 0;
+            topicRegion.consumerLagMessages = null;
+            topicRegion.lagSampledAt = null;
+            clearRateWindow(topicRegion);
+            refreshTopicStatus(topic);
           }
         }
       }),

--- a/packages/runtime/src/kafka-ingress-processing.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress-processing.internal.test.ts
@@ -54,6 +54,7 @@ describe("Kafka ingress source processing internals", () => {
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
         runtimeCore.requestHealthRefresh,
+        Effect.void,
       );
 
       const ingress = yield* makeViewServerKafkaIngress(
@@ -261,6 +262,7 @@ describe("Kafka ingress source processing internals", () => {
       const observer = yield* makeViewServerKafkaHealthObserver(
         ledger,
         runtimeCore.requestHealthRefresh,
+        Effect.void,
       );
 
       const exit = yield* Effect.exit(

--- a/packages/runtime/src/kafka-ingress-processing.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress-processing.internal.test.ts
@@ -11,6 +11,7 @@ import {
   processKafkaMessage,
   registerKafkaConsumerHealthListeners,
 } from "./kafka-ingress";
+import { makeViewServerKafkaHealthObserver } from "./kafka-health-observation";
 import type { ResolvedViewServerKafkaRuntimeOptions } from "./runtime-options";
 import {
   committedKafkaStart,
@@ -50,16 +51,20 @@ describe("Kafka ingress source processing internals", () => {
         regions: emptyKafkaOptions.regions,
         topics: {},
       });
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        runtimeCore.requestHealthRefresh,
+      );
 
       const ingress = yield* makeViewServerKafkaIngress(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         emptyKafkaOptions,
-        ledger,
+        observer,
       );
       yield* ingress.close;
       yield* ingress.close;
+      yield* observer.close;
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect(health.status).toBe("ready");
@@ -164,10 +169,6 @@ describe("Kafka ingress source processing internals", () => {
           },
         },
       });
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const consumer = new Consumer<Buffer, Buffer, Buffer, Buffer>({
         bootstrapBrokers: ["127.0.0.1:1"],
         clientId: "view-server-scoped-listener-test",
@@ -177,7 +178,6 @@ describe("Kafka ingress source processing internals", () => {
       const listenerRegistration = yield* registerKafkaConsumerHealthListeners(
         consumer,
         ledger,
-        requestHealthRefresh,
         "local",
         [ordersSourceTopic],
         scope,
@@ -196,11 +196,9 @@ describe("Kafka ingress source processing internals", () => {
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect({
-        healthRefreshRequestCount,
         region: health.kafka?.regions["local"],
         topic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
-        healthRefreshRequestCount: 0,
         region: {
           status: "starting",
           brokers: regions.local,
@@ -260,19 +258,23 @@ describe("Kafka ingress source processing internals", () => {
           },
         },
       });
+      const observer = yield* makeViewServerKafkaHealthObserver(
+        ledger,
+        runtimeCore.requestHealthRefresh,
+      );
 
       const exit = yield* Effect.exit(
         makeViewServerKafkaIngress(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           invalidKafkaOptions,
-          ledger,
+          observer,
         ),
       );
 
       expect(Exit.isFailure(exit)).toBe(true);
 
+      yield* observer.close;
       yield* runtimeCore.close;
     }),
   );
@@ -296,7 +298,6 @@ describe("Kafka ingress source processing internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -309,7 +310,6 @@ describe("Kafka ingress source processing internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "cold",
@@ -329,7 +329,6 @@ describe("Kafka ingress source processing internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -351,7 +350,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -371,7 +369,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           viewServer,
           failingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -468,7 +465,6 @@ describe("Kafka ingress source processing internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -485,7 +481,6 @@ describe("Kafka ingress source processing internals", () => {
       yield* processKafkaMessage(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "cold",
@@ -582,7 +577,6 @@ describe("Kafka ingress source processing internals", () => {
       yield* processKafkaMessage(
         preciseViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         preciseKafkaOptions,
         ledger,
         "local",
@@ -666,16 +660,11 @@ describe("Kafka ingress source processing internals", () => {
       });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
 
       const error = yield* Effect.flip(
         processKafkaMessage(
           throwingViewServer,
           runtimeCore.internalClient,
-          requestHealthRefresh,
           throwingKafkaOptions,
           ledger,
           "local",
@@ -699,7 +688,6 @@ describe("Kafka ingress source processing internals", () => {
           region: error.region,
           sourceTopic: error.sourceTopic,
         },
-        healthRefreshRequestCount,
         kafkaTopic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
         error: {
@@ -708,7 +696,6 @@ describe("Kafka ingress source processing internals", () => {
           region: "local",
           sourceTopic: ordersSourceTopic,
         },
-        healthRefreshRequestCount: 1,
         kafkaTopic: {
           status: "degraded",
           sourceTopic: ordersSourceTopic,
@@ -787,7 +774,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           untaggedDecodeViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           untaggedDecodeKafkaOptions,
           ledger,
           "local",
@@ -887,7 +873,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           forgedMappingTagViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           forgedMappingTagKafkaOptions,
           ledger,
           "local",
@@ -993,7 +978,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           primitiveDecodeViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           primitiveDecodeKafkaOptions,
           ledger,
           "local",
@@ -1060,16 +1044,11 @@ describe("Kafka ingress source processing internals", () => {
       });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
 
       const exit = yield* Effect.exit(
         processKafkaMessage(
           viewServer,
           runtimeCore.internalClient,
-          requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -1084,7 +1063,6 @@ describe("Kafka ingress source processing internals", () => {
       const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
       expect(Exit.isSuccess(exit)).toBe(true);
-      expect(healthRefreshRequestCount).toBe(2);
       expect(health.kafka?.topics[ordersSourceTopic]).toStrictEqual({
         status: "degraded",
         sourceTopic: ordersSourceTopic,
@@ -1129,10 +1107,6 @@ describe("Kafka ingress source processing internals", () => {
       });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const commitFailedMessage = kafkaMessage({
         topic: ordersSourceTopic,
         key: null,
@@ -1145,7 +1119,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.internalClient,
-          requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -1161,7 +1134,6 @@ describe("Kafka ingress source processing internals", () => {
           region: error.region,
           sourceTopic: error.sourceTopic,
         },
-        healthRefreshRequestCount,
         kafkaTopic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
         error: {
@@ -1170,7 +1142,6 @@ describe("Kafka ingress source processing internals", () => {
           region: "local",
           sourceTopic: ordersSourceTopic,
         },
-        healthRefreshRequestCount: 2,
         kafkaTopic: {
           status: "degraded",
           sourceTopic: ordersSourceTopic,
@@ -1216,11 +1187,6 @@ describe("Kafka ingress source processing internals", () => {
       });
       yield* ledger.regionConnected("local", 1_000);
       yield* ledger.topicConnected(ordersSourceTopic, "local", 1, 1_000);
-
-      let healthRefreshRequestCount = 0;
-      const requestHealthRefresh = Effect.sync(() => {
-        healthRefreshRequestCount += 1;
-      });
       const commitFailedMessage = kafkaMessage({
         topic: ordersSourceTopic,
         key: "order-commit-failed",
@@ -1237,7 +1203,6 @@ describe("Kafka ingress source processing internals", () => {
         processKafkaMessage(
           viewServer,
           runtimeCore.internalClient,
-          requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -1258,7 +1223,6 @@ describe("Kafka ingress source processing internals", () => {
           region: error.region,
           sourceTopic: error.sourceTopic,
         },
-        healthRefreshRequestCount,
         snapshot,
         kafkaTopic: health.kafka?.topics[ordersSourceTopic],
       }).toStrictEqual({
@@ -1268,7 +1232,6 @@ describe("Kafka ingress source processing internals", () => {
           region: "local",
           sourceTopic: ordersSourceTopic,
         },
-        healthRefreshRequestCount: 1,
         snapshot: {
           status: "ready",
           statusCode: "Ready",

--- a/packages/runtime/src/kafka-ingress-processing.internal.test.ts
+++ b/packages/runtime/src/kafka-ingress-processing.internal.test.ts
@@ -51,11 +51,7 @@ describe("Kafka ingress source processing internals", () => {
         regions: emptyKafkaOptions.regions,
         topics: {},
       });
-      const observer = yield* makeViewServerKafkaHealthObserver(
-        ledger,
-        runtimeCore.requestHealthRefresh,
-        Effect.void,
-      );
+      const observer = yield* makeViewServerKafkaHealthObserver(ledger, Effect.void);
 
       const ingress = yield* makeViewServerKafkaIngress(
         viewServer,
@@ -259,11 +255,7 @@ describe("Kafka ingress source processing internals", () => {
           },
         },
       });
-      const observer = yield* makeViewServerKafkaHealthObserver(
-        ledger,
-        runtimeCore.requestHealthRefresh,
-        Effect.void,
-      );
+      const observer = yield* makeViewServerKafkaHealthObserver(ledger, Effect.void);
 
       const exit = yield* Effect.exit(
         makeViewServerKafkaIngress(

--- a/packages/runtime/src/kafka-ingress.ts
+++ b/packages/runtime/src/kafka-ingress.ts
@@ -25,7 +25,11 @@ import {
   Ref,
   Scope,
 } from "effect";
-import type { ViewServerKafkaHealthLedger } from "./kafka-health";
+import {
+  recordKafkaAssignments,
+  recordKafkaLag,
+  type ViewServerKafkaHealthObservation,
+} from "./kafka-health-observation";
 import {
   publishAndCommitKafkaDecodedBatch,
   recordAndCommitKeylessKafkaMessage,
@@ -124,8 +128,6 @@ type KafkaConsumerHealthListenerProcessedState = {
   readonly count: number;
   readonly waiters: ReadonlyArray<KafkaConsumerHealthListenerWaiter>;
 };
-type ViewServerKafkaHealthRefreshRequest = Effect.Effect<void>;
-
 const kafkaMessageBatchSize = 256;
 const kafkaMessageQueueCapacity = kafkaMessageBatchSize * 4;
 const kafkaMessageBatchFlushInterval = Duration.millis(2);
@@ -146,9 +148,6 @@ const ignoreKafkaConsumerCloseFailure = ignoreLoggedTypedFailuresPreserveNonType
 );
 const ignoreKafkaStartedResourceCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
   "Ignoring Kafka started resource close failure.",
-);
-const ignoreKafkaHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
-  "Ignoring Kafka health refresh failure.",
 );
 const ignoreKafkaAsyncIteratorCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
   "Ignoring Kafka stream iterator close failure.",
@@ -209,14 +208,6 @@ export const sourceTopicsForRegion = <
   return topics;
 };
 
-export const assignedPartitionsForSourceTopic = (
-  assignments: ReadonlyArray<GroupAssignment> | null | undefined,
-  sourceTopic: string,
-): number => {
-  const assignment = assignments?.find((candidate) => candidate.topic === sourceTopic);
-  return assignment?.partitions.length ?? 0;
-};
-
 const snapshotKafkaAssignments = (
   assignments: ReadonlyArray<GroupAssignment> | null | undefined,
 ): ReadonlyArray<GroupAssignment> | null | undefined =>
@@ -225,20 +216,8 @@ const snapshotKafkaAssignments = (
     partitions: [...assignment.partitions],
   }));
 
-const consumerLagMessagesFromLag = (lags: ReadonlyArray<bigint>): bigint | null => {
-  let total = 0n;
-  let hasKnownLag = false;
-  for (const lag of lags) {
-    if (lag >= 0n) {
-      hasKnownLag = true;
-      total += lag;
-    }
-  }
-  return hasKnownLag ? total : null;
-};
-
 export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   error: ViewServerKafkaIngressError,
   options?: {
@@ -250,7 +229,7 @@ export const recordKafkaStreamError = <const Topics extends ViewServerRuntimeTop
     .pipe(Effect.andThen(Effect.fail(error)));
 
 const recordKafkaStreamCause = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   error: ViewServerKafkaIngressError,
   cause: Cause.Cause<ViewServerKafkaIngressError>,
@@ -261,60 +240,6 @@ const recordKafkaStreamCause = <const Topics extends ViewServerRuntimeTopicDefin
   health
     .regionDisconnected(region, error.message, options)
     .pipe(Effect.andThen(Effect.failCause(cause)));
-
-const requestKafkaHealthRefresh = (requestHealthRefresh: ViewServerKafkaHealthRefreshRequest) =>
-  requestHealthRefresh.pipe(ignoreKafkaHealthRefreshFailure);
-
-export const recordKafkaAssignments = Effect.fn(
-  "ViewServerRuntime.kafka.consumer.recordAssignments",
-)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  health: ViewServerKafkaHealthLedger<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  region: string,
-  topics: ReadonlyArray<string>,
-  assignments: ReadonlyArray<GroupAssignment> | null | undefined,
-  nowMillis: number,
-) {
-  yield* health.regionConnected(region, nowMillis);
-  yield* Effect.forEach(
-    topics,
-    (sourceTopic) =>
-      health.topicConnected(
-        sourceTopic,
-        region,
-        assignedPartitionsForSourceTopic(assignments, sourceTopic),
-        nowMillis,
-      ),
-    { discard: true },
-  );
-  yield* requestKafkaHealthRefresh(requestHealthRefresh);
-});
-
-export const recordKafkaLag = Effect.fn("ViewServerRuntime.kafka.consumer.recordLag")(function* <
-  const Topics extends ViewServerRuntimeTopicDefinitions,
->(
-  health: ViewServerKafkaHealthLedger<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-  region: string,
-  topics: ReadonlyArray<string>,
-  lag: Offsets,
-  nowMillis: number,
-) {
-  yield* health.regionRecovered(region, nowMillis);
-  yield* Effect.forEach(
-    topics,
-    (sourceTopic) => {
-      const sourceTopicLag = lag.get(sourceTopic);
-      return health.topicLagSampled(sourceTopic, region, {
-        consumerLagMessages:
-          sourceTopicLag === undefined ? null : consumerLagMessagesFromLag(sourceTopicLag),
-        nowMillis,
-      });
-    },
-    { discard: true },
-  );
-  yield* requestKafkaHealthRefresh(requestHealthRefresh);
-});
 
 export const closeKafkaConsumerAfterStartFailure = Effect.fn(
   "ViewServerRuntime.kafka.consumer.closeAfterStartFailure",
@@ -385,28 +310,13 @@ export const closeKafkaConsumer = Effect.fn("ViewServerRuntime.kafka.consumer.cl
   },
 );
 
-const acquireKafkaConsumerResources = Effect.fn(
-  "ViewServerRuntime.kafka.consumer.acquireResources",
-)(function* (
-  region: string,
-  brokers: string,
-  topics: ReadonlyArray<string>,
-  consume: ResolvedViewServerKafkaRuntimeOptions<ViewServerRuntimeTopicDefinitions>["consume"],
-) {
-  return yield* acquireKafkaDeliveryResource(
-    makeKafkaConsumer(region, brokers, topics, consume),
-    (resources) => closeKafkaConsumer(resources).pipe(ignoreKafkaStartedResourceCloseFailure),
-  );
-});
-
 const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.decodeForBatch")(
   function* <
     const Topics extends ViewServerRuntimeTopicDefinitions,
     const Regions extends RuntimeRegions,
     const Topic extends ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>["topics"][string],
   >(
-    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
     region: string,
     sourceTopic: string,
     topic: Topic,
@@ -427,7 +337,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
       timestamp: Number(message.timestamp),
       headers: kafkaHeadersFromMessage(message.headers),
     };
-    const requestHealthRefreshAfterLedgerUpdate = requestKafkaHealthRefresh(requestHealthRefresh);
     const handleMappingFailure = (failure: unknown, cause: Cause.Cause<unknown>) =>
       health
         .mappingFailed(sourceTopic, region, {
@@ -436,7 +345,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
           nowMillis,
         })
         .pipe(
-          Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
           Effect.andThen(
             Effect.failCause(
               kafkaIngressFailureCause(
@@ -462,7 +370,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
             nowMillis,
           })
           .pipe(
-            Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
             Effect.andThen(
               Effect.failCause(
                 kafkaIngressFailureCause(
@@ -484,7 +391,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
           nowMillis,
         })
         .pipe(
-          Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
           Effect.andThen(
             Effect.failCause(
               kafkaIngressFailureCause(
@@ -507,7 +413,6 @@ const decodeKafkaMessageForBatch = Effect.fn("ViewServerRuntime.kafka.message.de
           nowMillis,
         })
         .pipe(
-          Effect.andThen(requestHealthRefreshAfterLedgerUpdate),
           Effect.andThen(
             Effect.fail(
               new ViewServerKafkaIngressError({
@@ -571,9 +476,8 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
   >(
     config: ViewServerTopicConfig<Topics>,
     client: KafkaIngressRuntimeClient<Topics>,
-    requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
     options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
     region: string,
     batch: ReadonlyArray<KafkaConsumerMessage>,
   ) {
@@ -599,16 +503,9 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
           sourceTopic,
         });
         const flushExit = yield* Effect.exit(
-          publishAndCommitKafkaDecodedBatch(
-            client,
-            requestHealthRefresh,
-            health,
-            region,
-            decodedMessages,
-            {
-              preserveLastErrorForSourceTopic: sourceTopic,
-            },
-          ),
+          publishAndCommitKafkaDecodedBatch(client, health, region, decodedMessages, {
+            preserveLastErrorForSourceTopic: sourceTopic,
+          }),
         );
         decodedMessages.length = 0;
         return yield* Effect.failCause(
@@ -618,19 +515,12 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
         );
       }
       if (!kafkaConsumerMessageHasKey(message)) {
-        yield* publishAndCommitKafkaDecodedBatch(
-          client,
-          requestHealthRefresh,
-          health,
-          region,
-          decodedMessages,
-        );
+        yield* publishAndCommitKafkaDecodedBatch(client, health, region, decodedMessages);
         decodedMessages.length = 0;
-        yield* recordAndCommitKeylessKafkaMessage(requestHealthRefresh, health, region, message);
+        yield* recordAndCommitKeylessKafkaMessage(health, region, message);
         continue;
       }
       const decoded = yield* decodeKafkaMessageForBatch(
-        requestHealthRefresh,
         health,
         region,
         sourceTopic,
@@ -648,16 +538,9 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
             Option.flatMap(Cause.findErrorOption(cause), kafkaIngressErrorSourceTopic),
           );
           return Effect.exit(
-            publishAndCommitKafkaDecodedBatch(
-              client,
-              requestHealthRefresh,
-              health,
-              region,
-              decodedMessages,
-              {
-                preserveLastErrorForSourceTopic,
-              },
-            ),
+            publishAndCommitKafkaDecodedBatch(client, health, region, decodedMessages, {
+              preserveLastErrorForSourceTopic,
+            }),
           ).pipe(
             Effect.andThen((flushExit) =>
               Exit.isFailure(flushExit)
@@ -669,13 +552,7 @@ export const processKafkaMessageBatch = Effect.fn("ViewServerRuntime.kafka.messa
       );
       decodedMessages.push(decoded);
     }
-    yield* publishAndCommitKafkaDecodedBatch(
-      client,
-      requestHealthRefresh,
-      health,
-      region,
-      decodedMessages,
-    );
+    yield* publishAndCommitKafkaDecodedBatch(client, health, region, decodedMessages);
   },
 );
 
@@ -685,15 +562,12 @@ export const processKafkaMessage = Effect.fn("ViewServerRuntime.kafka.message.pr
 >(
   config: ViewServerTopicConfig<Topics>,
   client: KafkaIngressRuntimeClient<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   message: KafkaConsumerMessage,
 ) {
-  yield* processKafkaMessageBatch(config, client, requestHealthRefresh, options, health, region, [
-    message,
-  ]);
+  yield* processKafkaMessageBatch(config, client, options, health, region, [message]);
 });
 
 const produceKafkaStreamQueueEvents = Effect.fn(
@@ -824,9 +698,8 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
 >(
   config: ViewServerTopicConfig<Topics>,
   client: KafkaIngressRuntimeClient<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   stream: AsyncIterable<KafkaConsumerMessage>,
 ) {
@@ -847,15 +720,7 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
           return yield* Effect.failCause(terminal.cause);
         }
         const processExit = yield* Effect.exit(
-          processKafkaMessageBatch(
-            config,
-            client,
-            requestHealthRefresh,
-            options,
-            health,
-            region,
-            next.batch,
-          ),
+          processKafkaMessageBatch(config, client, options, health, region, next.batch),
         );
         const terminal = next.terminal;
         if (Exit.isFailure(processExit)) {
@@ -887,7 +752,7 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
           {
             preserveTopicErrors: true,
           },
-        ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
+        );
       }
       const streamError = kafkaStreamError(region, Cause.squash(cause));
       return recordKafkaStreamCause(
@@ -895,7 +760,7 @@ export const runKafkaMessageStream = Effect.fn("ViewServerRuntime.kafka.stream.r
         region,
         streamError,
         kafkaIngressFailureCause(streamError, cause),
-      ).pipe(Effect.ensuring(requestKafkaHealthRefresh(requestHealthRefresh)));
+      );
     }),
   );
 });
@@ -904,8 +769,7 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
   "ViewServerRuntime.kafka.consumer.registerHealthListeners",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   consumer: KafkaConsumer,
-  health: ViewServerKafkaHealthLedger<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   topics: ReadonlyArray<string>,
   scope: Scope.Scope,
@@ -998,14 +862,7 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
     enqueueHealthEvent(
       Effect.gen(function* () {
         const nowMillis = yield* Clock.currentTimeMillis;
-        yield* recordKafkaAssignments(
-          health,
-          requestHealthRefresh,
-          region,
-          topics,
-          assignments,
-          nowMillis,
-        );
+        yield* recordKafkaAssignments(health, region, topics, assignments, nowMillis);
       }),
     );
   };
@@ -1013,32 +870,22 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
     enqueueHealthEvent(
       Effect.gen(function* () {
         const nowMillis = yield* Clock.currentTimeMillis;
-        yield* recordKafkaLag(health, requestHealthRefresh, region, topics, lag, nowMillis);
+        yield* recordKafkaLag(health, region, topics, lag, nowMillis);
       }),
     );
   };
   const groupLeaveListener = () => {
-    enqueueHealthEvent(
-      health
-        .regionDisconnected(region, "Kafka consumer left group")
-        .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh))),
-    );
+    enqueueHealthEvent(health.regionDisconnected(region, "Kafka consumer left group"));
   };
   const groupRebalanceListener = () => {
     enqueueHealthEvent(
-      health
-        .regionDisconnected(region, "Kafka consumer group rebalance in progress", {
-          preserveTopicErrors: true,
-        })
-        .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh))),
+      health.regionDisconnected(region, "Kafka consumer group rebalance in progress", {
+        preserveTopicErrors: true,
+      }),
     );
   };
   const lagErrorListener = (error: unknown) => {
-    enqueueHealthEvent(
-      health
-        .regionDegraded(region, messageFromUnknown(error))
-        .pipe(Effect.andThen(requestKafkaHealthRefresh(requestHealthRefresh))),
-    );
+    enqueueHealthEvent(health.regionDegraded(region, messageFromUnknown(error)));
   };
   consumer.on("consumer:group:join", groupJoinListener);
   consumer.on("consumer:group:leave", groupLeaveListener);
@@ -1054,7 +901,6 @@ export const registerKafkaConsumerHealthListeners = Effect.fn(
         consumer.off("consumer:group:rebalance", groupRebalanceListener);
         consumer.off("consumer:lag", lagListener);
         consumer.off("consumer:lag:error", lagErrorListener);
-        consumer.stopLagMonitoring();
       });
       yield* Queue.shutdown(healthEventQueue);
     }),
@@ -1072,15 +918,107 @@ const startKafkaLagMonitoring = Effect.fn("ViewServerRuntime.kafka.consumer.star
   },
 );
 
+const stopKafkaLagMonitoring = Effect.fn("ViewServerRuntime.kafka.consumer.stopLagMonitoring")(
+  function* (consumer: KafkaConsumer) {
+    yield* Effect.sync(() => {
+      consumer.stopLagMonitoring();
+    });
+  },
+);
+
+const closeStartedKafkaConsumerResources = (resources: {
+  readonly consumer: CloseableKafkaConsumer;
+  readonly stream: CloseableKafkaStream;
+}) => closeKafkaConsumer(resources).pipe(ignoreKafkaStartedResourceCloseFailure);
+
+const closeKafkaConsumerHealthListenerRegistration = (
+  registration: KafkaConsumerHealthListenerRegistration,
+) => registration.close;
+
+export const acquireKafkaRegionResources = Effect.fn(
+  "ViewServerRuntime.kafka.region.acquireResourceStages",
+)(function* <Resources, Registration, E, R, R2, R3, R4, R5>(
+  acquireResources: Effect.Effect<Resources, E, R>,
+  register: (resources: Resources) => Effect.Effect<Registration, never, R2>,
+  start: (resources: Resources) => Effect.Effect<void, never, R3>,
+  closeResources: (resources: Resources) => Effect.Effect<void, never, R4>,
+  closeRegistration: (registration: Registration) => Effect.Effect<void, never, R5>,
+) {
+  return yield* Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const resources = yield* restore(acquireResources);
+      const registrationExit = yield* Effect.exit(register(resources));
+      if (Exit.isFailure(registrationExit)) {
+        const cleanupExit = yield* Effect.exit(closeResources(resources));
+        return yield* Effect.failCause(
+          Exit.isFailure(cleanupExit)
+            ? Cause.combine(registrationExit.cause, cleanupExit.cause)
+            : registrationExit.cause,
+        );
+      }
+      const registration = registrationExit.value;
+      const startExit = yield* Effect.exit(start(resources));
+      if (Exit.isFailure(startExit)) {
+        const registrationCleanupExit = yield* Effect.exit(closeRegistration(registration));
+        const resourceCleanupExit = yield* Effect.exit(closeResources(resources));
+        const cleanupExit = Exit.asVoidAll([registrationCleanupExit, resourceCleanupExit]);
+        return yield* Effect.failCause(
+          Exit.isFailure(cleanupExit)
+            ? Cause.combine(startExit.cause, cleanupExit.cause)
+            : startExit.cause,
+        );
+      }
+      return { registration, resources };
+    }),
+  );
+});
+
+const acquireKafkaRegionConsumerResources = Effect.fn(
+  "ViewServerRuntime.kafka.region.acquireResources",
+)(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  health: ViewServerKafkaHealthObservation<Topics>,
+  region: string,
+  brokers: string,
+  topics: ReadonlyArray<string>,
+  consume: ResolvedViewServerKafkaRuntimeOptions<ViewServerRuntimeTopicDefinitions>["consume"],
+  workerScope: Scope.Scope,
+) {
+  const acquired = yield* acquireKafkaRegionResources(
+    makeKafkaConsumer(region, brokers, topics, consume),
+    (resources) =>
+      registerKafkaConsumerHealthListeners(resources.consumer, health, region, topics, workerScope),
+    (resources) => startKafkaLagMonitoring(resources.consumer, topics),
+    closeStartedKafkaConsumerResources,
+    closeKafkaConsumerHealthListenerRegistration,
+  );
+  return {
+    ...acquired.resources,
+    listenerRegistration: acquired.registration,
+  };
+});
+
+const closeKafkaRegionConsumerResources = Effect.fn(
+  "ViewServerRuntime.kafka.region.closeResources",
+)(function* (resources: {
+  readonly consumer: KafkaConsumer;
+  readonly stream: CloseableKafkaStream;
+  readonly listenerRegistration: KafkaConsumerHealthListenerRegistration;
+}) {
+  yield* runAllFinalizers([
+    stopKafkaLagMonitoring(resources.consumer),
+    closeKafkaConsumerHealthListenerRegistration(resources.listenerRegistration),
+    closeStartedKafkaConsumerResources(resources),
+  ]);
+});
+
 const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
   const Regions extends RuntimeRegions,
 >(
   config: ViewServerTopicConfig<Topics>,
   client: KafkaIngressRuntimeClient<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
   region: string,
   brokers: string,
   topics: ReadonlyArray<string>,
@@ -1088,39 +1026,25 @@ const startRegionConsumer = Effect.fn("ViewServerRuntime.kafka.region.start")(fu
 ) {
   yield* startWorker(
     Effect.gen(function* () {
-      const { consumer, stream } = yield* acquireKafkaConsumerResources(
-        region,
-        brokers,
-        topics,
-        options.consume,
-      );
       const workerScope = yield* Effect.scope;
-      yield* Effect.acquireRelease(
-        registerKafkaConsumerHealthListeners(
-          consumer,
+      const { consumer, stream } = yield* acquireKafkaDeliveryResource(
+        acquireKafkaRegionConsumerResources(
           health,
-          requestHealthRefresh,
           region,
+          brokers,
           topics,
+          options.consume,
           workerScope,
         ),
-        (registration) => registration.close,
+        closeKafkaRegionConsumerResources,
       );
-      yield* startKafkaLagMonitoring(consumer, topics);
       const nowMillis = yield* Clock.currentTimeMillis;
       yield* health.regionConnected(region, nowMillis);
-      yield* recordKafkaAssignments(
-        health,
-        requestHealthRefresh,
-        region,
-        topics,
-        consumer.assignments,
-        nowMillis,
-      );
+      yield* recordKafkaAssignments(health, region, topics, consumer.assignments, nowMillis);
       return stream;
     }),
-    (stream) =>
-      runKafkaMessageStream(config, client, requestHealthRefresh, options, health, region, stream),
+    (stream) => runKafkaMessageStream(config, client, options, health, region, stream),
+    health.regionStopped(region),
   );
 });
 
@@ -1142,9 +1066,8 @@ export const makeViewServerKafkaIngress: <
 >(
   config: ViewServerTopicConfig<Topics>,
   client: KafkaIngressRuntimeClient<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
 ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError> = Effect.fn(
   "ViewServerRuntime.kafka.ingress.make",
 )(function* <
@@ -1153,9 +1076,8 @@ export const makeViewServerKafkaIngress: <
 >(
   config: ViewServerTopicConfig<Topics>,
   client: KafkaIngressRuntimeClient<Topics>,
-  requestHealthRefresh: ViewServerKafkaHealthRefreshRequest,
   options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-  health: ViewServerKafkaHealthLedger<Topics>,
+  health: ViewServerKafkaHealthObservation<Topics>,
 ) {
   return yield* makeScopedKafkaDelivery((startWorker) =>
     startKafkaRegionDeliveries(Object.entries(options.regions), (region, brokers) => {
@@ -1166,7 +1088,6 @@ export const makeViewServerKafkaIngress: <
       return startRegionConsumer(
         config,
         client,
-        requestHealthRefresh,
         options,
         health,
         region,

--- a/packages/runtime/src/kafka-microbatch-recovery.internal.test.ts
+++ b/packages/runtime/src/kafka-microbatch-recovery.internal.test.ts
@@ -63,7 +63,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           viewServer,
           publishManyFailingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -147,7 +146,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           viewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -326,7 +324,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         processKafkaMessageBatch(
           mappingViewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           mappingKafkaOptions,
           ledger,
           "local",
@@ -503,7 +500,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           multiSourceViewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           multiSourceKafkaOptions,
           ledger,
           "local",
@@ -703,7 +699,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         processKafkaMessageBatch(
           missingPaymentsViewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           multiSourceKafkaOptions,
           ledger,
           "local",
@@ -859,7 +854,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         processKafkaMessageBatch(
           missingPaymentsViewServer,
           publishManyFailingClient,
-          runtimeCore.requestHealthRefresh,
           multiSourceKafkaOptions,
           ledger,
           "local",
@@ -1041,7 +1035,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           defectingViewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           defectingKafkaOptions,
           ledger,
           "local",
@@ -1162,7 +1155,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           viewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -1341,7 +1333,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           mixedInterruptViewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           mixedInterruptKafkaOptions,
           ledger,
           "local",
@@ -1503,7 +1494,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           mixedCauseViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           mixedCauseKafkaOptions,
           ledger,
           "local",
@@ -1658,7 +1648,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           interruptingViewServer,
           batchingClient,
-          runtimeCore.requestHealthRefresh,
           interruptingKafkaOptions,
           ledger,
           "local",
@@ -1763,7 +1752,6 @@ describe("Kafka microbatch failure recovery internals", () => {
           runKafkaMessageStream(
             viewServer,
             runtimeCore.internalClient,
-            runtimeCore.requestHealthRefresh,
             kafkaOptions,
             ledger,
             "local",
@@ -1872,7 +1860,6 @@ describe("Kafka microbatch failure recovery internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",

--- a/packages/runtime/src/kafka-microbatch.internal.test.ts
+++ b/packages/runtime/src/kafka-microbatch.internal.test.ts
@@ -58,16 +58,9 @@ describe("Kafka microbatch publishing internals", () => {
               ),
             ),
         };
-        let healthRefreshes = 0;
-        const requestHealthRefresh = Effect.sync(() => {
-          healthRefreshes += 1;
-          operations.push("healthRefresh");
-        });
-
         yield* runKafkaMessageStream(
           viewServer,
           batchingClient,
-          requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -118,13 +111,11 @@ describe("Kafka microbatch publishing internals", () => {
         const health = ledger.healthOverlay(yield* runtimeCore.client.health(), 0);
 
         expect({
-          healthRefreshes,
           operations,
           snapshot,
           kafkaTopic: health.kafka?.topics[ordersSourceTopic],
         }).toStrictEqual({
-          healthRefreshes: 1,
-          operations: ["publishMany:orders:3", "commit:1", "commit:2", "commit:3", "healthRefresh"],
+          operations: ["publishMany:orders:3", "commit:1", "commit:2", "commit:3"],
           snapshot: {
             status: "ready",
             statusCode: "Ready",
@@ -214,7 +205,6 @@ describe("Kafka microbatch publishing internals", () => {
       yield* runKafkaMessageStream(
         viewServer,
         batchingClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -305,7 +295,6 @@ describe("Kafka microbatch publishing internals", () => {
       yield* runKafkaMessageStream(
         viewServer,
         batchingClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -384,7 +373,6 @@ describe("Kafka microbatch publishing internals", () => {
         runKafkaMessageStream(
           viewServer,
           publishManyFailingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -513,7 +501,6 @@ describe("Kafka microbatch publishing internals", () => {
         runKafkaMessageStream(
           viewServer,
           publishManyFailingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -662,7 +649,6 @@ describe("Kafka microbatch publishing internals", () => {
       yield* processKafkaMessageBatch(
         multiSourceViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         multiSourceKafkaOptions,
         ledger,
         "local",
@@ -797,7 +783,6 @@ describe("Kafka microbatch publishing internals", () => {
       yield* processKafkaMessageBatch(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         topicOwnedKafkaOptions,
         ledger,
         "local",
@@ -937,7 +922,6 @@ describe("Kafka microbatch publishing internals", () => {
         runKafkaMessageStream(
           multiSourceViewServer,
           publishManyFailingClient,
-          runtimeCore.requestHealthRefresh,
           multiSourceKafkaOptions,
           ledger,
           "local",

--- a/packages/runtime/src/kafka-source-contract.internal.test.ts
+++ b/packages/runtime/src/kafka-source-contract.internal.test.ts
@@ -74,7 +74,6 @@ describe("Kafka source mapping contracts", () => {
         processKafkaMessage(
           missingGhostViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           health,
           "local",
@@ -147,7 +146,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -227,7 +225,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -306,7 +303,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -322,7 +318,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -403,7 +398,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -419,7 +413,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -490,7 +483,6 @@ describe("Kafka source mapping contracts", () => {
       yield* processKafkaMessage(
         kafkaBackedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -585,7 +577,6 @@ describe("Kafka source mapping contracts", () => {
         processKafkaMessage(
           invalidMappingViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           health,
           "local",

--- a/packages/runtime/src/kafka-stream-runtime.internal.test.ts
+++ b/packages/runtime/src/kafka-stream-runtime.internal.test.ts
@@ -90,7 +90,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           defectiveClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -177,7 +176,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           interruptingClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -277,7 +275,6 @@ describe("Kafka message stream runtime internals", () => {
       const streamFiber = yield* runKafkaMessageStream(
         viewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         ledger,
         "local",
@@ -311,7 +308,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -412,7 +408,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -494,7 +489,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -571,7 +565,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -658,7 +651,6 @@ describe("Kafka message stream runtime internals", () => {
         runKafkaMessageStream(
           viewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           ledger,
           "local",
@@ -898,7 +890,6 @@ describe("Kafka message stream runtime internals", () => {
           runKafkaMessageStream(
             viewServer,
             runtimeCore.internalClient,
-            runtimeCore.requestHealthRefresh,
             kafkaOptions,
             ledger,
             "local",

--- a/packages/runtime/src/kafka-tombstone-batching.internal.test.ts
+++ b/packages/runtime/src/kafka-tombstone-batching.internal.test.ts
@@ -67,7 +67,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -84,7 +83,6 @@ describe("Kafka tombstone batching contracts", () => {
         processKafkaMessage(
           topicOwnedViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           health,
           "local",
@@ -178,7 +176,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessage(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -280,7 +277,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessageBatch(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -380,7 +376,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessageBatch(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -464,7 +459,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessageBatch(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -592,7 +586,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessageBatch(
         topicOwnedViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -701,7 +694,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessage(
         mixedSourceViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -718,7 +710,6 @@ describe("Kafka tombstone batching contracts", () => {
       yield* processKafkaMessageBatch(
         mixedSourceViewServer,
         runtimeCore.internalClient,
-        runtimeCore.requestHealthRefresh,
         kafkaOptions,
         health,
         "local",
@@ -846,7 +837,6 @@ describe("Kafka tombstone batching contracts", () => {
         yield* processKafkaMessage(
           kafkaBackedViewServer,
           runtimeCore.internalClient,
-          runtimeCore.requestHealthRefresh,
           kafkaOptions,
           health,
           "local",

--- a/packages/runtime/src/runtime-composition-lifecycle.test.ts
+++ b/packages/runtime/src/runtime-composition-lifecycle.test.ts
@@ -316,11 +316,13 @@ describe("Real View Server composition lifecycle", () => {
               }).pipe(Effect.andThen(runtimeCore.close)),
             })),
           ),
-        makeKafkaHealthObserver: (health, requestHealthRefresh) =>
+        makeKafkaHealthObserver: (health, requestHealthRefresh, flushHealth) =>
           Effect.sync(() => {
             events.push("acquire:kafkaHealthObserver");
           }).pipe(
-            Effect.andThen(defaults.makeKafkaHealthObserver(health, requestHealthRefresh)),
+            Effect.andThen(
+              defaults.makeKafkaHealthObserver(health, requestHealthRefresh, flushHealth),
+            ),
             Effect.map((observer) => ({
               ...observer,
               close: Effect.sync(() => {
@@ -371,6 +373,62 @@ describe("Real View Server composition lifecycle", () => {
     }),
   );
 
+  it.effect("flushes stopped Kafka health before runtime-core teardown", () =>
+    Effect.gen(function* () {
+      const defaults = makeDefaultRuntimeDependencies<typeof kafkaViewServer.topics>();
+      let ingressClosed = false;
+      let runtimeCoreClosed = false;
+      let flushedAfterIngress = false;
+      const dependencies: ViewServerRuntimeDependencies<typeof kafkaViewServer.topics> = {
+        ...defaults,
+        makeRuntimeCore: (config, options) =>
+          defaults.makeRuntimeCore(config, options).pipe(
+            Effect.map((runtimeCore) => ({
+              ...runtimeCore,
+              close: Effect.sync(() => {
+                runtimeCoreClosed = true;
+              }).pipe(Effect.andThen(runtimeCore.close)),
+              refreshHealth: Effect.sync(() => {
+                if (ingressClosed && !runtimeCoreClosed) {
+                  flushedAfterIngress = true;
+                }
+              }).pipe(Effect.andThen(runtimeCore.refreshHealth)),
+            })),
+          ),
+        makeServer: () =>
+          Effect.succeed({
+            url: "ws://127.0.0.1:0/rpc",
+            healthUrl: "http://127.0.0.1:0/health",
+            metricsUrl: "http://127.0.0.1:0/metrics",
+            close: Effect.void,
+          }),
+        makeKafkaIngress: (_config, _client, _options, observation) =>
+          Effect.succeed({
+            close: observation.regionStopped("local").pipe(
+              Effect.andThen(
+                Effect.sync(() => {
+                  ingressClosed = true;
+                }),
+              ),
+            ),
+          }),
+      };
+
+      const runtime = yield* makeViewServerRuntimeWithDependencies(dependencies, kafkaViewServer, {
+        kafka: {
+          consumerGroupId: "runtime-observer-final-flush-test",
+        },
+      });
+      yield* runtime.close;
+
+      expect({ flushedAfterIngress, ingressClosed, runtimeCoreClosed }).toStrictEqual({
+        flushedAfterIngress: true,
+        ingressClosed: true,
+        runtimeCoreClosed: true,
+      });
+    }),
+  );
+
   it.effect("closes a Kafka health observer when acquisition receives a pending interrupt", () =>
     Effect.gen(function* () {
       const defaults = makeDefaultRuntimeDependencies<typeof kafkaViewServer.topics>();
@@ -380,9 +438,9 @@ describe("Real View Server composition lifecycle", () => {
       let cleanupObserver = Effect.void;
       const dependencies: ViewServerRuntimeDependencies<typeof kafkaViewServer.topics> = {
         ...defaults,
-        makeKafkaHealthObserver: (health, requestHealthRefresh) =>
+        makeKafkaHealthObserver: (health, requestHealthRefresh, flushHealth) =>
           Effect.uninterruptible(
-            defaults.makeKafkaHealthObserver(health, requestHealthRefresh).pipe(
+            defaults.makeKafkaHealthObserver(health, requestHealthRefresh, flushHealth).pipe(
               Effect.map((observer) => {
                 const close = Effect.sync(() => {
                   observerCloseCount += 1;

--- a/packages/runtime/src/runtime-composition-lifecycle.test.ts
+++ b/packages/runtime/src/runtime-composition-lifecycle.test.ts
@@ -298,6 +298,133 @@ describe("Real View Server composition lifecycle", () => {
     }),
   );
 
+  it.effect("keeps the Kafka observation resource alive until Kafka ingress has stopped", () =>
+    Effect.gen(function* () {
+      const events: Array<string> = [];
+      const defaults = makeDefaultRuntimeDependencies<typeof kafkaViewServer.topics>();
+      const dependencies: ViewServerRuntimeDependencies<typeof kafkaViewServer.topics> = {
+        ...defaults,
+        makeRuntimeCore: (config, options) =>
+          Effect.sync(() => {
+            events.push("acquire:runtimeCore");
+          }).pipe(
+            Effect.andThen(defaults.makeRuntimeCore(config, options)),
+            Effect.map((runtimeCore) => ({
+              ...runtimeCore,
+              close: Effect.sync(() => {
+                events.push("close:runtimeCore");
+              }).pipe(Effect.andThen(runtimeCore.close)),
+            })),
+          ),
+        makeKafkaHealthObserver: (health, requestHealthRefresh) =>
+          Effect.sync(() => {
+            events.push("acquire:kafkaHealthObserver");
+          }).pipe(
+            Effect.andThen(defaults.makeKafkaHealthObserver(health, requestHealthRefresh)),
+            Effect.map((observer) => ({
+              ...observer,
+              close: Effect.sync(() => {
+                events.push("close:kafkaHealthObserver");
+              }).pipe(Effect.andThen(observer.close)),
+            })),
+          ),
+        makeServer: () =>
+          Effect.sync(() => {
+            events.push("acquire:server");
+            return {
+              url: "ws://127.0.0.1:0/rpc",
+              healthUrl: "http://127.0.0.1:0/health",
+              metricsUrl: "http://127.0.0.1:0/metrics",
+              close: Effect.sync(() => {
+                events.push("close:server");
+              }),
+            };
+          }),
+        makeKafkaIngress: () =>
+          Effect.sync(() => {
+            events.push("acquire:kafkaIngress");
+            return {
+              close: Effect.sync(() => {
+                events.push("close:kafkaIngress");
+              }),
+            };
+          }),
+      };
+
+      const runtime = yield* makeViewServerRuntimeWithDependencies(dependencies, kafkaViewServer, {
+        kafka: {
+          consumerGroupId: "runtime-observation-ownership-test",
+        },
+      });
+      yield* runtime.close;
+
+      expect(events).toStrictEqual([
+        "acquire:runtimeCore",
+        "acquire:kafkaHealthObserver",
+        "acquire:server",
+        "acquire:kafkaIngress",
+        "close:kafkaIngress",
+        "close:server",
+        "close:kafkaHealthObserver",
+        "close:runtimeCore",
+      ]);
+    }),
+  );
+
+  it.effect("closes a Kafka health observer when acquisition receives a pending interrupt", () =>
+    Effect.gen(function* () {
+      const defaults = makeDefaultRuntimeDependencies<typeof kafkaViewServer.topics>();
+      const observerCreated = yield* Deferred.make<void>();
+      const allowObserverReturn = yield* Deferred.make<void>();
+      let observerCloseCount = 0;
+      let cleanupObserver = Effect.void;
+      const dependencies: ViewServerRuntimeDependencies<typeof kafkaViewServer.topics> = {
+        ...defaults,
+        makeKafkaHealthObserver: (health, requestHealthRefresh) =>
+          Effect.uninterruptible(
+            defaults.makeKafkaHealthObserver(health, requestHealthRefresh).pipe(
+              Effect.map((observer) => {
+                const close = Effect.sync(() => {
+                  observerCloseCount += 1;
+                }).pipe(Effect.andThen(observer.close));
+                cleanupObserver = close;
+                return {
+                  ...observer,
+                  close,
+                };
+              }),
+              Effect.tap(() => Deferred.succeed(observerCreated, undefined)),
+              Effect.tap(() => Deferred.await(allowObserverReturn)),
+            ),
+          ),
+      };
+      const startup = yield* makeViewServerRuntimeWithDependencies(dependencies, kafkaViewServer, {
+        kafka: {
+          consumerGroupId: "runtime-observer-interruption-test",
+        },
+      }).pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(observerCreated);
+      const interrupt = yield* Fiber.interrupt(startup).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(allowObserverReturn, undefined);
+      yield* Fiber.join(interrupt);
+      const startupExit = yield* Fiber.await(startup);
+      const closeCountBeforeManualCleanup = observerCloseCount;
+      yield* cleanupObserver;
+
+      expect({
+        closeCountBeforeManualCleanup,
+        startupInterrupted: Exit.hasInterrupts(startupExit),
+      }).toStrictEqual({
+        closeCountBeforeManualCleanup: 1,
+        startupInterrupted: true,
+      });
+    }),
+  );
+
   it.effect("shares one join-idempotent close across every public owner", () =>
     Effect.gen(function* () {
       const cleanupStarted = yield* Deferred.make<void>();

--- a/packages/runtime/src/runtime-composition-lifecycle.test.ts
+++ b/packages/runtime/src/runtime-composition-lifecycle.test.ts
@@ -316,13 +316,11 @@ describe("Real View Server composition lifecycle", () => {
               }).pipe(Effect.andThen(runtimeCore.close)),
             })),
           ),
-        makeKafkaHealthObserver: (health, requestHealthRefresh, flushHealth) =>
+        makeKafkaHealthObserver: (health, refreshHealth) =>
           Effect.sync(() => {
             events.push("acquire:kafkaHealthObserver");
           }).pipe(
-            Effect.andThen(
-              defaults.makeKafkaHealthObserver(health, requestHealthRefresh, flushHealth),
-            ),
+            Effect.andThen(defaults.makeKafkaHealthObserver(health, refreshHealth)),
             Effect.map((observer) => ({
               ...observer,
               close: Effect.sync(() => {
@@ -438,9 +436,9 @@ describe("Real View Server composition lifecycle", () => {
       let cleanupObserver = Effect.void;
       const dependencies: ViewServerRuntimeDependencies<typeof kafkaViewServer.topics> = {
         ...defaults,
-        makeKafkaHealthObserver: (health, requestHealthRefresh, flushHealth) =>
+        makeKafkaHealthObserver: (health, refreshHealth) =>
           Effect.uninterruptible(
-            defaults.makeKafkaHealthObserver(health, requestHealthRefresh, flushHealth).pipe(
+            defaults.makeKafkaHealthObserver(health, refreshHealth).pipe(
               Effect.map((observer) => {
                 const close = Effect.sync(() => {
                   observerCloseCount += 1;

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -69,6 +69,7 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
   readonly makeKafkaHealthObserver: (
     health: ViewServerKafkaHealthLedger<Topics>,
     requestHealthRefresh: Effect.Effect<void>,
+    flushHealth: Effect.Effect<void>,
   ) => Effect.Effect<ViewServerKafkaHealthObserver<Topics>>;
   readonly makeGrpcHealthLedger: <const Clients extends GrpcRuntimeClients>(
     config: ViewServerRuntimeDependencyConfig<Topics>,

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -68,8 +68,7 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
   ) => ViewServerKafkaHealthLedger<Topics>;
   readonly makeKafkaHealthObserver: (
     health: ViewServerKafkaHealthLedger<Topics>,
-    requestHealthRefresh: Effect.Effect<void>,
-    flushHealth: Effect.Effect<void>,
+    refreshHealth: Effect.Effect<void>,
   ) => Effect.Effect<ViewServerKafkaHealthObserver<Topics>>;
   readonly makeGrpcHealthLedger: <const Clients extends GrpcRuntimeClients>(
     config: ViewServerRuntimeDependencyConfig<Topics>,

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -20,6 +20,11 @@ import {
 import type { Effect } from "effect";
 import type { HttpServerError } from "effect/unstable/http";
 import { makeViewServerKafkaHealthLedger, type ViewServerKafkaHealthLedger } from "./kafka-health";
+import {
+  makeViewServerKafkaHealthObserver,
+  type ViewServerKafkaHealthObservation,
+  type ViewServerKafkaHealthObserver,
+} from "./kafka-health-observation";
 import { makeViewServerGrpcHealthLedger, type ViewServerGrpcHealthLedger } from "./grpc-health";
 import {
   makeViewServerGrpcIngress,
@@ -61,6 +66,10 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
     config: ViewServerRuntimeDependencyConfig<Topics>,
     options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
   ) => ViewServerKafkaHealthLedger<Topics>;
+  readonly makeKafkaHealthObserver: (
+    health: ViewServerKafkaHealthLedger<Topics>,
+    requestHealthRefresh: Effect.Effect<void>,
+  ) => Effect.Effect<ViewServerKafkaHealthObserver<Topics>>;
   readonly makeGrpcHealthLedger: <const Clients extends GrpcRuntimeClients>(
     config: ViewServerRuntimeDependencyConfig<Topics>,
     options: ResolvedViewServerGrpcRuntimeOptions<Topics, Clients>,
@@ -77,9 +86,8 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
   readonly makeKafkaIngress: <const Regions extends RuntimeRegions>(
     config: ViewServerRuntimeDependencyConfig<Topics>,
     client: ViewServerRuntimeCoreInternalClient<Topics>,
-    requestHealthRefresh: Effect.Effect<void>,
     options: ResolvedViewServerKafkaRuntimeOptions<Topics, Regions>,
-    health: ViewServerKafkaHealthLedger<Topics>,
+    health: ViewServerKafkaHealthObservation<Topics>,
   ) => Effect.Effect<ViewServerKafkaIngress, ViewServerKafkaIngressError>;
   readonly makeTcpPublishIngress: (
     config: ViewServerRuntimeDependencyConfig<Topics>,
@@ -144,6 +152,7 @@ export const makeDefaultRuntimeDependencies = <
     });
   },
   makeGrpcLeaseManager: makeViewServerGrpcLeaseManager,
+  makeKafkaHealthObserver: makeViewServerKafkaHealthObserver,
   makeKafkaIngress: makeViewServerKafkaIngress,
   makeTcpPublishIngress: makeViewServerTcpPublishIngress,
   makeGrpcIngress: makeViewServerGrpcIngress,

--- a/packages/runtime/src/runtime-kafka-options.test.ts
+++ b/packages/runtime/src/runtime-kafka-options.test.ts
@@ -651,7 +651,7 @@ describe("Runtime Kafka options and health", () => {
             metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
-        makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
+        makeKafkaIngress: (_config, _client, options) => {
           kafkaOptionsSummary = {
             consumerGroupId: options.consumerGroupId,
             regions: options.regions,
@@ -725,8 +725,8 @@ describe("Runtime Kafka options and health", () => {
       });
       const dependencies: ViewServerRuntimeDependencies<typeof kafkaBackedViewServer.topics> = {
         ...makeDefaultRuntimeDependencies<typeof kafkaBackedViewServer.topics>(),
-        makeKafkaIngress: (_config, _client, _requestHealthRefresh, _options, health) =>
-          health.regionDisconnected("local", "lost").pipe(
+        makeKafkaIngress: (_config, _client, _options, observation) =>
+          observation.regionDisconnected("local", "lost").pipe(
             Effect.as({
               close: Effect.void,
             }),

--- a/packages/runtime/src/runtime-source-composition.test.ts
+++ b/packages/runtime/src/runtime-source-composition.test.ts
@@ -64,7 +64,7 @@ describe("Runtime source composition and options", () => {
             metricsUrl: "http://127.0.0.1:0/metrics",
             close: Effect.void,
           }),
-        makeKafkaIngress: (_config, _client, _requestHealthRefresh, options) => {
+        makeKafkaIngress: (_config, _client, options) => {
           kafkaOptionsSummary = {
             consume: options.consume,
             consumerGroupId: options.consumerGroupId,


### PR DESCRIPTION
Closes #338

## Summary
- route assignment, lag, decode, publish, commit, failure, and shutdown outcomes through one Kafka health observation Interface
- cadence health refreshes away from the per-message delivery hot path while preserving a final flush on observer shutdown
- make Region teardown ordered and join-safe, clear stale assignment/lag state, and preserve combined cleanup defect causes
- keep observer ownership separate from Kafka consumer acquisition and lifecycle, with independent delivery and observation regressions

## Validation
- vp run -w ready
- runtime: 51 files, 453 tests, no type errors, 100% statements/branches/functions/lines
- strict Effect diagnostics: runtime 95/95, zero findings
- vp run -w bench:baseline:kafka-ingest
- vp run -w bench:baseline:kafka-sustained-firehose
- vp run -w bench:baseline:smoke
- Effect, Vitest, and architecture review loop: zero blocking and zero non-blocking findings

No changeset: this is an internal runtime observation and lifecycle refactor with no publishable public API change.