### PR TITLE
Execute active queries through an acyclic Topic Store interface

### DIFF
--- a/packages/column-live-view-engine/src/active-materialized-query.ts
+++ b/packages/column-live-view-engine/src/active-materialized-query.ts
@@ -1,24 +1,16 @@
 import { Effect, Option } from "effect";
 import type { SnapshotEvent, DeltaEvent } from "@effect-view-server/config";
-import type { ActiveQueryStoreState, LiveQueryExecution } from "./active-query";
+import type {
+  ActiveQueryRegistry,
+  LiveQueryExecution,
+  MaterializedQueryExecution,
+  MaterializedQueryExecutionSlot,
+} from "./active-query-contract";
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
-import type { QueryEvaluation } from "./query-result";
-import type { GroupedIncrementalExecutionDiagnosticCounts } from "./grouped-incremental-execution";
 import type { QueryResultSemantics } from "./query-result-semantics";
+import type { TopicStoreQueryInterface } from "./topic-store-query-interface";
 
 type RowObject = object;
-
-export type MaterializedQueryExecution = {
-  readonly diagnostics: () => GroupedIncrementalExecutionDiagnosticCounts;
-  readonly incremental: boolean;
-  readonly latest: () => QueryEvaluation<object>;
-};
-
-export type MaterializedQueryExecutionSlot = {
-  readonly execution: MaterializedQueryExecution;
-  readonly releaseRetainedChanges: () => void;
-  refs: number;
-};
 
 export type MaterializedQueryExecutionModeCounts = {
   readonly activeFallback: number;
@@ -29,13 +21,13 @@ export type MaterializedQueryExecutionModeCounts = {
 };
 
 const getActiveMaterializedQueryMap = (
-  store: ActiveQueryStoreState,
+  registry: ActiveQueryRegistry,
 ): Map<string, MaterializedQueryExecutionSlot> => {
-  return store.activeQueries.materialized;
+  return registry.materialized;
 };
 
 const leaseMaterializedQueryExecution = <ResultRow extends RowObject>(
-  store: ActiveQueryStoreState,
+  store: TopicStoreQueryInterface,
   execution: MaterializedQueryExecution,
   resultSemantics: QueryResultSemantics<ResultRow>,
 ): LiveQueryExecution<ResultRow> => {
@@ -66,13 +58,14 @@ const leaseMaterializedQueryExecution = <ResultRow extends RowObject>(
 export const acquireMaterializedQueryExecution = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.materialized.acquire",
 )(function <ResultRow extends RowObject>(
-  store: ActiveQueryStoreState,
+  store: TopicStoreQueryInterface,
+  registry: ActiveQueryRegistry,
   cacheKey: string,
   resultSemantics: QueryResultSemantics<ResultRow>,
   makeExecution: (releaseRetainedChanges: () => void) => MaterializedQueryExecution,
 ) {
   return Effect.sync(() => {
-    const map = getActiveMaterializedQueryMap(store);
+    const map = getActiveMaterializedQueryMap(registry);
     const existing = map.get(cacheKey);
     if (existing !== undefined) {
       const entry = existing;
@@ -104,9 +97,9 @@ export const acquireMaterializedQueryExecution = Effect.fn(
 
 export const releaseMaterializedQueryExecution = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.materialized.release",
-)((store: ActiveQueryStoreState, cacheKey: string) =>
+)((registry: ActiveQueryRegistry, cacheKey: string) =>
   Effect.sync(() => {
-    const map = getActiveMaterializedQueryMap(store);
+    const map = getActiveMaterializedQueryMap(registry);
     const existing = map.get(cacheKey);
     if (existing === undefined) {
       return undefined;
@@ -124,9 +117,9 @@ export const releaseMaterializedQueryExecution = Effect.fn(
 
 export const clearMaterializedQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.materialized.clearStore",
-)((store: ActiveQueryStoreState) =>
+)((registry: ActiveQueryRegistry) =>
   Effect.sync(() => {
-    const map = getActiveMaterializedQueryMap(store);
+    const map = getActiveMaterializedQueryMap(registry);
     for (const entry of map.values()) {
       entry.releaseRetainedChanges();
     }
@@ -136,18 +129,20 @@ export const clearMaterializedQueryExecutions = Effect.fn(
 
 export const activeMaterializedQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.materialized.countStore",
-)((store: ActiveQueryStoreState) => Effect.sync(() => getActiveMaterializedQueryMap(store).size));
+)((registry: ActiveQueryRegistry) =>
+  Effect.sync(() => getActiveMaterializedQueryMap(registry).size),
+);
 
 export const activeMaterializedQueryExecutionModeCounts = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.materialized.countModes",
-)((store: ActiveQueryStoreState) =>
+)((registry: ActiveQueryRegistry) =>
   Effect.sync(() => {
     let activeFallback = 0;
     let activeIncremental = 0;
     let groupedFullEvaluationCount = 0;
     let groupedPatchedEvaluationCount = 0;
 
-    for (const entry of getActiveMaterializedQueryMap(store).values()) {
+    for (const entry of getActiveMaterializedQueryMap(registry).values()) {
       if (entry.execution.incremental) {
         activeIncremental += 1;
       } else {

--- a/packages/column-live-view-engine/src/active-query-contract.ts
+++ b/packages/column-live-view-engine/src/active-query-contract.ts
@@ -1,0 +1,92 @@
+import type { DeltaEvent, SnapshotEvent } from "@effect-view-server/config";
+import type { Effect, Option } from "effect";
+import type { QueryEvaluation } from "./query-result";
+import type { RawQueryPlanWindow } from "./raw-query-plan";
+import type { TopicRowEntry } from "./row-scan";
+
+type RowObject = object;
+
+export type LiveQueryExecutionCursor = {
+  evaluation: QueryEvaluation<RowObject>;
+};
+
+type RawQueryExecutionUpdate<ResultRow extends RowObject> = Effect.Effect<
+  Option.Option<DeltaEvent<ResultRow>>,
+  never,
+  never
+>;
+
+export type LiveQueryExecution<ResultRow extends RowObject> = {
+  readonly initial: (queryId: string) => SnapshotEvent<ResultRow>;
+  readonly createCursor: () => LiveQueryExecutionCursor;
+  readonly next: (
+    queryId: string,
+    cursor: LiveQueryExecutionCursor,
+  ) => RawQueryExecutionUpdate<ResultRow>;
+};
+
+export type RawQueryExecution<ResultRow extends RowObject> = LiveQueryExecution<ResultRow>;
+
+export type ActiveQueryBaseEvaluation<Row extends RowObject> = {
+  readonly keyIndex: ReadonlyMap<string, number>;
+  readonly keys: ReadonlyArray<string>;
+  readonly retainedWindowFilled: boolean;
+  readonly totalRows: number;
+  readonly version: number;
+  readonly window: ReadonlyArray<RetainedWindowEntry<Row>>;
+};
+
+export type RetainedWindowEntry<Row extends RowObject = RowObject> = TopicRowEntry<Row> & {
+  readonly key: string;
+  readonly row: Row;
+  readonly slot?: number;
+};
+
+export type ActiveQueryBaseExecution = {
+  readonly latest: () => ActiveQueryBaseEvaluation<RowObject>;
+};
+
+export type RawQueryExecutionWindowSlot = {
+  readonly window: RawQueryPlanWindow;
+  refs: number;
+};
+
+export type RawQueryExecutionSlot = {
+  readonly execution: ActiveQueryBaseExecution;
+  readonly releaseRetainedChanges: () => void;
+  readonly windows: Map<string, RawQueryExecutionWindowSlot>;
+  refs: number;
+};
+
+export type MaterializedQueryExecution = {
+  readonly diagnostics: () => {
+    readonly fullEvaluationCount: number;
+    readonly patchedEvaluationCount: number;
+  };
+  readonly incremental: boolean;
+  readonly latest: () => QueryEvaluation<RowObject>;
+};
+
+export type MaterializedQueryExecutionSlot = {
+  readonly execution: MaterializedQueryExecution;
+  readonly releaseRetainedChanges: () => void;
+  refs: number;
+};
+
+export type ActiveQueryRegistry = {
+  readonly raw: Map<string, RawQueryExecutionSlot>;
+  readonly materialized: Map<string, MaterializedQueryExecutionSlot>;
+};
+
+export type ActiveQueryExecutionCounts = {
+  readonly activeFallbackGroupedViews: number;
+  readonly activeIncrementalGroupedViews: number;
+  readonly activeViews: number;
+  readonly groupedFullEvaluationCount: number;
+  readonly groupedPatchedEvaluationCount: number;
+};
+
+export const createActiveQueryRegistry = (): ActiveQueryRegistry => ({
+  raw: new Map(),
+  materialized: new Map(),
+});

--- a/packages/column-live-view-engine/src/active-query-grouped.test.ts
+++ b/packages/column-live-view-engine/src/active-query-grouped.test.ts
@@ -4,14 +4,14 @@ import { fromStringUnsafe } from "effect/BigDecimal";
 import { defaultGroupedIncrementalAdmissionLimits, InvalidRowError } from "./index";
 import {
   acquireMaterializedQueryExecution,
+  activeQueryTestInterface,
   releaseMaterializedQueryExecution,
-} from "./active-query";
+} from "../test-harness/active-query-interface";
 import { rawQueryCompilerMetadata } from "./raw-query-compiler";
 import { prepareRuntimeGroupedQuery } from "./grouped-query-compiler";
 import { makeIncrementalGroupedQueryExecution } from "./grouped-incremental-execution";
 import type { TopicRowChangeBatch } from "./row-scan";
 import { publishTopicStoreRow, TopicStore } from "./topic-store";
-import { topicStoreReadModel } from "./topic-store-state";
 import {
   applyDelta,
   expectDefined,
@@ -1406,7 +1406,7 @@ describe("Grouped incremental query execution", () => {
       yield* publishTopicStoreRow(store, order("initial", "open", 10, 1), (topic, message) =>
         InvalidRowError.make({ topic, message }),
       );
-      const readModel = topicStoreReadModel(store);
+      const readModel = activeQueryTestInterface(store);
       const compiled = yield* prepareRuntimeGroupedQuery(
         "orders",
         rawQueryCompilerMetadata(Order),

--- a/packages/column-live-view-engine/src/active-query-lifecycle.test.ts
+++ b/packages/column-live-view-engine/src/active-query-lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import {
+  acquireRawQueryExecution,
+  activeQueryTestInterface,
+  activeQueryTestMetadata,
+  activeStoreRawQueryExecutionCount,
+  releaseRawQueryExecution,
+} from "../test-harness/active-query-interface";
+import { prepareRuntimeRawQuery } from "./raw-query-compiler";
+import { publishTopicStoreRow, resetTopicStore, TopicStore } from "./topic-store";
+
+const invalidRow = (_topic: string, message: string): Error => new Error(message);
+describe("column-live-view-engine Active Query lifecycle", () => {
+  it.effect("releases retained raw changes when a topic reset clears active queries", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "raw-insert-reset-release",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const queryInterface = activeQueryTestInterface(store);
+      const compiled = yield* prepareRuntimeRawQuery(
+        "raw-insert-reset-release",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          limit: 2,
+        },
+      );
+
+      yield* acquireRawQueryExecution(queryInterface, compiled);
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+      expect(queryInterface.changesSince(3)).toBeDefined();
+
+      yield* resetTopicStore(store);
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(0);
+
+      yield* publishTopicStoreRow(store, { id: "e", status: "open", score: 5 }, invalidRow);
+      expect(queryInterface.changesSince(0)).toBeUndefined();
+    }),
+  );
+
+  it.effect("no-ops release when execution cache does not contain a query", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "numbers",
+        Schema.Struct({ id: Schema.String, score: Schema.Number }),
+        "id",
+        () => {},
+      );
+      const compiled = yield* prepareRuntimeRawQuery("numbers", activeQueryTestMetadata(store), {
+        select: ["id"],
+        where: {
+          score: 1,
+        },
+      });
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), compiled);
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/active-query-materialization.test.ts
+++ b/packages/column-live-view-engine/src/active-query-materialization.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Cause, Effect, Exit, Option, Result, Schema } from "effect";
+import {
+  acquireMaterializedQueryExecution,
+  acquireRawQueryExecution,
+  activeQueryTestInterface,
+  activeQueryTestMetadata,
+  activeStoreRawQueryExecutionCount,
+  createActiveQueryRegistry,
+  releaseMaterializedQueryExecution,
+  releaseRawQueryExecution,
+} from "../test-harness/active-query-interface";
+import { replaceRetainedMatchingEntryAtIndex } from "./active-raw-query";
+import { prepareRuntimeRawQuery } from "./raw-query-compiler";
+import { makeQueryResultSemantics } from "./query-result-semantics";
+import { publishTopicStoreRow, TopicStore } from "./topic-store";
+
+const invalidRow = (_topic: string, message: string): Error => new Error(message);
+const emptyResultSemantics = makeQueryResultSemantics([]);
+
+describe("column-live-view-engine Active Query materialization", () => {
+  it("falls back when an indexed retained replacement points at a different key", () => {
+    const windowEntries = [
+      { key: "a", row: { id: "a", score: 2 } },
+      { key: "b", row: { id: "b", score: 1 } },
+    ];
+    const replaced = replaceRetainedMatchingEntryAtIndex(
+      windowEntries,
+      0,
+      "b",
+      { id: "b", score: 3 },
+      (left, right) => right.row.score - left.row.score,
+      50,
+    );
+
+    expect(replaced).toBeUndefined();
+    expect(windowEntries).toStrictEqual([
+      { key: "a", row: { id: "a", score: 2 } },
+      { key: "b", row: { id: "b", score: 1 } },
+    ]);
+  });
+
+  it.effect("binds a storage projection once per raw execution lease", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "projection-bind-frequency",
+        Schema.Struct({
+          id: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", score: 1 }, invalidRow);
+      const queryInterface = activeQueryTestInterface(store);
+      const storageProjection = Option.getOrThrow(
+        Option.fromUndefinedOr(queryInterface.storageProjection),
+      );
+      let projectionReads = 0;
+      const observedQueryInterface = {
+        ...queryInterface,
+        get storageProjection() {
+          projectionReads += 1;
+          return storageProjection;
+        },
+      };
+      const compiled = yield* prepareRuntimeRawQuery(
+        "projection-bind-frequency",
+        activeQueryTestMetadata(store),
+        { select: ["id", "score"] },
+      );
+
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
+      const cursor = execution.createCursor();
+      expect(execution.initial("query").rows).toStrictEqual([{ id: "a", score: 1 }]);
+      expect((yield* execution.next("query", cursor))._tag).toBe("None");
+      yield* publishTopicStoreRow(store, { id: "b", score: 2 }, invalidRow);
+      expect((yield* execution.next("query", cursor))._tag).toBe("Some");
+      expect(projectionReads).toBe(1);
+
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
+    }),
+  );
+
+  it.effect("rejects incompatible projection proofs before acquiring raw execution ownership", () =>
+    Effect.gen(function* () {
+      const target = new TopicStore(
+        "projection-ownership-target",
+        Schema.Struct({
+          id: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      const incompatible = new TopicStore(
+        "projection-ownership-incompatible",
+        Schema.Struct({
+          id: Schema.String,
+          score: Schema.String,
+        }),
+        "id",
+        () => {},
+      );
+      const targetQueryInterface = activeQueryTestInterface(target);
+      const targetCompiled = yield* prepareRuntimeRawQuery(
+        "projection-ownership-target",
+        activeQueryTestMetadata(target),
+        { select: ["id"] },
+      );
+      const incompatibleCompiled = yield* prepareRuntimeRawQuery(
+        "projection-ownership-incompatible",
+        activeQueryTestMetadata(incompatible),
+        { select: ["id"] },
+      );
+
+      const emptyRegistryExit = yield* Effect.exit(
+        acquireRawQueryExecution(targetQueryInterface, incompatibleCompiled),
+      );
+      const emptyRegistryError = Exit.match(emptyRegistryExit, {
+        onFailure: (cause) =>
+          Result.match(Cause.findDefect(cause), {
+            onFailure: () => "missing projection binding error",
+            onSuccess: (defect) =>
+              defect instanceof Error ? defect.message : "unexpected non-error defect",
+          }),
+        onSuccess: () => "unexpected projection binding success",
+      });
+      expect(emptyRegistryError).toBe(
+        "Topic Storage projection schema does not match its compiled proof.",
+      );
+      expect(yield* activeStoreRawQueryExecutionCount(targetQueryInterface)).toBe(0);
+
+      yield* acquireRawQueryExecution(targetQueryInterface, targetCompiled);
+      expect(yield* activeStoreRawQueryExecutionCount(targetQueryInterface)).toBe(1);
+      const existingEntryExit = yield* Effect.exit(
+        acquireRawQueryExecution(targetQueryInterface, incompatibleCompiled),
+      );
+      const existingEntryError = Exit.match(existingEntryExit, {
+        onFailure: (cause) =>
+          Result.match(Cause.findDefect(cause), {
+            onFailure: () => "missing projection binding error",
+            onSuccess: (defect) =>
+              defect instanceof Error ? defect.message : "unexpected non-error defect",
+          }),
+        onSuccess: () => "unexpected projection binding success",
+      });
+      expect(existingEntryError).toBe(
+        "Topic Storage projection schema does not match its compiled proof.",
+      );
+      expect(yield* activeStoreRawQueryExecutionCount(targetQueryInterface)).toBe(1);
+
+      yield* releaseRawQueryExecution(targetQueryInterface, targetCompiled);
+      expect(yield* activeStoreRawQueryExecutionCount(targetQueryInterface)).toBe(0);
+    }),
+  );
+
+  it.effect("keeps materialized execution caches local to the active query registry", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "materialized-registry-isolation",
+        Schema.Struct({
+          id: Schema.String,
+        }),
+        "id",
+        () => {},
+      );
+      const queryInterface = activeQueryTestInterface(store);
+      const isolatedQueryInterface = {
+        ...queryInterface,
+        activeQueries: createActiveQueryRegistry(),
+      };
+
+      const emptyEvaluation = (version: number) => ({
+        rows: [],
+        keys: [],
+        window: [],
+        totalRows: 0,
+        version,
+      });
+
+      const emptyDiagnostics = () => ({
+        fullEvaluationCount: 0,
+        patchedEvaluationCount: 0,
+      });
+
+      const firstExecution = yield* acquireMaterializedQueryExecution(
+        queryInterface,
+        "grouped",
+        emptyResultSemantics,
+        () => ({
+          diagnostics: emptyDiagnostics,
+          incremental: false,
+          latest: () => emptyEvaluation(queryInterface.version()),
+        }),
+      );
+      const secondExecution = yield* acquireMaterializedQueryExecution(
+        isolatedQueryInterface,
+        "grouped",
+        emptyResultSemantics,
+        () => ({
+          diagnostics: emptyDiagnostics,
+          incremental: false,
+          latest: () => emptyEvaluation(isolatedQueryInterface.version()),
+        }),
+      );
+
+      expect(Object.isFrozen(firstExecution)).toBe(true);
+      expect(() => Object.assign(firstExecution, secondExecution)).toThrowError(TypeError);
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedQueryInterface)).toBe(1);
+
+      yield* releaseMaterializedQueryExecution(queryInterface, "grouped");
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(0);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedQueryInterface)).toBe(1);
+
+      yield* releaseMaterializedQueryExecution(isolatedQueryInterface, "grouped");
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedQueryInterface)).toBe(0);
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/active-query-raw.test.ts
+++ b/packages/column-live-view-engine/src/active-query-raw.test.ts
@@ -1,564 +1,22 @@
-import { fromStringUnsafe } from "effect/BigDecimal";
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit, Option, Result, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 import {
-  acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
-  activeStoreRawQueryExecutionCount,
-  createActiveQueryRegistry,
-  releaseMaterializedQueryExecution,
+  activeQueryTestInterface,
+  activeQueryTestMetadata,
   releaseRawQueryExecution,
-} from "./active-query";
-import { replaceRetainedMatchingEntryAtIndex } from "./active-raw-query";
-import { prepareRuntimeGroupedQuery } from "./grouped-query-compiler";
+} from "../test-harness/active-query-interface";
 import { prepareRuntimeRawQuery } from "./raw-query-compiler";
-import { makeQueryResultSemantics } from "./query-result-semantics";
 import {
   deleteTopicStoreRow,
   patchTopicStoreRow,
   publishTopicStoreRow,
   publishTopicStoreRows,
-  resetTopicStore,
   TopicStore,
 } from "./topic-store";
-import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 
 const invalidRow = (_topic: string, message: string): Error => new Error(message);
-const emptyResultSemantics = makeQueryResultSemantics([]);
-
-describe("column-live-view-engine active query execution", () => {
-  it("falls back when an indexed retained replacement points at a different key", () => {
-    const windowEntries = [
-      { key: "a", row: { id: "a", score: 2 } },
-      { key: "b", row: { id: "b", score: 1 } },
-    ];
-    const replaced = replaceRetainedMatchingEntryAtIndex(
-      windowEntries,
-      0,
-      "b",
-      { id: "b", score: 3 },
-      (left, right) => right.row.score - left.row.score,
-      50,
-    );
-
-    expect(replaced).toBeUndefined();
-    expect(windowEntries).toStrictEqual([
-      { key: "a", row: { id: "a", score: 2 } },
-      { key: "b", row: { id: "b", score: 1 } },
-    ]);
-  });
-
-  it.effect("reuses execution state for identical compiled raw queries", () =>
-    Effect.gen(function* () {
-      const rowSchema = Schema.Struct({
-        id: Schema.String,
-        status: Schema.String,
-        score: Schema.Number,
-        count: Schema.BigInt,
-        value: Schema.BigDecimal,
-      });
-      const store = new TopicStore("scores", rowSchema, "id", () => {});
-
-      yield* publishTopicStoreRow(
-        store,
-        {
-          id: "1",
-          status: "open",
-          score: 10,
-          count: 1n,
-          value: fromStringUnsafe("1.00"),
-        },
-        invalidRow,
-      );
-      yield* publishTopicStoreRow(
-        store,
-        {
-          id: "2",
-          status: "closed",
-          score: 20,
-          count: 2n,
-          value: fromStringUnsafe("2.00"),
-        },
-        invalidRow,
-      );
-
-      const compiled = yield* prepareRuntimeRawQuery("scores", topicStoreRawQueryMetadata(store), {
-        select: ["id", "score", "count", "value"],
-        where: {
-          status: "open",
-        },
-        orderBy: [
-          {
-            field: "score",
-            direction: "desc",
-          },
-        ],
-      });
-
-      const firstExecution = yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
-      const secondExecution = yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
-      expect(Object.isFrozen(firstExecution)).toBe(true);
-      expect(() => Object.assign(firstExecution, secondExecution)).toThrowError(TypeError);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-
-      const firstCursor = firstExecution.createCursor();
-      const secondCursor = secondExecution.createCursor();
-
-      const initialFirst = firstExecution.initial("query-a");
-      const initialSecond = secondExecution.initial("query-b");
-      expect(initialFirst.rows).toStrictEqual(initialSecond.rows);
-      expect(initialFirst.totalRows).toBe(1);
-      expect(initialFirst.keys).toStrictEqual(["1"]);
-
-      const beforePublishFirst = yield* firstExecution.next("query-a", firstCursor);
-      const beforePublishSecond = yield* secondExecution.next("query-b", secondCursor);
-      expect(beforePublishFirst._tag).toBe("None");
-      expect(beforePublishSecond._tag).toBe("None");
-
-      yield* publishTopicStoreRow(
-        store,
-        {
-          id: "3",
-          status: "open",
-          score: 5,
-          count: 3n,
-          value: fromStringUnsafe("3.00"),
-        },
-        invalidRow,
-      );
-
-      const afterPublishFirst = yield* firstExecution.next("query-a", firstCursor);
-      const afterPublishSecond = yield* secondExecution.next("query-b", secondCursor);
-      expect(afterPublishFirst._tag).toBe("Some");
-      expect(afterPublishSecond._tag).toBe("Some");
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      const afterRefcountDecrement = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
-        compiled,
-      );
-      expect(afterRefcountDecrement.initial("query-c").totalRows).toBe(2);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
-
-      const afterRefcountExhausted = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
-        compiled,
-      );
-      expect(afterRefcountExhausted.initial("query-d").totalRows).toBe(2);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
-    }),
-  );
-
-  it.effect("binds a storage projection once per raw execution lease", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "projection-bind-frequency",
-        Schema.Struct({
-          id: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", score: 1 }, invalidRow);
-      const readModel = topicStoreReadModel(store);
-      const storageProjection = Option.getOrThrow(
-        Option.fromUndefinedOr(readModel.storageProjection),
-      );
-      let projectionReads = 0;
-      const observedReadModel = {
-        ...readModel,
-        get storageProjection() {
-          projectionReads += 1;
-          return storageProjection;
-        },
-      };
-      const compiled = yield* prepareRuntimeRawQuery(
-        "projection-bind-frequency",
-        topicStoreRawQueryMetadata(store),
-        { select: ["id", "score"] },
-      );
-
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
-      const cursor = execution.createCursor();
-      expect(execution.initial("query").rows).toStrictEqual([{ id: "a", score: 1 }]);
-      expect((yield* execution.next("query", cursor))._tag).toBe("None");
-      yield* publishTopicStoreRow(store, { id: "b", score: 2 }, invalidRow);
-      expect((yield* execution.next("query", cursor))._tag).toBe("Some");
-      expect(projectionReads).toBe(1);
-
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
-    }),
-  );
-
-  it.effect("rejects incompatible projection proofs before acquiring raw execution ownership", () =>
-    Effect.gen(function* () {
-      const target = new TopicStore(
-        "projection-ownership-target",
-        Schema.Struct({
-          id: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      const incompatible = new TopicStore(
-        "projection-ownership-incompatible",
-        Schema.Struct({
-          id: Schema.String,
-          score: Schema.String,
-        }),
-        "id",
-        () => {},
-      );
-      const targetReadModel = topicStoreReadModel(target);
-      const targetCompiled = yield* prepareRuntimeRawQuery(
-        "projection-ownership-target",
-        topicStoreRawQueryMetadata(target),
-        { select: ["id"] },
-      );
-      const incompatibleCompiled = yield* prepareRuntimeRawQuery(
-        "projection-ownership-incompatible",
-        topicStoreRawQueryMetadata(incompatible),
-        { select: ["id"] },
-      );
-
-      const emptyRegistryExit = yield* Effect.exit(
-        acquireRawQueryExecution(targetReadModel, incompatibleCompiled),
-      );
-      const emptyRegistryError = Exit.match(emptyRegistryExit, {
-        onFailure: (cause) =>
-          Result.match(Cause.findDefect(cause), {
-            onFailure: () => "missing projection binding error",
-            onSuccess: (defect) =>
-              defect instanceof Error ? defect.message : "unexpected non-error defect",
-          }),
-        onSuccess: () => "unexpected projection binding success",
-      });
-      expect(emptyRegistryError).toBe(
-        "Topic Storage projection schema does not match its compiled proof.",
-      );
-      expect(yield* activeStoreRawQueryExecutionCount(targetReadModel)).toBe(0);
-
-      yield* acquireRawQueryExecution(targetReadModel, targetCompiled);
-      expect(yield* activeStoreRawQueryExecutionCount(targetReadModel)).toBe(1);
-      const existingEntryExit = yield* Effect.exit(
-        acquireRawQueryExecution(targetReadModel, incompatibleCompiled),
-      );
-      const existingEntryError = Exit.match(existingEntryExit, {
-        onFailure: (cause) =>
-          Result.match(Cause.findDefect(cause), {
-            onFailure: () => "missing projection binding error",
-            onSuccess: (defect) =>
-              defect instanceof Error ? defect.message : "unexpected non-error defect",
-          }),
-        onSuccess: () => "unexpected projection binding success",
-      });
-      expect(existingEntryError).toBe(
-        "Topic Storage projection schema does not match its compiled proof.",
-      );
-      expect(yield* activeStoreRawQueryExecutionCount(targetReadModel)).toBe(1);
-
-      yield* releaseRawQueryExecution(targetReadModel, targetCompiled);
-      expect(yield* activeStoreRawQueryExecutionCount(targetReadModel)).toBe(0);
-    }),
-  );
-
-  it.effect("keeps execution caches local to the active query registry", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "registry-isolation",
-        Schema.Struct({
-          id: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", score: 1 }, invalidRow);
-
-      const compiled = yield* prepareRuntimeRawQuery(
-        "registry-isolation",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          orderBy: [{ field: "score", direction: "desc" }],
-        },
-      );
-      const readModel = topicStoreReadModel(store);
-      const isolatedReadModel = {
-        ...readModel,
-        activeQueries: createActiveQueryRegistry(),
-      };
-
-      yield* acquireRawQueryExecution(readModel, compiled);
-      yield* acquireRawQueryExecution(isolatedReadModel, compiled);
-
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
-      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
-
-      yield* releaseRawQueryExecution(readModel, compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
-      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
-
-      yield* releaseRawQueryExecution(isolatedReadModel, compiled);
-      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(0);
-    }),
-  );
-
-  it.effect("keeps materialized execution caches local to the active query registry", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "materialized-registry-isolation",
-        Schema.Struct({
-          id: Schema.String,
-        }),
-        "id",
-        () => {},
-      );
-      const readModel = topicStoreReadModel(store);
-      const isolatedReadModel = {
-        ...readModel,
-        activeQueries: createActiveQueryRegistry(),
-      };
-
-      const emptyEvaluation = (version: number) => ({
-        rows: [],
-        keys: [],
-        window: [],
-        totalRows: 0,
-        version,
-      });
-
-      const emptyDiagnostics = () => ({
-        fullEvaluationCount: 0,
-        patchedEvaluationCount: 0,
-      });
-
-      const firstExecution = yield* acquireMaterializedQueryExecution(
-        readModel,
-        "grouped",
-        emptyResultSemantics,
-        () => ({
-          diagnostics: emptyDiagnostics,
-          incremental: false,
-          latest: () => emptyEvaluation(readModel.version()),
-        }),
-      );
-      const secondExecution = yield* acquireMaterializedQueryExecution(
-        isolatedReadModel,
-        "grouped",
-        emptyResultSemantics,
-        () => ({
-          diagnostics: emptyDiagnostics,
-          incremental: false,
-          latest: () => emptyEvaluation(isolatedReadModel.version()),
-        }),
-      );
-
-      expect(Object.isFrozen(firstExecution)).toBe(true);
-      expect(() => Object.assign(firstExecution, secondExecution)).toThrowError(TypeError);
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
-      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
-
-      yield* releaseMaterializedQueryExecution(readModel, "grouped");
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
-      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(1);
-
-      yield* releaseMaterializedQueryExecution(isolatedReadModel, "grouped");
-      expect(yield* activeStoreRawQueryExecutionCount(isolatedReadModel)).toBe(0);
-    }),
-  );
-
-  it.effect("shares base evaluation across different projections", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "projection-sharing",
-        Schema.Struct({
-          id: Schema.String,
-          status: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
-
-      const idOnly = yield* prepareRuntimeRawQuery(
-        "projection-sharing",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-        },
-      );
-      const idAndScore = yield* prepareRuntimeRawQuery(
-        "projection-sharing",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "score"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-        },
-      );
-
-      const idOnlyExecution = yield* acquireRawQueryExecution(topicStoreReadModel(store), idOnly);
-      const idAndScoreExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
-        idAndScore,
-      );
-
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      expect(idOnlyExecution.initial("ids").rows).toStrictEqual([{ id: "b" }, { id: "a" }]);
-      expect(idAndScoreExecution.initial("scores").rows).toStrictEqual([
-        { id: "b", score: 2 },
-        { id: "a", score: 1 },
-      ]);
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), idOnly);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), idAndScore);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
-    }),
-  );
-
-  it.effect("shares base evaluation across different windows", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "window-sharing",
-        Schema.Struct({
-          id: Schema.String,
-          status: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
-
-      const firstWindow = yield* prepareRuntimeRawQuery(
-        "window-sharing",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "score"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          offset: 0,
-          limit: 1,
-        },
-      );
-      const secondWindow = yield* prepareRuntimeRawQuery(
-        "window-sharing",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          offset: 1,
-          limit: 1,
-        },
-      );
-
-      const firstExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
-        firstWindow,
-      );
-      expect(firstExecution.initial("first").rows).toStrictEqual([{ id: "c", score: 3 }]);
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      expect(firstExecution.initial("first-after-unknown-release").rows).toStrictEqual([
-        { id: "c", score: 3 },
-      ]);
-
-      const secondExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
-        secondWindow,
-      );
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      expect(secondExecution.initial("second").rows).toStrictEqual([{ id: "b" }]);
-
-      const firstCursor = firstExecution.createCursor();
-      const secondCursor = secondExecution.createCursor();
-
-      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
-
-      const firstDelta = yield* firstExecution.next("first", firstCursor);
-      const secondDelta = yield* secondExecution.next("second", secondCursor);
-      expect(Option.getOrThrow(firstDelta)).toStrictEqual({
-        type: "delta",
-        topic: "window-sharing",
-        queryId: "first",
-        fromVersion: 3,
-        toVersion: 4,
-        operations: [
-          {
-            type: "remove",
-            key: "c",
-          },
-          {
-            type: "insert",
-            key: "d",
-            row: {
-              id: "d",
-              score: 4,
-            },
-            index: 0,
-          },
-        ],
-        totalRows: 4,
-      });
-      expect(Option.getOrThrow(secondDelta)).toStrictEqual({
-        type: "delta",
-        topic: "window-sharing",
-        queryId: "second",
-        fromVersion: 3,
-        toVersion: 4,
-        operations: [
-          {
-            type: "remove",
-            key: "b",
-          },
-          {
-            type: "insert",
-            key: "c",
-            row: {
-              id: "c",
-            },
-            index: 0,
-          },
-        ],
-        totalRows: 4,
-      });
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), firstWindow);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
-      expect(secondExecution.initial("second-after-release").rows).toStrictEqual([{ id: "c" }]);
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(0);
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), secondWindow);
-    }),
-  );
-
+describe("column-live-view-engine Active Query raw", () => {
   it.effect("updates raw active windows from retained insert-only changes without rescanning", () =>
     Effect.gen(function* () {
       const store = new TopicStore(
@@ -576,18 +34,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-insert-incremental",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -598,7 +56,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -630,8 +88,8 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
-      expect(readModel.changesSince(3)).toBeUndefined();
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
+      expect(queryInterface.changesSince(3)).toBeUndefined();
     }),
   );
 
@@ -652,18 +110,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-insert-incremental-count-only",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -674,7 +132,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -692,49 +150,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
-    }),
-  );
-
-  it.effect("releases retained raw changes when a topic reset clears active queries", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "raw-insert-reset-release",
-        Schema.Struct({
-          id: Schema.String,
-          status: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
-
-      const readModel = topicStoreReadModel(store);
-      const compiled = yield* prepareRuntimeRawQuery(
-        "raw-insert-reset-release",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          limit: 2,
-        },
-      );
-
-      yield* acquireRawQueryExecution(readModel, compiled);
-      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
-      expect(readModel.changesSince(3)).toBeDefined();
-
-      yield* resetTopicStore(store);
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
-
-      yield* publishTopicStoreRow(store, { id: "e", status: "open", score: 5 }, invalidRow);
-      expect(readModel.changesSince(0)).toBeUndefined();
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -755,18 +171,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-match-update-move-up",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -777,7 +193,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -811,7 +227,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -832,18 +248,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-match-update-move-down-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -854,7 +270,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -886,7 +302,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3, 3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -907,18 +323,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-match-update-unlimited-move-down",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -928,7 +344,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b", "a"]);
       const cursor = execution.createCursor();
 
@@ -962,7 +378,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([undefined]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -985,18 +401,18 @@ describe("column-live-view-engine active query execution", () => {
         yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 1 }, invalidRow);
 
         const scanLimits: Array<number | undefined> = [];
-        const readModel = topicStoreReadModel(store);
-        const observedReadModel = {
-          ...readModel,
-          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        const queryInterface = activeQueryTestInterface(store);
+        const observedQueryInterface = {
+          ...queryInterface,
+          scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
             scanLimits.push(plan.limit);
-            return readModel.scanRawWindow(plan);
+            return queryInterface.scanRawWindow(plan);
           },
         };
 
         const compiled = yield* prepareRuntimeRawQuery(
           "raw-match-update-batched-replacements",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id", "score"],
             where: {
@@ -1006,7 +422,7 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
         expect(execution.initial("query").keys).toStrictEqual(["a", "b", "c"]);
         const cursor = execution.createCursor();
 
@@ -1056,7 +472,7 @@ describe("column-live-view-engine active query execution", () => {
         });
         expect(scanLimits).toStrictEqual([undefined]);
 
-        yield* releaseRawQueryExecution(observedReadModel, compiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, compiled);
       }),
   );
 
@@ -1078,18 +494,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-match-update-remove-before-replace",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1100,7 +516,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["d", "c", "b"]);
       const cursor = execution.createCursor();
 
@@ -1148,7 +564,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([4]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -1170,18 +586,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-match-update-outside-lookahead-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1192,7 +608,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["d", "c"]);
       const cursor = execution.createCursor();
 
@@ -1224,7 +640,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3, 3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -1246,18 +662,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 7 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-match-update-tail-worsens-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1268,7 +684,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["a", "b"]);
       const cursor = execution.createCursor();
 
@@ -1303,7 +719,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3, 3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -1324,18 +740,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-pending-insert-match-update",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1346,7 +762,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -1379,7 +795,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -1399,19 +815,19 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
         changesSince: () => undefined,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-unavailable-changes-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1422,7 +838,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
       const cursor = execution.createCursor();
 
@@ -1446,7 +862,7 @@ describe("column-live-view-engine active query execution", () => {
       ]);
       expect(scanLimits).toStrictEqual([3, 3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -1466,18 +882,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-mixed-insert-incremental",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1488,7 +904,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
       const cursor = execution.createCursor();
 
@@ -1519,7 +935,7 @@ describe("column-live-view-engine active query execution", () => {
       ]);
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -1540,18 +956,18 @@ describe("column-live-view-engine active query execution", () => {
         yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
 
         const scanLimits: Array<number | undefined> = [];
-        const readModel = topicStoreReadModel(store);
-        const observedReadModel = {
-          ...readModel,
-          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        const queryInterface = activeQueryTestInterface(store);
+        const observedQueryInterface = {
+          ...queryInterface,
+          scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
             scanLimits.push(plan.limit);
-            return readModel.scanRawWindow(plan);
+            return queryInterface.scanRawWindow(plan);
           },
         };
 
         const compiled = yield* prepareRuntimeRawQuery(
           "raw-zero-limit-incremental",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id"],
             where: {
@@ -1561,7 +977,7 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
         expect(execution.initial("query").totalRows).toBe(1);
         const cursor = execution.createCursor();
 
@@ -1579,7 +995,7 @@ describe("column-live-view-engine active query execution", () => {
         });
         expect(scanLimits).toStrictEqual([0]);
 
-        yield* releaseRawQueryExecution(observedReadModel, compiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, compiled);
       }),
   );
 
@@ -1609,18 +1025,18 @@ describe("column-live-view-engine active query execution", () => {
       );
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-non-matching-change-incremental",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1645,7 +1061,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       };
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, observedCompiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, observedCompiled);
       expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
       const cursor = execution.createCursor();
       compareCount = 0;
@@ -1665,7 +1081,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(scanLimits).toStrictEqual([3]);
       expect(compareCount).toBe(0);
 
-      yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, observedCompiled);
     }),
   );
 
