### PR TITLE
Scope each leased gRPC Subscription from upstream stream to client release

### DIFF
--- a/packages/runtime/src/grpc-lease-manager-lifecycle.test.ts
+++ b/packages/runtime/src/grpc-lease-manager-lifecycle.test.ts
@@ -2633,4 +2633,78 @@ describe("gRPC lease manager lifecycle", () => {
       yield* runtimeCore.close;
     }),
   );
+
+  it.live("retires leased health before admitting a replacement for the same route", () =>
+    Effect.gen(function* () {
+      let acquireCount = 0;
+      const feed = grpcLeasedViewServer({
+        streamForRegion: () => {
+          acquireCount += 1;
+          return Stream.never;
+        },
+      });
+      const grpcOptions = yield* resolveLeasedGrpcRuntimeOptions(feed);
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(feed, {});
+      const health = makeLeasedGrpcHealth(grpcOptions);
+      const retirementStarted = yield* Deferred.make<void>();
+      const allowRetirement = yield* Deferred.make<void>();
+      const delayedHealth = {
+        ...health,
+        leasedFeedRemoved: (feedKey: string) =>
+          Deferred.succeed(retirementStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(allowRetirement)),
+            Effect.andThen(health.leasedFeedRemoved(feedKey)),
+          ),
+      };
+      const manager = yield* makeViewServerGrpcLeaseManager(
+        feed,
+        runtimeCore.internalClient,
+        runtimeCore.liveClient,
+        runtimeCore.internalLiveClient,
+        Effect.void,
+        grpcOptions,
+        delayedHealth,
+      );
+      const firstSubscription = yield* manager.liveClient.subscribe(
+        "orders",
+        leasedOrdersQuery("usa"),
+      );
+      const firstCloseFiber = yield* firstSubscription
+        .close()
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(retirementStarted);
+
+      const overlapError = yield* manager.liveClient
+        .subscribe("orders", leasedOrdersQuery("usa"))
+        .pipe(Effect.flip);
+      const acquireCountDuringRetirement = acquireCount;
+      yield* Deferred.succeed(allowRetirement, undefined);
+      yield* Fiber.join(firstCloseFiber);
+      const replacement = yield* manager.liveClient.subscribe("orders", leasedOrdersQuery("usa"));
+      const replacementHealth = health.healthOverlay(yield* runtimeCore.client.health(), 2_000);
+
+      expect({
+        overlapError,
+        acquireCountDuringRetirement,
+        acquireCount,
+        subscriberCount:
+          replacementHealth.grpc?.feeds.orders?.leased["orders/orders/leased/region=%22usa%22"]
+            ?.subscriberCount,
+      }).toStrictEqual({
+        overlapError: {
+          _tag: "ViewServerRuntimeError",
+          code: "RuntimeUnavailable",
+          topic: "orders",
+          message:
+            "gRPC leased upstream is not accepting new subscribers after completion or failure.",
+        },
+        acquireCountDuringRetirement: 1,
+        acquireCount: 2,
+        subscriberCount: 1,
+      });
+      yield* replacement.close();
+      yield* manager.close;
+      yield* runtimeCore.close;
+    }),
+  );
 });

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -92,6 +92,7 @@ type LeasedFeedRoute = Readonly<Record<string, unknown>>;
 type LeasedFeedRuntimeInput = ViewServerGrpcSourceInput<LeasedFeedRoute>;
 
 type ActiveLease = {
+  readonly owner: symbol;
   readonly feedName: string;
   readonly feed: RuntimeLeasedFeedDefinition;
   readonly subscription: GrpcLeasedSubscription<ViewServerGrpcIngressError>;
@@ -739,6 +740,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         }),
       ),
     );
+    const owner = Symbol(feedKey);
     const subscription = yield* makeGrpcLeasedSubscription<ViewServerGrpcIngressError>({
       parentScope: managerScope,
       topic,
@@ -765,12 +767,19 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
           health.clientDegraded(feed.client, terminal.healthMessage),
           ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
         ]),
-      onClosed: Effect.sync(() => leases.delete(feedKey)).pipe(
-        Effect.andThen(health.leasedFeedRemoved(feedKey)),
+      onClosed: health.leasedFeedRemoved(feedKey).pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            if (leases.get(feedKey)?.owner === owner) {
+              leases.delete(feedKey);
+            }
+          }),
+        ),
         Effect.andThen(ignoreGrpcHealthRefreshFailure(requestHealthRefresh)),
       ),
     });
     const lease: ActiveLease = {
+      owner,
       feedName,
       feed,
       subscription,

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -493,7 +493,8 @@ const acquireLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.acqui
       };
     }),
   );
-  // The Subscription owns forking this worker, so acquisition intentionally returns it as a value.
+  // Returning runFeed directly makes Effect.fn flatten the nested Effect in its inferred result.
+  // Wrap it so acquisition returns the worker as a value for the Subscription to fork and own.
   return yield* Effect.succeed(runFeed);
 });
 

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -92,7 +92,6 @@ type LeasedFeedRoute = Readonly<Record<string, unknown>>;
 type LeasedFeedRuntimeInput = ViewServerGrpcSourceInput<LeasedFeedRoute>;
 
 type ActiveLease = {
-  readonly owner: symbol;
   readonly feedName: string;
   readonly feed: RuntimeLeasedFeedDefinition;
   readonly subscription: GrpcLeasedSubscription<ViewServerGrpcIngressError>;
@@ -740,7 +739,6 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         }),
       ),
     );
-    const owner = Symbol(feedKey);
     const subscription = yield* makeGrpcLeasedSubscription<ViewServerGrpcIngressError>({
       parentScope: managerScope,
       topic,
@@ -767,19 +765,14 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
           health.clientDegraded(feed.client, terminal.healthMessage),
           ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
         ]),
