### PR TITLE
Decouple TCP Publish from Runtime Core

### DIFF
--- a/packages/config/src/internal.ts
+++ b/packages/config/src/internal.ts
@@ -8,6 +8,11 @@ import {
 import type { RowSchema } from "./topic-contract";
 
 export { validateDecodedRow } from "./decoded-row-validation";
+export type {
+  ViewServerRuntimeDecodedMutation,
+  ViewServerRuntimeDecodedMutationClient,
+  ViewServerRuntimeTopicDefinitions,
+} from "./runtime-contract";
 
 type KafkaSourceTopicRegistry = Record<
   string,

--- a/packages/config/src/internal.ts
+++ b/packages/config/src/internal.ts
@@ -13,6 +13,7 @@ export type {
   ViewServerRuntimeDecodedMutationClient,
   ViewServerRuntimeTopicDefinitions,
 } from "./runtime-contract";
+export { viewServerRuntimeDecodedMutationTrust } from "./runtime-contract";
 
 type KafkaSourceTopicRegistry = Record<
   string,

--- a/packages/config/src/runtime-client-contract.test-d.ts
+++ b/packages/config/src/runtime-client-contract.test-d.ts
@@ -6,7 +6,11 @@ import {
   type ViewServerRuntimeClient,
   type ViewServerRuntimeError,
 } from "./index";
-import type { ViewServerRuntimeDecodedMutationClient } from "./internal";
+import {
+  type ViewServerRuntimeDecodedMutationClient,
+  type ViewServerRuntimeTopicDefinitions,
+  viewServerRuntimeDecodedMutationTrust,
+} from "./internal";
 
 import { viewServer } from "../test-harness/live-query";
 import { Order } from "../test-harness/schemas";
@@ -112,6 +116,34 @@ describe("Runtime client and configuration generic contracts", () => {
     };
 
     expectTypeOf(assertRuntimeContracts).toBeFunction();
+
+    const assertGenericDecodedPatch = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+      runtime: ViewServerRuntimeDecodedMutationClient<Topics>,
+      topic: Extract<keyof Topics, string>,
+      patch: Partial<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>,
+    ) => {
+      const untrustedEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic,
+        key: "row-1",
+        // @ts-expect-error outer-generic decoded patches require the internal trust capability
+        patch,
+      });
+      const trustedEffect = runtime.execute(
+        {
+          _tag: "PatchDecodedFields",
+          topic,
+          key: "row-1",
+          patch,
+        },
+        viewServerRuntimeDecodedMutationTrust,
+      );
+
+      expectTypeOf(untrustedEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
+      expectTypeOf(trustedEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
+    };
+
+    expectTypeOf(assertGenericDecodedPatch).toBeFunction();
 
     const assertDecodedMutationContract = (
       runtime: ViewServerRuntimeDecodedMutationClient<typeof viewServer.topics>,
@@ -222,6 +254,15 @@ describe("Runtime client and configuration generic contracts", () => {
           unexpected: true,
         },
       });
+      const invalidTopicMismatchedPatchEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "orders",
+        key: "order-1",
+        patch: {
+          // @ts-expect-error decoded patches remain correlated with the selected topic
+          symbol: "AAPL",
+        },
+      });
       const rowWithExtraField = {
         id: "order-1",
         customerId: "customer-1",
@@ -319,6 +360,9 @@ describe("Runtime client and configuration generic contracts", () => {
         Effect.Effect<void, ViewServerRuntimeError>
       >();
       expectTypeOf(invalidPatchFieldEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidTopicMismatchedPatchEffect).toMatchTypeOf<
         Effect.Effect<void, ViewServerRuntimeError>
       >();
       expectTypeOf(invalidExtraRowVariableEffect).toMatchTypeOf<

--- a/packages/config/src/runtime-client-contract.test-d.ts
+++ b/packages/config/src/runtime-client-contract.test-d.ts
@@ -15,6 +15,24 @@ import {
 import { viewServer } from "../test-harness/live-query";
 import { Order } from "../test-harness/schemas";
 
+type OrderRow = typeof Order.Type;
+type LimitOrderRow = OrderRow & {
+  readonly execution: "limit";
+  readonly venue: string;
+};
+type MarketOrderRow = OrderRow & {
+  readonly execution: "market";
+  readonly liquidityTaking: boolean;
+};
+type UnionOrderTopics = {
+  readonly unionOrders: {
+    readonly schema: typeof Order & {
+      readonly Type: LimitOrderRow | MarketOrderRow;
+    };
+    readonly key: "id";
+  };
+};
+
 describe("Runtime client and configuration generic contracts", () => {
   it("accepts valid contracts and rejects invalid contracts", () => {
     const assertRuntimeContracts = (runtime: ViewServerRuntimeClient<typeof viewServer.topics>) => {
@@ -117,19 +135,49 @@ describe("Runtime client and configuration generic contracts", () => {
 
     expectTypeOf(assertRuntimeContracts).toBeFunction();
 
-    const assertGenericDecodedPatch = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+    const assertGenericDecodedMutation = <const Topics extends ViewServerRuntimeTopicDefinitions>(
       runtime: ViewServerRuntimeDecodedMutationClient<Topics>,
       topic: Extract<keyof Topics, string>,
+      row: Topics[Extract<keyof Topics, string>]["schema"]["Type"],
+      rows: ReadonlyArray<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>,
       patch: Partial<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>,
     ) => {
-      const untrustedEffect = runtime.execute({
+      const untrustedPublishEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic,
+        // @ts-expect-error outer-generic decoded rows require the internal trust capability
+        rows: [row],
+      });
+      const untrustedPublishManyEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic,
+        // @ts-expect-error outer-generic decoded row arrays require the internal trust capability
+        rows,
+      });
+      const untrustedPatchEffect = runtime.execute({
         _tag: "PatchDecodedFields",
         topic,
         key: "row-1",
         // @ts-expect-error outer-generic decoded patches require the internal trust capability
         patch,
       });
-      const trustedEffect = runtime.execute(
+      const trustedPublishEffect = runtime.execute(
+        {
+          _tag: "PublishDecodedRows",
+          topic,
+          rows: [row],
+        },
+        viewServerRuntimeDecodedMutationTrust,
+      );
+      const trustedPublishManyEffect = runtime.execute(
+        {
+          _tag: "PublishDecodedRows",
+          topic,
+          rows,
+        },
+        viewServerRuntimeDecodedMutationTrust,
+      );
+      const trustedPatchEffect = runtime.execute(
         {
           _tag: "PatchDecodedFields",
           topic,
@@ -139,11 +187,121 @@ describe("Runtime client and configuration generic contracts", () => {
         viewServerRuntimeDecodedMutationTrust,
       );
 
-      expectTypeOf(untrustedEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
-      expectTypeOf(trustedEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
+      expectTypeOf(untrustedPublishEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(untrustedPublishManyEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(untrustedPatchEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(trustedPublishEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(trustedPublishManyEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(trustedPatchEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
     };
 
-    expectTypeOf(assertGenericDecodedPatch).toBeFunction();
+    expectTypeOf(assertGenericDecodedMutation).toBeFunction();
+
+    const assertUnionRowBranchExactness = (
+      runtime: ViewServerRuntimeDecodedMutationClient<UnionOrderTopics>,
+      limitOrder: LimitOrderRow,
+      marketOrder: MarketOrderRow,
+      limitPatch: Partial<LimitOrderRow>,
+      marketPatch: Partial<MarketOrderRow>,
+      limitOrBlendedRow: LimitOrderRow | (LimitOrderRow & { readonly liquidityTaking: true }),
+      limitOrBlendedPatch:
+        | Partial<LimitOrderRow>
+        | (Partial<LimitOrderRow> & { readonly liquidityTaking: true }),
+    ) => {
+      const validLimitRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "unionOrders",
+        rows: [limitOrder],
+      });
+      const validMarketRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "unionOrders",
+        rows: [marketOrder],
+      });
+      const validLimitPatchEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "unionOrders",
+        key: "order-1",
+        patch: limitPatch,
+      });
+      const validMarketPatchEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "unionOrders",
+        key: "order-1",
+        patch: marketPatch,
+      });
+      const invalidBlendedRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "unionOrders",
+        // @ts-expect-error decoded rows cannot blend fields from separate schema union branches
+        rows: [
+          {
+            ...limitOrder,
+            liquidityTaking: true,
+          },
+        ],
+      });
+      const invalidBlendedPatchEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "unionOrders",
+        key: "order-1",
+        // @ts-expect-error decoded patches cannot blend fields from separate schema union branches
+        patch: {
+          venue: "LSE",
+          liquidityTaking: true,
+        },
+      });
+      const invalidUnionBlendedRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "unionOrders",
+        // @ts-expect-error a valid branch union cannot hide a blended decoded row member
+        rows: [limitOrBlendedRow],
+      });
+      const invalidUnionBlendedPatchEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "unionOrders",
+        key: "order-1",
+        // @ts-expect-error a valid branch union cannot hide a blended decoded patch member
+        patch: limitOrBlendedPatch,
+      });
+
+      expectTypeOf(validLimitRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(validMarketRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(validLimitPatchEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(validMarketPatchEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidBlendedRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidBlendedPatchEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidUnionBlendedRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidUnionBlendedPatchEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+    };
+
+    expectTypeOf(assertUnionRowBranchExactness).toBeFunction();
 
     const assertDecodedMutationContract = (
       runtime: ViewServerRuntimeDecodedMutationClient<typeof viewServer.topics>,
@@ -300,7 +458,6 @@ describe("Runtime client and configuration generic contracts", () => {
         // @ts-expect-error optional extra patch fields remain rejected when present
         patch: patchWithOptionalExtraField,
       });
-      type OrderRow = typeof Order.Type;
       const assertUnionExactness = (
         row: OrderRow | (OrderRow & { readonly unexpected: true }),
         patch: Partial<OrderRow> | (Partial<OrderRow> & { readonly unexpected: true }),

--- a/packages/config/src/runtime-client-contract.test-d.ts
+++ b/packages/config/src/runtime-client-contract.test-d.ts
@@ -6,6 +6,7 @@ import {
   type ViewServerRuntimeClient,
   type ViewServerRuntimeError,
 } from "./index";
+import type { ViewServerRuntimeDecodedMutationClient } from "./internal";
 
 import { viewServer } from "../test-harness/live-query";
 import { Order } from "../test-harness/schemas";
@@ -111,6 +112,227 @@ describe("Runtime client and configuration generic contracts", () => {
     };
 
     expectTypeOf(assertRuntimeContracts).toBeFunction();
+
+    const assertDecodedMutationContract = (
+      runtime: ViewServerRuntimeDecodedMutationClient<typeof viewServer.topics>,
+    ) => {
+      const checkEffect = runtime.execute({
+        _tag: "CheckMutationAllowed",
+        topic: "orders",
+      });
+      const publishEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        rows: [
+          {
+            id: "order-1",
+            customerId: "customer-1",
+            status: "open",
+            price: 42,
+            region: "usa",
+            updatedAt: 1,
+          },
+        ],
+      });
+      const patchEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "orders",
+        key: "order-1",
+        patch: { status: "closed" },
+      });
+      const deleteEffect = runtime.execute({
+        _tag: "DeleteDecodedRow",
+        topic: "orders",
+        key: "order-1",
+      });
+
+      expectTypeOf<Effect.Error<typeof checkEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
+      expectTypeOf<Effect.Error<typeof publishEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
+      expectTypeOf<Effect.Error<typeof patchEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
+      expectTypeOf<Effect.Error<typeof deleteEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
+
+      const invalidTopicEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        // @ts-expect-error decoded mutations are constrained to configured topics
+        topic: "customers",
+        rows: [],
+      });
+      const invalidTagEffect = runtime.execute({
+        // @ts-expect-error decoded mutations reject unknown operation tags
+        _tag: "Reset",
+        topic: "orders",
+      });
+      const invalidIncompleteRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        // @ts-expect-error decoded rows must include every required topic field
+        rows: [{ id: "order-1" }],
+      });
+      const invalidExtraRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        // @ts-expect-error decoded rows reject fields outside the selected topic
+        rows: [
+          {
+            id: "order-1",
+            customerId: "customer-1",
+            status: "open",
+            price: 42,
+            region: "usa",
+            updatedAt: 1,
+            unexpected: true,
+          },
+        ],
+      });
+      const invalidWrongRowFieldEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        rows: [
+          {
+            id: "order-1",
+            customerId: "customer-1",
+            status: "open",
+            // @ts-expect-error decoded row field values must match the selected topic
+            price: "not-a-number",
+            region: "usa",
+            updatedAt: 1,
+          },
+        ],
+      });
+      const invalidTopicMismatchedRowEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        rows: [
+          {
+            id: "trade-1",
+            // @ts-expect-error decoded rows must match the mutation topic
+            symbol: "AAPL",
+            quantity: 1,
+            price: 42,
+            updatedAt: 1,
+          },
+        ],
+      });
+      const invalidPatchFieldEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "orders",
+        key: "order-1",
+        patch: {
+          // @ts-expect-error decoded patches reject fields outside the selected topic
+          unexpected: true,
+        },
+      });
+      const rowWithExtraField = {
+        id: "order-1",
+        customerId: "customer-1",
+        status: "open",
+        price: 42,
+        region: "usa",
+        updatedAt: 1,
+        unexpected: true,
+      } as const;
+      const invalidExtraRowVariableEffect = runtime.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        // @ts-expect-error decoded row variables retain exact topic-field checking
+        rows: [rowWithExtraField],
+      });
+      const patchWithExtraField = {
+        status: "closed",
+        unexpected: true,
+      } as const;
+      const invalidExtraPatchVariableEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "orders",
+        key: "order-1",
+        // @ts-expect-error decoded patch variables retain exact topic-field checking
+        patch: patchWithExtraField,
+      });
+      const patchWithOptionalExtraField: {
+        readonly status?: "closed";
+        readonly unexpected?: true;
+      } = { status: "closed", unexpected: true };
+      const invalidOptionalExtraPatchVariableEffect = runtime.execute({
+        _tag: "PatchDecodedFields",
+        topic: "orders",
+        key: "order-1",
+        // @ts-expect-error optional extra patch fields remain rejected when present
+        patch: patchWithOptionalExtraField,
+      });
+      type OrderRow = typeof Order.Type;
+      const assertUnionExactness = (
+        row: OrderRow | (OrderRow & { readonly unexpected: true }),
+        patch: Partial<OrderRow> | (Partial<OrderRow> & { readonly unexpected: true }),
+      ) => {
+        const invalidUnionRowEffect = runtime.execute({
+          _tag: "PublishDecodedRows",
+          topic: "orders",
+          // @ts-expect-error unions cannot hide decoded row fields outside the selected topic
+          rows: [row],
+        });
+        const invalidUnionPatchEffect = runtime.execute({
+          _tag: "PatchDecodedFields",
+          topic: "orders",
+          key: "order-1",
+          // @ts-expect-error unions cannot hide decoded patch fields outside the selected topic
+          patch,
+        });
+
+        expectTypeOf(invalidUnionRowEffect).toMatchTypeOf<
+          Effect.Effect<void, ViewServerRuntimeError>
+        >();
+        expectTypeOf(invalidUnionPatchEffect).toMatchTypeOf<
+          Effect.Effect<void, ViewServerRuntimeError>
+        >();
+      };
+
+      expectTypeOf(assertUnionExactness).toBeFunction();
+      const assertRowContainerUnionExactness = (
+        rows: ReadonlyArray<OrderRow> | ReadonlyArray<OrderRow & { readonly unexpected: true }>,
+      ) => {
+        const invalidRowContainerUnionEffect = runtime.execute({
+          _tag: "PublishDecodedRows",
+          topic: "orders",
+          // @ts-expect-error unions of row containers cannot hide fields outside the selected topic
+          rows,
+        });
+
+        expectTypeOf(invalidRowContainerUnionEffect).toMatchTypeOf<
+          Effect.Effect<void, ViewServerRuntimeError>
+        >();
+      };
+
+      expectTypeOf(assertRowContainerUnionExactness).toBeFunction();
+
+      expectTypeOf(invalidTopicEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
+      expectTypeOf(invalidTagEffect).toMatchTypeOf<Effect.Effect<void, ViewServerRuntimeError>>();
+      expectTypeOf(invalidIncompleteRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidExtraRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidWrongRowFieldEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidTopicMismatchedRowEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidPatchFieldEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidExtraRowVariableEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidExtraPatchVariableEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+      expectTypeOf(invalidOptionalExtraPatchVariableEffect).toMatchTypeOf<
+        Effect.Effect<void, ViewServerRuntimeError>
+      >();
+    };
+
+    expectTypeOf(assertDecodedMutationContract).toBeFunction();
 
     expectTypeOf<ViewServerBackpressureError>().toMatchTypeOf<ViewServerRuntimeError>();
 

--- a/packages/config/src/runtime-client-contract.test-d.ts
+++ b/packages/config/src/runtime-client-contract.test-d.ts
@@ -13,7 +13,7 @@ import {
 } from "./internal";
 
 import { viewServer } from "../test-harness/live-query";
-import { Order } from "../test-harness/schemas";
+import { Order, Trade } from "../test-harness/schemas";
 
 type OrderRow = typeof Order.Type;
 type LimitOrderRow = OrderRow & {
@@ -305,6 +305,8 @@ describe("Runtime client and configuration generic contracts", () => {
 
     const assertDecodedMutationContract = (
       runtime: ViewServerRuntimeDecodedMutationClient<typeof viewServer.topics>,
+      tradeRow: typeof Trade.Type,
+      tradePatch: { readonly symbol: string },
     ) => {
       const checkEffect = runtime.execute({
         _tag: "CheckMutationAllowed",
@@ -335,11 +337,36 @@ describe("Runtime client and configuration generic contracts", () => {
         topic: "orders",
         key: "order-1",
       });
+      const invalidTrustedTopicMismatchedRowEffect = runtime.execute(
+        {
+          _tag: "PublishDecodedRows",
+          topic: "orders",
+          // @ts-expect-error trusted decoded rows remain correlated with the selected topic
+          rows: [tradeRow],
+        },
+        viewServerRuntimeDecodedMutationTrust,
+      );
+      const invalidTrustedTopicMismatchedPatchEffect = runtime.execute(
+        {
+          _tag: "PatchDecodedFields",
+          topic: "orders",
+          key: "order-1",
+          // @ts-expect-error trusted decoded patches remain correlated with the selected topic
+          patch: tradePatch,
+        },
+        viewServerRuntimeDecodedMutationTrust,
+      );
 
       expectTypeOf<Effect.Error<typeof checkEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
       expectTypeOf<Effect.Error<typeof publishEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
       expectTypeOf<Effect.Error<typeof patchEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
       expectTypeOf<Effect.Error<typeof deleteEffect>>().toEqualTypeOf<ViewServerRuntimeError>();
+      expectTypeOf<
+        Effect.Error<typeof invalidTrustedTopicMismatchedRowEffect>
+      >().toEqualTypeOf<ViewServerRuntimeError>();
+      expectTypeOf<
+        Effect.Error<typeof invalidTrustedTopicMismatchedPatchEffect>
+      >().toEqualTypeOf<ViewServerRuntimeError>();
 
       const invalidTopicEffect = runtime.execute({
         _tag: "PublishDecodedRows",

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -114,13 +114,32 @@ type ExactDecodedMutation<
       }
     : unknown;
 
+type ViewServerRuntimeTrustedDecodedPatchMutation<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+> = {
+  readonly _tag: "PatchDecodedFields";
+  readonly topic: Extract<keyof Topics, string>;
+  readonly key: string;
+  readonly patch: Partial<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>;
+};
+
 export type ViewServerRuntimeDecodedMutationClient<
   Topics extends ViewServerRuntimeTopicDefinitions,
 > = {
-  readonly execute: <const Mutation extends ViewServerRuntimeDecodedMutation<Topics>>(
-    mutation: Mutation & ExactDecodedMutation<Topics, Mutation>,
-  ) => Effect.Effect<void, ViewServerRuntimeError>;
+  readonly execute: {
+    <const Mutation extends ViewServerRuntimeDecodedMutation<Topics>>(
+      mutation: Mutation & ExactDecodedMutation<Topics, Mutation>,
+    ): Effect.Effect<void, ViewServerRuntimeError>;
+    (
+      mutation: ViewServerRuntimeTrustedDecodedPatchMutation<Topics>,
+      trust: typeof viewServerRuntimeDecodedMutationTrust,
+    ): Effect.Effect<void, ViewServerRuntimeError>;
+  };
 };
+
+export const viewServerRuntimeDecodedMutationTrust: unique symbol = Symbol(
+  "ViewServerRuntimeDecodedMutationTrust",
+);
 
 export type ViewServerTransportError =
   | ViewServerBackpressureError

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -1,4 +1,4 @@
-import type { Config, Effect } from "effect";
+import type { Config, Effect, Schema } from "effect";
 import type { ViewServerHealth } from "./health-contract";
 import type { ExactLiveQueryInputForTopic } from "./source-query-contract";
 import type {
@@ -7,6 +7,8 @@ import type {
   LiveQueryRow,
   LiveQueryResult,
   RawQuery,
+  RowSchema,
+  TopicDefinitions,
   TopicRow,
 } from "./topic-contract";
 
@@ -35,6 +37,90 @@ export type ViewServerRuntimeError =
       readonly message: string;
       readonly topic?: string;
     };
+
+export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
+  Record<
+    string,
+    {
+      readonly schema: RowSchema & Schema.Codec<object, unknown, never, unknown>;
+      readonly key: string;
+    }
+  >;
+
+type ViewServerRuntimeDecodedMutationForTopic<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> =
+  | {
+      readonly _tag: "CheckMutationAllowed";
+      readonly topic: Topic;
+    }
+  | {
+      readonly _tag: "PublishDecodedRows";
+      readonly topic: Topic;
+      readonly rows: ReadonlyArray<Topics[Topic]["schema"]["Type"]>;
+    }
+  | {
+      readonly _tag: "PatchDecodedFields";
+      readonly topic: Topic;
+      readonly key: string;
+      readonly patch: Partial<Topics[Topic]["schema"]["Type"]>;
+    }
+  | {
+      readonly _tag: "DeleteDecodedRow";
+      readonly topic: Topic;
+      readonly key: string;
+    };
+
+export type ViewServerRuntimeDecodedMutation<Topics extends ViewServerRuntimeTopicDefinitions> = {
+  readonly [Topic in Extract<keyof Topics, string>]: ViewServerRuntimeDecodedMutationForTopic<
+    Topics,
+    Topic
+  >;
+}[Extract<keyof Topics, string>];
+
+type KeysOfUnion<Value> = Value extends Value ? keyof Value : never;
+
+type ExactDecodedRows<Row, Rows extends ReadonlyArray<unknown>> = [Rows[number]] extends [Row]
+  ? Exclude<KeysOfUnion<Rows[number]>, KeysOfUnion<Row>> extends never
+    ? Rows
+    : never
+  : never;
+
+type ExactDecodedPatch<Row, Patch> = [Patch] extends [Partial<Row>]
+  ? Exclude<KeysOfUnion<Patch>, KeysOfUnion<Row>> extends never
+    ? Patch
+    : never
+  : never;
+
+type ExactDecodedMutation<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Mutation extends ViewServerRuntimeDecodedMutation<Topics>,
+> = Mutation extends {
+  readonly _tag: "PublishDecodedRows";
+  readonly topic: infer Topic extends Extract<keyof Topics, string>;
+  readonly rows: infer Rows extends ReadonlyArray<unknown>;
+}
+  ? {
+      readonly rows: ExactDecodedRows<Topics[Topic]["schema"]["Type"], Rows>;
+    }
+  : Mutation extends {
+        readonly _tag: "PatchDecodedFields";
+        readonly topic: infer Topic extends Extract<keyof Topics, string>;
+        readonly patch: infer Patch;
+      }
+    ? {
+        readonly patch: ExactDecodedPatch<Topics[Topic]["schema"]["Type"], Patch>;
+      }
+    : unknown;
+
+export type ViewServerRuntimeDecodedMutationClient<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+> = {
+  readonly execute: <const Mutation extends ViewServerRuntimeDecodedMutation<Topics>>(
+    mutation: Mutation & ExactDecodedMutation<Topics, Mutation>,
+  ) => Effect.Effect<void, ViewServerRuntimeError>;
+};
 
 export type ViewServerTransportError =
   | ViewServerBackpressureError

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -139,17 +139,20 @@ type ExactDecodedMutation<
       }
     : unknown;
 
-type ViewServerRuntimeTrustedDecodedMutation<Topics extends ViewServerRuntimeTopicDefinitions> =
+type ViewServerRuntimeTrustedDecodedMutation<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> =
   | {
       readonly _tag: "PublishDecodedRows";
-      readonly topic: Extract<keyof Topics, string>;
-      readonly rows: ReadonlyArray<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>;
+      readonly topic: Topic;
+      readonly rows: ReadonlyArray<Topics[NoInfer<Topic>]["schema"]["Type"]>;
     }
   | {
       readonly _tag: "PatchDecodedFields";
-      readonly topic: Extract<keyof Topics, string>;
+      readonly topic: Topic;
       readonly key: string;
-      readonly patch: Partial<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>;
+      readonly patch: Partial<Topics[NoInfer<Topic>]["schema"]["Type"]>;
     };
 
 export type ViewServerRuntimeDecodedMutationClient<
@@ -159,8 +162,8 @@ export type ViewServerRuntimeDecodedMutationClient<
     <const Mutation extends ViewServerRuntimeDecodedMutation<Topics>>(
       mutation: Mutation & ExactDecodedMutation<Topics, Mutation>,
     ): Effect.Effect<void, ViewServerRuntimeError>;
-    (
-      mutation: ViewServerRuntimeTrustedDecodedMutation<Topics>,
+    <const Topic extends Extract<keyof Topics, string>>(
+      mutation: ViewServerRuntimeTrustedDecodedMutation<Topics, Topic>,
       trust: typeof viewServerRuntimeDecodedMutationTrust,
     ): Effect.Effect<void, ViewServerRuntimeError>;
   };

--- a/packages/config/src/runtime-contract.ts
+++ b/packages/config/src/runtime-contract.ts
@@ -79,18 +79,43 @@ export type ViewServerRuntimeDecodedMutation<Topics extends ViewServerRuntimeTop
   >;
 }[Extract<keyof Topics, string>];
 
-type KeysOfUnion<Value> = Value extends Value ? keyof Value : never;
-
-type ExactDecodedRows<Row, Rows extends ReadonlyArray<unknown>> = [Rows[number]] extends [Row]
-  ? Exclude<KeysOfUnion<Rows[number]>, KeysOfUnion<Row>> extends never
-    ? Rows
+type ExactDecodedValueMember<Allowed, Value> = Allowed extends Allowed
+  ? [Value] extends [Allowed]
+    ? Exclude<keyof Value, keyof Allowed> extends never
+      ? Value
+      : never
     : never
   : never;
 
-type ExactDecodedPatch<Row, Patch> = [Patch] extends [Partial<Row>]
-  ? Exclude<KeysOfUnion<Patch>, KeysOfUnion<Row>> extends never
-    ? Patch
-    : never
+type KeysOfUnion<Value> = Value extends Value ? keyof Value : never;
+
+type DecodedValueMemberIsExact<Allowed, Value> = [ExactDecodedValueMember<Allowed, Value>] extends [
+  never,
+]
+  ? false
+  : true;
+
+type DecodedValueExactness<Allowed, Value> = Value extends Value
+  ? DecodedValueMemberIsExact<Allowed, Value>
+  : never;
+
+type ExactDecodedValue<Allowed, Value> =
+  Exclude<KeysOfUnion<Value>, KeysOfUnion<Allowed>> extends never
+    ? false extends DecodedValueExactness<Allowed, Value>
+      ? never
+      : Value
+    : never;
+
+type ExactDecodedRows<Row, Rows extends ReadonlyArray<unknown>> = [Rows[number]] extends [
+  ExactDecodedValue<Row, Rows[number]>,
+]
+  ? Rows
+  : never;
+
+type DecodedPatch<Row> = Row extends Row ? Partial<Row> : never;
+
+type ExactDecodedPatch<Row, Patch> = [Patch] extends [ExactDecodedValue<DecodedPatch<Row>, Patch>]
+  ? Patch
   : never;
 
 type ExactDecodedMutation<
@@ -114,14 +139,18 @@ type ExactDecodedMutation<
       }
     : unknown;
 
-type ViewServerRuntimeTrustedDecodedPatchMutation<
-  Topics extends ViewServerRuntimeTopicDefinitions,
-> = {
-  readonly _tag: "PatchDecodedFields";
-  readonly topic: Extract<keyof Topics, string>;
-  readonly key: string;
-  readonly patch: Partial<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>;
-};
+type ViewServerRuntimeTrustedDecodedMutation<Topics extends ViewServerRuntimeTopicDefinitions> =
+  | {
+      readonly _tag: "PublishDecodedRows";
+      readonly topic: Extract<keyof Topics, string>;
+      readonly rows: ReadonlyArray<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>;
+    }
+  | {
+      readonly _tag: "PatchDecodedFields";
+      readonly topic: Extract<keyof Topics, string>;
+      readonly key: string;
+      readonly patch: Partial<Topics[Extract<keyof Topics, string>]["schema"]["Type"]>;
+    };
 
 export type ViewServerRuntimeDecodedMutationClient<
   Topics extends ViewServerRuntimeTopicDefinitions,
@@ -131,7 +160,7 @@ export type ViewServerRuntimeDecodedMutationClient<
       mutation: Mutation & ExactDecodedMutation<Topics, Mutation>,
     ): Effect.Effect<void, ViewServerRuntimeError>;
     (
-      mutation: ViewServerRuntimeTrustedDecodedPatchMutation<Topics>,
+      mutation: ViewServerRuntimeTrustedDecodedMutation<Topics>,
       trust: typeof viewServerRuntimeDecodedMutationTrust,
     ): Effect.Effect<void, ViewServerRuntimeError>;
   };

--- a/packages/runtime-core/src/runtime-client.ts
+++ b/packages/runtime-core/src/runtime-client.ts
@@ -12,6 +12,7 @@ import type {
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@effect-view-server/config";
+import type { ViewServerRuntimeDecodedMutationClient } from "@effect-view-server/config/internal";
 import { validateLiveQuerySourceRoute } from "@effect-view-server/config";
 import { Effect } from "effect";
 import { makeCoalescedHealthReader } from "./health";
@@ -24,6 +25,7 @@ import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
 
 export type RuntimeCoreClientInstance<Topics extends DecodableTopicDefinitions> = {
   readonly client: ViewServerRuntimeClient<Topics>;
+  readonly decodedMutationClient: ViewServerRuntimeDecodedMutationClient<Topics>;
   readonly internalClient: ViewServerRuntimeCoreInternalClient<Topics>;
   readonly requestHealthRefresh: Effect.Effect<void>;
 };
@@ -88,6 +90,7 @@ export const makeRuntimeCoreClient = Effect.fn("ViewServerRuntimeCore.client.mak
               .pipe(Effect.flatMap(() => internalClient.snapshot(topic, query))),
           health: internalClient.health,
         },
+        decodedMutationClient: mutationPipeline.decodedMutationClient,
         internalClient,
         requestHealthRefresh,
       } satisfies RuntimeCoreClientInstance<Topics>;

--- a/packages/runtime-core/src/runtime-core-construction.ts
+++ b/packages/runtime-core/src/runtime-core-construction.ts
@@ -133,6 +133,7 @@ export const makeViewServerRuntimeCoreInternalWithConstructionOptions: <
             };
             return {
               client: runtimeClient.client,
+              decodedMutationClient: runtimeClient.decodedMutationClient,
               internalClient: runtimeClient.internalClient,
               publicClient: runtimeClient.client,
               liveClient: {

--- a/packages/runtime-core/src/runtime-core-types.ts
+++ b/packages/runtime-core/src/runtime-core-types.ts
@@ -8,6 +8,7 @@ import type {
   ViewServerRuntimeClient,
   ViewServerRuntimeError,
 } from "@effect-view-server/config";
+import type { ViewServerRuntimeDecodedMutationClient } from "@effect-view-server/config/internal";
 import type { Duration, Effect } from "effect";
 import type { RuntimeCoreHealthOverlay, RuntimeCoreTransportHealth } from "./health";
 import type { ViewServerRuntimeCoreInternalLiveClient } from "./live-client";
@@ -48,6 +49,7 @@ export type ViewServerRuntimeCoreInternalInstance<Topics extends DecodableTopicD
   "client" | "liveClient"
 > & {
   readonly client: ViewServerRuntimeClient<Topics>;
+  readonly decodedMutationClient: ViewServerRuntimeDecodedMutationClient<Topics>;
   readonly internalClient: ViewServerRuntimeCoreInternalClient<Topics>;
   readonly publicClient: ViewServerRuntimeCorePublicClient<Topics>;
   readonly liveClient: ViewServerRuntimeLiveClient<Topics>;

--- a/packages/runtime-core/src/runtime-mutation.test.ts
+++ b/packages/runtime-core/src/runtime-mutation.test.ts
@@ -124,42 +124,43 @@ describe("Runtime Core mutation", () => {
   );
 
   it.effect("executes decoded mutations through the neutral mutation client", () =>
-    Effect.gen(function* () {
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
-      yield* runtimeCore.decodedMutationClient.execute({
-        _tag: "CheckMutationAllowed",
-        topic: "orders",
-      });
-      yield* runtimeCore.decodedMutationClient.execute({
-        _tag: "PublishDecodedRows",
-        topic: "orders",
-        rows: [order("kept", 20), order("deleted", 30)],
-      });
-      yield* runtimeCore.decodedMutationClient.execute({
-        _tag: "PatchDecodedFields",
-        topic: "orders",
-        key: "kept",
-        patch: { price: 21, status: "closed" },
-      });
-      yield* runtimeCore.decodedMutationClient.execute({
-        _tag: "DeleteDecodedRow",
-        topic: "orders",
-        key: "deleted",
-      });
+    Effect.scoped(
+      Effect.gen(function* () {
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+        yield* Effect.addFinalizer(() => runtimeCore.close);
+        yield* runtimeCore.decodedMutationClient.execute({
+          _tag: "CheckMutationAllowed",
+          topic: "orders",
+        });
+        yield* runtimeCore.decodedMutationClient.execute({
+          _tag: "PublishDecodedRows",
+          topic: "orders",
+          rows: [order("kept", 20), order("deleted", 30)],
+        });
+        yield* runtimeCore.decodedMutationClient.execute({
+          _tag: "PatchDecodedFields",
+          topic: "orders",
+          key: "kept",
+          patch: { price: 21, status: "closed" },
+        });
+        yield* runtimeCore.decodedMutationClient.execute({
+          _tag: "DeleteDecodedRow",
+          topic: "orders",
+          key: "deleted",
+        });
 
-      const snapshot = yield* runtimeCore.client.snapshot("orders", {
-        select: ["id", "price", "status"],
-        limit: 10,
-      });
-      expect(snapshot).toStrictEqual({
-        rows: [{ id: "kept", price: 21, status: "closed" }],
-        totalRows: 1,
-        version: 3,
-        status: "ready",
-        statusCode: "Ready",
-      });
-
-      yield* runtimeCore.close;
-    }),
+        const snapshot = yield* runtimeCore.client.snapshot("orders", {
+          select: ["id", "price", "status"],
+          limit: 10,
+        });
+        expect(snapshot).toStrictEqual({
+          rows: [{ id: "kept", price: 21, status: "closed" }],
+          totalRows: 1,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+        });
+      }),
+    ),
   );
 });

--- a/packages/runtime-core/src/runtime-mutation.test.ts
+++ b/packages/runtime-core/src/runtime-mutation.test.ts
@@ -122,4 +122,44 @@ describe("Runtime Core mutation", () => {
       yield* runtimeCore.close;
     }),
   );
+
+  it.effect("executes decoded mutations through the neutral mutation client", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
+      yield* runtimeCore.decodedMutationClient.execute({
+        _tag: "CheckMutationAllowed",
+        topic: "orders",
+      });
+      yield* runtimeCore.decodedMutationClient.execute({
+        _tag: "PublishDecodedRows",
+        topic: "orders",
+        rows: [order("kept", 20), order("deleted", 30)],
+      });
+      yield* runtimeCore.decodedMutationClient.execute({
+        _tag: "PatchDecodedFields",
+        topic: "orders",
+        key: "kept",
+        patch: { price: 21, status: "closed" },
+      });
+      yield* runtimeCore.decodedMutationClient.execute({
+        _tag: "DeleteDecodedRow",
+        topic: "orders",
+        key: "deleted",
+      });
+
+      const snapshot = yield* runtimeCore.client.snapshot("orders", {
+        select: ["id", "price", "status"],
+        limit: 10,
+      });
+      expect(snapshot).toStrictEqual({
+        rows: [{ id: "kept", price: 21, status: "closed" }],
+        totalRows: 1,
+        version: 3,
+        status: "ready",
+        statusCode: "Ready",
+      });
+
+      yield* runtimeCore.close;
+    }),
+  );
 });