@@ -1686,7 +1102,7 @@ describe("column-live-view-engine active query execution", () => {
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-retained-insert-slot-sort",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1712,7 +1128,7 @@ describe("column-live-view-engine active query execution", () => {
       };
 
       const execution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(store),
+        activeQueryTestInterface(store),
         observedCompiled,
       );
       expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
@@ -1726,7 +1142,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(cursor.evaluation.keys).toStrictEqual(["c", "b"]);
       expect(compareCount).toBe(0);
 
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), observedCompiled);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), observedCompiled);
     }),
   );
 
@@ -1747,7 +1163,7 @@ describe("column-live-view-engine active query execution", () => {
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-retained-insert-row-sort-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1771,13 +1187,13 @@ describe("column-live-view-engine active query execution", () => {
           },
         },
       };
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
         compareRawSlots: () => undefined,
       };
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, observedCompiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, observedCompiled);
       expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
       const cursor = execution.createCursor();
       compareCount = 0;
@@ -1789,7 +1205,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(cursor.evaluation.keys).toStrictEqual(["c", "b"]);
       expect(compareCount).toBeGreaterThan(0);
 
-      yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, observedCompiled);
     }),
   );
 
@@ -1810,7 +1226,7 @@ describe("column-live-view-engine active query execution", () => {
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-retained-insert-missing-slot-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1834,13 +1250,13 @@ describe("column-live-view-engine active query execution", () => {
           },
         },
       };
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        slotForKey: (key: string) => (key === "c" ? undefined : readModel.slotForKey?.(key)),
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        slotForKey: (key: string) => (key === "c" ? undefined : queryInterface.slotForKey?.(key)),
       };
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, observedCompiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, observedCompiled);
       expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
       const cursor = execution.createCursor();
       compareCount = 0;