-      onClosed: health.leasedFeedRemoved(feedKey).pipe(
-        Effect.andThen(
-          Effect.sync(() => {
-            if (leases.get(feedKey)?.owner === owner) {
-              leases.delete(feedKey);
-            }
-          }),
+      onClosed: health
+        .leasedFeedRemoved(feedKey)
+        .pipe(
+          Effect.andThen(Effect.sync(() => leases.delete(feedKey))),
+          Effect.andThen(ignoreGrpcHealthRefreshFailure(requestHealthRefresh)),
         ),
-        Effect.andThen(ignoreGrpcHealthRefreshFailure(requestHealthRefresh)),
-      ),
     });
     const lease: ActiveLease = {
-      owner,
       feedName,
       feed,
       subscription,

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -5,7 +5,6 @@ import type {
   LiveQueryRow,
   RawQuery,
   RowSchema,
-  StatusEvent,
   TopicRow,
   ViewServerTopicConfig,
   ViewServerRuntimeClient,
@@ -18,14 +17,12 @@ import {
   runAllFinalizers,
 } from "@effect-view-server/effect-utils";
 import type {
-  ViewServerLiveEvent,
   ViewServerRuntimeLiveClient,
   ViewServerLiveSubscription,
 } from "@effect-view-server/client";
 import {
   Cause,
   Clock,
-  Deferred,
   Effect,
   Exit,
   Option,
@@ -40,10 +37,13 @@ import {
   makeGrpcLeasedIdentityContract,
   type GrpcLeasedGroupedKeyRetentionObserver,
   type GrpcLeasedIdentityContract,
-  type GrpcLeasedIdentityError,
-  type GrpcLeasedIdentityLease,
-  type GrpcLeasedResultKeyTranslation,
 } from "./grpc-leased-identity";
+import {
+  makeGrpcLeasedSubscription,
+  type GrpcLeasedSubscription,
+  type GrpcLeasedSubscriptionLease,
+  type GrpcLeasedUpstreamTerminal,
+} from "./grpc-leased-subscription";
 import {
   callLeasedGrpcSourceAcquire,
   callLeasedGrpcSourceRelease,
@@ -63,7 +63,6 @@ import {
   makeSourceOwnershipPolicy,
   type ViewServerRuntimeCoreInternalClient,
   type ViewServerRuntimeCoreInternalLiveClient,
-  type ViewServerRuntimeCoreTerminalObserver,
 } from "@effect-view-server/runtime-core/internal";
 
 type ViewServerGrpcHealthRefreshRequest = Effect.Effect<void>;
@@ -92,59 +91,10 @@ type LeasedFeedRoute = Readonly<Record<string, unknown>>;
 
 type LeasedFeedRuntimeInput = ViewServerGrpcSourceInput<LeasedFeedRoute>;
 
-type UpstreamLeaseTerminal = {
-  readonly _tag: "Upstream";
-  readonly message: string;
-};
-
-type EngineLeaseTerminal = {
-  readonly _tag: "Engine";
-  readonly ready: Deferred.Deferred<void>;
-  readonly status: StatusEvent;
-};
-
-type RuntimeLeaseTerminal = {
-  readonly _tag: "Runtime";
-};
-
-type ClosedLeaseTerminal = {
-  readonly _tag: "Closed";
-};
-
-type LeaseTerminal =
-  | UpstreamLeaseTerminal
-  | EngineLeaseTerminal
-  | RuntimeLeaseTerminal
-  | ClosedLeaseTerminal;
-
-type LeaseTerminalRegistration = {
-  readonly observer: ViewServerRuntimeCoreTerminalObserver;
-  readonly queryId: Deferred.Deferred<string>;
-};
-
-const closedLeaseTerminal: ClosedLeaseTerminal = {
-  _tag: "Closed",
-};
-
-type LeaseRowOwner = {
+type ActiveLease = {
   readonly feedName: string;
   readonly feed: RuntimeLeasedFeedDefinition;
-  readonly identity: GrpcLeasedIdentityLease;
-  readonly storageKeys: Set<string>;
-};
-
-type ActiveLease = LeaseRowOwner & {
-  readonly feedKey: string;
-  readonly scope: Scope.Scope;
-  readonly cleanupRows: Effect.Effect<void, ViewServerGrpcIngressError, never>;
-  readonly terminalSignals: Set<Deferred.Deferred<LeaseTerminal>>;
-  readonly subscriptions: Set<ActiveLeaseSubscription>;
-  subscribers: number;
-  acceptingSubscribers: boolean;
-};
-
-type ActiveLeaseSubscription = {
-  readonly close: () => Effect.Effect<void, ViewServerTransportError, never>;
+  readonly subscription: GrpcLeasedSubscription<ViewServerGrpcIngressError>;
 };
 
 /**
@@ -155,8 +105,7 @@ type ActiveLeaseSubscription = {
 type ViewServerGrpcGroupedKeyRetentionObserver = GrpcLeasedGroupedKeyRetentionObserver;
 
 type AcquiredLease = {
-  readonly lease: ActiveLease;
-  readonly terminalSignal: Deferred.Deferred<LeaseTerminal>;
+  readonly subscriptionLease: GrpcLeasedSubscriptionLease;
 };
 
 export type ViewServerGrpcLeaseManager<Topics extends ViewServerRuntimeTopicDefinitions> = {
@@ -176,9 +125,6 @@ const ignoreGrpcFeedReleaseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFa
 );
 const ignoreGrpcHealthRefreshFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
   "Ignoring leased gRPC health refresh failure.",
-);
-const ignoreLeasedSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
-  "Ignoring leased gRPC subscription close failure.",
 );
 const ignoreLeasedReleaseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
   "Ignoring leased gRPC release failure.",
@@ -323,7 +269,7 @@ type LeasedRowWithStorageKey = {
 const internalizeLeasedRow = Effect.fn("ViewServerRuntime.grpc.leased.row.internalize")(function* <
   Row extends object,
 >(lease: ActiveLease, row: Row) {
-  const internalKey = yield* Effect.fromResult(lease.identity.internalizeRowKey(row)).pipe(
+  const internalKey = yield* Effect.fromResult(lease.subscription.internalizeRowKey(row)).pipe(
     Effect.mapError((error) =>
       grpcLeaseError({
         message: error.message,
@@ -334,7 +280,6 @@ const internalizeLeasedRow = Effect.fn("ViewServerRuntime.grpc.leased.row.intern
       }),
     ),
   );
-  lease.storageKeys.add(internalKey.storageKey);
   return {
     storageKey: internalKey.storageKey,
     row,
@@ -343,7 +288,7 @@ const internalizeLeasedRow = Effect.fn("ViewServerRuntime.grpc.leased.row.intern
 
 const validateLeasedRowRoute = Effect.fn("ViewServerRuntime.grpc.leased.row.validateRoute")(
   function* <Row extends object>(lease: ActiveLease, row: Row) {
-    return yield* Effect.fromResult(lease.identity.validateRowRoute(row)).pipe(
+    return yield* Effect.fromResult(lease.subscription.validateRowRoute(row)).pipe(
       Effect.mapError((error) =>
         grpcLeaseError({
           message: error.message,
@@ -357,87 +302,14 @@ const validateLeasedRowRoute = Effect.fn("ViewServerRuntime.grpc.leased.row.vali
   },
 );
 
-const resultKeyEncodingErrorStatus = (
-  lease: ActiveLease,
-  queryId: string,
-  error: GrpcLeasedIdentityError,
-): StatusEvent => ({
-  type: "status",
-  topic: lease.feed.topic,
-  queryId,
-  status: "error",
-  code: "RuntimeUnavailable",
-  message: error.message,
-});
-
-const grpcLeasedResultKeyFailureTypeId: unique symbol = Symbol(
-  "@effect-view-server/runtime/GrpcLeasedResultKeyFailure",
-);
-
-type GrpcLeasedResultKeyFailure = {
-  readonly [grpcLeasedResultKeyFailureTypeId]: true;
-  readonly queryId: string;
-  readonly error: GrpcLeasedIdentityError;
-};
-
-const resultKeyTranslationFailure = (
-  queryId: string,
-  error: GrpcLeasedIdentityError,
-): GrpcLeasedResultKeyFailure => ({
-  [grpcLeasedResultKeyFailureTypeId]: true,
-  queryId,
-  error,
-});
-
-const isResultKeyTranslationFailure = <Row extends object>(
-  value: ViewServerLiveEvent<Row> | GrpcLeasedResultKeyFailure,
-): value is GrpcLeasedResultKeyFailure => grpcLeasedResultKeyFailureTypeId in value;
-
-const isTerminalStatusEvent = (event: ViewServerLiveEvent<unknown>): event is StatusEvent =>
-  event.type === "status" && (event.status === "closed" || event.status === "error");
-
-const makeLeaseTerminalRegistration = Effect.fn(
-  "ViewServerRuntime.grpc.leased.terminalRegistration.make",
-)(function* (terminalSignal: Deferred.Deferred<LeaseTerminal>) {
-  const ready = yield* Deferred.make<void>();
-  const queryId = yield* Deferred.make<string>();
-  const observer: ViewServerRuntimeCoreTerminalObserver = {
-    onQueryRegistered: (registeredQueryId) =>
-      Deferred.succeed(queryId, registeredQueryId).pipe(Effect.asVoid),
-    onTerminalOccurrence: (status) =>
-      Deferred.succeed(terminalSignal, {
-        _tag: "Engine",
-        ready,
-        status,
-      }).pipe(Effect.asVoid),
-    onTerminalReady: () => Deferred.succeed(ready, undefined).pipe(Effect.asVoid),
-  };
-  return {
-    observer,
-    queryId,
-  } satisfies LeaseTerminalRegistration;
-});
-
-const notifyLeaseSubscribers = Effect.fn("ViewServerRuntime.grpc.leased.subscribers.notify")(
-  function* (lease: ActiveLease, message: string) {
-    const terminal: UpstreamLeaseTerminal = {
-      _tag: "Upstream",
-      message,
-    };
-    yield* Effect.forEach(lease.terminalSignals, (signal) => Deferred.succeed(signal, terminal), {
-      discard: true,
-    });
-  },
-);
-
 const resetLeaseRowCount = Effect.fn("ViewServerRuntime.grpc.leased.health.rowCount.reset")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
     health: ViewServerGrpcHealthLedger<Topics>,
-    lease: ActiveLease,
+    feedKey: string,
   ) {
     const nowMillis = yield* Clock.currentTimeMillis;
-    yield* health.rowsPublished(lease.feedKey, {
+    yield* health.rowsPublished(feedKey, {
       messages: 0,
       rows: 0,
       rowCount: 0,
@@ -446,33 +318,6 @@ const resetLeaseRowCount = Effect.fn("ViewServerRuntime.grpc.leased.health.rowCo
     yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
   },
 );
-
-const externalizeLeasedEvent = <Row extends object>(
-  resultKeys: GrpcLeasedResultKeyTranslation<Row>,
-  event: ViewServerLiveEvent<Row>,
-): ViewServerLiveEvent<Row> | GrpcLeasedResultKeyFailure => {
-  if (event.type === "snapshot") {
-    const keys = resultKeys.translateSnapshot(event.keys, event.rows);
-    if (Result.isFailure(keys)) {
-      return resultKeyTranslationFailure(event.queryId, keys.failure);
-    }
-    return {
-      ...event,
-      keys: keys.success,
-    };
-  }
-  if (event.type === "delta") {
-    const operations = resultKeys.translateDelta(event.operations);
-    if (Result.isFailure(operations)) {
-      return resultKeyTranslationFailure(event.queryId, operations.failure);
-    }
-    return {
-      ...event,
-      operations: operations.success,
-    };
-  }
-  return event;
-};
 
 const callRuntimePublishMany = Effect.fn(
   "ViewServerRuntime.grpc.leased.runtime.publishManyDecoded",
@@ -554,14 +399,14 @@ const publishLeasedBatch = Effect.fn("ViewServerRuntime.grpc.leased.publishBatch
 ) {
   const rows = yield* Effect.forEach(values, (value) =>
     Effect.gen(function* () {
-      const route = lease.identity.materializeRoute();
+      const route = lease.subscription.materializeRoute();
       const row = yield* mapLeasedValue(config, lease.feedName, lease.feed, route, value);
       return yield* validateLeasedRowRoute(lease, row);
     }).pipe(
       Effect.tapError((error) =>
         Clock.currentTimeMillis.pipe(
           Effect.flatMap((nowMillis) =>
-            health.mappingFailed(lease.feedKey, {
+            health.mappingFailed(lease.subscription.feedKey, {
               message: error.message,
               nowMillis,
             }),
@@ -576,7 +421,7 @@ const publishLeasedBatch = Effect.fn("ViewServerRuntime.grpc.leased.publishBatch
     Effect.tapError((error) =>
       Clock.currentTimeMillis.pipe(
         Effect.flatMap((nowMillis) =>
-          health.publishFailed(lease.feedKey, {
+          health.publishFailed(lease.subscription.feedKey, {
             message: error.message,
             nowMillis,
           }),
@@ -585,10 +430,10 @@ const publishLeasedBatch = Effect.fn("ViewServerRuntime.grpc.leased.publishBatch
     ),
   );
   const nowMillis = yield* Clock.currentTimeMillis;
-  yield* health.rowsPublished(lease.feedKey, {
+  yield* health.rowsPublished(lease.subscription.feedKey, {
     messages: values.length,
     rows: rows.length,
-    rowCount: lease.storageKeys.size,
+    rowCount: lease.subscription.retainedRowCount(),
     nowMillis,
   });
   yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
@@ -597,7 +442,7 @@ const publishLeasedBatch = Effect.fn("ViewServerRuntime.grpc.leased.publishBatch
 const internalFeedFailureMessage = (feedName: string, cause: Cause.Cause<unknown>): string =>
   `gRPC leased feed ${feedName} failed: ${Cause.pretty(cause)}`;
 
-const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")(function* <
+const acquireLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.acquire")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
 >(
   config: ViewServerTopicConfig<Topics>,
@@ -605,53 +450,15 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
   requestHealthRefresh: ViewServerGrpcHealthRefreshRequest,
   health: ViewServerGrpcHealthLedger<Topics>,
   lease: ActiveLease,
-  lock: Semaphore.Semaphore,
   grpcClient: unknown,
   request: unknown,
 ) {
-  const releaseRoute = lease.identity.materializeRoute();
-  const releaseResources = (yield* Effect.cached(
-    callFeedRelease(
-      lease.feedName,
-      lease.feed,
-      makeGrpcSourceInput(grpcClient, request, releaseRoute),
-    ).pipe(
-      ignoreGrpcFeedReleaseFailure,
-      Effect.withSpan("ViewServerRuntime.grpc.leased.resources.release"),
-    ),
-  )).pipe(Effect.uninterruptible);
-  yield* Scope.addFinalizer(lease.scope, releaseResources);
-  const acquireRoute = lease.identity.materializeRoute();
+  const acquireRoute = lease.subscription.materializeRoute();
   const stream = yield* callFeedAcquire(
     lease.feedName,
     lease.feed,
     makeGrpcSourceInput(grpcClient, request, acquireRoute),
   );
-  const degradeInactiveLease = (input: {
-    readonly publicMessage: string;
-    readonly healthMessage: string;
-  }) =>
-    lock.withPermit(
-      Effect.gen(function* () {
-        lease.acceptingSubscribers = false;
-        const cleanupRows = Effect.gen(function* () {
-          const cleanupExit = yield* lease.cleanupRows.pipe(Effect.exit);
-          if (Exit.isSuccess(cleanupExit)) {
-            yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
-            return;
-          }
-          yield* ignoreLeasedReleaseFailure(Effect.failCause(cleanupExit.cause));
-          yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-        });
-        yield* runAllFinalizers([
-          releaseResources,
-          health.feedDegraded(lease.feedKey, input.healthMessage),
-          health.clientDegraded(lease.feed.client, input.healthMessage),
-          cleanupRows,
-          notifyLeaseSubscribers(lease, input.publicMessage),
-        ]);
-      }),
-    );
   const runFeed = stream.pipe(
     Stream.mapError((cause) =>
       grpcLeaseError({
@@ -667,29 +474,27 @@ const startLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.start")
       publishLeasedBatch(config, runtimeClient, requestHealthRefresh, health, lease, values),
     ),
     Effect.exit,
-    Effect.flatMap((exit) => {
+    Effect.map((exit): GrpcLeasedUpstreamTerminal => {
       if (Exit.isSuccess(exit)) {
-        return degradeInactiveLease({
-          publicMessage: "gRPC leased upstream completed unexpectedly.",
+        return {
+          message: "gRPC leased upstream completed unexpectedly.",
           healthMessage: `gRPC leased feed ${lease.feedName} completed unexpectedly.`,
-        });
+        };
       }
       if (Cause.hasInterruptsOnly(exit.cause)) {
-        return Effect.when(
-          degradeInactiveLease({
-            publicMessage: "gRPC leased upstream interrupted unexpectedly.",
-            healthMessage: `gRPC leased feed ${lease.feedName} interrupted unexpectedly.`,
-          }),
-          Effect.sync(() => lease.acceptingSubscribers),
-        ).pipe(Effect.asVoid);
+        return {
+          message: "gRPC leased upstream interrupted unexpectedly.",
+          healthMessage: `gRPC leased feed ${lease.feedName} interrupted unexpectedly.`,
+        };
       }
-      return degradeInactiveLease({
-        publicMessage: "gRPC leased upstream failed.",
+      return {
+        message: "gRPC leased upstream failed.",
         healthMessage: internalFeedFailureMessage(lease.feedName, exit.cause),
-      });
+      };
     }),
   );
-  yield* runFeed.pipe(Effect.forkIn(lease.scope, { startImmediately: true }));
+  // The Subscription owns forking this worker, so acquisition intentionally returns it as a value.
+  return yield* Effect.succeed(runFeed);
 });
 
 const closeLeaseRows = Effect.fn("ViewServerRuntime.grpc.leased.rows.close")(function* <
@@ -697,12 +502,14 @@ const closeLeaseRows = Effect.fn("ViewServerRuntime.grpc.leased.rows.close")(fun
 >(
   config: ViewServerTopicConfig<Topics>,
   runtimeClient: ViewServerRuntimeCoreInternalClient<Topics>,
-  lease: LeaseRowOwner,
+  feedName: string,
+  feed: RuntimeLeasedFeedDefinition,
+  storageKeys: ReadonlySet<string>,
 ) {
-  const topic = yield* runtimeTopicFor(config, lease.feed.topic, lease.feedName);
+  const topic = yield* runtimeTopicFor(config, feed.topic, feedName);
   yield* Effect.forEach(
-    lease.storageKeys,
-    (key) => callRuntimeDelete(runtimeClient, topic, key, lease.feedName),
+    storageKeys,
+    (key) => callRuntimeDelete(runtimeClient, topic, key, feedName),
     {
       discard: true,
     },
@@ -765,7 +572,7 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
   const identityContracts = new Map<string, GrpcLeasedIdentityContract>();
   const sourceOwnership = makeSourceOwnershipPolicy(config);
   const lock = yield* Semaphore.make(1);
-  const subscriptionScope = yield* Scope.make("parallel");
+  const managerScope = yield* Scope.make("sequential");
   let closed = false;
 
   const captureLeasedQuery = <
@@ -867,30 +674,21 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       );
     }
     const existing = leases.get(feedKey);
-    const terminalSignal = yield* Deferred.make<LeaseTerminal>();
     if (existing !== undefined) {
-      return yield* Effect.uninterruptible(
-        Effect.gen(function* () {
-          if (!existing.acceptingSubscribers) {
-            yield* Deferred.succeed(terminalSignal, closedLeaseTerminal);
-            return yield* Effect.fail(
-              runtimeError({
-                code: "RuntimeUnavailable",
-                topic,
-                message:
-                  "gRPC leased upstream is not accepting new subscribers after completion or failure.",
-              }),
-            );
-          }
-          existing.subscribers += 1;
-          existing.terminalSignals.add(terminalSignal);
-          yield* health.subscriberAdded(feedKey);
-          return Option.some({
-            lease: existing,
-            terminalSignal,
-          });
-        }),
-      );
+      const subscriptionLease = yield* existing.subscription.acquire;
+      if (Option.isNone(subscriptionLease)) {
+        return yield* Effect.fail(
+          runtimeError({
+            code: "RuntimeUnavailable",
+            topic,
+            message:
+              "gRPC leased upstream is not accepting new subscribers after completion or failure.",
+          }),
+        );
+      }
+      return Option.some({
+        subscriptionLease: subscriptionLease.value,
+      });
     }
     const clientDefinition = options.clients[feed.client];
     if (clientDefinition === undefined) {
@@ -941,25 +739,41 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
         }),
       ),
     );
-    const scope = yield* Scope.make("parallel");
-    const rowOwner: LeaseRowOwner = {
+    const subscription = yield* makeGrpcLeasedSubscription<ViewServerGrpcIngressError>({
+      parentScope: managerScope,
+      topic,
+      identity,
+      ...(groupedKeyRetentionObserver === undefined ? {} : { groupedKeyRetentionObserver }),
+      cleanupRows: (storageKeys) =>
+        closeLeaseRows(config, runtimeClient, feedName, feed, storageKeys),
+      onCleanupFailure: (cause) =>
+        runAllFinalizers([
+          ignoreLeasedReleaseFailure(Effect.failCause(cause)),
+          health.feedDegraded(feedKey, `gRPC leased feed row cleanup failed for ${feedName}`),
+          health.clientDegraded(feed.client, `gRPC leased feed row cleanup failed for ${feedName}`),
+          ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
+        ]),
+      onRowsCleared: resetLeaseRowCount(requestHealthRefresh, health, feedKey),
+      onStopping: health
+        .feedStopping(feedKey)
+        .pipe(Effect.andThen(ignoreGrpcHealthRefreshFailure(requestHealthRefresh))),
+      onSubscriberAdded: health.subscriberAdded(feedKey),
+      onSubscriberRemoved: health.subscriberRemoved(feedKey),
+      onUpstreamTerminal: (terminal) =>
+        runAllFinalizers([
+          health.feedDegraded(feedKey, terminal.healthMessage),
+          health.clientDegraded(feed.client, terminal.healthMessage),
+          ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
+        ]),
+      onClosed: Effect.sync(() => leases.delete(feedKey)).pipe(
+        Effect.andThen(health.leasedFeedRemoved(feedKey)),
+        Effect.andThen(ignoreGrpcHealthRefreshFailure(requestHealthRefresh)),
+      ),
+    });
+    const lease: ActiveLease = {
       feedName,
       feed,
-      identity,
-      storageKeys: new Set<string>(),
-    };
-    const cleanupRows = (yield* Effect.cached(
-      closeLeaseRows(config, runtimeClient, rowOwner),
-    )).pipe(Effect.uninterruptible);
-    const lease: ActiveLease = {
-      ...rowOwner,
-      feedKey,
-      scope,
-      cleanupRows,
-      terminalSignals: new Set<Deferred.Deferred<LeaseTerminal>>([terminalSignal]),
-      subscriptions: new Set<ActiveLeaseSubscription>(),
-      subscribers: 1,
-      acceptingSubscribers: true,
+      subscription,
     };
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
@@ -972,31 +786,38 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
           topic,
           clientName: feed.client,
         });
-        yield* health.subscriberAdded(feedKey);
+        const subscriptionLease = Option.getOrThrow(yield* subscription.acquire);
         yield* health.feedReady(feedKey);
         yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
+        const releaseRoute = subscription.materializeRoute();
         const startExit = yield* restore(
-          startLeaseStream(
-            config,
-            runtimeClient,
-            requestHealthRefresh,
-            health,
-            lease,
-            lock,
-            grpcClient,
-            request,
-          ),
+          subscription.start({
+            acquire: acquireLeaseStream(
+              config,
+              runtimeClient,
+              requestHealthRefresh,
+              health,
+              lease,
+              grpcClient,
+              request,
+            ),
+            release: callFeedRelease(
+              feedName,
+              feed,
+              makeGrpcSourceInput(grpcClient, request, releaseRoute),
+            ).pipe(
+              ignoreGrpcFeedReleaseFailure,
+              Effect.withSpan("ViewServerRuntime.grpc.leased.resources.release"),
+            ),
+          }),
         ).pipe(Effect.exit);
         if (Exit.isFailure(startExit)) {
           const cleanupExit = yield* runAllFinalizers([
-            Scope.close(scope, Exit.void),
+            subscription.close,
             health.clientDegraded(
               feed.client,
               `gRPC leased feed ${feedName} failed to start: ${String(startExit.cause)}`,
             ),
-            Deferred.succeed(terminalSignal, closedLeaseTerminal),
-            health.leasedFeedRemoved(feedKey),
-            Effect.sync(() => leases.delete(feedKey)),
             ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
           ]).pipe(Effect.exit);
           const cause = Exit.isFailure(cleanupExit)
@@ -1005,208 +826,11 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
           return yield* Effect.failCause(normalizeAcquireLeaseCause(topic)(cause));
         }
         return Option.some({
-          lease,
-          terminalSignal,
+          subscriptionLease,
         });
       }),
     );
   });
-
-  const releaseLeaseUnderPermit: (
-    lease: ActiveLease,
-  ) => Effect.Effect<Option.Option<ActiveLease>, never, never> = Effect.fn(
-    "ViewServerRuntime.grpc.leased.releaseLeaseUnderPermit",
-  )(function* (lease: ActiveLease) {
-    const current = leases.get(lease.feedKey);
-    if (current === undefined) {
-      return Option.none();
-    }
-    current.subscribers -= 1;
-    yield* health.subscriberRemoved(lease.feedKey);
-    if (current.subscribers > 0) {
-      yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-      return Option.none();
-    }
-    if (!current.acceptingSubscribers) {
-      return Option.some(current);
-    }
-    current.acceptingSubscribers = false;
-    yield* health.feedStopping(lease.feedKey);
-    yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-    return Option.some(current);
-  });
-
-  const cleanupReleasedLease: (lease: ActiveLease) => Effect.Effect<void, never, never> = Effect.fn(
-    "ViewServerRuntime.grpc.leased.releaseLease.cleanup",
-  )(function* (lease: ActiveLease) {
-    const cleanupRowsAndHealth = Effect.gen(function* () {
-      const cleanupExit = yield* lease.cleanupRows.pipe(Effect.exit);
-      if (Exit.isFailure(cleanupExit)) {
-        yield* ignoreLeasedReleaseFailure(Effect.failCause(cleanupExit.cause));
-        yield* health.feedDegraded(
-          lease.feedKey,
-          `gRPC leased feed row cleanup failed for ${lease.feedName}`,
-        );
-        yield* health.clientDegraded(
-          lease.feed.client,
-          `gRPC leased feed row cleanup failed for ${lease.feedName}`,
-        );
-        yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-        return;
-      }
-      yield* resetLeaseRowCount(requestHealthRefresh, health, lease);
-      yield* lock.withPermit(
-        Effect.gen(function* () {
-          leases.delete(lease.feedKey);
-          yield* health.leasedFeedRemoved(lease.feedKey);
-        }),
-      );
-      yield* ignoreGrpcHealthRefreshFailure(requestHealthRefresh);
-    });
-    yield* runAllFinalizers([Scope.close(lease.scope, Exit.void), cleanupRowsAndHealth]);
-  });
-
-  const releaseLease: (lease: ActiveLease) => Effect.Effect<void, never, never> = Effect.fn(
-    "ViewServerRuntime.grpc.leased.releaseLease",
-  )(function* (lease: ActiveLease) {
-    const releasedLease = yield* lock.withPermit(releaseLeaseUnderPermit(lease));
-    if (Option.isSome(releasedLease)) {
-      yield* cleanupReleasedLease(releasedLease.value);
-    }
-  });
-
-  const withLeaseClose = <Row extends object>(input: {
-    readonly subscription: ViewServerLiveSubscription<Row>;
-    readonly lease: ActiveLease;
-    readonly query: unknown;
-    readonly terminalSignal: Deferred.Deferred<LeaseTerminal>;
-    readonly terminalRegistration: LeaseTerminalRegistration;
-  }): Effect.Effect<ViewServerLiveSubscription<Row>, never, never> =>
-    Effect.gen(function* () {
-      const resultKeys = input.lease.identity.resultKeys<Row>(
-        input.query,
-        groupedKeyRetentionObserver,
-      );
-      function close(): Effect.Effect<void, never, never> {
-        return closeEffect;
-      }
-      const subscriptionOwner: ActiveLeaseSubscription = { close };
-      const closeEffect = (yield* Effect.cached(
-        Effect.gen(function* () {
-          input.lease.terminalSignals.delete(input.terminalSignal);
-          yield* Deferred.succeed(input.terminalSignal, closedLeaseTerminal);
-          yield* runAllFinalizers([
-            input.subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
-            releaseLease(input.lease),
-            Effect.sync(() => input.lease.subscriptions.delete(subscriptionOwner)),
-            Effect.sync(() => resultKeys.clear()),
-          ]);
-        }).pipe(Effect.withSpan("ViewServerRuntime.grpc.leased.subscription.close")),
-      )).pipe(Effect.uninterruptible);
-      const runtimeTerminal: RuntimeLeaseTerminal = {
-        _tag: "Runtime",
-      };
-      const claimRuntimeTerminal = (terminal: RuntimeLeaseTerminal) =>
-        Effect.gen(function* () {
-          yield* Deferred.succeed(input.terminalSignal, terminal);
-          return (yield* Deferred.await(input.terminalSignal)) === terminal;
-        });
-      const runtimeEvents = input.subscription.events.pipe(
-        Stream.map((event) => externalizeLeasedEvent(resultKeys, event)),
-        Stream.filterEffect((translated) => {
-          if (isResultKeyTranslationFailure(translated)) {
-            return claimRuntimeTerminal(runtimeTerminal);
-          }
-          if (isTerminalStatusEvent(translated)) {
-            return Effect.succeed(false);
-          }
-          return Effect.succeed(true);
-        }),
-        Stream.takeUntil(isResultKeyTranslationFailure),
-        Stream.map((translated) =>
-          isResultKeyTranslationFailure(translated)
-            ? resultKeyEncodingErrorStatus(input.lease, translated.queryId, translated.error)
-            : translated,
-        ),
-      );
-      const terminalStatusEvents = Stream.fromEffect(Deferred.await(input.terminalSignal)).pipe(
-        Stream.flatMap((terminal) => {
-          if (terminal._tag === "Engine") {
-            return Stream.succeed(terminal.status);
-          }
-          if (terminal._tag === "Upstream") {
-            return Stream.fromEffect(Deferred.await(input.terminalRegistration.queryId)).pipe(
-              Stream.map(
-                (queryId): StatusEvent => ({
-                  type: "status",
-                  topic: input.lease.feed.topic,
-                  queryId,
-                  status: "error",
-                  code: "RuntimeUnavailable",
-                  message: terminal.message,
-                }),
-              ),
-            );
-          }
-          return Stream.empty;
-        }),
-      );
-      const wrappedSubscription: ViewServerLiveSubscription<Row> = {
-        events: runtimeEvents.pipe(
-          Stream.concat(terminalStatusEvents),
-          Stream.takeUntil(isTerminalStatusEvent),
-          Stream.ensuring(close()),
-        ),
-        close: () => close(),
-      };
-      const closeAfterTerminal = Deferred.await(input.terminalSignal).pipe(
-        Effect.flatMap((terminal) => {
-          if (terminal._tag === "Engine") {
-            return Deferred.await(terminal.ready).pipe(Effect.andThen(close()));
-          }
-          return terminal._tag === "Runtime" || terminal._tag === "Upstream"
-            ? close()
-            : Effect.void;
-        }),
-      );
-      const registered = yield* lock.withPermit(
-        Effect.gen(function* () {
-          const terminalAlreadyClaimed = yield* Deferred.isDone(input.terminalSignal);
-          if (closed || !input.lease.acceptingSubscribers || terminalAlreadyClaimed) {
-            return false;
-          }
-          input.lease.subscriptions.add(subscriptionOwner);
-          yield* closeAfterTerminal.pipe(
-            Effect.forkIn(subscriptionScope, { startImmediately: true }),
-          );
-          return true;
-        }),
-      );
-      if (!registered) {
-        const terminal = yield* Deferred.await(input.terminalSignal);
-        if (terminal._tag === "Engine") {
-          yield* Deferred.await(terminal.ready);
-        }
-        yield* close();
-      }
-      return wrappedSubscription;
-    });
-
-  const releaseAcquiredLeaseUnderPermit = (
-    acquired: AcquiredLease,
-  ): Effect.Effect<Option.Option<ActiveLease>, never, never> =>
-    Effect.gen(function* () {
-      acquired.lease.terminalSignals.delete(acquired.terminalSignal);
-      yield* Deferred.succeed(acquired.terminalSignal, closedLeaseTerminal);
-      return yield* releaseLeaseUnderPermit(acquired.lease);
-    });
-  const releaseAcquiredLease = (acquired: AcquiredLease): Effect.Effect<void, never, never> =>
-    Effect.gen(function* () {
-      const releasedLease = yield* lock.withPermit(releaseAcquiredLeaseUnderPermit(acquired));
-      if (Option.isSome(releasedLease)) {
-        yield* cleanupReleasedLease(releasedLease.value);
-      }
-    });
 
   function subscribe<
     Topic extends Extract<keyof Topics, string>,
@@ -1245,25 +869,19 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       const acquired = lease.value;
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const terminalRegistration = yield* makeLeaseTerminalRegistration(
-            acquired.terminalSignal,
-          );
           const subscription = yield* restore(
             internalLiveClient.subscribeObservedInternal<Topic, Query>(
               topic,
               ownedQuery,
-              terminalRegistration.observer,
+              acquired.subscriptionLease.terminalObserver,
             ),
           );
-          return yield* withLeaseClose({
+          return yield* acquired.subscriptionLease.attach({
             subscription,
-            lease: acquired.lease,
             query: ownedQuery,
-            terminalSignal: acquired.terminalSignal,
-            terminalRegistration,
           });
         }),
-      ).pipe(Effect.onError(() => releaseAcquiredLease(acquired)));
+      ).pipe(Effect.onError(() => acquired.subscriptionLease.close));
     });
   }
 
@@ -1288,25 +906,19 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
       const acquired = lease.value;
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const terminalRegistration = yield* makeLeaseTerminalRegistration(
-            acquired.terminalSignal,
-          );
           const subscription = yield* restore(
             internalLiveClient.subscribeRuntimeObservedInternal(
               topic,
               ownedQuery,
-              terminalRegistration.observer,
+              acquired.subscriptionLease.terminalObserver,
             ),
           );
-          return yield* withLeaseClose({
+          return yield* acquired.subscriptionLease.attach({
             subscription,
-            lease: acquired.lease,
             query: ownedQuery,
-            terminalSignal: acquired.terminalSignal,
-            terminalRegistration,
           });
         }),
-      ).pipe(Effect.onError(() => releaseAcquiredLease(acquired)));
+      ).pipe(Effect.onError(() => acquired.subscriptionLease.close));
     });
   };
 
@@ -1349,40 +961,14 @@ export const makeViewServerGrpcLeaseManager = Effect.fn(
 
   const close = (yield* Effect.cached(
     Effect.gen(function* () {
-      const activeLeases = yield* lock.withPermit(
+      yield* lock.withPermit(
         Effect.sync(() => {
           closed = true;
-          const currentLeases = Array.from(leases.values());
-          leases.clear();
-          for (const lease of currentLeases) {
-            lease.acceptingSubscribers = false;
-          }
-          return currentLeases;
         }),
       );
       yield* runAllFinalizers([
-        runAllFinalizers(
-          activeLeases.map((lease) =>
-            runAllFinalizers([
-              Scope.close(lease.scope, Exit.void),
-              runAllFinalizers(
-                Array.from(lease.terminalSignals, (signal) =>
-                  Deferred.succeed(signal, closedLeaseTerminal),
-                ),
-              ),
-              Effect.sync(() => lease.terminalSignals.clear()),
-              runAllFinalizers(
-                Array.from(lease.subscriptions, (subscription) =>
-                  subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
-                ),
-              ),
-              Effect.sync(() => lease.subscriptions.clear()),
-              lease.cleanupRows.pipe(ignoreLeasedReleaseFailure),
-              health.leasedFeedRemoved(lease.feedKey),
-            ]),
-          ),
-        ),
-        Scope.close(subscriptionScope, Exit.void),
+        Scope.close(managerScope, Exit.void),
+        Effect.sync(() => leases.clear()),
         ignoreGrpcHealthRefreshFailure(requestHealthRefresh),
       ]);
     }).pipe(Effect.withSpan("ViewServerRuntime.grpc.leased.close")),

--- a/packages/runtime/src/grpc-lease-manager.ts
+++ b/packages/runtime/src/grpc-lease-manager.ts
@@ -493,8 +493,9 @@ const acquireLeaseStream = Effect.fn("ViewServerRuntime.grpc.leased.stream.acqui
       };
     }),
   );
-  // Returning runFeed directly makes Effect.fn flatten the nested Effect in its inferred result.
-  // Wrap it so acquisition returns the worker as a value for the Subscription to fork and own.
+  // The Subscription must receive runFeed as a value so it can fork and own the worker.
+  // Strict Effect diagnostics treat direct nested-Effect returns as accidental, so wrap it
+  // to make the intentional Effect<Effect<GrpcLeasedUpstreamTerminal>> explicit.
   return yield* Effect.succeed(runFeed);
 });
 

--- a/packages/runtime/src/grpc-leased-subscription.test.ts
+++ b/packages/runtime/src/grpc-leased-subscription.test.ts
@@ -172,4 +172,81 @@ describe("leased gRPC Subscription", () => {
       });
     }),
   );
+
+  it.live("reports a failed upstream cleanup exactly once", () =>
+    Effect.gen(function* () {
+      const identityContract = yield* Effect.fromResult(
+        makeGrpcLeasedIdentityContract({
+          topic: "orders",
+          feedName: "orders",
+          routeBy: ["region"],
+          schema: SubscriptionRow,
+          keyField: "id",
+        }),
+      );
+      const identity = yield* Effect.fromResult(
+        identityContract.leaseFromQuery({ where: { region: { eq: "usa" } } }),
+      );
+      const parentScope = yield* Scope.make("sequential");
+      const cleanupReported = yield* Deferred.make<void>();
+      const counters = {
+        cleanup: 0,
+        cleanupFailure: 0,
+        closed: 0,
+        release: 0,
+        subscriberAdded: 0,
+        subscriberRemoved: 0,
+      };
+      const subscription = yield* makeGrpcLeasedSubscription({
+        parentScope,
+        topic: "orders",
+        identity,
+        cleanupRows: () =>
+          Effect.sync(() => {
+            counters.cleanup += 1;
+          }).pipe(Effect.andThen(Effect.fail("cleanup failed"))),
+        onCleanupFailure: () =>
+          Effect.sync(() => {
+            counters.cleanupFailure += 1;
+          }).pipe(Effect.andThen(Deferred.succeed(cleanupReported, undefined)), Effect.asVoid),
+        onClosed: Effect.sync(() => {
+          counters.closed += 1;
+        }),
+        onRowsCleared: Effect.die("failed cleanup must not clear rows"),
+        onStopping: Effect.void,
+        onSubscriberAdded: Effect.sync(() => {
+          counters.subscriberAdded += 1;
+        }),
+        onSubscriberRemoved: Effect.sync(() => {
+          counters.subscriberRemoved += 1;
+        }),
+        onUpstreamTerminal: () => Effect.void,
+      });
+      const lease = Option.getOrThrow(yield* subscription.acquire);
+      yield* subscription.start({
+        acquire: Effect.succeed(
+          Effect.succeed({
+            message: "upstream completed",
+            healthMessage: "upstream completed",
+          }),
+        ),
+        release: Effect.sync(() => {
+          counters.release += 1;
+        }),
+      });
+
+      yield* Deferred.await(cleanupReported);
+      yield* lease.close;
+      yield* Scope.close(parentScope, Exit.void);
+
+      expect(counters).toStrictEqual({
+        cleanup: 1,
+        cleanupFailure: 1,
+        closed: 0,
+        release: 1,
+        subscriberAdded: 1,
+        subscriberRemoved: 1,
+      });
+    }),
+  );
 });

--- a/packages/runtime/src/grpc-leased-subscription.test.ts
+++ b/packages/runtime/src/grpc-leased-subscription.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Deferred, Effect, Exit, Fiber, Option, Result, Schema, Scope, Stream } from "effect";
+import { makeGrpcLeasedIdentityContract } from "./grpc-leased-identity";
+import { makeGrpcLeasedSubscription } from "./grpc-leased-subscription";
+
+const SubscriptionRow = Schema.Struct({
+  id: Schema.String,
+  region: Schema.String,
+});
+
+describe("leased gRPC Subscription", () => {
+  it.live("owns upstream, client, retained-row, and health cleanup exactly once", () =>
+    Effect.gen(function* () {
+      const identityContract = yield* Effect.fromResult(
+        makeGrpcLeasedIdentityContract({
+          topic: "orders",
+          feedName: "orders",
+          routeBy: ["region"],
+          schema: SubscriptionRow,
+          keyField: "id",
+        }),
+      );
+      const identity = yield* Effect.fromResult(
+        identityContract.leaseFromQuery({ where: { region: { eq: "usa" } } }),
+      );
+      const parentScope = yield* Scope.make("sequential");
+      const counters = {
+        cleanup: 0,
+        closed: 0,
+        rawClose: 0,
+        release: 0,
+        rowsCleared: 0,
+        subscriberAdded: 0,
+        subscriberRemoved: 0,
+        stopping: 0,
+      };
+      const subscription = yield* makeGrpcLeasedSubscription({
+        parentScope,
+        topic: "orders",
+        identity,
+        cleanupRows: (keys) =>
+          Effect.sync(() => {
+            counters.cleanup += 1;
+            expect(Array.from(keys)).toStrictEqual([
+              '["leased-row","orders/orders/leased/region=%22usa%22","order-1"]',
+            ]);
+          }),
+        onCleanupFailure: () => Effect.die("cleanup must succeed"),
+        onClosed: Effect.sync(() => {
+          counters.closed += 1;
+        }),
+        onRowsCleared: Effect.sync(() => {
+          counters.rowsCleared += 1;
+        }),
+        onStopping: Effect.sync(() => {
+          counters.stopping += 1;
+        }),
+        onSubscriberAdded: Effect.sync(() => {
+          counters.subscriberAdded += 1;
+        }),
+        onSubscriberRemoved: Effect.sync(() => {
+          counters.subscriberRemoved += 1;
+        }),
+        onUpstreamTerminal: () => Effect.void,
+      });
+      const internalKey = subscription.internalizeRowKey({ id: "order-1", region: "usa" });
+      expect(Result.isSuccess(internalKey)).toBe(true);
+      const acquired = yield* subscription.acquire;
+      const lease = Option.getOrThrow(acquired);
+      const wrapped = yield* lease.attach({
+        query: { select: ["id"] },
+        subscription: {
+          events: Stream.never,
+          close: () =>
+            Effect.sync(() => {
+              counters.rawClose += 1;
+            }),
+        },
+      });
+      yield* subscription.start({
+        acquire: Effect.succeed(Effect.never),
+        release: Effect.sync(() => {
+          counters.release += 1;
+        }),
+      });
+
+      yield* Effect.all([wrapped.close(), wrapped.close(), Scope.close(parentScope, Exit.void)], {
+        concurrency: "unbounded",
+        discard: true,
+      });
+
+      expect(counters).toStrictEqual({
+        cleanup: 1,
+        closed: 1,
+        rawClose: 1,
+        release: 1,
+        rowsCleared: 1,
+        subscriberAdded: 1,
+        subscriberRemoved: 1,
+        stopping: 1,
+      });
+    }),
+  );
+
+  it.live("keeps client release as the winner over a queued upstream terminal", () =>
+    Effect.gen(function* () {
+      const identityContract = yield* Effect.fromResult(
+        makeGrpcLeasedIdentityContract({
+          topic: "orders",
+          feedName: "orders",
+          routeBy: ["region"],
+          schema: SubscriptionRow,
+          keyField: "id",
+        }),
+      );
+      const identity = yield* Effect.fromResult(
+        identityContract.leaseFromQuery({ where: { region: { eq: "usa" } } }),
+      );
+      const parentScope = yield* Scope.make("sequential");
+      const stoppingStarted = yield* Deferred.make<void>();
+      const allowStopping = yield* Deferred.make<void>();
+      const finishUpstream = yield* Deferred.make<void>();
+      let closed = 0;
+      let released = 0;
+      let upstreamTerminals = 0;
+      const subscription = yield* makeGrpcLeasedSubscription({
+        parentScope,
+        topic: "orders",
+        identity,
+        cleanupRows: () => Effect.void,
+        onCleanupFailure: () => Effect.die("cleanup must succeed"),
+        onClosed: Effect.sync(() => {
+          closed += 1;
+        }),
+        onRowsCleared: Effect.void,
+        onStopping: Deferred.succeed(stoppingStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(allowStopping)),
+        ),
+        onSubscriberAdded: Effect.void,
+        onSubscriberRemoved: Effect.void,
+        onUpstreamTerminal: () =>
+          Effect.sync(() => {
+            upstreamTerminals += 1;
+          }),
+      });
+      const lease = Option.getOrThrow(yield* subscription.acquire);
+      yield* subscription.start({
+        acquire: Effect.succeed(
+          Deferred.await(finishUpstream).pipe(
+            Effect.as({
+              message: "upstream completed",
+              healthMessage: "upstream completed",
+            }),
+          ),
+        ),
+        release: Effect.sync(() => {
+          released += 1;
+        }),
+      });
+
+      const closeFiber = yield* lease.close.pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(stoppingStarted);
+      yield* Deferred.succeed(finishUpstream, undefined);
+      yield* Deferred.succeed(allowStopping, undefined);
+      yield* Fiber.join(closeFiber);
+      yield* Scope.close(parentScope, Exit.void);
+
+      expect({ closed, released, upstreamTerminals }).toStrictEqual({
+        closed: 1,
+        released: 1,
+        upstreamTerminals: 0,
+      });
+    }),
+  );
+});

--- a/packages/runtime/src/grpc-leased-subscription.test.ts
+++ b/packages/runtime/src/grpc-leased-subscription.test.ts
@@ -249,4 +249,60 @@ describe("leased gRPC Subscription", () => {
       });
     }),
   );
+
+  it.live("detaches completed subscriptions from the parent scope under route churn", () =>
+    Effect.gen(function* () {
+      const identityContract = yield* Effect.fromResult(
+        makeGrpcLeasedIdentityContract({
+          topic: "orders",
+          feedName: "orders",
+          routeBy: ["region"],
+          schema: SubscriptionRow,
+          keyField: "id",
+        }),
+      );
+      const identity = yield* Effect.fromResult(
+        identityContract.leaseFromQuery({ where: { region: { eq: "usa" } } }),
+      );
+      const parentScope = yield* Scope.make("sequential");
+      let cleaned = 0;
+      let closed = 0;
+
+      yield* Effect.forEach(
+        Array.from({ length: 25 }),
+        () =>
+          Effect.gen(function* () {
+            const subscription = yield* makeGrpcLeasedSubscription({
+              parentScope,
+              topic: "orders",
+              identity,
+              cleanupRows: () =>
+                Effect.sync(() => {
+                  cleaned += 1;
+                }),
+              onCleanupFailure: () => Effect.die("cleanup must succeed"),
+              onClosed: Effect.sync(() => {
+                closed += 1;
+              }),
+              onRowsCleared: Effect.void,
+              onStopping: Effect.void,
+              onSubscriberAdded: Effect.void,
+              onSubscriberRemoved: Effect.void,
+              onUpstreamTerminal: () => Effect.void,
+            });
+            yield* subscription.close;
+          }),
+        { discard: true },
+      );
+
+      const retainedParentFinalizers =
+        parentScope.state._tag === "Open" ? parentScope.state.finalizers.size : 0;
+      expect({ cleaned, closed, retainedParentFinalizers }).toStrictEqual({
+        cleaned: 25,
+        closed: 25,
+        retainedParentFinalizers: 0,
+      });
+      yield* Scope.close(parentScope, Exit.void);
+    }),
+  );
 });

--- a/packages/runtime/src/grpc-leased-subscription.ts
+++ b/packages/runtime/src/grpc-leased-subscription.ts
@@ -202,7 +202,8 @@ export type GrpcLeasedSubscription<Error> = {
 export const makeGrpcLeasedSubscription = Effect.fn(
   "ViewServerRuntime.grpc.leased.subscription.make",
 )(function* <Error>(input: GrpcLeasedSubscriptionInput<Error>) {
-  const scope = yield* Scope.fork(input.parentScope, "sequential");
+  const ownerScope = yield* Scope.fork(input.parentScope, "sequential");
+  const scope = yield* Scope.make("sequential");
   const lock = yield* Semaphore.make(1);
   const storageKeys = new Set<string>();
   const activeClientLeases = new Set<ActiveClientLease>();
@@ -258,7 +259,7 @@ export const makeGrpcLeasedSubscription = Effect.fn(
       yield* runAllFinalizers([...clientCloses, Scope.close(scope, Exit.void)]);
     },
   );
-  const close = (yield* Effect.cached(
+  const closeResources = (yield* Effect.cached(
     closeSubscription().pipe(
       Effect.onExit(() =>
         Effect.sync(() => {
@@ -276,9 +277,13 @@ export const makeGrpcLeasedSubscription = Effect.fn(
   const awaitClose = Deferred.await(closeExit).pipe(
     Effect.flatMap((exit) => (Exit.isFailure(exit) ? Effect.failCause(exit.cause) : Effect.void)),
   );
+  const close = closeResources.pipe(
+    Effect.ensuring(Scope.close(ownerScope, Exit.void)),
+    Effect.uninterruptible,
+  );
   yield* Scope.addFinalizer(
-    input.parentScope,
-    Effect.suspend(() => (closeCompleted ? Effect.void : close)),
+    ownerScope,
+    Effect.suspend(() => (closeCompleted ? Effect.void : closeResources)),
   );
 
   const releaseSubscriber = Effect.fn(

--- a/packages/runtime/src/grpc-leased-subscription.ts
+++ b/packages/runtime/src/grpc-leased-subscription.ts
@@ -1,0 +1,525 @@
+import type { StatusEvent } from "@effect-view-server/config";
+import type { ViewServerLiveEvent, ViewServerLiveSubscription } from "@effect-view-server/client";
+import {
+  ignoreLoggedTypedFailuresPreserveNonTypedFailures,
+  runAllFinalizers,
+} from "@effect-view-server/effect-utils";
+import type { ViewServerRuntimeCoreTerminalObserver } from "@effect-view-server/runtime-core/internal";
+import { Cause, Deferred, Effect, Exit, Option, Result, Scope, Semaphore, Stream } from "effect";
+import type {
+  GrpcLeasedGroupedKeyRetentionObserver,
+  GrpcLeasedIdentityError,
+  GrpcLeasedIdentityLease,
+  GrpcLeasedInternalRowKey,
+  GrpcLeasedResultKeyTranslation,
+} from "./grpc-leased-identity";
+
+export type GrpcLeasedUpstreamTerminal = {
+  readonly message: string;
+  readonly healthMessage: string;
+};
+
+type UpstreamSubscriptionTerminal = {
+  readonly _tag: "Upstream";
+  readonly message: string;
+};
+
+type EngineSubscriptionTerminal = {
+  readonly _tag: "Engine";
+  readonly ready: Deferred.Deferred<void>;
+  readonly status: StatusEvent;
+};
+
+type RuntimeSubscriptionTerminal = {
+  readonly _tag: "Runtime";
+};
+
+type ClosedSubscriptionTerminal = {
+  readonly _tag: "Closed";
+};
+
+type SubscriptionTerminal =
+  | UpstreamSubscriptionTerminal
+  | EngineSubscriptionTerminal
+  | RuntimeSubscriptionTerminal
+  | ClosedSubscriptionTerminal;
+
+const closedSubscriptionTerminal: ClosedSubscriptionTerminal = {
+  _tag: "Closed",
+};
+
+const ignoreLeasedSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring leased gRPC subscription close failure.",
+);
+
+const grpcLeasedResultKeyFailureTypeId: unique symbol = Symbol(
+  "@effect-view-server/runtime/GrpcLeasedResultKeyFailure",
+);
+
+type GrpcLeasedResultKeyFailure = {
+  readonly [grpcLeasedResultKeyFailureTypeId]: true;
+  readonly queryId: string;
+  readonly error: GrpcLeasedIdentityError;
+};
+
+const resultKeyTranslationFailure = (
+  queryId: string,
+  error: GrpcLeasedIdentityError,
+): GrpcLeasedResultKeyFailure => ({
+  [grpcLeasedResultKeyFailureTypeId]: true,
+  queryId,
+  error,
+});
+
+const isResultKeyTranslationFailure = <Row extends object>(
+  value: ViewServerLiveEvent<Row> | GrpcLeasedResultKeyFailure,
+): value is GrpcLeasedResultKeyFailure => grpcLeasedResultKeyFailureTypeId in value;
+
+const isTerminalStatusEvent = (event: ViewServerLiveEvent<unknown>): event is StatusEvent =>
+  event.type === "status" && (event.status === "closed" || event.status === "error");
+
+const externalizeLeasedEvent = <Row extends object>(
+  resultKeys: GrpcLeasedResultKeyTranslation<Row>,
+  event: ViewServerLiveEvent<Row>,
+): ViewServerLiveEvent<Row> | GrpcLeasedResultKeyFailure => {
+  if (event.type === "snapshot") {
+    const keys = resultKeys.translateSnapshot(event.keys, event.rows);
+    if (Result.isFailure(keys)) {
+      return resultKeyTranslationFailure(event.queryId, keys.failure);
+    }
+    return {
+      ...event,
+      keys: keys.success,
+    };
+  }
+  if (event.type === "delta") {
+    const operations = resultKeys.translateDelta(event.operations);
+    if (Result.isFailure(operations)) {
+      return resultKeyTranslationFailure(event.queryId, operations.failure);
+    }
+    return {
+      ...event,
+      operations: operations.success,
+    };
+  }
+  return event;
+};
+
+const resultKeyEncodingErrorStatus = (
+  topic: string,
+  queryId: string,
+  error: GrpcLeasedIdentityError,
+): StatusEvent => ({
+  type: "status",
+  topic,
+  queryId,
+  status: "error",
+  code: "RuntimeUnavailable",
+  message: error.message,
+});
+
+type SubscriptionTerminalRegistration = {
+  readonly observer: ViewServerRuntimeCoreTerminalObserver;
+  readonly queryId: Deferred.Deferred<string>;
+};
+
+const makeSubscriptionTerminalRegistration = Effect.fn(
+  "ViewServerRuntime.grpc.leased.subscription.terminalRegistration.make",
+)(function* (terminal: Deferred.Deferred<SubscriptionTerminal>) {
+  const ready = yield* Deferred.make<void>();
+  const queryId = yield* Deferred.make<string>();
+  const observer: ViewServerRuntimeCoreTerminalObserver = {
+    onQueryRegistered: (registeredQueryId) =>
+      Deferred.succeed(queryId, registeredQueryId).pipe(Effect.asVoid),
+    onTerminalOccurrence: (status) =>
+      Deferred.succeed(terminal, {
+        _tag: "Engine",
+        ready,
+        status,
+      }).pipe(Effect.asVoid),
+    onTerminalReady: () => Deferred.succeed(ready, undefined).pipe(Effect.asVoid),
+  };
+  return {
+    observer,
+    queryId,
+  } satisfies SubscriptionTerminalRegistration;
+});
+
+export type GrpcLeasedSubscriptionAttachInput<Row extends object> = {
+  readonly query: unknown;
+  readonly subscription: ViewServerLiveSubscription<Row>;
+};
+
+export type GrpcLeasedSubscriptionLease = {
+  readonly terminalObserver: ViewServerRuntimeCoreTerminalObserver;
+  readonly attach: <Row extends object>(
+    input: GrpcLeasedSubscriptionAttachInput<Row>,
+  ) => Effect.Effect<ViewServerLiveSubscription<Row>>;
+  readonly close: Effect.Effect<void>;
+};
+
+export type GrpcLeasedSubscriptionStart<Error> = {
+  readonly acquire: Effect.Effect<Effect.Effect<GrpcLeasedUpstreamTerminal>, Error>;
+  readonly release: Effect.Effect<void>;
+};
+
+export type GrpcLeasedSubscriptionInput<Error> = {
+  readonly parentScope: Scope.Scope;
+  readonly topic: string;
+  readonly identity: GrpcLeasedIdentityLease;
+  readonly groupedKeyRetentionObserver?: GrpcLeasedGroupedKeyRetentionObserver;
+  readonly cleanupRows: (keys: ReadonlySet<string>) => Effect.Effect<void, Error>;
+  readonly onCleanupFailure: (cause: Cause.Cause<Error>) => Effect.Effect<void>;
+  readonly onClosed: Effect.Effect<void>;
+  readonly onRowsCleared: Effect.Effect<void>;
+  readonly onStopping: Effect.Effect<void>;
+  readonly onSubscriberAdded: Effect.Effect<void>;
+  readonly onSubscriberRemoved: Effect.Effect<void>;
+  readonly onUpstreamTerminal: (terminal: GrpcLeasedUpstreamTerminal) => Effect.Effect<void>;
+};
+
+type ClientCloseDisposition = "None" | "Initiate" | "Join";
+
+type ActiveClientLease = {
+  readonly markClosed: Effect.Effect<boolean>;
+  readonly closeChild: Effect.Effect<void>;
+  readonly notifyUpstream: (terminal: GrpcLeasedUpstreamTerminal) => Effect.Effect<boolean>;
+};
+
+export type GrpcLeasedSubscription<Error> = {
+  readonly feedKey: string;
+  readonly materializeRoute: GrpcLeasedIdentityLease["materializeRoute"];
+  readonly validateRowRoute: GrpcLeasedIdentityLease["validateRowRoute"];
+  readonly internalizeRowKey: <Row extends object>(
+    row: Row,
+  ) => Result.Result<GrpcLeasedInternalRowKey, GrpcLeasedIdentityError>;
+  readonly retainedRowCount: () => number;
+  readonly acquire: Effect.Effect<Option.Option<GrpcLeasedSubscriptionLease>>;
+  readonly start: (input: GrpcLeasedSubscriptionStart<Error>) => Effect.Effect<void, Error>;
+  readonly close: Effect.Effect<void>;
+};
+
+export const makeGrpcLeasedSubscription = Effect.fn(
+  "ViewServerRuntime.grpc.leased.subscription.make",
+)(function* <Error>(input: GrpcLeasedSubscriptionInput<Error>) {
+  const scope = yield* Scope.fork(input.parentScope, "sequential");
+  const lock = yield* Semaphore.make(1);
+  const storageKeys = new Set<string>();
+  const activeClientLeases = new Set<ActiveClientLease>();
+  let subscribers = 0;
+  let acceptingSubscribers = true;
+  let closing = false;
+  let closeCompleted = false;
+  const closeExit = yield* Deferred.make<Exit.Exit<void, never>>();
+
+  const cleanupRowsExit = yield* Effect.cached(
+    input.cleanupRows(storageKeys).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => storageKeys.clear()).pipe(Effect.andThen(input.onRowsCleared)),
+      ),
+      Effect.exit,
+    ),
+  );
+
+  const finalize = Effect.fn("ViewServerRuntime.grpc.leased.subscription.finalize")(function* () {
+    const cleanupExit = yield* cleanupRowsExit;
+    if (Exit.isFailure(cleanupExit)) {
+      yield* input.onCleanupFailure(cleanupExit.cause);
+      return;
+    }
+    yield* input.onClosed;
+  });
+  yield* Scope.addFinalizer(scope, finalize());
+
+  const close = (yield* Effect.cached(
+    lock
+      .withPermit(
+        Effect.gen(function* () {
+          const shouldStop = acceptingSubscribers && subscribers > 0;
+          acceptingSubscribers = false;
+          closing = true;
+          if (shouldStop) {
+            yield* input.onStopping;
+          }
+          return Array.from(activeClientLeases, (lease) =>
+            runAllFinalizers([lease.markClosed, lease.closeChild]),
+          );
+        }),
+      )
+      .pipe(
+        Effect.flatMap((clientCloses) =>
+          runAllFinalizers([...clientCloses, Scope.close(scope, Exit.void)]),
+        ),
+        Effect.onExit(() =>
+          Effect.sync(() => {
+            closeCompleted = true;
+          }),
+        ),
+        Effect.exit,
+        Effect.flatMap((exit) =>
+          Deferred.succeed(closeExit, exit).pipe(
+            Effect.andThen(Exit.isFailure(exit) ? Effect.failCause(exit.cause) : Effect.void),
+          ),
+        ),
+      ),
+  )).pipe(Effect.uninterruptible);
+  const awaitClose = Deferred.await(closeExit).pipe(
+    Effect.flatMap((exit) => (Exit.isFailure(exit) ? Effect.failCause(exit.cause) : Effect.void)),
+  );
+  yield* Scope.addFinalizer(
+    input.parentScope,
+    Effect.suspend(() => (closeCompleted ? Effect.void : close)),
+  );
+
+  const releaseSubscriber = Effect.fn(
+    "ViewServerRuntime.grpc.leased.subscription.releaseSubscriber",
+  )(function* (
+    activeClientLease: ActiveClientLease,
+    closeDisposition: Deferred.Deferred<ClientCloseDisposition>,
+  ) {
+    const disposition = yield* lock.withPermit(
+      Effect.gen(function* () {
+        activeClientLeases.delete(activeClientLease);
+        subscribers -= 1;
+        yield* input.onSubscriberRemoved;
+        if (closing) {
+          return "Join" as const;
+        }
+        if (subscribers > 0) {
+          return "None" as const;
+        }
+        closing = true;
+        acceptingSubscribers = false;
+        yield* input.onStopping;
+        return "Initiate" as const;
+      }),
+    );
+    yield* Deferred.succeed(closeDisposition, disposition);
+  });
+
+  const acquire: Effect.Effect<Option.Option<GrpcLeasedSubscriptionLease>> = Effect.uninterruptible(
+    lock.withPermit(
+      Effect.gen(function* () {
+        if (!acceptingSubscribers) {
+          return Option.none<GrpcLeasedSubscriptionLease>();
+        }
+        const leaseScope = yield* Scope.fork(scope, "sequential");
+        const terminal = yield* Deferred.make<SubscriptionTerminal>();
+        const terminalRegistration = yield* makeSubscriptionTerminalRegistration(terminal);
+        const closeDisposition = yield* Deferred.make<ClientCloseDisposition>();
+        const closeChild = (yield* Effect.cached(Scope.close(leaseScope, Exit.void))).pipe(
+          Effect.uninterruptible,
+        );
+        const activeClientLease: ActiveClientLease = {
+          markClosed: Deferred.succeed(terminal, closedSubscriptionTerminal),
+          closeChild,
+          notifyUpstream: (upstream) =>
+            Deferred.succeed(terminal, {
+              _tag: "Upstream",
+              message: upstream.message,
+            }),
+        };
+        subscribers += 1;
+        activeClientLeases.add(activeClientLease);
+        yield* Scope.addFinalizer(
+          leaseScope,
+          releaseSubscriber(activeClientLease, closeDisposition),
+        );
+        yield* input.onSubscriberAdded;
+
+        const closeLease = (yield* Effect.cached(
+          runAllFinalizers([
+            Deferred.succeed(terminal, closedSubscriptionTerminal),
+            closeChild,
+            Deferred.await(closeDisposition).pipe(
+              Effect.flatMap((disposition) =>
+                disposition === "None"
+                  ? Effect.void
+                  : disposition === "Initiate"
+                    ? close
+                    : awaitClose,
+              ),
+            ),
+          ]),
+        )).pipe(Effect.uninterruptible);
+        const closeAfterTerminalClaim = runAllFinalizers([
+          closeChild,
+          Deferred.await(closeDisposition).pipe(
+            Effect.flatMap((disposition) => (disposition === "Initiate" ? close : Effect.void)),
+          ),
+        ]);
+
+        const attach = <Row extends object>({
+          query,
+          subscription,
+        }: GrpcLeasedSubscriptionAttachInput<Row>): Effect.Effect<
+          ViewServerLiveSubscription<Row>
+        > =>
+          Effect.gen(function* () {
+            const resultKeys = input.identity.resultKeys<Row>(
+              query,
+              input.groupedKeyRetentionObserver,
+            );
+            yield* Scope.addFinalizer(
+              leaseScope,
+              subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
+            );
+            yield* Scope.addFinalizer(
+              leaseScope,
+              Effect.sync(() => resultKeys.clear()),
+            );
+
+            const runtimeTerminal: RuntimeSubscriptionTerminal = {
+              _tag: "Runtime",
+            };
+            const claimRuntimeTerminal = (nextTerminal: RuntimeSubscriptionTerminal) =>
+              Effect.gen(function* () {
+                yield* Deferred.succeed(terminal, nextTerminal);
+                return (yield* Deferred.await(terminal)) === nextTerminal;
+              });
+            const runtimeEvents = subscription.events.pipe(
+              Stream.map((event) => externalizeLeasedEvent(resultKeys, event)),
+              Stream.filterEffect((translated) => {
+                if (isResultKeyTranslationFailure(translated)) {
+                  return claimRuntimeTerminal(runtimeTerminal);
+                }
+                if (isTerminalStatusEvent(translated)) {
+                  return Effect.succeed(false);
+                }
+                return Effect.succeed(true);
+              }),
+              Stream.takeUntil(isResultKeyTranslationFailure),
+              Stream.map((translated) =>
+                isResultKeyTranslationFailure(translated)
+                  ? resultKeyEncodingErrorStatus(input.topic, translated.queryId, translated.error)
+                  : translated,
+              ),
+            );
+            const terminalStatusEvents = Stream.fromEffect(Deferred.await(terminal)).pipe(
+              Stream.flatMap((nextTerminal) => {
+                if (nextTerminal._tag === "Engine") {
+                  return Stream.succeed(nextTerminal.status);
+                }
+                if (nextTerminal._tag === "Upstream") {
+                  return Stream.fromEffect(Deferred.await(terminalRegistration.queryId)).pipe(
+                    Stream.map(
+                      (queryId): StatusEvent => ({
+                        type: "status",
+                        topic: input.topic,
+                        queryId,
+                        status: "error",
+                        code: "RuntimeUnavailable",
+                        message: nextTerminal.message,
+                      }),
+                    ),
+                  );
+                }
+                return Stream.empty;
+              }),
+            );
+            const closeAfterTerminal = Deferred.await(terminal).pipe(
+              Effect.flatMap((nextTerminal) => {
+                if (nextTerminal._tag === "Engine") {
+                  return Deferred.await(nextTerminal.ready).pipe(
+                    Effect.andThen(closeAfterTerminalClaim),
+                  );
+                }
+                return nextTerminal._tag === "Runtime" || nextTerminal._tag === "Upstream"
+                  ? closeAfterTerminalClaim
+                  : Effect.void;
+              }),
+            );
+            yield* closeAfterTerminal.pipe(Effect.forkIn(leaseScope, { startImmediately: true }));
+            const closeEvents = Deferred.isDone(terminal).pipe(
+              Effect.flatMap((terminalDone) =>
+                terminalDone
+                  ? Deferred.await(terminal).pipe(
+                      Effect.flatMap((claimedTerminal) =>
+                        claimedTerminal._tag === "Closed"
+                          ? runAllFinalizers([activeClientLease.markClosed, closeChild])
+                          : closeLease,
+                      ),
+                    )
+                  : closeLease,
+              ),
+            );
+            return {
+              events: runtimeEvents.pipe(
+                Stream.concat(terminalStatusEvents),
+                Stream.takeUntil(isTerminalStatusEvent),
+                Stream.ensuring(closeEvents),
+              ),
+              close: () => closeLease,
+            } satisfies ViewServerLiveSubscription<Row>;
+          });
+
+        return Option.some({
+          terminalObserver: terminalRegistration.observer,
+          attach,
+          close: closeLease,
+        });
+      }),
+    ),
+  );
+
+  const start = Effect.fn("ViewServerRuntime.grpc.leased.subscription.start")(function* (
+    startInput: GrpcLeasedSubscriptionStart<Error>,
+  ) {
+    const release = (yield* Effect.cached(startInput.release)).pipe(Effect.uninterruptible);
+    yield* Scope.addFinalizer(scope, release);
+    const runUpstream = yield* startInput.acquire;
+    const terminate = Effect.fn("ViewServerRuntime.grpc.leased.subscription.terminate")(function* (
+      terminal: GrpcLeasedUpstreamTerminal,
+    ) {
+      const activeClients = yield* lock.withPermit(
+        Effect.sync(() => {
+          acceptingSubscribers = false;
+          closing = true;
+          return Array.from(activeClientLeases);
+        }).pipe(Effect.when(Effect.sync(() => acceptingSubscribers))),
+      );
+      yield* Effect.forEach(
+        Option.toArray(activeClients),
+        (clients) =>
+          runAllFinalizers([
+            release,
+            input.onUpstreamTerminal(terminal),
+            Effect.gen(function* () {
+              const cleanupExit = yield* cleanupRowsExit;
+              if (Exit.isFailure(cleanupExit)) {
+                yield* input.onCleanupFailure(cleanupExit.cause);
+              }
+            }),
+            ...clients.map((client) => client.notifyUpstream(terminal)),
+            close,
+          ]),
+        { discard: true },
+      );
+    });
+    yield* runUpstream.pipe(
+      Effect.flatMap(terminate),
+      Effect.forkIn(scope, { startImmediately: true }),
+    );
+  });
+
+  const internalizeRowKey = <Row extends object>(
+    row: Row,
+  ): Result.Result<GrpcLeasedInternalRowKey, GrpcLeasedIdentityError> => {
+    const internalKey = input.identity.internalizeRowKey(row);
+    if (Result.isSuccess(internalKey)) {
+      storageKeys.add(internalKey.success.storageKey);
+    }
+    return internalKey;
+  };
+
+  return {
+    feedKey: input.identity.feedKey,
+    materializeRoute: input.identity.materializeRoute,
+    validateRowRoute: input.identity.validateRowRoute,
+    internalizeRowKey,
+    retainedRowCount: () => storageKeys.size,
+    acquire,
+    start,
+    close,
+  };
+});

--- a/packages/runtime/src/grpc-leased-subscription.ts
+++ b/packages/runtime/src/grpc-leased-subscription.ts
@@ -221,19 +221,28 @@ export const makeGrpcLeasedSubscription = Effect.fn(
     ),
   );
 
+  const cleanupRowsOutcome = yield* Effect.cached(
+    Effect.gen(function* () {
+      const cleanupExit = yield* cleanupRowsExit;
+      if (Exit.isFailure(cleanupExit)) {
+        yield* input.onCleanupFailure(cleanupExit.cause);
+      }
+      return cleanupExit;
+    }),
+  );
+
   const finalize = Effect.fn("ViewServerRuntime.grpc.leased.subscription.finalize")(function* () {
-    const cleanupExit = yield* cleanupRowsExit;
+    const cleanupExit = yield* cleanupRowsOutcome;
     if (Exit.isFailure(cleanupExit)) {
-      yield* input.onCleanupFailure(cleanupExit.cause);
       return;
     }
     yield* input.onClosed;
   });
   yield* Scope.addFinalizer(scope, finalize());
 
-  const close = (yield* Effect.cached(
-    lock
-      .withPermit(
+  const closeSubscription = Effect.fn("ViewServerRuntime.grpc.leased.subscription.close")(
+    function* () {
+      const clientCloses = yield* lock.withPermit(
         Effect.gen(function* () {
           const shouldStop = acceptingSubscribers && subscribers > 0;
           acceptingSubscribers = false;
@@ -245,23 +254,24 @@ export const makeGrpcLeasedSubscription = Effect.fn(
             runAllFinalizers([lease.markClosed, lease.closeChild]),
           );
         }),
-      )
-      .pipe(
-        Effect.flatMap((clientCloses) =>
-          runAllFinalizers([...clientCloses, Scope.close(scope, Exit.void)]),
-        ),
-        Effect.onExit(() =>
-          Effect.sync(() => {
-            closeCompleted = true;
-          }),
-        ),
-        Effect.exit,
-        Effect.flatMap((exit) =>
-          Deferred.succeed(closeExit, exit).pipe(
-            Effect.andThen(Exit.isFailure(exit) ? Effect.failCause(exit.cause) : Effect.void),
-          ),
+      );
+      yield* runAllFinalizers([...clientCloses, Scope.close(scope, Exit.void)]);
+    },
+  );
+  const close = (yield* Effect.cached(
+    closeSubscription().pipe(
+      Effect.onExit(() =>
+        Effect.sync(() => {
+          closeCompleted = true;
+        }),
+      ),
+      Effect.exit,
+      Effect.flatMap((exit) =>
+        Deferred.succeed(closeExit, exit).pipe(
+          Effect.andThen(Exit.isFailure(exit) ? Effect.failCause(exit.cause) : Effect.void),
         ),
       ),
+    ),
   )).pipe(Effect.uninterruptible);
   const awaitClose = Deferred.await(closeExit).pipe(
     Effect.flatMap((exit) => (Exit.isFailure(exit) ? Effect.failCause(exit.cause) : Effect.void)),
@@ -349,109 +359,105 @@ export const makeGrpcLeasedSubscription = Effect.fn(
           ),
         ]);
 
-        const attach = <Row extends object>({
-          query,
-          subscription,
-        }: GrpcLeasedSubscriptionAttachInput<Row>): Effect.Effect<
-          ViewServerLiveSubscription<Row>
-        > =>
-          Effect.gen(function* () {
-            const resultKeys = input.identity.resultKeys<Row>(
-              query,
-              input.groupedKeyRetentionObserver,
-            );
-            yield* Scope.addFinalizer(
-              leaseScope,
-              subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
-            );
-            yield* Scope.addFinalizer(
-              leaseScope,
-              Effect.sync(() => resultKeys.clear()),
-            );
+        const attach = Effect.fn("ViewServerRuntime.grpc.leased.subscription.attach")(function* <
+          Row extends object,
+        >({ query, subscription }: GrpcLeasedSubscriptionAttachInput<Row>) {
+          const resultKeys = input.identity.resultKeys<Row>(
+            query,
+            input.groupedKeyRetentionObserver,
+          );
+          yield* Scope.addFinalizer(
+            leaseScope,
+            subscription.close().pipe(ignoreLeasedSubscriptionCloseFailure),
+          );
+          yield* Scope.addFinalizer(
+            leaseScope,
+            Effect.sync(() => resultKeys.clear()),
+          );
 
-            const runtimeTerminal: RuntimeSubscriptionTerminal = {
-              _tag: "Runtime",
-            };
-            const claimRuntimeTerminal = (nextTerminal: RuntimeSubscriptionTerminal) =>
-              Effect.gen(function* () {
-                yield* Deferred.succeed(terminal, nextTerminal);
-                return (yield* Deferred.await(terminal)) === nextTerminal;
-              });
-            const runtimeEvents = subscription.events.pipe(
-              Stream.map((event) => externalizeLeasedEvent(resultKeys, event)),
-              Stream.filterEffect((translated) => {
-                if (isResultKeyTranslationFailure(translated)) {
-                  return claimRuntimeTerminal(runtimeTerminal);
-                }
-                if (isTerminalStatusEvent(translated)) {
-                  return Effect.succeed(false);
-                }
-                return Effect.succeed(true);
-              }),
-              Stream.takeUntil(isResultKeyTranslationFailure),
-              Stream.map((translated) =>
-                isResultKeyTranslationFailure(translated)
-                  ? resultKeyEncodingErrorStatus(input.topic, translated.queryId, translated.error)
-                  : translated,
-              ),
-            );
-            const terminalStatusEvents = Stream.fromEffect(Deferred.await(terminal)).pipe(
-              Stream.flatMap((nextTerminal) => {
-                if (nextTerminal._tag === "Engine") {
-                  return Stream.succeed(nextTerminal.status);
-                }
-                if (nextTerminal._tag === "Upstream") {
-                  return Stream.fromEffect(Deferred.await(terminalRegistration.queryId)).pipe(
-                    Stream.map(
-                      (queryId): StatusEvent => ({
-                        type: "status",
-                        topic: input.topic,
-                        queryId,
-                        status: "error",
-                        code: "RuntimeUnavailable",
-                        message: nextTerminal.message,
-                      }),
+          const runtimeTerminal: RuntimeSubscriptionTerminal = {
+            _tag: "Runtime",
+          };
+          const claimRuntimeTerminal = (nextTerminal: RuntimeSubscriptionTerminal) =>
+            Effect.gen(function* () {
+              yield* Deferred.succeed(terminal, nextTerminal);
+              return (yield* Deferred.await(terminal)) === nextTerminal;
+            });
+          const runtimeEvents = subscription.events.pipe(
+            Stream.map((event) => externalizeLeasedEvent(resultKeys, event)),
+            Stream.filterEffect((translated) => {
+              if (isResultKeyTranslationFailure(translated)) {
+                return claimRuntimeTerminal(runtimeTerminal);
+              }
+              if (isTerminalStatusEvent(translated)) {
+                return Effect.succeed(false);
+              }
+              return Effect.succeed(true);
+            }),
+            Stream.takeUntil(isResultKeyTranslationFailure),
+            Stream.map((translated) =>
+              isResultKeyTranslationFailure(translated)
+                ? resultKeyEncodingErrorStatus(input.topic, translated.queryId, translated.error)
+                : translated,
+            ),
+          );
+          const terminalStatusEvents = Stream.fromEffect(Deferred.await(terminal)).pipe(
+            Stream.flatMap((nextTerminal) => {
+              if (nextTerminal._tag === "Engine") {
+                return Stream.succeed(nextTerminal.status);
+              }
+              if (nextTerminal._tag === "Upstream") {
+                return Stream.fromEffect(Deferred.await(terminalRegistration.queryId)).pipe(
+                  Stream.map(
+                    (queryId): StatusEvent => ({
+                      type: "status",
+                      topic: input.topic,
+                      queryId,
+                      status: "error",
+                      code: "RuntimeUnavailable",
+                      message: nextTerminal.message,
+                    }),
+                  ),
+                );
+              }
+              return Stream.empty;
+            }),
+          );
+          const closeAfterTerminal = Deferred.await(terminal).pipe(
+            Effect.flatMap((nextTerminal) => {
+              if (nextTerminal._tag === "Engine") {
+                return Deferred.await(nextTerminal.ready).pipe(
+                  Effect.andThen(closeAfterTerminalClaim),
+                );
+              }
+              return nextTerminal._tag === "Runtime" || nextTerminal._tag === "Upstream"
+                ? closeAfterTerminalClaim
+                : Effect.void;
+            }),
+          );
+          yield* closeAfterTerminal.pipe(Effect.forkIn(leaseScope, { startImmediately: true }));
+          const closeEvents = Deferred.isDone(terminal).pipe(
+            Effect.flatMap((terminalDone) =>
+              terminalDone
+                ? Deferred.await(terminal).pipe(
+                    Effect.flatMap((claimedTerminal) =>
+                      claimedTerminal._tag === "Closed"
+                        ? runAllFinalizers([activeClientLease.markClosed, closeChild])
+                        : closeLease,
                     ),
-                  );
-                }
-                return Stream.empty;
-              }),
-            );
-            const closeAfterTerminal = Deferred.await(terminal).pipe(
-              Effect.flatMap((nextTerminal) => {
-                if (nextTerminal._tag === "Engine") {
-                  return Deferred.await(nextTerminal.ready).pipe(
-                    Effect.andThen(closeAfterTerminalClaim),
-                  );
-                }
-                return nextTerminal._tag === "Runtime" || nextTerminal._tag === "Upstream"
-                  ? closeAfterTerminalClaim
-                  : Effect.void;
-              }),
-            );
-            yield* closeAfterTerminal.pipe(Effect.forkIn(leaseScope, { startImmediately: true }));
-            const closeEvents = Deferred.isDone(terminal).pipe(
-              Effect.flatMap((terminalDone) =>
-                terminalDone
-                  ? Deferred.await(terminal).pipe(
-                      Effect.flatMap((claimedTerminal) =>
-                        claimedTerminal._tag === "Closed"
-                          ? runAllFinalizers([activeClientLease.markClosed, closeChild])
-                          : closeLease,
-                      ),
-                    )
-                  : closeLease,
-              ),
-            );
-            return {
-              events: runtimeEvents.pipe(
-                Stream.concat(terminalStatusEvents),
-                Stream.takeUntil(isTerminalStatusEvent),
-                Stream.ensuring(closeEvents),
-              ),
-              close: () => closeLease,
-            } satisfies ViewServerLiveSubscription<Row>;
-          });
+                  )
+                : closeLease,
+            ),
+          );
+          return {
+            events: runtimeEvents.pipe(
+              Stream.concat(terminalStatusEvents),
+              Stream.takeUntil(isTerminalStatusEvent),
+              Stream.ensuring(closeEvents),
+            ),
+            close: () => closeLease,
+          } satisfies ViewServerLiveSubscription<Row>;
+        });
 
         return Option.some({
           terminalObserver: terminalRegistration.observer,
@@ -484,12 +490,7 @@ export const makeGrpcLeasedSubscription = Effect.fn(
           runAllFinalizers([
             release,
             input.onUpstreamTerminal(terminal),
-            Effect.gen(function* () {
-              const cleanupExit = yield* cleanupRowsExit;
-              if (Exit.isFailure(cleanupExit)) {
-                yield* input.onCleanupFailure(cleanupExit.cause);
-              }
-            }),
+            cleanupRowsOutcome.pipe(Effect.asVoid),
             ...clients.map((client) => client.notifyUpstream(terminal)),
             close,
           ]),


### PR DESCRIPTION
Closes #342

## What

- introduce a deep leased gRPC Subscription module that owns the upstream worker, client leases, terminal arbitration, result-key translation, retained storage keys, and lifecycle cleanup
- make backpressure, upstream termination, interruption, client close, and runtime close converge through one cached exact-once finalization path
- detach completed Subscription owner scopes from the manager scope while preserving manager-close joins
- keep route retirement installed until health removal finishes so replacement acquisition cannot race stale health cleanup
- split direct Subscription lifecycle and cleanup coverage from manager query, validation, routing, and lifecycle coverage

## Why

The lease manager previously spread one Subscription lifetime across manager-owned registries and scopes. That made terminal races, overlapping close paths, cleanup failures, retained rows, and health-route retirement harder to coordinate and allowed completed routes to retain parent-scope finalizers.

Each leased feed now has one Subscription-owned lifetime. Whichever terminal source wins closes the same scoped resources and all concurrent closers join the same cached outcome.

## Validation

- focused leased Subscription and lifecycle tests: 32 passed
- focused behavioral-owner review suites: 79 passed
- full runtime suite: 462 passed with 100% statement, branch, function, and line coverage
- `vp check`
- strict Effect diagnostics: 95 files, zero findings
- `vp run -w bench:baseline:smoke`
- `vp run -w bench:baseline:grpc-materialized`
- `vp run -w bench:baseline:grpc-leased`
- `vp run -w bench:baseline:grpc-leased-retained` with 50,000 retained rows
- independent Effect, Vitest, and architecture reviews: clean, no blocking or non-blocking findings