--- a/packages/runtime-core/src/runtime-source-ownership.test.ts
+++ b/packages/runtime-core/src/runtime-source-ownership.test.ts
@@ -268,6 +268,51 @@ describe("Runtime Core source ownership", () => {
     }),
   );
 
+  it.effect("applies Source Ownership Policy to the neutral decoded mutation client", () =>
+    Effect.gen(function* () {
+      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(kafkaOwnedViewServer, {});
+      const checkError = yield* runtimeCore.decodedMutationClient
+        .execute({
+          _tag: "CheckMutationAllowed",
+          topic: "orders",
+        })
+        .pipe(Effect.flip);
+      const publishError = yield* runtimeCore.decodedMutationClient
+        .execute({
+          _tag: "PublishDecodedRows",
+          topic: "orders",
+          rows: [order("blocked", 10)],
+        })
+        .pipe(Effect.flip);
+      const patchError = yield* runtimeCore.decodedMutationClient
+        .execute({
+          _tag: "PatchDecodedFields",
+          topic: "orders",
+          key: "blocked",
+          patch: { price: 20 },
+        })
+        .pipe(Effect.flip);
+      const deleteError = yield* runtimeCore.decodedMutationClient
+        .execute({
+          _tag: "DeleteDecodedRow",
+          topic: "orders",
+          key: "blocked",
+        })
+        .pipe(Effect.flip);
+      const resetError = yield* runtimeCore.client.reset().pipe(Effect.flip);
+
+      expect([checkError, publishError, patchError, deleteError]).toStrictEqual([
+        publicSourceOwnedRuntimeMutationError,
+        publicSourceOwnedRuntimeMutationError,
+        publicSourceOwnedRuntimeMutationError,
+        publicSourceOwnedRuntimeMutationError,
+      ]);
+      expect(resetError).toStrictEqual(publicSourceOwnedRuntimeResetError);
+
+      yield* runtimeCore.close;
+    }),
+  );
+
   it.effect("rejects public grpcSource leased subscriptions before route validation", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCore(leasedGrpcSourceViewServer, {});

--- a/packages/runtime-core/src/runtime-source-ownership.test.ts
+++ b/packages/runtime-core/src/runtime-source-ownership.test.ts
@@ -270,60 +270,79 @@ describe("Runtime Core source ownership", () => {
   );
 
   it.effect("applies Source Ownership Policy to the neutral decoded mutation client", () =>
-    Effect.gen(function* () {
-      const runtimeCore = yield* makeViewServerRuntimeCoreInternal(kafkaOwnedViewServer, {});
-      const checkError = yield* runtimeCore.decodedMutationClient
-        .execute({
-          _tag: "CheckMutationAllowed",
-          topic: "orders",
-        })
-        .pipe(Effect.flip);
-      const publishError = yield* runtimeCore.decodedMutationClient
-        .execute({
-          _tag: "PublishDecodedRows",
-          topic: "orders",
-          rows: [order("blocked", 10)],
-        })
-        .pipe(Effect.flip);
-      const patchError = yield* runtimeCore.decodedMutationClient
-        .execute({
-          _tag: "PatchDecodedFields",
-          topic: "orders",
-          key: "blocked",
-          patch: { price: 20 },
-        })
-        .pipe(Effect.flip);
-      const trustedPatchError = yield* runtimeCore.decodedMutationClient
-        .execute(
-          {
+    Effect.scoped(
+      Effect.gen(function* () {
+        const runtimeCore = yield* makeViewServerRuntimeCoreInternal(kafkaOwnedViewServer, {});
+        yield* Effect.addFinalizer(() => runtimeCore.close);
+        const checkError = yield* runtimeCore.decodedMutationClient
+          .execute({
+            _tag: "CheckMutationAllowed",
+            topic: "orders",
+          })
+          .pipe(Effect.flip);
+        const publishError = yield* runtimeCore.decodedMutationClient
+          .execute({
+            _tag: "PublishDecodedRows",
+            topic: "orders",
+            rows: [order("blocked", 10)],
+          })
+          .pipe(Effect.flip);
+        const trustedPublishError = yield* runtimeCore.decodedMutationClient
+          .execute(
+            {
+              _tag: "PublishDecodedRows",
+              topic: "orders",
+              rows: [order("blocked-trusted", 11)],
+            },
+            viewServerRuntimeDecodedMutationTrust,
+          )
+          .pipe(Effect.flip);
+        const patchError = yield* runtimeCore.decodedMutationClient
+          .execute({
             _tag: "PatchDecodedFields",
             topic: "orders",
             key: "blocked",
-            patch: { price: 21 },
-          },
-          viewServerRuntimeDecodedMutationTrust,
-        )
-        .pipe(Effect.flip);
-      const deleteError = yield* runtimeCore.decodedMutationClient
-        .execute({
-          _tag: "DeleteDecodedRow",
-          topic: "orders",
-          key: "blocked",
-        })
-        .pipe(Effect.flip);
-      const resetError = yield* runtimeCore.client.reset().pipe(Effect.flip);
+            patch: { price: 20 },
+          })
+          .pipe(Effect.flip);
+        const trustedPatchError = yield* runtimeCore.decodedMutationClient
+          .execute(
+            {
+              _tag: "PatchDecodedFields",
+              topic: "orders",
+              key: "blocked",
+              patch: { price: 21 },
+            },
+            viewServerRuntimeDecodedMutationTrust,
+          )
+          .pipe(Effect.flip);
+        const deleteError = yield* runtimeCore.decodedMutationClient
+          .execute({
+            _tag: "DeleteDecodedRow",
+            topic: "orders",
+            key: "blocked",
+          })
+          .pipe(Effect.flip);
+        const resetError = yield* runtimeCore.client.reset().pipe(Effect.flip);
 
-      expect([checkError, publishError, patchError, trustedPatchError, deleteError]).toStrictEqual([
-        publicSourceOwnedRuntimeMutationError,
-        publicSourceOwnedRuntimeMutationError,
-        publicSourceOwnedRuntimeMutationError,
-        publicSourceOwnedRuntimeMutationError,
-        publicSourceOwnedRuntimeMutationError,
-      ]);
-      expect(resetError).toStrictEqual(publicSourceOwnedRuntimeResetError);
-
-      yield* runtimeCore.close;
-    }),
+        expect([
+          checkError,
+          publishError,
+          trustedPublishError,
+          patchError,
+          trustedPatchError,
+          deleteError,
+        ]).toStrictEqual([
+          publicSourceOwnedRuntimeMutationError,
+          publicSourceOwnedRuntimeMutationError,
+          publicSourceOwnedRuntimeMutationError,
+          publicSourceOwnedRuntimeMutationError,
+          publicSourceOwnedRuntimeMutationError,
+          publicSourceOwnedRuntimeMutationError,
+        ]);
+        expect(resetError).toStrictEqual(publicSourceOwnedRuntimeResetError);
+      }),
+    ),
   );
 
   it.effect("rejects public grpcSource leased subscriptions before route validation", () =>

--- a/packages/runtime-core/src/runtime-source-ownership.test.ts
+++ b/packages/runtime-core/src/runtime-source-ownership.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import type { ViewServerRuntimeError } from "@effect-view-server/config";
+import { viewServerRuntimeDecodedMutationTrust } from "@effect-view-server/config/internal";
 import { Effect, Stream } from "effect";
 import { makeViewServerRuntimeCoreInternal } from "./internal";
 import { makeViewServerRuntimeCore } from "./index";
@@ -292,6 +293,17 @@ describe("Runtime Core source ownership", () => {
           patch: { price: 20 },
         })
         .pipe(Effect.flip);
+      const trustedPatchError = yield* runtimeCore.decodedMutationClient
+        .execute(
+          {
+            _tag: "PatchDecodedFields",
+            topic: "orders",
+            key: "blocked",
+            patch: { price: 21 },
+          },
+          viewServerRuntimeDecodedMutationTrust,
+        )
+        .pipe(Effect.flip);
       const deleteError = yield* runtimeCore.decodedMutationClient
         .execute({
           _tag: "DeleteDecodedRow",
@@ -301,7 +313,8 @@ describe("Runtime Core source ownership", () => {
         .pipe(Effect.flip);
       const resetError = yield* runtimeCore.client.reset().pipe(Effect.flip);
 
-      expect([checkError, publishError, patchError, deleteError]).toStrictEqual([
+      expect([checkError, publishError, patchError, trustedPatchError, deleteError]).toStrictEqual([
+        publicSourceOwnedRuntimeMutationError,
         publicSourceOwnedRuntimeMutationError,
         publicSourceOwnedRuntimeMutationError,
         publicSourceOwnedRuntimeMutationError,

--- a/packages/runtime-core/src/source-mutation-pipeline.ts
+++ b/packages/runtime-core/src/source-mutation-pipeline.ts
@@ -10,7 +10,11 @@ import type {
   ViewServerRuntimeError,
   ViewServerTopicConfig,
 } from "@effect-view-server/config";
-import type { ViewServerRuntimeDecodedMutationClient } from "@effect-view-server/config/internal";
+import type {
+  ViewServerRuntimeDecodedMutation,
+  ViewServerRuntimeDecodedMutationClient,
+  viewServerRuntimeDecodedMutationTrust,
+} from "@effect-view-server/config/internal";
 import { Effect } from "effect";
 import { engineErrorToRuntimeError } from "./runtime-error";
 import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
@@ -150,25 +154,26 @@ export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTo
     reset,
   };
   const decodedMutationClient: ViewServerRuntimeDecodedMutationClient<Topics> = {
-    execute: Effect.fn("ViewServerRuntimeCore.sourceMutation.decoded.execute")(
-      function* (mutation) {
-        yield* sourceOwnership.requirePublicMutationAllowed(mutation.topic, "runtimeCore");
-        if (mutation._tag === "CheckMutationAllowed") {
-          return;
-        }
-        if (mutation._tag === "PublishDecodedRows") {
-          return yield* internalMutations.publishManyDecodedRows(mutation.topic, mutation.rows);
-        }
-        if (mutation._tag === "PatchDecodedFields") {
-          return yield* internalMutations.patchDecodedFields(
-            mutation.topic,
-            mutation.key,
-            mutation.patch,
-          );
-        }
-        return yield* internalMutations.delete(mutation.topic, mutation.key);
-      },
-    ),
+    execute: Effect.fn("ViewServerRuntimeCore.sourceMutation.decoded.execute")(function* (
+      mutation: ViewServerRuntimeDecodedMutation<Topics>,
+      _trust?: typeof viewServerRuntimeDecodedMutationTrust,
+    ) {
+      yield* sourceOwnership.requirePublicMutationAllowed(mutation.topic, "runtimeCore");
+      if (mutation._tag === "CheckMutationAllowed") {
+        return;
+      }
+      if (mutation._tag === "PublishDecodedRows") {
+        return yield* internalMutations.publishManyDecodedRows(mutation.topic, mutation.rows);
+      }
+      if (mutation._tag === "PatchDecodedFields") {
+        return yield* internalMutations.patchDecodedFields(
+          mutation.topic,
+          mutation.key,
+          mutation.patch,
+        );
+      }
+      return yield* internalMutations.delete(mutation.topic, mutation.key);
+    }),
   };
   const checkedMutations: ViewServerRuntimeCoreCheckedMutations<Topics> = {
     publish: (topic, row) =>

--- a/packages/runtime-core/src/source-mutation-pipeline.ts
+++ b/packages/runtime-core/src/source-mutation-pipeline.ts
@@ -19,6 +19,15 @@ import { Effect } from "effect";
 import { engineErrorToRuntimeError } from "./runtime-error";
 import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
 
+type AssertNever<Value extends never> = Value;
+
+type UnhandledDecodedMutationTag<Topics extends DecodableTopicDefinitions> = AssertNever<
+  Exclude<
+    ViewServerRuntimeDecodedMutation<Topics>["_tag"],
+    "CheckMutationAllowed" | "DeleteDecodedRow" | "PatchDecodedFields" | "PublishDecodedRows"
+  >
+>;
+
 export type RuntimeCoreDecodedRowWithStorageKey = {
   readonly storageKey: string;
   readonly row: object;
@@ -156,23 +165,23 @@ export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTo
   const decodedMutationClient: ViewServerRuntimeDecodedMutationClient<Topics> = {
     execute: Effect.fn("ViewServerRuntimeCore.sourceMutation.decoded.execute")(function* (
       mutation: ViewServerRuntimeDecodedMutation<Topics>,
-      _trust?: typeof viewServerRuntimeDecodedMutationTrust,
+      _trust?: typeof viewServerRuntimeDecodedMutationTrust | UnhandledDecodedMutationTag<Topics>,
     ) {
       yield* sourceOwnership.requirePublicMutationAllowed(mutation.topic, "runtimeCore");
-      if (mutation._tag === "CheckMutationAllowed") {
-        return;
+      switch (mutation._tag) {
+        case "CheckMutationAllowed":
+          return;
+        case "PublishDecodedRows":
+          return yield* internalMutations.publishManyDecodedRows(mutation.topic, mutation.rows);
+        case "PatchDecodedFields":
+          return yield* internalMutations.patchDecodedFields(
+            mutation.topic,
+            mutation.key,
+            mutation.patch,
+          );
+        case "DeleteDecodedRow":
+          return yield* internalMutations.delete(mutation.topic, mutation.key);
       }
-      if (mutation._tag === "PublishDecodedRows") {
-        return yield* internalMutations.publishManyDecodedRows(mutation.topic, mutation.rows);
-      }
-      if (mutation._tag === "PatchDecodedFields") {
-        return yield* internalMutations.patchDecodedFields(
-          mutation.topic,
-          mutation.key,
-          mutation.patch,
-        );
-      }
-      return yield* internalMutations.delete(mutation.topic, mutation.key);
     }),
   };
   const checkedMutations: ViewServerRuntimeCoreCheckedMutations<Topics> = {

--- a/packages/runtime-core/src/source-mutation-pipeline.ts
+++ b/packages/runtime-core/src/source-mutation-pipeline.ts
@@ -10,6 +10,7 @@ import type {
   ViewServerRuntimeError,
   ViewServerTopicConfig,
 } from "@effect-view-server/config";
+import type { ViewServerRuntimeDecodedMutationClient } from "@effect-view-server/config/internal";
 import { Effect } from "effect";
 import { engineErrorToRuntimeError } from "./runtime-error";
 import { makeSourceOwnershipPolicy } from "./source-ownership-policy";
@@ -53,6 +54,7 @@ export type ViewServerRuntimeCoreCheckedMutations<Topics extends DecodableTopicD
 export type RuntimeCoreMutationPipeline<Topics extends DecodableTopicDefinitions> = {
   readonly internalMutations: ViewServerRuntimeCoreInternalMutations<Topics>;
   readonly checkedMutations: ViewServerRuntimeCoreCheckedMutations<Topics>;
+  readonly decodedMutationClient: ViewServerRuntimeDecodedMutationClient<Topics>;
 };
 
 const applyEngineMutation = Effect.fn("ViewServerRuntimeCore.sourceMutation.apply")(function* (
@@ -147,6 +149,27 @@ export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTo
     delete: deleteRow,
     reset,
   };
+  const decodedMutationClient: ViewServerRuntimeDecodedMutationClient<Topics> = {
+    execute: Effect.fn("ViewServerRuntimeCore.sourceMutation.decoded.execute")(
+      function* (mutation) {
+        yield* sourceOwnership.requirePublicMutationAllowed(mutation.topic, "runtimeCore");
+        if (mutation._tag === "CheckMutationAllowed") {
+          return;
+        }
+        if (mutation._tag === "PublishDecodedRows") {
+          return yield* internalMutations.publishManyDecodedRows(mutation.topic, mutation.rows);
+        }
+        if (mutation._tag === "PatchDecodedFields") {
+          return yield* internalMutations.patchDecodedFields(
+            mutation.topic,
+            mutation.key,
+            mutation.patch,
+          );
+        }
+        return yield* internalMutations.delete(mutation.topic, mutation.key);
+      },
+    ),
+  };
   const checkedMutations: ViewServerRuntimeCoreCheckedMutations<Topics> = {
     publish: (topic, row) =>
       sourceOwnership
@@ -172,5 +195,6 @@ export const makeRuntimeCoreMutationPipeline = <const Topics extends DecodableTo
   return {
     internalMutations,
     checkedMutations,
+    decodedMutationClient,
   };
 };

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -252,10 +252,14 @@ const makeViewServerRuntimeFromResolvedOptions = Effect.fn(
         ? undefined
         : yield* acquireRuntimeResource(
             runtimeScope,
-            dependencies.makeTcpPublishIngress(dependencyConfig, runtimeCore.internalClient, {
-              ...resolvedOptions.tcpPublishOptions,
-              ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
-            }),
+            dependencies.makeTcpPublishIngress(
+              dependencyConfig,
+              runtimeCore.decodedMutationClient,
+              {
+                ...resolvedOptions.tcpPublishOptions,
+                ...(resolvedOptions.auth === undefined ? {} : { auth: resolvedOptions.auth }),
+              },
+            ),
             (resource) => resource.close,
           );
     const close: Effect.Effect<void> = (yield* Effect.cached(

--- a/packages/runtime/src/runtime-dependencies.ts
+++ b/packages/runtime/src/runtime-dependencies.ts
@@ -1,8 +1,8 @@
 import type { ViewServerRuntimeError } from "@effect-view-server/config";
+import type { ViewServerRuntimeDecodedMutationClient } from "@effect-view-server/config/internal";
 import { type ViewServerRuntimeCoreOptionsFor } from "@effect-view-server/runtime-core";
 import {
   makeViewServerRuntimeCoreInternal,
-  type ViewServerRuntimeCoreInternalClient,
   type ViewServerRuntimeCoreInternalInstance,
 } from "@effect-view-server/runtime-core/internal";
 import {
@@ -39,7 +39,7 @@ export type ViewServerRuntimeDependencies<Topics extends ViewServerRuntimeTopicD
   ) => Effect.Effect<ViewServerWebSocketServer, HttpServerError.ServeError>;
   readonly makeTcpPublishIngress: (
     config: ViewServerRuntimeDependencyConfig<Topics>,
-    client: ViewServerRuntimeCoreInternalClient<Topics>,
+    client: ViewServerRuntimeDecodedMutationClient<Topics>,
     options: ViewServerTcpPublishIngressOptions,
   ) => Effect.Effect<ViewServerTcpPublishIngress, ViewServerTcpPublishIngressError>;
 };

--- a/packages/runtime/src/runtime-types.ts
+++ b/packages/runtime/src/runtime-types.ts
@@ -9,10 +9,8 @@ import type {
   ExactLiveQueryInputForTopic,
   ExactPatch,
   RuntimeRegions,
-  RowSchema,
   TopicRouteBy,
   TopicRow,
-  TopicDefinitions,
   ViewServerHealth,
   ViewServerKafkaStartFrom,
   ViewServerRuntimeClient,
@@ -23,22 +21,15 @@ import type {
   RuntimeKafkaSourceOwnershipConstraint,
   RuntimeKafkaSourceRegionConstraint,
   TopicOwnedKafkaSourceTopic,
+  ViewServerRuntimeTopicDefinitions,
 } from "@effect-view-server/config/internal";
-import type { Effect, Schema } from "effect";
+import type { Effect } from "effect";
 import type { ViewServerGrpcRuntimeOptions } from "./grpc-runtime-option-contract";
 import type { ViewServerKafkaRuntimeOptions } from "./kafka-runtime-option-contract";
 
 export type { ViewServerGrpcRuntimeOptions } from "./grpc-runtime-option-contract";
 export type { ViewServerKafkaRuntimeOptions } from "./kafka-runtime-option-contract";
-
-export type ViewServerRuntimeTopicDefinitions = TopicDefinitions &
-  Record<
-    string,
-    {
-      readonly schema: RowSchema & Schema.Codec<object, unknown, never, unknown>;
-      readonly key: string;
-    }
-  >;
+export type { ViewServerRuntimeTopicDefinitions } from "@effect-view-server/config/internal";
 
 type RuntimeHttpPath = `/${string}`;
 

--- a/packages/runtime/src/tcp-publish-command.ts
+++ b/packages/runtime/src/tcp-publish-command.ts
@@ -1,7 +1,8 @@
 import type { RowSchema, ViewServerRuntimeError } from "@effect-view-server/config";
-import type {
-  ViewServerRuntimeDecodedMutationClient,
-  ViewServerRuntimeTopicDefinitions,
+import {
+  type ViewServerRuntimeDecodedMutationClient,
+  type ViewServerRuntimeTopicDefinitions,
+  viewServerRuntimeDecodedMutationTrust,
 } from "@effect-view-server/config/internal";
 import type { ViewServerAuth, ViewServerAuthRequest } from "@effect-view-server/server";
 import { validateViewServerAuthRequest, ViewServerAuthError } from "@effect-view-server/server";
@@ -425,12 +426,15 @@ export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPubli
       const key = yield* decodeTcpKey(topicDefinition, command.key);
       const patch = yield* decodeTcpPatch(topicDefinition, topicDefinition.topic, command.patch);
       yield* client
-        .execute({
-          _tag: "PatchDecodedFields",
-          topic: topicDefinition.topic,
-          key,
-          patch,
-        })
+        .execute(
+          {
+            _tag: "PatchDecodedFields",
+            topic: topicDefinition.topic,
+            key,
+            patch,
+          },
+          viewServerRuntimeDecodedMutationTrust,
+        )
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "patch")));
       return;
     }

--- a/packages/runtime/src/tcp-publish-command.ts
+++ b/packages/runtime/src/tcp-publish-command.ts
@@ -403,22 +403,28 @@ export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPubli
         makeTcpRowDefaultDecoders(topicDefinition),
       );
       yield* client
-        .execute({
-          _tag: "PublishDecodedRows",
-          topic: topicDefinition.topic,
-          rows: [row],
-        })
+        .execute(
+          {
+            _tag: "PublishDecodedRows",
+            topic: topicDefinition.topic,
+            rows: [row],
+          },
+          viewServerRuntimeDecodedMutationTrust,
+        )
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publish")));
       return;
     }
     if (command.op === "publishMany") {
       const rows = yield* decodeTcpRows(topicDefinition, topicDefinition.topic, command.rows);
       yield* client
-        .execute({
-          _tag: "PublishDecodedRows",
-          topic: topicDefinition.topic,
-          rows,
-        })
+        .execute(
+          {
+            _tag: "PublishDecodedRows",
+            topic: topicDefinition.topic,
+            rows,
+          },
+          viewServerRuntimeDecodedMutationTrust,
+        )
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publishMany")));
       return;
     }

--- a/packages/runtime/src/tcp-publish-command.ts
+++ b/packages/runtime/src/tcp-publish-command.ts
@@ -1,12 +1,11 @@
 import type { RowSchema, ViewServerRuntimeError } from "@effect-view-server/config";
 import type {
-  SourceOwnershipPolicy,
-  ViewServerRuntimeCoreInternalClient,
-} from "@effect-view-server/runtime-core/internal";
+  ViewServerRuntimeDecodedMutationClient,
+  ViewServerRuntimeTopicDefinitions,
+} from "@effect-view-server/config/internal";
 import type { ViewServerAuth, ViewServerAuthRequest } from "@effect-view-server/server";
 import { validateViewServerAuthRequest, ViewServerAuthError } from "@effect-view-server/server";
 import { Effect, Option, Result, Schema } from "effect";
-import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
 export class ViewServerTcpPublishIngressError extends Schema.TaggedErrorClass<ViewServerTcpPublishIngressError>()(
   "ViewServerTcpPublishIngressError",
@@ -34,12 +33,15 @@ export type TcpPublishCommandAuthContext = {
 type TcpFieldSchema = NonNullable<RowSchema["fields"][string]>;
 type TcpDecodePhase = "key" | "patch" | "row";
 type TcpFieldDefaultDecoder = Effect.Effect<Option.Option<unknown>>;
-type TcpConfiguredTopic<Topics extends ViewServerRuntimeTopicDefinitions> = {
+type TcpConfiguredTopic<
+  Topics extends ViewServerRuntimeTopicDefinitions,
+  Topic extends Extract<keyof Topics, string> = Extract<keyof Topics, string>,
+> = {
   readonly fieldSchemas: ReadonlyMap<string, TcpFieldSchema>;
   readonly keyField: string;
   readonly keySchema: TcpFieldSchema;
-  readonly schema: RowSchema;
-  readonly topic: Extract<keyof Topics, string>;
+  readonly schema: Topics[Topic]["schema"];
+  readonly topic: Topic;
 };
 
 const TcpJsonObject = Schema.Record(Schema.String, Schema.Json);
@@ -263,8 +265,11 @@ const makeTcpMissingFieldDefaultDecoder = (
   ).pipe(Effect.withSpan("ViewServerRuntime.tcpPublish.field.default.decode"));
 };
 
-const makeTcpRowDefaultDecoders = <const Topics extends ViewServerRuntimeTopicDefinitions>(
-  topicDefinition: TcpConfiguredTopic<Topics>,
+const makeTcpRowDefaultDecoders = <
+  const Topics extends ViewServerRuntimeTopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  topicDefinition: TcpConfiguredTopic<Topics, Topic>,
 ): ReadonlyMap<string, TcpFieldDefaultDecoder> => {
   const defaultDecoders = new Map<string, TcpFieldDefaultDecoder>();
   for (const [field, fieldSchema] of topicDefinition.fieldSchemas) {
@@ -275,7 +280,8 @@ const makeTcpRowDefaultDecoders = <const Topics extends ViewServerRuntimeTopicDe
 
 const decodeTcpKey = Effect.fn("ViewServerRuntime.tcpPublish.key.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
->(topicDefinition: TcpConfiguredTopic<Topics>, key: string) {
+  Topic extends Extract<keyof Topics, string>,
+>(topicDefinition: TcpConfiguredTopic<Topics, Topic>, key: string) {
   const decodedKey = yield* decodeTcpFieldForRuntime(
     topicDefinition.keySchema,
     topicDefinition.topic,
@@ -293,8 +299,9 @@ const decodeTcpKey = Effect.fn("ViewServerRuntime.tcpPublish.key.decode")(functi
 
 const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
 >(
-  topicDefinition: TcpConfiguredTopic<Topics>,
+  topicDefinition: TcpConfiguredTopic<Topics, Topic>,
   topic: string,
   row: Record<string, unknown>,
   defaultDecoders: ReadonlyMap<string, TcpFieldDefaultDecoder>,
@@ -326,8 +333,9 @@ const decodeTcpRow = Effect.fn("ViewServerRuntime.tcpPublish.row.decode")(functi
 
 const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
 >(
-  topicDefinition: TcpConfiguredTopic<Topics>,
+  topicDefinition: TcpConfiguredTopic<Topics, Topic>,
   topic: string,
   rows: ReadonlyArray<Record<string, unknown>>,
 ) {
@@ -339,8 +347,13 @@ const decodeTcpRows = Effect.fn("ViewServerRuntime.tcpPublish.rows.decode")(func
 
 const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(function* <
   const Topics extends ViewServerRuntimeTopicDefinitions,
->(topicDefinition: TcpConfiguredTopic<Topics>, topic: string, patch: Record<string, unknown>) {
-  const decodedPatch: Record<string, unknown> = {};
+  Topic extends Extract<keyof Topics, string>,
+>(
+  topicDefinition: TcpConfiguredTopic<Topics, Topic>,
+  topic: string,
+  patch: Record<string, unknown>,
+) {
+  const decodedPatch: Partial<Topics[Topic]["schema"]["Type"]> = {};
   for (const [field, value] of Object.entries(patch)) {
     const fieldSchema = topicDefinition.fieldSchemas.get(field);
     if (fieldSchema === undefined) {
@@ -354,12 +367,6 @@ const decodeTcpPatch = Effect.fn("ViewServerRuntime.tcpPublish.patch.decode")(fu
   }
   return decodedPatch;
 });
-
-const ensureTopicCanBeMutated = (
-  topic: string,
-  sourceOwnership: SourceOwnershipPolicy,
-): Effect.Effect<void, ViewServerRuntimeError> =>
-  sourceOwnership.requirePublicMutationAllowed(topic, "runtimeCore");
 
 const mapRuntimeError =
   (topic: string, operation: "delete" | "patch" | "publish" | "publishMany") =>
@@ -376,15 +383,17 @@ export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPubli
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     context: TcpPublishCommandAuthContext,
     config: { readonly topics: Topics },
-    client: ViewServerRuntimeCoreInternalClient<Topics>,
+    client: ViewServerRuntimeDecodedMutationClient<Topics>,
     options: TcpPublishCommandOptions,
-    sourceOwnership: SourceOwnershipPolicy,
     line: string,
   ) {
     const command = yield* parseCommand(line);
     yield* validateViewServerAuthRequest(options.auth, tcpAuthRequest(command, context));
     const topicDefinition = yield* topicSchema(config, command.topic);
-    yield* ensureTopicCanBeMutated(topicDefinition.topic, sourceOwnership);
+    yield* client.execute({
+      _tag: "CheckMutationAllowed",
+      topic: topicDefinition.topic,
+    });
     if (command.op === "publish") {
       const row = yield* decodeTcpRow(
         topicDefinition,
@@ -393,14 +402,22 @@ export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPubli
         makeTcpRowDefaultDecoders(topicDefinition),
       );
       yield* client
-        .publishManyDecodedRows(topicDefinition.topic, [row])
+        .execute({
+          _tag: "PublishDecodedRows",
+          topic: topicDefinition.topic,
+          rows: [row],
+        })
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publish")));
       return;
     }
     if (command.op === "publishMany") {
       const rows = yield* decodeTcpRows(topicDefinition, topicDefinition.topic, command.rows);
       yield* client
-        .publishManyDecodedRows(topicDefinition.topic, rows)
+        .execute({
+          _tag: "PublishDecodedRows",
+          topic: topicDefinition.topic,
+          rows,
+        })
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "publishMany")));
       return;
     }
@@ -408,13 +425,22 @@ export const handleTcpPublishCommandLine = Effect.fn("ViewServerRuntime.tcpPubli
       const key = yield* decodeTcpKey(topicDefinition, command.key);
       const patch = yield* decodeTcpPatch(topicDefinition, topicDefinition.topic, command.patch);
       yield* client
-        .patchDecodedFields(topicDefinition.topic, key, patch)
+        .execute({
+          _tag: "PatchDecodedFields",
+          topic: topicDefinition.topic,
+          key,
+          patch,
+        })
         .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "patch")));
       return;
     }
     const key = yield* decodeTcpKey(topicDefinition, command.key);
     yield* client
-      .delete(topicDefinition.topic, key)
+      .execute({
+        _tag: "DeleteDecodedRow",
+        topic: topicDefinition.topic,
+        key,
+      })
       .pipe(Effect.mapError(mapRuntimeError(topicDefinition.topic, "delete")));
   },
 );

--- a/packages/runtime/src/tcp-publish-ingress.ts
+++ b/packages/runtime/src/tcp-publish-ingress.ts
@@ -1,6 +1,9 @@
 import type { ViewServerTopicConfig } from "@effect-view-server/config";
+import type {
+  ViewServerRuntimeDecodedMutationClient,
+  ViewServerRuntimeTopicDefinitions,
+} from "@effect-view-server/config/internal";
 import type { ViewServerAuth } from "@effect-view-server/server";
-import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
 import { Effect } from "effect";
 import * as Net from "node:net";
 import { ViewServerTcpPublishIngressError } from "./tcp-publish-command";
@@ -8,7 +11,6 @@ import {
   makeTcpPublishSocketServer,
   type TcpPublishServerFactory,
 } from "./tcp-publish-socket-runtime";
-import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
 export { ViewServerTcpPublishIngressError } from "./tcp-publish-command";
 export { tcpPublishUrl, writeTcpJsonLine } from "./tcp-publish-socket-runtime";
@@ -101,7 +103,7 @@ export const makeViewServerTcpPublishIngressWithServerFactory = Effect.fn(
   "ViewServerRuntime.tcpPublish.makeWithServerFactory",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeCoreInternalClient<Topics>,
+  client: ViewServerRuntimeDecodedMutationClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
   createServer: TcpPublishServerFactory,
 ) {
@@ -112,7 +114,7 @@ export const makeViewServerTcpPublishIngressWithServerFactory = Effect.fn(
 export const makeViewServerTcpPublishIngress = Effect.fn("ViewServerRuntime.tcpPublish.make")(
   function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
     config: ViewServerTopicConfig<Topics>,
-    client: ViewServerRuntimeCoreInternalClient<Topics>,
+    client: ViewServerRuntimeDecodedMutationClient<Topics>,
     options: ViewServerTcpPublishIngressOptions,
   ) {
     return yield* makeViewServerTcpPublishIngressWithServerFactory(

--- a/packages/runtime/src/tcp-publish-interface.test.ts
+++ b/packages/runtime/src/tcp-publish-interface.test.ts
@@ -1680,6 +1680,7 @@ describe("TCP publish Interface", () => {
       );
       const missingTopicKeyFieldIngress = yield* makeViewServerTcpPublishIngress(
         missingTopicKeyFieldConfig,
+        // @ts-expect-error intentionally mismatched client for the malformed runtime key guard.
         runtimeCore.decodedMutationClient,
         { port: 0 },
       );

--- a/packages/runtime/src/tcp-publish-interface.test.ts
+++ b/packages/runtime/src/tcp-publish-interface.test.ts
@@ -1675,12 +1675,12 @@ describe("TCP publish Interface", () => {
       const missingTopicSchemaIngress = yield* makeViewServerTcpPublishIngress(
         // @ts-expect-error intentionally malformed config for the runtime defensive guard.
         missingTopicSchemaConfig,
-        runtimeCore.internalClient,
+        runtimeCore.decodedMutationClient,
         { port: 0 },
       );
       const missingTopicKeyFieldIngress = yield* makeViewServerTcpPublishIngress(
         missingTopicKeyFieldConfig,
-        runtimeCore.internalClient,
+        runtimeCore.decodedMutationClient,
         { port: 0 },
       );
 
@@ -1776,9 +1776,11 @@ describe("TCP publish Interface", () => {
         { maxGlobalQueuedCommands: 0, port: 0 },
       ];
       const errors = yield* Effect.forEach(invalidOptions, (options) =>
-        makeViewServerTcpPublishIngress(viewServer, runtimeCore.internalClient, options).pipe(
-          Effect.flip,
-        ),
+        makeViewServerTcpPublishIngress(
+          viewServer,
+          runtimeCore.decodedMutationClient,
+          options,
+        ).pipe(Effect.flip),
       );
 
       expect(
@@ -1854,7 +1856,7 @@ describe("TCP publish Interface", () => {
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(sourceOwnedViewServer, {});
       const ingress = yield* makeViewServerTcpPublishIngress(
         sourceOwnedViewServer,
-        runtimeCore.internalClient,
+        runtimeCore.decodedMutationClient,
         {
           port: 0,
         },

--- a/packages/runtime/src/tcp-publish-interface.test.ts
+++ b/packages/runtime/src/tcp-publish-interface.test.ts
@@ -1679,8 +1679,8 @@ describe("TCP publish Interface", () => {
         { port: 0 },
       );
       const missingTopicKeyFieldIngress = yield* makeViewServerTcpPublishIngress(
+        // @ts-expect-error intentionally malformed config for the runtime key guard.
         missingTopicKeyFieldConfig,
-        // @ts-expect-error intentionally mismatched client for the malformed runtime key guard.
         runtimeCore.decodedMutationClient,
         { port: 0 },
       );

--- a/packages/runtime/src/tcp-publish-lifecycle.test.ts
+++ b/packages/runtime/src/tcp-publish-lifecycle.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "@effect/vitest";
 import type { ViewServerRuntimeError } from "@effect-view-server/config";
-import type {
-  ViewServerRuntimeDecodedMutation,
-  ViewServerRuntimeDecodedMutationClient,
-  ViewServerRuntimeTopicDefinitions,
+import {
+  type ViewServerRuntimeDecodedMutation,
+  type ViewServerRuntimeDecodedMutationClient,
+  type ViewServerRuntimeTopicDefinitions,
+  viewServerRuntimeDecodedMutationTrust,
 } from "@effect-view-server/config/internal";
 import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
 import { Cause, Deferred, Effect, Exit, Fiber, Option, Schema } from "effect";
@@ -34,8 +35,28 @@ const withDecodedPublish = <const Topics extends ViewServerRuntimeTopicDefinitio
   client: ViewServerRuntimeDecodedMutationClient<Topics>,
   publish: (rows: ReadonlyArray<object>) => Effect.Effect<void, ViewServerRuntimeError>,
 ): ViewServerRuntimeDecodedMutationClient<Topics> => ({
-  execute: (mutation) =>
-    mutation._tag === "PublishDecodedRows" ? publish(mutation.rows) : client.execute(mutation),
+  execute: (
+    mutation: ViewServerRuntimeDecodedMutation<Topics>,
+    _trust?: typeof viewServerRuntimeDecodedMutationTrust,
+  ) => {
+    if (mutation._tag === "PublishDecodedRows") {
+      return publish(mutation.rows);
+    }
+    if (mutation._tag === "PatchDecodedFields") {
+      return client.execute(mutation, viewServerRuntimeDecodedMutationTrust);
+    }
+    if (mutation._tag === "CheckMutationAllowed") {
+      return client.execute({
+        _tag: "CheckMutationAllowed",
+        topic: mutation.topic,
+      });
+    }
+    return client.execute({
+      _tag: "DeleteDecodedRow",
+      topic: mutation.topic,
+      key: mutation.key,
+    });
+  },
 });
 
 describe("TCP publish lifecycle ownership", () => {

--- a/packages/runtime/src/tcp-publish-lifecycle.test.ts
+++ b/packages/runtime/src/tcp-publish-lifecycle.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
-import { type ViewServerRuntimeError } from "@effect-view-server/config";
+import type { ViewServerRuntimeError } from "@effect-view-server/config";
+import type {
+  ViewServerRuntimeDecodedMutation,
+  ViewServerRuntimeDecodedMutationClient,
+  ViewServerRuntimeTopicDefinitions,
+} from "@effect-view-server/config/internal";
 import { makeViewServerRuntimeCoreInternal } from "@effect-view-server/runtime-core/internal";
-import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";
 import { Cause, Deferred, Effect, Exit, Fiber, Option, Schema } from "effect";
 import { TestClock } from "effect/testing";
 import type { ViewServerRuntimeDependencies } from "./internal";
@@ -26,6 +30,14 @@ import * as Net from "node:net";
 
 import { order, Order, viewServer } from "../test-harness/runtime-config";
 
+const withDecodedPublish = <const Topics extends ViewServerRuntimeTopicDefinitions>(
+  client: ViewServerRuntimeDecodedMutationClient<Topics>,
+  publish: (rows: ReadonlyArray<object>) => Effect.Effect<void, ViewServerRuntimeError>,
+): ViewServerRuntimeDecodedMutationClient<Topics> => ({
+  execute: (mutation) =>
+    mutation._tag === "PublishDecodedRows" ? publish(mutation.rows) : client.execute(mutation),
+});
+
 describe("TCP publish lifecycle ownership", () => {
   it.effect("owns accepted TCP socket deadlines with Effect time", () =>
     Effect.acquireUseRelease(
@@ -34,7 +46,7 @@ describe("TCP publish lifecycle ownership", () => {
         Effect.acquireUseRelease(
           makeViewServerTcpPublishIngressWithServerFactory(
             viewServer,
-            runtimeCore.internalClient,
+            runtimeCore.decodedMutationClient,
             { port: 0 },
             (connectionListener) => Net.createServer(connectionListener),
           ),
@@ -83,19 +95,17 @@ describe("TCP publish lifecycle ownership", () => {
           const allowCommandFinalizer = yield* Deferred.make<void>();
           const commandFinalized = yield* Deferred.make<void>();
           const closeCompleted = yield* Deferred.make<void>();
-          const client: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-            ...runtimeCore.internalClient,
-            publishManyDecodedRows: () =>
-              Effect.acquireUseRelease(
-                Deferred.succeed(commandStarted, undefined),
-                () => Effect.never,
-                () =>
-                  Deferred.succeed(commandFinalizerStarted, undefined).pipe(
-                    Effect.andThen(Deferred.await(allowCommandFinalizer)),
-                    Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
-                  ),
-              ),
-          };
+          const client = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+            Effect.acquireUseRelease(
+              Deferred.succeed(commandStarted, undefined),
+              () => Effect.never,
+              () =>
+                Deferred.succeed(commandFinalizerStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(allowCommandFinalizer)),
+                  Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
+                ),
+            ),
+          );
 
           yield* Effect.acquireUseRelease(
             makeViewServerTcpPublishIngress(viewServer, client, { port: 0 }),
@@ -161,19 +171,17 @@ describe("TCP publish lifecycle ownership", () => {
           const commandFinalizerStarted = yield* Deferred.make<void>();
           const allowCommandFinalizer = yield* Deferred.make<void>();
           const commandFinalized = yield* Deferred.make<void>();
-          const client: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-            ...runtimeCore.internalClient,
-            publishManyDecodedRows: () =>
-              Effect.acquireUseRelease(
-                Deferred.succeed(commandStarted, undefined),
-                () => Effect.never,
-                () =>
-                  Deferred.succeed(commandFinalizerStarted, undefined).pipe(
-                    Effect.andThen(Deferred.await(allowCommandFinalizer)),
-                    Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
-                  ),
-              ),
-          };
+          const client = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+            Effect.acquireUseRelease(
+              Deferred.succeed(commandStarted, undefined),
+              () => Effect.never,
+              () =>
+                Deferred.succeed(commandFinalizerStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(allowCommandFinalizer)),
+                  Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
+                ),
+            ),
+          );
 
           yield* Effect.acquireUseRelease(
             makeViewServerTcpPublishIngress(viewServer, client, {
@@ -236,24 +244,21 @@ describe("TCP publish lifecycle ownership", () => {
           const allowCommandFinalizer = yield* Deferred.make<void>();
           const commandFinalized = yield* Deferred.make<void>();
           let publishCalls = 0;
-          const client: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-            ...runtimeCore.internalClient,
-            publishManyDecodedRows: () => {
-              publishCalls += 1;
-              if (publishCalls > 1) {
-                return Effect.void;
-              }
-              return Effect.acquireUseRelease(
-                Deferred.succeed(commandStarted, undefined),
-                () => Effect.never,
-                () =>
-                  Deferred.succeed(commandFinalizerStarted, undefined).pipe(
-                    Effect.andThen(Deferred.await(allowCommandFinalizer)),
-                    Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
-                  ),
-              );
-            },
-          };
+          const client = withDecodedPublish(runtimeCore.decodedMutationClient, () => {
+            publishCalls += 1;
+            if (publishCalls > 1) {
+              return Effect.void;
+            }
+            return Effect.acquireUseRelease(
+              Deferred.succeed(commandStarted, undefined),
+              () => Effect.never,
+              () =>
+                Deferred.succeed(commandFinalizerStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(allowCommandFinalizer)),
+                  Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
+                ),
+            );
+          });
 
           yield* Effect.acquireUseRelease(
             makeViewServerTcpPublishIngress(viewServer, client, {
@@ -317,61 +322,46 @@ describe("TCP publish lifecycle ownership", () => {
       const closedQueuePublishInterrupted = yield* Deferred.make<void>();
       const fifoIds: Array<string> = [];
       let slowPublishCalls = 0;
-      const slowPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: () => {
-          slowPublishCalls += 1;
-          if (slowPublishCalls === 1) {
-            return Deferred.succeed(slowPublishStarted, undefined).pipe(
-              Effect.andThen(Effect.never),
-              Effect.ensuring(Deferred.succeed(slowPublishInterrupted, undefined)),
-            );
-          }
-          if (slowPublishCalls === 2) {
-            return Effect.acquireUseRelease(
-              Deferred.succeed(recoveryPublishStarted, undefined),
-              () => Deferred.await(allowRecoveryPublish),
-              () => Deferred.succeed(recoveryPublishFinalized, undefined),
-            );
-          }
-          return Effect.void;
-        },
-      };
-      const fifoPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: (_topic, rows) =>
-          Effect.sync(() => {
-            fifoIds.push(...rows.map((row) => Schema.decodeUnknownSync(Order)(row).id));
-          }),
-      };
-      const globalPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: () =>
-          Deferred.succeed(globalPublishStarted, undefined).pipe(
+      const slowPublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, () => {
+        slowPublishCalls += 1;
+        if (slowPublishCalls === 1) {
+          return Deferred.succeed(slowPublishStarted, undefined).pipe(
             Effect.andThen(Effect.never),
-            Effect.ensuring(Deferred.succeed(globalPublishInterrupted, undefined)),
-          ),
-      };
-      const disconnectedPublishClient: ViewServerRuntimeCoreInternalClient<
-        typeof viewServer.topics
-      > = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: () =>
-          Deferred.succeed(disconnectedPublishStarted, undefined).pipe(
-            Effect.andThen(Effect.never),
-            Effect.ensuring(Deferred.succeed(disconnectedPublishInterrupted, undefined)),
-          ),
-      };
-      const closedQueuePublishClient: ViewServerRuntimeCoreInternalClient<
-        typeof viewServer.topics
-      > = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: () =>
-          Deferred.succeed(closedQueuePublishStarted, undefined).pipe(
-            Effect.andThen(Effect.never),
-            Effect.ensuring(Deferred.succeed(closedQueuePublishInterrupted, undefined)),
-          ),
-      };
+            Effect.ensuring(Deferred.succeed(slowPublishInterrupted, undefined)),
+          );
+        }
+        if (slowPublishCalls === 2) {
+          return Effect.acquireUseRelease(
+            Deferred.succeed(recoveryPublishStarted, undefined),
+            () => Deferred.await(allowRecoveryPublish),
+            () => Deferred.succeed(recoveryPublishFinalized, undefined),
+          );
+        }
+        return Effect.void;
+      });
+      const fifoPublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, (rows) =>
+        Effect.sync(() => {
+          fifoIds.push(...rows.map((row) => Schema.decodeUnknownSync(Order)(row).id));
+        }),
+      );
+      const globalPublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+        Deferred.succeed(globalPublishStarted, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(Deferred.succeed(globalPublishInterrupted, undefined)),
+        ),
+      );
+      const disconnectedPublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+        Deferred.succeed(disconnectedPublishStarted, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(Deferred.succeed(disconnectedPublishInterrupted, undefined)),
+        ),
+      );
+      const closedQueuePublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+        Deferred.succeed(closedQueuePublishStarted, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(Deferred.succeed(closedQueuePublishInterrupted, undefined)),
+        ),
+      );
       const fifoCommandLines = ["fifo-1", "fifo-2"].map(
         (id) =>
           `${JSON.stringify({
@@ -387,7 +377,7 @@ describe("TCP publish lifecycle ownership", () => {
       })}\n`;
       const oversizedIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
-        runtimeCore.internalClient,
+        runtimeCore.decodedMutationClient,
         {
           maxLineBytes: 8,
           port: 0,
@@ -395,7 +385,7 @@ describe("TCP publish lifecycle ownership", () => {
       );
       const oversizedCompleteLineIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
-        runtimeCore.internalClient,
+        runtimeCore.decodedMutationClient,
         {
           maxLineBytes: 8,
           port: 0,
@@ -432,7 +422,7 @@ describe("TCP publish lifecycle ownership", () => {
       );
       const connectionCappedIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
-        runtimeCore.internalClient,
+        runtimeCore.decodedMutationClient,
         {
           maxConnections: 1,
           port: 0,
@@ -779,28 +769,26 @@ describe("TCP publish lifecycle ownership", () => {
   it.live("returns typed TCP publish errors for runtime mutation failures", () =>
     Effect.gen(function* () {
       const runtimeCore = yield* makeViewServerRuntimeCoreInternal(viewServer, {});
-      const defectPublishClient: ViewServerRuntimeCoreInternalClient<typeof viewServer.topics> = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: () => Effect.die("tcp publish defect"),
-      };
-      const unavailablePublishClient: ViewServerRuntimeCoreInternalClient<
+      const defectPublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+        Effect.die("tcp publish defect"),
+      );
+      const unavailablePublishClient = withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+        Effect.fail({
+          _tag: "ViewServerRuntimeError",
+          code: "RuntimeUnavailable",
+          message: "runtime unavailable for tcp test",
+        } satisfies ViewServerRuntimeError),
+      );
+      const typedFailurePublishClient: ViewServerRuntimeDecodedMutationClient<
         typeof viewServer.topics
       > = {
-        ...runtimeCore.internalClient,
-        publishManyDecodedRows: () =>
-          Effect.fail({
-            _tag: "ViewServerRuntimeError",
-            code: "RuntimeUnavailable",
-            message: "runtime unavailable for tcp test",
-          } satisfies ViewServerRuntimeError),
+        ...runtimeCore.decodedMutationClient,
       };
-      const typedFailurePublishClient: ViewServerRuntimeCoreInternalClient<
-        typeof viewServer.topics
-      > = {
-        ...runtimeCore.internalClient,
-      };
-      Object.defineProperty(typedFailurePublishClient, "publishManyDecodedRows", {
-        value: () => Effect.fail(new RuntimeTestFailure({ message: "runtime typed failure" })),
+      Object.defineProperty(typedFailurePublishClient, "execute", {
+        value: (mutation: ViewServerRuntimeDecodedMutation<typeof viewServer.topics>) =>
+          mutation._tag === "PublishDecodedRows"
+            ? Effect.fail(new RuntimeTestFailure({ message: "runtime typed failure" }))
+            : runtimeCore.decodedMutationClient.execute(mutation),
       });
       const defectPublishIngress = yield* makeViewServerTcpPublishIngress(
         viewServer,
@@ -885,7 +873,7 @@ describe("TCP publish lifecycle ownership", () => {
           yield* Effect.acquireUseRelease(
             makeViewServerTcpPublishIngressWithServerFactory(
               viewServer,
-              runtimeCore.internalClient,
+              runtimeCore.decodedMutationClient,
               { port: 0 },
               (connectionListener) => {
                 const created = Net.createServer(connectionListener);
@@ -988,7 +976,7 @@ describe("TCP publish lifecycle ownership", () => {
           yield* Effect.acquireUseRelease(
             makeViewServerTcpPublishIngressWithServerFactory(
               viewServer,
-              runtimeCore.internalClient,
+              runtimeCore.decodedMutationClient,
               { maxConnections: 1, port: 0 },
               (connectionListener) => {
                 acceptSocket = connectionListener;
@@ -1136,7 +1124,7 @@ describe("TCP publish lifecycle ownership", () => {
           let acceptedSocket: Net.Socket | undefined;
           const ingress = yield* makeViewServerTcpPublishIngressWithServerFactory(
             viewServer,
-            runtimeCore.internalClient,
+            runtimeCore.decodedMutationClient,
             { maxConnections: 1, port: 0 },
             (connectionListener) => {
               acceptSocket = connectionListener;
@@ -1284,19 +1272,17 @@ describe("TCP publish lifecycle ownership", () => {
             makeViewServerRuntimeCoreInternal(config, options).pipe(
               Effect.map((runtimeCore) => ({
                 ...runtimeCore,
-                internalClient: {
-                  ...runtimeCore.internalClient,
-                  publishManyDecodedRows: () =>
-                    Deferred.succeed(commandStarted, undefined).pipe(
-                      Effect.andThen(Effect.never),
-                      Effect.ensuring(
-                        Deferred.succeed(commandInterruptStarted, undefined).pipe(
-                          Effect.andThen(Deferred.await(allowCommandFinalize)),
-                          Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
-                        ),
+                decodedMutationClient: withDecodedPublish(runtimeCore.decodedMutationClient, () =>
+                  Deferred.succeed(commandStarted, undefined).pipe(
+                    Effect.andThen(Effect.never),
+                    Effect.ensuring(
+                      Deferred.succeed(commandInterruptStarted, undefined).pipe(
+                        Effect.andThen(Deferred.await(allowCommandFinalize)),
+                        Effect.andThen(Deferred.succeed(commandFinalized, undefined)),
                       ),
                     ),
-                },
+                  ),
+                ),
                 close: Deferred.succeed(runtimeCoreCloseStarted, undefined).pipe(
                   Effect.andThen(runtimeCore.close),
                 ),
@@ -1433,7 +1419,7 @@ describe("TCP publish lifecycle ownership", () => {
           let server: Net.Server | undefined;
           const startupFiber = yield* makeViewServerTcpPublishIngressWithServerFactory(
             viewServer,
-            runtimeCore.internalClient,
+            runtimeCore.decodedMutationClient,
             { port: 0 },
             (connectionListener) => {
               const createdServer = Net.createServer(connectionListener);
@@ -1489,7 +1475,7 @@ describe("TCP publish lifecycle ownership", () => {
           let server: Net.Server | undefined;
           const exit = yield* makeViewServerTcpPublishIngressWithServerFactory(
             viewServer,
-            runtimeCore.internalClient,
+            runtimeCore.decodedMutationClient,
             { port: 0 },
             (connectionListener) => {
               const createdServer = Net.createServer(connectionListener);

--- a/packages/runtime/src/tcp-publish-socket-runtime.ts
+++ b/packages/runtime/src/tcp-publish-socket-runtime.ts
@@ -1,10 +1,9 @@
 import type { ViewServerRuntimeError, ViewServerTopicConfig } from "@effect-view-server/config";
+import type {
+  ViewServerRuntimeDecodedMutationClient,
+  ViewServerRuntimeTopicDefinitions,
+} from "@effect-view-server/config/internal";
 import { ViewServerAuthError } from "@effect-view-server/server";
-import {
-  makeSourceOwnershipPolicy,
-  type SourceOwnershipPolicy,
-  type ViewServerRuntimeCoreInternalClient,
-} from "@effect-view-server/runtime-core/internal";
 import { Cause, Effect, Exit, FiberSet, Option, Queue, Schema, Scope } from "effect";
 import * as Net from "node:net";
 import {
@@ -13,7 +12,6 @@ import {
   ViewServerTcpPublishIngressError,
 } from "./tcp-publish-command";
 import type { ViewServerTcpPublishIngressOptions } from "./tcp-publish-ingress";
-import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";
 
 type TcpResponseSocket = {
   readonly destroyed: boolean;
@@ -241,9 +239,8 @@ const executeLine = Effect.fn("ViewServerRuntime.tcpPublish.socket.executeLine")
   socket: Net.Socket,
   state: TcpPublishSocketState,
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeCoreInternalClient<Topics>,
+  client: ViewServerRuntimeDecodedMutationClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
-  sourceOwnership: SourceOwnershipPolicy,
   line: string,
 ) {
   const exit = yield* handleTcpPublishCommandLine(
@@ -253,7 +250,6 @@ const executeLine = Effect.fn("ViewServerRuntime.tcpPublish.socket.executeLine")
     config,
     client,
     options,
-    sourceOwnership,
     line,
   ).pipe(Effect.exit);
   if (Exit.isSuccess(exit)) {
@@ -272,9 +268,8 @@ const runSocketWorker = Effect.fn("ViewServerRuntime.tcpPublish.socket.worker")(
   state: TcpPublishSocketState,
   serverState: TcpPublishServerState,
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeCoreInternalClient<Topics>,
+  client: ViewServerRuntimeDecodedMutationClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
-  sourceOwnership: SourceOwnershipPolicy,
 ) {
   while (state.closed === false && serverState.closed === false) {
     const queuedLine = yield* Queue.poll(state.queue);
@@ -285,7 +280,7 @@ const runSocketWorker = Effect.fn("ViewServerRuntime.tcpPublish.socket.worker")(
       socket.destroy();
       return;
     }
-    yield* executeLine(socket, state, config, client, options, sourceOwnership, line.value).pipe(
+    yield* executeLine(socket, state, config, client, options, line.value).pipe(
       Effect.ensuring(
         Effect.sync(() => {
           state.queuedCommands -= 1;
@@ -345,13 +340,12 @@ export const makeTcpPublishSocketServer = Effect.fn(
   "ViewServerRuntime.tcpPublish.socketServer.make",
 )(function* <const Topics extends ViewServerRuntimeTopicDefinitions>(
   config: ViewServerTopicConfig<Topics>,
-  client: ViewServerRuntimeCoreInternalClient<Topics>,
+  client: ViewServerRuntimeDecodedMutationClient<Topics>,
   options: ViewServerTcpPublishIngressOptions,
   createServer: TcpPublishServerFactory,
 ) {
   const serverScope = yield* Scope.make("parallel");
   const runLifecycleFiber = Effect.runForkWith(yield* Effect.context<never>());
-  const sourceOwnership = makeSourceOwnershipPolicy(config);
   const state: TcpPublishServerState = {
     closed: false,
     pendingSockets: new Set(),
@@ -509,9 +503,7 @@ export const makeTcpPublishSocketServer = Effect.fn(
           return yield* closeSocket;
         }
         runSocketFiber(
-          restore(
-            runSocketWorker(socket, socketState, state, config, client, options, sourceOwnership),
-          ),
+          restore(runSocketWorker(socket, socketState, state, config, client, options)),
         );
       }),
     );

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -158,6 +158,33 @@ describe("internal Seam checker", () => {
     ).toStrictEqual([]);
   });
 
+  it("keeps TCP Publish on the neutral decoded-mutation contract", () => {
+    expect(
+      runtimeSourceSeamViolationsForFile({
+        contents:
+          'import type { ViewServerRuntimeCoreInternalClient } from "@effect-view-server/runtime-core/internal";',
+        path: join(process.cwd(), "packages/runtime/src/tcp-publish-command.ts"),
+      }),
+    ).toStrictEqual([
+      "packages/runtime/src/tcp-publish-command.ts imports Runtime Core implementation types through @effect-view-server/runtime-core/internal instead of the neutral decoded-mutation contract.",
+    ]);
+    expect(
+      runtimeSourceSeamViolationsForFile({
+        contents:
+          'import type { ViewServerRuntimeDecodedMutationClient } from "@effect-view-server/config/internal";',
+        path: join(process.cwd(), "packages/runtime/src/tcp-publish-command.ts"),
+      }),
+    ).toStrictEqual([]);
+    expect(
+      runtimeSourceSeamViolationsForFile({
+        contents: 'import type { ViewServerRuntimeTopicDefinitions } from "./runtime-types";',
+        path: join(process.cwd(), "packages/runtime/src/tcp-publish-ingress.ts"),
+      }),
+    ).toStrictEqual([
+      "packages/runtime/src/tcp-publish-ingress.ts imports Runtime Core implementation types through ./runtime-types instead of the neutral decoded-mutation contract.",
+    ]);
+  });
+
   it("rejects private, stale, bare-root, deep, and evasive consumer imports", () => {
     const staleScope = "@view" + "-server";
     expect(

--- a/scripts/check-internal-seams.ts
+++ b/scripts/check-internal-seams.ts
@@ -842,6 +842,8 @@ const runtimeAdapterOptionModule =
 const runtimeAdapterLeafModule =
   /^packages\/runtime\/src\/(?!tcp-publish-)(.+)-(?:ingress|lease-manager)\.ts$/;
 
+const tcpPublishAdapterModule = /^packages\/runtime\/src\/tcp-publish-[^/]+\.ts$/;
+
 const runtimeAdapterImplementationSpecifier = (adapter: string, specifier: string): boolean =>
   specifier === `./${adapter}-ingress` ||
   specifier === `./${adapter}-lease-manager` ||
@@ -895,6 +897,19 @@ export const runtimeSourceSeamViolationsForFile = ({
     violations.push(
       `${relativePath} imports central runtime options instead of its Adapter-owned option module.`,
     );
+  }
+  if (tcpPublishAdapterModule.test(relativePath)) {
+    for (const specifier of moduleSpecifiers) {
+      if (
+        specifier === "@effect-view-server/runtime-core" ||
+        specifier.startsWith("@effect-view-server/runtime-core/") ||
+        specifier === "./runtime-types"
+      ) {
+        violations.push(
+          `${relativePath} imports Runtime Core implementation types through ${specifier} instead of the neutral decoded-mutation contract.`,
+        );
+      }
+    }
   }
   return violations;
 };

--- a/scripts/package-surface-policy.ts
+++ b/scripts/package-surface-policy.ts
@@ -354,6 +354,7 @@ export const packageSurfacePolicy = {
         allowedWorkspaceSpecifiers: [
           "@effect-view-server/client",
           "@effect-view-server/config",
+          "@effect-view-server/config/internal",
           "@effect-view-server/effect-utils",
           "@effect-view-server/column-live-view-engine",
           "@effect-view-server/column-live-view-engine/internal",


### PR DESCRIPTION
Closes #346

## Summary
- add a neutral, topic-correlated decoded mutation Interface under the internal config contract
- drive TCP publish, patch, and delete through the neutral client while keeping Source Ownership Policy in Runtime Core
- enforce the TCP-to-Runtime-Core package seam and preserve scoped listener, connection, command, deadline, and shutdown ownership
- add exactness type regressions for extra fields, optional fields, element unions, and row-container unions

## Validation
- vp run -w ready
- vp run -w bench:baseline:smoke
- config package: 25 files, 79 tests, no type errors, 100% coverage
- runtime-core package: 8 files, 73 tests, 100% coverage
- runtime package: 50 files, 459 tests, no type errors, 100% coverage
- strict Effect diagnostics: config, runtime-core, and runtime all clean
- independent Effect, Vitest/type, and architecture reviews all clean

No changeset: this is an internal architecture refactor and preserves the public runtime API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schema-exact, type-safe decoded mutation workflow (check, publish, patch, delete) with an optional trusted execution mode.
  * Exposed `decodedMutationClient` on the runtime core and routed TCP publish operations through it with topic-aware validation.
  * Re-exported decoded-mutation topic/type definitions and the trusted capability symbol.
* **Bug Fixes**
  * Updated TCP publish command handling to perform an explicit permission check and improved decoded-mutation error mapping/normalization.
* **Tests**
  * Expanded runtime, TCP publish lifecycle, type-contract, and internal seam-check coverage; updated package surface policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->