@@ -1852,7 +1268,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(cursor.evaluation.keys).toStrictEqual(["c", "b"]);
       expect(compareCount).toBeGreaterThan(0);
 
-      yield* releaseRawQueryExecution(observedReadModel, observedCompiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, observedCompiled);
     }),
   );
 
@@ -1878,10 +1294,10 @@ describe("column-live-view-engine active query execution", () => {
           invalidRow,
         );
 
-        const readModel = topicStoreReadModel(store);
+        const queryInterface = activeQueryTestInterface(store);
         const compiled = yield* prepareRuntimeRawQuery(
           "raw-noop-then-visible-version",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id", "score"],
             where: {
@@ -1892,7 +1308,7 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const execution = yield* acquireRawQueryExecution(readModel, compiled);
+        const execution = yield* acquireRawQueryExecution(queryInterface, compiled);
         expect(execution.initial("query").keys).toStrictEqual(["b", "a"]);
         const cursor = execution.createCursor();
 
@@ -1935,7 +1351,7 @@ describe("column-live-view-engine active query execution", () => {
           totalRows: 3,
         });
 
-        yield* releaseRawQueryExecution(readModel, compiled);
+        yield* releaseRawQueryExecution(queryInterface, compiled);
       }),
   );
 
@@ -1957,18 +1373,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "d", status: "closed", score: 4 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-retained-update-enters-predicate",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -1979,7 +1395,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -2011,7 +1427,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -2032,18 +1448,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-same-key-pending-insert-removed",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -2054,7 +1470,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -2065,7 +1481,7 @@ describe("column-live-view-engine active query execution", () => {
       expect(Option.isNone(delta)).toBe(true);
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -2087,18 +1503,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 70 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-retained-removal-consumes-lookahead",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -2109,7 +1525,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["a", "b"]);
       const cursor = execution.createCursor();
 
@@ -2170,7 +1586,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3, 3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -2194,18 +1610,18 @@ describe("column-live-view-engine active query execution", () => {
         yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
 
         const scanLimits: Array<number | undefined> = [];
-        const readModel = topicStoreReadModel(store);
-        const observedReadModel = {
-          ...readModel,
-          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        const queryInterface = activeQueryTestInterface(store);
+        const observedQueryInterface = {
+          ...queryInterface,
+          scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
             scanLimits.push(plan.limit);
-            return readModel.scanRawWindow(plan);
+            return queryInterface.scanRawWindow(plan);
           },
         };
 
         const compiled = yield* prepareRuntimeRawQuery(
           "raw-retained-exhausted-lookahead-rejects-later-insert",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id", "score"],
             where: {
@@ -2216,7 +1632,7 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
         expect(execution.initial("query").keys).toStrictEqual(["d", "c"]);
         const cursor = execution.createCursor();
 
@@ -2290,7 +1706,7 @@ describe("column-live-view-engine active query execution", () => {
         });
         expect(scanLimits).toStrictEqual([3, 3]);
 
-        yield* releaseRawQueryExecution(observedReadModel, compiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, compiled);
       }),
   );
 
@@ -2314,18 +1730,18 @@ describe("column-live-view-engine active query execution", () => {
         yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
         const scanLimits: Array<number | undefined> = [];
-        const readModel = topicStoreReadModel(store);
-        const observedReadModel = {
-          ...readModel,
-          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        const queryInterface = activeQueryTestInterface(store);
+        const observedQueryInterface = {
+          ...queryInterface,
+          scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
             scanLimits.push(plan.limit);
-            return readModel.scanRawWindow(plan);
+            return queryInterface.scanRawWindow(plan);
           },
         };
 
         const compiled = yield* prepareRuntimeRawQuery(
           "raw-delete-outside-retained-window",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id", "score"],
             where: {
@@ -2336,7 +1752,7 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
         expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
         const cursor = execution.createCursor();
 
@@ -2354,7 +1770,7 @@ describe("column-live-view-engine active query execution", () => {
         });
         expect(scanLimits).toStrictEqual([3]);
 
-        yield* releaseRawQueryExecution(observedReadModel, compiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, compiled);
       }),
   );
 
@@ -2378,18 +1794,18 @@ describe("column-live-view-engine active query execution", () => {
         yield* publishTopicStoreRow(store, { id: "d", status: "closed", score: 4 }, invalidRow);
 
         const scanLimits: Array<number | undefined> = [];
-        const readModel = topicStoreReadModel(store);
-        const observedReadModel = {
-          ...readModel,
-          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        const queryInterface = activeQueryTestInterface(store);
+        const observedQueryInterface = {
+          ...queryInterface,
+          scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
             scanLimits.push(plan.limit);
-            return readModel.scanRawWindow(plan);
+            return queryInterface.scanRawWindow(plan);
           },
         };
 
         const compiled = yield* prepareRuntimeRawQuery(
           "raw-zero-limit-mixed-incremental",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id"],
             where: {
@@ -2399,7 +1815,7 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+        const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
         expect(execution.initial("query").totalRows).toBe(2);
         const cursor = execution.createCursor();
 
@@ -2427,7 +1843,7 @@ describe("column-live-view-engine active query execution", () => {
         });
         expect(scanLimits).toStrictEqual([0]);
 
-        yield* releaseRawQueryExecution(observedReadModel, compiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, compiled);
       }),
   );
 
@@ -2448,18 +1864,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-visible-delete-fallback",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -2470,7 +1886,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["c", "b"]);
       const cursor = execution.createCursor();
 
@@ -2502,7 +1918,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -2524,18 +1940,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const compiled = yield* prepareRuntimeRawQuery(
         "raw-visible-delete-exhausted-lookahead",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -2546,7 +1962,7 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const execution = yield* acquireRawQueryExecution(observedReadModel, compiled);
+      const execution = yield* acquireRawQueryExecution(observedQueryInterface, compiled);
       expect(execution.initial("query").keys).toStrictEqual(["d", "c"]);
       const cursor = execution.createCursor();
 
@@ -2592,7 +2008,7 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([3, 3]);
 
-      yield* releaseRawQueryExecution(observedReadModel, compiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, compiled);
     }),
   );
 
@@ -2616,18 +2032,18 @@ describe("column-live-view-engine active query execution", () => {
       yield* publishTopicStoreRow(store, { id: "f", status: "open", score: 6 }, invalidRow);
 
       const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
           scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
+          return queryInterface.scanRawWindow(plan);
         },
       };
 
       const wideCompiled = yield* prepareRuntimeRawQuery(
         "raw-visible-delete-shared-wide-lookahead",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -2639,7 +2055,7 @@ describe("column-live-view-engine active query execution", () => {
       );
       const narrowCompiled = yield* prepareRuntimeRawQuery(
         "raw-visible-delete-shared-wide-lookahead",
-        topicStoreRawQueryMetadata(store),
+        activeQueryTestMetadata(store),
         {
           select: ["id", "score"],
           where: {
@@ -2650,8 +2066,11 @@ describe("column-live-view-engine active query execution", () => {
         },
       );
 
-      const wideExecution = yield* acquireRawQueryExecution(observedReadModel, wideCompiled);
-      const narrowExecution = yield* acquireRawQueryExecution(observedReadModel, narrowCompiled);
+      const wideExecution = yield* acquireRawQueryExecution(observedQueryInterface, wideCompiled);
+      const narrowExecution = yield* acquireRawQueryExecution(
+        observedQueryInterface,
+        narrowCompiled,
+      );
       expect(wideExecution.initial("wide-query").keys).toStrictEqual([
         "f",
         "e",
@@ -2705,8 +2124,8 @@ describe("column-live-view-engine active query execution", () => {
       });
       expect(scanLimits).toStrictEqual([192]);
 
-      yield* releaseRawQueryExecution(observedReadModel, narrowCompiled);
-      yield* releaseRawQueryExecution(observedReadModel, wideCompiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, narrowCompiled);
+      yield* releaseRawQueryExecution(observedQueryInterface, wideCompiled);
     }),
   );
 
@@ -2735,18 +2154,18 @@ describe("column-live-view-engine active query execution", () => {
         );
 
         const scanLimits: Array<number | undefined> = [];
-        const readModel = topicStoreReadModel(store);
-        const observedReadModel = {
-          ...readModel,
-          scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
+        const queryInterface = activeQueryTestInterface(store);
+        const observedQueryInterface = {
+          ...queryInterface,
+          scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
             scanLimits.push(plan.limit);
-            return readModel.scanRawWindow(plan);
+            return queryInterface.scanRawWindow(plan);
           },
         };
 
         const wideCompiled = yield* prepareRuntimeRawQuery(
           "raw-visible-delete-insert-preserves-lookahead",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id", "score"],
             where: {
@@ -2758,7 +2177,7 @@ describe("column-live-view-engine active query execution", () => {
         );
         const narrowCompiled = yield* prepareRuntimeRawQuery(
           "raw-visible-delete-insert-preserves-lookahead",
-          topicStoreRawQueryMetadata(store),
+          activeQueryTestMetadata(store),
           {
             select: ["id", "score"],
             where: {
@@ -2769,8 +2188,11 @@ describe("column-live-view-engine active query execution", () => {
           },
         );
 
-        const wideExecution = yield* acquireRawQueryExecution(observedReadModel, wideCompiled);
-        const narrowExecution = yield* acquireRawQueryExecution(observedReadModel, narrowCompiled);
+        const wideExecution = yield* acquireRawQueryExecution(observedQueryInterface, wideCompiled);
+        const narrowExecution = yield* acquireRawQueryExecution(
+          observedQueryInterface,
+          narrowCompiled,
+        );
         expect(wideExecution.initial("wide-query").keys.slice(0, 3)).toStrictEqual([
           "row-219",
           "row-218",
@@ -2881,682 +2303,8 @@ describe("column-live-view-engine active query execution", () => {
         });
         expect(scanLimits).toStrictEqual([192]);
 
-        yield* releaseRawQueryExecution(observedReadModel, narrowCompiled);
-        yield* releaseRawQueryExecution(observedReadModel, wideCompiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, narrowCompiled);
+        yield* releaseRawQueryExecution(observedQueryInterface, wideCompiled);
       }),
-  );
-
-  it.effect("shrinks shared base windows immediately when larger windows release", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "window-shrink",
-        Schema.Struct({
-          id: Schema.String,
-          status: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
-
-      const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
-          scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
-        },
-      };
-
-      const wideWindow = yield* prepareRuntimeRawQuery(
-        "window-shrink",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          offset: 0,
-          limit: 3,
-        },
-      );
-      const narrowWindow = yield* prepareRuntimeRawQuery(
-        "window-shrink",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          offset: 1,
-          limit: 1,
-        },
-      );
-
-      const wideExecution = yield* acquireRawQueryExecution(observedReadModel, wideWindow);
-      expect(wideExecution.initial("wide").keys).toStrictEqual(["d", "c", "b"]);
-
-      const narrowExecution = yield* acquireRawQueryExecution(observedReadModel, narrowWindow);
-      expect(narrowExecution.initial("narrow").keys).toStrictEqual(["c"]);
-
-      yield* releaseRawQueryExecution(observedReadModel, wideWindow);
-      expect(scanLimits).toStrictEqual([4, 3]);
-      expect(narrowExecution.initial("narrow-after-shrink").keys).toStrictEqual(["c"]);
-
-      yield* releaseRawQueryExecution(observedReadModel, narrowWindow);
-    }),
-  );
-
-  it.effect("compacts unbounded shared base windows when unbounded windows release", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "window-unbounded",
-        Schema.Struct({
-          id: Schema.String,
-          status: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
-
-      const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
-          scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
-        },
-      };
-
-      const boundedWindow = yield* prepareRuntimeRawQuery(
-        "window-unbounded",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          offset: 1,
-          limit: 1,
-        },
-      );
-      const unboundedWindow = yield* prepareRuntimeRawQuery(
-        "window-unbounded",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-        },
-      );
-
-      const boundedExecution = yield* acquireRawQueryExecution(observedReadModel, boundedWindow);
-      expect(boundedExecution.initial("bounded").keys).toStrictEqual(["b"]);
-
-      const unboundedExecution = yield* acquireRawQueryExecution(
-        observedReadModel,
-        unboundedWindow,
-      );
-      expect(unboundedExecution.initial("unbounded").keys).toStrictEqual(["c", "b", "a"]);
-
-      yield* releaseRawQueryExecution(observedReadModel, unboundedWindow);
-      expect(scanLimits).toStrictEqual([3, undefined, 3]);
-      expect(boundedExecution.initial("bounded-after-compact").keys).toStrictEqual(["b"]);
-
-      yield* releaseRawQueryExecution(observedReadModel, boundedWindow);
-    }),
-  );
-
-  it.effect("does not expand shared base rows for zero-limit windows", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "window-zero-limit",
-        Schema.Struct({
-          id: Schema.String,
-          status: Schema.String,
-          score: Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
-      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
-
-      const scanLimits: Array<number | undefined> = [];
-      const readModel = topicStoreReadModel(store);
-      const observedReadModel = {
-        ...readModel,
-        scanRawWindow: (plan: Parameters<typeof readModel.scanRawWindow>[0]) => {
-          scanLimits.push(plan.limit);
-          return readModel.scanRawWindow(plan);
-        },
-      };
-
-      const zeroWindow = yield* prepareRuntimeRawQuery(
-        "window-zero-limit",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          where: {
-            status: "open",
-          },
-          orderBy: [{ field: "score", direction: "desc" }],
-          offset: 10,
-          limit: 0,
-        },
-      );
-
-      const zeroExecution = yield* acquireRawQueryExecution(observedReadModel, zeroWindow);
-      const initial = zeroExecution.initial("zero");
-      expect(scanLimits).toStrictEqual([0]);
-      expect(initial.rows).toStrictEqual([]);
-      expect(initial.keys).toStrictEqual([]);
-      expect(initial.totalRows).toBe(2);
-
-      yield* releaseRawQueryExecution(observedReadModel, zeroWindow);
-    }),
-  );
-
-  it.effect("no-ops release when execution cache does not contain a query", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "numbers",
-        Schema.Struct({ id: Schema.String, score: Schema.Number }),
-        "id",
-        () => {},
-      );
-      const compiled = yield* prepareRuntimeRawQuery("numbers", topicStoreRawQueryMetadata(store), {
-        select: ["id"],
-        where: {
-          score: 1,
-        },
-      });
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), compiled);
-    }),
-  );
-
-  it.effect("covers query cache key paths for numeric, bigint, and BigDecimal filters", () =>
-    Effect.gen(function* () {
-      const numericStore = new TopicStore(
-        "numbers",
-        Schema.Struct({ id: Schema.String, score: Schema.Number }),
-        "id",
-        () => {},
-      );
-      const bigintStore = new TopicStore(
-        "bigints",
-        Schema.Struct({ id: Schema.String, amount: Schema.BigInt }),
-        "id",
-        () => {},
-      );
-      const decimalStore = new TopicStore(
-        "decimals",
-        Schema.Struct({ id: Schema.String, price: Schema.BigDecimal }),
-        "id",
-        () => {},
-      );
-
-      yield* publishTopicStoreRow(numericStore, { id: "a", score: 10 }, invalidRow);
-      yield* publishTopicStoreRow(bigintStore, { id: "b", amount: 5n }, invalidRow);
-      yield* publishTopicStoreRow(
-        decimalStore,
-        { id: "c", price: fromStringUnsafe("1.23") },
-        invalidRow,
-      );
-
-      const infFilter = yield* prepareRuntimeRawQuery(
-        "numbers",
-        topicStoreRawQueryMetadata(numericStore),
-        {
-          select: ["id", "score"],
-          where: {
-            score: Number.POSITIVE_INFINITY,
-          },
-        },
-      );
-      const nanFilter = yield* prepareRuntimeRawQuery(
-        "numbers",
-        topicStoreRawQueryMetadata(numericStore),
-        {
-          select: ["id", "score"],
-          where: {
-            score: Number.NaN,
-          },
-        },
-      );
-      const zeroFilter = yield* prepareRuntimeRawQuery(
-        "numbers",
-        topicStoreRawQueryMetadata(numericStore),
-        {
-          select: ["id", "score"],
-          where: {
-            score: 10,
-          },
-        },
-      );
-      const positiveZeroFilter = yield* prepareRuntimeRawQuery(
-        "numbers",
-        topicStoreRawQueryMetadata(numericStore),
-        {
-          select: ["id", "score"],
-          where: {
-            score: 0,
-          },
-        },
-      );
-      const negativeZeroFilter = yield* prepareRuntimeRawQuery(
-        "numbers",
-        topicStoreRawQueryMetadata(numericStore),
-        {
-          select: ["id", "score"],
-          where: {
-            score: -0,
-          },
-        },
-      );
-      const offsetFilter = yield* prepareRuntimeRawQuery(
-        "numbers",
-        topicStoreRawQueryMetadata(numericStore),
-        {
-          select: ["id", "score"],
-          offset: 1,
-        },
-      );
-      const bigIntFilter = yield* prepareRuntimeRawQuery(
-        "bigints",
-        topicStoreRawQueryMetadata(bigintStore),
-        {
-          select: ["id", "amount"],
-          where: {
-            amount: 3n,
-          },
-        },
-      );
-      const decimalFilter = yield* prepareRuntimeRawQuery(
-        "decimals",
-        topicStoreRawQueryMetadata(decimalStore),
-        {
-          select: ["id", "price"],
-          where: {
-            price: fromStringUnsafe("1.23"),
-          },
-        },
-      );
-
-      const infExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(numericStore),
-        infFilter,
-      );
-      const nanExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(numericStore),
-        nanFilter,
-      );
-      const zeroExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(numericStore),
-        zeroFilter,
-      );
-      yield* acquireRawQueryExecution(topicStoreReadModel(numericStore), positiveZeroFilter);
-      yield* acquireRawQueryExecution(topicStoreReadModel(numericStore), negativeZeroFilter);
-      const offsetExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(numericStore),
-        offsetFilter,
-      );
-      const bigintExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(bigintStore),
-        bigIntFilter,
-      );
-      const decimalExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(decimalStore),
-        decimalFilter,
-      );
-
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(numericStore))).toBe(5);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(bigintStore))).toBe(1);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(decimalStore))).toBe(1);
-
-      const infCursor = infExecution.createCursor();
-      const nanCursor = nanExecution.createCursor();
-      const zeroCursor = zeroExecution.createCursor();
-      const offsetCursor = offsetExecution.createCursor();
-      const bigintCursor = bigintExecution.createCursor();
-      const decimalCursor = decimalExecution.createCursor();
-
-      expect(infExecution.initial("q").totalRows).toBe(0);
-      expect(nanExecution.initial("q").totalRows).toBe(0);
-      expect(zeroExecution.initial("q").totalRows).toBe(1);
-      expect(offsetExecution.initial("q").totalRows).toBe(1);
-      expect(bigintExecution.initial("q").totalRows).toBe(0);
-      expect(decimalExecution.initial("q").totalRows).toBe(1);
-
-      expect((yield* infExecution.next("q", infCursor))._tag).toBe("None");
-      expect((yield* nanExecution.next("q", nanCursor))._tag).toBe("None");
-      expect((yield* zeroExecution.next("q", zeroCursor))._tag).toBe("None");
-      expect((yield* offsetExecution.next("q", offsetCursor))._tag).toBe("None");
-      expect((yield* bigintExecution.next("q", bigintCursor))._tag).toBe("None");
-      expect((yield* decimalExecution.next("q", decimalCursor))._tag).toBe("None");
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), infFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), nanFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), zeroFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), positiveZeroFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), negativeZeroFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(numericStore), offsetFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(bigintStore), bigIntFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(decimalStore), decimalFilter);
-    }),
-  );
-
-  it.effect("covers cache keys for nullish, array, object, and boolean filter values", () =>
-    Effect.gen(function* () {
-      const eventStore = new TopicStore(
-        "events",
-        Schema.Struct({
-          id: Schema.String,
-          label: Schema.String,
-          tags: Schema.Array(Schema.String),
-          metadata: Schema.Struct({
-            kind: Schema.String,
-            scope: Schema.String,
-          }),
-          active: Schema.Boolean,
-        }),
-        "id",
-        () => {},
-      );
-
-      yield* publishTopicStoreRow(
-        eventStore,
-        {
-          id: "a",
-          label: "foo",
-          tags: ["open", "closed"],
-          metadata: { kind: "test", scope: "global" },
-          active: true,
-        },
-        invalidRow,
-      );
-
-      const undefinedFilter = yield* prepareRuntimeRawQuery(
-        "events",
-        topicStoreRawQueryMetadata(eventStore),
-        {
-          select: ["id", "label"],
-          where: {
-            label: undefined,
-          },
-        },
-      );
-      const nullFilter = yield* prepareRuntimeRawQuery(
-        "events",
-        topicStoreRawQueryMetadata(eventStore),
-        {
-          select: ["id", "label"],
-          where: {
-            label: null,
-          },
-        },
-      );
-      const arrayFilter = yield* prepareRuntimeRawQuery(
-        "events",
-        topicStoreRawQueryMetadata(eventStore),
-        {
-          select: ["id", "tags"],
-          where: {
-            tags: ["open", "closed"],
-          },
-        },
-      );
-      const objectFilter = yield* prepareRuntimeRawQuery(
-        "events",
-        topicStoreRawQueryMetadata(eventStore),
-        {
-          select: ["id", "metadata"],
-          where: {
-            metadata: { kind: "test", scope: "global" },
-          },
-        },
-      );
-      const booleanFilter = yield* prepareRuntimeRawQuery(
-        "events",
-        topicStoreRawQueryMetadata(eventStore),
-        {
-          select: ["id", "active"],
-          where: {
-            active: true,
-          },
-        },
-      );
-
-      const undefinedExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(eventStore),
-        undefinedFilter,
-      );
-      const nullExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(eventStore),
-        nullFilter,
-      );
-      const arrayExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(eventStore),
-        arrayFilter,
-      );
-      const objectExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(eventStore),
-        objectFilter,
-      );
-      const booleanExecution = yield* acquireRawQueryExecution(
-        topicStoreReadModel(eventStore),
-        booleanFilter,
-      );
-
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(eventStore))).toBe(5);
-
-      expect(undefinedExecution.initial("query").totalRows).toBe(0);
-      expect(nullExecution.initial("query").totalRows).toBe(0);
-      expect(arrayExecution.initial("query").totalRows).toBe(1);
-      expect(objectExecution.initial("query").totalRows).toBe(1);
-      expect(booleanExecution.initial("query").totalRows).toBe(1);
-
-      const undefinedCursor = undefinedExecution.createCursor();
-      const nullCursor = nullExecution.createCursor();
-      const arrayCursor = arrayExecution.createCursor();
-      const objectCursor = objectExecution.createCursor();
-      const booleanCursor = booleanExecution.createCursor();
-
-      expect((yield* undefinedExecution.next("query", undefinedCursor))._tag).toBe("None");
-      expect((yield* nullExecution.next("query", nullCursor))._tag).toBe("None");
-      expect((yield* arrayExecution.next("query", arrayCursor))._tag).toBe("None");
-      expect((yield* objectExecution.next("query", objectCursor))._tag).toBe("None");
-      expect((yield* booleanExecution.next("query", booleanCursor))._tag).toBe("None");
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), undefinedFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), nullFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), arrayFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), objectFilter);
-      yield* releaseRawQueryExecution(topicStoreReadModel(eventStore), booleanFilter);
-    }),
-  );
-
-  it.effect("does not collide delimiter-bearing field names in cache keys", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "delimiter-fields",
-        Schema.Struct({
-          id: Schema.String,
-          a: Schema.Number,
-          b: Schema.Number,
-          "a:asc;b": Schema.Number,
-        }),
-        "id",
-        () => {},
-      );
-      const splitFieldsQuery = yield* prepareRuntimeRawQuery(
-        "delimiter-fields",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          orderBy: [
-            {
-              field: "a",
-              direction: "asc",
-            },
-            {
-              field: "b",
-              direction: "desc",
-            },
-          ],
-        },
-      );
-      const delimiterFieldQuery = yield* prepareRuntimeRawQuery(
-        "delimiter-fields",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id"],
-          orderBy: [
-            {
-              field: "a:asc;b",
-              direction: "desc",
-            },
-          ],
-        },
-      );
-
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), splitFieldsQuery);
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), delimiterFieldQuery);
-
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(2);
-
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), splitFieldsQuery);
-      yield* releaseRawQueryExecution(topicStoreReadModel(store), delimiterFieldQuery);
-    }),
-  );
-
-  it.effect("canonicalizes schema-backed null-prototype filter values before cache-keying", () =>
-    Effect.gen(function* () {
-      const store = new TopicStore(
-        "special",
-        Schema.Struct({
-          id: Schema.String,
-          payload: Schema.Record(Schema.String, Schema.String),
-        }),
-        "id",
-        () => {},
-      );
-      const queryPayload: Record<string, string> = Object.create(null);
-      queryPayload["venue"] = "xnys";
-
-      const nullPrototypeQuery = yield* prepareRuntimeRawQuery(
-        "special",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "payload"],
-          where: {
-            payload: queryPayload,
-          },
-        },
-      );
-      const plainRecordQuery = yield* prepareRuntimeRawQuery(
-        "special",
-        topicStoreRawQueryMetadata(store),
-        {
-          select: ["id", "payload"],
-          where: {
-            payload: { venue: "xnys" },
-          },
-        },
-      );
-      const nullPrototypeGrouped = yield* prepareRuntimeGroupedQuery(
-        "special",
-        topicStoreRawQueryMetadata(store),
-        {
-          groupBy: ["payload"],
-          aggregates: { rowCount: { aggFunc: "count" } },
-          where: { payload: queryPayload },
-        },
-      );
-      const plainRecordGrouped = yield* prepareRuntimeGroupedQuery(
-        "special",
-        topicStoreRawQueryMetadata(store),
-        {
-          groupBy: ["payload"],
-          aggregates: { rowCount: { aggFunc: "count" } },
-          where: { payload: { venue: "xnys" } },
-        },
-      );
-
-      expect(nullPrototypeQuery.plan.queryCacheKey).toBe(plainRecordQuery.plan.queryCacheKey);
-      expect(nullPrototypeGrouped.cacheKey).toBe(plainRecordGrouped.cacheKey);
-    }),
-  );
-
-  it.effect("rejects non-serializable filter values before cache-keying", () =>
-    Effect.gen(function* () {
-      const firstFunction = () => "first";
-      const firstSymbol = Symbol("first");
-      const firstMap = new Map([["marker", "first"]]);
-      const store = new TopicStore(
-        "special-non-serializable",
-        Schema.Struct({
-          id: Schema.String,
-          marker: Schema.Unknown,
-        }),
-        "id",
-        () => {},
-      );
-
-      const functionFilter = yield* Effect.flip(
-        prepareRuntimeRawQuery("special-non-serializable", topicStoreRawQueryMetadata(store), {
-          select: ["id", "marker"],
-          where: {
-            marker: firstFunction,
-          },
-        }),
-      );
-      expect(functionFilter).toMatchObject({
-        _tag: "InvalidQueryError",
-        message: expect.stringContaining("unsupported query value"),
-      });
-
-      const symbolFilter = yield* Effect.flip(
-        prepareRuntimeRawQuery("special-non-serializable", topicStoreRawQueryMetadata(store), {
-          select: ["id", "marker"],
-          where: {
-            marker: firstSymbol,
-          },
-        }),
-      );
-      expect(symbolFilter).toMatchObject({
-        _tag: "InvalidQueryError",
-        message: expect.stringContaining("unsupported query value"),
-      });
-
-      const mapFilter = yield* Effect.flip(
-        prepareRuntimeRawQuery("special-non-serializable", topicStoreRawQueryMetadata(store), {
-          select: ["id", "marker"],
-          where: {
-            marker: firstMap,
-          },
-        }),
-      );
-      expect(mapFilter).toMatchObject({
-        _tag: "InvalidQueryError",
-        message: expect.stringContaining("unsupported query value"),
-      });
-    }),
   );
 });

--- a/packages/column-live-view-engine/src/active-query-sharing.test.ts
+++ b/packages/column-live-view-engine/src/active-query-sharing.test.ts
@@ -1,0 +1,1024 @@
+import { fromStringUnsafe } from "effect/BigDecimal";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option, Schema } from "effect";
+import {
+  acquireRawQueryExecution,
+  activeQueryTestInterface,
+  activeQueryTestMetadata,
+  activeStoreRawQueryExecutionCount,
+  createActiveQueryRegistry,
+  releaseRawQueryExecution,
+} from "../test-harness/active-query-interface";
+import { prepareRuntimeGroupedQuery } from "./grouped-query-compiler";
+import { prepareRuntimeRawQuery } from "./raw-query-compiler";
+import { publishTopicStoreRow, TopicStore } from "./topic-store";
+
+const invalidRow = (_topic: string, message: string): Error => new Error(message);
+describe("column-live-view-engine Active Query sharing", () => {
+  it.effect("reuses execution state for identical compiled raw queries", () =>
+    Effect.gen(function* () {
+      const rowSchema = Schema.Struct({
+        id: Schema.String,
+        status: Schema.String,
+        score: Schema.Number,
+        count: Schema.BigInt,
+        value: Schema.BigDecimal,
+      });
+      const store = new TopicStore("scores", rowSchema, "id", () => {});
+
+      yield* publishTopicStoreRow(
+        store,
+        {
+          id: "1",
+          status: "open",
+          score: 10,
+          count: 1n,
+          value: fromStringUnsafe("1.00"),
+        },
+        invalidRow,
+      );
+      yield* publishTopicStoreRow(
+        store,
+        {
+          id: "2",
+          status: "closed",
+          score: 20,
+          count: 2n,
+          value: fromStringUnsafe("2.00"),
+        },
+        invalidRow,
+      );
+
+      const compiled = yield* prepareRuntimeRawQuery("scores", activeQueryTestMetadata(store), {
+        select: ["id", "score", "count", "value"],
+        where: {
+          status: "open",
+        },
+        orderBy: [
+          {
+            field: "score",
+            direction: "desc",
+          },
+        ],
+      });
+
+      const firstExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        compiled,
+      );
+      const secondExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        compiled,
+      );
+      expect(Object.isFrozen(firstExecution)).toBe(true);
+      expect(() => Object.assign(firstExecution, secondExecution)).toThrowError(TypeError);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+
+      const firstCursor = firstExecution.createCursor();
+      const secondCursor = secondExecution.createCursor();
+
+      const initialFirst = firstExecution.initial("query-a");
+      const initialSecond = secondExecution.initial("query-b");
+      expect(initialFirst.rows).toStrictEqual(initialSecond.rows);
+      expect(initialFirst.totalRows).toBe(1);
+      expect(initialFirst.keys).toStrictEqual(["1"]);
+
+      const beforePublishFirst = yield* firstExecution.next("query-a", firstCursor);
+      const beforePublishSecond = yield* secondExecution.next("query-b", secondCursor);
+      expect(beforePublishFirst._tag).toBe("None");
+      expect(beforePublishSecond._tag).toBe("None");
+
+      yield* publishTopicStoreRow(
+        store,
+        {
+          id: "3",
+          status: "open",
+          score: 5,
+          count: 3n,
+          value: fromStringUnsafe("3.00"),
+        },
+        invalidRow,
+      );
+
+      const afterPublishFirst = yield* firstExecution.next("query-a", firstCursor);
+      const afterPublishSecond = yield* secondExecution.next("query-b", secondCursor);
+      expect(afterPublishFirst._tag).toBe("Some");
+      expect(afterPublishSecond._tag).toBe("Some");
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+      const afterRefcountDecrement = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        compiled,
+      );
+      expect(afterRefcountDecrement.initial("query-c").totalRows).toBe(2);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), compiled);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(0);
+
+      const afterRefcountExhausted = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        compiled,
+      );
+      expect(afterRefcountExhausted.initial("query-d").totalRows).toBe(2);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), compiled);
+    }),
+  );
+
+  it.effect("keeps execution caches local to the active query registry", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "registry-isolation",
+        Schema.Struct({
+          id: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", score: 1 }, invalidRow);
+
+      const compiled = yield* prepareRuntimeRawQuery(
+        "registry-isolation",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          orderBy: [{ field: "score", direction: "desc" }],
+        },
+      );
+      const queryInterface = activeQueryTestInterface(store);
+      const isolatedQueryInterface = {
+        ...queryInterface,
+        activeQueries: createActiveQueryRegistry(),
+      };
+
+      yield* acquireRawQueryExecution(queryInterface, compiled);
+      yield* acquireRawQueryExecution(isolatedQueryInterface, compiled);
+
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedQueryInterface)).toBe(1);
+
+      yield* releaseRawQueryExecution(queryInterface, compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(0);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedQueryInterface)).toBe(1);
+
+      yield* releaseRawQueryExecution(isolatedQueryInterface, compiled);
+      expect(yield* activeStoreRawQueryExecutionCount(isolatedQueryInterface)).toBe(0);
+    }),
+  );
+
+  it.effect("shares base evaluation across different projections", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "projection-sharing",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const idOnly = yield* prepareRuntimeRawQuery(
+        "projection-sharing",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+        },
+      );
+      const idAndScore = yield* prepareRuntimeRawQuery(
+        "projection-sharing",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+        },
+      );
+
+      const idOnlyExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        idOnly,
+      );
+      const idAndScoreExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        idAndScore,
+      );
+
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+      expect(idOnlyExecution.initial("ids").rows).toStrictEqual([{ id: "b" }, { id: "a" }]);
+      expect(idAndScoreExecution.initial("scores").rows).toStrictEqual([
+        { id: "b", score: 2 },
+        { id: "a", score: 1 },
+      ]);
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), idOnly);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), idAndScore);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(0);
+    }),
+  );
+
+  it.effect("shares base evaluation across different windows", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-sharing",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const firstWindow = yield* prepareRuntimeRawQuery(
+        "window-sharing",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id", "score"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 0,
+          limit: 1,
+        },
+      );
+      const secondWindow = yield* prepareRuntimeRawQuery(
+        "window-sharing",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 1,
+          limit: 1,
+        },
+      );
+
+      const firstExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        firstWindow,
+      );
+      expect(firstExecution.initial("first").rows).toStrictEqual([{ id: "c", score: 3 }]);
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), secondWindow);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+      expect(firstExecution.initial("first-after-unknown-release").rows).toStrictEqual([
+        { id: "c", score: 3 },
+      ]);
+
+      const secondExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(store),
+        secondWindow,
+      );
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+      expect(secondExecution.initial("second").rows).toStrictEqual([{ id: "b" }]);
+
+      const firstCursor = firstExecution.createCursor();
+      const secondCursor = secondExecution.createCursor();
+
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const firstDelta = yield* firstExecution.next("first", firstCursor);
+      const secondDelta = yield* secondExecution.next("second", secondCursor);
+      expect(Option.getOrThrow(firstDelta)).toStrictEqual({
+        type: "delta",
+        topic: "window-sharing",
+        queryId: "first",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: "c",
+          },
+          {
+            type: "insert",
+            key: "d",
+            row: {
+              id: "d",
+              score: 4,
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 4,
+      });
+      expect(Option.getOrThrow(secondDelta)).toStrictEqual({
+        type: "delta",
+        topic: "window-sharing",
+        queryId: "second",
+        fromVersion: 3,
+        toVersion: 4,
+        operations: [
+          {
+            type: "remove",
+            key: "b",
+          },
+          {
+            type: "insert",
+            key: "c",
+            row: {
+              id: "c",
+            },
+            index: 0,
+          },
+        ],
+        totalRows: 4,
+      });
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), firstWindow);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
+      expect(secondExecution.initial("second-after-release").rows).toStrictEqual([{ id: "c" }]);
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), secondWindow);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(0);
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), secondWindow);
+    }),
+  );
+
+  it.effect("shrinks shared base windows immediately when larger windows release", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-shrink",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "d", status: "open", score: 4 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return queryInterface.scanRawWindow(plan);
+        },
+      };
+
+      const wideWindow = yield* prepareRuntimeRawQuery(
+        "window-shrink",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 0,
+          limit: 3,
+        },
+      );
+      const narrowWindow = yield* prepareRuntimeRawQuery(
+        "window-shrink",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 1,
+          limit: 1,
+        },
+      );
+
+      const wideExecution = yield* acquireRawQueryExecution(observedQueryInterface, wideWindow);
+      expect(wideExecution.initial("wide").keys).toStrictEqual(["d", "c", "b"]);
+
+      const narrowExecution = yield* acquireRawQueryExecution(observedQueryInterface, narrowWindow);
+      expect(narrowExecution.initial("narrow").keys).toStrictEqual(["c"]);
+
+      yield* releaseRawQueryExecution(observedQueryInterface, wideWindow);
+      expect(scanLimits).toStrictEqual([4, 3]);
+      expect(narrowExecution.initial("narrow-after-shrink").keys).toStrictEqual(["c"]);
+
+      yield* releaseRawQueryExecution(observedQueryInterface, narrowWindow);
+    }),
+  );
+
+  it.effect("compacts unbounded shared base windows when unbounded windows release", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-unbounded",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "c", status: "open", score: 3 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return queryInterface.scanRawWindow(plan);
+        },
+      };
+
+      const boundedWindow = yield* prepareRuntimeRawQuery(
+        "window-unbounded",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 1,
+          limit: 1,
+        },
+      );
+      const unboundedWindow = yield* prepareRuntimeRawQuery(
+        "window-unbounded",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+        },
+      );
+
+      const boundedExecution = yield* acquireRawQueryExecution(
+        observedQueryInterface,
+        boundedWindow,
+      );
+      expect(boundedExecution.initial("bounded").keys).toStrictEqual(["b"]);
+
+      const unboundedExecution = yield* acquireRawQueryExecution(
+        observedQueryInterface,
+        unboundedWindow,
+      );
+      expect(unboundedExecution.initial("unbounded").keys).toStrictEqual(["c", "b", "a"]);
+
+      yield* releaseRawQueryExecution(observedQueryInterface, unboundedWindow);
+      expect(scanLimits).toStrictEqual([3, undefined, 3]);
+      expect(boundedExecution.initial("bounded-after-compact").keys).toStrictEqual(["b"]);
+
+      yield* releaseRawQueryExecution(observedQueryInterface, boundedWindow);
+    }),
+  );
+
+  it.effect("does not expand shared base rows for zero-limit windows", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "window-zero-limit",
+        Schema.Struct({
+          id: Schema.String,
+          status: Schema.String,
+          score: Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      yield* publishTopicStoreRow(store, { id: "a", status: "open", score: 1 }, invalidRow);
+      yield* publishTopicStoreRow(store, { id: "b", status: "open", score: 2 }, invalidRow);
+
+      const scanLimits: Array<number | undefined> = [];
+      const queryInterface = activeQueryTestInterface(store);
+      const observedQueryInterface = {
+        ...queryInterface,
+        scanRawWindow: (plan: Parameters<typeof queryInterface.scanRawWindow>[0]) => {
+          scanLimits.push(plan.limit);
+          return queryInterface.scanRawWindow(plan);
+        },
+      };
+
+      const zeroWindow = yield* prepareRuntimeRawQuery(
+        "window-zero-limit",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          where: {
+            status: "open",
+          },
+          orderBy: [{ field: "score", direction: "desc" }],
+          offset: 10,
+          limit: 0,
+        },
+      );
+
+      const zeroExecution = yield* acquireRawQueryExecution(observedQueryInterface, zeroWindow);
+      const initial = zeroExecution.initial("zero");
+      expect(scanLimits).toStrictEqual([0]);
+      expect(initial.rows).toStrictEqual([]);
+      expect(initial.keys).toStrictEqual([]);
+      expect(initial.totalRows).toBe(2);
+
+      yield* releaseRawQueryExecution(observedQueryInterface, zeroWindow);
+    }),
+  );
+
+  it.effect("covers query cache key paths for numeric, bigint, and BigDecimal filters", () =>
+    Effect.gen(function* () {
+      const numericStore = new TopicStore(
+        "numbers",
+        Schema.Struct({ id: Schema.String, score: Schema.Number }),
+        "id",
+        () => {},
+      );
+      const bigintStore = new TopicStore(
+        "bigints",
+        Schema.Struct({ id: Schema.String, amount: Schema.BigInt }),
+        "id",
+        () => {},
+      );
+      const decimalStore = new TopicStore(
+        "decimals",
+        Schema.Struct({ id: Schema.String, price: Schema.BigDecimal }),
+        "id",
+        () => {},
+      );
+
+      yield* publishTopicStoreRow(numericStore, { id: "a", score: 10 }, invalidRow);
+      yield* publishTopicStoreRow(bigintStore, { id: "b", amount: 5n }, invalidRow);
+      yield* publishTopicStoreRow(
+        decimalStore,
+        { id: "c", price: fromStringUnsafe("1.23") },
+        invalidRow,
+      );
+
+      const infFilter = yield* prepareRuntimeRawQuery(
+        "numbers",
+        activeQueryTestMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: Number.POSITIVE_INFINITY,
+          },
+        },
+      );
+      const nanFilter = yield* prepareRuntimeRawQuery(
+        "numbers",
+        activeQueryTestMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: Number.NaN,
+          },
+        },
+      );
+      const zeroFilter = yield* prepareRuntimeRawQuery(
+        "numbers",
+        activeQueryTestMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: 10,
+          },
+        },
+      );
+      const positiveZeroFilter = yield* prepareRuntimeRawQuery(
+        "numbers",
+        activeQueryTestMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: 0,
+          },
+        },
+      );
+      const negativeZeroFilter = yield* prepareRuntimeRawQuery(
+        "numbers",
+        activeQueryTestMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          where: {
+            score: -0,
+          },
+        },
+      );
+      const offsetFilter = yield* prepareRuntimeRawQuery(
+        "numbers",
+        activeQueryTestMetadata(numericStore),
+        {
+          select: ["id", "score"],
+          offset: 1,
+        },
+      );
+      const bigIntFilter = yield* prepareRuntimeRawQuery(
+        "bigints",
+        activeQueryTestMetadata(bigintStore),
+        {
+          select: ["id", "amount"],
+          where: {
+            amount: 3n,
+          },
+        },
+      );
+      const decimalFilter = yield* prepareRuntimeRawQuery(
+        "decimals",
+        activeQueryTestMetadata(decimalStore),
+        {
+          select: ["id", "price"],
+          where: {
+            price: fromStringUnsafe("1.23"),
+          },
+        },
+      );
+
+      const infExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(numericStore),
+        infFilter,
+      );
+      const nanExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(numericStore),
+        nanFilter,
+      );
+      const zeroExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(numericStore),
+        zeroFilter,
+      );
+      yield* acquireRawQueryExecution(activeQueryTestInterface(numericStore), positiveZeroFilter);
+      yield* acquireRawQueryExecution(activeQueryTestInterface(numericStore), negativeZeroFilter);
+      const offsetExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(numericStore),
+        offsetFilter,
+      );
+      const bigintExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(bigintStore),
+        bigIntFilter,
+      );
+      const decimalExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(decimalStore),
+        decimalFilter,
+      );
+
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(numericStore))).toBe(
+        5,
+      );
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(bigintStore))).toBe(
+        1,
+      );
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(decimalStore))).toBe(
+        1,
+      );
+
+      const infCursor = infExecution.createCursor();
+      const nanCursor = nanExecution.createCursor();
+      const zeroCursor = zeroExecution.createCursor();
+      const offsetCursor = offsetExecution.createCursor();
+      const bigintCursor = bigintExecution.createCursor();
+      const decimalCursor = decimalExecution.createCursor();
+
+      expect(infExecution.initial("q").totalRows).toBe(0);
+      expect(nanExecution.initial("q").totalRows).toBe(0);
+      expect(zeroExecution.initial("q").totalRows).toBe(1);
+      expect(offsetExecution.initial("q").totalRows).toBe(1);
+      expect(bigintExecution.initial("q").totalRows).toBe(0);
+      expect(decimalExecution.initial("q").totalRows).toBe(1);
+
+      expect((yield* infExecution.next("q", infCursor))._tag).toBe("None");
+      expect((yield* nanExecution.next("q", nanCursor))._tag).toBe("None");
+      expect((yield* zeroExecution.next("q", zeroCursor))._tag).toBe("None");
+      expect((yield* offsetExecution.next("q", offsetCursor))._tag).toBe("None");
+      expect((yield* bigintExecution.next("q", bigintCursor))._tag).toBe("None");
+      expect((yield* decimalExecution.next("q", decimalCursor))._tag).toBe("None");
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(numericStore), infFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(numericStore), nanFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(numericStore), zeroFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(numericStore), positiveZeroFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(numericStore), negativeZeroFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(numericStore), offsetFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(bigintStore), bigIntFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(decimalStore), decimalFilter);
+    }),
+  );
+
+  it.effect("covers cache keys for nullish, array, object, and boolean filter values", () =>
+    Effect.gen(function* () {
+      const eventStore = new TopicStore(
+        "events",
+        Schema.Struct({
+          id: Schema.String,
+          label: Schema.String,
+          tags: Schema.Array(Schema.String),
+          metadata: Schema.Struct({
+            kind: Schema.String,
+            scope: Schema.String,
+          }),
+          active: Schema.Boolean,
+        }),
+        "id",
+        () => {},
+      );
+
+      yield* publishTopicStoreRow(
+        eventStore,
+        {
+          id: "a",
+          label: "foo",
+          tags: ["open", "closed"],
+          metadata: { kind: "test", scope: "global" },
+          active: true,
+        },
+        invalidRow,
+      );
+
+      const undefinedFilter = yield* prepareRuntimeRawQuery(
+        "events",
+        activeQueryTestMetadata(eventStore),
+        {
+          select: ["id", "label"],
+          where: {
+            label: undefined,
+          },
+        },
+      );
+      const nullFilter = yield* prepareRuntimeRawQuery(
+        "events",
+        activeQueryTestMetadata(eventStore),
+        {
+          select: ["id", "label"],
+          where: {
+            label: null,
+          },
+        },
+      );
+      const arrayFilter = yield* prepareRuntimeRawQuery(
+        "events",
+        activeQueryTestMetadata(eventStore),
+        {
+          select: ["id", "tags"],
+          where: {
+            tags: ["open", "closed"],
+          },
+        },
+      );
+      const objectFilter = yield* prepareRuntimeRawQuery(
+        "events",
+        activeQueryTestMetadata(eventStore),
+        {
+          select: ["id", "metadata"],
+          where: {
+            metadata: { kind: "test", scope: "global" },
+          },
+        },
+      );
+      const booleanFilter = yield* prepareRuntimeRawQuery(
+        "events",
+        activeQueryTestMetadata(eventStore),
+        {
+          select: ["id", "active"],
+          where: {
+            active: true,
+          },
+        },
+      );
+
+      const undefinedExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(eventStore),
+        undefinedFilter,
+      );
+      const nullExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(eventStore),
+        nullFilter,
+      );
+      const arrayExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(eventStore),
+        arrayFilter,
+      );
+      const objectExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(eventStore),
+        objectFilter,
+      );
+      const booleanExecution = yield* acquireRawQueryExecution(
+        activeQueryTestInterface(eventStore),
+        booleanFilter,
+      );
+
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(eventStore))).toBe(
+        5,
+      );
+
+      expect(undefinedExecution.initial("query").totalRows).toBe(0);
+      expect(nullExecution.initial("query").totalRows).toBe(0);
+      expect(arrayExecution.initial("query").totalRows).toBe(1);
+      expect(objectExecution.initial("query").totalRows).toBe(1);
+      expect(booleanExecution.initial("query").totalRows).toBe(1);
+
+      const undefinedCursor = undefinedExecution.createCursor();
+      const nullCursor = nullExecution.createCursor();
+      const arrayCursor = arrayExecution.createCursor();
+      const objectCursor = objectExecution.createCursor();
+      const booleanCursor = booleanExecution.createCursor();
+
+      expect((yield* undefinedExecution.next("query", undefinedCursor))._tag).toBe("None");
+      expect((yield* nullExecution.next("query", nullCursor))._tag).toBe("None");
+      expect((yield* arrayExecution.next("query", arrayCursor))._tag).toBe("None");
+      expect((yield* objectExecution.next("query", objectCursor))._tag).toBe("None");
+      expect((yield* booleanExecution.next("query", booleanCursor))._tag).toBe("None");
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(eventStore), undefinedFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(eventStore), nullFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(eventStore), arrayFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(eventStore), objectFilter);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(eventStore), booleanFilter);
+    }),
+  );
+
+  it.effect("does not collide delimiter-bearing field names in cache keys", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "delimiter-fields",
+        Schema.Struct({
+          id: Schema.String,
+          a: Schema.Number,
+          b: Schema.Number,
+          "a:asc;b": Schema.Number,
+        }),
+        "id",
+        () => {},
+      );
+      const splitFieldsQuery = yield* prepareRuntimeRawQuery(
+        "delimiter-fields",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          orderBy: [
+            {
+              field: "a",
+              direction: "asc",
+            },
+            {
+              field: "b",
+              direction: "desc",
+            },
+          ],
+        },
+      );
+      const delimiterFieldQuery = yield* prepareRuntimeRawQuery(
+        "delimiter-fields",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id"],
+          orderBy: [
+            {
+              field: "a:asc;b",
+              direction: "desc",
+            },
+          ],
+        },
+      );
+
+      yield* acquireRawQueryExecution(activeQueryTestInterface(store), splitFieldsQuery);
+      yield* acquireRawQueryExecution(activeQueryTestInterface(store), delimiterFieldQuery);
+
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(2);
+
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), splitFieldsQuery);
+      yield* releaseRawQueryExecution(activeQueryTestInterface(store), delimiterFieldQuery);
+    }),
+  );
+
+  it.effect("canonicalizes schema-backed null-prototype filter values before cache-keying", () =>
+    Effect.gen(function* () {
+      const store = new TopicStore(
+        "special",
+        Schema.Struct({
+          id: Schema.String,
+          payload: Schema.Record(Schema.String, Schema.String),
+        }),
+        "id",
+        () => {},
+      );
+      const queryPayload: Record<string, string> = Object.create(null);
+      queryPayload["venue"] = "xnys";
+
+      const nullPrototypeQuery = yield* prepareRuntimeRawQuery(
+        "special",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id", "payload"],
+          where: {
+            payload: queryPayload,
+          },
+        },
+      );
+      const plainRecordQuery = yield* prepareRuntimeRawQuery(
+        "special",
+        activeQueryTestMetadata(store),
+        {
+          select: ["id", "payload"],
+          where: {
+            payload: { venue: "xnys" },
+          },
+        },
+      );
+      const nullPrototypeGrouped = yield* prepareRuntimeGroupedQuery(
+        "special",
+        activeQueryTestMetadata(store),
+        {
+          groupBy: ["payload"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          where: { payload: queryPayload },
+        },
+      );
+      const plainRecordGrouped = yield* prepareRuntimeGroupedQuery(
+        "special",
+        activeQueryTestMetadata(store),
+        {
+          groupBy: ["payload"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          where: { payload: { venue: "xnys" } },
+        },
+      );
+
+      expect(nullPrototypeQuery.plan.queryCacheKey).toBe(plainRecordQuery.plan.queryCacheKey);
+      expect(nullPrototypeGrouped.cacheKey).toBe(plainRecordGrouped.cacheKey);
+    }),
+  );
+
+  it.effect("rejects non-serializable filter values before cache-keying", () =>
+    Effect.gen(function* () {
+      const firstFunction = () => "first";
+      const firstSymbol = Symbol("first");
+      const firstMap = new Map([["marker", "first"]]);
+      const store = new TopicStore(
+        "special-non-serializable",
+        Schema.Struct({
+          id: Schema.String,
+          marker: Schema.Unknown,
+        }),
+        "id",
+        () => {},
+      );
+
+      const functionFilter = yield* Effect.flip(
+        prepareRuntimeRawQuery("special-non-serializable", activeQueryTestMetadata(store), {
+          select: ["id", "marker"],
+          where: {
+            marker: firstFunction,
+          },
+        }),
+      );
+      expect(functionFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
+
+      const symbolFilter = yield* Effect.flip(
+        prepareRuntimeRawQuery("special-non-serializable", activeQueryTestMetadata(store), {
+          select: ["id", "marker"],
+          where: {
+            marker: firstSymbol,
+          },
+        }),
+      );
+      expect(symbolFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
+
+      const mapFilter = yield* Effect.flip(
+        prepareRuntimeRawQuery("special-non-serializable", activeQueryTestMetadata(store), {
+          select: ["id", "marker"],
+          where: {
+            marker: firstMap,
+          },
+        }),
+      );
+      expect(mapFilter).toMatchObject({
+        _tag: "InvalidQueryError",
+        message: expect.stringContaining("unsupported query value"),
+      });
+    }),
+  );
+});

--- a/packages/column-live-view-engine/src/active-query.ts
+++ b/packages/column-live-view-engine/src/active-query.ts
@@ -1,19 +1,12 @@
-import { Effect, Option } from "effect";
-import type { DeltaEvent, SnapshotEvent } from "@effect-view-server/config";
-import type { QueryEvaluation } from "./query-result";
-import type { TopicRawWindowScan } from "./raw-window-scan";
-import type { TopicRowScan } from "./row-scan";
-import {
-  activeRawQueryExecutionCount,
-  clearRawQueryExecutions,
-  type RawQueryExecutionSlot,
-} from "./active-raw-query";
-import type { MaterializedQueryExecutionSlot } from "./active-materialized-query";
+import { Effect } from "effect";
+import { activeRawQueryExecutionCount, clearRawQueryExecutions } from "./active-raw-query";
 import {
   activeMaterializedQueryExecutionCount,
   activeMaterializedQueryExecutionModeCounts,
   clearMaterializedQueryExecutions,
 } from "./active-materialized-query";
+import type { ActiveQueryExecutionCounts, ActiveQueryRegistry } from "./active-query-contract";
+
 export {
   acquireRawQueryExecution,
   evaluateRawQuery,
@@ -24,84 +17,43 @@ export {
   acquireMaterializedQueryExecution,
   releaseMaterializedQueryExecution,
 } from "./active-materialized-query";
-export type { MaterializedQueryExecution } from "./active-materialized-query";
-
-type RowObject = object;
-
-export type ActiveQueryStoreState = TopicRowScan<object> &
-  TopicRawWindowScan<object> & {
-    readonly activeQueries: ActiveQueryRegistry;
-    readonly releaseChanges: () => void;
-    readonly retainChanges: () => void;
-    readonly topic: string;
-  };
-
-export type LiveQueryExecutionCursor = {
-  evaluation: QueryEvaluation<RowObject>;
-};
-
-type RawQueryExecutionUpdate<ResultRow extends RowObject> = Effect.Effect<
-  Option.Option<DeltaEvent<ResultRow>>,
-  never,
-  never
->;
-
-export type LiveQueryExecution<ResultRow extends RowObject> = {
-  readonly initial: (queryId: string) => SnapshotEvent<ResultRow>;
-  readonly createCursor: () => LiveQueryExecutionCursor;
-  readonly next: (
-    queryId: string,
-    cursor: LiveQueryExecutionCursor,
-  ) => RawQueryExecutionUpdate<ResultRow>;
-};
-
-export type RawQueryExecution<ResultRow extends RowObject> = LiveQueryExecution<ResultRow>;
-
-export type ActiveQueryRegistry = {
-  readonly raw: Map<string, RawQueryExecutionSlot>;
-  readonly materialized: Map<string, MaterializedQueryExecutionSlot>;
-};
-
-export type ActiveQueryExecutionCounts = {
-  readonly activeFallbackGroupedViews: number;
-  readonly activeIncrementalGroupedViews: number;
-  readonly activeViews: number;
-  readonly groupedFullEvaluationCount: number;
-  readonly groupedPatchedEvaluationCount: number;
-};
-
-export const createActiveQueryRegistry = (): ActiveQueryRegistry => ({
-  raw: new Map(),
-  materialized: new Map(),
-});
+export {
+  createActiveQueryRegistry,
+  type ActiveQueryExecutionCounts,
+  type ActiveQueryRegistry,
+  type LiveQueryExecution,
+  type LiveQueryExecutionCursor,
+  type MaterializedQueryExecution,
+  type RawQueryExecution,
+} from "./active-query-contract";
 
 export const clearStoreRawQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.clearStore",
-)((store: ActiveQueryStoreState) =>
+)((registry: ActiveQueryRegistry) =>
   Effect.uninterruptible(
     Effect.gen(function* () {
-      yield* clearRawQueryExecutions(store);
-      yield* clearMaterializedQueryExecutions(store);
+      yield* clearRawQueryExecutions(registry);
+      yield* clearMaterializedQueryExecutions(registry);
     }),
   ),
 );
 
 export const activeStoreRawQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.countStore",
-)((store: ActiveQueryStoreState) =>
+)((registry: ActiveQueryRegistry) =>
   Effect.gen(function* () {
-    const rawCount = yield* activeRawQueryExecutionCount(store);
-    const materializedCount = yield* activeMaterializedQueryExecutionCount(store);
+    const rawCount = yield* activeRawQueryExecutionCount(registry);
+    const materializedCount = yield* activeMaterializedQueryExecutionCount(registry);
     return rawCount + materializedCount;
   }),
 );
 
 export const activeStoreQueryExecutionCounts = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.countStoreModes",
-)((store: ActiveQueryStoreState) =>
+)((registry: ActiveQueryRegistry) =>
   Effect.gen(function* () {
-    const rawCount = yield* activeRawQueryExecutionCount(store);
-    const materializedCounts = yield* activeMaterializedQueryExecutionModeCounts(store);
+    const rawCount = yield* activeRawQueryExecutionCount(registry);
+    const materializedCounts = yield* activeMaterializedQueryExecutionModeCounts(registry);
     return {
       activeFallbackGroupedViews: materializedCounts.activeFallback,
       activeIncrementalGroupedViews: materializedCounts.activeIncremental,

--- a/packages/column-live-view-engine/src/active-raw-query.ts
+++ b/packages/column-live-view-engine/src/active-raw-query.ts
@@ -1,6 +1,14 @@
 import { Effect, Option } from "effect";
 import type { DeltaEvent, LiveQueryResult } from "@effect-view-server/config";
-import type { ActiveQueryStoreState, RawQueryExecution } from "./active-query";
+import type {
+  ActiveQueryBaseEvaluation,
+  ActiveQueryBaseExecution,
+  ActiveQueryRegistry,
+  RawQueryExecution,
+  RawQueryExecutionSlot,
+  RawQueryExecutionWindowSlot,
+  RetainedWindowEntry,
+} from "./active-query-contract";
 import type { CompiledRawQuery } from "./raw-query-compiler";
 import {
   rawQueryPlanWindow,
@@ -10,44 +18,13 @@ import {
 import { deltaEvent, deltaOperations, snapshotEvent } from "./query-result";
 import type { QueryEvaluation } from "./query-result";
 import type { TopicRawWindowScan } from "./raw-window-scan";
-import type { TopicRowEntry } from "./row-scan";
 import {
   bindTopicStorageProjection,
   type TopicStorageProjectionSession,
 } from "./topic-storage-projection";
+import type { TopicStoreQueryInterface } from "./topic-store-query-interface";
 
 type RowObject = object;
-
-type ActiveQueryBaseExecution = {
-  readonly latest: () => ActiveQueryBaseEvaluation<object>;
-};
-
-export type RawQueryExecutionSlot = {
-  readonly execution: ActiveQueryBaseExecution;
-  readonly releaseRetainedChanges: () => void;
-  readonly windows: Map<string, RawQueryExecutionWindowSlot>;
-  refs: number;
-};
-
-type RawQueryExecutionWindowSlot = {
-  readonly window: RawQueryPlanWindow;
-  refs: number;
-};
-
-type ActiveQueryBaseEvaluation<Row extends RowObject> = {
-  readonly keyIndex: ReadonlyMap<string, number>;
-  readonly keys: ReadonlyArray<string>;
-  readonly retainedWindowFilled: boolean;
-  readonly totalRows: number;
-  readonly version: number;
-  readonly window: ReadonlyArray<RetainedWindowEntry<Row>>;
-};
-
-type RetainedWindowEntry<Row extends RowObject = RowObject> = TopicRowEntry<Row> & {
-  readonly key: string;
-  readonly row: Row;
-  readonly slot?: number;
-};
 
 const retainedWindowFilled = (
   window: ReadonlyArray<{ readonly key: string; readonly row: RowObject }>,
@@ -63,8 +40,10 @@ const retainedWindowLookahead = (window: RawQueryPlanWindow): number => {
   return window.limit >= 128 ? 64 : 1;
 };
 
-const getActiveRawQueryMap = (store: ActiveQueryStoreState): Map<string, RawQueryExecutionSlot> => {
-  return store.activeQueries.raw;
+const getActiveRawQueryMap = (
+  registry: ActiveQueryRegistry,
+): Map<string, RawQueryExecutionSlot> => {
+  return registry.raw;
 };
 
 const retainedWindowKeyIndex = (
@@ -78,14 +57,14 @@ const retainedWindowKeyIndex = (
 };
 
 const getActiveRawQueryEntry = <ResultRow extends RowObject>(
-  store: ActiveQueryStoreState,
+  registry: ActiveQueryRegistry,
   compiled: CompiledRawQuery<object, ResultRow>,
 ): {
   map: Map<string, RawQueryExecutionSlot>;
   key: string;
 } => {
   const key = compiled.plan.queryCacheKey;
-  const map = getActiveRawQueryMap(store);
+  const map = getActiveRawQueryMap(registry);
   return { map, key };
 };
 
@@ -181,7 +160,7 @@ const retainedLimitAfterInsertedChanges = (
 };
 
 const updateBaseEvaluationFromRetainedChanges = (
-  store: ActiveQueryStoreState,
+  store: TopicStoreQueryInterface,
   compiled: CompiledRawQuery<object, object>,
   evaluation: ActiveQueryBaseEvaluation<object>,
   baseWindow: RawQueryPlanWindow,
@@ -468,7 +447,7 @@ export const evaluateRawQueryResult = <Row extends RowObject, ResultRow extends 
 };
 
 const leaseRawQueryExecution = <ResultRow extends RowObject>(
-  store: ActiveQueryStoreState,
+  store: TopicStoreQueryInterface,
   execution: ActiveQueryBaseExecution,
   compiled: CompiledRawQuery<object, ResultRow>,
   storageProjection: TopicStorageProjectionSession<ResultRow> | undefined,
@@ -561,7 +540,7 @@ const releaseRawQueryWindow = (
 
 const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.make")(
   (
-    store: ActiveQueryStoreState,
+    store: TopicStoreQueryInterface,
     canonicalCompiled: CompiledRawQuery<object, object>,
     windows: ReadonlyMap<string, RawQueryExecutionWindowSlot>,
   ) =>
@@ -612,11 +591,12 @@ const makeRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.ma
 
 export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.acquire")(
   function* <ResultRow extends RowObject>(
-    store: ActiveQueryStoreState,
+    store: TopicStoreQueryInterface,
+    registry: ActiveQueryRegistry,
     compiled: CompiledRawQuery<object, ResultRow>,
   ) {
     const storageProjection = bindStoreProjection(store, compiled);
-    const { map, key } = getActiveRawQueryEntry(store, compiled);
+    const { map, key } = getActiveRawQueryEntry(registry, compiled);
     const existing = map.get(key);
     if (existing !== undefined) {
       const entry = existing;
@@ -643,11 +623,11 @@ export const acquireRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
 
 export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.release")(
   <ResultRow extends RowObject>(
-    store: ActiveQueryStoreState,
+    registry: ActiveQueryRegistry,
     compiled: CompiledRawQuery<object, ResultRow>,
   ) =>
     Effect.sync(() => {
-      const { map, key } = getActiveRawQueryEntry(store, compiled);
+      const { map, key } = getActiveRawQueryEntry(registry, compiled);
       const existing = map.get(key);
       if (existing === undefined) {
         return undefined;
@@ -668,9 +648,9 @@ export const releaseRawQueryExecution = Effect.fn("ColumnLiveViewEngine.activeQu
 );
 
 export const clearRawQueryExecutions = Effect.fn("ColumnLiveViewEngine.activeQuery.raw.clearStore")(
-  (store: ActiveQueryStoreState) =>
+  (registry: ActiveQueryRegistry) =>
     Effect.sync(() => {
-      const map = getActiveRawQueryMap(store);
+      const map = getActiveRawQueryMap(registry);
       for (const entry of map.values()) {
         entry.releaseRetainedChanges();
       }
@@ -680,4 +660,4 @@ export const clearRawQueryExecutions = Effect.fn("ColumnLiveViewEngine.activeQue
 
 export const activeRawQueryExecutionCount = Effect.fn(
   "ColumnLiveViewEngine.activeQuery.raw.countStore",
-)((store: ActiveQueryStoreState) => Effect.sync(() => getActiveRawQueryMap(store).size));
+)((registry: ActiveQueryRegistry) => Effect.sync(() => getActiveRawQueryMap(registry).size));

--- a/packages/column-live-view-engine/src/subscription-lifecycle.test.ts
+++ b/packages/column-live-view-engine/src/subscription-lifecycle.test.ts
@@ -6,10 +6,13 @@ import { TopicRowStorage } from "./topic-row-storage";
 import {
   acquireMaterializedQueryExecution,
   acquireRawQueryExecution,
+  activeQueryTestInterface,
+  activeQueryTestInterfaceForStorage,
+  activeQueryTestMetadata,
   activeStoreRawQueryExecutionCount,
   clearStoreRawQueryExecutions,
   releaseMaterializedQueryExecution,
-} from "./active-query";
+} from "../test-harness/active-query-interface";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
 import {
   acquireSubscriptionHandoff,
@@ -32,7 +35,6 @@ import {
   resetTopicStore,
   TopicStore,
 } from "./topic-store";
-import { topicStoreRawQueryMetadata, topicStoreReadModel } from "./topic-store-state";
 import { expectDefined } from "../test-harness/events";
 import { order, Order } from "../test-harness/public-engine";
 import { registerTestTopicStoreSubscriber } from "../test-harness/topic-store";
@@ -336,15 +338,15 @@ describe("Subscription lifecycle ownership", () => {
   it.effect("exposes bounded row-change batches for active query catch-up", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});
-      const readModel = topicStoreReadModel(store);
-      expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
-      expect(readModel.changesSince(-1)).toBeUndefined();
-      expect(readModel.changesSince(1)).toBeUndefined();
+      const queryInterface = activeQueryTestInterface(store);
+      expect(queryInterface.changesSince(queryInterface.version())).toStrictEqual([]);
+      expect(queryInterface.changesSince(-1)).toBeUndefined();
+      expect(queryInterface.changesSince(1)).toBeUndefined();
 
       yield* publishTopicStoreRow(store, order("initial", "open", 10, 1), (topic, message) =>
         InvalidRowError.make({ topic, message }),
       );
-      expect(readModel.changesSince(0)).toBeUndefined();
+      expect(queryInterface.changesSince(0)).toBeUndefined();
 
       const compiled = yield* prepareRuntimeGroupedQuery(
         "orders",
@@ -355,17 +357,17 @@ describe("Subscription lifecycle ownership", () => {
         },
       );
       const execution = yield* acquireMaterializedQueryExecution(
-        readModel,
+        queryInterface,
         "journal-bounds",
         compiled.plan.resultSemantics,
-        () => makeIncrementalGroupedQueryExecution(readModel, compiled, () => {}),
+        () => makeIncrementalGroupedQueryExecution(queryInterface, compiled, () => {}),
       );
-      expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
+      expect(queryInterface.changesSince(queryInterface.version())).toStrictEqual([]);
 
       yield* publishTopicStoreRow(store, order("first-active", "open", 11, 2), (topic, message) =>
         InvalidRowError.make({ topic, message }),
       );
-      expect(readModel.changesSince(1)).toStrictEqual([
+      expect(queryInterface.changesSince(1)).toStrictEqual([
         {
           version: 2,
           changes: [
@@ -386,11 +388,11 @@ describe("Subscription lifecycle ownership", () => {
         );
       }
 
-      expect(readModel.version()).toBe(1_027);
-      expect(readModel.changesSince(0)).toBeUndefined();
-      expect(readModel.changesSince(readModel.version())).toStrictEqual([]);
-      yield* releaseMaterializedQueryExecution(readModel, "journal-bounds");
-      expect(readModel.changesSince(readModel.version() - 1)).toBeUndefined();
+      expect(queryInterface.version()).toBe(1_027);
+      expect(queryInterface.changesSince(0)).toBeUndefined();
+      expect(queryInterface.changesSince(queryInterface.version())).toStrictEqual([]);
+      yield* releaseMaterializedQueryExecution(queryInterface, "journal-bounds");
+      expect(queryInterface.changesSince(queryInterface.version() - 1)).toBeUndefined();
       const cursor = execution.createCursor();
       const unchanged = yield* execution.next("released-journal", cursor);
       expect(Option.isNone(unchanged)).toBe(true);
@@ -414,19 +416,34 @@ describe("Subscription lifecycle ownership", () => {
         },
       );
       yield* acquireMaterializedQueryExecution(
-        storage.readModel,
+        activeQueryTestInterfaceForStorage(storage),
         "overflow-journal",
         compiled.plan.resultSemantics,
-        () => makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
+        () =>
+          makeIncrementalGroupedQueryExecution(
+            activeQueryTestInterfaceForStorage(storage),
+            compiled,
+            () => {},
+          ),
       );
       yield* acquireMaterializedQueryExecution(
-        storage.readModel,
+        activeQueryTestInterfaceForStorage(storage),
         "overflow-journal-second",
         compiled.plan.resultSemantics,
-        () => makeIncrementalGroupedQueryExecution(storage.readModel, compiled, () => {}),
+        () =>
+          makeIncrementalGroupedQueryExecution(
+            activeQueryTestInterfaceForStorage(storage),
+            compiled,
+            () => {},
+          ),
       );
-      yield* releaseMaterializedQueryExecution(storage.readModel, "overflow-journal-second");
-      expect(storage.readModel.changesSince(storage.version)).toStrictEqual([]);
+      yield* releaseMaterializedQueryExecution(
+        activeQueryTestInterfaceForStorage(storage),
+        "overflow-journal-second",
+      );
+      expect(
+        activeQueryTestInterfaceForStorage(storage).changesSince(storage.version),
+      ).toStrictEqual([]);
 
       const baseVersion = storage.version;
       storage.setPreparedMany(
@@ -436,14 +453,16 @@ describe("Subscription lifecycle ownership", () => {
         ),
       );
       storage.advanceVersion();
-      expect(storage.readModel.changesSince(baseVersion)).toBeUndefined();
+      expect(activeQueryTestInterfaceForStorage(storage).changesSince(baseVersion)).toBeUndefined();
 
       const recoveredVersion = storage.version;
       storage.setPrepared(
         yield* storage.prepareRow(order("after-overflow", "closed", 1, 1), invalidRow),
       );
       storage.advanceVersion();
-      expect(storage.readModel.changesSince(recoveredVersion)).toStrictEqual([
+      expect(
+        activeQueryTestInterfaceForStorage(storage).changesSince(recoveredVersion),
+      ).toStrictEqual([
         {
           version: recoveredVersion + 1,
           changes: [
@@ -469,16 +488,22 @@ describe("Subscription lifecycle ownership", () => {
         );
         storage.advanceVersion();
       }
-      expect(storage.readModel.changesSince(multiVersionOverflowStart)).toBeUndefined();
+      expect(
+        activeQueryTestInterfaceForStorage(storage).changesSince(multiVersionOverflowStart),
+      ).toBeUndefined();
 
-      yield* clearStoreRawQueryExecutions(storage.readModel);
-      expect(yield* activeStoreRawQueryExecutionCount(storage.readModel)).toBe(0);
+      yield* clearStoreRawQueryExecutions(activeQueryTestInterfaceForStorage(storage));
+      expect(
+        yield* activeStoreRawQueryExecutionCount(activeQueryTestInterfaceForStorage(storage)),
+      ).toBe(0);
       storage.setPrepared(
         yield* storage.prepareRow(order("after-clear", "open", 1, 1), invalidRow),
       );
       const afterClearVersion = storage.version;
       storage.advanceVersion();
-      expect(storage.readModel.changesSince(afterClearVersion)).toBeUndefined();
+      expect(
+        activeQueryTestInterfaceForStorage(storage).changesSince(afterClearVersion),
+      ).toBeUndefined();
 
       const fallbackStorage = new TopicRowStorage("orders", Order, "id", {
         maxEntries: 4,
@@ -494,13 +519,22 @@ describe("Subscription lifecycle ownership", () => {
       );
       fallbackStorage.advanceVersion();
       yield* acquireMaterializedQueryExecution(
-        fallbackStorage.readModel,
+        activeQueryTestInterfaceForStorage(fallbackStorage),
         "fallback-clear",
         compiled.plan.resultSemantics,
-        () => makeIncrementalGroupedQueryExecution(fallbackStorage.readModel, compiled, () => {}),
+        () =>
+          makeIncrementalGroupedQueryExecution(
+            activeQueryTestInterfaceForStorage(fallbackStorage),
+            compiled,
+            () => {},
+          ),
       );
-      yield* clearStoreRawQueryExecutions(fallbackStorage.readModel);
-      expect(yield* activeStoreRawQueryExecutionCount(fallbackStorage.readModel)).toBe(0);
+      yield* clearStoreRawQueryExecutions(activeQueryTestInterfaceForStorage(fallbackStorage));
+      expect(
+        yield* activeStoreRawQueryExecutionCount(
+          activeQueryTestInterfaceForStorage(fallbackStorage),
+        ),
+      ).toBe(0);
     }),
   );
 
@@ -521,12 +555,12 @@ describe("Subscription lifecycle ownership", () => {
         },
       );
       const execution = yield* acquireMaterializedQueryExecution(
-        storage.readModel,
+        activeQueryTestInterfaceForStorage(storage),
         "demoted-grouped-journal",
         compiled.plan.resultSemantics,
         (releaseRetainedChanges) =>
           makeIncrementalGroupedQueryExecution(
-            storage.readModel,
+            activeQueryTestInterfaceForStorage(storage),
             compiled,
             releaseRetainedChanges,
             {
@@ -551,9 +585,14 @@ describe("Subscription lifecycle ownership", () => {
         yield* storage.prepareRow(order("after-demotion", "closed", 1, 1), invalidRow),
       );
       storage.advanceVersion();
-      expect(storage.readModel.changesSince(demotedVersion)).toBeUndefined();
+      expect(
+        activeQueryTestInterfaceForStorage(storage).changesSince(demotedVersion),
+      ).toBeUndefined();
 
-      yield* releaseMaterializedQueryExecution(storage.readModel, "demoted-grouped-journal");
+      yield* releaseMaterializedQueryExecution(
+        activeQueryTestInterfaceForStorage(storage),
+        "demoted-grouped-journal",
+      );
     }),
   );
 
@@ -634,10 +673,10 @@ describe("Subscription lifecycle ownership", () => {
   it.effect("interrupted topic-store close still releases subscribers and active queries", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});
-      const compiled = yield* prepareRuntimeRawQuery("orders", topicStoreRawQueryMetadata(store), {
+      const compiled = yield* prepareRuntimeRawQuery("orders", activeQueryTestMetadata(store), {
         select: ["id"],
       });
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+      yield* acquireRawQueryExecution(activeQueryTestInterface(store), compiled);
 
       const closeStarted = yield* Deferred.make<void>();
       const subscriber: LiveTopicSubscriber = {
@@ -656,7 +695,7 @@ describe("Subscription lifecycle ownership", () => {
         closed: false,
       };
       yield* registerTestTopicStoreSubscriber(store, subscriber);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
 
       const closeFiber = yield* Effect.forkChild(closeTopicStoreSubscriptions(store));
       yield* Deferred.await(closeStarted);
@@ -671,10 +710,10 @@ describe("Subscription lifecycle ownership", () => {
   it.effect("interrupted topic-store reset still releases subscribers and active queries", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});
-      const compiled = yield* prepareRuntimeRawQuery("orders", topicStoreRawQueryMetadata(store), {
+      const compiled = yield* prepareRuntimeRawQuery("orders", activeQueryTestMetadata(store), {
         select: ["id"],
       });
-      yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+      yield* acquireRawQueryExecution(activeQueryTestInterface(store), compiled);
 
       const closeStarted = yield* Deferred.make<void>();
       const subscriber: LiveTopicSubscriber = {
@@ -693,7 +732,7 @@ describe("Subscription lifecycle ownership", () => {
         closed: false,
       };
       yield* registerTestTopicStoreSubscriber(store, subscriber);
-      expect(yield* activeStoreRawQueryExecutionCount(topicStoreReadModel(store))).toBe(1);
+      expect(yield* activeStoreRawQueryExecutionCount(activeQueryTestInterface(store))).toBe(1);
 
       const resetFiber = yield* Effect.forkChild(resetTopicStore(store));
       yield* Deferred.await(closeStarted);
@@ -709,7 +748,7 @@ describe("Subscription lifecycle ownership", () => {
   it.effect("materialized active queries ignore unchanged evaluations and unknown releases", () =>
     Effect.gen(function* () {
       const store = new TopicStore("orders", Order, "id", () => {});
-      const readModel = topicStoreReadModel(store);
+      const queryInterface = activeQueryTestInterface(store);
       let evaluationCount = 0;
       const evaluate = () => {
         evaluationCount += 1;
@@ -718,7 +757,7 @@ describe("Subscription lifecycle ownership", () => {
           keys: [],
           window: [],
           totalRows: 0,
-          version: readModel.version(),
+          version: queryInterface.version(),
         };
       };
       const makeExecution = () => {
@@ -734,7 +773,7 @@ describe("Subscription lifecycle ownership", () => {
       };
 
       const execution = yield* acquireMaterializedQueryExecution(
-        readModel,
+        queryInterface,
         "empty-materialized",
         emptyResultSemantics,
         makeExecution,
@@ -745,17 +784,17 @@ describe("Subscription lifecycle ownership", () => {
       expect(Option.isNone(unchanged)).toBe(true);
       expect(evaluationCount).toBe(1);
       yield* acquireMaterializedQueryExecution(
-        readModel,
+        queryInterface,
         "second-materialized",
         emptyResultSemantics,
         makeExecution,
       );
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(2);
-      yield* releaseMaterializedQueryExecution(readModel, "empty-materialized");
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(1);
-      yield* releaseMaterializedQueryExecution(readModel, "missing-materialized");
-      yield* releaseMaterializedQueryExecution(readModel, "second-materialized");
-      expect(yield* activeStoreRawQueryExecutionCount(readModel)).toBe(0);
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(2);
+      yield* releaseMaterializedQueryExecution(queryInterface, "empty-materialized");
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(1);
+      yield* releaseMaterializedQueryExecution(queryInterface, "missing-materialized");
+      yield* releaseMaterializedQueryExecution(queryInterface, "second-materialized");
+      expect(yield* activeStoreRawQueryExecutionCount(queryInterface)).toBe(0);
     }),
   );
 });

--- a/packages/column-live-view-engine/src/topic-predicate-candidate-index.test.ts
+++ b/packages/column-live-view-engine/src/topic-predicate-candidate-index.test.ts
@@ -24,7 +24,7 @@ import {
   resetTopicStore,
   TopicStore,
 } from "./topic-store";
-import { topicStoreReadModel } from "./topic-store-state";
+import { topicStoreTestQueryInterface } from "../test-harness/topic-store";
 import { makeColumns } from "../test-harness/columns";
 import { order, Order, position, Position } from "../test-harness/public-engine";
 
@@ -46,7 +46,7 @@ describe("Topic predicate candidate index", () => {
         (topic, message) => InvalidRowError.make({ topic, message }),
       );
 
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const callbackSkipped = readModel.scanRawWindow({
         predicate: {
           filters: [{ field: "note", operator: "startsWith", value: "he" }],
@@ -102,7 +102,7 @@ describe("Topic predicate candidate index", () => {
         { ...order("noted", "open", 40, 4), note: "hello" },
         (topic, message) => InvalidRowError.make({ topic, message }),
       );
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const indexedNumberIn = readModel.scanRawWindow({
         predicate: {
           filters: [
@@ -173,7 +173,7 @@ describe("Topic predicate candidate index", () => {
         InvalidRowError.make({ topic, message }),
       );
 
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const compareByKey = (left: { readonly key: string }, right: { readonly key: string }) =>
         left.key.localeCompare(right.key);
 
@@ -1055,7 +1055,7 @@ describe("Topic predicate candidate index", () => {
         (topic, message) => InvalidRowError.make({ topic, message }),
       );
 
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const callbackSkipped = readModel.scanRawWindow({
         predicate: {
           filters: [{ field: "price", operator: "gt", value: 10 }],
@@ -1121,7 +1121,7 @@ describe("Topic predicate candidate index", () => {
           InvalidRowError.make({ topic, message }),
         );
 
-        const readModel = topicStoreReadModel(store);
+        const readModel = topicStoreTestQueryInterface(store);
         const fallbackResult = readModel.scanRawWindow({
           predicate: {
             filters: [{ field: "status", operator: "eq", value: "match" }],
@@ -2474,7 +2474,7 @@ describe("Topic predicate candidate index", () => {
         InvalidRowError.make({ topic, message }),
       );
 
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const rangeHinted = readModel.scanRawWindow({
         predicate: {
           filters: [{ field: "quantity", operator: "gt", value: 10n }],
@@ -2505,7 +2505,7 @@ describe("Topic predicate candidate index", () => {
         InvalidRowError.make({ topic, message }),
       );
 
-      const orderReadModel = topicStoreReadModel(orderStore);
+      const orderReadModel = topicStoreTestQueryInterface(orderStore);
       const exactNumberNotEqual = orderReadModel.scanRawWindow({
         predicate: {
           filters: [{ field: "price", operator: "neq", value: 20 }],
@@ -2615,7 +2615,7 @@ describe("Topic predicate candidate index", () => {
         (topic, message) => InvalidRowError.make({ topic, message }),
       );
 
-      const positionReadModel = topicStoreReadModel(positionStore);
+      const positionReadModel = topicStoreTestQueryInterface(positionStore);
       const manualBigDecimalRangeHint = positionReadModel.scanRawWindow({
         predicate: {
           filters: [{ field: "price", operator: "gt", value: fromStringUnsafe("20") }],
@@ -2666,7 +2666,7 @@ describe("Topic predicate candidate index", () => {
         InvalidRowError.make({ topic, message }),
       );
 
-      const looseNumberReadModel = topicStoreReadModel(looseNumberStore);
+      const looseNumberReadModel = topicStoreTestQueryInterface(looseNumberStore);
       const exactFiniteRange = looseNumberReadModel.scanRawWindow({
         predicate: {
           filters: [{ field: "value", operator: "gt", value: 10 }],

--- a/packages/column-live-view-engine/src/topic-row-storage.ts
+++ b/packages/column-live-view-engine/src/topic-row-storage.ts
@@ -1,6 +1,5 @@
 import type { RowSchema } from "@effect-view-server/config";
 import { Effect } from "effect";
-import { createActiveQueryRegistry, type ActiveQueryStoreState } from "./active-query";
 import type {
   TopicRowChange,
   TopicRowChangeBatch,
@@ -63,6 +62,7 @@ import {
   makeTopicStorageProjectionCapability,
   type TopicStorageProjectionCapability,
 } from "./topic-storage-projection";
+import type { TopicStoreQueryInterface } from "./topic-store-query-interface";
 
 type RowObject = object;
 
@@ -86,7 +86,7 @@ const noopAppendBatchReservation: AppendBatchReservation = {
 
 export class TopicRowStorage {
   readonly rawQueryMetadata: RawQueryCompilerMetadata;
-  readonly readModel: ActiveQueryStoreState & {
+  readonly queryInterface: TopicStoreQueryInterface & {
     readonly storageProjection: TopicStorageProjectionCapability;
   };
   readonly valueSemantics: TopicRowValueSemantics;
@@ -152,8 +152,7 @@ export class TopicRowStorage {
         this.reservableColumns.push(column);
       }
     }
-    this.readModel = {
-      activeQueries: createActiveQueryRegistry(),
+    this.queryInterface = {
       topic,
       changesSince: (version) => this.changesSince(version),
       compareRawSlots: (plan) => this.compareRawSlots(plan),

--- a/packages/column-live-view-engine/src/topic-storage-projection-proof.test.ts
+++ b/packages/column-live-view-engine/src/topic-storage-projection-proof.test.ts
@@ -28,7 +28,7 @@ describe("Topic Storage projection proof", () => {
       let slotForKeyCalls = 0;
       const evaluation = evaluateRawQuery(
         {
-          ...storage.readModel,
+          ...storage.queryInterface,
           scanRawWindow: () => ({
             keys: ["projected-from-slot-2"],
             window: [
@@ -92,7 +92,7 @@ describe("Topic Storage projection proof", () => {
       let slotForKeyCalls = 0;
       const evaluation = evaluateRawQuery(
         {
-          ...storage.readModel,
+          ...storage.queryInterface,
           scanRawWindow: () => ({
             keys: ["moved-row"],
             window: [
@@ -106,7 +106,7 @@ describe("Topic Storage projection proof", () => {
           }),
           slotForKey: (key) => {
             slotForKeyCalls += 1;
-            return storage.readModel.slotForKey?.(key);
+            return storage.queryInterface.slotForKey?.(key);
           },
           version: () => 2,
         },
@@ -234,7 +234,7 @@ describe("Topic Storage projection proof", () => {
       expect(() =>
         evaluateRawQuery(
           {
-            ...incompatibleStorage.readModel,
+            ...incompatibleStorage.queryInterface,
             keyAtSlot: () => "hostile",
             scanRawWindow: () => ({
               keys: ["hostile"],
@@ -276,7 +276,7 @@ describe("Topic Storage projection proof", () => {
         Reflect.get(grouped.plan.resultSemantics, "topicStorageProjectionProof"),
       ).toBeUndefined();
       expect(Reflect.get(grouped.plan.resultSemantics, "projectTopicStorageRow")).toBeUndefined();
-      expect(Object.isFrozen(storage.readModel.storageProjection)).toBe(true);
+      expect(Object.isFrozen(storage.queryInterface.storageProjection)).toBe(true);
     }),
   );
 
@@ -290,10 +290,10 @@ describe("Topic Storage projection proof", () => {
         select: ["id", "price"],
       });
       const proof = first.plan.resultSemantics.topicStorageProjectionProof;
-      const session = bindTopicStorageProjection(storage.readModel.storageProjection, proof);
+      const session = bindTopicStorageProjection(storage.queryInterface.storageProjection, proof);
 
-      expect(Object.isFrozen(storage.readModel.storageProjection)).toBe(true);
-      expect(Object.isFrozen(Object.getPrototypeOf(storage.readModel.storageProjection))).toBe(
+      expect(Object.isFrozen(storage.queryInterface.storageProjection)).toBe(true);
+      expect(Object.isFrozen(Object.getPrototypeOf(storage.queryInterface.storageProjection))).toBe(
         true,
       );
       expect(Object.isFrozen(session)).toBe(true);
@@ -310,7 +310,10 @@ describe("Topic Storage projection proof", () => {
       });
       expect(() =>
         Reflect.construct(
-          Reflect.get(Object.getPrototypeOf(storage.readModel.storageProjection), "constructor"),
+          Reflect.get(
+            Object.getPrototypeOf(storage.queryInterface.storageProjection),
+            "constructor",
+          ),
           [],
         ),
       ).toThrowError("Topic Storage projection construction is private.");
@@ -328,7 +331,7 @@ describe("Topic Storage projection proof", () => {
       ).toThrowError("Query Result Topic Storage projection proof binding is private.");
       expect(() =>
         Reflect.apply(
-          Reflect.get(Object.getPrototypeOf(storage.readModel.storageProjection), "bind"),
+          Reflect.get(Object.getPrototypeOf(storage.queryInterface.storageProjection), "bind"),
           Object.freeze({}),
           [first.plan.resultSemantics.topicStorageProjectionProof],
         ),
@@ -349,9 +352,12 @@ describe("Topic Storage projection proof", () => {
         select: ["price"],
       });
       const idProof = idQuery.plan.resultSemantics.topicStorageProjectionProof;
-      const idSession = bindTopicStorageProjection(storage.readModel.storageProjection, idProof);
+      const idSession = bindTopicStorageProjection(
+        storage.queryInterface.storageProjection,
+        idProof,
+      );
       const priceSession = bindTopicStorageProjection(
-        storage.readModel.storageProjection,
+        storage.queryInterface.storageProjection,
         priceQuery.plan.resultSemantics.topicStorageProjectionProof,
       );
       const proxyProof = new Proxy(idProof, {});
@@ -361,11 +367,11 @@ describe("Topic Storage projection proof", () => {
       };
 
       expect(() =>
-        bindTopicStorageProjection(storage.readModel.storageProjection, proxyProof),
+        bindTopicStorageProjection(storage.queryInterface.storageProjection, proxyProof),
       ).toThrowError("Query Result Topic Storage projection proof is not authentic.");
       expect(() =>
         Reflect.apply(bindTopicStorageProjection, undefined, [
-          storage.readModel.storageProjection,
+          storage.queryInterface.storageProjection,
           spreadProof,
         ]),
       ).toThrowError("Query Result Topic Storage projection proof is not authentic.");
@@ -409,13 +415,13 @@ describe("Topic Storage projection proof", () => {
       Reflect.set(storedEntry, "row", Object.freeze({ price: 10 }));
       expect(() =>
         bindTopicStorageProjection(
-          storage.readModel.storageProjection,
+          storage.queryInterface.storageProjection,
           compiled.plan.resultSemantics.topicStorageProjectionProof,
         ).projectResultRow(0),
       ).toThrowError("Projected Query Result Row does not satisfy its compiled proof.");
       expect(() =>
         bindTopicStorageProjection(
-          storage.readModel.storageProjection,
+          storage.queryInterface.storageProjection,
           compiled.plan.resultSemantics.topicStorageProjectionProof,
         ).projectOwnedResultRow(0),
       ).toThrowError("Projected Query Result Row does not satisfy its compiled proof.");
@@ -439,10 +445,10 @@ describe("Topic Storage projection proof", () => {
         select: ["id", "price"],
       });
 
-      expect(() => evaluateRawQuery(storage.readModel, compiled)).toThrowError(
+      expect(() => evaluateRawQuery(storage.queryInterface, compiled)).toThrowError(
         "Projected Query Result Row does not satisfy its compiled proof.",
       );
-      expect(() => evaluateRawQueryResult(storage.readModel, compiled)).toThrowError(
+      expect(() => evaluateRawQueryResult(storage.queryInterface, compiled)).toThrowError(
         "Projected Query Result Row does not satisfy its compiled proof.",
       );
     }),
@@ -474,7 +480,9 @@ describe("Topic Storage projection proof", () => {
         { select: ["id", "note"] },
       );
 
-      expect(evaluateRawQuery(storage.readModel, compiled).rows).toStrictEqual([{ id: "stored" }]);
+      expect(evaluateRawQuery(storage.queryInterface, compiled).rows).toStrictEqual([
+        { id: "stored" },
+      ]);
     }),
   );
 
@@ -496,7 +504,7 @@ describe("Topic Storage projection proof", () => {
         { select: ["id", "__proto__"] },
       );
 
-      const projected = evaluateRawQuery(storage.readModel, compiled).rows[0]!;
+      const projected = evaluateRawQuery(storage.queryInterface, compiled).rows[0]!;
       expect(Object.getPrototypeOf(projected)).toBe(Object.prototype);
       expect(Object.prototype.propertyIsEnumerable.call(projected, "__proto__")).toBe(true);
       expect(projected).toStrictEqual({ id: "stored", ["__proto__"]: "plain-data" });
@@ -563,7 +571,7 @@ describe("Topic Storage projection proof", () => {
         rawQueryCompilerMetadata(StructuredOrder),
         { select: ["id", "payload"] },
       );
-      const ownedResult = evaluateRawQueryResult(storage.readModel, compiled);
+      const ownedResult = evaluateRawQueryResult(storage.queryInterface, compiled);
       expect(ownedResult.rows).toStrictEqual([{ id: "stored", payload: { count: 1 } }]);
       expect(Reflect.get(ownedResult.rows[0]!, "payload")).not.toBe(
         Reflect.get(prepared.row, "payload"),
@@ -571,10 +579,10 @@ describe("Topic Storage projection proof", () => {
 
       expect(Reflect.set(Reflect.get(prepared.row, "payload"), "count", "wrong")).toBe(true);
 
-      expect(() => evaluateRawQuery(storage.readModel, compiled)).toThrowError(
+      expect(() => evaluateRawQuery(storage.queryInterface, compiled)).toThrowError(
         "Projected Query Result Row does not satisfy its compiled proof.",
       );
-      expect(() => evaluateRawQueryResult(storage.readModel, compiled)).toThrowError(
+      expect(() => evaluateRawQueryResult(storage.queryInterface, compiled)).toThrowError(
         "Projected Query Result Row does not satisfy its compiled proof.",
       );
     }),
@@ -600,7 +608,7 @@ describe("Topic Storage projection proof", () => {
         orderBy: [{ field: "price", direction: "desc" }],
         limit: 2,
       });
-      const evaluation = evaluateRawQuery(storage.readModel, compiled);
+      const evaluation = evaluateRawQuery(storage.queryInterface, compiled);
 
       expect(evaluation).toStrictEqual({
         keys: ["moved", "deleted"],

--- a/packages/column-live-view-engine/src/topic-store-ordered-window.test.ts
+++ b/packages/column-live-view-engine/src/topic-store-ordered-window.test.ts
@@ -11,7 +11,7 @@ import {
   publishTopicStoreRows,
   TopicStore,
 } from "./topic-store";
-import { topicStoreReadModel } from "./topic-store-state";
+import { topicStoreTestQueryInterface } from "../test-harness/topic-store";
 import { rawWindowOrderedSlotIndex } from "./topic-raw-ordered-window-index";
 import { numericRowField } from "../test-harness/columns";
 import { expectDefined } from "../test-harness/events";
@@ -33,7 +33,7 @@ describe("Topic Store ordered-window execution", () => {
       );
       yield* deleteTopicStoreRow(store, "1");
 
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const scannedKeys: Array<string> = [];
       readModel.scanRows((key) => {
         scannedKeys.push(key);
@@ -515,7 +515,7 @@ describe("Topic Store ordered-window execution", () => {
         return priceComparison === 0 ? left.key.localeCompare(right.key) : priceComparison;
       };
 
-      const readModel = topicStoreReadModel(store);
+      const readModel = topicStoreTestQueryInterface(store);
       const boundedWindow = readModel.scanRawWindow({
         predicate: {
           filters: [],
@@ -875,7 +875,7 @@ describe("Topic Store ordered-window execution", () => {
         numericRowField(left.row, "price") - numericRowField(right.row, "price") ||
         left.key.localeCompare(right.key);
 
-      const heapWindow = topicStoreReadModel(store).scanRawWindow({
+      const heapWindow = topicStoreTestQueryInterface(store).scanRawWindow({
         predicate: {
           filters: [],
           callbackRequired: false,
@@ -930,7 +930,7 @@ describe("Topic Store ordered-window execution", () => {
         right: { readonly row: object },
       ) => numericRowField(left.row, "price") - numericRowField(right.row, "price");
 
-      const priceOnlyTieWindow = topicStoreReadModel(store).scanRawWindow({
+      const priceOnlyTieWindow = topicStoreTestQueryInterface(store).scanRawWindow({
         predicate: {
           filters: [],
           callbackRequired: false,
@@ -963,7 +963,7 @@ describe("Topic Store ordered-window execution", () => {
         numericRowField(left.row, "updatedAt") - numericRowField(right.row, "updatedAt") ||
         left.key.localeCompare(right.key);
 
-      const candidateHeapWindow = topicStoreReadModel(store).scanRawWindow({
+      const candidateHeapWindow = topicStoreTestQueryInterface(store).scanRawWindow({
         predicate: {
           filters: [{ field: "region", operator: "eq", value: "emea" }],
           callbackRequired: false,
@@ -1013,7 +1013,7 @@ describe("Topic Store ordered-window execution", () => {
       ]);
       expect(candidateHeapWindow.totalRows).toBe(4_899);
 
-      const unboundedFallbackWindow = topicStoreReadModel(store).scanRawWindow({
+      const unboundedFallbackWindow = topicStoreTestQueryInterface(store).scanRawWindow({
         predicate: {
           filters: [],
           callbackRequired: false,

--- a/packages/column-live-view-engine/src/topic-store-plan-semantics.test.ts
+++ b/packages/column-live-view-engine/src/topic-store-plan-semantics.test.ts
@@ -4,7 +4,7 @@ import { evaluateRawQuery } from "./active-query";
 import { InvalidRowError } from "./index";
 import { prepareRuntimeRawQuery, rawQueryCompilerMetadata } from "./raw-query-compiler";
 import { publishTopicStoreRows, TopicStore } from "./topic-store";
-import { topicStoreReadModel } from "./topic-store-state";
+import { topicStoreTestQueryInterface } from "../test-harness/topic-store";
 import { position, Position } from "../test-harness/public-engine";
 
 describe("Topic Store plan semantics", () => {
@@ -17,7 +17,7 @@ describe("Topic Store plan semantics", () => {
         (topic, message) => InvalidRowError.make({ topic, message }),
       );
 
-      const result = topicStoreReadModel(store).scanRawWindow({
+      const result = topicStoreTestQueryInterface(store).scanRawWindow({
         predicate: {
           filters: [],
           callbackRequired: false,

--- a/packages/column-live-view-engine/src/topic-store-query-interface.ts
+++ b/packages/column-live-view-engine/src/topic-store-query-interface.ts
@@ -1,0 +1,11 @@
+import type { TopicRawWindowScan } from "./raw-window-scan";
+import type { TopicRowScan } from "./row-scan";
+
+type RowObject = object;
+
+export type TopicStoreQueryInterface<Row extends RowObject = RowObject> = TopicRowScan<Row> &
+  TopicRawWindowScan<Row> & {
+    readonly releaseChanges: () => void;
+    readonly retainChanges: () => void;
+    readonly topic: string;
+  };

--- a/packages/column-live-view-engine/src/topic-store-query.ts
+++ b/packages/column-live-view-engine/src/topic-store-query.ts
@@ -24,11 +24,7 @@ import {
 } from "./raw-query-compiler";
 import { InvalidQueryError } from "./raw-query-decoder";
 import type { QueryEvaluation } from "./query-result";
-import {
-  topicStoreRawQueryMetadata,
-  topicStoreReadModel,
-  type TopicStore,
-} from "./topic-store-state";
+import { topicStoreQueryResources, type TopicStore } from "./topic-store-state";
 
 type RowObject = object;
 
@@ -37,7 +33,7 @@ export const topicStoreQueryMetadata = Effect.fn("ColumnLiveViewEngine.topicStor
     store: TopicStore,
     schema: SchemaValue,
   ) {
-    const metadata = topicStoreRawQueryMetadata(store);
+    const { metadata } = topicStoreQueryResources(store);
     if (!rawQueryCompilerMetadataMatchesSchema(metadata, schema)) {
       return yield* InvalidQueryError.make({
         topic: store.topic,
@@ -62,7 +58,11 @@ export const prepareTopicStoreRawQuery = Effect.fn(
 export const prepareTopicStoreRuntimeRawQuery = Effect.fn(
   "ColumnLiveViewEngine.topicStore.query.raw.prepareRuntime",
 )(function* (store: TopicStore, query: unknown) {
-  return yield* prepareRuntimeRawQuery(store.topic, topicStoreRawQueryMetadata(store), query);
+  return yield* prepareRuntimeRawQuery(
+    store.topic,
+    topicStoreQueryResources(store).metadata,
+    query,
+  );
 });
 
 export const prepareTopicStoreGroupedQuery = Effect.fn(
@@ -79,18 +79,24 @@ export const prepareTopicStoreGroupedQuery = Effect.fn(
 export const prepareTopicStoreRuntimeGroupedQuery = Effect.fn(
   "ColumnLiveViewEngine.topicStore.query.grouped.prepareRuntime",
 )(function* (store: TopicStore, query: unknown) {
-  return yield* prepareRuntimeGroupedQuery(store.topic, topicStoreRawQueryMetadata(store), query);
+  return yield* prepareRuntimeGroupedQuery(
+    store.topic,
+    topicStoreQueryResources(store).metadata,
+    query,
+  );
 });
 
 export const evaluateTopicStoreRawQueryResult = <ResultRow extends RowObject>(
   store: TopicStore,
   compiled: CompiledRawQuery<object, ResultRow>,
-): LiveQueryResult<ResultRow> => evaluateRawQueryResult(topicStoreReadModel(store), compiled);
+): LiveQueryResult<ResultRow> =>
+  evaluateRawQueryResult(topicStoreQueryResources(store).queryInterface, compiled);
 
 export const evaluateTopicStoreGroupedQuery = <ResultRow extends RowObject>(
   store: TopicStore,
   compiled: CompiledGroupedQuery<object, ResultRow>,
-): QueryEvaluation<RowObject> => evaluateCompiledGroupedQuery(topicStoreReadModel(store), compiled);
+): QueryEvaluation<RowObject> =>
+  evaluateCompiledGroupedQuery(topicStoreQueryResources(store).queryInterface, compiled);
 
 export const acquireTopicStoreRawQueryExecution = Effect.fn(
   "ColumnLiveViewEngine.topicStore.query.raw.acquire",
@@ -98,13 +104,15 @@ export const acquireTopicStoreRawQueryExecution = Effect.fn(
   store: TopicStore,
   compiled: CompiledRawQuery<object, ResultRow>,
 ) {
-  return yield* acquireRawQueryExecution(topicStoreReadModel(store), compiled);
+  const { activeQueries, queryInterface } = topicStoreQueryResources(store);
+  return yield* acquireRawQueryExecution(queryInterface, activeQueries, compiled);
 });
 
 export const releaseTopicStoreRawQueryExecution = <ResultRow extends RowObject>(
   store: TopicStore,
   compiled: CompiledRawQuery<object, ResultRow>,
-): Effect.Effect<void> => releaseRawQueryExecution(topicStoreReadModel(store), compiled);
+): Effect.Effect<void> =>
+  releaseRawQueryExecution(topicStoreQueryResources(store).activeQueries, compiled);
 
 export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
   "ColumnLiveViewEngine.topicStore.query.materialized.acquire",
@@ -113,14 +121,15 @@ export const acquireTopicStoreMaterializedQueryExecution = Effect.fn(
   compiled: CompiledGroupedQuery<object, ResultRow>,
   groupedIncrementalAdmissionLimits: GroupedIncrementalAdmissionLimits,
 ) {
-  const readModel = topicStoreReadModel(store);
+  const { activeQueries, queryInterface } = topicStoreQueryResources(store);
   return yield* acquireMaterializedQueryExecution(
-    readModel,
+    queryInterface,
+    activeQueries,
     compiled.cacheKey,
     compiled.plan.resultSemantics,
     (releaseRetainedChanges) =>
       makeIncrementalGroupedQueryExecution(
-        readModel,
+        queryInterface,
         compiled,
         releaseRetainedChanges,
         groupedIncrementalAdmissionLimits,
@@ -132,4 +141,7 @@ export const releaseTopicStoreMaterializedQueryExecution = <ResultRow extends Ro
   store: TopicStore,
   compiled: CompiledGroupedQuery<object, ResultRow>,
 ): Effect.Effect<void> =>
-  releaseMaterializedQueryExecution(topicStoreReadModel(store), compiled.cacheKey);
+  releaseMaterializedQueryExecution(
+    topicStoreQueryResources(store).activeQueries,
+    compiled.cacheKey,
+  );

--- a/packages/column-live-view-engine/src/topic-store-state.ts
+++ b/packages/column-live-view-engine/src/topic-store-state.ts
@@ -1,16 +1,17 @@
 import type { RowSchema } from "@effect-view-server/config";
 import { Effect, Semaphore } from "effect";
+import { activeStoreQueryExecutionCounts, clearStoreRawQueryExecutions } from "./active-query";
 import {
-  activeStoreQueryExecutionCounts,
-  clearStoreRawQueryExecutions,
+  createActiveQueryRegistry,
   type ActiveQueryExecutionCounts,
-  type ActiveQueryStoreState,
-} from "./active-query";
+  type ActiveQueryRegistry,
+} from "./active-query-contract";
 import { TopicRowStorage } from "./topic-row-storage";
 import { createTopicHealthLedger } from "./topic-health-ledger";
 import type { TopicStoreMutationAdmission, TopicStoreMutationState } from "./topic-store-mutation";
 import type { RawQueryCompilerMetadata } from "./raw-query-compiler";
 import type { LiveTopicSubscriber } from "./topic-subscriber";
+import type { TopicStoreQueryInterface } from "./topic-store-query-interface";
 
 const topicStoreSubscriptionPermitBrand: unique symbol = Symbol("TopicStoreSubscriptionPermit");
 
@@ -19,7 +20,15 @@ export type TopicStoreSubscriptionPermit = {
   readonly store: TopicStore;
 };
 
-export type TopicStoreState = TopicStoreMutationState;
+export type TopicStoreQueryResources = {
+  readonly activeQueries: ActiveQueryRegistry;
+  readonly metadata: RawQueryCompilerMetadata;
+  readonly queryInterface: TopicStoreQueryInterface;
+};
+
+export type TopicStoreState = TopicStoreMutationState & {
+  readonly queryResources: TopicStoreQueryResources;
+};
 
 const topicStoreStates = new WeakMap<TopicStore, TopicStoreState>();
 
@@ -44,8 +53,14 @@ export class TopicStore {
   ) {
     const storage = new TopicRowStorage(topic, schema, keyField);
     const subscribers = new Set<LiveTopicSubscriber>();
+    const queryResources: TopicStoreQueryResources = Object.freeze({
+      activeQueries: createActiveQueryRegistry(),
+      metadata: storage.rawQueryMetadata,
+      queryInterface: storage.queryInterface,
+    });
     const state: TopicStoreState = {
       storage,
+      queryResources,
       subscribers,
       mutationSemaphore: Semaphore.makeUnsafe(1),
       notificationSemaphore: Semaphore.makeUnsafe(1),
@@ -113,19 +128,18 @@ export const topicStoreHealthSource = (store: TopicStore): TopicStoreHealthSourc
   };
 };
 
-export const topicStoreRawQueryMetadata = (store: TopicStore): RawQueryCompilerMetadata =>
-  topicStoreState(store).storage.rawQueryMetadata;
-
-export const topicStoreReadModel = (store: TopicStore): ActiveQueryStoreState =>
-  topicStoreState(store).storage.readModel;
+export const topicStoreQueryResources = (store: TopicStore): TopicStoreQueryResources =>
+  topicStoreState(store).queryResources;
 
 export const clearTopicStoreQueryExecutions = Effect.fn(
   "ColumnLiveViewEngine.topicStore.queryExecutions.clear",
-)((store: TopicStore) => clearStoreRawQueryExecutions(topicStoreReadModel(store)));
+)((store: TopicStore) =>
+  clearStoreRawQueryExecutions(topicStoreState(store).queryResources.activeQueries),
+);
 
 export const collectTopicStoreActiveQueryCounts = Effect.fn(
   "ColumnLiveViewEngine.topicStore.queryExecutions.count",
 )(
   (store: TopicStore): Effect.Effect<ActiveQueryExecutionCounts> =>
-    activeStoreQueryExecutionCounts(topicStoreReadModel(store)),
+    activeStoreQueryExecutionCounts(topicStoreState(store).queryResources.activeQueries),
 );

--- a/packages/column-live-view-engine/test-harness/active-query-interface.ts
+++ b/packages/column-live-view-engine/test-harness/active-query-interface.ts
@@ -1,0 +1,91 @@
+import {
+  acquireMaterializedQueryExecution as acquireMaterializedQueryExecutionFromInterface,
+  acquireRawQueryExecution as acquireRawQueryExecutionFromInterface,
+  activeStoreRawQueryExecutionCount as activeStoreRawQueryExecutionCountFromRegistry,
+  clearStoreRawQueryExecutions as clearStoreRawQueryExecutionsFromRegistry,
+  releaseMaterializedQueryExecution as releaseMaterializedQueryExecutionFromRegistry,
+  releaseRawQueryExecution as releaseRawQueryExecutionFromRegistry,
+} from "../src/active-query";
+import {
+  createActiveQueryRegistry,
+  type ActiveQueryRegistry,
+  type MaterializedQueryExecution,
+} from "../src/active-query-contract";
+import type { CompiledRawQuery, RawQueryCompilerMetadata } from "../src/raw-query-compiler";
+import type { QueryResultSemantics } from "../src/query-result-semantics";
+import { TopicRowStorage } from "../src/topic-row-storage";
+import { topicStoreQueryResources, type TopicStore } from "../src/topic-store-state";
+import type { TopicStoreQueryInterface } from "../src/topic-store-query-interface";
+
+type RowObject = object;
+
+export type ActiveQueryTestInterface = TopicStoreQueryInterface & {
+  readonly activeQueries: ActiveQueryRegistry;
+};
+
+const storageRegistries = new WeakMap<TopicRowStorage, ActiveQueryRegistry>();
+
+const combineTestInterface = (
+  queryInterface: TopicStoreQueryInterface,
+  activeQueries: ActiveQueryRegistry,
+): ActiveQueryTestInterface => ({
+  ...queryInterface,
+  activeQueries,
+});
+
+export const activeQueryTestInterface = (store: TopicStore): ActiveQueryTestInterface => {
+  const { activeQueries, queryInterface } = topicStoreQueryResources(store);
+  return combineTestInterface(queryInterface, activeQueries);
+};
+
+export const activeQueryTestInterfaceForStorage = (
+  storage: TopicRowStorage,
+): ActiveQueryTestInterface => {
+  const existing = storageRegistries.get(storage);
+  if (existing !== undefined) {
+    return combineTestInterface(storage.queryInterface, existing);
+  }
+  const activeQueries = createActiveQueryRegistry();
+  storageRegistries.set(storage, activeQueries);
+  return combineTestInterface(storage.queryInterface, activeQueries);
+};
+
+export const activeQueryTestMetadata = (store: TopicStore): RawQueryCompilerMetadata =>
+  topicStoreQueryResources(store).metadata;
+
+export const acquireRawQueryExecution = <ResultRow extends RowObject>(
+  queryInterface: ActiveQueryTestInterface,
+  compiled: CompiledRawQuery<object, ResultRow>,
+) => acquireRawQueryExecutionFromInterface(queryInterface, queryInterface.activeQueries, compiled);
+
+export const releaseRawQueryExecution = <ResultRow extends RowObject>(
+  queryInterface: ActiveQueryTestInterface,
+  compiled: CompiledRawQuery<object, ResultRow>,
+) => releaseRawQueryExecutionFromRegistry(queryInterface.activeQueries, compiled);
+
+export const acquireMaterializedQueryExecution = <ResultRow extends RowObject>(
+  queryInterface: ActiveQueryTestInterface,
+  cacheKey: string,
+  resultSemantics: QueryResultSemantics<ResultRow>,
+  makeExecution: (releaseRetainedChanges: () => void) => MaterializedQueryExecution,
+) =>
+  acquireMaterializedQueryExecutionFromInterface(
+    queryInterface,
+    queryInterface.activeQueries,
+    cacheKey,
+    resultSemantics,
+    makeExecution,
+  );
+
+export const releaseMaterializedQueryExecution = (
+  queryInterface: ActiveQueryTestInterface,
+  cacheKey: string,
+) => releaseMaterializedQueryExecutionFromRegistry(queryInterface.activeQueries, cacheKey);
+
+export const clearStoreRawQueryExecutions = (queryInterface: ActiveQueryTestInterface) =>
+  clearStoreRawQueryExecutionsFromRegistry(queryInterface.activeQueries);
+
+export const activeStoreRawQueryExecutionCount = (queryInterface: ActiveQueryTestInterface) =>
+  activeStoreRawQueryExecutionCountFromRegistry(queryInterface.activeQueries);
+
+export { createActiveQueryRegistry };

--- a/packages/column-live-view-engine/test-harness/topic-store.ts
+++ b/packages/column-live-view-engine/test-harness/topic-store.ts
@@ -5,6 +5,13 @@ import {
   registerTopicStoreSubscription,
   TopicStore,
 } from "../src/topic-store";
+import { topicStoreQueryResources } from "../src/topic-store-state";
+
+export const topicStoreTestQueryInterface = (store: TopicStore) =>
+  topicStoreQueryResources(store).queryInterface;
+
+export const topicStoreTestQueryMetadata = (store: TopicStore) =>
+  topicStoreQueryResources(store).metadata;
 
 export const registerTestTopicStoreSubscriber = (
   store: TopicStore,

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -19,6 +19,7 @@ import {
   collectPackageSurfaceViolations,
   consumerImportViolationsFor,
   consumerMarkdownImportViolationsFor,
+  engineTypeDependencyViolationsForFile,
   facadeProjectionViolationsForSource,
   isTestFile,
   packageImportViolationsForSource,
@@ -644,7 +645,25 @@ describe("internal Seam checker", () => {
         repositoryRoot: "/repo",
       }),
     ).toStrictEqual([
-      "packages/column-live-view-engine/src/active-query.ts references topicStoreReadModel outside the Topic Store Module.",
+      "packages/column-live-view-engine/src/active-query.ts references topicStoreReadModel outside the Topic Store Interface.",
+    ]);
+    expect(
+      topicStoreHelperViolationsForFile({
+        contents: "const metadata = topicStoreRawQueryMetadata(store);",
+        path: "/repo/packages/column-live-view-engine/src/topic-store-query.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/topic-store-query.ts references topicStoreRawQueryMetadata outside the Topic Store Interface.",
+    ]);
+    expect(
+      topicStoreHelperViolationsForFile({
+        contents: "const query = topicStoreReadModel(store);",
+        path: "/repo/packages/column-live-view-engine/src/topic-store-query.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/topic-store-query.ts references topicStoreReadModel outside the Topic Store Interface.",
     ]);
     expect(
       topicStoreStateExportViolationsForFile({
@@ -696,6 +715,63 @@ describe("internal Seam checker", () => {
     ).toStrictEqual([
       "packages/column-live-view-engine/src/topic-store.ts namespace imports restricted Topic Store state internals.",
     ]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents: 'import type { ActiveQueryRegistry } from "./active-query";',
+        path: "/repo/packages/column-live-view-engine/src/topic-row-storage.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/topic-row-storage.ts imports Active Query state below the Topic Store Interface.",
+    ]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents: 'import type { LiveQueryExecution } from "./active-query";',
+        path: "/repo/packages/column-live-view-engine/src/active-raw-query.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/active-raw-query.ts imports the Active Query facade from an Active Query leaf module.",
+    ]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents: 'import type { LiveQueryExecution } from "./active-query";',
+        path: "/repo/packages/column-live-view-engine/src/active-query-contract.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/active-query-contract.ts imports ./active-query above the allowed lower Active Query contracts.",
+    ]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents: 'import type { RawQueryExecutionSlot } from "./active-raw-query";',
+        path: "/repo/packages/column-live-view-engine/src/active-query-contract.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/active-query-contract.ts imports ./active-raw-query above the allowed lower Active Query contracts.",
+    ]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents:
+          'import type { MaterializedQueryExecution } from "./active-materialized-query";',
+        path: "/repo/packages/column-live-view-engine/src/active-query-contract.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([
+      "packages/column-live-view-engine/src/active-query-contract.ts imports ./active-materialized-query above the allowed lower Active Query contracts.",
+    ]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents: [
+          'import type { QueryEvaluation } from "./query-result";',
+          'import type { RawQueryPlanWindow } from "./raw-query-plan";',
+          'import type { TopicRowEntry } from "./row-scan";',
+        ].join("\n"),
+        path: "/repo/packages/column-live-view-engine/src/active-query-contract.ts",
+        repositoryRoot: "/repo",
+      }),
+    ).toStrictEqual([]);
     expect(
       topicStoreStateExportViolationsForFile({
         contents: [
@@ -761,6 +837,15 @@ describe("internal Seam checker", () => {
       topicStoreStateExportViolationsForFile({
         contents: "export const topicStoreState = true;",
         path: join(process.cwd(), "packages/column-live-view-engine/src/topic-store-state.ts"),
+      }),
+    ).toStrictEqual([]);
+    expect(
+      engineTypeDependencyViolationsForFile({
+        contents: 'import type { TopicRowScan } from "./row-scan";',
+        path: join(
+          process.cwd(),
+          "packages/column-live-view-engine/src/topic-store-query-interface.ts",
+        ),
       }),
     ).toStrictEqual([]);
   });

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -639,6 +639,7 @@ export const collectPackageSurfaceViolations = (
 const restrictedTopicStoreHelpers = [
   {
     name: "makeTopicStoreSubscriptionPermit",
+    boundary: "Topic Store Module",
     allowed: new Set([
       "packages/column-live-view-engine/src/topic-store-state.ts",
       "packages/column-live-view-engine/src/topic-store-subscription.ts",
@@ -646,22 +647,27 @@ const restrictedTopicStoreHelpers = [
   },
   {
     name: "topicStoreRawQueryMetadata",
-    allowed: new Set([
-      "packages/column-live-view-engine/src/topic-store-query.ts",
-      "packages/column-live-view-engine/src/topic-store-state.ts",
-    ]),
+    boundary: "Topic Store Interface",
+    allowed: new Set<string>(),
   },
   {
     name: "topicStoreReadModel",
+    boundary: "Topic Store Interface",
+    allowed: new Set<string>(),
+  },
+  {
+    name: "topicStoreState",
+    boundary: "Topic Store Module",
     allowed: new Set([
-      "packages/column-live-view-engine/src/topic-store-query.ts",
+      "packages/column-live-view-engine/src/topic-store-mutation.ts",
       "packages/column-live-view-engine/src/topic-store-state.ts",
     ]),
   },
   {
-    name: "topicStoreState",
+    name: "topicStoreQueryResources",
+    boundary: "Topic Store Module",
     allowed: new Set([
-      "packages/column-live-view-engine/src/topic-store-mutation.ts",
+      "packages/column-live-view-engine/src/topic-store-query.ts",
       "packages/column-live-view-engine/src/topic-store-state.ts",
     ]),
   },
@@ -681,10 +687,66 @@ export const topicStoreHelperViolationsForFile = ({
   return restrictedTopicStoreHelpers.flatMap((helper) =>
     identifiers.has(helper.name) && !helper.allowed.has(relativePath)
       ? [
-          `${relativePath} references ${helper.name} outside the Topic Store Module.`,
+          `${relativePath} references ${helper.name} outside the ${helper.boundary}.`,
         ]
       : [],
   );
+};
+
+const activeQueryLeafModules = new Set([
+  "packages/column-live-view-engine/src/active-materialized-query.ts",
+  "packages/column-live-view-engine/src/active-raw-query.ts",
+]);
+
+const activeQueryContractModule =
+  "packages/column-live-view-engine/src/active-query-contract.ts";
+
+const allowedActiveQueryContractImports = new Set([
+  "./query-result",
+  "./raw-query-plan",
+  "./row-scan",
+]);
+
+const lowerTopicStoreModules = new Set([
+  "packages/column-live-view-engine/src/topic-row-storage.ts",
+  "packages/column-live-view-engine/src/topic-store-query-interface.ts",
+]);
+
+export const engineTypeDependencyViolationsForFile = ({
+  contents,
+  path,
+  repositoryRoot = repoRoot,
+}: {
+  readonly contents: string;
+  readonly path: string;
+  readonly repositoryRoot?: string;
+}): ReadonlyArray<string> => {
+  const relativePath = toPosixPath(relative(repositoryRoot, path));
+  const moduleSpecifiers = inspectTypeScriptModule({ fileName: path, source: contents }).moduleSpecifiers;
+  const violations: Array<string> = [];
+  if (activeQueryLeafModules.has(relativePath) && moduleSpecifiers.includes("./active-query")) {
+    violations.push(
+      `${relativePath} imports the Active Query facade from an Active Query leaf module.`,
+    );
+  }
+  if (relativePath === activeQueryContractModule) {
+    for (const specifier of moduleSpecifiers) {
+      if (specifier.startsWith("./") && !allowedActiveQueryContractImports.has(specifier)) {
+        violations.push(
+          `${relativePath} imports ${specifier} above the allowed lower Active Query contracts.`,
+        );
+      }
+    }
+  }
+  if (
+    lowerTopicStoreModules.has(relativePath) &&
+    moduleSpecifiers.some((specifier) => specifier.startsWith("./active-"))
+  ) {
+    violations.push(
+      `${relativePath} imports Active Query state below the Topic Store Interface.`,
+    );
+  }
+  return violations;
 };
 
 const restrictedStateExportNames: ReadonlySet<string> = new Set(
@@ -753,6 +815,7 @@ export const collectEngineSeamViolations = (
       const contents = readFileSync(path, "utf8");
       helperViolations.push(
         ...topicStoreHelperViolationsForFile({ contents, path, repositoryRoot }),
+        ...engineTypeDependencyViolationsForFile({ contents, path, repositoryRoot }),
       );
       stateExportViolations.push(
         ...topicStoreStateExportViolationsForFile({ contents, path, repositoryRoot }),


### PR DESCRIPTION
Closes #343

Summary
- introduce a narrow Topic Store query interface and move active-query registry ownership into per-store query resources
- make Active Query contracts dependency-bottom and enforce the acyclic import direction with repository seam checks
- partition Active Query coverage into raw, grouped, materialization, sharing, and lifecycle owners without losing behavior

Validation
- vp run column-live-view-engine#test: 55 files, 382 tests, no type errors, 100% coverage
- vp test run scripts --coverage: 24 files, 326 tests, 100% coverage
- vp check
- vp run -w check:effect
- vp run -w check:internal-seams
- vp run -w bench:baseline:smoke
- vp run -w bench:baseline:raw-read-write
- vp run -w bench:baseline:active-query-sharing

Review
- final Effect, Vitest, and architecture review round: no blocking or non-blocking findings