### PR TITLE
Upgrade Effect and define source adapter architecture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".repos/effect"]
 	path = .repos/effect
-	url = https://github.com/Effect-TS/effect-smol.git
+	url = https://github.com/Effect-TS/effect.git

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,20 +19,32 @@ A View Server runtime created inside the current process for tests, demos, Story
 _Avoid_: Mock server, fake client, test hook
 
 **View Server Topic**:
-A configured logical table with one schema, one row key field, and one authoritative store.
+A configured logical table with one Topic Schema, one canonical Topic Row ID, and one authoritative store.
 _Avoid_: Kafka topic, channel, collection
 
+**View Server Config**:
+The one frozen browser-safe declaration created by `defineViewServerConfig(...)` and shared by React, Remote Browser Clients, In-Memory View Server, and the real runtime. It is the sole type authority for View Server Topics, Topic Schemas, queries, Feed Routes, source failures, health, and adapter metrics. Every Topic appears once and owns zero or one canonical Source Definition; there is no mirrored browser contract and server runtime topic tree. It contains browser-safe Source Adapter options, including Mapping functions, generated descriptors, platform-neutral codecs, and diagnostic Schemas that may contribute to the browser bundle, but no concrete transport client, credential, platform Layer, Node dependency, or ManagedRuntime. V1 accepts that bundle tradeoff rather than introducing code generation, a build transform, automatic projection, or duplicate authoring.
+_Avoid_: Separate contract/runtime configs, duplicated topic tree, generated untyped client metadata, server resource in shared config
+
+**View Server Runtime Effect**:
+The scoped server-edge Effect returned by `runViewServerRuntime(viewServer, options)`. Its environment is the exact union inferred from the one View Server Config's Source Adapter runtime services, retry Schedules, and application dependencies. Application code satisfies that union with aggregate adapter/platform Layers through `Effect.provide(...)` before `NodeRuntime.runMain(...)`.
+_Avoid_: Transport-specific runtime option bag, hidden adapter runtime, reusable module calling Effect.run
+
+**Runtime Composition Failure**:
+A fatal typed failure before View Server transport availability caused by invalid or tampered View Server Config, a missing Source Adapter Runtime Service, missing or extra aggregate Layer resource entries, Effect Config failure, or failure acquiring mandatory aggregate Layer infrastructure. It fails the View Server Runtime Effect and no server port is opened. An operational Source Attempt acquisition or execution failure is never a Runtime Composition Failure; Source Supervision isolates it while the runtime and unrelated Topics remain available.
+_Avoid_: Broker outage classified as fatal startup, partially listening invalid runtime, missing Layer converted to source retry
+
 **Topic Row**:
-A schema-decoded object stored in a View Server Topic.
+A Topic-Schema-decoded object stored in a View Server Topic. Every Topic Row contains exactly one required canonical `id: string` field.
 _Avoid_: Record, document, message
 
 **Topic Row Value Semantics**:
 The schema-derived ownership, equivalence, canonical JSON representation, and ordering rules for every configured Topic Row field. The Column Live View Engine compiles these rules once per View Server Topic and reuses them at ingestion, projection, grouping, comparison, Snapshot, and Delta boundaries. Canonical identity normalizes order-insensitive persistent collections while preserving ordinary sequence order. Topic configuration rejects non-injective or unrecognized codec transformations and equality domains without a congruent canonical identity/order witness.
 _Avoid_: Deep clone helper, generic object equality, JSON stringify semantics
 
-**Row Key**:
-The configured string field that uniquely identifies a Topic Row and acts as the final deterministic sort tiebreaker.
-_Avoid_: Primary key when discussing external databases, id unless the configured field is actually named id
+**Topic Row ID**:
+The required `id: Schema.String` field declared by every Topic Schema. Its decoded string uniquely identifies a Topic Row and acts as the final deterministic sort tiebreaker; the field name and Schema are not configurable.
+_Avoid_: Configurable Row Key, primary key when discussing external databases, optional ID, numeric ID
 
 **Timestamp**:
 A Topic Row temporal value represented as a number or bigint. View Server does not model native JavaScript Date values or date-specific query semantics.
@@ -133,7 +145,7 @@ A live event describing inserts, updates, moves, or removals needed to advance a
 _Avoid_: Patch when referring to client-visible result changes
 
 **Status Event**:
-A live event describing readiness, staleness, closure, backpressure, or typed query/runtime failure for a Live Query.
+A transport-agnostic live event describing readiness, staleness, closure, backpressure, or typed query/runtime failure for a Live Query. Source retry and exhaustion affect this status without attaching Source Adapter Metrics or a complete Source Health snapshot to every Snapshot, Delta, or Status Event.
 _Avoid_: Error string, log message
 
 **Subscription**:
@@ -262,8 +274,164 @@ _Avoid_: Guessed field value, implicit string field, server-side key reconstruct
 An external Kafka topic or future server-side source that provides messages to be mapped into a View Server Topic.
 _Avoid_: View Server Topic
 
+**Source Adapter**:
+A build-time integration declared once with `SourceAdapter.make(...)` and implemented with `SourceAdapterServer.make(...)`. Its browser-safe declaration owns Source Adapter Identity, one complete Source Adapter Failure Schema, mandatory schema-backed Source Adapter Metrics, supported Source Lifecycles, and complete browser-safe Source Definition constructors. Its server implementation provides the matching nominal Source Adapter Runtime Service whose lifecycle factories acquire scoped Source Attempts and yield streams of Source Deliveries while preserving typed configuration, Mapping, environment requirements, failures, and metrics.
+_Avoid_: Runtime-discovered plugin, transport built into Runtime Core, imperative Runtime Client integration, untyped callback
+
+**Source Adapter Package Surface**:
+The required package-export boundary for a Source Adapter: `/contract` contains browser-safe Source Definition constructors, Schemas, and optional client service-token factories; `/server` contains the matching Source Adapter Runtime Service implementation and transport-neutral Layers; platform exports such as `/node` contain concrete transport-driver Layers. Every published platform export provides the standard `layer(viewServer, resolvedOptions)` and `layerConfig(viewServer, configWrappedOptions)` pair. Both accept exact adapter-wide resource maps inferred from the View Server Config and return one aggregate scoped Layer providing the adapter runtime service plus all concrete clients and resources. The Config variant accepts exact `Config.Wrap<Options>`, calls `Config.unwrap(...)` once during Layer construction, and retains `Config.ConfigError`; other service requirements remain visible in the Layer environment. Adapter authors consume the SDK only through `effect-view-server/source-adapter`, `effect-view-server/source-adapter/server`, and `effect-view-server/source-adapter/testing`; internal or deep SDK imports are invalid. A published adapter peer-depends on `effect-view-server` plus every Effect ecosystem package used by its public or runtime surfaces, and keeps those packages as development dependencies for its own build and tests. SDK conformance tests prove that `/contract` cannot resolve Node APIs, server implementations, concrete clients, or transport-driver packages.
+_Avoid_: Adapter-specific run function, hidden Runtime, missing layerConfig, bundled Effect runtime, bundled View Server SDK, undeclared Effect platform peer, one adapter root that mixes browser contracts and broker clients, hidden platform dependency, untested conditional export
+
+**Source Adapter Conformance Kit**:
+The mandatory behavioral and package-boundary test suite exported from `effect-view-server/source-adapter/testing`. For every supported Source Lifecycle, a published adapter supplies a controllable test Layer that can acquire a Source Attempt, emit valid deliveries, fail acquisition or execution with its exact adapter failure, complete unexpectedly, expose metrics changes, and observe scoped finalization. Leased adapters additionally expose exact-route acquisition and final-release observation. The shared kit uses `@effect/vitest` scoped Layer suites and TestClock to verify readiness, sequential delivery and settlement, retry and exhaustion, interruption, finalizer completion, metrics validation, bounded-buffer behavior when used, leased sharing and cleanup, and recovery without hidden runtimes. It also verifies package exports, browser safety, peer dependencies, nominal linkage, Schemas, and positive and negative public type inference. First-party and third-party adapters meet the same contract.
+_Avoid_: Shape-only certification, bespoke adapter test semantics, real-time retry sleeps, optional conformance, first-party exception
+
+**Source Adapter Identity**:
+Diagnostic metadata carried by every Source Definition: a required adapter name and optional adapter version. View Server validates this metadata and exposes it in source health, typed errors, spans, and logs; it never uses Source Adapter Identity for registration, dispatch, compatibility, or Source Definition equality. Package-manager peer ranges, public TypeScript API compatibility, nominal SDK brands, and runtime envelope validation enforce adapter compatibility; there is no redundant Source Adapter protocol field.
+_Avoid_: Adapter registry key, runtime plugin lookup, SDK protocol version, compatibility dispatch, source identity
+
+**Source Adapter Runtime Service**:
+The nominal server-only Effect service implemented by `SourceAdapterServer.make(...)` for one exact Source Adapter declaration. `SourceAdapter.make(...)` creates its opaque browser-safe Effect `Context.Service` tag automatically for nominal type and runtime linkage; adapter authors never declare or repeat a tag ID, service interface, failure type, metrics type, or lifecycle list. The contract contains no implementation or Layer. `SourceAdapterServer.make(...)` accepts only the matching Source Adapter handle and implements exactly its declared lifecycles. The resulting service receives the exact frozen adapter-specific Source Definition, Source Target, and Topic-Bound Source Toolkit; supplies the matching lifecycle factory, mandatory local metrics Effect, and default Source Retry Policy; and returns a scoped Source Attempt acquisition Effect. `runViewServerRuntime(...)` requires this service whenever the one View Server Config uses that adapter. View Server resolves the nominal service directly from Effect Context and never dispatches through Source Adapter Identity or a runtime registry.
+_Avoid_: Author-defined duplicate Context tag, repeated tag ID, adapter-name registry, string dispatch, hidden ManagedRuntime, transport branch in Runtime Core
+
+**Source Adapter Metrics**:
+The mandatory adapter-defined, Schema-backed metrics value included in every source health payload and inferred exactly through the one View Server Config into Remote Browser Client and React APIs. Each supported Source Lifecycle declares its own metrics Schema instead of a boolean capability, so a selected materialized or leased Source Definition has one exact metrics type without a lifecycle union or optional fields. Its Source Adapter Runtime Service supplies an infallible Effect that reads only a valid local metrics snapshot, including before the Source Stream becomes ready; the Effect's requirements remain visible. View Server samples that Effect exactly once per second with Effect Clock, freezes and Schema-validates the result, and publishes only the cached snapshot. Metric-only publications occur at most once per cadence; lifecycle transitions and Source Item Rejections publish immediately with the latest cached metrics. V1 exposes no global, adapter, source, or subscriber cadence setting. Source health always contains both mandatory SDK-owned `runtime` metrics and mandatory adapter-owned `adapter` metrics. A Source Adapter without matching lifecycle metrics Schemas and runtime implementation is invalid.
+_Avoid_: Optional details, missing metrics, unknown metrics object, server-only untyped health payload
+
+**Source Rejection Location**:
+The mandatory lifecycle-specific Schema-backed adapter value identifying one rejected source item without exposing its raw payload. Each Source Adapter lifecycle declares its exact location Schema beside its metrics Schema, and its Source Item Rejection constructor accepts only that type. Kafka uses safe region, external topic, partition, offset, and phase fields; gRPC uses safe logical client, method, and stream-item context. The exact value round-trips through Source Diagnostics and structured telemetry.
+_Avoid_: Raw key or value, unknown location object, optional location, message payload in health
+
+**Source Runtime Metrics**:
+The mandatory SDK-owned metrics value paired with Source Adapter Metrics in every source health payload. It contains epoch-nanosecond `bigint` timestamps named with an `AtNanos` suffix, cumulative source-wide `bigint` counters for attempts, retries, deliveries, rejected source items, mutation outcomes, and settlement outcomes, a numeric retained-row count, and a non-empty list of Source Delivery Lane metrics. Every lane has a stable, non-empty, retry-stable unique identifier and an exact unbuffered-or-bounded Source Buffer value; a simple source therefore still reports one lane. Status and failures remain outside metrics. View Server reads time only through `Clock.currentTimeNanos`; contracts and the Wire Protocol carry raw `bigint`, never Date or Temporal objects, so consumers may explicitly construct `Temporal.Instant` without losing precision.
+_Avoid_: Aggregate-only buffer metrics, empty lanes, unstable lane ID, millisecond timestamp, number timestamp, ambiguous time unit, Date, Temporal object on wire, optional buffer metrics
+
+**Source Status**:
+The mandatory Schema-backed tagged union describing exactly one Source lifecycle state: `Starting`, `Ready`, `Degraded`, `WaitingToRetry`, `Reacquiring`, `Exhausted`, or `Stopping`. Each branch contains only its valid fields and nanosecond timestamps. `Degraded` means delivery continues after at least one settled Source Item Rejection and contains the latest exact safe rejection; it remains sticky for that logical source lifetime because skipped input may leave the view incomplete. Waiting and reacquisition retain the exact Source Termination; exhaustion retains Source Retry Exhaustion; stopping names runtime shutdown or final Leased Feed release. React and Remote Browser Client APIs infer the complete union and narrow exhaustively on `_tag` without optional failure or retry fields. Live Query availability maps `Degraded` to ready while Source Diagnostics retains the distinction.
+_Avoid_: Status string plus optional fields, nullable failure bag, ambiguous retry phase, erased termination
+
+**Source Target**:
+The mandatory tagged union identifying the source health subject as either `Materialized` with no route or `Leased` with its exact Feed Route. Route presence is never optional.
+_Avoid_: Optional route, lifecycle string with unrelated route field, inferred target
+
+**Source Diagnostics**:
+The explicit scoped `subscribeSourceHealth(...)` Remote Browser Client operation and `useSourceHealth(...)` React hook for observing cadence-cached Source Health independently of Live Query events. Both are addressed only by exact View Server Topic and, for a leased source, its exact Feed Route; Source Adapter Identity and transport client names are never lookup keys. Their inputs are inferred from the one View Server Config: source-free Topics are invalid, materialized Topics reject `routeBy`, leased Topics require exact `routeBy`, and unknown, missing, or extra Route Fields fail without `as const`. A subscription emits the latest cached value immediately and then emits only subsequent cached health changes. React consumes it through Effect Stream and Atom integration; local consumers share the same keyed subscription, and Scope closes the remote subscription on unmount or client shutdown. There is no separate one-shot source-health operation in v1. Materialized Source Diagnostics always yield the exact active Source Health type. Leased Source Diagnostics instead yield an exact `Inactive` or `Active` tagged union: `Inactive` contains the exact Feed Route and no fake metrics, while `Active` contains the complete exact Source Health. Observing an inactive route never creates or retains its Leased Feed, executes its Request Factory, acquires a Source Attempt, delays final release, or preserves route-owned rows. Ordinary Live Query data APIs remain transport-agnostic and never carry adapter metrics on their Snapshot or Delta hot path.
+_Avoid_: Metrics on every Delta, implicit broker API in useLiveQuery, adapter-ID lookup, transport-client lookup, optional leased route, untyped details bag, live health network request per event
+
+**Source Adapter Failure**:
+An adapter-specific typed failure described by the Source Adapter's required Schema and carried either by a Source Item Rejection diagnostic or the Source Stream's Effect error channel. The Source Adapter wraps foreign library errors into its complete failure union and owns redaction; every field admitted by its failure Schema is safe for consumers. An Adapter Failure is one branch of Source Execution Failure and is never required to repeat SDK-owned failure variants. Whether an exact failure is item-local and settled or attempt-terminal is determined by the Source Lane Event versus Stream error channel, not by erasing its type.
+_Avoid_: Unknown error, opaque transport exception, raw library error, erased Effect error channel
+
+**Source Runtime Failure**:
+A schema-backed SDK-owned failure produced by the common ingestion pipeline, such as Source Buffer overflow, invalid Source Delivery, invalid Topic Row, or leased Route Field mismatch. Every Source Adapter receives this exact shared failure vocabulary automatically rather than copying it into its adapter-specific failure union. An item-local invalid Topic Row or Route Field mismatch may be carried by a settled Source Item Rejection when its ordered source remains usable; a failure value is not automatically terminal merely because it belongs to this vocabulary.
+_Avoid_: Adapter-defined copy of SDK error, string-only runtime failure, untyped ingestion exception
+
+**Source Execution Failure**:
+The exact tagged union of either an Adapter Failure carrying the Source Adapter's inferred failure type or a Source Runtime Failure carrying the SDK-owned failure type. The outer tags prevent collisions between adapter and SDK failure tags and preserve both branches through Source Item Rejection diagnostics, supervision, source health, Live Query status, and the Wire Protocol. A Source Execution Failure carried by a settled rejection is non-terminal; the same vocabulary in the Stream error channel terminates its Source Attempt.
+_Avoid_: Flattened error union, tag collision, erased adapter failure, message-only status
+
+**Source Definition**:
+The topic-owned opaque declaration created once by a Source Adapter's browser-safe materialized or leased constructor inside `defineViewServerConfig(...)`. It carries Source Adapter Identity, Source Lifecycle, Route Fields when leased, exact failure, metrics, and Source Rejection Location Schemas, the nominal Source Adapter Runtime Service requirement, other browser-safe Effect requirements, an exact default-or-override retry selection, and the adapter-owned validated per-source options. It carries no concrete transport client, client service token, credential, platform Layer, Runtime Client, or executable runtime service. Importing and invoking the Source Adapter is build-time declaration; View Server does not resolve adapter names through a registry.
+_Avoid_: Arbitrary source object, second server topic declaration, transport-specific topic property, adapter registry entry, adapter ID lookup, concrete client
+
+**Source Definition Constructor**:
+A browser-safe adapter-owned public function that validates and snapshots adapter-specific options before invoking exactly one SDK Materialized or Leased lifecycle primitive. Its public name is domain-specific rather than globally prescribed: Kafka may expose `source(...)`, a gRPC helper may expose `materialized(...)` and `leased(...)`, and another adapter may use its transport vocabulary. Constructor spelling never creates a lifecycle; the nominal Source Definition records the exact SDK lifecycle, and conformance proves it.
+_Avoid_: Lifecycle inferred from method name, mandatory global constructor spelling, third lifecycle, raw Source Definition object
+
+**Source Adapter Resource Reference**:
+An adapter-owned logical literal string in a browser-safe Source Definition that selects one concrete runtime resource from the adapter's aggregate Layer. Each adapter chooses its own field and collection vocabulary, such as Kafka Region, gRPC client, RabbitMQ connection, or another logical endpoint. The value is never a URL, credential, concrete client, or per-resource Context service tag. The aggregate Layer derives the exact required literal union from all matching Source Definitions, rejects missing and extra resource entries, constructs one O(1) lookup map during Layer acquisition, and uses it for every Source Attempt. An adapter needing no named external resource declares no Resource Reference.
+_Avoid_: Bootstrap address in Source Definition, credential alias resolved globally, duplicated registration tree, Context tag per connection, repeated linear scan
+
+**Source Lifecycle**:
+The explicit runtime-owned lifetime category of a Source Definition: materialized or leased. One materialized source begins Source Attempt acquisition when the View Server Runtime Effect starts and remains active for that runtime Scope independently of Live Queries. A leased source acquires one supervised Source Attempt on demand for each exact Feed Route shared by one or more Subscriptions.
+_Avoid_: Implicit adapter lifecycle, generic source mode, transport-specific lifecycle
+
+**Source Attempt**:
+One View Server-owned child Scope running the scoped Effect returned by a Source Adapter lifecycle factory. The Effect acquires or subscribes to every attempt-specific consumer, subscription, channel, iterator, callback registration, or lease and yields one or more continuous Source Delivery Lanes. The outer aggregate adapter Layer may provide shared transports, pools, factories, credential refreshers, and resource maps, but it never owns a source's attempt-level subscription permanently. Successful Effect acquisition is the exact readiness handshake even when every lane remains idle; failure before all required lanes are acquired never reports ready. Each lane applies and settles deliveries sequentially, while sibling lanes run concurrently without a hidden merge buffer. Failure or unexpected completion of any lane terminates the complete attempt, interrupts its siblings, closes its Scope, and passes Source Termination to Source Supervision. Source Attempt finalizers follow Effect's infallible-finalizer rule: they are idempotent, record external close rejection in mandatory adapter metrics and structured diagnostics, and complete before retry. Retry creates a fresh Scope and reacquires every attempt-level resource and lane without rebuilding the application Layer.
+_Avoid_: Single globally serialized multi-cluster stream, first-delivery readiness, Ready stream event, connection polling, reused failed scope, adapter-owned retry scope
+
+**Source Delivery Lane**:
+One continuous ordered Stream of Source Lane Events inside a Source Attempt. A pull source normally exposes one lane; an adapter that acquires several independent ordered inputs may expose a non-empty collection of lanes. View Server consumes each lane event sequentially and sibling lanes concurrently using structured Effect fibers rather than merging them through a hidden queue. A settled Source Item Rejection does not terminate its lane. One lane's actual Effect failure or successful completion terminates the entire Source Attempt, so Source Supervision retries the attempt as one ownership unit.
+_Avoid_: Global serialization across independent clusters, unowned fork, hidden merge queue, per-lane retry scope
+
+**Source Lane Event**:
+One nominal SDK-created ordered element in a Source Delivery Lane: either a Source Delivery containing non-empty mutations or a Source Item Rejection containing no mutation. View Server applies and settles a delivery or records and settles a rejection before consuming the next event in that lane. Effect Stream failure remains separate and terminates the Source Attempt.
+_Avoid_: Raw union lookalike, empty Source Delivery, rejected item in Stream error channel, unordered side-channel
+
+**Topic-Bound Source Toolkit**:
+The narrow nominal helper passed by View Server to one Source Adapter lifecycle factory. It exposes the exact View Server Topic name plus Topic-bound `upsert`, `delete`, `delivery`, and `reject` constructors that preserve and runtime-validate the configured Topic Row, canonical ID, adapter failure, lifecycle rejection location, Feed Route, and settlement types. It exposes no Runtime Client, publish callback, Subscriber, session, reference count, browser header, internal Topic Store, mutable config, or raw Schema-validation bypass. The adapter's own external codecs perform transport decoding; View Server's constructors own final Topic contract validation.
+_Avoid_: Runtime Client, generic publish function, Topic Store handle, raw Schema decoder, mutable topic object
+
+**Source Delivery**:
+One nominal SDK-created Source Adapter emission containing a `Chunk.NonEmptyChunk` of ordered Source Mutations whose settlement is tied to the outcome of applying those mutations to its Source-Owned Topic. Its constructors are bound to the exact Source Definition and Topic: Upsert accepts only a complete Topic Row and Delete accepts only that Topic's key. An empty source poll emits no Stream element rather than an empty Source Delivery. Delivery settlement is atomic, but Runtime Core state application is not transactional: mutations applied before a later mutation fails remain visible.
+_Avoid_: Empty delivery, raw lookalike object, bare Topic Row, already-acknowledged message, direct Runtime Client command
+
+**Source No-Op Item**:
+An external source item that an adapter intentionally maps to no View Server mutation, such as a heartbeat or adapter-level filter miss. The adapter settles it inside the pull-ordered Source Stream production effect before proceeding; settlement failure becomes an Adapter Failure and enters Source Supervision. A malformed, unparseable, or invalid item is instead a visible Source Item Rejection. The SDK defines no Skip mutation or empty Source Delivery, while a tombstone remains a real keyed Delete even when its Topic Row is already absent.
+_Avoid_: Empty Source Delivery, generic Skip mutation, treating tombstone as no-op, unordered early acknowledgement
+
+**Source Item Rejection**:
+A nominal SDK-created Source Lane Event for one item-local decode, Mapping, canonical-ID, Route Field congruence, or Topic Schema failure that does not make the underlying ordered source unusable. It carries the exact schema-backed safe failure, adapter-owned safe source location, `rejectedAtNanos`, and rejection settlement; it never contains the raw payload automatically. View Server records the rejection, increments `rejectedItemCount`, marks Source Health, the affected Topic health row, and aggregate View Server health `Degraded`, and executes settlement before pulling the next lane event. Successful settlement continues delivery; settlement failure terminates the Source Attempt through ordinary Source Supervision. Kafka settlement commits the rejected offset, while gRPC uses a no-op settlement and continues only when the decoded response stream remains usable. `Degraded` is sticky for the logical source lifetime and Live Query availability remains ready. Liveness and readiness transports remain successful while reporting degraded state rather than removing or restarting the instance.
+_Avoid_: Poison pill retry loop, silent drop, raw payload in health, fake mutation, immediate recovery to Ready, transport failure treated as item rejection
+
+**Source Buffer**:
+A finite SDK-owned bridge used only when an external push or callback producer cannot remain directly pull-driven by its Source Stream. The SDK exposes separate constructors for backpressurable and non-pausable producers so their emission contracts cannot be confused. The backpressurable emitter returns an Effect that suspends at capacity and must be composed by the producer. The non-pausable synchronous emitter returns no ignorable capacity result; on the first full-buffer emission, the SDK increments overflow metrics and fails the Stream exactly once with `SourceBufferOverflow`. Both constructors use an internal bounded Queue, validate a positive finite integer capacity during pure construction, own callback unregistration through Scope, and update depth and high-water mark locally. The Queue and its strategy are never exposed. Sliding, dropping, and unbounded buffering are invalid because losing one Upsert or Delete can corrupt the authoritative materialized view.
+_Avoid_: Public Queue, strategy option, shared callback constructor, ignored offer boolean, unbounded callback queue, silent drop, sliding mutation buffer, hidden View Server prefetch
+
+**Source Mutation**:
+A nominal SDK-created complete-row change inside a Source Delivery: either an Upsert containing one complete Topic Row with its canonical Topic Row ID, or a Delete identifying one Topic Row ID. Source Mutation constructors are bound to the exact Source Definition and Topic so invalid rows, IDs, and structural substitutes fail before reaching View Server. The common SDK exposes no separate storage key and no ID-plus-partial-row Upsert. An Upsert inserts a missing row or completely replaces an existing row; partial patch mutations are not part of the Source Adapter contract.
+_Avoid_: Raw mutation object, partial source patch, merge-upsert, transport-specific event, Runtime Client command
+
+**Kafka Local Row Key**:
+The transport-local string returned by a first-party Kafka Source Definition's `localRowKey` callback before the adapter constructs the canonical Topic Row ID. The Kafka adapter always combines the exact Region and local key as `region:localRowKey`, injects that composite into `id`, and uses the same operation for Upserts and tombstone Deletes. Region identifiers are non-empty and may not contain `:`; local keys may contain `:` because decoding splits only at the first separator. The adapter exposes canonical construction and decoding helpers. This rule applies even to a one-region source, so independent Kafka clusters cannot silently collide in one View Server Topic.
+_Avoid_: User-composed Kafka public key, `rowKey` callback, hidden region namespace, delimiter without validation, region normalization
+
+**Kafka Start Position**:
+The mandatory exact policy on a first-party Kafka Source Definition that selects initial offsets independently in every selected cluster and partition. Its variants are `earliest`, `latest`, `committed`, absolute `timestamp` with epoch-nanosecond `bigint`, and `durationAgo` with Effect `Duration.Input`. `committed`, `timestamp`, and `durationAgo` carry a mandatory `earliest`, `latest`, or `fail` fallback for a partition without a usable offset. Relative time is read through Effect Clock and fixed once per logical source lifetime; the adapter converts nanoseconds to Kafka's millisecond timestamp resolution before using timestamp offset lookup and freezes the resolved initial partition offsets. A Source Attempt retry resumes the active consumer group's latest committed offsets and uses the frozen initial offset only where no commit exists. A complete materialized runtime restart or fresh Leased Feed after final release creates a new logical lifetime and reevaluates `durationAgo`. There is no implicit default.
+_Avoid_: Moving retry window, optional start position, Date, millisecond number without unit, hidden earliest fallback, Effect-internal `_tag` in authored configuration
+
+**Kafka Consumer Group Prefix**:
+The mandatory non-empty logical View Server replica identity supplied once to the aggregate `kafkaNode.layer(...)`. The Kafka Source Adapter Runtime Service deterministically derives each Topic's active Kafka Consumer Group ID from this prefix and the exact View Server Topic name by independently applying canonical UTF-8 percent encoding to both components and joining them with `:`. For example, prefix `my-view-server` and Topic `orders` resolve to `my-view-server:orders`. This prevents two Topics using one replica prefix from accidentally sharing an active group while keeping the usual value readable. Every concurrently running View Server replica that builds a complete local view must use a distinct prefix; the same logical replica may reuse its stable prefix across restarts. The same resolved ID applies in every cluster selected by that Topic and owns the commits used for connection recovery and Source Attempt retry. The prefix is never optional, repeated per Source Definition, stored in an individual Kafka region entry, or supplied by generic runtime options, and the resolved ID is present in exact Kafka adapter health so deployment collisions are diagnosable. A `committed` Kafka Start Position may name a different literal Consumer Group ID whose offsets seed the initial position, but subsequent commits belong to the resolved active group.
+_Avoid_: Shared group across live full-view replicas, misleading final `consumerGroupId` input, optional prefix, raw string concatenation, generic runtime option, per-source repetition, random group, implicit cross-topic sharing
+
+**Kafka Aggregate Node Layer**:
+The scoped Layer returned by either `kafkaNode.layer(viewServer, options)` for resolved options or `kafkaNode.layerConfig(viewServer, config)` for an Effect Config-wrapped option tree. Both infer all required Regions from the View Server Config, reject missing and extra entries, and provide the Kafka Source Adapter Runtime Service backed by scoped clients; the Config-backed form resolves once during Layer construction and preserves typed configuration failure.
+_Avoid_: Empty Region map, missing or extra Region, repeated per-Topic region-to-client map, mixed resolved/Config leaf union, repeated consumer-group prefix, one mandatory Layer per Kafka client, hidden ManagedRuntime
+
+**gRPC Logical Client**:
+A literal name from a gRPC Source helper's generated service-descriptor record. It selects the exact service and server-streaming methods at declaration time and addresses the matching scoped runtime client options in the aggregate gRPC Layer; it is not an endpoint or client instance.
+_Avoid_: Base URL as client name, browser client, untyped string, Context token
+
+**gRPC Request Factory**:
+The synchronous exact function that constructs the selected server-streaming method's generated request-init object once per logical source lifetime. A materialized factory takes no Route; a leased factory receives its exact Feed Route, so a different Feed Route creates a different request while same-route subscribers and retries reuse one snapshotted request.
+_Avoid_: Network call, Promise, Effect, Option, `undefined`, `any`, unknown payload, reusable mutable request object, unchecked object factory
+
+**gRPC Source Invocation**:
+The first-party gRPC adapter-owned execution of a Source Definition's selected client, server-streaming method, and Request Factory inside a scoped Source Attempt. Topic declarations provide no acquisition or release callback; the adapter owns Stream conversion, interruption, and finalization.
+_Avoid_: Per-Topic acquire callback, per-Topic release callback, caller-owned AbortController, imperative Runtime Client bridge
+
+**Source Settlement**:
+The adapter-owned completion action for a Source Delivery, selected from the complete success, typed failure, defect, or cancellation `Exit` of View Server mutation application. It returns an Effect whose typed failure belongs to the adapter's declared failure union and whose requirements remain visible. Following Effect's `acquireUseRelease` semantics, successful settlement preserves the application outcome, while settlement failure becomes the operational Adapter Failure; the original application Exit remains diagnostic context rather than a fabricated compound Wire Protocol error.
+_Avoid_: Acknowledge before publish, swallowed commit failure, View Server transport-specific acknowledgement
+
+**Source Termination**:
+The standard input to a Source Definition's selected supervision Schedule: either one exact Source Execution Failure or an unexpected successful completion of the continuous Source Stream. The infallible Schedule alone decides retry timing and exhaustion; fiber interruption bypasses Source Termination and is never retried.
+_Avoid_: Interruption as failure, adapter retry loop, separate retryable boolean, swallowed successful completion
+
+**Source Retry Policy**:
+The mandatory infallible Effect Schedule selected for every Source Definition and supervised by View Server. Each Source Adapter Runtime Service declares one transport-aware default per supported Source Lifecycle, while every shared source constructor accepts a standard optional override and records an exact `UseAdapterDefault` or `Override` branch rather than `undefined`. View Server supplies no global default. The Schedule input is the exact Source Termination type, its error is `never`, and its environment requirements remain visible in the View Server Runtime Effect. A no-retry lifecycle defaults to `Schedule.recurs(0)`.
+_Avoid_: View Server global retry, hidden adapter loop, retry boolean, undefined policy selection, erased Schedule environment
+
+**Source Retry Exhaustion**:
+The schema-backed `RetryExhausted` status produced when a Source Termination Schedule stops. It retains the last exact Source Termination, including the complete Adapter Failure or Source Runtime Failure when termination was caused by failure, so consumers can diagnose exhaustion without losing its cause.
+_Avoid_: Generic retries-exhausted message, discarded final failure, transport error replacement
+
+**Source Supervision**:
+The View Server-owned execution and health observation of a continuous Source Adapter's mandatory infallible Effect Schedule over Source Termination. The Schedule owns retry timing and exhaustion for typed failures and unexpected successful completion; View Server creates a fresh child Scope and reacquires the Source Attempt, reads Schedule metadata for health, never retries interruption, and exposes exhaustion as terminal source failure. A retrying source makes dependent Live Queries stale, terminal exhaustion makes them error, and recovery makes them ready again without closing their Subscriptions or discarding their last rows.
+_Avoid_: Adapter-owned reconnect loop, transport-blind retry, retrying interruption, unobserved reconnect
+
 **Source-Owned Topic**:
-A View Server Topic whose mutations are owned by a configured source declaration such as `kafkaSource` or `grpcSource`. Direct Runtime Client mutation, TCP publish mutation, and direct reset are rejected for Source-Owned Topics.
+A View Server Topic whose mutations are owned by its configured `source` declaration. Direct Runtime Client mutation, TCP publish mutation, and direct reset are rejected for Source-Owned Topics.
 _Avoid_: Runtime-owned topic, external mutation topic
 
 **Source Ownership Policy**:
@@ -279,7 +447,7 @@ The exact `routeBy` object on a leased-topic Live Query that supplies one value 
 _Avoid_: Route array, multi-feed query, route extracted from where
 
 **Leased Feed**:
-An on-demand source-backed Topic Row partition identified by one Feed Route and retained while one or more Subscriptions lease it. Different Live Queries may share the same Leased Feed while applying independent local filtering.
+An on-demand source-backed Topic Row partition identified by one exact Feed Route and owned by one runtime child Scope. The first subscriber creates the feed; same-route subscribers share its supervised Source Stream and retained rows while applying independent local filtering. Retry and exhaustion retain that feed while subscribers remain. The final subscriber closes its Scope, runs adapter finalizers, deletes its route-owned rows, and removes active health state; a later subscription creates a fresh feed and Schedule state.
 _Avoid_: Public View Server Topic, permanent materialized source, query-specific upstream filter
 
 **Package Surface Policy**:
@@ -301,13 +469,20 @@ A named Kafka/source deployment location configured for ingestion.
 _Avoid_: Location string, environment, cluster unless discussing infrastructure
 
 **Mapping**:
-The typed ingress transformation from decoded source values into a View Server Topic Row. Kafka
-`map` receives the decoded value and key, Region, derived `rowKey`, and metadata, then returns the
-non-key fields; the runtime combines the derived key with those fields and validates the completed
-Topic Row through the containing schema. The Kafka schema is not exposed on `map`'s public typed
-input. gRPC `map` receives the streamed value, the leased route when present, and the containing
-Topic schema, then returns the complete Topic Row for runtime validation.
-_Avoid_: Serializer, mapper when it obscures the target Topic Row contract
+The synchronous typed ingress transformation from decoded source values into a View Server Topic Row. First-party Mapping is a plain hot-path function: it returns its exact row-shaped result immediately and never returns Effect, Promise, Option, `undefined`, or another asynchronous or optional wrapper. Kafka `map` receives the decoded value and key, Region, derived Local Row Key, and metadata, then returns the non-ID fields; the adapter constructs `id` and validates the completed Topic Row through its Topic Schema. The Kafka schema is not exposed on `map`'s public typed input. Each Source Adapter owns its Mapping and ID-producing convenience; the common SDK requires only the resulting complete Topic Row and does not impose Kafka's Local Row Key concept on other transports. A synchronous Mapping throw becomes that adapter's exact schema-backed Mapping Failure inside a Source Item Rejection, so a still-usable source can settle the rejected item and continue. Asynchronous enrichment, service lookup, adapter-specific filtering, and effectful transformation belong upstream or in a custom Source Adapter API.
+_Avoid_: Effectful first-party mapper, Promise mapper, optional mapping result, serializer, mapper when it obscures the target Topic Row contract
+
+**gRPC Mapping**:
+The synchronous typed transformation from one selected server-streaming method response into one complete Topic Row. Materialized Mapping receives only the exact `value`; leased Mapping additionally receives the exact Feed Route, while neither receives the Topic Schema. It follows the first-party Mapping contract and therefore returns the complete Topic Row immediately.
+_Avoid_: Schema callback argument, client, request, session, transport options, asynchronous enrichment
+
+**Upstream Source Authentication**:
+The adapter-runtime-owned credentials and authentication mechanism used to connect to an external source. They are provided through the Source Adapter's aggregate Layer and transport interceptors, may be refreshed inside that scoped runtime service, and are never copied implicitly from a Remote Browser Client or Subscription. View Server authenticates and authorizes each browser query before source acquisition. When caller identity genuinely changes the upstream dataset, that distinction must be represented explicitly in the exact Feed Route and authorized at the View Server boundary so Leased Feed sharing remains deterministic.
+_Avoid_: Forwarded browser headers, subscriber session in Source Definition, first-subscriber credential capture, implicit per-user Leased Feed
+
+**Mapping Failure**:
+The exact schema-backed Source Adapter Failure produced when a first-party Mapping callback throws synchronously. It preserves safe diagnostic context owned by that adapter and becomes a Source Item Rejection when the underlying ordered source can continue. Only inability to settle that rejection or continue the underlying source enters Source Supervision; the raw thrown value is never exposed to consumers.
+_Avoid_: Defect, raw unknown exception, rejected Promise, swallowed row, poison-pill retry loop
 
 **Kafka Delivery Contract**:
 The operational guarantee for Kafka ingestion. During a live process, Kafka messages are decoded and mapped, grouped into short microbatches, published into Runtime Core with `publishMany`, and committed only after the relevant Runtime Core publish succeeds. Success health is recorded after commit. A failed publish leaves the original Kafka messages uncommitted. If a batch contains a bad later message after earlier messages were decoded, the decoded prefix is published and committed before the decode/mapping failure is surfaced. Kafka startup uses an explicit `startFrom` policy: `earliest`, `latest`, or a committed consumer group with fallback; health exposes the normalized consumer group, mode, and fallback mode actually used. Across process restarts, the in-memory Runtime Core has no durable row checkpoint yet, so committed consumer-group resume is not a full rebuild strategy by itself.
@@ -324,7 +499,7 @@ _Avoid_: Browser write, send, emit
 ## Relationships
 
 - A **View Server** owns one or more **View Server Topics**.
-- A **View Server Topic** has exactly one configured **Row Key**.
+- A **View Server Topic** has exactly one canonical **Topic Row ID** declared as `id: Schema.String` in its Topic Schema.
 - A **Topic Row** belongs to exactly one **View Server Topic**.
 - A **Timestamp** is a numeric Topic Row field and uses the same typed comparison semantics as its number or bigint representation.
 - **Topic Row Value Semantics** are derived from that Topic Row's configured schema and are shared by local and Wire Protocol ownership boundaries.
@@ -407,6 +582,18 @@ _Avoid_: Browser write, send, emit
 - A **Live Client** can subscribe to **Live Queries** but cannot publish mutations.
 - A **Runtime Client** can publish mutations but is not exposed to browsers by the Real View Server.
 - A **Remote Browser Client** is a **Live Client** adapter for the **Wire Protocol**.
+- React, the **Remote Browser Client**, In-Memory View Server, and the real runtime consume the same browser-safe **View Server Config**; applications never author a mirrored server topic tree.
+- React hooks derive topic names, selected result rows, valid filter paths and operators, sort fields, group fields, aggregate fields and aliases, Feed Routes, and Source Adapter Failure unions directly from the **View Server Config** without requiring `as const`.
+- `runViewServerRuntime(viewServer, options)` returns a **View Server Runtime Effect** whose requirements preserve the union inferred from every Source Definition's nominal Source Adapter Runtime Service, retry Schedule, and application dependencies.
+- Application code satisfies the **View Server Runtime Effect** with aggregate adapter and platform Layers through `Effect.provide(...)` before `NodeRuntime.runMain(...)`.
+- A Source Adapter never creates a hidden ManagedRuntime or calls `Effect.run*` inside reusable integration code.
+- Pure View Server Config, Source Definition, and aggregate adapter Layer constructors throw named configuration errors immediately for deterministic programmer mistakes and return frozen snapshots rather than Effects or hidden running resources.
+- Environment, file, and secret configuration is decoded through Effect Config or Schema, while Layer construction, resource acquisition, and source execution failures remain in typed Effect error channels.
+- Runtime startup defensively revalidates every common Source Definition envelope before invoking its nominal Source Adapter Runtime Service, even though pure builders already validated it.
+- Every **View Server Topic** appears once in the **View Server Config** and declares zero or one nominal **Source Definition** through the matching adapter's materialized or leased constructor.
+- A materialized Source Definition rejects `routeBy`; a leased Source Definition requires a non-empty unique `routeBy` containing statically named top-level supported scalar fields from its Topic Row Schema, inferred without `as const`.
+- External source names, browser-safe codecs, Mapping functions, Local Row Key functions, Start Position, Schedules, Effects, and other browser-safe Effect requirements may belong to Source Definition options; credentials, concrete client tokens, concrete clients, sockets, transport-driver packages, Node APIs, and platform Layers may not.
+- A **Source Adapter Runtime Service** executes only Source Definitions created by its exact nominal Source Adapter declaration, and View Server rejects structural substitutes.
 - The **Strict JSON Materializer** makes local semantic materialization and NDJSON acceptance agree; explicit schema codecs restore semantic runtime values after the strict JSON boundary.
 - A **Field Filter Codec** protects the **Wire Protocol** from unsafe or incorrectly typed filter values.
 - A **Raw Query Codec** protects Raw Query wire payloads from unknown fields, unsafe filters, and invalid windows.
@@ -422,8 +609,195 @@ _Avoid_: Browser write, send, emit
 - A **Real View Server** and **In-Memory View Server** differ only by transport and ingress **Adapters**, not by query, storage, health, or subscription logic.
 - A **Source Topic** uses one **Kafka Source Codec** for its value and optionally one **Kafka Source Codec** for its key.
 - A **Source Topic** is mapped into a **View Server Topic** through a **Mapping**.
+- A **Source Adapter** is imported and composed at build time; runtime plugin discovery is not part of the current source model.
+- `SourceAdapter.make(...)` declares Source Adapter Identity and the complete Source Adapter Failure Schema exactly once in `/contract`; each supported Source Lifecycle is declared by its mandatory Source Adapter Metrics Schema and mandatory Source Rejection Location Schema rather than a boolean.
+- `SourceAdapter.make(...)` creates the adapter's opaque browser-safe `Context.Service` tag; adapter authors do not manually declare or repeat a runtime service tag or service contract.
+- `SourceAdapterServer.make(...)` accepts that exact nominal adapter handle and can implement only its declared lifecycles, failure, metrics, and runtime service shape.
+- The browser-safe opaque service tag provides linkage only; its implementation, concrete transport, clients, and Layers remain absent from `/contract`.
+- Each Source Adapter lifecycle factory receives exactly the frozen adapter-specific Source Definition, exact Source Target, and Topic-Bound Source Toolkit; a leased target includes the exact Feed Route.
+- The Topic-Bound Source Toolkit exposes exact nominal `upsert`, `delete`, `delivery`, and `reject` constructors plus Topic name, and performs the final runtime validation promised by their public types.
+- Lifecycle factories receive no Runtime Client, publish callback, Subscriber, session, reference count, browser headers, internal Topic Store, mutable config, or raw Topic Schema-validation escape hatch.
+- Materialized and leased Source Lifecycles may declare different Source Adapter Metrics Schemas, and a selected Source Definition carries only its exact lifecycle metrics type without optional fields.
+- Materialized and leased Source Lifecycles each declare one exact Source Rejection Location Schema; Source Item Rejection constructors and Source Diagnostics preserve that exact type without unknown or optional location bags.
+- Every source health payload contains mandatory `{ runtime, adapter }` metrics: SDK-owned runtime metrics and the exact adapter-owned lifecycle metrics.
+- Mandatory **Source Runtime Metrics** contain `startedAtNanos`, `lastAttemptStartedAtNanos`, nullable `lastDeliveryAtNanos`, nullable `lastAppliedMutationAtNanos`, and nullable `lastTerminationAtNanos`, all as epoch-nanosecond `bigint` values from Effect Clock.
+- Source Runtime Metrics use cumulative `bigint` values for current attempt, retry count, received deliveries, `rejectedItemCount`, attempted mutations, applied Upserts, applied Deletes, failed mutations, completed settlements, failed settlements, and Source Buffer overflow count; `lastRejectionAtNanos` is a mandatory nullable epoch-nanosecond timestamp.
+- Source Runtime Metrics use `number` only for actual in-memory sizes and capacities: retained rows, Source Buffer capacity, depth, and high-water mark.
+- Source Runtime Metrics contain a non-empty `lanes` tuple whose entries have stable non-empty unique IDs and exactly one `{ _tag: "Unbuffered" }` or `{ _tag: "Bounded", capacity, depth, highWaterMark, overflowCount }` buffer value; neither a lane nor its buffer is optional.
+- Source Delivery Lane IDs remain stable across retries so cached health and metrics continuity do not depend on array position; the first-party Kafka adapter uses its exact region names.
+- `completedSettlementCount` means the settlement Effect completed and does not infer adapter-specific acknowledge, negative-acknowledge, or commit semantics; those belong in Source Adapter Metrics.
+- Source lifecycle status and exact failures remain outside metrics rather than duplicating state inside Source Runtime Metrics.
+- **Source Status** is an exhaustive Schema tagged union of `Starting`, `Ready`, `Degraded`, `WaitingToRetry`, `Reacquiring`, `Exhausted`, and `Stopping`; no branch uses optional status-dependent fields.
+- `Starting` is initial attempt `1n`; `Ready` begins immediately after successful Source Attempt acquisition; `Degraded` contains the latest exact settled Source Item Rejection and remains sticky for the logical source lifetime; `WaitingToRetry` contains the exact termination, next attempt, and `retryAtNanos`; `Reacquiring` contains the exact previous termination; `Exhausted` contains Source Retry Exhaustion; and `Stopping` identifies runtime shutdown or final Leased Feed release.
+- **Source Target** is exactly `{ _tag: "Materialized" }` or `{ _tag: "Leased", route }`; Feed Route is never optional.
+- Every source health value always contains Source Adapter Identity, Source Target, Source Status, mandatory `{ runtime, adapter }` metrics, and `sampledAtNanos`.
+- Live Queries map `Ready` and `Degraded` to ready availability, `WaitingToRetry` and `Reacquiring` to stale, `Exhausted` to error, and recovery to ready while retaining their existing Subscription and rows; exact degraded state remains visible through Source Diagnostics.
+- A Source Item Rejection makes its exact Source Health, affected Topic health row, and aggregate View Server health summary degraded, while Live Query availability stays ready and later valid source items continue.
+- Liveness and readiness endpoints remain successful for a degraded source and return the degraded state in their payload; they do not evict or restart the View Server automatically.
+- Operators may alert on aggregate degraded status or increasing `rejectedItemCount` without putting health RPCs or refresh work on the source-event hot path.
+- Ordinary Live Query Snapshot, Delta, and Status Event APIs remain transport-agnostic and never carry Source Adapter Metrics or full Source Health payloads on the live-event hot path.
+- Remote Browser Client and React expose Source Diagnostics through an explicit separately subscribed or read API whose inputs and exact result are inferred from the selected Topic Source Definition.
+- `subscribeSourceHealth(...)` and `useSourceHealth(...)` accept only an exact source-owned Topic; source-free Topics are rejected at compile time.
+- A materialized Topic's Source Diagnostics input rejects `routeBy`, while a leased Topic requires its exact Feed Route and rejects unknown, missing, or extra Route Fields without requiring `as const`.
+- Source Diagnostics never use Source Adapter Identity, Kafka Region, gRPC client name, or another transport-specific identifier as the public lookup key.
+- Source Diagnostics read only View Server's cadence-cached Source Health; they never trigger a broker RPC, adapter metrics Effect, or health recomputation per query event.
+- `subscribeSourceHealth(...)` emits the current cached health immediately and subsequent cached changes through one scoped subscription shared by matching local consumers; React unmount and client shutdown release it.
+- Source Diagnostics define no one-shot source-health operation in v1; a non-reactive caller may consume the first element of the scoped subscription explicitly.
+- A Source Diagnostics subscription is an observer and never increments a Leased Feed's Live Query reference count, invokes its Request Factory, acquires its Source Attempt, or delays its final release and route-owned row cleanup.
+- Materialized Source Diagnostics expose their exact active Source Health directly; leased Source Diagnostics expose exactly `Inactive` with Feed Route or `Active` with complete Source Health, with no optional health or fabricated zero metrics.
+- An inactive leased route emits `Inactive` immediately, transitions to `Active` only when a real Live Query owns that Leased Feed, and returns to `Inactive` after the last owning Live Query releases it.
+- Every Source Adapter Runtime Service supplies an infallible Effect for each bound source's exact Source Adapter Metrics value, returns a valid initial local snapshot before readiness, and preserves that Effect's requirements in the View Server Runtime Effect.
+- A Source Adapter Metrics Effect performs no broker RPC, network request, or blocking refresh; an adapter may maintain its local snapshot with Effect Metric, Ref, or an optimized transport ledger.
+- View Server samples Source Adapter Metrics exactly once per second with Effect Clock, freezes and Schema-validates each sample, and publishes only the cached snapshot.
+- Metric-only Source Health changes publish at most once per one-second cadence; lifecycle transitions and Source Item Rejections publish immediately with the latest cached metrics.
+- V1 exposes no global, adapter-specific, source-specific, or subscriber-specific health cadence setting.
+- Delivery processing may update cheap local metrics state but never invokes health refresh, metrics Schema encoding, or Wire Protocol publication.
+- A schema-invalid Source Adapter Metrics sample becomes an `InvalidSourceMetrics` Source Runtime Failure and terminates the current source attempt through ordinary Source Supervision.
+- `SourceAdapterServer.make(...)` imports that exact declaration in `/server` and must implement every declared Source Lifecycle with no undeclared lifecycle factory.
+- Source Adapter lifecycle factory inputs, outputs, failure type, and Effect requirements remain inferred from the declaration and implementation without repeated identity strings, Schemas, or linking casts.
+- A **Source Adapter** provides runtime Schemas for its failure union and every value crossing health or Wire Protocol boundaries, but its complete browser-safe Source Definition options do not require one encompassing Schema or JSON representation.
+- Every source health payload contains exact Source Adapter Metrics validated by the declared metrics Schema; Remote Browser Client and React types infer that value without casts or `as const`.
+- Serializable adapter option subtrees may use Effect Schema or Effect Config, while executable codecs, Mapping, Row Key functions, Schedules, Effects, and service references use exact TypeScript contracts plus adapter-owned construction validation.
+- The Source Adapter SDK validates and snapshots its common Source Definition envelope, and adapter-specific option validation completes before the Source Adapter Runtime Service starts it.
+- Every **Source Adapter Package Surface** exposes a browser-safe `/contract`, a server-only `/server`, and optional platform-specific Layer exports such as `/node`.
+- View Server exposes the Source Adapter SDK only through `effect-view-server/source-adapter`, `effect-view-server/source-adapter/server`, and `effect-view-server/source-adapter/testing`; package export checks reject deep or internal SDK imports.
+- First-party Kafka and gRPC Source Adapters are ordinary SDK consumers exposed through `effect-view-server/kafka/contract`, `effect-view-server/kafka/server`, `effect-view-server/kafka/node`, `effect-view-server/grpc/contract`, `effect-view-server/grpc/server`, and `effect-view-server/grpc/node`.
+- A published Source Adapter package declares `effect-view-server` and every Effect ecosystem package used by its public or runtime surfaces as peer dependencies and keeps them as development dependencies for its own build and tests; it never bundles private runtime copies of those packages.
+- While Effect remains beta or View Server remains pre-1.0, a published Source Adapter declares exact peer versions for View Server and every Effect ecosystem package it uses. After both are stable, an adapter may widen a peer range only across versions its conformance matrix executes successfully.
+- Source Adapter SDK conformance tests reject a `/contract` export that resolves Node APIs, Source Adapter Runtime Service implementations, concrete clients, platform Layers, or transport-driver packages.
+- Conformance builds a real browser fixture for every Source Adapter contract and enforces a documented bundle-size budget so browser-safe Mapping functions, descriptors, codecs, and Schemas cannot accidentally pull large server dependency graphs.
+- V1 deliberately accepts browser bundle contribution from runtime contract values in the one authored View Server Config and introduces no mirrored browser config, code generation, custom build transform, automatic projection, or second Topic tree.
+- Every published platform adapter export provides both `layer(viewServer, resolvedOptions)` and `layerConfig(viewServer, configWrappedOptions)`; a custom startup function or hidden Runtime is non-conformant.
+- `layerConfig(...)` accepts exact Effect `Config.Wrap<Options>`, resolves it once with `Config.unwrap(...)` during Layer construction, and preserves `Config.ConfigError` in the Layer error channel.
+- Both platform constructors infer all and only the adapter resources required by the supplied View Server Config, reject missing and extra entries through public types and runtime validation, and provide one aggregate scoped adapter-plus-clients Layer.
+- Any other Effect service requirements of a platform Layer remain visible in its environment and are composed by the application at the Effect boundary.
+- A published Source Adapter is conformant only when every declared Source Lifecycle runs the shared behavioral conformance kit with an adapter-supplied controllable test Layer; TypeScript shape compatibility alone is insufficient.
+- The conformance Layer must make acquisition, valid delivery, adapter failure, unexpected completion, metrics changes, and scoped finalization observable; a leased lifecycle must additionally make exact-route acquisition and final release observable.
+- The conformance kit uses Effect scoped Layer suites and TestClock to prove readiness, ordering, settlement, retry and exhaustion, interruption, finalization, metrics, bounded buffering when present, recovery, leased sharing and cleanup, and absence of hidden runtimes.
+- Source Adapter conformance includes positive and negative public type tests, exact Schema tests, nominal-linkage rejection, package exports, required peer dependencies, duplicate-bundle rejection, and browser-safety checks.
+- Source Adapter package conformance rejects peer ranges broader than the versions covered by the adapter's conformance matrix.
+- First-party Kafka and gRPC Source Adapters pass the same conformance kit as published third-party adapters without exceptions.
+- Runtime Core and the generic runtime contain no privileged Kafka or gRPC Source Lifecycle path; transport acquisition, decoding, Mapping, settlement, metrics, and external-resource finalization live behind those first-party Source Adapter modules.
+- Generic View Server Runtime options contain no `kafka`, `grpc`, or future transport-specific configuration bags.
+- Invalid or tampered View Server Config, missing adapter service, missing or extra aggregate resource entries, Effect Config failure, and mandatory aggregate Layer acquisition failure are fatal Runtime Composition Failures; View Server opens no server ports.
+- Operational Source Attempt acquisition, transport/framing, Stream, rejection-settlement, or Source Settlement failure enters that source's independent Source Supervision and never terminates the View Server Runtime Effect or unrelated Topics; item-local decode, Mapping, ID, Route Field, and row-validation failures instead become settled Source Item Rejections when the underlying source can continue.
+- A source that fails before first readiness exposes empty retained rows with stale or exhausted error status; a source that previously became ready preserves its last rows through retry and exhaustion.
+- Source-specific external topic or feed names, browser-safe codecs, mappings, Start Position, retry overrides, and consumer behavior belong to the one shared Source Definition constructor; brokers, endpoints, credentials, TLS, connection pools, and concrete transport clients belong to adapter platform Layers.
+- A Source Adapter may define its own logical literal Resource Reference fields in Source Definitions; the SDK does not impose one universal property or collection name.
+- Source Adapter Resource References contain no URLs, credentials, concrete clients, or per-resource Context tags and require no separate registration tree in `defineViewServerConfig(...)`.
+- The aggregate adapter Layer derives the exact required Resource Reference union from the supplied View Server Config, rejects missing and extra runtime entries through types and validation, and builds one O(1) resource lookup map during scoped Layer acquisition.
+- A Source Adapter that needs no named external resource declares no Resource Reference rather than fabricating a singleton name.
+- A **View Server Topic** declares zero or one `source` containing a **Source Definition**; transport-specific source properties are not part of the source model.
+- View Server owns the common **Source Definition** envelope, while its **Source Adapter** owns the type and runtime validation of adapter-specific configuration.
+- A **Source Definition** carries its Source Adapter's nominal Runtime Service requirement and browser-safe options; View Server never resolves adapter IDs through a registry.
+- Every **Source Definition** carries a **Source Adapter Identity** with a required adapter name and optional adapter version.
+- Every **Source Definition** is nominally bound to its exact Source Adapter Runtime Service and containing View Server Topic.
+- **Source Adapter Identity** appears in source health, typed errors, spans, and logs, but is never a registration key, dispatch key, or Source Definition equality key.
+- Source Adapter compatibility is enforced through declared peer dependency ranges, public TypeScript API compatibility, nominal SDK brands, and runtime Source Definition envelope validation rather than a protocol field injected by the same runtime SDK.
+- Every **Source Adapter** supplies a Schema for its complete typed **Source Adapter Failure** union and wraps foreign library errors before they enter either a Source Item Rejection diagnostic or the Source Stream's Effect error channel.
+- The SDK composes each adapter-specific **Source Adapter Failure** with the shared **Source Runtime Failure** vocabulary as one exact tagged **Source Execution Failure**; adapters do not redeclare SDK-owned variants.
+- The Adapter Failure and Source Runtime Failure branches have distinct outer tags, preventing collisions between adapter-defined and SDK-defined failure tags.
+- Source health and dependent Live Query status events expose the exact schema-backed **Source Execution Failure** inferred from the Topic's Source Definition; they do not flatten either branch into a message.
+- A **Source Execution Failure** retains a human-readable message for convenience, while the Source Adapter owns redaction of its branch and treats every field admitted by its failure Schema as consumer-visible.
+- A Source Definition preserves its adapter runtime, client token, Schedule, and application Effect requirements, which application code satisfies with Layers at the application composition edge.
+- Every **Source Definition** explicitly declares exactly one **Source Lifecycle** through a materialized or leased Source Adapter constructor; there is no generic source constructor.
+- A **Source Adapter** may support either **Source Lifecycle** or both and exposes only its supported constructors.
+- Source Adapters may give their public Source Definition Constructors domain-appropriate names; the SDK does not require literal `.materialized(...)` or `.leased(...)` method names.
+- Every public Source Definition Constructor wraps exactly one nominal SDK Materialized or Leased primitive, and the conformance kit proves that lifecycle independently of constructor spelling.
+- A Source Adapter cannot create or emulate a third Source Lifecycle through an adapter-specific constructor.
+- One materialized source begins scoped Source Attempt acquisition with the View Server Runtime Effect, independently of Live Query lifetime.
+- A leased lifecycle factory receives only the exact frozen Feed Route and its typed adapter options; it returns a scoped Source Attempt acquisition Effect and never receives subscriber objects, reference counts, Runtime Clients, or View Server cleanup callbacks.
+- View Server creates one child Scope and supervised Source Stream for the first subscriber to an exact Feed Route, then shares that Leased Feed with every same-route subscriber.
+- A retrying or exhausted Leased Feed retains its rows and remains shared while at least one subscriber exists.
+- The last Leased Feed subscriber closes its child Scope, runs adapter finalizers, deletes only that feed's route-owned rows, and removes its active health state.
+- A subscription arriving after complete Leased Feed release creates a fresh feed with fresh Source Termination Schedule state.
+- A **Source Adapter** lifecycle factory returns a scoped Effect that acquires one **Source Attempt** and yields its non-empty Source Delivery Lanes of nominal Source Lane Events; View Server owns the attempt Scope, lane consumption, interruption, backpressure, Topic Row validation, rejection accounting, and Runtime Core mutation.
+- A Source Attempt contains a non-empty collection of **Source Delivery Lanes**; a simple source has one lane, while a multi-input adapter may preserve independent input ordering with several lanes.
+- View Server applies and settles each Source Delivery or records and settles each Source Item Rejection sequentially within its lane, while running sibling lanes concurrently with structured Effect fibers and no merge queue.
+- A settled Source Item Rejection continues its lane and marks health Degraded; actual Effect failure or unexpected completion of any Source Delivery Lane terminates the complete Source Attempt, interrupts sibling lanes, awaits all attempt finalizers, and makes Source Supervision reacquire every lane together.
+- Successful Source Attempt acquisition marks the source ready immediately, including when its Stream has not emitted a Source Delivery; first-delivery readiness, Ready control events, and polling are invalid.
+- Source Attempt acquisition failure enters Source Supervision without reporting ready; Stream failure or unexpected completion closes the attempt Scope and does the same.
+- Every retry creates a fresh child Scope and reacquires a fresh Source Attempt rather than rerunning work inside a failed Scope.
+- Aggregate platform Layers own only reusable shared infrastructure such as transports, pools, factories, credential refreshers, and O(1) resource maps; Source Attempt Scopes own consumers, subscriptions, channels, iterators, callback registrations, and leases.
+- Source retry reacquires every attempt-level resource without rebuilding the aggregate platform Layer or disturbing unrelated Topics and Feed Routes.
+- Final Leased Feed release closes only that feed's attempt-level resources; shared adapter resources remain available to other active sources until the enclosing View Server Runtime Scope closes.
+- Runtime shutdown interrupts and finalizes all Source Attempts before releasing aggregate adapter Layer resources through ordinary nested Effect Scope ordering.
+- A shared transport outage may terminate several dependent Source Attempts, but each source remains independently supervised by its own Source Retry Policy and health state.
+- An adapter that permanently hides a source-specific subscription or consumer in its aggregate Layer is non-conformant.
+- Source Attempt finalizers are infallible and idempotent, matching Effect `acquireRelease`, Stream `onExit`, and Stream `ensuring`; View Server awaits them before reacquisition.
+- An external close rejection is recorded in mandatory Source Adapter Metrics and a structured log or span containing Source Adapter Identity, Feed Route when leased, and attempt number; it never becomes an untyped defect.
+- Any expected failure that affects delivery correctness must occur during Source Attempt acquisition, Stream execution, or Source Settlement rather than being deferred to Scope cleanup.
+- Only Topic-bound SDK constructors create nominal **Source Mutations** and **Source Deliveries**; View Server rejects raw structurally compatible objects.
+- A Source Upsert constructor accepts only the exact complete Topic Row, while a Source Delete constructor accepts only the exact Topic key.
+- The complete Upsert row contains its canonical Topic Row ID; the common SDK exposes neither a separate storage key nor an ID-plus-partial-row Upsert.
+- A Source Adapter may offer adapter-specific Row Key and Mapping conveniences, but it assembles and Schema-validates the final complete Topic Row before constructing an Upsert.
+- A tombstone or equivalent delete event may derive the Topic Row ID from transport key metadata and construct a Delete without decoding, mapping, or fabricating a row value.
+- The first-party Kafka adapter names its callback `localRowKey`; it never trusts a callback to include Region in the canonical Topic Row ID.
+- The Kafka adapter validates each region as a non-empty string without `:`, constructs every public Kafka-owned row key as `region:localRowKey`, and exposes matching construction and decoding helpers.
+- Kafka region text and local row-key text are preserved exactly without casing, accent, or whitespace transformation; the first `:` is the canonical boundary and a local row key may contain later colons.
+- Kafka applies the composite public row-key rule to every source, including one-region sources, and uses the identical composition path for Upserts and tombstone Deletes.
+- Every first-party Kafka Source Definition declares one mandatory exact **Kafka Start Position**; Kafka aggregate Layer region entries do not select source offsets.
+- A Kafka Source Definition selects clients with the same non-empty literal `regions` tuple that supplies its Mapping and diagnostics region union; it declares no client service token or repeated region-to-client map.
+- One **Kafka Aggregate Node Layer** receives the View Server Config, a non-empty **Kafka Consumer Group Prefix**, and one exact record mapping all and only the required logical regions to concrete platform options.
+- The Kafka Aggregate Node Layer provides the Kafka Source Adapter Runtime Service backed by all configured scoped clients, so ordinary Node applications require one `Effect.provide(KafkaLive)` call regardless of Kafka Topic count.
+- The Kafka adapter canonically derives the active Consumer Group ID from the prefix and exact View Server Topic name, exposes that resolved ID in adapter health, uses it in every cluster selected by that Topic, and owns all commits after the initial Start Position.
+- Concurrent View Server replicas that each build a complete local view use distinct Kafka Consumer Group Prefixes; one logical replica may retain its stable prefix across process restarts.
+- Kafka Start Position is exactly `earliest`, `latest`, `committed`, `timestamp`, or `durationAgo`; the latter three carry a mandatory `earliest`, `latest`, or `fail` missing-offset fallback.
+- `timestamp.atNanos` is a non-negative epoch-nanosecond `bigint`; `durationAgo.duration` is a finite non-negative Effect Duration input resolved with Effect Clock, never Date or `Date.now()`.
+- The Kafka adapter converts the requested nanosecond boundary to Kafka's millisecond timestamp resolution and asks each selected cluster for the earliest partition offset at or after that boundary.
+- `durationAgo` is evaluated once per materialized runtime lifetime or acquired Leased Feed lifetime, and the resulting initial partition offsets are frozen for that lifetime.
+- A Kafka Source Attempt retry or connection recovery uses the active consumer group's latest committed offset per partition; only a partition without a commit reuses its frozen initial position and fallback.
+- A complete runtime restart reevaluates a materialized source's `DurationAgo`; final Leased Feed release discards its frozen positions, so a later fresh subscription reevaluates them as well.
+- For a Leased Feed, View Server alone derives internal partitioned storage identity from the exact Feed Route and Topic Row ID.
+- Every **Source Delivery** contains a `Chunk.NonEmptyChunk` of Source Mutations; one mutation uses `Chunk.of(...)`, several use `Chunk.make(...)`, and an empty source poll emits no Stream element.
+- A **Source No-Op Item** is an intentional heartbeat or filter miss settled by its adapter inside sequential Stream production before that source proceeds; it does not create an empty Source Delivery, Source Item Rejection, or shared Skip mutation.
+- An item-local decode, Mapping, canonical-ID, Route Field, or Topic Schema failure becomes a nominal **Source Item Rejection** instead of a Source No-Op Item or Stream failure when the underlying ordered source remains usable.
+- View Server records a Source Item Rejection, increments `rejectedItemCount`, stores its latest exact safe diagnostic in sticky Degraded health, then runs rejection settlement before consuming the next lane event.
+- Successful rejection settlement continues the lane; rejection settlement failure enters Source Supervision. Kafka commits the rejected offset, while gRPC continues with an infallible no-op settlement only when its decoded response stream remains usable.
+- Source Item Rejection health and logs never expose the raw source payload automatically; adapter-owned safe location metadata identifies the item.
+- Failure while settling a Source No-Op Item is an Adapter Failure and consumes the ordinary Source Termination Schedule.
+- A source tombstone emits a keyed Delete and is not a Source No-Op Item, including when the target Topic Row is already absent.
+- A pull-based Source Stream adds no **Source Buffer**; a push or callback integration uses a finite adapter-configurable Source Buffer and never an unbounded queue.
+- A full **Source Buffer** pauses a backpressurable producer or fails a non-pausable producer with a typed schema-backed overflow failure; silent dropping and sliding are forbidden.
+- The Source Adapter SDK exposes distinct Source Buffer constructors for backpressurable and non-pausable producers rather than a mode flag or raw Queue.
+- A backpressurable Source Buffer emitter returns an Effect that suspends at capacity; its adapter must compose that Effect into the producer's flow-control operation.
+- A non-pausable Source Buffer emitter is synchronous and returns no capacity boolean an adapter could ignore; the first failed bounded offer increments overflow metrics and fails the Stream exactly once with SDK-owned `SourceBufferOverflow`.
+- Source Buffer capacity is a positive finite integer validated during pure construction; callback registration and unregistration are scoped, and the SDK maintains depth and high-water mark through cheap local updates.
+- View Server adds no hidden unbounded source prefetch, and source health exposes Source Buffer depth, capacity, high-water mark, and overflow count.
+- A **Source Adapter** never receives a Runtime Client or imperative publish callback.
+- Every **Source Mutation** is either a complete-row Upsert or a keyed Delete; Source Adapters do not emit partial patches.
+- A Source Upsert inserts a missing Topic Row or completely replaces the existing Topic Row with the same key.
+- View Server processes **Source Deliveries** from one source Stream sequentially and applies the Source Mutations inside each delivery in order.
+- One **Source Delivery** is settlement-atomic but not state-atomic: settlement succeeds only when all its mutations succeed, while mutations applied before a later failure are not rolled back.
+- Independent materialized source Streams and distinct leased-route source Streams may execute concurrently.
+- View Server applies each **Source Delivery** inside an Effect resource bracket and passes the application outcome to **Source Settlement** exactly once.
+- A successful **Source Settlement** occurs only after every mutation in its **Source Delivery** has been applied successfully.
+- Source Settlement returns an Effect whose typed failure is the adapter's declared failure type and whose Effect requirements remain visible in the View Server Runtime Effect.
+- Successful settlement preserves the original mutation-application outcome; failed settlement becomes the operational Adapter Failure consumed by Source Supervision, matching Effect's `acquireUseRelease` semantics.
+- When mutation application and settlement both fail, View Server retains the original application Exit in spans and logs but does not invent a compound consumer-facing failure value.
+- Mutations applied before settlement failure remain visible and are not rolled back; retry safety relies on complete-row Upsert and keyed Delete idempotence.
+- A Source Delivery may omit external settlement semantics, in which case the SDK supplies an infallible no-op settlement.
+- Every Source Definition selects one mandatory infallible Effect Schedule whose input is **Source Termination** and whose environment requirements remain visible in the View Server Runtime Effect.
+- `SourceAdapterServer.make(...)` requires one default **Source Retry Policy** for each implemented Source Lifecycle; materialized and leased defaults may differ.
+- Every shared Source Definition constructor accepts a standard optional Source Retry Policy override and records an exact `UseAdapterDefault` or `Override` selection rather than `undefined`.
+- View Server defines no global or fallback Source Retry Policy.
+- A Source Retry Policy has the exact Source Termination input, an error type of `never`, and preserves its Effect environment; a lifecycle that never retries uses `Schedule.recurs(0)`.
+- The Source Termination Schedule alone decides retry timing and exhaustion; there is no separate retryable predicate, retry boolean, or adapter-owned retry loop.
+- A failed Source Termination contains one exact **Source Execution Failure**; an unexpected successful completion remains its own distinguishable Source Termination branch.
+- When the Schedule stops, **Source Retry Exhaustion** retains its last exact Source Termination rather than replacing it with a generic terminal error.
+- View Server owns **Source Supervision**, fresh scoped Source Attempt acquisition, and retry health derived from Effect Schedule metadata.
+- **Source Supervision** never retries fiber interruption.
+- A retrying source keeps dependent Live Query Subscriptions open, preserves their last rows, and reports them as stale.
+- Exhausted source retries keep dependent Live Query Subscriptions open, preserve their last rows, and report them as error rather than closing them.
+- A recovered source returns dependent Live Queries to ready availability and resumes events through their existing Subscriptions; Source Diagnostics returns to Degraded instead of Ready when that logical source lifetime already settled a rejection.
+- Source failure never becomes SubscriptionClosed and never erases retained Live Query rows.
+- Source Adapter v1 Streams are continuous: successful completion while the source scope remains owned becomes an `UnexpectedCompletion` **Source Termination** and consumes the same adapter-defined Schedule as typed failure.
+- Finite one-shot source completion is not part of the Source Adapter v1 lifecycle model.
 - A leased source declaration defines one ordered set of **Route Fields**, while each leased-topic **Live Query** supplies one exact **Feed Route** through its `routeBy` object.
 - One **Feed Route** identifies exactly one **Leased Feed**; a Live Query never fans out across several Leased Feeds.
+- Remote Browser Client headers, credentials, and session identity are never forwarded automatically to a Source Adapter or upstream source.
+- View Server authenticates and authorizes each Live Query at its own boundary; the Source Adapter's aggregate Layer and transport interceptors own all upstream credentials and refresh behavior.
+- If caller identity changes the upstream dataset, that distinction must be an explicit authorized Route Field so exact Feed Route identity continues to determine Leased Feed sharing.
 - **Feed Route** identity preserves each supplied scalar value exactly and never uses **Text Matching** or query normalization; differently cased or accented strings remain different routes and are passed unchanged to the leased source Adapter.
 - Every Topic Row admitted to a **Leased Feed** has Route Field values congruent with that feed's Feed Route; a mismatched mapped row is invalid rather than rewritten or retained.
 - A leased-topic **Live Query** applies its **Root Conjunction** only after its Feed Route has selected the Leased Feed, so `where` never owns source routing.
@@ -439,6 +813,10 @@ _Avoid_: Browser write, send, emit
 > **Dev:** "Can the browser publish an **Order** row through the **Remote Browser Client**?"
 >
 > **Domain expert:** "No. The browser only uses the **Live Client** side: it starts a **Live Query** and receives a **Snapshot**, **Deltas**, and **Status Events**. Server-side ingestion uses a **Runtime Client** or runtime adapters to **Publish** rows."
+>
+> **Dev:** "Can I put an arbitrary object in a topic's `source` property?"
+>
+> **Domain expert:** "No. `source` contains a **Source Definition** created by a **Source Adapter**. View Server validates its common envelope, and that Source Adapter validates its own configuration."
 >
 > **Dev:** "For tests, should we mock the hook?"
 >

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,6 +2,10 @@
 
 This context defines the language for the View Server project: a type-safe live view system that serves initial snapshots and live deltas from an authoritative in-memory engine to React applications over a real server or an in-memory test runtime.
 
+## Document Status
+
+Runtime code and published package exports are authoritative for currently available behavior. All Source Adapter, Source Definition, Source Adapter Runtime Service, and canonical Topic Row ID material throughout this document describes accepted target architecture whose implementation is pending; none of that material describes a currently available public package export or configuration contract.
+
 ## Language
 
 ### Product Concepts
@@ -19,15 +23,15 @@ A View Server runtime created inside the current process for tests, demos, Story
 _Avoid_: Mock server, fake client, test hook
 
 **View Server Topic**:
-A configured logical table with one Topic Schema, one canonical Topic Row ID, and one authoritative store.
+A configured logical table with one Topic Schema and one authoritative store. In the accepted target architecture, it has one canonical Topic Row ID.
 _Avoid_: Kafka topic, channel, collection
 
 **View Server Config**:
-The one frozen browser-safe declaration created by `defineViewServerConfig(...)` and shared by React, Remote Browser Clients, In-Memory View Server, and the real runtime. It is the sole type authority for View Server Topics, Topic Schemas, queries, Feed Routes, source failures, health, and adapter metrics. Every Topic appears once and owns zero or one canonical Source Definition; there is no mirrored browser contract and server runtime topic tree. It contains browser-safe Source Adapter options, including Mapping functions, generated descriptors, platform-neutral codecs, and diagnostic Schemas that may contribute to the browser bundle, but no concrete transport client, credential, platform Layer, Node dependency, or ManagedRuntime. V1 accepts that bundle tradeoff rather than introducing code generation, a build transform, automatic projection, or duplicate authoring.
+The one frozen browser-safe declaration created by `defineViewServerConfig(...)` and shared by React, Remote Browser Clients, In-Memory View Server, and the real runtime. It is the sole type authority for View Server Topics, Topic Schemas, queries, Feed Routes, and health. In the accepted target architecture, it also owns source failures and adapter metrics; every Topic owns zero or one canonical Source Definition without a mirrored browser contract and server runtime topic tree. That target declaration contains browser-safe Source Adapter options, including Mapping functions, generated descriptors, platform-neutral codecs, and diagnostic Schemas that may contribute to the browser bundle, but no concrete transport client, credential, platform Layer, Node dependency, or ManagedRuntime. V1 accepts that bundle tradeoff rather than introducing code generation, a build transform, automatic projection, or duplicate authoring.
 _Avoid_: Separate contract/runtime configs, duplicated topic tree, generated untyped client metadata, server resource in shared config
 
 **View Server Runtime Effect**:
-The scoped server-edge Effect returned by `runViewServerRuntime(viewServer, options)`. Its environment is the exact union inferred from the one View Server Config's Source Adapter runtime services, retry Schedules, and application dependencies. Application code satisfies that union with aggregate adapter/platform Layers through `Effect.provide(...)` before `NodeRuntime.runMain(...)`.
+The scoped server-edge Effect returned by `runViewServerRuntime(viewServer, options)`. In the accepted target architecture, its environment is the exact union inferred from the one View Server Config's Source Adapter runtime services, retry Schedules, and application dependencies. Application code will satisfy that union with aggregate adapter/platform Layers through `Effect.provide(...)` before `NodeRuntime.runMain(...)`.
 _Avoid_: Transport-specific runtime option bag, hidden adapter runtime, reusable module calling Effect.run
 
 **Runtime Composition Failure**:
@@ -35,7 +39,7 @@ A fatal typed failure before View Server transport availability caused by invali
 _Avoid_: Broker outage classified as fatal startup, partially listening invalid runtime, missing Layer converted to source retry
 
 **Topic Row**:
-A Topic-Schema-decoded object stored in a View Server Topic. Every Topic Row contains exactly one required canonical `id: string` field.
+A Topic-Schema-decoded object stored in a View Server Topic. In the accepted target architecture, every Topic Row contains exactly one required canonical `id: string` field.
 _Avoid_: Record, document, message
 
 **Topic Row Value Semantics**:
@@ -43,7 +47,7 @@ The schema-derived ownership, equivalence, canonical JSON representation, and or
 _Avoid_: Deep clone helper, generic object equality, JSON stringify semantics
 
 **Topic Row ID**:
-The required `id: Schema.String` field declared by every Topic Schema. Its decoded string uniquely identifies a Topic Row and acts as the final deterministic sort tiebreaker; the field name and Schema are not configurable.
+In the accepted target architecture, the required `id: Schema.String` field declared by every Topic Schema. Its decoded string uniquely identifies a Topic Row and acts as the final deterministic sort tiebreaker; the field name and Schema are not configurable.
 _Avoid_: Configurable Row Key, primary key when discussing external databases, optional ID, numeric ID
 
 **Timestamp**:
@@ -269,6 +273,8 @@ A string key emitted by an AG Grid Set Filter that the AG Grid Adapter decodes i
 _Avoid_: Guessed field value, implicit string field, server-side key reconstruction
 
 ### Ingestion Concepts
+
+The Source Adapter concepts in this section describe accepted target architecture whose implementation is pending.
 
 **Source Topic**:
 An external Kafka topic or future server-side source that provides messages to be mapped into a View Server Topic.
@@ -583,17 +589,17 @@ _Avoid_: Browser write, send, emit
 - A **Runtime Client** can publish mutations but is not exposed to browsers by the Real View Server.
 - A **Remote Browser Client** is a **Live Client** adapter for the **Wire Protocol**.
 - React, the **Remote Browser Client**, In-Memory View Server, and the real runtime consume the same browser-safe **View Server Config**; applications never author a mirrored server topic tree.
-- React hooks derive topic names, selected result rows, valid filter paths and operators, sort fields, group fields, aggregate fields and aliases, Feed Routes, and Source Adapter Failure unions directly from the **View Server Config** without requiring `as const`.
-- `runViewServerRuntime(viewServer, options)` returns a **View Server Runtime Effect** whose requirements preserve the union inferred from every Source Definition's nominal Source Adapter Runtime Service, retry Schedule, and application dependencies.
-- Application code satisfies the **View Server Runtime Effect** with aggregate adapter and platform Layers through `Effect.provide(...)` before `NodeRuntime.runMain(...)`.
-- A Source Adapter never creates a hidden ManagedRuntime or calls `Effect.run*` inside reusable integration code.
-- Pure View Server Config, Source Definition, and aggregate adapter Layer constructors throw named configuration errors immediately for deterministic programmer mistakes and return frozen snapshots rather than Effects or hidden running resources.
-- Environment, file, and secret configuration is decoded through Effect Config or Schema, while Layer construction, resource acquisition, and source execution failures remain in typed Effect error channels.
-- Runtime startup defensively revalidates every common Source Definition envelope before invoking its nominal Source Adapter Runtime Service, even though pure builders already validated it.
-- Every **View Server Topic** appears once in the **View Server Config** and declares zero or one nominal **Source Definition** through the matching adapter's materialized or leased constructor.
-- A materialized Source Definition rejects `routeBy`; a leased Source Definition requires a non-empty unique `routeBy` containing statically named top-level supported scalar fields from its Topic Row Schema, inferred without `as const`.
-- External source names, browser-safe codecs, Mapping functions, Local Row Key functions, Start Position, Schedules, Effects, and other browser-safe Effect requirements may belong to Source Definition options; credentials, concrete client tokens, concrete clients, sockets, transport-driver packages, Node APIs, and platform Layers may not.
-- A **Source Adapter Runtime Service** executes only Source Definitions created by its exact nominal Source Adapter declaration, and View Server rejects structural substitutes.
+- React hooks derive topic names, selected result rows, valid filter paths and operators, sort fields, group fields, aggregate fields, and aliases directly from the **View Server Config** without requiring `as const`. In the accepted target architecture, they will also derive Feed Routes and Source Adapter Failure unions from that config.
+- `runViewServerRuntime(viewServer, options)` returns a **View Server Runtime Effect**. In the accepted target architecture, its requirements will preserve the union inferred from every Source Definition's nominal Source Adapter Runtime Service, retry Schedule, and application dependencies.
+- Application code will satisfy the **View Server Runtime Effect** with aggregate adapter and platform Layers through `Effect.provide(...)` before `NodeRuntime.runMain(...)`.
+- A Source Adapter will never create a hidden ManagedRuntime or call `Effect.run*` inside reusable integration code.
+- Pure View Server Config, Source Definition, and aggregate adapter Layer constructors will throw named configuration errors immediately for deterministic programmer mistakes and return frozen snapshots rather than Effects or hidden running resources.
+- Environment, file, and secret configuration will be decoded through Effect Config or Schema, while Layer construction, resource acquisition, and source execution failures will remain in typed Effect error channels.
+- Runtime startup will defensively revalidate every common Source Definition envelope before invoking its nominal Source Adapter Runtime Service, even though pure builders already validated it.
+- Every **View Server Topic** will appear once in the **View Server Config** and declare zero or one nominal **Source Definition** through the matching adapter's materialized or leased constructor.
+- A materialized Source Definition will reject `routeBy`; a leased Source Definition will require a non-empty unique `routeBy` containing statically named top-level supported scalar fields from its Topic Row Schema, inferred without `as const`.
+- External source names, browser-safe codecs, Mapping functions, Local Row Key functions, Start Position, Schedules, Effects, and other browser-safe Effect requirements may belong to Source Definition options; credentials, concrete client tokens, concrete clients, sockets, transport-driver packages, Node APIs, and platform Layers will not.
+- A **Source Adapter Runtime Service** will execute only Source Definitions created by its exact nominal Source Adapter declaration, and View Server will reject structural substitutes.
 - The **Strict JSON Materializer** makes local semantic materialization and NDJSON acceptance agree; explicit schema codecs restore semantic runtime values after the strict JSON boundary.
 - A **Field Filter Codec** protects the **Wire Protocol** from unsafe or incorrectly typed filter values.
 - A **Raw Query Codec** protects Raw Query wire payloads from unknown fields, unsafe filters, and invalid windows.
@@ -659,9 +665,9 @@ _Avoid_: Browser write, send, emit
 - Every source health payload contains exact Source Adapter Metrics validated by the declared metrics Schema; Remote Browser Client and React types infer that value without casts or `as const`.
 - Serializable adapter option subtrees may use Effect Schema or Effect Config, while executable codecs, Mapping, Row Key functions, Schedules, Effects, and service references use exact TypeScript contracts plus adapter-owned construction validation.
 - The Source Adapter SDK validates and snapshots its common Source Definition envelope, and adapter-specific option validation completes before the Source Adapter Runtime Service starts it.
-- Every **Source Adapter Package Surface** exposes a browser-safe `/contract`, a server-only `/server`, and optional platform-specific Layer exports such as `/node`.
-- View Server exposes the Source Adapter SDK only through `effect-view-server/source-adapter`, `effect-view-server/source-adapter/server`, and `effect-view-server/source-adapter/testing`; package export checks reject deep or internal SDK imports.
-- First-party Kafka and gRPC Source Adapters are ordinary SDK consumers exposed through `effect-view-server/kafka/contract`, `effect-view-server/kafka/server`, `effect-view-server/kafka/node`, `effect-view-server/grpc/contract`, `effect-view-server/grpc/server`, and `effect-view-server/grpc/node`.
+- Every planned **Source Adapter Package Surface** will expose a browser-safe `/contract`, a server-only `/server`, and optional platform-specific Layer exports such as `/node`.
+- View Server will expose the planned Source Adapter SDK only through `effect-view-server/source-adapter`, `effect-view-server/source-adapter/server`, and `effect-view-server/source-adapter/testing`; package export checks will reject deep or internal SDK imports when those surfaces are implemented.
+- First-party Kafka and gRPC Source Adapters will become ordinary SDK consumers exposed through the planned `effect-view-server/kafka/contract`, `effect-view-server/kafka/server`, `effect-view-server/kafka/node`, `effect-view-server/grpc/contract`, `effect-view-server/grpc/server`, and `effect-view-server/grpc/node` package surfaces.
 - A published Source Adapter package declares `effect-view-server` and every Effect ecosystem package used by its public or runtime surfaces as peer dependencies and keeps them as development dependencies for its own build and tests; it never bundles private runtime copies of those packages.
 - While Effect remains beta or View Server remains pre-1.0, a published Source Adapter declares exact peer versions for View Server and every Effect ecosystem package it uses. After both are stable, an adapter may widen a peer range only across versions its conformance matrix executes successfully.
 - Source Adapter SDK conformance tests reject a `/contract` export that resolves Node APIs, Source Adapter Runtime Service implementations, concrete clients, platform Layers, or transport-driver packages.

--- a/docs/adr/0001-topic-owned-source-modules.md
+++ b/docs/adr/0001-topic-owned-source-modules.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Accepted. The transport-specific source-property choice is superseded by ADR 0006; topic-owned source declarations remain accepted.
+Accepted ownership decision: production source declarations belong to the Topic they mutate. The canonical `source` property, Source Adapter contracts, and canonical Topic Row ID described by ADRs 0006–0010 are accepted target architecture whose implementation is pending; current transport-specific Topic source properties and configurable Topic keys remain the available public API until that migration is implemented.
 
 ## Context
 
-A View Server Topic is the logical table users query. It owns one Topic Schema with the canonical `id: Schema.String` field and one authoritative store. External Source Topics, gRPC feeds, TCP publish commands, and direct Runtime Client mutations are ways to mutate that View Server Topic.
+A View Server Topic is the logical table users query. It owns one Topic Schema and one authoritative store. In the accepted target architecture, that Topic Schema has the canonical `id: Schema.String` field. External Source Topics, gRPC feeds, TCP publish commands, and direct Runtime Client mutations are ways to mutate that View Server Topic.
 
 The early Kafka runtime shape allowed source declarations to be owned by runtime options. That made source ownership shallow: topic schema lived in the View Server config, while Kafka Source Codec, Region, Mapping, source topic name, and delivery behavior could live elsewhere. The Interface forced callers and maintainers to understand two places before they could answer basic questions:
 
@@ -22,17 +22,17 @@ That split weakens Locality. It also weakens type inference because runtime-owne
 
 Every production source declaration belongs to the View Server Topic it mutates.
 
-As specified by ADR 0006, the accepted source shapes are one canonical `source` property containing a nominal Source Definition created by a Source Adapter, or no `source` for direct Runtime Client or TCP publish ingestion. The Source Adapter constructor on the right-hand side keeps Kafka, gRPC, or another integration explicit without forcing the View Server Topic model to know transport-specific property names.
+As specified by ADR 0006, the target source shapes will be one canonical `source` property containing a nominal Source Definition created by a Source Adapter, or no `source` for direct Runtime Client or TCP publish ingestion. The Source Adapter constructor on the right-hand side will keep Kafka, gRPC, or another integration explicit without forcing the View Server Topic model to know transport-specific property names.
 
-Runtime options must not declare source ownership or contain transport-specific adapter configuration. Per-source ownership and behavior stay in the one Topic-owned Source Definition. Concrete brokers, clients, credentials, endpoints, and platform resources belong to the Source Adapter's aggregate Layer supplied to the View Server Runtime Effect.
+In that target architecture, runtime options will not declare source ownership or contain transport-specific adapter configuration. Per-source ownership and behavior will stay in the one Topic-owned Source Definition. Concrete brokers, clients, credentials, endpoints, and platform resources will belong to the Source Adapter's aggregate Layer supplied to the View Server Runtime Effect.
 
-Runtime-owned transport helpers and transport-specific Topic properties are deleted rather than treated as compatibility paths. The public facade and package subexports keep negative export tests for removed names so they cannot silently return.
+Runtime-owned transport helpers and transport-specific Topic properties will be deleted rather than treated as compatibility paths. The public facade and package subexports will keep negative export tests for removed names so they cannot silently return.
 
 ## Consequences
 
 Source Ownership Policy is the focused Module for ownership decisions: given a View Server config, it can answer which topics are source-owned, which topics allow direct runtime/TCP mutation, and which topics require leased gRPC lifecycle.
 
-Kafka Delivery Contract stays local to Kafka source ingestion. Kafka tombstones can be interpreted using the topic-owned source declaration, decoded key, Region, metadata, canonical Topic Row ID, and target schema.
+Kafka Delivery Contract stays local to Kafka source ingestion. In the target architecture, Kafka tombstones can be interpreted using the topic-owned source declaration, decoded key, Region, metadata, canonical Topic Row ID, and target schema.
 Microbatch publishing groups only contiguous compatible messages. It must not globally regroup interleaved topics or source topics, because that would trade a small publish-count win for weaker Kafka-order semantics.
 
 gRPC Source Lifecycle stays local to gRPC source ingestion. Materialized and leased gRPC feeds can use the same topic-owned policy without a second source registry.

--- a/docs/adr/0001-topic-owned-source-modules.md
+++ b/docs/adr/0001-topic-owned-source-modules.md
@@ -2,17 +2,17 @@
 
 ## Status
 
-Accepted.
+Accepted. The transport-specific source-property choice is superseded by ADR 0006; topic-owned source declarations remain accepted.
 
 ## Context
 
-A View Server Topic is the logical table users query. It owns one schema, one Row Key field, and one authoritative store. External Source Topics, gRPC feeds, TCP publish commands, and direct Runtime Client mutations are ways to mutate that View Server Topic.
+A View Server Topic is the logical table users query. It owns one Topic Schema with the canonical `id: Schema.String` field and one authoritative store. External Source Topics, gRPC feeds, TCP publish commands, and direct Runtime Client mutations are ways to mutate that View Server Topic.
 
 The early Kafka runtime shape allowed source declarations to be owned by runtime options. That made source ownership shallow: topic schema lived in the View Server config, while Kafka Source Codec, Region, Mapping, source topic name, and delivery behavior could live elsewhere. The Interface forced callers and maintainers to understand two places before they could answer basic questions:
 
 - Which Source Topics can mutate this View Server Topic?
 - Which Mapping produces this Topic Row?
-- Which Row Key and target schema validate the mutation?
+- Which Topic Row ID and target schema validate the mutation?
 - Which source owns Kafka tombstone behavior?
 - Which runtime options are operational settings versus source ownership settings?
 
@@ -22,23 +22,17 @@ That split weakens Locality. It also weakens type inference because runtime-owne
 
 Every production source declaration belongs to the View Server Topic it mutates.
 
-Accepted source shapes are:
+As specified by ADR 0006, the accepted source shapes are one canonical `source` property containing a nominal Source Definition created by a Source Adapter, or no `source` for direct Runtime Client or TCP publish ingestion. The Source Adapter constructor on the right-hand side keeps Kafka, gRPC, or another integration explicit without forcing the View Server Topic model to know transport-specific property names.
 
-- `kafkaSource` on a View Server Topic.
-- `grpcSource` on a View Server Topic.
-- No source declaration for direct Runtime Client or TCP publish ingestion.
+Runtime options must not declare source ownership or contain transport-specific adapter configuration. Per-source ownership and behavior stay in the one Topic-owned Source Definition. Concrete brokers, clients, credentials, endpoints, and platform resources belong to the Source Adapter's aggregate Layer supplied to the View Server Runtime Effect.
 
-The generic `source` alias is not accepted. Source ownership must stay explicit in code, docs, and type errors so there is no ambiguity between Kafka-owned topics, gRPC-owned topics, and directly-published topics.
-
-Runtime options may configure operational concerns such as Kafka consumer group, startup mode, Region broker overrides, ports, and lifecycle. Runtime options must not declare source ownership. In particular, `runtime.kafka.topics` is rejected and must not be reintroduced as a compatibility path.
-
-Runtime-owned Kafka helpers are deleted rather than treated as a compatibility path. The public facade and package subexports must keep negative export tests for removed names so they cannot silently return.
+Runtime-owned transport helpers and transport-specific Topic properties are deleted rather than treated as compatibility paths. The public facade and package subexports keep negative export tests for removed names so they cannot silently return.
 
 ## Consequences
 
 Source Ownership Policy is the focused Module for ownership decisions: given a View Server config, it can answer which topics are source-owned, which topics allow direct runtime/TCP mutation, and which topics require leased gRPC lifecycle.
 
-Kafka Delivery Contract stays local to Kafka source ingestion. Kafka tombstones can be interpreted using the topic-owned source declaration, decoded key, Region, metadata, configured Row Key, and target schema.
+Kafka Delivery Contract stays local to Kafka source ingestion. Kafka tombstones can be interpreted using the topic-owned source declaration, decoded key, Region, metadata, canonical Topic Row ID, and target schema.
 Microbatch publishing groups only contiguous compatible messages. It must not globally regroup interleaved topics or source topics, because that would trade a small publish-count win for weaker Kafka-order semantics.
 
 gRPC Source Lifecycle stays local to gRPC source ingestion. Materialized and leased gRPC feeds can use the same topic-owned policy without a second source registry.

--- a/docs/adr/0006-one-canonical-topic-source-property.md
+++ b/docs/adr/0006-one-canonical-topic-source-property.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted design. Implementation is pending, so this ADR does not describe a currently available public configuration contract.
 
 ## Context
 

--- a/docs/adr/0006-one-canonical-topic-source-property.md
+++ b/docs/adr/0006-one-canonical-topic-source-property.md
@@ -1,0 +1,27 @@
+# ADR 0006: One canonical topic source property
+
+## Status
+
+Accepted.
+
+## Context
+
+Transport-specific `kafkaSource` and `grpcSource` properties keep ownership visible, but force configuration, public types, validation, Source Ownership Policy, and runtime composition to know every source kind. That prevents a third-party Source Adapter from joining the same source model without changing View Server itself.
+
+Splitting one application into a browser-safe topic contract and a second server-only topic tree would keep dependencies separate, but would make users describe the same View Server topology twice. That duplication is more error-prone and materially worse than the existing single-config API.
+
+## Decision
+
+A View Server Topic declares zero or one canonical `source` property in the one shared `defineViewServerConfig(...)` call. The value is an SDK-branded Source Definition created by a Source Adapter's browser-safe materialized or leased constructor. Arbitrary structural lookalikes are invalid. `kafkaSource` and `grpcSource` are removed in a hard migration with no aliases or compatibility layer.
+
+The Source Definition is the topic-owned declaration and type authority for that source. It carries Source Adapter Identity, Source Lifecycle, Route Fields when leased, exact failure and metrics Schemas, a nominal reference to the adapter's Effect runtime service, and the adapter-owned browser-safe source options needed by its runtime implementation. The Source Adapter validates and freezes those options during the single View Server Config construction. A Source Definition never contains a Runtime Client, concrete transport client, platform Layer, secret value, or imperative publish callback.
+
+The matching server adapter package provides the nominal runtime service through an Effect Layer. View Server asks that exact service to acquire Source Attempts; it never switches on Kafka, gRPC, adapter names, or runtime string IDs. Importing a Source Adapter constructor and providing its matching Layer is build-time composition rather than runtime discovery. Source Adapter Identity remains diagnostic metadata for health, failures, spans, and logs and is not the service lookup key or a compatibility protocol.
+
+The standard server entrypoint remains one call over the same View Server Config. Its Effect requirements are inferred from every Source Definition's adapter runtime service, Schedule requirements, and other explicit dependencies. A platform aggregate Layer may satisfy all ordinary requirements for one adapter at once. For example, the first-party Kafka Node Layer provides the Kafka runtime service backed by every required region client; `runViewServerRuntime(...)` itself remains transport-agnostic.
+
+Materialized and leased Source Definitions are distinct. A Source Adapter may support either Source Lifecycle or both and exposes only those constructors. Leased construction requires a non-empty set of Route Fields, while materialized construction rejects `routeBy`. View Server validates the shared Source Definition envelope and the adapter runtime service validates its own nominal definition before acquisition.
+
+## Consequences
+
+Applications author every Topic, Topic Schema with canonical `id: Schema.String`, and Source Definition once. React and the server consume the same frozen View Server Config, so no second topic tree can drift. Adapter contract modules and every option accepted by their shared source constructors must remain browser-safe; credentials, sockets, concrete clients, Node libraries, and platform resources move to `/server` or `/node` Layers. Kafka and gRPC become ordinary first-party Source Adapters instead of privileged Runtime Core cases. Topics without `source` retain direct Runtime Client and TCP publish ingestion.

--- a/docs/adr/0007-source-adapters-return-effect-streams.md
+++ b/docs/adr/0007-source-adapters-return-effect-streams.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted design. Implementation is pending, so this ADR does not describe currently available Source Adapter runtime APIs.
 
 ## Context
 

--- a/docs/adr/0007-source-adapters-return-effect-streams.md
+++ b/docs/adr/0007-source-adapters-return-effect-streams.md
@@ -1,0 +1,163 @@
+# ADR 0007: Source Adapter attempts acquire Effect Streams
+
+## Status
+
+Accepted.
+
+## Context
+
+A third-party source integration could receive a Runtime Client, invoke an imperative publish callback, or return a declarative stream. Giving adapters mutation authority would let them bypass Source Ownership Policy, Topic Row validation, leased Route Field congruence, health accounting, and runtime backpressure; callbacks would also make cancellation and resource ownership harder to compose consistently.
+
+## Decision
+
+A Source Adapter lifecycle factory returns a scoped Effect that acquires or subscribes one Source Attempt and yields a non-empty collection of continuous Source Delivery Lanes for a materialized source or acquired Leased Feed. Each lane is an Effect Stream of nominal SDK-created Source Lane Events: either a Source Delivery or Source Item Rejection. A simple pull source yields one lane; a multi-input adapter may yield several lanes so independent external ordering domains do not become globally serialized. Successful Effect acquisition after every required lane resource is acquired is the exact readiness handshake even when all lanes remain idle; acquisition failure rolls back already-acquired resources and never reports ready. View Server owns a fresh child Scope for every attempt. A settled rejection continues its lane, while actual lane Effect failure or unexpected completion terminates the complete attempt, interrupts sibling lanes, and closes that Scope; retry creates a fresh Scope and reacquires every lane. First-delivery readiness, Ready control events, and readiness polling are invalid.
+
+The aggregate platform Layer owns only reusable shared infrastructure such as transports, pools, factories, credential refreshers, and O(1) resource maps. Every source-specific consumer, subscription, channel, iterator, callback registration, or lease is acquired inside the Source Attempt child Scope. Retry therefore reacquires fresh attempt-level resources without rebuilding the application Layer. Final Leased Feed release closes its attempt resources without disturbing shared clients used by other topics/routes, while runtime shutdown closes all child attempts before the aggregate Layer resources. A shared transport outage may terminate several dependent attempts, but each source keeps its own Schedule and health state. Hiding a permanent source subscription inside the aggregate Layer is invalid.
+
+Source Attempt release follows Effect's infallible-finalizer contract. Adapter finalizers are infallible and idempotent, and View Server waits for them before reacquiring. Expected failures that affect delivery correctness occur during attempt acquisition, Stream execution, or Source Settlement rather than being deferred to cleanup. If an external client's close operation rejects, the finalizer records that rejection in mandatory adapter metrics and emits a structured log or span containing Source Adapter Identity, Feed Route when leased, and attempt number, then completes. It does not turn cleanup rejection into an untyped defect. Conformance tests exercise finalization on acquisition or Stream failure, retry, interruption, final Leased Feed release, and runtime shutdown. Fallible Source Settlement remains distinct because acknowledgement failure affects replay correctness.
+
+Each Source Delivery contains an ordered `Chunk.NonEmptyChunk` of normalized Source Mutations plus an adapter-owned settlement finalizer. Topic-bound SDK constructors create both values: Upsert accepts only the exact complete Topic Row including its canonical `id: string`, Delete accepts only the exact Topic Row ID, and raw structurally compatible mutation or delivery objects are rejected. The common SDK exposes neither internal storage keys nor an ID-plus-partial-row Upsert. `Chunk.of(...)` represents one mutation and `Chunk.make(...)` represents one or more. An empty source poll emits no Stream element rather than an empty Source Delivery. An Upsert inserts a missing Topic Row or completely replaces an existing Topic Row; partial patch mutations are not part of the Source Adapter contract. The acquisition Effect and Stream carry typed adapter failures and declare adapter dependencies through their Effect environments. View Server consumes the Stream and owns interruption, finalization, backpressure, Topic Row validation, Route Field congruence, rejection accounting, mutation application, and health accounting.
+
+An external item that intentionally produces no mutation is a Source No-Op Item, not an empty Source Delivery or generic Skip mutation. Examples include heartbeats and adapter-level filter misses. The adapter settles such an item inside its pull-ordered Stream production effect before proceeding. A failure to settle is wrapped in the adapter's declared failure union and enters ordinary Source Supervision. A malformed, unparseable, or otherwise invalid item is not an invisible no-op: it becomes a nominal Source Item Rejection. Tombstones remain real keyed Delete mutations, including idempotent deletion of an already-absent Topic Row.
+
+A Source Item Rejection represents one item-local decode, Mapping, canonical-ID, Route Field congruence, or Topic Schema failure when the underlying ordered source remains usable. It contains the exact schema-backed safe failure, adapter-owned safe source location, `rejectedAtNanos`, and an adapter-owned settlement Effect; the raw payload is never included automatically. View Server records the rejection, increments `rejectedItemCount`, changes active health to sticky `Degraded`, and runs settlement before consuming the next lane event. Successful settlement continues the lane. Settlement failure terminates the attempt. Kafka settlement commits the rejected offset so later partition records remain consumable; gRPC uses an infallible no-op settlement and pulls the next decoded response only when its response stream remains valid. A transport or framing failure that prevents safe continuation remains a Stream failure rather than a rejection.
+
+This follows Effect beta.100's Stream distinction: a `Result.fail` produced by `Stream.filterMapEffect` rejects an element while the Stream continues, whereas failure of the surrounding Effect enters the Stream error channel. Source Lane Events retain that semantic split but make a rejection explicit because View Server must settle it sequentially, expose its exact typed diagnostic, and retain sticky Degraded health rather than silently filtering it away.
+
+Adapter-specific APIs may retain ergonomic Local Row Key and Mapping functions. They must assemble and Schema-validate the final complete Topic Row with its canonical Topic Row ID before constructing an Upsert. Delete events do not need a row value: a Kafka tombstone, for example, decodes the record key, derives the canonical ID through the Kafka adapter's Local Row Key function and Region composition, and constructs a Delete without decoding or mapping its null value. For Leased Feeds, View Server derives any internal partitioned storage identity from Feed Route plus Topic Row ID; that identity never enters the Source Adapter API.
+
+Every Source Adapter supplies a Schema for its complete adapter-specific failure union. The SDK composes that exact type with its schema-backed Source Runtime Failure vocabulary as a tagged Source Execution Failure: one branch carries the adapter failure and one carries a common ingestion failure such as Source Buffer overflow or invalid Source Delivery. Item-local invalid Topic Row and leased Route Field failures may be carried safely by a Source Item Rejection instead of terminating the Stream. Distinct outer tags prevent collisions between adapter-defined and SDK-defined failure tags. Adapters never repeat common SDK failures in their own union. Source health and dependent Live Query status events expose the exact composed failure type inferred from the Topic's Source Definition, together with a convenient human-readable message. Failures are not flattened into strings. Adapters wrap foreign library errors into their declared failure union and own redaction of that branch; every field admitted by the adapter failure Schema is considered safe for consumers. Raw exceptions and opaque unknown errors are not part of the Source Adapter contract.
+
+View Server brackets every Source Delivery with Effect's `acquireUseRelease` semantics and passes the mutation application's complete Effect `Exit` to Source Settlement. Successful application settles only after all mutations in that Source Delivery succeed; typed failure, defect, and cancellation remain distinguishable. Settlement is uninterruptible, executes at most once, returns an Effect whose typed failure belongs to the adapter's declared failure union, and preserves its Effect requirements in the View Server runtime Effect. Matching Effect beta.100's bracket behavior, successful settlement preserves the application outcome, while settlement failure becomes the operational Adapter Failure consumed by Source Supervision. When application and settlement both fail, View Server records the original application Exit in spans and logs but does not invent a compound consumer-facing failure. Already-applied mutations remain visible and are not rolled back. Adapters without external settlement semantics omit settlement and receive the SDK's infallible no-op finalizer.
+
+View Server consumes every Source Lane Event sequentially within its Source Delivery Lane. It applies and settles Source Deliveries in order, or records and settles Source Item Rejections before continuing. Sibling lanes inside the same Source Attempt execute concurrently through structured Effect fibers without first merging through a hidden queue. A settled rejection does not terminate the lane; actual Effect failure or successful completion of any lane terminates the complete attempt, interrupts the remaining lanes, and sends one Source Termination through the attempt's single Source Supervision policy. A Source Delivery is settlement-atomic but not state-atomic: mutations applied before a later mutation fails remain visible and are not rolled back. Complete-row Upserts and Deletes make replay safe after unsuccessful settlement. Independent materialized sources, sibling delivery lanes, and distinct leased-route Source Attempts may execute concurrently.
+
+Every Source Definition contains an exact retry-policy selection: either the matching Source Adapter runtime service's mandatory lifecycle default or an explicit infallible Effect Schedule override supplied to the shared source constructor. `SourceAdapterServer.make(...)` requires one transport-aware default Schedule for each implemented Source Lifecycle, and materialized and leased defaults may differ. The source constructor translates absence of a public override into a concrete internal `UseAdapterDefault` branch rather than storing `undefined`. View Server defines no global retry default. The selected Schedule input is the standard Source Termination union: either an exact Source Execution Failure or UnexpectedCompletion. The Schedule alone owns retry timing, error-sensitive delays, and exhaustion; there is no separate retryable predicate or boolean. Its error type is `never`, its Effect environment remains visible in `runViewServerRuntime(...)`, and a no-retry lifecycle uses `Schedule.recurs(0)`.
+
+View Server owns Source Supervision: it executes the adapter-defined Schedule, creates a fresh child Scope and reacquires the Source Attempt, reads Effect Schedule attempt and elapsed metadata for generic source health, and exposes exhaustion as a schema-backed `RetryExhausted` status containing the last exact Source Termination. Source Adapter v1 Streams are continuous. Successful completion while the source scope remains owned becomes UnexpectedCompletion and consumes the same Schedule while remaining distinguishable from typed failure in health. Fiber interruption is lifecycle cancellation, never becomes Source Termination, and is never retried. Finite one-shot source completion is outside the v1 lifecycle model.
+
+Operational source failures never fail the enclosing View Server Runtime Effect. Source Attempt acquisition, transport/framing, Stream execution, rejection-settlement, and Source Settlement failure affect only that source's supervision and health; unrelated Topics and server transports remain available. Item-local decode, Mapping, ID, Route Field, and Topic Row validation failures instead become settled Source Item Rejections when the underlying source can continue. If a terminating source failure occurs before first readiness, dependent Live Queries retain an empty result and report stale or exhausted error status. If it was previously ready, they retain the last rows. Invalid View Server Config, missing adapter service, exact-resource mismatch, Effect Config failure, and mandatory aggregate Layer acquisition failure remain fatal runtime-composition failures before server ports open and never enter Source Supervision.
+
+Source ingestion availability and Live Query lifetime are independent. While Source Supervision is retrying, View Server keeps dependent Live Query Subscriptions open, preserves their last rows, and reports them as stale. Exhausted retries keep those Subscriptions and rows intact but report an error. If the source recovers, the existing Subscriptions return to ready and resume events. Source failure never becomes SubscriptionClosed and never clears the retained Live Query result.
+
+Source Adapters never receive a Runtime Client, internal mutation client, or imperative publish callback. External connections and protocol decoding remain inside the Source Adapter and use Effect scoped-resource primitives.
+
+A materialized lifecycle factory returns a scoped Effect that begins acquiring one Source Attempt when the View Server runtime Effect starts and remains owned by the runtime Scope independently of Live Queries. A leased lifecycle factory receives the exact frozen Feed Route and returns the scoped acquisition Effect for one Source Attempt on that route. It never receives subscriber objects, reference counts, Runtime Clients, or View Server cleanup callbacks.
+
+View Server owns leased reference counting and Scope lifetime. The first subscriber for an exact Feed Route creates one child Scope and supervised Stream; same-route subscribers share that Leased Feed and its retained rows. Retry and Schedule exhaustion do not release the feed while subscribers remain, and new same-route subscribers join its current ready, stale, or error state. The final subscriber closes the child Scope, runs adapter finalizers, deletes only that feed's route-owned rows, and removes its active health state. A later subscription creates a fresh feed with fresh Schedule state.
+
+Source Adapters never create a ManagedRuntime or call `Effect.run*` inside reusable integration code. Their runtime services retain all Effect requirements in `R`. `runViewServerRuntime(viewServer, options)` exposes the exact union of requirements inferred from the one View Server Config. Application code supplies aggregate adapter and client Layers through Effect's ordinary `Effect.provide(...)` composition before `NodeRuntime.runMain(...)`.
+
+The complete Source Definition options are a browser-safe executable code API, not one serializable boundary value. They may contain Schemas, platform-neutral codecs, Mapping and Local Row Key functions, Schedules, Effects, and other browser-safe Effect requirements. They may not import concrete transports, Node APIs, credentials, sockets, concrete client tokens, or platform Layers. Source Adapters require Schemas for their failure union and any data crossing health or Wire Protocol boundaries, may use Schema or Effect Config for serializable option subtrees, and use exact TypeScript contracts plus adapter-owned construction checks for executable members. The SDK validates and snapshots its common Source Definition envelope, and all adapter-specific construction validation completes before the source runtime service executes it.
+
+Native pull-based Source Streams add no queue. A Source Adapter bridging an external push or callback producer must use one of the SDK's two finite Source Buffer constructors with adapter-configurable capacity. The SDK deliberately separates backpressurable and non-pausable producers rather than exposing a mode flag, raw Queue, or buffering strategy. The backpressurable constructor gives the producer an Effectful emitter that suspends on the internal bounded Queue at capacity and must be composed into the producer's flow-control operation. The non-pausable constructor gives a synchronous emitter with no capacity boolean an adapter could accidentally ignore; when its internal bounded offer first fails because the buffer is full, the SDK increments the overflow count and fails the Stream exactly once with SDK-owned, schema-backed `SourceBufferOverflow`. Later emissions cannot silently revive or corrupt that failed buffer.
+
+Both constructors validate a positive finite integer capacity during pure construction, register and unregister callbacks through the Source Attempt Scope, and update depth and high-water mark through cheap local state. Queue shutdown cancels or completes pending backpressured emission during scoped teardown without turning lifecycle interruption into Source Termination. Sliding, dropping, and unbounded strategies are forbidden because losing one Upsert or Delete can permanently corrupt the materialized view. View Server adds no hidden unbounded prefetch. Source health exposes buffer depth, capacity, high-water mark, and overflow count per Source Delivery Lane rather than collapsing independent pressure into one aggregate buffer.
+
+Each adapter runtime service supplies an infallible Effect that reads the bound source's exact lifecycle-specific Source Adapter Metrics from local state and returns a valid initial snapshot before the Source Stream becomes ready. The Effect performs no broker RPC, network request, or blocking refresh; adapters may implement it with Effect Metric, Ref, or an optimized transport ledger, and its requirements remain visible in the View Server runtime Effect. View Server samples it exactly once per second with Effect Clock, freezes and Schema-validates each result, and exposes only the cached snapshot. Metric-only changes publish at most once per cadence, while lifecycle transitions and Source Item Rejections publish immediately with the latest cached metrics. V1 exposes no global, adapter, source, or subscriber cadence option. Delivery processing may update cheap local counters but never performs health refresh, metrics encoding, or Wire Protocol publication. A schema-invalid snapshot is an `InvalidSourceMetrics` Source Runtime Failure that terminates the current source attempt through ordinary Source Supervision.
+
+Every source health payload pairs those adapter metrics with mandatory SDK-owned Source Runtime Metrics:
+
+```ts
+type SourceBufferMetrics =
+  | { readonly _tag: "Unbuffered" }
+  | {
+      readonly _tag: "Bounded";
+      readonly capacity: number;
+      readonly depth: number;
+      readonly highWaterMark: number;
+      readonly overflowCount: bigint;
+    };
+
+type SourceRuntimeLaneMetrics = {
+  readonly id: string;
+  readonly buffer: SourceBufferMetrics;
+};
+
+type SourceRuntimeMetrics = {
+  readonly startedAtNanos: bigint;
+  readonly lastAttemptStartedAtNanos: bigint;
+  readonly lastDeliveryAtNanos: bigint | null;
+  readonly lastRejectionAtNanos: bigint | null;
+  readonly lastAppliedMutationAtNanos: bigint | null;
+  readonly lastTerminationAtNanos: bigint | null;
+  readonly currentAttempt: bigint;
+  readonly retryCount: bigint;
+  readonly receivedDeliveryCount: bigint;
+  readonly rejectedItemCount: bigint;
+  readonly attemptedMutationCount: bigint;
+  readonly appliedUpsertCount: bigint;
+  readonly appliedDeleteCount: bigint;
+  readonly failedMutationCount: bigint;
+  readonly completedSettlementCount: bigint;
+  readonly failedSettlementCount: bigint;
+  readonly retainedRowCount: number;
+  readonly lanes: readonly [SourceRuntimeLaneMetrics, ...ReadonlyArray<SourceRuntimeLaneMetrics>];
+};
+```
+
+All absolute times are epoch nanoseconds read through `Clock.currentTimeNanos` and named with an `AtNanos` suffix. Contracts and the Wire Protocol carry the raw `bigint`, never Date or Temporal objects; consumers may pass it to `Temporal.Instant.fromEpochNanoseconds`. Cumulative counters use `bigint`, while actual JavaScript collection sizes and capacities use `number`. Delivery, rejection, mutation, and settlement counters remain source-wide aggregates. `lanes` is always non-empty; each entry has a non-empty ID that is unique within the attempt and stable across retries, plus its exact buffer state. A simple source reports one lane, and Kafka uses exact region names as lane IDs. `completedSettlementCount` records completion of the settlement Effect without guessing adapter-specific acknowledgement semantics. Lifecycle status and exact failures remain outside metrics.
+
+Source health uses exhaustive Effect Schema tagged unions rather than status strings plus optional fields:
+
+```ts
+type SourceItemRejectionDiagnostic<E, Location> = {
+  readonly failure: E;
+  readonly location: Location;
+  readonly rejectedAtNanos: bigint;
+};
+
+type SourceStatus<E, Location> =
+  | {
+      readonly _tag: "Starting";
+      readonly attempt: 1n;
+      readonly startedAtNanos: bigint;
+    }
+  | {
+      readonly _tag: "Ready";
+      readonly attempt: bigint;
+      readonly readyAtNanos: bigint;
+    }
+  | {
+      readonly _tag: "Degraded";
+      readonly attempt: bigint;
+      readonly degradedAtNanos: bigint;
+      readonly latestRejection: SourceItemRejectionDiagnostic<E, Location>;
+    }
+  | {
+      readonly _tag: "WaitingToRetry";
+      readonly nextAttempt: bigint;
+      readonly retryAtNanos: bigint;
+      readonly termination: SourceTermination<E>;
+    }
+  | {
+      readonly _tag: "Reacquiring";
+      readonly attempt: bigint;
+      readonly startedAtNanos: bigint;
+      readonly previousTermination: SourceTermination<E>;
+    }
+  | {
+      readonly _tag: "Exhausted";
+      readonly exhaustedAtNanos: bigint;
+      readonly exhaustion: SourceRetryExhaustion<E>;
+    }
+  | {
+      readonly _tag: "Stopping";
+      readonly stoppingAtNanos: bigint;
+      readonly reason: "RuntimeShutdown" | "LeaseReleased";
+    };
+
+type SourceTarget<Route> =
+  | { readonly _tag: "Materialized" }
+  | { readonly _tag: "Leased"; readonly route: Route };
+```
+
+Every source health value always contains Source Adapter Identity, Source Target, Source Status, mandatory `{ runtime, adapter }` metrics, and `sampledAtNanos`. Route, rejection, failure, retry timing, and exhaustion are never optional fields. Live Queries map both `Ready` and `Degraded` to ready availability, `WaitingToRetry` and `Reacquiring` to stale, `Exhausted` to error, and recovery to ready while preserving their Subscription and retained rows. Exact degraded state remains visible through Source Diagnostics. One settled Source Item Rejection also marks the affected Topic health row and aggregate View Server health summary degraded. Liveness and readiness transports continue to respond successfully while returning that degraded state; they do not evict or restart the instance. Operators can alert on degraded status or `rejectedItemCount` without introducing a health refresh on the lane hot path.
+
+Ordinary Live Query Snapshot, Delta, and Status Event APIs stay transport-agnostic and do not carry Source Adapter Metrics or complete Source Health values. Remote Browser Client `subscribeSourceHealth(...)` and React `useSourceHealth(...)` expose exact adapter diagnostics addressed solely by selected View Server Topic and, for leased sources, exact Feed Route. Source-free Topics are rejected; materialized Topics reject `routeBy`; leased Topics require an exact route and reject missing, unknown, or extra Route Fields without `as const`. Source Adapter Identity and transport identifiers never become lookup keys. The scoped client subscription emits the latest cached value immediately and subsequent cached changes, is shared across matching local consumers, and is released through Scope on React unmount or client shutdown. There is no separate one-shot source-health API in v1; callers needing one value explicitly take the first subscription element. These APIs consume only View Server's cadence-cached Source Health; they do not perform a broker RPC, run the adapter metrics Effect, recompute health per Live Query event, or poll from React.
+
+Source Diagnostics are observers rather than Leased Feed owners. A diagnostics subscription never increments the Live Query reference count, invokes the Request Factory, acquires a Source Attempt, delays final release, or preserves route-owned rows. Materialized Source Diagnostics always expose the exact active Source Health type. Leased Source Diagnostics expose an exact tagged union: `Inactive` contains the exact Feed Route and no fabricated metrics; `Active` contains the complete exact Source Health. An inactive route emits `Inactive` immediately, becomes `Active` only while at least one real Live Query owns the Leased Feed, and returns to `Inactive` after final release.
+
+## Consequences
+
+Materialized and leased source execution can share one lifecycle-neutral ingestion and supervision pipeline while differing only in runtime-owned Scope lifetime and Feed Route. A non-empty collection of concurrent ordered Source Delivery Lanes preserves throughput across independent clusters without weakening per-input ordering or adding a hidden merge buffer; structured failure of one lane still makes the Source Attempt one supervision and ownership unit. Child Scopes make Leased Feed acquisition, sharing, interruption, finalization, row cleanup, and later fresh reacquisition follow Effect's structured resource ownership instead of adapter-managed reference counting. Infallible idempotent finalizers match Effect's resource contract, while mandatory metrics and structured diagnostics keep external close rejection visible without introducing defects into Scope cleanup. Mandatory local metrics Effects preserve exact adapter observability without putting remote reads, encoding, or publication on the delivery hot path, while bounded View Server sampling keeps health cost predictable. Kafka commit and queue acknowledgement policies remain adapter-owned while preserving publish-before-settlement ordering. Effect's bracket failure semantics make a failed acknowledgement the operational failure while retaining the application Exit as diagnostic context; complete-row Upsert and keyed Delete idempotence make replay safe without rollback. Topic-bound nominal constructors keep row and key inference exact, prevent structural lookalikes, and make empty deliveries unrepresentable. Settling intentional no-op items within sequential Stream production preserves source ordering without adding transport-specific variants to the universal mutation model. Explicit settled Source Item Rejections prevent one poison item from blocking all later ordered input while sticky Degraded health honestly reports possible incompleteness. Complete-row Upserts keep source replay and restart behavior independent of pre-existing Runtime Core state; adapters consuming partial external events must materialize complete Topic Rows before emitting Source Mutations. One typed Schedule keeps classification, error-sensitive delay, exhaustion, and retry metadata in Effect's policy model without redundant callbacks or hand-written loops. Finite lossless buffering prevents push integrations from hiding memory growth or silently corrupting source state. Composing an adapter-specific Schema with the SDK's shared Source Runtime Failure Schema follows Effect's domain-plus-framework error composition pattern, preserves exact diagnostics end to end, and avoids duplicated common variants or tag collisions. Retaining the last Source Termination in `RetryExhausted` makes terminal status actionable without erasing the adapter failure, runtime failure, or unexpected completion that consumed the retry policy. Executable adapter configuration stays strongly typed without pretending functions and Effects are JSON data. Explicit Layer requirements keep resource ownership composable and make missing adapter services a compile-time error. Treating successful completion as unexpected prevents a Source-Owned Topic from silently becoming stale while health remains ready. Keeping source failures non-terminal for Live Query Subscriptions preserves the last useful result and avoids coupling one supervised ingestion fiber to every consumer lifetime. Adapter tests can provide Layers and consume Streams without starting a complete server, while end-to-end runtime tests still prove mutation convergence and cleanup.

--- a/docs/adr/0008-separate-browser-contract-from-runtime-source-composition.md
+++ b/docs/adr/0008-separate-browser-contract-from-runtime-source-composition.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted design. Implementation is pending, and every package import described as planned below remains unavailable until its package surface is implemented and verified.
 
 ## Context
 

--- a/docs/adr/0008-separate-browser-contract-from-runtime-source-composition.md
+++ b/docs/adr/0008-separate-browser-contract-from-runtime-source-composition.md
@@ -1,0 +1,145 @@
+# ADR 0008: One shared View Server Config with Layer-provided source runtimes
+
+## Status
+
+Accepted.
+
+## Context
+
+The Remote Browser Client needs Topic Row Schemas plus exact source failure and metrics Schemas at runtime to decode the Wire Protocol. Source execution may depend on Kafka, gRPC, message queues, custom streaming transports, credentials, sockets, or platform-specific libraries that must not enter the browser dependency graph.
+
+A separate browser contract and mirrored server runtime configuration would create a hard dependency boundary, but would also force users to describe the same topic topology twice. Referencing contract fragments from a second tree still adds ceremony and creates a drift surface. The existing one-config View Server API is the ergonomic baseline.
+
+Effect v4 distinguishes immutable descriptions from capabilities supplied through Context and Layer. View Server uses that same boundary without duplicating application configuration.
+
+## Decision
+
+Applications author exactly one frozen View Server Config through `defineViewServerConfig(...)`. It owns Topic names, Topic Schemas with canonical `id: Schema.String`, query metadata, and each Topic's zero-or-one canonical Source Definition. React, the Remote Browser Client, In-Memory View Server, and the real runtime all receive that same value. There is no `defineViewServerContract(...)`, `defineViewServerRuntime(...)`, mirrored server topic tree, per-topic implementation list, or generated compatibility alias.
+
+This simplicity has an explicit v1 bundle tradeoff. Runtime values captured by browser-safe Source Definitions—Mapping functions, generated service descriptors, platform-neutral codecs, failure Schemas, rejection-location Schemas, and metrics Schemas—may enter the browser bundle even though React never executes ingestion. TypeScript types cannot replace the runtime Schemas needed to decode exact Source Diagnostics, and ordinary tree shaking cannot reliably remove nested object members. V1 accepts that cost rather than adding mirrored authoring, code generation, a custom build transform, or automatic contract projection. Every adapter's conformance suite builds a real browser fixture and enforces a documented bundle-size budget. Concrete transports, clients, credentials, Node modules, sockets, and platform Layers remain forbidden from the contract graph regardless of tree shaking.
+
+A Source Adapter's shared contract surface creates complete topic-owned Source Definitions. These constructors accept the adapter's strongly typed browser-safe per-source options, including external source names, logical region or endpoint names, Schemas and codecs without platform imports, Mapping and Local Row Key functions, Source Start Position, Route Fields, and an optional explicit Source Retry Policy override. The definition also carries exact failure, lifecycle metrics, and lifecycle rejection-location Schemas plus its nominal Source Adapter identity. It contains no concrete transport client, client service token, credential value, socket, platform API, Node import, Layer, ManagedRuntime, or imperative mutation client.
+
+The server-only `/server` surface implements the adapter's nominal runtime service. Platform surfaces such as `/node` provide concrete client Layers and must expose the standard aggregate `layer(...)` and `layerConfig(...)` pair that derives its exact logical-client map from the View Server Config and provides the adapter runtime service. Runtime resources remain scoped, failures remain typed, and no reusable adapter module calls `Effect.run*`.
+
+The first-party Kafka API illustrates the complete composition. The one shared configuration declares each source once using the same concise region strings as the current Kafka API:
+
+```ts
+import { defineViewServerConfig } from "effect-view-server/config";
+import { kafka } from "effect-view-server/kafka/contract";
+
+export const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      source: kafka.source({
+        topic: "source-orders-v3",
+        regions: ["usa", "london"],
+        value: kafka.protobuf(OrdersValueSchema),
+        key: kafka.protobuf(OrdersKeySchema),
+        localRowKey: ({ key }) => key.orderId,
+        map: ({ key, value, region }) => ({
+          customerId: value.customerId,
+          status: value.status,
+          price: value.price,
+          region,
+          strategyId: key.strategyId,
+          updatedAt: value.updatedAt,
+        }),
+        startFrom: {
+          mode: "durationAgo",
+          duration: "5 minutes",
+          fallback: "earliest",
+        },
+      }),
+    },
+  },
+});
+```
+
+The first-party gRPC contract preserves exact generated request and response inference without exposing transport lifecycle callbacks:
+
+```ts
+const grpcSources = grpc.topicSources({
+  orders: ordersService,
+  strategies: strategiesService,
+});
+
+export const viewServer = defineViewServerConfig({
+  topics: {
+    strategies: {
+      schema: Strategy,
+      source: grpcSources.materialized({
+        client: "strategies",
+        method: "streamStrategies",
+        request: () => ({ universe: "global" }),
+        map: ({ value }) => ({
+          id: `${value.strategyId}:${value.region}`,
+          strategyId: value.strategyId,
+          region: value.region,
+          status: value.status,
+          notional: value.notional,
+          updatedAt: value.updatedAt,
+        }),
+      }),
+    },
+  },
+});
+```
+
+`client` autocompletes only descriptor-record keys, `method` autocompletes only that client's server-streaming methods, `request` is recursively exact against the selected generated request-init type, and Mapping receives the exact generated response message. The gRPC adapter owns method invocation, AsyncIterable-to-Stream conversion, cancellation, and finalization. Its public Source Definition accepts no `acquire` or `release` callback.
+
+The Node entrypoint provides one aggregate Kafka Layer and preserves the current generic runtime options:
+
+```ts
+import { NodeRuntime } from "@effect/platform-node";
+import { Effect } from "effect";
+import { kafkaNode } from "effect-view-server/kafka/node";
+import { runViewServerRuntime } from "effect-view-server/runtime";
+
+const KafkaLive = kafkaNode.layer(viewServer, {
+  consumerGroupPrefix: "orders-view:replica-0",
+  regions: {
+    usa: usaOptions,
+    london: londonOptions,
+  },
+});
+
+NodeRuntime.runMain(
+  runViewServerRuntime(viewServer, {
+    host: "127.0.0.1",
+    websocketPort: 8080,
+    tcpPublishPort: 8081,
+  }).pipe(Effect.provide(KafkaLive)),
+);
+```
+
+When deployment values come from the active Effect Config Provider, the matching Config-backed constructor preserves the same exact inferred region record and resolves it during Layer construction:
+
+```ts
+import { Config } from "effect";
+
+const KafkaLive = kafkaNode.layerConfig(viewServer, {
+  consumerGroupPrefix: Config.string("KAFKA_CONSUMER_GROUP_PREFIX"),
+  regions: {
+    usa: {
+      bootstrapServers: Config.string("KAFKA_USA_BOOTSTRAP"),
+    },
+    london: {
+      bootstrapServers: Config.string("KAFKA_LONDON_BOOTSTRAP"),
+    },
+  },
+});
+```
+
+Kafka region strings are logical identities, not bootstrap addresses or credential values. The same literal names select regions in Topic-owned Source Definitions and key the concrete `regions` map supplied once to `kafkaNode.layer(viewServer, ...)` or the Config-wrapped map supplied to `kafkaNode.layerConfig(viewServer, ...)`. Both constructors derive the exact union of required regions from the View Server Config and reject missing or extra region entries. `layer(...)` snapshots already-resolved options; `layerConfig(...)` recursively resolves its exact option tree once through Effect `Config.unwrap(...)` during Layer construction. Both acquire clients as scoped resources and provide the Kafka Source Adapter runtime service. A custom application may instead compose lower-level `/server` and `/node` Layers explicitly.
+
+`runViewServerRuntime(viewServer, options)` exposes the exact union of still-unsatisfied Source Adapter runtime, retry Schedule, and application service requirements. Effect v4 `Effect.provide(...)` removes the outputs of `KafkaLive` from that requirement union while preserving Layer construction failures. If several Source Adapters are used, the application supplies their aggregate Layers as the non-empty Layer tuple supported directly by `Effect.provide([KafkaLive, OtherLive])`.
+
+View Server runtime options remain generic server concerns such as host, WebSocket port, TCP publish port, admission, authentication, health, and query-engine settings. They contain no hardcoded `kafka`, `grpc`, or future transport-specific bags. Adapter-wide settings belong to the adapter Layer; topic-specific settings belong to the one Source Definition.
+
+Pure View Server Config and Source Definition constructors throw named configuration errors for deterministic declaration mistakes and return frozen snapshots. First-party platform adapters follow Effect's paired `layer(...)` and `layerConfig(...)` convention: the latter accepts an exact `Config.Wrap` option tree and preserves `Config.ConfigError` in its Layer error channel. Source acquisition and execution failures likewise remain typed. The first-party gRPC adapter converts the selected ConnectRPC AsyncIterable through Effect's scoped `Stream.fromAsyncIterable(...)`, whose finalizer invokes the iterator's `return()` when its Scope closes early; the adapter may additionally own an AbortController when required by the concrete transport. Runtime startup defensively revalidates the common Source Definition envelope before invoking the nominal adapter runtime service.
+
+## Consequences
+
+Users retain the current one-config API and pay one explicit aggregate Layer per Source Adapter rather than a second topic tree. They do not repeat client tokens or region-to-client mappings across Topics. React keeps exact topic, query, Feed Route, failure, status, and metrics inference without importing transport implementations. Published adapters must keep their contract entrypoint and accepted Source Definition options browser-safe, while server and platform code remains independently testable and replaceable through Effect Layers. Public type tests prove valid inference and reject missing, extra, mismatched, or structurally forged definitions and aggregate Layer entries without requiring `as const`.

--- a/docs/adr/0008-separate-browser-contract-from-runtime-source-composition.md
+++ b/docs/adr/0008-separate-browser-contract-from-runtime-source-composition.md
@@ -22,11 +22,10 @@ A Source Adapter's shared contract surface creates complete topic-owned Source D
 
 The server-only `/server` surface implements the adapter's nominal runtime service. Platform surfaces such as `/node` provide concrete client Layers and must expose the standard aggregate `layer(...)` and `layerConfig(...)` pair that derives its exact logical-client map from the View Server Config and provides the adapter runtime service. Runtime resources remain scoped, failures remain typed, and no reusable adapter module calls `Effect.run*`.
 
-The first-party Kafka API illustrates the complete composition. The one shared configuration declares each source once using the same concise region strings as the current Kafka API:
+The first-party Kafka API illustrates the complete composition. The one shared configuration declares each source once using the same concise region strings as the current Kafka API. In the pseudocode below, `kafka` comes from the planned `effect-view-server/kafka/contract` export:
 
 ```ts
 import { defineViewServerConfig } from "effect-view-server/config";
-import { kafka } from "effect-view-server/kafka/contract";
 
 export const viewServer = defineViewServerConfig({
   topics: {
@@ -89,12 +88,11 @@ export const viewServer = defineViewServerConfig({
 
 `client` autocompletes only descriptor-record keys, `method` autocompletes only that client's server-streaming methods, `request` is recursively exact against the selected generated request-init type, and Mapping receives the exact generated response message. The gRPC adapter owns method invocation, AsyncIterable-to-Stream conversion, cancellation, and finalization. Its public Source Definition accepts no `acquire` or `release` callback.
 
-The Node entrypoint provides one aggregate Kafka Layer and preserves the current generic runtime options:
+The Node entrypoint provides one aggregate Kafka Layer and preserves the current generic runtime options. In the pseudocode below, `kafkaNode` comes from the planned `effect-view-server/kafka/node` export:
 
 ```ts
 import { NodeRuntime } from "@effect/platform-node";
 import { Effect } from "effect";
-import { kafkaNode } from "effect-view-server/kafka/node";
 import { runViewServerRuntime } from "effect-view-server/runtime";
 
 const KafkaLive = kafkaNode.layer(viewServer, {

--- a/docs/adr/0009-standard-source-adapter-package-exports.md
+++ b/docs/adr/0009-standard-source-adapter-package-exports.md
@@ -1,0 +1,166 @@
+# ADR 0009: Standard Source Adapter package exports
+
+## Status
+
+Accepted.
+
+## Context
+
+Source Adapters can wrap broker clients, sockets, native modules, protobuf or other codecs, and environment-specific resource Layers. The shared View Server Config and React client must still import exact Source Definitions and failure Schemas in a browser. Leaving package boundaries to convention would let one transitive Node dependency break or bloat consumer browser builds.
+
+Effect separates portable contracts and services from concrete platform implementations, including dedicated Node and browser packages. Source Adapter packages need an equally explicit boundary that an SDK test kit can verify.
+
+## Decision
+
+Every Source Adapter package exposes these standard public seams:
+
+- `/contract` contains browser-safe Source Definition constructors, Source Adapter Identity metadata, Source Adapter Failure Schemas, and mandatory Source Adapter Metrics Schemas.
+- `/server` contains the matching Source Adapter runtime service implementation, lifecycle factories, and transport-neutral runtime Layers.
+- Platform exports such as `/node` contain concrete transport-driver Services and Layers. Every published platform export provides paired aggregate `layer(...)` and `layerConfig(...)` constructors that derive the exact required logical-client map from the View Server Config and provide the adapter runtime.
+
+The publishable View Server package exposes the SDK through exactly three matching public modules:
+
+- `effect-view-server/source-adapter` contains the portable declaration and Source Definition API.
+- `effect-view-server/source-adapter/server` contains server-only Source Adapter runtime-service APIs and executable helpers.
+- `effect-view-server/source-adapter/testing` contains the reusable conformance kit.
+
+Adapter packages do not import internal workspace packages, `src` paths, `dist` paths, or unapproved nested SDK modules. View Server package-export checks cover all three approved modules and reject those deep alternatives.
+
+Kafka and gRPC prove the extension seam by becoming ordinary first-party SDK consumers. Because this repository publishes only the `effect-view-server` package, their standard adapter surfaces are publishable package subpaths:
+
+- `effect-view-server/kafka/contract`
+- `effect-view-server/kafka/server`
+- `effect-view-server/kafka/node`
+- `effect-view-server/grpc/contract`
+- `effect-view-server/grpc/server`
+- `effect-view-server/grpc/node`
+
+Runtime Core and the generic View Server Runtime have no private Kafka or gRPC lifecycle hooks. External acquisition, protocol decoding, Mapping, settlement, adapter metrics, and transport finalization move behind the same Source Adapter Interface available to third parties. The `/node` modules provide concrete Node transport Layers; the portable contract and generic server implementation seams do not import those concrete Layers.
+
+The hard migration removes top-level `runtimeOptions.kafka` and `runtimeOptions.grpc` completely, with no aliases. Generic runtime options retain only generic server, query-engine, admission, authentication, health, and subscription concerns. Per-source external topic or feed names, browser-safe codecs, Mapping and Row Key functions, Start Position, and consumer behavior belong to the adapter's shared Source Definition constructor in the one View Server Config. Brokers, endpoints, credentials, TLS, connection pools, and concrete transport clients belong to adapter platform Layers. Application composition supplies aggregate adapter Layers to `runViewServerRuntime(viewServer, options)` through `Effect.provide(...)` at the application edge.
+
+Runtime composition and source availability are separate failure domains. Invalid/tampered View Server Config, a missing adapter service, missing or extra aggregate resources, `Config.unwrap(...)` failure, or failure acquiring mandatory aggregate Layer infrastructure fails the View Server Runtime Effect before transport ports open. Once composition succeeds, operational Source Attempt acquisition or execution failures remain inside that source's typed supervision, retry, and health state; they do not stop server transports or unrelated Topics.
+
+The first-party Kafka contract uses each Source Definition's non-empty `regions` tuple as its logical client selection. Region strings are not bootstrap addresses or credential values. `kafkaNode.layer(viewServer, ...)` derives the exact union of required region names across Kafka-owned Topics and accepts one exact `regions` record mapping those names to concrete resolved platform options. `kafkaNode.layerConfig(viewServer, ...)` accepts the corresponding exact `Config.Wrap` tree. Both reject missing and extra entries; the Config-backed constructor uses Effect `Config.unwrap(...)` once during Layer construction and retains `Config.ConfigError` in its typed error channel. They provide brokers, credentials, TLS, scoped client resources, and the Kafka Source Adapter runtime service in one aggregate Layer.
+
+The first-party gRPC contract creates its source helper from one exact record of browser-safe generated service descriptors. The helper's materialized and leased constructors return only nominal Source Definitions for the canonical Topic `source` property; they never return or own the surrounding Topic definition, Topic Schema, or canonical Topic Row ID contract. A Source Definition's `client` is constrained to the descriptor record's literal keys. After selecting a client, `method` is constrained to the exact server-streaming method names declared by that service; unary and other method shapes are invalid. The materialized `request` factory takes no route argument, while the leased factory receives the exact Route Fields object. Its return is checked recursively against the selected generated method's request-init type: extra top-level or nested fields, incompatible values, and `any` are invalid. Materialized Mapping receives only `{ value }`; leased Mapping receives only `{ value, route }`; `value` is the exact generated response-message type and the Topic Schema is never passed into the callback. Mapping is a synchronous plain-object transformation and cannot return Effect, Promise, Option, `undefined`, or another asynchronous or optional wrapper. It returns the complete Topic Row immediately. A synchronous Mapping throw, invalid mapped row, or Route Field mismatch becomes an exact schema-backed Source Item Rejection with safe gRPC location metadata; the adapter uses an infallible no-op rejection settlement and pulls the next already-decoded response while the upstream stream remains usable. A transport or protobuf framing failure that invalidates the stream remains terminal for the Source Attempt. Public type tests prove all inference and rejection behavior without `as const`.
+
+The logical gRPC client name is not a URL, concrete client, connection, or browser concern. At runtime, the gRPC adapter uses it for O(1) lookup in the exact client options record supplied once to `grpcNode.layer(viewServer, ...)` or `grpcNode.layerConfig(viewServer, ...)`. The latter accepts Config-wrapped endpoints and transport options and preserves typed Config failure during scoped Layer construction.
+
+First-party gRPC Source Definitions expose no user-authored `acquire` or `release` callback. The adapter invokes the selected typed client method with the exact request, converts its AsyncIterable through Effect's scoped `Stream.fromAsyncIterable(...)`, wraps transport failures in its declared exact failure Schema, and owns iterator return, optional AbortController cancellation, and all other finalization in the Source Attempt Scope. Custom acquisition behavior belongs to another Source Adapter implementation or a controllable adapter test Layer, not a callback escape hatch repeated across Topics.
+
+A gRPC Request Factory is synchronous and returns only the selected generated method's exact request-init object; Promise, Effect, Option, `undefined`, `any`, incompatible protobuf messages, and extra nested fields are invalid. It is evaluated once per logical source lifetime and its result is snapshotted before invocation. A materialized source evaluates it when its runtime lifetime starts. A leased source evaluates it when the first subscriber creates one exact Feed Route's Leased Feed. Same-route subscribers share that request and Source Stream, and Source Attempt retries reuse the same request. A different exact Feed Route creates a different Leased Feed and evaluates the factory again; final release followed by later reacquisition does the same. Changing only local query filtering, sorting, grouping, projection, or pagination while retaining the exact Feed Route does not restart the source or reevaluate its request. A synchronous throw becomes the adapter's exact request-construction failure. Dynamic configuration, credentials, refreshed authentication, and headers belong to gRPC Layer transport configuration or interceptors rather than mutable request capture.
+
+Remote Browser Client headers, credentials, and session identity are never forwarded automatically to gRPC or any other upstream Source Adapter. View Server authenticates and authorizes the Live Query at its own boundary. The aggregate adapter Layer and its interceptors own upstream service authentication and refresh. Because one Leased Feed is shared by exact Feed Route, capturing the first subscriber's identity would be nondeterministic and could leak data between subscribers. If caller identity genuinely changes the upstream dataset, it must be represented explicitly in an exact Route Field and authorized by View Server; it is never a hidden request or Mapping input.
+
+First-party Kafka Mapping follows the same synchronous boundary: it returns the exact non-ID row fields immediately and cannot return Effect, Promise, Option, `undefined`, or another asynchronous or optional wrapper. The Kafka adapter constructs the canonical ID and validates the complete Topic Row. An item-local key/value decode, Mapping, canonical-ID, or Topic Schema failure becomes an exact schema-backed Source Item Rejection containing safe region, external topic, partition, offset, phase, and message context but never the raw key or value. View Server records sticky Degraded health and then Kafka commits that rejected offset before pulling the next record. Successful commit continues the lane so one poison record cannot pin a partition; commit failure terminates the Source Attempt and enters retry. Effectful or asynchronous enrichment belongs upstream or in a custom Source Adapter rather than in the first-party per-message hot path.
+
+A Kafka Source Definition accepts a non-empty `regions` tuple. Its literal values become the exact `region` union supplied to codecs, Local Row Key, Mapping, failures, and adapter metrics without `as const`; the aggregate Layer resolves each value through its one exact region record in O(1). One Kafka Source Attempt acquires all selected regions before reporting ready and rolls back earlier acquisitions if a later acquisition fails. Each region supplies an independent Source Delivery Lane: delivery and settlement stay sequential within a region, regions execute concurrently, and termination of one region terminates the complete attempt and reacquires all regions through the one Source Retry Policy. This preserves the current multi-cluster single-topic behavior and concurrency without a transport-specific Runtime Core path.
+
+Kafka does not rely on application code to avoid cross-region Topic Row ID collisions. Its shared source constructor names the callback `localRowKey`, and that callback returns only the transport-local string derived from the decoded Kafka key or metadata. The adapter validates every region identifier as non-empty and free of `:`, then constructs and injects the canonical Topic Row ID as `region:localRowKey`. It preserves both strings exactly without case, accent, or whitespace normalization. A local key may itself contain colons because the first colon is the canonical boundary. Public `kafka.rowId(...)` construction and decoding helpers own this stable representation so consumers do not hand-assemble it.
+
+The composite rule applies even when a Kafka source selects one region. The Mapping omits `id`; the adapter injects the complete composite into that canonical field before Topic Schema validation and Source Upsert construction. A tombstone decodes its transport key, invokes `localRowKey`, composes the same region-qualified Topic Row ID, and emits Delete without decoding or mapping its null value. Conformance tests prove distinct regions cannot collide for identical local keys, colons in local keys roundtrip, invalid region identifiers fail pure construction, and Upsert/Delete use byte-for-byte identical ID composition.
+
+Every Kafka Source Definition also declares a mandatory exact start-position policy; no client Layer or adapter default chooses offsets:
+
+```ts
+type KafkaStartPosition =
+  | "earliest"
+  | "latest"
+  | {
+      readonly mode: "committed";
+      readonly consumerGroupId: string;
+      readonly fallback: "earliest" | "latest" | "fail";
+    }
+  | {
+      readonly mode: "timestamp";
+      readonly atNanos: bigint;
+      readonly fallback: "earliest" | "latest" | "fail";
+    }
+  | {
+      readonly mode: "durationAgo";
+      readonly duration: Duration.Input;
+      readonly fallback: "earliest" | "latest" | "fail";
+    };
+```
+
+`Timestamp.atNanos` is a non-negative epoch-nanosecond `bigint`. `DurationAgo.duration` is a finite non-negative Effect Duration input evaluated through Effect Clock, never Date or `Date.now()`. The adapter converts the requested boundary to Kafka's millisecond timestamp resolution and uses the driver's timestamp offset lookup to select the earliest available record at or after that boundary in every partition. `Committed`, `Timestamp`, and `DurationAgo` require an explicit per-partition missing-offset fallback; invalid, infinite, negative, or incomplete policies fail construction. The active source's derived Consumer Group ID remains separate from the `Committed` branch's literal seed group whose offsets are used as the initial position.
+
+Application code supplies one explicit non-empty `consumerGroupPrefix` to the aggregate `kafkaNode.layer(viewServer, ...)`, rather than supplying a misleading final `consumerGroupId` or repeating the prefix in every Source Definition. The Layer represents one logical Kafka-consuming View Server replica and provides the Kafka Source Adapter runtime service backed by its mandatory exact region record. Pure Layer construction validates and snapshots deterministic options; Effect Config may resolve dynamic deployment input through the Layer's typed construction channel.
+
+The adapter deterministically derives each active Kafka Consumer Group ID from `(consumerGroupPrefix, exact View Server Topic name)` when the runtime service binds a Source Definition to its containing Topic. It canonically UTF-8 percent-encodes each component independently with uppercase hexadecimal escapes and joins the components with one literal `:`, so ordinary inputs remain readable while embedded separators, percent signs, Unicode, and other punctuation cannot create ambiguous or colliding IDs. Prefix `my-view-server` and Topic `orders` therefore resolve to `my-view-server:orders`. Runtime binding rejects an empty prefix or a derived ID that violates the Kafka driver's accepted group-ID constraints before Source Attempt acquisition.
+
+The prefix identifies one logical View Server replica. Every concurrently running replica that builds its own complete local Topic Stores must use a distinct prefix because Kafka consumer groups distribute partitions rather than broadcast every partition to every member. Sharing one resolved group across live replicas would give each replica only a partial view. A logical replica may preserve its stable prefix across process restarts; the selected Kafka Start Position still follows the separately specified new-lifetime semantics. Cross-process uniqueness is an explicit deployment invariant rather than a claim the local runtime can prove.
+
+The prefix is never optional, inherited as a hidden default, read from generic runtime options, repeated per source, or selected by an individual Kafka region entry. The resolved active ID is mandatory exact Kafka adapter health data so operators can identify collisions across replicas. It applies independently in every cluster selected by that Topic and owns all commits produced by successful Source Settlements. A `committed` start-position branch may read initial offsets from another literal named group, but after initial positioning every commit and reconnect belongs to the Topic's resolved active group. Conformance tests prove canonical encoding, derivation stability, cross-topic separation under one prefix, invalid-input rejection, identical IDs across the Topic's selected clusters, and health exposure.
+
+Relative start positioning is scoped to one logical source lifetime, not one retry attempt. At materialized runtime start or first acquisition of a Leased Feed, the adapter reads Effect Clock once, resolves `DurationAgo`, and freezes the resulting initial offsets for every known cluster partition. `Timestamp`, `Earliest`, `Latest`, and `Committed` initial resolutions are frozen at the same boundary. If one Source Delivery Lane loses its connection or any other failure causes Source Attempt reacquisition, the adapter first resumes each partition from the active source consumer group's latest successfully committed offset. Only a partition without an active-group commit reuses its frozen initial offset and explicit fallback. It never recalculates a moving relative window during retry, so a long outage cannot silently skip the early part of that outage.
+
+A complete process/runtime restart creates a new materialized source lifetime and deliberately reevaluates `DurationAgo`; requesting five minutes therefore rebuilds from the latest five-minute window on every restart even when an earlier process used the same group. A Leased Feed retains its frozen offsets across retries while subscribers remain. Final subscriber release destroys that logical feed lifetime, and a later subscription creates a fresh feed and reevaluates the policy. Kafka integration tests cover reconnect after partial progress, commit failure replay, outage longer than the relative duration, process restart, leased retry, and leased release followed by reacquisition.
+
+A published Source Adapter declares `effect-view-server` plus every Effect ecosystem package used by its public or runtime surfaces as peer dependencies and repeats them as development dependencies only for its own build and tests. An adapter using `effect`, `@effect/platform-node`, or another Effect integration therefore declares each package it actually uses, while an adapter that does not expose React values does not force `@effect/atom-react` onto consumers. It never bundles private runtime copies of those packages. This follows Effect's own integration-package model, where platform and transport packages peer-depend on `effect`, and preserves one shared set of Effect and Source Adapter SDK runtime identities in the consuming application.
+
+While Effect remains beta or View Server remains pre-1.0, those peer versions are exact. Once both are stable, an adapter may publish a wider compatible peer range only when its CI conformance matrix executes the complete kit against every admitted View Server and Effect version combination. Package conformance rejects a range broader than the tested matrix. Peer dependency resolution and tested public API compatibility are the compatibility contract; the SDK does not add a tautological runtime protocol field.
+
+The `/contract` dependency graph may use Effect and the browser-safe Source Adapter SDK surface. It may not resolve Node APIs, `/server`, Source Adapter runtime implementations, transport-driver packages, concrete clients, credentials, sockets, or platform-specific Layers. Its materialized and leased Source Definition constructors accept the adapter's complete browser-safe per-source options; leased additionally requires the non-empty unique Route Fields needed by the one View Server Config. It must declare Schema-backed Source Adapter Metrics that every source health payload contains; optional details bags and adapters without metrics are invalid. External source names, Schemas, platform-neutral codecs, Mapping functions, Local Row Key functions, Start Position, and Schedule overrides may live in `/contract`; transport implementation and platform resources may not. These runtime contract values may contribute to the consumer's browser bundle. V1 accepts that explicit tradeoff to preserve one authored View Server Config and adds no mirrored browser contract, code generation, custom build transform, or automatic projection. Conformance builds a real browser fixture and enforces a documented bundle-size budget for every adapter contract.
+
+`SourceAdapter.make(...)` creates one opaque browser-safe Effect `Context.Service` tag as part of the nominal adapter handle. This follows Effect v4's service model while preventing adapter authors from manually duplicating a tag ID, service interface, failure type, metrics type, or lifecycle declaration. The tag supplies type and runtime linkage only; `/contract` contains no runtime service implementation, concrete transport, client, or Layer. `SourceAdapterServer.make(adapter, implementation)` accepts that exact handle and can implement only its declared lifecycles, failures, metrics, and runtime service contract.
+
+Every published platform export uses the mandatory standard Effect constructor pair: `layer(viewServer, resolvedOptions)` and `layerConfig(viewServer, configWrappedOptions)`. Both infer all and only the adapter-wide resources required by the supplied View Server Config, reject missing and extra entries through public types and runtime validation, and return one aggregate scoped Layer that provides the adapter runtime service plus its concrete clients/resources. The Config variant accepts exact `Config.Wrap<Options>`, invokes `Config.unwrap(...)` once during Layer construction, preserves `Config.ConfigError`, and leaves every other Effect service requirement visible in its Layer environment. Package conformance rejects a platform adapter that omits either constructor or substitutes an adapter-specific startup function, hidden Runtime, or internal `Effect.run*` call.
+
+An adapter may define browser-safe logical resource references in its Source Definition options, using its own domain vocabulary such as `connection`, `cluster`, or `endpoint`. These are literal names only, never URLs, credentials, concrete clients, or per-resource Effect service tags. There is no duplicated adapter registration tree in `defineViewServerConfig(...)`. The aggregate platform Layer derives the exact required literal union from all matching Source Definitions, accepts all and only those runtime resource entries, and builds one O(1) lookup map during Layer acquisition. An adapter requiring no named external resource declares none rather than fabricating a singleton reference. The SDK standardizes inference and validation behavior without forcing one resource property name across transports.
+
+The aggregate platform Layer owns reusable infrastructure only: transports, connection pools, factories, credential refreshers, and exact resource maps. Source-specific consumers, subscriptions, channels, iterators, callback registrations, and leases are attempt-level resources acquired with Effect's scoped primitives inside each View Server-owned Source Attempt child Scope. A source retry reacquires those resources without rebuilding the aggregate Layer. Final Leased Feed release cannot close shared infrastructure used by another topic or route; runtime shutdown closes child attempts before outer adapter resources through nested Scope ownership. A shared resource outage may fail several Source Streams, but each one remains independently supervised by its own retry Schedule and health. Package conformance rejects an adapter that permanently hides a source-specific subscription in its aggregate Layer.
+
+Materialized and Leased are the only SDK Source Lifecycle primitives, but the SDK does not force every adapter to publish methods literally named `.materialized(...)` and `.leased(...)`. An adapter may expose domain-appropriate browser-safe wrappers such as Kafka `source(...)`, gRPC `materialized(...)` and `leased(...)`, or another transport-specific constructor name. Each wrapper must create exactly one nominal SDK Materialized or Leased Source Definition, and conformance proves the recorded lifecycle independently of public method spelling. Adapter-specific naming cannot introduce a third lifecycle.
+
+The Source Adapter SDK provides a mandatory conformance kit, not only reusable shape assertions. For every supported Source Lifecycle, the adapter's own tests supply a controllable transport Layer that can acquire a Source Attempt, emit valid deliveries, fail acquisition or Stream execution with the exact adapter failure, complete unexpectedly, expose local metrics changes, and observe scoped finalization. A leased lifecycle's driver also makes exact-route acquisition, same-route sharing, distinct-route isolation, and final release observable. The kit uses `@effect/vitest` Layer-scoped suites, scoped Effects, and TestClock rather than hidden ManagedRuntimes or wall-clock sleeps.
+
+The behavioral suite verifies acquisition readiness, sequential delivery and mutation ordering within a lane, concurrent sibling lanes, whole-attempt termination when one lane fails or completes, settlement on every application Exit, item-local Source Item Rejection recording and continuation, sticky Degraded health, rejection-settlement failure, retry timing and exhaustion, recovery, interruption, awaited idempotent finalization, mandatory metrics and invalid-metrics termination, bounded-buffer behavior when the adapter uses a callback bridge, and leased route sharing and cleanup. It rejects empty lane collections, empty or duplicate lane IDs, IDs that change across retry, missing per-lane buffer metrics, raw payloads in rejection diagnostics, and Source Item Rejections that lack exact safe location. Package conformance separately verifies export presence, nominal Source Definition/runtime-service linkage and lookalike rejection, exact failure, metrics, and rejection-location Schemas, positive and negative public type inference, required peer dependencies, forbidden dependency resolution, duplicate bundled SDK or Effect code, and browser bundling. Platform conformance verifies aggregate Layers reject empty, missing, extra, or duplicate logical-client entries and satisfy their exact runtime services. A published adapter is not conformant merely because its TypeScript values structurally fit. First-party Kafka and gRPC modules pass the same complete kit required of third-party adapters and may not use a privileged internal Runtime Core path.
+
+Adapter authors declare the portable contract once:
+
+```ts
+export const rabbitMq = SourceAdapter.make({
+  name: "@company/rabbitmq-adapter",
+  version: "1.0.0",
+  failure: RabbitMqFailure,
+  lifecycles: {
+    materialized: {
+      metrics: RabbitMqMaterializedMetrics,
+      rejectionLocation: RabbitMqMaterializedRejectionLocation,
+    },
+    leased: {
+      metrics: RabbitMqLeasedMetrics,
+      rejectionLocation: RabbitMqLeasedRejectionLocation,
+    },
+  },
+});
+```
+
+The `/server` export implements that exact declaration:
+
+```ts
+export const rabbitMqServer = SourceAdapterServer.make(rabbitMq, {
+  materialized: {
+    retry: materializedRetry,
+    make: makeMaterialized,
+  },
+  leased: {
+    retry: leasedRetry,
+    make: makeLeased,
+  },
+});
+```
+
+Source Adapter Identity and the complete Source Adapter Failure Schema are never repeated. Each supported Source Lifecycle is declared by its mandatory Source Adapter Metrics Schema and mandatory Source Rejection Location Schema rather than a boolean, and the contract exposes only those materialized or leased Source Definition constructors. `SourceAdapterServer.make(...)` requires every declared lifecycle factory, an infallible local metrics Effect matching the lifecycle Schema, and one default infallible Source Retry Policy for each; it rejects undeclared factories and preserves each factory's input, output, failure, exact lifecycle metrics, exact rejection location, metrics Effect requirements, Schedule environment, and other Effect requirements without linking casts. Shared source constructors accept a standard optional retry override and store an exact `UseAdapterDefault` or `Override` selection rather than `undefined`. View Server supplies no global retry policy.
+
+Every lifecycle `make` factory receives one narrow exact input: the frozen adapter-specific Source Definition options, the Source Target (`Materialized` or `Leased` with exact Feed Route), and a Topic-Bound Source Toolkit. That toolkit exposes exact Topic name and nominal `upsert`, `delete`, `delivery`, and `reject` constructors. Those constructors preserve and runtime-validate Topic Row, canonical ID, adapter failure, rejection-location, route, and settlement types. The factory receives no Runtime Client, imperative publish callback, Subscriber, session, reference count, browser headers, internal Topic Store, mutable config, or raw Schema-validation bypass. The adapter's external codecs own transport decoding; the toolkit owns the final View Server Topic boundary.
+
+The Source Definition options consumed by server lifecycle factories are executable typed APIs rather than one schema-decoded JSON object. Each factory receives the exact frozen Topic binding and adapter-owned browser-safe options, then returns a scoped Effect whose successful acquisition yields the continuous Source Delivery Stream for one Source Attempt; successful acquisition is readiness, and both acquisition and Stream failures retain the declared adapter error type and Effect requirements. An adapter may use Effect Schema or Effect Config for serializable option subtrees, while functions, codecs, Schedules, Effects, and service references remain exact TypeScript values with adapter-owned construction validation. Failure unions and all consumer-visible or wire-visible data remain schema-backed. The SDK snapshots and validates the common Source Definition envelope before the runtime service executes it.
+
+Source Adapter declaration, Source Definition, and Layer constructors are pure. Deterministic static mistakes throw a named adapter configuration error immediately, and successful construction returns a frozen snapshot. Dynamic configuration decoding, resource acquisition, and execution failures are not converted into constructor throws; they remain typed Effect failures in Config, Layer, or Source Stream channels. View Server revalidates the shared Source Definition envelope when the runtime Effect starts as a defense against hostile JavaScript input or post-construction tampering.
+
+## Consequences
+
+React imports stay transport-agnostic while preserving exact failure and per-lifecycle metrics decoding from the same View Server Config used by the server. Ordinary Live Query APIs expose transport-neutral data and availability status; an explicit Source Diagnostics API exposes the exact adapter health type without adding metrics to every Snapshot or Delta. Every source health value contains mandatory `{ runtime, adapter }` metrics, with no optional details or lifecycle-wide optional-field union. Metric-only diagnostics publish at the SDK's fixed one-second Effect Clock cadence, while lifecycle transitions and item rejections publish immediately; adapters cannot introduce per-source polling behavior. Adapter authors get a predictable package vocabulary, declare identity and failures once, and can publish several platform Layer implementations without changing their shared Source Definitions. Lifecycle or metrics drift between `/contract` and `/server` becomes a construction error. An adapter that mixes its broker client into `/contract` is invalid even if a particular bundler happens to tree-shake the dependency.

--- a/docs/adr/0009-standard-source-adapter-package-exports.md
+++ b/docs/adr/0009-standard-source-adapter-package-exports.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted design. Implementation is pending, so the package exports specified below are planned rather than currently available.
 
 ## Context
 
@@ -12,13 +12,13 @@ Effect separates portable contracts and services from concrete platform implemen
 
 ## Decision
 
-Every Source Adapter package exposes these standard public seams:
+When implemented, every Source Adapter package will expose these standard public seams:
 
 - `/contract` contains browser-safe Source Definition constructors, Source Adapter Identity metadata, Source Adapter Failure Schemas, and mandatory Source Adapter Metrics Schemas.
 - `/server` contains the matching Source Adapter runtime service implementation, lifecycle factories, and transport-neutral runtime Layers.
 - Platform exports such as `/node` contain concrete transport-driver Services and Layers. Every published platform export provides paired aggregate `layer(...)` and `layerConfig(...)` constructors that derive the exact required logical-client map from the View Server Config and provide the adapter runtime.
 
-The publishable View Server package exposes the SDK through exactly three matching public modules:
+The publishable View Server package will expose the SDK through exactly three matching public modules:
 
 - `effect-view-server/source-adapter` contains the portable declaration and Source Definition API.
 - `effect-view-server/source-adapter/server` contains server-only Source Adapter runtime-service APIs and executable helpers.
@@ -26,7 +26,7 @@ The publishable View Server package exposes the SDK through exactly three matchi
 
 Adapter packages do not import internal workspace packages, `src` paths, `dist` paths, or unapproved nested SDK modules. View Server package-export checks cover all three approved modules and reject those deep alternatives.
 
-Kafka and gRPC prove the extension seam by becoming ordinary first-party SDK consumers. Because this repository publishes only the `effect-view-server` package, their standard adapter surfaces are publishable package subpaths:
+Kafka and gRPC will prove the extension seam by becoming ordinary first-party SDK consumers. Because this repository publishes only the `effect-view-server` package, their planned standard adapter surfaces are these package subpaths:
 
 - `effect-view-server/kafka/contract`
 - `effect-view-server/kafka/server`

--- a/docs/adr/0010-canonical-topic-row-id.md
+++ b/docs/adr/0010-canonical-topic-row-id.md
@@ -1,0 +1,3 @@
+# Every Topic Row has one canonical string ID
+
+Every user-provided Topic Schema must declare the required field `id: Schema.String`, and Topic configuration has no separate `key` property. View Server rejects a missing, optional, transformed, refined, branded, or non-string `id` at compile time and defensively at runtime. This deliberately gives storage, queries, mutations, React rows, Wire Protocol schemas, and Source Adapters one universal identity contract. The common Source Adapter SDK requires only complete Upserts and ID-addressed Deletes; each adapter owns its ergonomic ID-producing API. Kafka composes `region:localRowKey`, while an adapter without that transport concept may require its Mapping to return the complete Topic Row directly.

--- a/docs/adr/0010-canonical-topic-row-id.md
+++ b/docs/adr/0010-canonical-topic-row-id.md
@@ -1,3 +1,7 @@
 # Every Topic Row has one canonical string ID
 
+## Status
+
+Accepted design. Implementation is pending, so the canonical `id` contract and removal of the separate `key` property are not yet available in the public configuration API.
+
 Every user-provided Topic Schema must declare the required field `id: Schema.String`, and Topic configuration has no separate `key` property. View Server rejects a missing, optional, transformed, refined, branded, or non-string `id` at compile time and defensively at runtime. This deliberately gives storage, queries, mutations, React rows, Wire Protocol schemas, and Source Adapters one universal identity contract. The common Source Adapter SDK requires only complete Upserts and ID-addressed Deletes; each adapter owns its ergonomic ID-producing API. Kafka composes `region:localRowKey`, while an adapter without that transport concept may require its Mapping to return the complete Topic Row directly.

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -281,11 +281,7 @@ export const makeViewServerClient: <
     return Effect.gen(function* () {
       type Row = LiveQueryRow<TopicRow<Topics, Topic>, Query>;
       const wireQuery = yield* viewServerEncodeLiveQuery(config, topic, capturedQuery.success);
-      const eventCodec = compileViewServerLiveEventCodec<Topics, Topic, Row>(
-        config,
-        topic,
-        wireQuery,
-      );
+      const eventCodec = compileViewServerLiveEventCodec(config, topic, capturedQuery.success);
       return yield* subscribeWire<Row, Topic>(topic, wireQuery, eventCodec.decodeTrusted);
     });
   }

--- a/packages/effect-utils/src/schema-json-identity.test.ts
+++ b/packages/effect-utils/src/schema-json-identity.test.ts
@@ -131,7 +131,10 @@ describe("Schema JSON identity", () => {
   it("rejects encoded values that are not strict JSON", () => {
     const identity = makeSchemaJsonIdentity(Schema.Unknown);
 
-    expect(() => identity.canonicalKey(new Map([["key", "value"]]))).toThrow(
+    const nonJson = new Map([["key", "value"]]);
+
+    expect(() => identity.canonicalKey(nonJson)).toThrow("Expected JSON value");
+    expect(() => identity.decodeEncoded(nonJson)).toThrow(
       "Expected a plain data record or dense array",
     );
   });

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -104,8 +104,8 @@
     "@bufbuild/protobuf": "2.12.0",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2",
-    "@effect/platform-browser": "4.0.0-beta.91",
-    "@effect/platform-node": "4.0.0-beta.91",
+    "@effect/platform-browser": "4.0.0-beta.100",
+    "@effect/platform-node": "4.0.0-beta.100",
     "@platformatic/kafka": "2.2.3"
   },
   "devDependencies": {
@@ -127,8 +127,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@effect/atom-react": "4.0.0-beta.91",
-    "effect": "4.0.0-beta.91",
+    "@effect/atom-react": "4.0.0-beta.100",
+    "effect": "4.0.0-beta.100",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },

--- a/packages/protocol/src/grouped-live-wire.test.ts
+++ b/packages/protocol/src/grouped-live-wire.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import {
   compileViewServerLiveEventCodec,
+  defineViewServerLiveEventQuery,
   viewServerDecodeGroupedQuery,
   viewServerDecodeLiveEvent,
   viewServerDecodeLiveQuery,
@@ -21,18 +22,14 @@ import {
 describe("Grouped live wire codec", () => {
   it.effect("compiles and reuses one grouped row contract across live events", () =>
     Effect.gen(function* () {
-      const aggregateDefinitions = {
-        rowCount: { aggFunc: "count" as const },
-      };
-      const query = {
-        aggregates: aggregateDefinitions,
+      const query = defineViewServerLiveEventQuery(viewServer, "orders", {
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+        },
         groupBy: ["id"],
-      };
-      const codec = compileViewServerLiveEventCodec<
-        typeof viewServer.topics,
-        "orders",
-        { readonly id: string; readonly rowCount: bigint }
-      >(viewServer, "orders", query);
+      });
+      const codec = compileViewServerLiveEventCodec(viewServer, "orders", query);
+      // @ts-expect-error hostile callers can mutate a query after its row contract is compiled.
       query.groupBy.push("status");
       Object.defineProperty(query.aggregates, "newCount", {
         configurable: true,
@@ -94,7 +91,7 @@ describe("Grouped live wire codec", () => {
 
   it.effect("encodes and decodes grouped query and grouped live event operations", () =>
     Effect.gen(function* () {
-      const groupedQuery = {
+      const groupedQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
           rowCount: { aggFunc: "count" },
@@ -115,7 +112,7 @@ describe("Grouped live wire codec", () => {
         ],
         offset: 0,
         limit: 10,
-      };
+      });
 
       const encodedGrouped = yield* viewServerEncodeGroupedQuery(
         viewServer,
@@ -189,7 +186,7 @@ describe("Grouped live wire codec", () => {
       const decodedGrouped = yield* viewServerDecodeGroupedQuery(
         viewServer,
         "orders",
-        encodedGrouped,
+        groupedQuery,
       );
       expect(decodedGrouped).toStrictEqual(groupedQuery);
 
@@ -245,20 +242,15 @@ describe("Grouped live wire codec", () => {
         distinctPrice: 2n,
       };
 
-      const groupedSnapshot = yield* viewServerEncodeLiveEvent(
-        viewServer,
-        "orders",
-        encodedGrouped,
-        {
-          type: "snapshot",
-          topic: "orders",
-          queryId: "grouped-0",
-          version: 1,
-          keys: ["a"],
-          rows: [groupedRow],
-          totalRows: 1,
-        },
-      );
+      const groupedSnapshot = yield* viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "grouped-0",
+        version: 1,
+        keys: ["a"],
+        rows: [groupedRow],
+        totalRows: 1,
+      });
       expect(groupedSnapshot).toStrictEqual({
         type: "snapshot",
         topic: "orders",
@@ -279,11 +271,12 @@ describe("Grouped live wire codec", () => {
         totalRows: 1,
       });
 
-      const decodedGroupedSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedGroupedSnapshot = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        typeof groupedRow
-      >(viewServer, "orders", encodedGrouped, groupedSnapshot);
+        groupedQuery,
+        groupedSnapshot,
+      );
       const decodedGroupedSnapshotRows =
         decodedGroupedSnapshot.type === "snapshot"
           ? decodedGroupedSnapshot.rows.map((row) => ({
@@ -306,12 +299,13 @@ describe("Grouped live wire codec", () => {
       });
 
       const invalidMinSnapshot = yield* Effect.flip(
-        viewServerEncodeLiveEvent(viewServer, "orders", encodedGrouped, {
+        viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
           type: "snapshot",
           topic: "orders",
           queryId: "grouped-undefined",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload violates the required min aggregate type.
           rows: [{ ...groupedRow, minPrice: undefined }],
           totalRows: 1,
         }),
@@ -324,7 +318,7 @@ describe("Grouped live wire codec", () => {
           "Invalid field minPrice: aggregate min cannot be undefined because price is required.",
       });
       const invalidMinEnvelope = yield* Effect.flip(
-        viewServerDecodeLiveEvent(viewServer, "orders", encodedGrouped, {
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
           type: "snapshot",
           topic: "orders",
           queryId: "grouped-undefined-envelope",
@@ -352,12 +346,13 @@ describe("Grouped live wire codec", () => {
           "Invalid field minPrice: aggregate min cannot be undefined because price is required.",
       });
 
-      const optionalMinQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+      const optionalMinQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
           minUnset: { aggFunc: "min", field: "unset" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(viewServer, "orders", optionalMinQuery);
       const optionalMinSnapshot = yield* viewServerEncodeLiveEvent(
         viewServer,
         "orders",
@@ -386,11 +381,12 @@ describe("Grouped live wire codec", () => {
         ],
         totalRows: 1,
       });
-      const decodedOptionalMinSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedOptionalMinSnapshot = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        { readonly id: string; readonly minUnset: undefined }
-      >(viewServer, "orders", optionalMinQuery, optionalMinSnapshot);
+        optionalMinQuery,
+        optionalMinSnapshot,
+      );
       expect(decodedOptionalMinSnapshot).toStrictEqual({
         type: "snapshot",
         topic: "orders",
@@ -401,12 +397,13 @@ describe("Grouped live wire codec", () => {
         totalRows: 1,
       });
 
-      const objectAggregateQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+      const objectAggregateQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
           firstMetadata: { aggFunc: "min", field: "metadata" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(viewServer, "orders", objectAggregateQuery);
       const objectAggregateSnapshot = yield* viewServerEncodeLiveEvent(
         viewServer,
         "orders",
@@ -449,14 +446,12 @@ describe("Grouped live wire codec", () => {
         ],
         totalRows: 1,
       });
-      const decodedObjectAggregateSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedObjectAggregateSnapshot = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        {
-          readonly id: string;
-          readonly firstMetadata: { readonly _viewServerScalar: string; readonly value: string };
-        }
-      >(viewServer, "orders", objectAggregateQuery, objectAggregateSnapshot);
+        objectAggregateQuery,
+        objectAggregateSnapshot,
+      );
       expect(decodedObjectAggregateSnapshot).toStrictEqual({
         type: "snapshot",
         topic: "orders",
@@ -475,12 +470,13 @@ describe("Grouped live wire codec", () => {
         totalRows: 1,
       });
 
-      const bigIntSumQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+      const bigIntSumQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
           totalQuantity: { aggFunc: "sum", field: "quantity" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(viewServer, "orders", bigIntSumQuery);
       const bigIntSumSnapshot = yield* viewServerEncodeLiveEvent(
         viewServer,
         "orders",
@@ -509,14 +505,12 @@ describe("Grouped live wire codec", () => {
         ],
         totalRows: 1,
       });
-      const decodedBigIntSumSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedBigIntSumSnapshot = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        {
-          readonly id: string;
-          readonly totalQuantity: bigint;
-        }
-      >(viewServer, "orders", bigIntSumQuery, bigIntSumSnapshot);
+        bigIntSumQuery,
+        bigIntSumSnapshot,
+      );
       expect(decodedBigIntSumSnapshot).toStrictEqual({
         type: "snapshot",
         topic: "orders",
@@ -527,7 +521,7 @@ describe("Grouped live wire codec", () => {
         totalRows: 1,
       });
 
-      const groupedDelta = yield* viewServerEncodeLiveEvent(viewServer, "orders", encodedGrouped, {
+      const groupedDelta = yield* viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
         type: "delta",
         topic: "orders",
         queryId: "grouped-0",
@@ -547,11 +541,12 @@ describe("Grouped live wire codec", () => {
         totalRows: 2,
       });
 
-      const decodedGroupedDelta = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedGroupedDelta = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        typeof groupedRow
-      >(viewServer, "orders", encodedGrouped, groupedDelta);
+        groupedQuery,
+        groupedDelta,
+      );
       const decodedGroupedDeltaOperations =
         decodedGroupedDelta.type === "delta"
           ? decodedGroupedDelta.operations.map((operation) =>

--- a/packages/protocol/src/index.test-d.ts
+++ b/packages/protocol/src/index.test-d.ts
@@ -4,6 +4,8 @@ import { Effect, Schema } from "effect";
 import type * as Protocol from "./index";
 import {
   compileViewServerLiveEventCodec,
+  defineViewServerLiveEventQuery,
+  viewServerDecodeLiveEvent,
   viewServerDecodeHealthSummaryEvent,
   viewServerDecodeHealthTopicEvent,
   viewServerDecodeTrustedLiveEvent,
@@ -481,25 +483,63 @@ describe("@effect-view-server/protocol type contract", () => {
     expectTypeOf(invalidTrustedDecode).not.toBeAny();
   });
 
-  it("preserves row and error types through a compiled live event codec", () => {
-    const codec = compileViewServerLiveEventCodec<
-      typeof typeViewServer.topics,
-      "orders",
-      Pick<typeof TypeOrder.Type, "id">
-    >(typeViewServer, "orders", { select: ["id"] });
-    const decoded = codec.decodeTrusted(trustedWireEvent);
-    type DecodedEvent = Effect.Success<typeof decoded>;
-    type DecodedSnapshot = Extract<DecodedEvent, { readonly type: "snapshot" }>;
-    expectTypeOf<DecodedSnapshot["rows"][number]>().toEqualTypeOf<
+  it("derives raw and grouped row types through public live event codecs", () => {
+    const rawCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", {
+      select: ["id"],
+    });
+    const rawDecoded = rawCodec.decodeTrusted(trustedWireEvent);
+    type RawDecodedEvent = Effect.Success<typeof rawDecoded>;
+    type RawDecodedSnapshot = Extract<RawDecodedEvent, { readonly type: "snapshot" }>;
+    type RawDecodedDeltaOperation = Extract<
+      RawDecodedEvent,
+      { readonly type: "delta" }
+    >["operations"][number];
+    type RawDecodedChangedRow = Extract<
+      RawDecodedDeltaOperation,
+      { readonly type: "insert" | "update" }
+    >["row"];
+    expectTypeOf<RawDecodedSnapshot["rows"][number]>().toEqualTypeOf<
       Pick<typeof TypeOrder.Type, "id">
     >();
-    expectTypeOf<Effect.Error<typeof decoded>>().toEqualTypeOf<ViewServerRuntimeError>();
+    expectTypeOf<RawDecodedChangedRow>().toEqualTypeOf<Pick<typeof TypeOrder.Type, "id">>();
+    expectTypeOf<Effect.Error<typeof rawDecoded>>().toEqualTypeOf<ViewServerRuntimeError>();
 
-    const invalidTrustedDecode = codec.decodeTrusted(
+    const invalidTrustedDecode = rawCodec.decodeTrusted(
       // @ts-expect-error compiled trusted decoder requires validated wire event proof.
       wireEvent,
     );
     expectTypeOf(invalidTrustedDecode).not.toBeAny();
+
+    const groupedCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", {
+      groupBy: ["id"],
+      aggregates: {
+        rowCount: { aggFunc: "count" },
+      },
+    });
+    const groupedDecoded = groupedCodec.decodeTrusted(trustedWireEvent);
+    type GroupedDecodedEvent = Effect.Success<typeof groupedDecoded>;
+    type GroupedDecodedSnapshot = Extract<GroupedDecodedEvent, { readonly type: "snapshot" }>;
+    type GroupedDecodedDeltaOperation = Extract<
+      GroupedDecodedEvent,
+      { readonly type: "delta" }
+    >["operations"][number];
+    type GroupedDecodedChangedRow = Extract<
+      GroupedDecodedDeltaOperation,
+      { readonly type: "insert" | "update" }
+    >["row"];
+    type ExpectedGroupedRow = {
+      readonly id: string;
+      readonly rowCount: bigint;
+    };
+    expectTypeOf<GroupedDecodedSnapshot["rows"][number]>().toEqualTypeOf<ExpectedGroupedRow>();
+    expectTypeOf<GroupedDecodedChangedRow>().toEqualTypeOf<ExpectedGroupedRow>();
+    expectTypeOf<Effect.Error<typeof groupedDecoded>>().toEqualTypeOf<ViewServerRuntimeError>();
+
+    // @ts-expect-error compiled codec row type is derived from the topic and query.
+    const fabricatedCodec: Protocol.ViewServerLiveEventCodec<{
+      readonly fabricated: boolean;
+    }> = rawCodec;
+    expectTypeOf(fabricatedCodec).not.toBeAny();
 
     const invalidTopicCodec = compileViewServerLiveEventCodec(
       typeViewServer,
@@ -508,6 +548,120 @@ describe("@effect-view-server/protocol type contract", () => {
       { select: ["id"] },
     );
     expectTypeOf(invalidTopicCodec).not.toBeAny();
+
+    // @ts-expect-error selected fields must be own fields of the configured topic row.
+    const unknownSelectedFieldCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", {
+      select: ["missing"],
+    });
+    expectTypeOf(unknownSelectedFieldCodec).not.toBeAny();
+
+    // @ts-expect-error inherited object fields are not topic row fields.
+    const inheritedSelectedFieldCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", {
+      select: ["toString"],
+    });
+    expectTypeOf(inheritedSelectedFieldCodec).not.toBeAny();
+
+    // @ts-expect-error grouped fields must be own fields of the configured topic row.
+    const unknownGroupedFieldCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", {
+      groupBy: ["missing"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+    });
+    expectTypeOf(unknownGroupedFieldCodec).not.toBeAny();
+
+    // @ts-expect-error inherited object fields are not topic row fields.
+    const inheritedGroupedFieldCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", {
+      groupBy: ["toString"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+    });
+    expectTypeOf(inheritedGroupedFieldCodec).not.toBeAny();
+  });
+
+  it("defines reusable exact live event queries without as const", () => {
+    const rawQuery = defineViewServerLiveEventQuery(typeViewServer, "orders", {
+      select: ["id"],
+    });
+    const rawCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", rawQuery);
+    const rawDecoded = rawCodec.decodeTrusted(trustedWireEvent);
+    type RawSnapshot = Extract<Effect.Success<typeof rawDecoded>, { readonly type: "snapshot" }>;
+    expectTypeOf<RawSnapshot["rows"][number]>().toEqualTypeOf<Pick<typeof TypeOrder.Type, "id">>();
+
+    const groupedQuery = defineViewServerLiveEventQuery(typeViewServer, "orders", {
+      groupBy: ["id"],
+      aggregates: { rowCount: { aggFunc: "count" } },
+    });
+    const groupedCodec = compileViewServerLiveEventCodec(typeViewServer, "orders", groupedQuery);
+    const groupedDecoded = groupedCodec.decodeTrusted(trustedWireEvent);
+    type GroupedSnapshot = Extract<
+      Effect.Success<typeof groupedDecoded>,
+      { readonly type: "snapshot" }
+    >;
+    expectTypeOf<GroupedSnapshot["rows"][number]>().toEqualTypeOf<{
+      readonly id: string;
+      readonly rowCount: bigint;
+    }>();
+
+    // @ts-expect-error reusable query builders reject fields outside the topic schema.
+    const invalidQuery = defineViewServerLiveEventQuery(typeViewServer, "orders", {
+      select: ["missing"],
+    });
+    expectTypeOf(invalidQuery).not.toBeAny();
+  });
+
+  it("derives one-shot live decoder rows and rejects fabricated row claims", () => {
+    const rawDecode = viewServerDecodeLiveEvent(
+      typeViewServer,
+      "orders",
+      { select: ["id"] },
+      wireEvent,
+    );
+    const trustedRawDecode = viewServerDecodeTrustedLiveEvent(
+      typeViewServer,
+      "orders",
+      { select: ["id"] },
+      trustedWireEvent,
+    );
+    const groupedDecode = viewServerDecodeLiveEvent(
+      typeViewServer,
+      "orders",
+      {
+        groupBy: ["id"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+      },
+      wireEvent,
+    );
+    type RawSnapshot = Extract<Effect.Success<typeof rawDecode>, { readonly type: "snapshot" }>;
+    type TrustedRawSnapshot = Extract<
+      Effect.Success<typeof trustedRawDecode>,
+      { readonly type: "snapshot" }
+    >;
+    type GroupedSnapshot = Extract<
+      Effect.Success<typeof groupedDecode>,
+      { readonly type: "snapshot" }
+    >;
+    expectTypeOf<RawSnapshot["rows"][number]>().toEqualTypeOf<Pick<typeof TypeOrder.Type, "id">>();
+    expectTypeOf<TrustedRawSnapshot["rows"][number]>().toEqualTypeOf<
+      Pick<typeof TypeOrder.Type, "id">
+    >();
+    expectTypeOf<GroupedSnapshot["rows"][number]>().toEqualTypeOf<{
+      readonly id: string;
+      readonly rowCount: bigint;
+    }>();
+
+    const fabricatedDecode = viewServerDecodeLiveEvent<
+      typeof typeViewServer.topics,
+      "orders",
+      // @ts-expect-error the third generic is a query contract, not a caller-selected row type.
+      { readonly fabricated: boolean }
+    >(typeViewServer, "orders", { fabricated: true }, wireEvent);
+    expectTypeOf(fabricatedDecode).not.toBeAny();
+
+    const fabricatedTrustedDecode = viewServerDecodeTrustedLiveEvent<
+      typeof typeViewServer.topics,
+      "orders",
+      // @ts-expect-error the third generic is a query contract, not a caller-selected row type.
+      { readonly fabricated: boolean }
+    >(typeViewServer, "orders", { fabricated: true }, trustedWireEvent);
+    expectTypeOf(fabricatedTrustedDecode).not.toBeAny();
   });
 
   it("preserves health event decoder output generics", () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -42,10 +42,13 @@ export {
 
 export {
   compileViewServerLiveEventCodec,
+  compileViewServerRuntimeLiveEventEncoder,
+  defineViewServerLiveEventQuery,
   viewServerEncodeLiveEvent,
   viewServerDecodeLiveEvent,
   viewServerDecodeTrustedLiveEvent,
   type ViewServerLiveEventCodec,
+  type ViewServerRuntimeLiveEventEncoder,
 } from "./protocol-event-codec";
 
 export {

--- a/packages/protocol/src/invalid-grouped-row-wire.test.ts
+++ b/packages/protocol/src/invalid-grouped-row-wire.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import {
+  compileViewServerRuntimeLiveEventEncoder,
+  defineViewServerLiveEventQuery,
   viewServerDecodeLiveEvent,
   viewServerEncodeGroupedQuery,
   viewServerEncodeLiveEvent,
@@ -12,13 +14,14 @@ import { viewServer } from "../test-harness/protocol";
 describe("Invalid grouped row wire inputs", () => {
   it.effect("rejects invalid grouped row and aggregate payloads", () =>
     Effect.gen(function* () {
-      const groupedQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+      const groupedQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
           rowCount: { aggFunc: "count" },
           averagePrice: { aggFunc: "avg", field: "price" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(viewServer, "orders", groupedQuery);
 
       const missingGroupedField = yield* Effect.flip(
         viewServerEncodeLiveEvent(viewServer, "orders", groupedQuery, {
@@ -27,6 +30,7 @@ describe("Invalid grouped row wire inputs", () => {
           queryId: "grouped-0",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload omits the required group field.
           rows: [{ rowCount: 1n, averagePrice: BigDecimal.fromStringUnsafe("1.5") }],
           totalRows: 1,
         }),
@@ -41,6 +45,7 @@ describe("Invalid grouped row wire inputs", () => {
           queryId: "grouped-0",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload omits the required count aggregate.
           rows: [{ id: "a", averagePrice: BigDecimal.fromStringUnsafe("1.5") }],
           totalRows: 1,
         }),
@@ -54,10 +59,10 @@ describe("Invalid grouped row wire inputs", () => {
         viewServerEncodeLiveEvent(
           viewServer,
           "orders",
+          // @ts-expect-error hostile query payload can omit an aggregate definition value.
           {
             groupBy: ["id"],
             aggregates: {
-              // @ts-expect-error hostile query payload can omit an aggregate definition value.
               missing: undefined,
             },
           },
@@ -89,6 +94,7 @@ describe("Invalid grouped row wire inputs", () => {
               id: "a",
               rowCount: 1n,
               averagePrice: BigDecimal.fromStringUnsafe("1.5"),
+              // @ts-expect-error hostile runtime payload contains an unexpected field.
               extra: true,
             },
           ],
@@ -110,6 +116,7 @@ describe("Invalid grouped row wire inputs", () => {
           rows: [
             {
               id: "a",
+              // @ts-expect-error hostile runtime payload violates the count aggregate type.
               rowCount: Symbol("bad"),
               averagePrice: BigDecimal.fromStringUnsafe("1.5"),
             },
@@ -131,6 +138,7 @@ describe("Invalid grouped row wire inputs", () => {
             {
               id: "a",
               rowCount: 1n,
+              // @ts-expect-error hostile runtime payload violates the average aggregate type.
               averagePrice: 1,
             },
           ],
@@ -143,50 +151,40 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const invalidGroupedField = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: 10,
-                rowCount: { _viewServerAggregate: "bigint", value: "1" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: 10,
+              rowCount: { _viewServerAggregate: "bigint", value: "1" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(invalidGroupedField.message).toBe("Invalid field id: Expected string, got 10");
 
       const missingDecodedGroupedField = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                rowCount: { _viewServerAggregate: "bigint", value: "1" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              rowCount: { _viewServerAggregate: "bigint", value: "1" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(missingDecodedGroupedField.message).toBe(
@@ -194,25 +192,20 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const missingDecodedGroupedAggregate = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(missingDecodedGroupedAggregate.message).toBe(
@@ -220,13 +213,13 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const missingDecodedGroupedAggregateDefinition = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
+        viewServerDecodeLiveEvent(
           viewServer,
           "orders",
+          // @ts-expect-error hostile query payload can omit an aggregate definition value.
           {
             groupBy: ["id"],
             aggregates: {
-              // @ts-expect-error hostile query payload can omit an aggregate definition value.
               missing: undefined,
             },
           },
@@ -252,27 +245,22 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const unexpectedDecodedGroupedField = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "bigint", value: "1" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-                extra: true,
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: "1" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+              extra: true,
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(unexpectedDecodedGroupedField.message).toBe(
@@ -280,26 +268,21 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const nonJsonDecodedGroupedAggregate = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "nope", value: "bad" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "nope", value: "bad" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(nonJsonDecodedGroupedAggregate.message).toBe(
@@ -307,26 +290,21 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const numericBigIntEnvelope = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "bigint", value: 1 },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: 1 },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(numericBigIntEnvelope.message).toBe(
@@ -334,76 +312,61 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const invalidGroupedBigInt = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "bigint", value: "not-a-bigint" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: "not-a-bigint" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "1.5" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(invalidGroupedBigInt.message).toBe("Aggregate rowCount must be a bigint envelope.");
 
       const invalidGroupedBigDecimal = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "bigint", value: "1" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: "nope" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: "1" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: "nope" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(invalidGroupedBigDecimal.message).toMatch(/Invalid aggregate averagePrice/);
 
       const numericBigDecimalEnvelope = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "bigint", value: "1" },
-                averagePrice: { _viewServerAggregate: "bigdecimal", value: 1 },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: "1" },
+              averagePrice: { _viewServerAggregate: "bigdecimal", value: 1 },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(numericBigDecimalEnvelope.message).toBe(
@@ -411,38 +374,34 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const wrongGroupedBigDecimalEnvelope = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-0",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                rowCount: { _viewServerAggregate: "bigint", value: "1" },
-                averagePrice: { _viewServerAggregate: "bigint", value: "1" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-0",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              rowCount: { _viewServerAggregate: "bigint", value: "1" },
+              averagePrice: { _viewServerAggregate: "bigint", value: "1" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(wrongGroupedBigDecimalEnvelope.message).toBe(
         "Aggregate averagePrice must be a BigDecimal envelope.",
       );
 
-      const groupedMinQuery = yield* viewServerEncodeGroupedQuery(viewServer, "orders", {
+      const groupedMinQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
         groupBy: ["id"],
         aggregates: {
           minPrice: { aggFunc: "min", field: "price" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(viewServer, "orders", groupedMinQuery);
 
       const invalidEncodedMin = yield* Effect.flip(
         viewServerEncodeLiveEvent(viewServer, "orders", groupedMinQuery, {
@@ -451,6 +410,7 @@ describe("Invalid grouped row wire inputs", () => {
           queryId: "grouped-min",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload violates the min aggregate type.
           rows: [{ id: "a", minPrice: "not-a-number" }],
           totalRows: 1,
         }),
@@ -461,25 +421,20 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const wrongJsonEnvelope = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedMinQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-min",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                minPrice: { _viewServerAggregate: "bigint", value: "1" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedMinQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-min",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              minPrice: { _viewServerAggregate: "bigint", value: "1" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(wrongJsonEnvelope.message).toBe(
@@ -487,56 +442,58 @@ describe("Invalid grouped row wire inputs", () => {
       );
 
       const invalidJsonAggregateValue = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", object>(
-          viewServer,
-          "orders",
-          groupedMinQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-min",
-            version: 1,
-            keys: ["a"],
-            rows: [
-              {
-                id: "a",
-                minPrice: { _viewServerAggregate: "json", value: "not-a-number" },
-              },
-            ],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", groupedMinQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "grouped-min",
+          version: 1,
+          keys: ["a"],
+          rows: [
+            {
+              id: "a",
+              minPrice: { _viewServerAggregate: "json", value: "not-a-number" },
+            },
+          ],
+          totalRows: 1,
+        }),
       );
 
       expect(invalidJsonAggregateValue.message).toBe(
         'Invalid field minPrice: Expected "Infinity" | "-Infinity" | "NaN", got "not-a-number"',
       );
 
-      const missingAggregateSourceField = yield* Effect.flip(
-        viewServerEncodeLiveEvent(
-          viewServer,
-          "orders",
-          {
-            groupBy: ["id"],
-            aggregates: {
-              badPrice: { aggFunc: "min", field: "missing" },
+      for (const field of ["missing", "toString"]) {
+        const invalidAggregateQuery = {
+          groupBy: ["id"],
+          aggregates: {
+            badPrice: { aggFunc: "min", field },
+          },
+        };
+        const invalidAggregateSourceField = yield* Effect.flip(
+          viewServerEncodeLiveEvent(
+            viewServer,
+            "orders",
+            // @ts-expect-error hostile callers can bypass exact grouped aggregate fields.
+            invalidAggregateQuery,
+            {
+              type: "snapshot",
+              topic: "orders",
+              queryId: `grouped-invalid-aggregate-field-${field}`,
+              version: 1,
+              keys: ["a"],
+              rows: [{ id: "a", badPrice: 1 }],
+              totalRows: 1,
             },
-          },
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "grouped-missing-field",
-            version: 1,
-            keys: ["a"],
-            rows: [{ id: "a", badPrice: 1 }],
-            totalRows: 1,
-          },
-        ),
-      );
+          ),
+        );
 
-      expect(missingAggregateSourceField.message).toBe(
-        "Aggregate references unknown field for topic orders: missing",
-      );
+        expect(invalidAggregateSourceField).toStrictEqual({
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidRow",
+          message: `Aggregate references unknown field for topic orders: ${field}`,
+          topic: "orders",
+        });
+      }
 
       const malformedEventSchemaConfig = {
         topics: {
@@ -647,6 +604,73 @@ describe("Invalid grouped row wire inputs", () => {
         ],
         totalRows: 1,
       });
+    }),
+  );
+
+  it.effect("rejects unknown and inherited group fields through public live codecs", () =>
+    Effect.gen(function* () {
+      for (const field of ["missing", "toString"]) {
+        const query = {
+          groupBy: [field],
+          aggregates: { rowCount: { aggFunc: "count" } },
+        } as const;
+        const expectedError = {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidRow",
+          message: `Grouped row field does not exist for topic orders: ${field}`,
+          topic: "orders",
+        } as const;
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeLiveEvent(
+            viewServer,
+            "orders",
+            // @ts-expect-error hostile callers can bypass the exact group-field contract.
+            query,
+            {
+              type: "snapshot",
+              topic: "orders",
+              queryId: `invalid-group-encode-${field}`,
+              version: 1,
+              keys: ["a"],
+              rows: [{ rowCount: 1n }],
+              totalRows: 1,
+            },
+          ),
+        );
+        expect(encodeError).toStrictEqual(expectedError);
+
+        const runtimeEncodeError = yield* Effect.flip(
+          compileViewServerRuntimeLiveEventEncoder(viewServer, "orders", query).encode({
+            type: "snapshot",
+            topic: "orders",
+            queryId: `invalid-group-runtime-encode-${field}`,
+            version: 1,
+            keys: ["a"],
+            rows: [{ rowCount: 1n }],
+            totalRows: 1,
+          }),
+        );
+        expect(runtimeEncodeError).toStrictEqual(expectedError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeLiveEvent(
+            viewServer,
+            "orders",
+            // @ts-expect-error hostile callers can bypass the exact group-field contract.
+            query,
+            {
+              type: "snapshot",
+              topic: "orders",
+              queryId: `invalid-group-decode-${field}`,
+              version: 1,
+              keys: ["a"],
+              rows: [{ rowCount: { _viewServerAggregate: "bigint", value: "1" } }],
+              totalRows: 1,
+            },
+          ),
+        );
+        expect(decodeError).toStrictEqual(expectedError);
+      }
     }),
   );
 });

--- a/packages/protocol/src/invalid-raw-row-wire.test.ts
+++ b/packages/protocol/src/invalid-raw-row-wire.test.ts
@@ -2,19 +2,23 @@ import { describe, expect, it } from "@effect/vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import {
+  compileViewServerRuntimeLiveEventEncoder,
+  defineViewServerLiveEventQuery,
   viewServerDecodeLiveEvent,
   viewServerEncodeGroupedQuery,
   viewServerEncodeLiveEvent,
 } from "./index";
 
-import { BadJsonField, Order, viewServer } from "../test-harness/protocol";
+import { BadJsonField, viewServer } from "../test-harness/protocol";
 
 describe("Invalid raw row wire inputs", () => {
   it.effect("rejects invalid raw row payloads", () =>
     Effect.gen(function* () {
-      const idQuery = { select: ["id"] };
+      const idQuery = defineViewServerLiveEventQuery(viewServer, "orders", { select: ["id"] });
 
-      const priceQuery = { select: ["price"] };
+      const priceQuery = defineViewServerLiveEventQuery(viewServer, "orders", {
+        select: ["price"],
+      });
 
       const wrongEncodeTopic = yield* Effect.flip(
         viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
@@ -29,18 +33,13 @@ describe("Invalid raw row wire inputs", () => {
       expect(wrongEncodeTopic.code).toBe("InvalidRow");
 
       const wrongDecodeTopic = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
-          viewServer,
-          "orders",
-          idQuery,
-          {
-            type: "status",
-            topic: "badjson",
-            queryId: "query-0",
-            status: "ready",
-            code: "Ready",
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", idQuery, {
+          type: "status",
+          topic: "badjson",
+          queryId: "query-0",
+          status: "ready",
+          code: "Ready",
+        }),
       );
 
       expect(wrongDecodeTopic.code).toBe("InvalidRow");
@@ -52,6 +51,7 @@ describe("Invalid raw row wire inputs", () => {
           queryId: "query-0",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload omits id and includes an unselected field.
           rows: [{ price: 10 }],
           totalRows: 1,
         }),
@@ -66,6 +66,7 @@ describe("Invalid raw row wire inputs", () => {
           queryId: "query-0",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload includes an unselected field.
           rows: [{ id: "a", price: 10 }],
           totalRows: 1,
         }),
@@ -80,6 +81,7 @@ describe("Invalid raw row wire inputs", () => {
           queryId: "query-0",
           version: 1,
           keys: ["a"],
+          // @ts-expect-error hostile runtime payload violates the selected field type.
           rows: [{ price: "nope" }],
           totalRows: 1,
         }),
@@ -92,58 +94,43 @@ describe("Invalid raw row wire inputs", () => {
       );
 
       const extraField = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
-          viewServer,
-          "orders",
-          idQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "query-0",
-            version: 1,
-            keys: ["a"],
-            rows: [{ id: "a", price: 10 }],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", idQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 1,
+          keys: ["a"],
+          rows: [{ id: "a", price: 10 }],
+          totalRows: 1,
+        }),
       );
 
       expect(extraField.message).toBe("Unexpected row field for topic orders: price");
 
       const missingDecodeField = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
-          viewServer,
-          "orders",
-          priceQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "query-0",
-            version: 1,
-            keys: ["a"],
-            rows: [{ id: "a" }],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", priceQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 1,
+          keys: ["a"],
+          rows: [{ id: "a" }],
+          totalRows: 1,
+        }),
       );
 
       expect(missingDecodeField.message).toBe("Missing row field for topic orders: price");
 
       const invalidFieldType = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
-          viewServer,
-          "orders",
-          priceQuery,
-          {
-            type: "snapshot",
-            topic: "orders",
-            queryId: "query-0",
-            version: 1,
-            keys: ["a"],
-            rows: [{ price: "nope" }],
-            totalRows: 1,
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", priceQuery, {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-0",
+          version: 1,
+          keys: ["a"],
+          rows: [{ price: "nope" }],
+          totalRows: 1,
+        }),
       );
 
       expect(invalidFieldType.code).toBe("InvalidRow");
@@ -206,7 +193,7 @@ describe("Invalid raw row wire inputs", () => {
         },
       });
 
-      const badJsonAggregateQuery = yield* viewServerEncodeGroupedQuery(
+      const badJsonAggregateQuery = defineViewServerLiveEventQuery(
         badJsonAggregateViewServer,
         "badAggregate",
         {
@@ -215,6 +202,11 @@ describe("Invalid raw row wire inputs", () => {
             badValue: { aggFunc: "min", field: "value" },
           },
         },
+      );
+      yield* viewServerEncodeGroupedQuery(
+        badJsonAggregateViewServer,
+        "badAggregate",
+        badJsonAggregateQuery,
       );
       Object.defineProperty(BadJsonAggregateRow.fields, "value", {
         configurable: true,
@@ -243,6 +235,7 @@ describe("Invalid raw row wire inputs", () => {
             queryId: "grouped-bad-aggregate",
             version: 1,
             keys: ["a"],
+            // @ts-expect-error hostile schema mutation invalidates the original aggregate type.
             rows: [{ id: "a", badValue: "not-json-safe" }],
             totalRows: 1,
           },
@@ -254,6 +247,70 @@ describe("Invalid raw row wire inputs", () => {
       expect(nonJsonAggregate.message).toBe(
         'Field badValue is not JSON-safe: Unsupported JSON value type "symbol" at $.',
       );
+    }),
+  );
+
+  it.effect("rejects unknown and inherited selected fields through public live codecs", () =>
+    Effect.gen(function* () {
+      for (const field of ["missing", "toString"]) {
+        const query = { select: [field] };
+        const expectedError = {
+          _tag: "ViewServerRuntimeError",
+          code: "InvalidRow",
+          message: `Selected row field does not exist for topic orders: ${field}`,
+          topic: "orders",
+        } as const;
+        const encodeError = yield* Effect.flip(
+          viewServerEncodeLiveEvent(
+            viewServer,
+            "orders",
+            // @ts-expect-error hostile callers can bypass the exact selected-field contract.
+            query,
+            {
+              type: "snapshot",
+              topic: "orders",
+              queryId: `invalid-selected-encode-${field}`,
+              version: 1,
+              keys: ["a"],
+              rows: [{}],
+              totalRows: 1,
+            },
+          ),
+        );
+        expect(encodeError).toStrictEqual(expectedError);
+
+        const runtimeEncodeError = yield* Effect.flip(
+          compileViewServerRuntimeLiveEventEncoder(viewServer, "orders", query).encode({
+            type: "snapshot",
+            topic: "orders",
+            queryId: `invalid-selected-runtime-encode-${field}`,
+            version: 1,
+            keys: ["a"],
+            rows: [{}],
+            totalRows: 1,
+          }),
+        );
+        expect(runtimeEncodeError).toStrictEqual(expectedError);
+
+        const decodeError = yield* Effect.flip(
+          viewServerDecodeLiveEvent(
+            viewServer,
+            "orders",
+            // @ts-expect-error hostile callers can bypass the exact selected-field contract.
+            query,
+            {
+              type: "snapshot",
+              topic: "orders",
+              queryId: `invalid-selected-decode-${field}`,
+              version: 1,
+              keys: ["a"],
+              rows: [{}],
+              totalRows: 1,
+            },
+          ),
+        );
+        expect(decodeError).toStrictEqual(expectedError);
+      }
     }),
   );
 });

--- a/packages/protocol/src/opaque-row-wire.test.ts
+++ b/packages/protocol/src/opaque-row-wire.test.ts
@@ -98,8 +98,7 @@ describe("Opaque row wire values", () => {
 
       expect(error).toStrictEqual({
         ...expectedOpaqueValueError,
-        message:
-          "Invalid row for topic opaque: Expected a plain data record or dense array at $.payload.",
+        message: "Invalid event: Expected a plain data record or dense array at $.rows[0].payload.",
       });
     }),
   );
@@ -181,7 +180,7 @@ describe("Opaque row wire values", () => {
       expect(directDecodeError).toStrictEqual({
         ...expectedOpaqueValueError,
         message:
-          "Invalid grouped row for topic opaque: Expected a plain data record or dense array at $.firstPayload.value.",
+          "Invalid event: Expected a plain data record or dense array at $.rows[0].firstPayload.value.",
       });
     }),
   );

--- a/packages/protocol/src/opaque-row-wire.test.ts
+++ b/packages/protocol/src/opaque-row-wire.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { defineViewServerConfig } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import {
+  defineViewServerLiveEventQuery,
   viewServerDecodeLiveEvent,
   viewServerEncodeGroupedQuery,
   viewServerEncodeLiveEvent,
@@ -21,7 +22,9 @@ const opaqueViewServer = defineViewServerConfig({
   },
 });
 
-const rawQuery = { select: ["id", "payload"] };
+const rawQuery = defineViewServerLiveEventQuery(opaqueViewServer, "opaque", {
+  select: ["id", "payload"],
+});
 
 const expectedOpaqueValueError = {
   _tag: "ViewServerRuntimeError",
@@ -87,7 +90,7 @@ describe("Opaque row wire values", () => {
         totalRows: 1,
       };
       const error = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof opaqueViewServer.topics, "opaque", typeof OpaqueRow.Type>(
+        viewServerDecodeLiveEvent(
           opaqueViewServer,
           "opaque",
           rawQuery,
@@ -105,12 +108,13 @@ describe("Opaque row wire values", () => {
 
   it.effect("rejects opaque Map aggregate values in grouped Snapshots and update Deltas", () =>
     Effect.gen(function* () {
-      const groupedQuery = yield* viewServerEncodeGroupedQuery(opaqueViewServer, "opaque", {
+      const groupedQuery = defineViewServerLiveEventQuery(opaqueViewServer, "opaque", {
         groupBy: ["id"],
         aggregates: {
           firstPayload: { aggFunc: "min", field: "payload" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(opaqueViewServer, "opaque", groupedQuery);
       const row = {
         id: "1",
         firstPayload: new Map([["venue", "xnys"]]),
@@ -165,11 +169,7 @@ describe("Opaque row wire values", () => {
         totalRows: 1,
       };
       const directDecodeError = yield* Effect.flip(
-        viewServerDecodeLiveEvent<
-          typeof opaqueViewServer.topics,
-          "opaque",
-          { readonly id: string; readonly firstPayload: object }
-        >(
+        viewServerDecodeLiveEvent(
           opaqueViewServer,
           "opaque",
           groupedQuery,
@@ -206,11 +206,12 @@ describe("Opaque row wire values", () => {
         totalRows: 1,
       });
 
-      const decoded = yield* viewServerDecodeLiveEvent<
-        typeof opaqueViewServer.topics,
+      const decoded = yield* viewServerDecodeLiveEvent(
+        opaqueViewServer,
         "opaque",
-        typeof OpaqueRow.Type
-      >(opaqueViewServer, "opaque", rawQuery, encoded);
+        rawQuery,
+        encoded,
+      );
       expect(decoded).toStrictEqual(encoded);
     }),
   );

--- a/packages/protocol/src/protocol-aggregate-row-codec.ts
+++ b/packages/protocol/src/protocol-aggregate-row-codec.ts
@@ -170,7 +170,8 @@ const decodeJsonAggregateValue = Effect.fn("ViewServerProtocol.row.aggregate.jso
 const aggregateFieldSchema = Effect.fn("ViewServerProtocol.row.aggregate.fieldSchema")(function* <
   const Topics extends TopicDefinitions,
 >(config: { readonly topics: Topics }, topic: Extract<keyof Topics, string>, field: string) {
-  const fieldSchema = config.topics[topic]!.schema.fields[field];
+  const fields = config.topics[topic]!.schema.fields;
+  const fieldSchema = Object.hasOwn(fields, field) ? fields[field] : undefined;
   if (fieldSchema === undefined) {
     return yield* Effect.fail(
       invalidRow(topic, `Aggregate references unknown field for topic ${topic}: ${field}`),

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -7,13 +7,12 @@ import type {
 } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import {
-  type ViewServerLooseWireEvent,
-  ViewServerLooseWireEventSchema,
   ViewServerTrustedWireEventSchema,
   type ViewServerTrustedWireEvent,
   ViewServerWireEventSchema,
   type ViewServerWireEvent,
 } from "./protocol-event-schema";
+import { materializeJsonFieldValue } from "./protocol-json-field-codec";
 import type { ViewServerEventQuery } from "./protocol-query-schema";
 import {
   compileViewServerGroupedRowContract,
@@ -175,7 +174,7 @@ const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValid
   config: { readonly topics: Topics },
   expectedTopic: Topic,
   rowContract: ViewServerEventRowContract,
-  wireEvent: ViewServerLooseWireEvent,
+  wireEvent: ViewServerWireEvent,
 ) {
   if (wireEvent.topic !== expectedTopic) {
     return yield* Effect.fail(
@@ -234,9 +233,12 @@ const decodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.decode")
   rowContract: ViewServerEventRowContract,
   event: ViewServerWireEvent,
 ) {
-  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerLooseWireEventSchema)(event).pipe(
-    Effect.mapError((error) => invalidRow(expectedTopic, `Invalid event: ${error.message}`)),
+  const materializedEvent = yield* materializeJsonFieldValue(event, (message) =>
+    invalidRow(expectedTopic, `Invalid event: ${message}`),
   );
+  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(
+    materializedEvent,
+  ).pipe(Effect.mapError((error) => invalidRow(expectedTopic, `Invalid event: ${error.message}`)));
   return yield* decodeValidatedLiveEvent<Topics, Topic, Row>(
     config,
     expectedTopic,

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -7,6 +7,8 @@ import type {
 } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import {
+  type ViewServerLooseWireEvent,
+  ViewServerLooseWireEventSchema,
   ViewServerTrustedWireEventSchema,
   type ViewServerTrustedWireEvent,
   ViewServerWireEventSchema,
@@ -173,7 +175,7 @@ const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValid
   config: { readonly topics: Topics },
   expectedTopic: Topic,
   rowContract: ViewServerEventRowContract,
-  wireEvent: ViewServerWireEvent,
+  wireEvent: ViewServerLooseWireEvent,
 ) {
   if (wireEvent.topic !== expectedTopic) {
     return yield* Effect.fail(
@@ -232,7 +234,7 @@ const decodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.decode")
   rowContract: ViewServerEventRowContract,
   event: ViewServerWireEvent,
 ) {
-  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(event).pipe(
+  const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerLooseWireEventSchema)(event).pipe(
     Effect.mapError((error) => invalidRow(expectedTopic, `Invalid event: ${error.message}`)),
   );
   return yield* decodeValidatedLiveEvent<Topics, Topic, Row>(

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -16,8 +16,8 @@ import { materializeJsonFieldValue } from "./protocol-json-field-codec";
 import type { ViewServerEventQuery } from "./protocol-query-schema";
 import {
   compileViewServerGroupedRowContract,
-  decodeGroupedRow,
-  decodeProjectedRow,
+  decodeMaterializedGroupedRow,
+  decodeMaterializedProjectedRow,
   decodeSystemRow,
   encodeGroupedRow,
   encodeProjectedRow,
@@ -190,9 +190,14 @@ const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValid
   if (wireEvent.type === "snapshot") {
     const rows = yield* Effect.forEach(wireEvent.rows, (row) => {
       if (rowContract._tag === "raw") {
-        return decodeProjectedRow(config, expectedTopic, rowContract.selectedFields, row);
+        return decodeMaterializedProjectedRow(
+          config,
+          expectedTopic,
+          rowContract.selectedFields,
+          row,
+        );
       }
-      return decodeGroupedRow(config, expectedTopic, rowContract.grouped, row);
+      return decodeMaterializedGroupedRow(config, expectedTopic, rowContract.grouped, row);
     });
     return typedLiveEvent<Row>({
       ...wireEvent,
@@ -207,8 +212,13 @@ const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValid
   for (const operation of wireEvent.operations) {
     if (operation.type === "insert" || operation.type === "update") {
       const row = yield* rowContract._tag === "raw"
-        ? decodeProjectedRow(config, expectedTopic, rowContract.selectedFields, operation.row)
-        : decodeGroupedRow(config, expectedTopic, rowContract.grouped, operation.row);
+        ? decodeMaterializedProjectedRow(
+            config,
+            expectedTopic,
+            rowContract.selectedFields,
+            operation.row,
+          )
+        : decodeMaterializedGroupedRow(config, expectedTopic, rowContract.grouped, operation.row);
       operations.push({
         ...operation,
         row,

--- a/packages/protocol/src/protocol-event-codec.ts
+++ b/packages/protocol/src/protocol-event-codec.ts
@@ -1,8 +1,12 @@
 import type {
   DeltaEvent,
+  ExactLiveQueryInputForTopic,
+  LiveQuery,
+  LiveQueryRow,
   SnapshotEvent,
   StatusEvent,
   TopicDefinitions,
+  TopicRow,
   ViewServerRuntimeError,
 } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
@@ -15,15 +19,11 @@ import {
 import { materializeJsonFieldValue } from "./protocol-json-field-codec";
 import type { ViewServerEventQuery } from "./protocol-query-schema";
 import {
-  compileViewServerGroupedRowContract,
-  decodeMaterializedGroupedRow,
-  decodeMaterializedProjectedRow,
+  compileViewServerEventRowPlan,
+  compileViewServerRuntimeEventRowPlan,
   decodeSystemRow,
-  encodeGroupedRow,
-  encodeProjectedRow,
   encodeSystemRow,
-  isViewServerEventGroupedQuery,
-  type ViewServerGroupedRowContract,
+  type ViewServerEventRowPlan,
 } from "./protocol-row-codec";
 
 export {
@@ -39,16 +39,6 @@ export type {
 
 export type ViewServerProtocolEvent<Row> = SnapshotEvent<Row> | DeltaEvent<Row> | StatusEvent;
 
-type ViewServerEventRowContract =
-  | {
-      readonly _tag: "grouped";
-      readonly grouped: ViewServerGroupedRowContract;
-    }
-  | {
-      readonly _tag: "raw";
-      readonly selectedFields: ReadonlySet<string>;
-    };
-
 export type ViewServerLiveEventCodec<Row> = {
   readonly decode: (
     event: ViewServerWireEvent,
@@ -57,22 +47,15 @@ export type ViewServerLiveEventCodec<Row> = {
     event: ViewServerTrustedWireEvent,
   ) => Effect.Effect<ViewServerProtocolEvent<Row>, ViewServerRuntimeError>;
   readonly encode: (
-    event: ViewServerProtocolEvent<object>,
+    event: ViewServerProtocolEvent<Row>,
   ) => Effect.Effect<ViewServerTrustedWireEvent, ViewServerRuntimeError>;
 };
 
-const compileViewServerEventRowContract = (
-  query: ViewServerEventQuery,
-): ViewServerEventRowContract =>
-  isViewServerEventGroupedQuery(query)
-    ? {
-        _tag: "grouped",
-        grouped: compileViewServerGroupedRowContract(query),
-      }
-    : {
-        _tag: "raw",
-        selectedFields: new Set(query.select),
-      };
+export type ViewServerRuntimeLiveEventEncoder = {
+  readonly encode: (
+    event: ViewServerProtocolEvent<object>,
+  ) => Effect.Effect<ViewServerTrustedWireEvent, ViewServerRuntimeError>;
+};
 
 const invalidRow = (topic: string, message: string): ViewServerRuntimeError => ({
   _tag: "ViewServerRuntimeError",
@@ -100,13 +83,14 @@ const encodeStatusEvent = Effect.fn("ViewServerProtocol.event.status.encode")(fu
   return yield* validateTrustedWireEvent(topic, wireEvent);
 });
 
-const encodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.encode")(function* <
+const encodeLiveEventWithPlan = Effect.fn("ViewServerProtocol.event.encode")(function* <
   const Topics extends TopicDefinitions,
+  Row extends object,
 >(
   config: { readonly topics: Topics },
   expectedTopic: Extract<keyof Topics, string>,
-  rowContract: ViewServerEventRowContract,
-  event: ViewServerProtocolEvent<object>,
+  rowPlan: ViewServerEventRowPlan<Row>,
+  event: ViewServerProtocolEvent<Row>,
 ) {
   if (event.topic !== expectedTopic) {
     return yield* Effect.fail(
@@ -120,12 +104,7 @@ const encodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.encode")
     return yield* encodeStatusEvent(expectedTopic, event);
   }
   if (event.type === "snapshot") {
-    const rows = yield* Effect.forEach(event.rows, (row) => {
-      if (rowContract._tag === "raw") {
-        return encodeProjectedRow(config, expectedTopic, rowContract.selectedFields, row);
-      }
-      return encodeGroupedRow(config, expectedTopic, rowContract.grouped, row);
-    });
+    const rows = yield* Effect.forEach(event.rows, rowPlan.encode);
     const wireEvent = {
       ...event,
       rows,
@@ -139,9 +118,7 @@ const encodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.encode")
   const operations: Array<WireDeltaOperation> = [];
   for (const operation of event.operations) {
     if (operation.type === "insert" || operation.type === "update") {
-      const row = yield* rowContract._tag === "raw"
-        ? encodeProjectedRow(config, expectedTopic, rowContract.selectedFields, operation.row)
-        : encodeGroupedRow(config, expectedTopic, rowContract.grouped, operation.row);
+      const row = yield* rowPlan.encode(operation.row);
       operations.push({
         ...operation,
         row,
@@ -157,25 +134,15 @@ const encodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.encode")
   return yield* validateTrustedWireEvent(expectedTopic, wireEvent);
 });
 
-function typedLiveEvent<Row>(
-  event: ViewServerProtocolEvent<Record<string, unknown>>,
-): ViewServerProtocolEvent<Row>;
-function typedLiveEvent(
-  event: ViewServerProtocolEvent<Record<string, unknown>>,
-): ViewServerProtocolEvent<Record<string, unknown>> {
-  return event;
-}
-
 const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValidated")(function* <
   const Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
-  Row,
+  Row extends object,
 >(
-  config: { readonly topics: Topics },
   expectedTopic: Topic,
-  rowContract: ViewServerEventRowContract,
+  rowPlan: ViewServerEventRowPlan<Row>,
   wireEvent: ViewServerWireEvent,
-) {
+): Effect.fn.Return<ViewServerProtocolEvent<Row>, ViewServerRuntimeError> {
   if (wireEvent.topic !== expectedTopic) {
     return yield* Effect.fail(
       invalidRow(
@@ -185,40 +152,23 @@ const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValid
     );
   }
   if (wireEvent.type === "status") {
-    return typedLiveEvent<Row>(wireEvent);
+    return wireEvent;
   }
   if (wireEvent.type === "snapshot") {
-    const rows = yield* Effect.forEach(wireEvent.rows, (row) => {
-      if (rowContract._tag === "raw") {
-        return decodeMaterializedProjectedRow(
-          config,
-          expectedTopic,
-          rowContract.selectedFields,
-          row,
-        );
-      }
-      return decodeMaterializedGroupedRow(config, expectedTopic, rowContract.grouped, row);
-    });
-    return typedLiveEvent<Row>({
+    const rows = yield* Effect.forEach(wireEvent.rows, rowPlan.decodeMaterialized);
+    return {
       ...wireEvent,
       rows,
-    });
+    };
   }
   type DecodedDeltaOperation = Extract<
-    ViewServerProtocolEvent<Record<string, unknown>>,
+    ViewServerProtocolEvent<Row>,
     { readonly type: "delta" }
   >["operations"][number];
   const operations: Array<DecodedDeltaOperation> = [];
   for (const operation of wireEvent.operations) {
     if (operation.type === "insert" || operation.type === "update") {
-      const row = yield* rowContract._tag === "raw"
-        ? decodeMaterializedProjectedRow(
-            config,
-            expectedTopic,
-            rowContract.selectedFields,
-            operation.row,
-          )
-        : decodeMaterializedGroupedRow(config, expectedTopic, rowContract.grouped, operation.row);
+      const row = yield* rowPlan.decodeMaterialized(operation.row);
       operations.push({
         ...operation,
         row,
@@ -227,88 +177,110 @@ const decodeValidatedLiveEvent = Effect.fn("ViewServerProtocol.event.decodeValid
       operations.push(operation);
     }
   }
-  return typedLiveEvent<Row>({
+  return {
     ...wireEvent,
     operations,
-  });
+  };
 });
 
 const decodeLiveEventWithContract = Effect.fn("ViewServerProtocol.event.decode")(function* <
   const Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
-  Row,
->(
-  config: { readonly topics: Topics },
-  expectedTopic: Topic,
-  rowContract: ViewServerEventRowContract,
-  event: ViewServerWireEvent,
-) {
+  Row extends object,
+>(expectedTopic: Topic, rowPlan: ViewServerEventRowPlan<Row>, event: ViewServerWireEvent) {
   const materializedEvent = yield* materializeJsonFieldValue(event, (message) =>
     invalidRow(expectedTopic, `Invalid event: ${message}`),
   );
   const wireEvent = yield* Schema.decodeUnknownEffect(ViewServerWireEventSchema)(
     materializedEvent,
   ).pipe(Effect.mapError((error) => invalidRow(expectedTopic, `Invalid event: ${error.message}`)));
-  return yield* decodeValidatedLiveEvent<Topics, Topic, Row>(
-    config,
-    expectedTopic,
-    rowContract,
-    wireEvent,
-  );
+  return yield* decodeValidatedLiveEvent<Topics, Topic, Row>(expectedTopic, rowPlan, wireEvent);
 });
+
+export const defineViewServerLiveEventQuery = <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
+>(
+  config: { readonly topics: Topics },
+  expectedTopic: Topic,
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+): Query => {
+  void config;
+  void expectedTopic;
+  return query;
+};
 
 export const compileViewServerLiveEventCodec = <
   const Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
-  Row = object,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
 >(
   config: { readonly topics: Topics },
   expectedTopic: Topic,
-  query: ViewServerEventQuery,
-): ViewServerLiveEventCodec<Row> => {
-  const rowContract = compileViewServerEventRowContract(query);
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+): ViewServerLiveEventCodec<LiveQueryRow<TopicRow<Topics, Topic>, Query>> => {
+  type Row = LiveQueryRow<TopicRow<Topics, Topic>, Query>;
+  const rowPlan = compileViewServerEventRowPlan(config, expectedTopic, query);
   const encode: ViewServerLiveEventCodec<Row>["encode"] = (event) =>
-    encodeLiveEventWithContract(config, expectedTopic, rowContract, event);
+    encodeLiveEventWithPlan(config, expectedTopic, rowPlan, event);
   const decode: ViewServerLiveEventCodec<Row>["decode"] = (event) =>
-    decodeLiveEventWithContract<Topics, Topic, Row>(config, expectedTopic, rowContract, event);
+    decodeLiveEventWithContract<Topics, Topic, Row>(expectedTopic, rowPlan, event);
   const decodeTrusted: ViewServerLiveEventCodec<Row>["decodeTrusted"] = (event) =>
-    decodeValidatedLiveEvent<Topics, Topic, Row>(config, expectedTopic, rowContract, event);
+    decodeValidatedLiveEvent<Topics, Topic, Row>(expectedTopic, rowPlan, event);
   return Object.freeze({ decode, decodeTrusted, encode });
 };
 
-export const viewServerEncodeLiveEvent = <const Topics extends TopicDefinitions>(
-  config: { readonly topics: Topics },
-  expectedTopic: Extract<keyof Topics, string>,
+export const compileViewServerRuntimeLiveEventEncoder = (
+  config: { readonly topics: TopicDefinitions },
+  expectedTopic: string,
   query: ViewServerEventQuery,
-  event: ViewServerProtocolEvent<object>,
+): ViewServerRuntimeLiveEventEncoder => {
+  const rowPlan = compileViewServerRuntimeEventRowPlan(config, expectedTopic, query);
+  const encode: ViewServerRuntimeLiveEventEncoder["encode"] = (event) =>
+    encodeLiveEventWithPlan(config, expectedTopic, rowPlan, event);
+  return Object.freeze({ encode });
+};
+
+export const viewServerEncodeLiveEvent = <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
+>(
+  config: { readonly topics: Topics },
+  expectedTopic: Topic,
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+  event: ViewServerProtocolEvent<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
 ): Effect.Effect<ViewServerTrustedWireEvent, ViewServerRuntimeError> =>
   compileViewServerLiveEventCodec(config, expectedTopic, query).encode(event);
 
 export const viewServerDecodeLiveEvent = <
   const Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
-  Row,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
 >(
   config: { readonly topics: Topics },
   expectedTopic: Topic,
-  query: ViewServerEventQuery,
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   event: ViewServerWireEvent,
-): Effect.Effect<ViewServerProtocolEvent<Row>, ViewServerRuntimeError> =>
-  compileViewServerLiveEventCodec<Topics, Topic, Row>(config, expectedTopic, query).decode(event);
+): Effect.Effect<
+  ViewServerProtocolEvent<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+  ViewServerRuntimeError
+> => compileViewServerLiveEventCodec(config, expectedTopic, query).decode(event);
 
 export const viewServerDecodeTrustedLiveEvent = <
   const Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
-  Row,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
 >(
   config: { readonly topics: Topics },
   expectedTopic: Topic,
-  query: ViewServerEventQuery,
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
   event: ViewServerTrustedWireEvent,
-): Effect.Effect<ViewServerProtocolEvent<Row>, ViewServerRuntimeError> =>
-  compileViewServerLiveEventCodec<Topics, Topic, Row>(config, expectedTopic, query).decodeTrusted(
-    event,
-  );
+): Effect.Effect<
+  ViewServerProtocolEvent<LiveQueryRow<TopicRow<Topics, Topic>, Query>>,
+  ViewServerRuntimeError
+> => compileViewServerLiveEventCodec(config, expectedTopic, query).decodeTrusted(event);
 
 export const encodeSystemLiveEvent = Effect.fn("ViewServerProtocol.system.event.encode")(function* <
   Row,

--- a/packages/protocol/src/protocol-event-schema.ts
+++ b/packages/protocol/src/protocol-event-schema.ts
@@ -8,10 +8,6 @@ export const ViewServerWireRowSchema: Schema.Codec<Schema.JsonObject> = Schema.R
 
 export type ViewServerWireRow = typeof ViewServerWireRowSchema.Type;
 
-export const ViewServerLooseWireRowSchema = Schema.Record(Schema.String, Schema.Unknown);
-
-export type ViewServerLooseWireRow = typeof ViewServerLooseWireRowSchema.Type;
-
 const SnapshotEventSchema = Schema.Struct({
   type: Schema.Literal("snapshot"),
   topic: Schema.String,
@@ -100,59 +96,6 @@ const StatusEventSchema: Schema.Codec<StatusEvent> = Schema.Union([
     message: Schema.optionalKey(Schema.String),
   }),
 ]);
-
-const LooseSnapshotEventSchema = Schema.Struct({
-  type: Schema.Literal("snapshot"),
-  topic: Schema.String,
-  queryId: Schema.String,
-  version: Schema.Number,
-  keys: Schema.Array(Schema.String),
-  rows: Schema.Array(ViewServerLooseWireRowSchema),
-  totalRows: Schema.Number,
-});
-
-const LooseDeltaOperationSchema = Schema.Union([
-  Schema.Struct({
-    type: Schema.Literal("insert"),
-    key: Schema.String,
-    row: ViewServerLooseWireRowSchema,
-    index: Schema.Number,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("update"),
-    key: Schema.String,
-    row: ViewServerLooseWireRowSchema,
-    index: Schema.Number,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("move"),
-    key: Schema.String,
-    fromIndex: Schema.Number,
-    toIndex: Schema.Number,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("remove"),
-    key: Schema.String,
-  }),
-]);
-
-const LooseDeltaEventSchema = Schema.Struct({
-  type: Schema.Literal("delta"),
-  topic: Schema.String,
-  queryId: Schema.String,
-  fromVersion: Schema.Number,
-  toVersion: Schema.Number,
-  operations: Schema.Array(LooseDeltaOperationSchema),
-  totalRows: Schema.Number,
-});
-
-export const ViewServerLooseWireEventSchema = Schema.Union([
-  LooseSnapshotEventSchema,
-  LooseDeltaEventSchema,
-  StatusEventSchema,
-]);
-
-export type ViewServerLooseWireEvent = typeof ViewServerLooseWireEventSchema.Type;
 
 export const ViewServerWireEventSchema = Schema.Union([
   SnapshotEventSchema,

--- a/packages/protocol/src/protocol-event-schema.ts
+++ b/packages/protocol/src/protocol-event-schema.ts
@@ -8,6 +8,10 @@ export const ViewServerWireRowSchema: Schema.Codec<Schema.JsonObject> = Schema.R
 
 export type ViewServerWireRow = typeof ViewServerWireRowSchema.Type;
 
+export const ViewServerLooseWireRowSchema = Schema.Record(Schema.String, Schema.Unknown);
+
+export type ViewServerLooseWireRow = typeof ViewServerLooseWireRowSchema.Type;
+
 const SnapshotEventSchema = Schema.Struct({
   type: Schema.Literal("snapshot"),
   topic: Schema.String,
@@ -96,6 +100,59 @@ const StatusEventSchema: Schema.Codec<StatusEvent> = Schema.Union([
     message: Schema.optionalKey(Schema.String),
   }),
 ]);
+
+const LooseSnapshotEventSchema = Schema.Struct({
+  type: Schema.Literal("snapshot"),
+  topic: Schema.String,
+  queryId: Schema.String,
+  version: Schema.Number,
+  keys: Schema.Array(Schema.String),
+  rows: Schema.Array(ViewServerLooseWireRowSchema),
+  totalRows: Schema.Number,
+});
+
+const LooseDeltaOperationSchema = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("insert"),
+    key: Schema.String,
+    row: ViewServerLooseWireRowSchema,
+    index: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("update"),
+    key: Schema.String,
+    row: ViewServerLooseWireRowSchema,
+    index: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("move"),
+    key: Schema.String,
+    fromIndex: Schema.Number,
+    toIndex: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("remove"),
+    key: Schema.String,
+  }),
+]);
+
+const LooseDeltaEventSchema = Schema.Struct({
+  type: Schema.Literal("delta"),
+  topic: Schema.String,
+  queryId: Schema.String,
+  fromVersion: Schema.Number,
+  toVersion: Schema.Number,
+  operations: Schema.Array(LooseDeltaOperationSchema),
+  totalRows: Schema.Number,
+});
+
+export const ViewServerLooseWireEventSchema = Schema.Union([
+  LooseSnapshotEventSchema,
+  LooseDeltaEventSchema,
+  StatusEventSchema,
+]);
+
+export type ViewServerLooseWireEvent = typeof ViewServerLooseWireEventSchema.Type;
 
 export const ViewServerWireEventSchema = Schema.Union([
   SnapshotEventSchema,

--- a/packages/protocol/src/protocol-json-field-codec.ts
+++ b/packages/protocol/src/protocol-json-field-codec.ts
@@ -38,6 +38,7 @@ type TopicNamedJsonFieldEncodeContext<E> = TopicNamedJsonFieldCodecContext<E> & 
 };
 
 type CompiledJsonFieldCodec<Row> = {
+  readonly accepts: (value: unknown) => boolean;
   readonly decode: (value: unknown) => Effect.Effect<Row, Schema.SchemaError>;
   readonly encode: (value: unknown) => Effect.Effect<Schema.Json, Schema.SchemaError>;
 };
@@ -54,6 +55,7 @@ function compiledJsonFieldCodec(schema: JsonFieldSchema): CompiledJsonFieldCodec
   }
   const codec = Schema.toCodecJson(schema);
   const compiled: CompiledJsonFieldCodec<unknown> = {
+    accepts: Schema.is(schema),
     decode: Schema.decodeUnknownEffect(codec),
     encode: Schema.encodeUnknownEffect(codec),
   };
@@ -75,9 +77,17 @@ export const encodeJsonFieldValue = Effect.fn("ViewServerProtocol.jsonField.enco
   value: unknown,
   errors: JsonFieldCodecErrors<E>,
 ) {
-  const encoded = yield* compiledJsonFieldCodec(schema)
-    .encode(value)
-    .pipe(Effect.mapError((error) => errors.invalid(error.message)));
+  const compiled = compiledJsonFieldCodec(schema);
+  const encoded = yield* compiled.encode(value).pipe(
+    Effect.catch((error) => {
+      if (!compiled.accepts(value)) {
+        return Effect.fail(errors.invalid(error.message));
+      }
+      return materializeJsonFieldValue(value, errors.notJsonSafe).pipe(
+        Effect.andThen(Effect.fail(errors.invalid(error.message))),
+      );
+    }),
+  );
   return yield* materializeJsonFieldValue(encoded, errors.notJsonSafe);
 });
 

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -1,5 +1,14 @@
-import type { TopicDefinitions, ViewServerRuntimeError } from "@effect-view-server/config";
-import { Effect, Schema, SchemaAST } from "effect";
+import {
+  viewServerSchemaFieldMetadata,
+  type ExactLiveQueryInputForTopic,
+  type LiveQuery,
+  type LiveQueryRow,
+  type TopicDefinitions,
+  type TopicRow,
+  type ViewServerRuntimeError,
+} from "@effect-view-server/config";
+import { Effect, Function, Result, Schema, SchemaAST } from "effect";
+import * as BigDecimal from "effect/BigDecimal";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
 import { type ViewServerWireRow, ViewServerWireRowSchema } from "./protocol-event-schema";
 import {
@@ -12,6 +21,7 @@ import {
 import type {
   ViewServerEventGroupedQuery,
   ViewServerEventQuery,
+  ViewServerEventRawQuery,
   ViewServerWireAggregate,
 } from "./protocol-query-schema";
 
@@ -19,6 +29,13 @@ const invalidRow = (topic: string, message: string): ViewServerRuntimeError => (
   _tag: "ViewServerRuntimeError",
   code: "InvalidRow",
   message,
+  topic,
+});
+
+const invalidRowContract = (topic: string): ViewServerRuntimeError => ({
+  _tag: "ViewServerRuntimeError",
+  code: "InvalidQuery",
+  message: `Could not compile the live-event row contract for topic ${topic}`,
   topic,
 });
 
@@ -44,9 +61,30 @@ const defineEnumerableOwn = <Value>(
 const rowFieldIsOptional = (schema: Schema.Codec<unknown, unknown, never, never>): boolean =>
   SchemaAST.isOptional(schema.ast);
 
+const ownRowFieldSchema = (
+  fields: Readonly<Record<string, Schema.Codec<unknown, unknown, never, never>>>,
+  field: string,
+): Schema.Codec<unknown, unknown, never, never> | undefined =>
+  Object.hasOwn(fields, field) ? fields[field] : undefined;
+
 type RowKind = "row" | "grouped row";
 
 type ViewServerUntrustedWireRow = Readonly<Record<string, unknown>>;
+
+type DecodedRowProof<Row extends object> = (row: object) => row is Row;
+
+type DecodedFieldProof = {
+  readonly field: string;
+  readonly isValue: (value: unknown) => boolean;
+  readonly required: boolean;
+};
+
+export type ViewServerEventRowPlan<Row extends object> = {
+  readonly decodeMaterialized: (
+    row: ViewServerWireRow,
+  ) => Effect.Effect<Row, ViewServerRuntimeError>;
+  readonly encode: (row: Row) => Effect.Effect<ViewServerWireRow, ViewServerRuntimeError>;
+};
 
 type InspectedRow = {
   readonly entries: ReadonlyArray<readonly [field: string, value: unknown]>;
@@ -132,6 +170,127 @@ export type ViewServerGroupedRowContract = {
   readonly groupFields: ReadonlySet<string>;
 };
 
+type ViewServerProjectedRowContract = {
+  readonly fieldSchemas: ReadonlyMap<
+    string,
+    Schema.Codec<unknown, unknown, never, never> | undefined
+  >;
+  readonly selectedFields: ReadonlySet<string>;
+};
+
+type ViewServerCompiledGroupedRowContract = ViewServerGroupedRowContract & {
+  readonly groupFieldSchemas: ReadonlyMap<
+    string,
+    Schema.Codec<unknown, unknown, never, never> | undefined
+  >;
+};
+
+const compileProjectedRowContract = (
+  fields: Readonly<Record<string, Schema.Codec<unknown, unknown, never, never>>>,
+  selectedFields: ReadonlySet<string>,
+): ViewServerProjectedRowContract => ({
+  fieldSchemas: new Map(
+    [...selectedFields].map((field) => [field, ownRowFieldSchema(fields, field)]),
+  ),
+  selectedFields,
+});
+
+const compileGroupedRowContractForTopic = (
+  fields: Readonly<Record<string, Schema.Codec<unknown, unknown, never, never>>>,
+  contract: ViewServerGroupedRowContract,
+): ViewServerCompiledGroupedRowContract => ({
+  ...contract,
+  groupFieldSchemas: new Map(
+    [...contract.groupFields].map((field) => [field, ownRowFieldSchema(fields, field)]),
+  ),
+});
+
+const compileDecodedRowProof = <Row extends object>(
+  fields: ReadonlyArray<DecodedFieldProof>,
+): DecodedRowProof<Row> => {
+  const fieldNames = new Set(fields.map((field) => field.field));
+  return (row): row is Row =>
+    fields.every((field) =>
+      Object.hasOwn(row, field.field)
+        ? field.isValue(Reflect.get(row, field.field))
+        : !field.required,
+    ) && Object.keys(row).every((field) => fieldNames.has(field));
+};
+
+const decodedTopicFieldProof = (
+  field: string,
+  schema: Schema.Codec<unknown, unknown, never, never> | undefined,
+): DecodedFieldProof | undefined =>
+  schema === undefined
+    ? undefined
+    : {
+        field,
+        isValue: Schema.is(schema),
+        required: !rowFieldIsOptional(schema),
+      };
+
+const decodedAggregateValueProof = (
+  fields: Readonly<Record<string, Schema.Codec<unknown, unknown, never, never>>>,
+  aggregate: ViewServerWireAggregate | undefined,
+): ((value: unknown) => boolean) | undefined => {
+  if (aggregate === undefined) {
+    return undefined;
+  }
+  if (aggregate.aggFunc === "count" || aggregate.aggFunc === "countDistinct") {
+    return (value) => typeof value === "bigint";
+  }
+  if (aggregate.aggFunc === "avg") {
+    return BigDecimal.isBigDecimal;
+  }
+  const fieldSchema = ownRowFieldSchema(fields, aggregate.field);
+  if (fieldSchema === undefined) {
+    return undefined;
+  }
+  if (aggregate.aggFunc === "sum") {
+    return viewServerSchemaFieldMetadata(fieldSchema).sumResultKind === "bigint"
+      ? (value) => typeof value === "bigint"
+      : BigDecimal.isBigDecimal;
+  }
+  const isFieldValue = Schema.is(fieldSchema);
+  return (aggregate.aggFunc === "min" || aggregate.aggFunc === "max") &&
+    SchemaAST.isOptional(fieldSchema.ast)
+    ? (value) => value === undefined || isFieldValue(value)
+    : isFieldValue;
+};
+
+const compileProjectedRowProof = <Row extends object>(
+  contract: ViewServerProjectedRowContract,
+): DecodedRowProof<Row> => {
+  const fields: Array<DecodedFieldProof> = [];
+  for (const [field, schema] of contract.fieldSchemas) {
+    const proof = decodedTopicFieldProof(field, schema);
+    if (proof !== undefined) {
+      fields.push(proof);
+    }
+  }
+  return compileDecodedRowProof<Row>(fields);
+};
+
+const compileGroupedRowProof = <Row extends object>(
+  topicFields: Readonly<Record<string, Schema.Codec<unknown, unknown, never, never>>>,
+  contract: ViewServerCompiledGroupedRowContract,
+): DecodedRowProof<Row> => {
+  const fields: Array<DecodedFieldProof> = [];
+  for (const [field, schema] of contract.groupFieldSchemas) {
+    const proof = decodedTopicFieldProof(field, schema);
+    if (proof !== undefined) {
+      fields.push(proof);
+    }
+  }
+  for (const alias of contract.aggregateAliases) {
+    const isValue = decodedAggregateValueProof(topicFields, contract.aggregates[alias]);
+    if (isValue !== undefined) {
+      fields.push({ field: alias, isValue, required: true });
+    }
+  }
+  return compileDecodedRowProof<Row>(fields);
+};
+
 const compileViewServerAggregate = (
   aggregate: ViewServerWireAggregate | undefined,
 ): ViewServerWireAggregate | undefined =>
@@ -162,19 +321,19 @@ export const compileViewServerGroupedRowContract = (
   };
 };
 
-export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.encode")(function* <
-  const Topics extends TopicDefinitions,
->(
-  config: { readonly topics: Topics },
-  topic: Extract<keyof Topics, string>,
-  selectedFields: ReadonlySet<string>,
-  row: object,
-) {
-  const topicSchema = config.topics[topic]!.schema;
+const encodeProjectedRowWithContract = Effect.fn(
+  "ViewServerProtocol.row.project.encodeWithContract",
+)(function* (topic: string, contract: ViewServerProjectedRowContract, row: object) {
+  const { fieldSchemas, selectedFields } = contract;
   const output: Record<string, Schema.Json> = {};
   const inspected = yield* inspectRow(topic, "row", row);
   for (const field of selectedFields) {
-    const fieldSchema = topicSchema.fields[field]!;
+    const fieldSchema = fieldSchemas.get(field);
+    if (fieldSchema === undefined) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Selected row field does not exist for topic ${topic}: ${field}`),
+      );
+    }
     if (!inspected.fields.has(field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing row field for topic ${topic}: ${field}`),
@@ -187,7 +346,12 @@ export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.enco
         invalidRow(topic, `Unexpected row field for topic ${topic}: ${field}`),
       );
     }
-    const fieldSchema = topicSchema.fields[field]!;
+    const fieldSchema = fieldSchemas.get(field);
+    if (fieldSchema === undefined) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Selected row field does not exist for topic ${topic}: ${field}`),
+      );
+    }
     const encoded = yield* encodeTopicNamedJsonFieldValue(
       topic,
       field,
@@ -200,17 +364,34 @@ export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.enco
   return output;
 });
 
-export const decodeMaterializedProjectedRow = Effect.fn(
-  "ViewServerProtocol.row.project.decodeMaterialized",
-)(function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
+export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.encode")(function* <
+  const Topics extends TopicDefinitions,
+>(
   config: { readonly topics: Topics },
-  topic: Topic,
+  topic: Extract<keyof Topics, string>,
   selectedFields: ReadonlySet<string>,
-  row: ViewServerWireRow,
+  row: object,
 ) {
+  const contract = compileProjectedRowContract(config.topics[topic]!.schema.fields, selectedFields);
+  return yield* encodeProjectedRowWithContract(topic, contract, row);
+});
+
+const decodeMaterializedProjectedRow = Effect.fn(
+  "ViewServerProtocol.row.project.decodeMaterialized",
+)(function* (
+  topic: string,
+  contract: ViewServerProjectedRowContract,
+  row: ViewServerWireRow,
+): Effect.fn.Return<object, ViewServerRuntimeError> {
+  const { fieldSchemas, selectedFields } = contract;
   const output: Record<string, unknown> = {};
   for (const field of selectedFields) {
-    const fieldSchema = config.topics[topic]!.schema.fields[field]!;
+    const fieldSchema = fieldSchemas.get(field);
+    if (fieldSchema === undefined) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Selected row field does not exist for topic ${topic}: ${field}`),
+      );
+    }
     if (!Object.hasOwn(row, field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing row field for topic ${topic}: ${field}`),
@@ -223,7 +404,12 @@ export const decodeMaterializedProjectedRow = Effect.fn(
         invalidRow(topic, `Unexpected row field for topic ${topic}: ${field}`),
       );
     }
-    const fieldSchema = config.topics[topic]!.schema.fields[field]!;
+    const fieldSchema = fieldSchemas.get(field);
+    if (fieldSchema === undefined) {
+      return yield* Effect.fail(
+        invalidRow(topic, `Selected row field does not exist for topic ${topic}: ${field}`),
+      );
+    }
     const decoded = yield* decodeMaterializedJsonFieldValue(fieldSchema, value, {
       invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
     });
@@ -242,8 +428,74 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
   row: ViewServerUntrustedWireRow,
 ) {
   const materialized = yield* materializeWireRow(topic, "row", row);
-  return yield* decodeMaterializedProjectedRow(config, topic, selectedFields, materialized);
+  const contract = compileProjectedRowContract(config.topics[topic]!.schema.fields, selectedFields);
+  return yield* decodeMaterializedProjectedRow(topic, contract, materialized);
 });
+
+const encodeGroupedRowWithContract = Effect.fn("ViewServerProtocol.row.grouped.encodeWithContract")(
+  function* <const Topics extends TopicDefinitions>(
+    config: { readonly topics: Topics },
+    topic: Extract<keyof Topics, string>,
+    contract: ViewServerCompiledGroupedRowContract,
+    row: object,
+  ) {
+    const { aggregateAliases, aggregates, groupFields, groupFieldSchemas } = contract;
+    const output: Record<string, Schema.Json> = {};
+    const inspected = yield* inspectRow(topic, "grouped row", row);
+    for (const field of groupFields) {
+      const fieldSchema = groupFieldSchemas.get(field);
+      if (fieldSchema === undefined) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Grouped row field does not exist for topic ${topic}: ${field}`),
+        );
+      }
+      if (!inspected.fields.has(field) && !rowFieldIsOptional(fieldSchema)) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
+        );
+      }
+    }
+    for (const alias of aggregateAliases) {
+      if (!inspected.fields.has(alias)) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
+        );
+      }
+    }
+    for (const [field, value] of inspected.entries) {
+      if (groupFields.has(field)) {
+        const fieldSchema = groupFieldSchemas.get(field);
+        if (fieldSchema === undefined) {
+          return yield* Effect.fail(
+            invalidRow(topic, `Grouped row field does not exist for topic ${topic}: ${field}`),
+          );
+        }
+        const encoded = yield* encodeTopicNamedJsonFieldValue(
+          topic,
+          field,
+          fieldSchema,
+          value,
+          rowJsonFieldContext,
+        );
+        defineEnumerableOwn(output, field, encoded);
+      } else if (aggregateAliases.has(field)) {
+        const aggregate = aggregates[field];
+        if (aggregate === undefined) {
+          return yield* Effect.fail(
+            invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
+          );
+        }
+        const encoded = yield* encodeAggregateValue(config, topic, field, aggregate, value);
+        defineEnumerableOwn(output, field, encoded);
+      } else {
+        return yield* Effect.fail(
+          invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
+        );
+      }
+    }
+    return output;
+  },
+);
 
 export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode")(function* <
   const Topics extends TopicDefinitions,
@@ -253,104 +505,69 @@ export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode
   contract: ViewServerGroupedRowContract,
   row: object,
 ) {
-  const topicSchema = config.topics[topic]!.schema;
-  const { aggregateAliases, aggregates, groupFields } = contract;
-  const output: Record<string, Schema.Json> = {};
-  const inspected = yield* inspectRow(topic, "grouped row", row);
-  for (const field of groupFields) {
-    const fieldSchema = topicSchema.fields[field]!;
-    if (!inspected.fields.has(field) && !rowFieldIsOptional(fieldSchema)) {
-      return yield* Effect.fail(
-        invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
-      );
-    }
-  }
-  for (const alias of aggregateAliases) {
-    if (!inspected.fields.has(alias)) {
-      return yield* Effect.fail(
-        invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
-      );
-    }
-  }
-  for (const [field, value] of inspected.entries) {
-    if (groupFields.has(field)) {
-      const fieldSchema = topicSchema.fields[field]!;
-      const encoded = yield* encodeTopicNamedJsonFieldValue(
-        topic,
-        field,
-        fieldSchema,
-        value,
-        rowJsonFieldContext,
-      );
-      defineEnumerableOwn(output, field, encoded);
-    } else if (aggregateAliases.has(field)) {
-      const aggregate = aggregates[field];
-      if (aggregate === undefined) {
-        return yield* Effect.fail(
-          invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
-        );
-      }
-      const encoded = yield* encodeAggregateValue(config, topic, field, aggregate, value);
-      defineEnumerableOwn(output, field, encoded);
-    } else {
-      return yield* Effect.fail(
-        invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
-      );
-    }
-  }
-  return output;
+  const compiled = compileGroupedRowContractForTopic(config.topics[topic]!.schema.fields, contract);
+  return yield* encodeGroupedRowWithContract(config, topic, compiled, row);
 });
 
-export const decodeMaterializedGroupedRow = Effect.fn(
-  "ViewServerProtocol.row.grouped.decodeMaterialized",
-)(function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
-  config: { readonly topics: Topics },
-  topic: Topic,
-  contract: ViewServerGroupedRowContract,
-  row: ViewServerWireRow,
-) {
-  const topicSchema = config.topics[topic]!.schema;
-  const { aggregateAliases, aggregates, groupFields } = contract;
-  const output: Record<string, unknown> = {};
-  for (const field of groupFields) {
-    const fieldSchema = topicSchema.fields[field]!;
-    if (!Object.hasOwn(row, field) && !rowFieldIsOptional(fieldSchema)) {
-      return yield* Effect.fail(
-        invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
-      );
-    }
-  }
-  for (const alias of aggregateAliases) {
-    if (!Object.hasOwn(row, alias)) {
-      return yield* Effect.fail(
-        invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
-      );
-    }
-  }
-  for (const [field, value] of Object.entries(row)) {
-    if (groupFields.has(field)) {
-      const fieldSchema = topicSchema.fields[field]!;
-      const decoded = yield* decodeMaterializedJsonFieldValue(fieldSchema, value, {
-        invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
-      });
-      defineEnumerableOwn(output, field, decoded);
-    } else if (aggregateAliases.has(field)) {
-      const aggregate = aggregates[field];
-      if (aggregate === undefined) {
+const decodeMaterializedGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decodeMaterialized")(
+  function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
+    config: { readonly topics: Topics },
+    topic: Topic,
+    contract: ViewServerCompiledGroupedRowContract,
+    row: ViewServerWireRow,
+  ): Effect.fn.Return<object, ViewServerRuntimeError> {
+    const { aggregateAliases, aggregates, groupFields, groupFieldSchemas } = contract;
+    const output: Record<string, unknown> = {};
+    for (const field of groupFields) {
+      const fieldSchema = groupFieldSchemas.get(field);
+      if (fieldSchema === undefined) {
         return yield* Effect.fail(
-          invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
+          invalidRow(topic, `Grouped row field does not exist for topic ${topic}: ${field}`),
         );
       }
-      const decoded = yield* decodeAggregateValue(config, topic, field, aggregate, value);
-      defineEnumerableOwn(output, field, decoded);
-    } else {
-      return yield* Effect.fail(
-        invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
-      );
+      if (!Object.hasOwn(row, field) && !rowFieldIsOptional(fieldSchema)) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
+        );
+      }
     }
-  }
-  return output;
-});
+    for (const alias of aggregateAliases) {
+      if (!Object.hasOwn(row, alias)) {
+        return yield* Effect.fail(
+          invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
+        );
+      }
+    }
+    for (const [field, value] of Object.entries(row)) {
+      if (groupFields.has(field)) {
+        const fieldSchema = groupFieldSchemas.get(field);
+        if (fieldSchema === undefined) {
+          return yield* Effect.fail(
+            invalidRow(topic, `Grouped row field does not exist for topic ${topic}: ${field}`),
+          );
+        }
+        const decoded = yield* decodeMaterializedJsonFieldValue(fieldSchema, value, {
+          invalid: (message) => invalidRow(topic, `Invalid field ${field}: ${message}`),
+        });
+        defineEnumerableOwn(output, field, decoded);
+      } else if (aggregateAliases.has(field)) {
+        const aggregate = aggregates[field];
+        if (aggregate === undefined) {
+          return yield* Effect.fail(
+            invalidRow(topic, `Missing grouped aggregate definition for topic ${topic}: ${field}`),
+          );
+        }
+        const decoded = yield* decodeAggregateValue(config, topic, field, aggregate, value);
+        defineEnumerableOwn(output, field, decoded);
+      } else {
+        return yield* Effect.fail(
+          invalidRow(topic, `Unexpected grouped row field for topic ${topic}: ${field}`),
+        );
+      }
+    }
+    return output;
+  },
+);
 
 export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode")(function* <
   const Topics extends TopicDefinitions,
@@ -362,8 +579,105 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   row: ViewServerUntrustedWireRow,
 ) {
   const materialized = yield* materializeWireRow(topic, "grouped row", row);
-  return yield* decodeMaterializedGroupedRow(config, topic, contract, materialized);
+  const compiled = compileGroupedRowContractForTopic(config.topics[topic]!.schema.fields, contract);
+  return yield* decodeMaterializedGroupedRow(config, topic, compiled, materialized);
 });
+
+const compileProjectedEventRowPlan = <ResultRow extends object>(
+  config: { readonly topics: TopicDefinitions },
+  topic: string,
+  query: ViewServerEventRawQuery,
+): ViewServerEventRowPlan<ResultRow> => {
+  const selectedFields = new Set(query.select);
+  const contract = compileProjectedRowContract(config.topics[topic]!.schema.fields, selectedFields);
+  const proof = compileProjectedRowProof<ResultRow>(contract);
+  const proofError = invalidRow(
+    topic,
+    `Decoded row does not satisfy its compiled contract for topic ${topic}`,
+  );
+  const proofFailure = Function.constant(proofError);
+  const decodeMaterialized: ViewServerEventRowPlan<ResultRow>["decodeMaterialized"] = (row) =>
+    decodeMaterializedProjectedRow(topic, contract, row).pipe(
+      Effect.filterOrFail(proof, proofFailure),
+    );
+  const encode: ViewServerEventRowPlan<ResultRow>["encode"] = (row) =>
+    encodeProjectedRowWithContract(topic, contract, row);
+  return Object.freeze({ decodeMaterialized, encode });
+};
+
+const compileGroupedEventRowPlan = <ResultRow extends object>(
+  config: { readonly topics: TopicDefinitions },
+  topic: string,
+  query: ViewServerEventGroupedQuery,
+): ViewServerEventRowPlan<ResultRow> => {
+  const contract = compileGroupedRowContractForTopic(
+    config.topics[topic]!.schema.fields,
+    compileViewServerGroupedRowContract(query),
+  );
+  const proof = compileGroupedRowProof<ResultRow>(config.topics[topic]!.schema.fields, contract);
+  const proofError = invalidRow(
+    topic,
+    `Decoded grouped row does not satisfy its compiled contract for topic ${topic}`,
+  );
+  const proofFailure = Function.constant(proofError);
+  const decodeMaterialized: ViewServerEventRowPlan<ResultRow>["decodeMaterialized"] = (row) =>
+    decodeMaterializedGroupedRow(config, topic, contract, row).pipe(
+      Effect.filterOrFail(proof, proofFailure),
+    );
+  const encode: ViewServerEventRowPlan<ResultRow>["encode"] = (row) =>
+    encodeGroupedRowWithContract(config, topic, contract, row);
+  return Object.freeze({ decodeMaterialized, encode });
+};
+
+const failedEventRowPlan = <Row extends object>(
+  error: ViewServerRuntimeError,
+): ViewServerEventRowPlan<Row> =>
+  Object.freeze({
+    decodeMaterialized: Function.constant(Effect.fail(error)),
+    encode: Function.constant(Effect.fail(error)),
+  });
+
+const compileRuntimeEventRowPlan = <Row extends object>(
+  config: { readonly topics: TopicDefinitions },
+  topic: string,
+  query: ViewServerEventQuery,
+): ViewServerEventRowPlan<Row> =>
+  Result.match(
+    Result.try({
+      try: () =>
+        isViewServerEventGroupedQuery(query)
+          ? compileGroupedEventRowPlan<Row>(config, topic, query)
+          : compileProjectedEventRowPlan<Row>(config, topic, query),
+      catch: () => invalidRowContract(topic),
+    }),
+    {
+      onFailure: failedEventRowPlan<Row>,
+      onSuccess: Function.identity,
+    },
+  );
+
+export function compileViewServerEventRowPlan<
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  const Query extends LiveQuery<TopicRow<Topics, Topic>>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+): ViewServerEventRowPlan<LiveQueryRow<TopicRow<Topics, Topic>, Query>>;
+export function compileViewServerEventRowPlan(
+  config: { readonly topics: TopicDefinitions },
+  topic: string,
+  query: ViewServerEventQuery,
+): ViewServerEventRowPlan<object> {
+  return compileRuntimeEventRowPlan(config, topic, query);
+}
+
+export const compileViewServerRuntimeEventRowPlan = (
+  config: { readonly topics: TopicDefinitions },
+  topic: string,
+  query: ViewServerEventQuery,
+): ViewServerEventRowPlan<object> => compileRuntimeEventRowPlan(config, topic, query);
 
 export const encodeSystemRow = Effect.fn("ViewServerProtocol.system.row.encode")(function* <Row>(
   topic: string,

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -1,7 +1,7 @@
 import type { TopicDefinitions, ViewServerRuntimeError } from "@effect-view-server/config";
 import { Effect, Schema, SchemaAST } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
-import { ViewServerWireRowSchema, type ViewServerWireRow } from "./protocol-event-schema";
+import { type ViewServerLooseWireRow, ViewServerWireRowSchema } from "./protocol-event-schema";
 import {
   decodeJsonFieldValue,
   decodeMaterializedJsonFieldValue,
@@ -107,7 +107,7 @@ const isViewServerWireRow = Schema.is(ViewServerWireRowSchema);
 const materializeWireRow = Effect.fn("ViewServerProtocol.row.materializeWire")(function* (
   topic: string,
   kind: RowKind,
-  row: ViewServerWireRow,
+  row: ViewServerLooseWireRow,
 ) {
   const materialized = yield* materializeJsonFieldValue(row, (message) =>
     invalidRow(topic, `Invalid ${kind} for topic ${topic}: ${message}`),
@@ -205,7 +205,7 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
   config: { readonly topics: Topics },
   topic: Topic,
   selectedFields: ReadonlySet<string>,
-  row: ViewServerWireRow,
+  row: ViewServerLooseWireRow,
 ) {
   const output: Record<string, unknown> = {};
   const materialized = yield* materializeWireRow(topic, "row", row);
@@ -295,7 +295,7 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   config: { readonly topics: Topics },
   topic: Topic,
   contract: ViewServerGroupedRowContract,
-  row: ViewServerWireRow,
+  row: ViewServerLooseWireRow,
 ) {
   const topicSchema = config.topics[topic]!.schema;
   const { aggregateAliases, aggregates, groupFields } = contract;
@@ -358,7 +358,7 @@ export const encodeSystemRow = Effect.fn("ViewServerProtocol.system.row.encode")
 export const decodeSystemRow = Effect.fn("ViewServerProtocol.system.row.decode")(function* <Row>(
   topic: string,
   schema: Schema.Codec<Row, unknown, never, never>,
-  row: ViewServerWireRow,
+  row: ViewServerLooseWireRow,
 ) {
   return yield* decodeJsonFieldValue(schema, row, {
     invalid: (message) => invalidRow(topic, `Invalid system row: ${message}`),

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -1,7 +1,7 @@
 import type { TopicDefinitions, ViewServerRuntimeError } from "@effect-view-server/config";
 import { Effect, Schema, SchemaAST } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
-import { type ViewServerLooseWireRow, ViewServerWireRowSchema } from "./protocol-event-schema";
+import { ViewServerWireRowSchema } from "./protocol-event-schema";
 import {
   decodeJsonFieldValue,
   decodeMaterializedJsonFieldValue,
@@ -45,6 +45,8 @@ const rowFieldIsOptional = (schema: Schema.Codec<unknown, unknown, never, never>
   SchemaAST.isOptional(schema.ast);
 
 type RowKind = "row" | "grouped row";
+
+type ViewServerUntrustedWireRow = Readonly<Record<string, unknown>>;
 
 type InspectedRow = {
   readonly entries: ReadonlyArray<readonly [field: string, value: unknown]>;
@@ -107,7 +109,7 @@ const isViewServerWireRow = Schema.is(ViewServerWireRowSchema);
 const materializeWireRow = Effect.fn("ViewServerProtocol.row.materializeWire")(function* (
   topic: string,
   kind: RowKind,
-  row: ViewServerLooseWireRow,
+  row: ViewServerUntrustedWireRow,
 ) {
   const materialized = yield* materializeJsonFieldValue(row, (message) =>
     invalidRow(topic, `Invalid ${kind} for topic ${topic}: ${message}`),
@@ -205,7 +207,7 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
   config: { readonly topics: Topics },
   topic: Topic,
   selectedFields: ReadonlySet<string>,
-  row: ViewServerLooseWireRow,
+  row: ViewServerUntrustedWireRow,
 ) {
   const output: Record<string, unknown> = {};
   const materialized = yield* materializeWireRow(topic, "row", row);
@@ -295,7 +297,7 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
   config: { readonly topics: Topics },
   topic: Topic,
   contract: ViewServerGroupedRowContract,
-  row: ViewServerLooseWireRow,
+  row: ViewServerUntrustedWireRow,
 ) {
   const topicSchema = config.topics[topic]!.schema;
   const { aggregateAliases, aggregates, groupFields } = contract;
@@ -358,7 +360,7 @@ export const encodeSystemRow = Effect.fn("ViewServerProtocol.system.row.encode")
 export const decodeSystemRow = Effect.fn("ViewServerProtocol.system.row.decode")(function* <Row>(
   topic: string,
   schema: Schema.Codec<Row, unknown, never, never>,
-  row: ViewServerLooseWireRow,
+  row: ViewServerUntrustedWireRow,
 ) {
   return yield* decodeJsonFieldValue(schema, row, {
     invalid: (message) => invalidRow(topic, `Invalid system row: ${message}`),

--- a/packages/protocol/src/protocol-row-codec.ts
+++ b/packages/protocol/src/protocol-row-codec.ts
@@ -1,7 +1,7 @@
 import type { TopicDefinitions, ViewServerRuntimeError } from "@effect-view-server/config";
 import { Effect, Schema, SchemaAST } from "effect";
 import { decodeAggregateValue, encodeAggregateValue } from "./protocol-aggregate-row-codec";
-import { ViewServerWireRowSchema } from "./protocol-event-schema";
+import { type ViewServerWireRow, ViewServerWireRowSchema } from "./protocol-event-schema";
 import {
   decodeJsonFieldValue,
   decodeMaterializedJsonFieldValue,
@@ -200,26 +200,24 @@ export const encodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.enco
   return output;
 });
 
-export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.decode")(function* <
-  const Topics extends TopicDefinitions,
-  Topic extends Extract<keyof Topics, string>,
->(
+export const decodeMaterializedProjectedRow = Effect.fn(
+  "ViewServerProtocol.row.project.decodeMaterialized",
+)(function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
   config: { readonly topics: Topics },
   topic: Topic,
   selectedFields: ReadonlySet<string>,
-  row: ViewServerUntrustedWireRow,
+  row: ViewServerWireRow,
 ) {
   const output: Record<string, unknown> = {};
-  const materialized = yield* materializeWireRow(topic, "row", row);
   for (const field of selectedFields) {
     const fieldSchema = config.topics[topic]!.schema.fields[field]!;
-    if (!Object.hasOwn(materialized, field) && !rowFieldIsOptional(fieldSchema)) {
+    if (!Object.hasOwn(row, field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing row field for topic ${topic}: ${field}`),
       );
     }
   }
-  for (const [field, value] of Object.entries(materialized)) {
+  for (const [field, value] of Object.entries(row)) {
     if (!selectedFields.has(field)) {
       return yield* Effect.fail(
         invalidRow(topic, `Unexpected row field for topic ${topic}: ${field}`),
@@ -232,6 +230,19 @@ export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.deco
     defineEnumerableOwn(output, field, decoded);
   }
   return output;
+});
+
+export const decodeProjectedRow = Effect.fn("ViewServerProtocol.row.project.decode")(function* <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  selectedFields: ReadonlySet<string>,
+  row: ViewServerUntrustedWireRow,
+) {
+  const materialized = yield* materializeWireRow(topic, "row", row);
+  return yield* decodeMaterializedProjectedRow(config, topic, selectedFields, materialized);
 });
 
 export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode")(function* <
@@ -290,35 +301,33 @@ export const encodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.encode
   return output;
 });
 
-export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode")(function* <
-  const Topics extends TopicDefinitions,
-  Topic extends Extract<keyof Topics, string>,
->(
+export const decodeMaterializedGroupedRow = Effect.fn(
+  "ViewServerProtocol.row.grouped.decodeMaterialized",
+)(function* <const Topics extends TopicDefinitions, Topic extends Extract<keyof Topics, string>>(
   config: { readonly topics: Topics },
   topic: Topic,
   contract: ViewServerGroupedRowContract,
-  row: ViewServerUntrustedWireRow,
+  row: ViewServerWireRow,
 ) {
   const topicSchema = config.topics[topic]!.schema;
   const { aggregateAliases, aggregates, groupFields } = contract;
   const output: Record<string, unknown> = {};
-  const materialized = yield* materializeWireRow(topic, "grouped row", row);
   for (const field of groupFields) {
     const fieldSchema = topicSchema.fields[field]!;
-    if (!Object.hasOwn(materialized, field) && !rowFieldIsOptional(fieldSchema)) {
+    if (!Object.hasOwn(row, field) && !rowFieldIsOptional(fieldSchema)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing grouped row field for topic ${topic}: ${field}`),
       );
     }
   }
   for (const alias of aggregateAliases) {
-    if (!Object.hasOwn(materialized, alias)) {
+    if (!Object.hasOwn(row, alias)) {
       return yield* Effect.fail(
         invalidRow(topic, `Missing grouped aggregate for topic ${topic}: ${alias}`),
       );
     }
   }
-  for (const [field, value] of Object.entries(materialized)) {
+  for (const [field, value] of Object.entries(row)) {
     if (groupFields.has(field)) {
       const fieldSchema = topicSchema.fields[field]!;
       const decoded = yield* decodeMaterializedJsonFieldValue(fieldSchema, value, {
@@ -341,6 +350,19 @@ export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode
     }
   }
   return output;
+});
+
+export const decodeGroupedRow = Effect.fn("ViewServerProtocol.row.grouped.decode")(function* <
+  const Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  config: { readonly topics: Topics },
+  topic: Topic,
+  contract: ViewServerGroupedRowContract,
+  row: ViewServerUntrustedWireRow,
+) {
+  const materialized = yield* materializeWireRow(topic, "grouped row", row);
+  return yield* decodeMaterializedGroupedRow(config, topic, contract, materialized);
 });
 
 export const encodeSystemRow = Effect.fn("ViewServerProtocol.system.row.encode")(function* <Row>(

--- a/packages/protocol/src/query-prototype-isolation.test.ts
+++ b/packages/protocol/src/query-prototype-isolation.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import { Order, viewServer } from "../test-harness/protocol";
-import { viewServerDecodeLiveEvent, viewServerEncodeLiveEvent } from "./protocol-event-codec";
+import { viewServer } from "../test-harness/protocol";
+import {
+  defineViewServerLiveEventQuery,
+  viewServerDecodeLiveEvent,
+  viewServerEncodeLiveEvent,
+} from "./protocol-event-codec";
 import { viewServerEncodeGroupedQuery } from "./protocol-grouped-query-codec";
 
 const withObjectPrototypeValue = <Value, Error, Requirements>(
@@ -54,7 +58,7 @@ describe("protocol query prototype isolation", () => {
       "groupBy",
       ["status"],
       Effect.gen(function* () {
-        const query = { select: ["id"] } as const;
+        const query = defineViewServerLiveEventQuery(viewServer, "orders", { select: ["id"] });
         const encoded = yield* viewServerEncodeLiveEvent(viewServer, "orders", query, {
           type: "snapshot",
           topic: "orders",
@@ -64,11 +68,7 @@ describe("protocol query prototype isolation", () => {
           rows: [{ id: "order-1" }],
           totalRows: 1,
         });
-        const decoded = yield* viewServerDecodeLiveEvent<
-          typeof viewServer.topics,
-          "orders",
-          Pick<typeof Order.Type, "id">
-        >(viewServer, "orders", query, encoded);
+        const decoded = yield* viewServerDecodeLiveEvent(viewServer, "orders", query, encoded);
 
         expect(decoded).toStrictEqual({
           type: "snapshot",

--- a/packages/protocol/src/raw-live-wire.test.ts
+++ b/packages/protocol/src/raw-live-wire.test.ts
@@ -3,6 +3,7 @@ import { VIEW_SERVER_HEALTH_TOPIC } from "@effect-view-server/config";
 import { Effect, Schema } from "effect";
 import {
   compileViewServerLiveEventCodec,
+  defineViewServerLiveEventQuery,
   ViewServerTrustedWireEventSchema,
   viewServerDecodeHealth,
   viewServerDecodeHealthQuery,
@@ -16,7 +17,6 @@ import {
 
 import {
   nonOwnTopicRowFields,
-  Order,
   unknownTopicRowFieldError,
   viewServer,
   wireHealth,
@@ -25,14 +25,11 @@ import {
 describe("Raw live wire codec", () => {
   it.effect("compiles and reuses one raw row contract across live events", () =>
     Effect.gen(function* () {
-      const query = {
+      const query = defineViewServerLiveEventQuery(viewServer, "orders", {
         select: ["id"],
-      };
-      const codec = compileViewServerLiveEventCodec<
-        typeof viewServer.topics,
-        "orders",
-        Pick<typeof Order.Type, "id">
-      >(viewServer, "orders", query);
+      });
+      const codec = compileViewServerLiveEventCodec(viewServer, "orders", query);
+      // @ts-expect-error hostile callers can mutate a query after its row contract is compiled.
       query.select.push("price");
 
       const snapshot = yield* codec.encode({
@@ -121,7 +118,7 @@ describe("Raw live wire codec", () => {
         where: [{ field: "price", type: "equals", filter: 10 }],
       });
 
-      const idQuery = { select: ["id"] };
+      const idQuery = defineViewServerLiveEventQuery(viewServer, "orders", { select: ["id"] });
       const statusEvent = yield* viewServerEncodeLiveEvent(viewServer, "orders", idQuery, {
         type: "status",
         topic: "orders",
@@ -184,52 +181,46 @@ describe("Raw live wire codec", () => {
       });
       expect(delta.type).toBe("delta");
 
-      const decodedStatus = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedStatus = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        typeof Order.Type
-      >(viewServer, "orders", idQuery, statusEvent);
+        idQuery,
+        statusEvent,
+      );
       expect(decodedStatus).toStrictEqual(statusEvent);
 
       const malformedStatusDecode = yield* Effect.flip(
-        viewServerDecodeLiveEvent<typeof viewServer.topics, "orders", typeof Order.Type>(
-          viewServer,
-          "orders",
-          idQuery,
-          {
-            type: "status",
-            topic: "orders",
-            queryId: "query-0",
-            status: "ready",
-            // @ts-expect-error hostile wire status can use an invalid ready code.
-            code: "InvalidRow",
-          },
-        ),
+        viewServerDecodeLiveEvent(viewServer, "orders", idQuery, {
+          type: "status",
+          topic: "orders",
+          queryId: "query-0",
+          status: "ready",
+          // @ts-expect-error hostile wire status can use an invalid ready code.
+          code: "InvalidRow",
+        }),
       );
       expect(malformedStatusDecode.message).toMatch(/Invalid event/);
 
-      const decodedSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
+      const decodedSnapshot = yield* viewServerDecodeLiveEvent(
+        viewServer,
         "orders",
-        Pick<typeof Order.Type, "id">
-      >(viewServer, "orders", idQuery, snapshot);
+        idQuery,
+        snapshot,
+      );
       expect(decodedSnapshot).toStrictEqual(snapshot);
 
-      const decodedDelta = yield* viewServerDecodeLiveEvent<
-        typeof viewServer.topics,
-        "orders",
-        Pick<typeof Order.Type, "id">
-      >(viewServer, "orders", idQuery, delta);
+      const decodedDelta = yield* viewServerDecodeLiveEvent(viewServer, "orders", idQuery, delta);
       expect(decodedDelta).toStrictEqual(delta);
 
       const trustedSnapshot = yield* Schema.decodeUnknownEffect(ViewServerTrustedWireEventSchema)(
         snapshot,
       );
-      const decodedTrustedSnapshot = yield* viewServerDecodeTrustedLiveEvent<
-        typeof viewServer.topics,
+      const decodedTrustedSnapshot = yield* viewServerDecodeTrustedLiveEvent(
+        viewServer,
         "orders",
-        Pick<typeof Order.Type, "id">
-      >(viewServer, "orders", idQuery, trustedSnapshot);
+        idQuery,
+        trustedSnapshot,
+      );
       expect(decodedTrustedSnapshot).toStrictEqual(snapshot);
 
       const decodedHealth = yield* viewServerDecodeHealth(viewServer, wireHealth);

--- a/packages/protocol/src/row-reflection-boundary.test.ts
+++ b/packages/protocol/src/row-reflection-boundary.test.ts
@@ -167,6 +167,15 @@ describe("Protocol row reflection boundaries", () => {
 
   it.effect("strictly materializes raw and grouped wire rows before decoding fields", () =>
     Effect.gen(function* () {
+      const rawRow = yield* decodeProjectedRow(viewServer, "orders", selectedId, { id: "a" });
+      expect(rawRow).toStrictEqual({ id: "a" });
+
+      const groupedRow = yield* decodeGroupedRow(viewServer, "orders", groupedContract, {
+        id: "a",
+        rowCount: { _viewServerAggregate: "bigint", value: "1" },
+      });
+      expect(groupedRow).toStrictEqual({ id: "a", rowCount: 1n });
+
       const nonEnumerableWireRow = {};
       Object.defineProperty(nonEnumerableWireRow, "id", {
         enumerable: false,

--- a/packages/protocol/src/row-reflection-boundary.test.ts
+++ b/packages/protocol/src/row-reflection-boundary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import {
   compileViewServerGroupedRowContract,
+  compileViewServerRuntimeEventRowPlan,
   decodeGroupedRow,
   decodeProjectedRow,
   encodeGroupedRow,
@@ -27,6 +28,12 @@ const groupedQuery = {
 } as const;
 
 const groupedContract = compileViewServerGroupedRowContract(groupedQuery);
+
+class InconsistentEmptySet extends Set<string> {
+  override has(_field: string): boolean {
+    return true;
+  }
+}
 
 describe("Protocol row reflection boundaries", () => {
   it.effect(
@@ -162,6 +169,106 @@ describe("Protocol row reflection boundaries", () => {
       expect(symbolError).toStrictEqual(
         invalidRow("Unexpected grouped row symbol field for topic orders: Symbol(secret)"),
       );
+    }),
+  );
+
+  it.effect("rejects unknown and inherited row-contract fields as typed errors", () =>
+    Effect.gen(function* () {
+      for (const field of ["missing", "toString"]) {
+        const selectedFields = new Set([field]);
+        const groupedFieldContract = compileViewServerGroupedRowContract({
+          groupBy: [field],
+          aggregates: {},
+        });
+        const selectedFieldError = invalidRow(
+          `Selected row field does not exist for topic orders: ${field}`,
+        );
+        const groupedFieldError = invalidRow(
+          `Grouped row field does not exist for topic orders: ${field}`,
+        );
+
+        const rawEncodeError = yield* Effect.flip(
+          encodeProjectedRow(viewServer, "orders", selectedFields, {}),
+        );
+        expect(rawEncodeError).toStrictEqual(selectedFieldError);
+
+        const rawDecodeError = yield* Effect.flip(
+          decodeProjectedRow(viewServer, "orders", selectedFields, {}),
+        );
+        expect(rawDecodeError).toStrictEqual(selectedFieldError);
+
+        const groupedEncodeError = yield* Effect.flip(
+          encodeGroupedRow(viewServer, "orders", groupedFieldContract, {}),
+        );
+        expect(groupedEncodeError).toStrictEqual(groupedFieldError);
+
+        const groupedDecodeError = yield* Effect.flip(
+          decodeGroupedRow(viewServer, "orders", groupedFieldContract, {}),
+        );
+        expect(groupedDecodeError).toStrictEqual(groupedFieldError);
+      }
+    }),
+  );
+
+  it.effect("rejects inconsistent hostile row contracts as typed errors", () =>
+    Effect.gen(function* () {
+      const selectedFields = new InconsistentEmptySet();
+      const groupedFields = new InconsistentEmptySet();
+      const hostileGroupedContract = {
+        aggregateAliases: new Set<string>(),
+        aggregates: {},
+        groupFields: groupedFields,
+      };
+      const selectedFieldError = invalidRow(
+        "Selected row field does not exist for topic orders: id",
+      );
+      const groupedFieldError = invalidRow("Grouped row field does not exist for topic orders: id");
+
+      const rawEncodeError = yield* Effect.flip(
+        encodeProjectedRow(viewServer, "orders", selectedFields, { id: "a" }),
+      );
+      expect(rawEncodeError).toStrictEqual(selectedFieldError);
+
+      const rawDecodeError = yield* Effect.flip(
+        decodeProjectedRow(viewServer, "orders", selectedFields, { id: "a" }),
+      );
+      expect(rawDecodeError).toStrictEqual(selectedFieldError);
+
+      const groupedEncodeError = yield* Effect.flip(
+        encodeGroupedRow(viewServer, "orders", hostileGroupedContract, { id: "a" }),
+      );
+      expect(groupedEncodeError).toStrictEqual(groupedFieldError);
+
+      const groupedDecodeError = yield* Effect.flip(
+        decodeGroupedRow(viewServer, "orders", hostileGroupedContract, { id: "a" }),
+      );
+      expect(groupedDecodeError).toStrictEqual(groupedFieldError);
+    }),
+  );
+
+  it.effect("turns hostile runtime query reflection into a failed row plan", () =>
+    Effect.gen(function* () {
+      let accessorReads = 0;
+      const hostileQuery = {
+        get select(): ReadonlyArray<string> {
+          accessorReads += 1;
+          throw new Error("query accessor must not escape");
+        },
+      };
+      const rowPlan = compileViewServerRuntimeEventRowPlan(viewServer, "orders", hostileQuery);
+      const expectedError = {
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
+        message: "Could not compile the live-event row contract for topic orders",
+        topic: "orders",
+      } as const;
+
+      const encodeError = yield* Effect.flip(rowPlan.encode({ id: "a" }));
+      expect(encodeError).toStrictEqual(expectedError);
+
+      const decodeError = yield* Effect.flip(rowPlan.decodeMaterialized({ id: "a" }));
+      expect(decodeError).toStrictEqual(expectedError);
+      expect(accessorReads).toBe(1);
     }),
   );
 

--- a/packages/protocol/src/schema-value-wire.test.ts
+++ b/packages/protocol/src/schema-value-wire.test.ts
@@ -5,6 +5,7 @@ import * as HashMap from "effect/HashMap";
 import * as Option from "effect/Option";
 import { Effect, Schema } from "effect";
 import {
+  defineViewServerLiveEventQuery,
   ViewServerWireEventSchema,
   viewServerDecodeLiveEvent,
   viewServerDecodeRawQuery,
@@ -124,9 +125,9 @@ describe("Schema value wire semantics", () => {
         const row = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(SemanticRow))(
           semanticWireRow,
         );
-        const query = {
+        const query = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
           select: ["id", "venue", "optionalQuantity", "tags", "quantities", "amount", "note"],
-        };
+        });
         const snapshot = yield* viewServerEncodeLiveEvent(semanticViewServer, "semantic", query, {
           type: "snapshot",
           topic: "semantic",
@@ -147,11 +148,12 @@ describe("Schema value wire semantics", () => {
         });
 
         const transportedSnapshot = yield* decodeTransportedEvent(snapshot);
-        const decodedSnapshot = yield* viewServerDecodeLiveEvent<
-          typeof semanticViewServer.topics,
+        const decodedSnapshot = yield* viewServerDecodeLiveEvent(
+          semanticViewServer,
           "semantic",
-          typeof SemanticRow.Type
-        >(semanticViewServer, "semantic", query, transportedSnapshot);
+          query,
+          transportedSnapshot,
+        );
         const decodedSnapshotEvent = yield* requireSnapshotEvent(decodedSnapshot);
         const summarizedSnapshot = {
           ...decodedSnapshotEvent,
@@ -193,11 +195,12 @@ describe("Schema value wire semantics", () => {
         });
 
         const transportedDelta = yield* decodeTransportedEvent(delta);
-        const decodedDelta = yield* viewServerDecodeLiveEvent<
-          typeof semanticViewServer.topics,
+        const decodedDelta = yield* viewServerDecodeLiveEvent(
+          semanticViewServer,
           "semantic",
-          typeof SemanticRow.Type
-        >(semanticViewServer, "semantic", query, transportedDelta);
+          query,
+          transportedDelta,
+        );
         const decodedDeltaEvent = yield* requireDeltaEvent(decodedDelta);
         const summarizedDelta = {
           ...decodedDeltaEvent,
@@ -226,7 +229,9 @@ describe("Schema value wire semantics", () => {
 
   it.effect("rejects unencoded semantic values before configured row decoding", () =>
     Effect.gen(function* () {
-      const query = { select: ["id", "amount"] };
+      const query = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
+        select: ["id", "amount"],
+      });
       const rawBigIntEvent = {
         type: "snapshot",
         topic: "semantic",
@@ -238,11 +243,7 @@ describe("Schema value wire semantics", () => {
       } as const;
       expect(Schema.is(ViewServerWireEventSchema)(rawBigIntEvent)).toBe(false);
       const rawBigIntError = yield* Effect.flip(
-        viewServerDecodeLiveEvent<
-          typeof semanticViewServer.topics,
-          "semantic",
-          typeof SemanticRow.Type
-        >(
+        viewServerDecodeLiveEvent(
           semanticViewServer,
           "semantic",
           query,
@@ -268,11 +269,7 @@ describe("Schema value wire semantics", () => {
       } as const;
       expect(Schema.is(ViewServerWireEventSchema)(rawBigDecimalEvent)).toBe(false);
       const rawBigDecimalError = yield* Effect.flip(
-        viewServerDecodeLiveEvent<
-          typeof semanticViewServer.topics,
-          "semantic",
-          typeof SemanticRow.Type
-        >(
+        viewServerDecodeLiveEvent(
           semanticViewServer,
           "semantic",
           query,
@@ -291,7 +288,9 @@ describe("Schema value wire semantics", () => {
 
   it.effect("rejects event and row accessors without invoking them", () =>
     Effect.gen(function* () {
-      const query = { select: ["id", "amount"] };
+      const query = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
+        select: ["id", "amount"],
+      });
       let accessorReads = 0;
       const eventAccessor = {
         type: "snapshot",
@@ -306,11 +305,7 @@ describe("Schema value wire semantics", () => {
         totalRows: 1,
       } as const;
       const eventAccessorError = yield* Effect.flip(
-        viewServerDecodeLiveEvent<
-          typeof semanticViewServer.topics,
-          "semantic",
-          typeof SemanticRow.Type
-        >(semanticViewServer, "semantic", query, eventAccessor),
+        viewServerDecodeLiveEvent(semanticViewServer, "semantic", query, eventAccessor),
       );
       expect(eventAccessorError).toStrictEqual({
         _tag: "ViewServerRuntimeError",
@@ -338,11 +333,7 @@ describe("Schema value wire semantics", () => {
         totalRows: 1,
       } as const;
       const rowAccessorError = yield* Effect.flip(
-        viewServerDecodeLiveEvent<
-          typeof semanticViewServer.topics,
-          "semantic",
-          typeof SemanticRow.Type
-        >(semanticViewServer, "semantic", query, rowAccessor),
+        viewServerDecodeLiveEvent(semanticViewServer, "semantic", query, rowAccessor),
       );
       expect(rowAccessorError).toStrictEqual({
         _tag: "ViewServerRuntimeError",
@@ -357,12 +348,13 @@ describe("Schema value wire semantics", () => {
   it.effect("round-trips Schema.Class group fields in grouped Snapshot and update Delta rows", () =>
     Effect.gen(function* () {
       const venue = Venue.make({ code: "XNYS" });
-      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+      const groupedQuery = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
         groupBy: ["venue"],
         aggregates: {
           rowCount: { aggFunc: "count" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", groupedQuery);
       const groupedRow = { venue, rowCount: 1n };
       const groupedWireRow = {
         venue: { code: "XNYS" },
@@ -392,11 +384,12 @@ describe("Schema value wire semantics", () => {
         totalRows: 1,
       });
 
-      const decodedSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof semanticViewServer.topics,
+      const decodedSnapshot = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
         "semantic",
-        typeof groupedRow
-      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(snapshot));
+        groupedQuery,
+        yield* decodeTransportedEvent(snapshot),
+      );
       expect(decodedSnapshot).toStrictEqual({
         type: "snapshot",
         topic: "semantic",
@@ -426,11 +419,12 @@ describe("Schema value wire semantics", () => {
         totalRows: 1,
       });
 
-      const decodedDelta = yield* viewServerDecodeLiveEvent<
-        typeof semanticViewServer.topics,
+      const decodedDelta = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
         "semantic",
-        typeof groupedRow
-      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(delta));
+        groupedQuery,
+        yield* decodeTransportedEvent(delta),
+      );
       expect(decodedDelta).toStrictEqual({
         type: "delta",
         topic: "semantic",
@@ -445,13 +439,14 @@ describe("Schema value wire semantics", () => {
 
   it.effect("round-trips Schema.Class min and max aggregate envelopes", () =>
     Effect.gen(function* () {
-      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+      const groupedQuery = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
         groupBy: ["id"],
         aggregates: {
           firstVenue: { aggFunc: "min", field: "venue" },
           lastVenue: { aggFunc: "max", field: "venue" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", groupedQuery);
       const groupedRow = {
         id: "1",
         firstVenue: Venue.make({ code: "XNYS" }),
@@ -487,11 +482,12 @@ describe("Schema value wire semantics", () => {
         totalRows: 1,
       });
 
-      const decoded = yield* viewServerDecodeLiveEvent<
-        typeof semanticViewServer.topics,
+      const decoded = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
         "semantic",
-        typeof groupedRow
-      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(encoded));
+        groupedQuery,
+        yield* decodeTransportedEvent(encoded),
+      );
       const snapshot = yield* requireSnapshotEvent(decoded);
       expect(snapshot.rows[0]?.firstVenue).toBeInstanceOf(Venue);
       expect(snapshot.rows[0]?.lastVenue).toBeInstanceOf(Venue);
@@ -507,15 +503,16 @@ describe("Schema value wire semantics", () => {
     }),
   );
 
-  it.effect("round-trips all-missing optional min and max values in Snapshot and Delta", () =>
+  it.effect("round-trips missing and present optional min and max values", () =>
     Effect.gen(function* () {
-      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+      const groupedQuery = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
         groupBy: ["id"],
         aggregates: {
           firstNote: { aggFunc: "min", field: "note" },
           lastNote: { aggFunc: "max", field: "note" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", groupedQuery);
       const groupedRow = {
         id: "1",
         firstNote: undefined,
@@ -549,11 +546,12 @@ describe("Schema value wire semantics", () => {
         rows: [wireRow],
         totalRows: 1,
       });
-      const decodedSnapshot = yield* viewServerDecodeLiveEvent<
-        typeof semanticViewServer.topics,
+      const decodedSnapshot = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
         "semantic",
-        typeof groupedRow
-      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(snapshot));
+        groupedQuery,
+        yield* decodeTransportedEvent(snapshot),
+      );
       expect(decodedSnapshot).toStrictEqual({
         type: "snapshot",
         topic: "semantic",
@@ -582,11 +580,12 @@ describe("Schema value wire semantics", () => {
         operations: [{ type: "update", key: "1", row: wireRow, index: 0 }],
         totalRows: 1,
       });
-      const decodedDelta = yield* viewServerDecodeLiveEvent<
-        typeof semanticViewServer.topics,
+      const decodedDelta = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
         "semantic",
-        typeof groupedRow
-      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(delta));
+        groupedQuery,
+        yield* decodeTransportedEvent(delta),
+      );
       expect(decodedDelta).toStrictEqual({
         type: "delta",
         topic: "semantic",
@@ -596,17 +595,68 @@ describe("Schema value wire semantics", () => {
         operations: [{ type: "update", key: "1", row: groupedRow, index: 0 }],
         totalRows: 1,
       });
+
+      const presentRow = {
+        id: "2",
+        firstNote: "alpha",
+        lastNote: "omega",
+      };
+      const presentSnapshot = yield* viewServerEncodeLiveEvent(
+        semanticViewServer,
+        "semantic",
+        groupedQuery,
+        {
+          type: "snapshot",
+          topic: "semantic",
+          queryId: "semantic-present-optional-extrema",
+          version: 3,
+          keys: ["2"],
+          rows: [presentRow],
+          totalRows: 1,
+        },
+      );
+      expect(presentSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-present-optional-extrema",
+        version: 3,
+        keys: ["2"],
+        rows: [
+          {
+            id: "2",
+            firstNote: { _viewServerAggregate: "json", value: "alpha" },
+            lastNote: { _viewServerAggregate: "json", value: "omega" },
+          },
+        ],
+        totalRows: 1,
+      });
+      const decodedPresentSnapshot = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
+        "semantic",
+        groupedQuery,
+        yield* decodeTransportedEvent(presentSnapshot),
+      );
+      expect(decodedPresentSnapshot).toStrictEqual({
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "semantic-present-optional-extrema",
+        version: 3,
+        keys: ["2"],
+        rows: [presentRow],
+        totalRows: 1,
+      });
     }),
   );
 
   it.effect("round-trips an omitted optional grouped field", () =>
     Effect.gen(function* () {
-      const groupedQuery = yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", {
+      const groupedQuery = defineViewServerLiveEventQuery(semanticViewServer, "semantic", {
         groupBy: ["note"],
         aggregates: {
           rowCount: { aggFunc: "count" },
         },
       });
+      yield* viewServerEncodeGroupedQuery(semanticViewServer, "semantic", groupedQuery);
       const groupedRow = { rowCount: 1n };
       const snapshot = yield* viewServerEncodeLiveEvent(
         semanticViewServer,
@@ -633,11 +683,12 @@ describe("Schema value wire semantics", () => {
         totalRows: 1,
       });
 
-      const decoded = yield* viewServerDecodeLiveEvent<
-        typeof semanticViewServer.topics,
+      const decoded = yield* viewServerDecodeLiveEvent(
+        semanticViewServer,
         "semantic",
-        typeof groupedRow
-      >(semanticViewServer, "semantic", groupedQuery, yield* decodeTransportedEvent(snapshot));
+        groupedQuery,
+        yield* decodeTransportedEvent(snapshot),
+      );
       expect(decoded).toStrictEqual({
         type: "snapshot",
         topic: "semantic",

--- a/packages/protocol/src/schema-value-wire.test.ts
+++ b/packages/protocol/src/schema-value-wire.test.ts
@@ -224,6 +224,136 @@ describe("Schema value wire semantics", () => {
       }),
   );
 
+  it.effect("rejects unencoded semantic values before configured row decoding", () =>
+    Effect.gen(function* () {
+      const query = { select: ["id", "amount"] };
+      const rawBigIntEvent = {
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "raw-bigint",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", amount: 123n }],
+        totalRows: 1,
+      } as const;
+      expect(Schema.is(ViewServerWireEventSchema)(rawBigIntEvent)).toBe(false);
+      const rawBigIntError = yield* Effect.flip(
+        viewServerDecodeLiveEvent<
+          typeof semanticViewServer.topics,
+          "semantic",
+          typeof SemanticRow.Type
+        >(
+          semanticViewServer,
+          "semantic",
+          query,
+          // @ts-expect-error unencoded bigint bypasses the public JSON wire type.
+          rawBigIntEvent,
+        ),
+      );
+      expect(rawBigIntError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        message: 'Invalid event: Unsupported JSON value type "bigint" at $.rows[0].amount.',
+        topic: "semantic",
+      });
+
+      const rawBigDecimalEvent = {
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "raw-big-decimal",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", amount: BigDecimal.make(123n, 2) }],
+        totalRows: 1,
+      } as const;
+      expect(Schema.is(ViewServerWireEventSchema)(rawBigDecimalEvent)).toBe(false);
+      const rawBigDecimalError = yield* Effect.flip(
+        viewServerDecodeLiveEvent<
+          typeof semanticViewServer.topics,
+          "semantic",
+          typeof SemanticRow.Type
+        >(
+          semanticViewServer,
+          "semantic",
+          query,
+          // @ts-expect-error unencoded BigDecimal bypasses the public JSON wire type.
+          rawBigDecimalEvent,
+        ),
+      );
+      expect(rawBigDecimalError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        message: "Invalid event: Expected a plain data record or dense array at $.rows[0].amount.",
+        topic: "semantic",
+      });
+    }),
+  );
+
+  it.effect("rejects event and row accessors without invoking them", () =>
+    Effect.gen(function* () {
+      const query = { select: ["id", "amount"] };
+      let accessorReads = 0;
+      const eventAccessor = {
+        type: "snapshot",
+        get topic(): string {
+          accessorReads += 1;
+          throw new Error("event accessor must not run");
+        },
+        queryId: "event-accessor",
+        version: 1,
+        keys: ["1"],
+        rows: [{ id: "1", amount: "1" }],
+        totalRows: 1,
+      } as const;
+      const eventAccessorError = yield* Effect.flip(
+        viewServerDecodeLiveEvent<
+          typeof semanticViewServer.topics,
+          "semantic",
+          typeof SemanticRow.Type
+        >(semanticViewServer, "semantic", query, eventAccessor),
+      );
+      expect(eventAccessorError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        message: "Invalid event: Accessor properties are not valid JSON data at $.topic.",
+        topic: "semantic",
+      });
+      expect(accessorReads).toBe(0);
+
+      const rowAccessor = {
+        type: "snapshot",
+        topic: "semantic",
+        queryId: "row-accessor",
+        version: 1,
+        keys: ["1"],
+        rows: [
+          {
+            id: "1",
+            get amount(): string {
+              accessorReads += 1;
+              throw new Error("row accessor must not run");
+            },
+          },
+        ],
+        totalRows: 1,
+      } as const;
+      const rowAccessorError = yield* Effect.flip(
+        viewServerDecodeLiveEvent<
+          typeof semanticViewServer.topics,
+          "semantic",
+          typeof SemanticRow.Type
+        >(semanticViewServer, "semantic", query, rowAccessor),
+      );
+      expect(rowAccessorError).toStrictEqual({
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidRow",
+        message: "Invalid event: Accessor properties are not valid JSON data at $.rows[0].amount.",
+        topic: "semantic",
+      });
+      expect(accessorReads).toBe(0);
+    }),
+  );
+
   it.effect("round-trips Schema.Class group fields in grouped Snapshot and update Delta rows", () =>
     Effect.gen(function* () {
       const venue = Venue.make({ code: "XNYS" });

--- a/packages/server/src/rpc-handlers.ts
+++ b/packages/server/src/rpc-handlers.ts
@@ -10,7 +10,7 @@ import type {
   ViewServerRuntimeError,
 } from "@effect-view-server/config";
 import {
-  compileViewServerLiveEventCodec,
+  compileViewServerRuntimeLiveEventEncoder,
   ViewServerRpcs,
   viewServerDecodeHealth,
   viewServerDecodeHealthQuery,
@@ -196,10 +196,10 @@ export const makeViewServerRpcHandlers = <const Topics extends TopicDefinitions>
             topic,
             payload.query,
           );
-          const eventCodec = compileViewServerLiveEventCodec(config, topic, query);
+          const eventEncoder = compileViewServerRuntimeLiveEventEncoder(config, topic, query);
           const subscription = yield* input.liveClient.subscribeProtocolQuery(topic, query);
           return subscription.events.pipe(
-            Stream.mapEffect(eventCodec.encode),
+            Stream.mapEffect(eventEncoder.encode),
             Stream.ensuring(subscription.close().pipe(ignoreSubscriptionCloseFailure)),
           );
         }),

--- a/plans/v2-column-live-view-engine-plan.md
+++ b/plans/v2-column-live-view-engine-plan.md
@@ -40,7 +40,7 @@ Before implementing product code, set up Effect v4 beta and the Effect language 
 Required package baseline:
 
 - Use the workspace-pinned `effect` v4 beta; do not update it as part of unrelated work.
-- Current workspace baseline: `effect@4.0.0-beta.91`.
+- Current workspace baseline: `effect@4.0.0-beta.100`.
 - Use `@effect/vitest` for all tests.
 - Run strict Effect language-service diagnostics before considering a change complete.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,20 +16,20 @@ catalogs:
       specifier: 2.1.2
       version: 2.1.2
     '@effect/atom-react':
-      specifier: 4.0.0-beta.91
-      version: 4.0.0-beta.91
+      specifier: 4.0.0-beta.100
+      version: 4.0.0-beta.100
     '@effect/language-service':
       specifier: 0.86.2
       version: 0.86.2
     '@effect/platform-browser':
-      specifier: 4.0.0-beta.91
-      version: 4.0.0-beta.91
+      specifier: 4.0.0-beta.100
+      version: 4.0.0-beta.100
     '@effect/platform-node':
-      specifier: 4.0.0-beta.91
-      version: 4.0.0-beta.91
+      specifier: 4.0.0-beta.100
+      version: 4.0.0-beta.100
     '@effect/vitest':
-      specifier: 4.0.0-beta.91
-      version: 4.0.0-beta.91
+      specifier: 4.0.0-beta.100
+      version: 4.0.0-beta.100
     '@platformatic/kafka':
       specifier: 2.2.3
       version: 2.2.3
@@ -70,8 +70,8 @@ catalogs:
       specifier: 4.1.9
       version: 4.1.9
     effect:
-      specifier: 4.0.0-beta.91
-      version: 4.0.0-beta.91
+      specifier: 4.0.0-beta.100
+      version: 4.0.0-beta.100
     markdown-it:
       specifier: ^14.3.0
       version: 14.3.0
@@ -147,7 +147,7 @@ importers:
         version: 0.86.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@types/markdown-it':
         specifier: 'catalog:'
         version: 14.1.2
@@ -174,7 +174,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -187,7 +187,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@types/react':
         specifier: 19.2.15
         version: 19.2.15
@@ -229,7 +229,7 @@ importers:
         version: 2.1.2(@bufbuild/protobuf@2.12.0)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@platformatic/kafka':
         specifier: 'catalog:'
         version: 2.2.3
@@ -244,7 +244,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -260,7 +260,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -317,7 +317,7 @@ importers:
         version: 2.1.2(@bufbuild/protobuf@2.12.0)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -329,7 +329,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -345,7 +345,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -402,7 +402,7 @@ importers:
         version: 2.1.2(@bufbuild/protobuf@2.12.0)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -414,7 +414,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -430,7 +430,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -490,7 +490,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -506,7 +506,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -557,7 +557,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@platformatic/kafka':
         specifier: 'catalog:'
         version: 2.2.3
@@ -572,7 +572,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -588,7 +588,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -648,7 +648,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -664,7 +664,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -712,7 +712,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -724,7 +724,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(rolldown@1.1.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       effect-view-server:
         specifier: workspace:*
         version: link:../../packages/effect-view-server
@@ -740,7 +740,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
@@ -800,17 +800,17 @@ importers:
         version: link:../protocol
       '@effect/platform-browser':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -834,11 +834,11 @@ importers:
         version: link:../effect-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -862,11 +862,11 @@ importers:
         version: 2.1.2(@bufbuild/protobuf@2.12.0)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -884,11 +884,11 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -914,11 +914,11 @@ importers:
         specifier: 2.1.2
         version: 2.1.2(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0))
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.91
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)
+        specifier: 4.0.0-beta.100
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)
       '@effect/platform-node':
-        specifier: 4.0.0-beta.91
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.100
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@platformatic/kafka':
         specifier: 2.2.3
         version: 2.2.3
@@ -952,10 +952,10 @@ importers:
         version: link:../server
       '@effect/atom-react':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(react@19.2.6)(scheduler@0.27.0)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(react@19.2.6)(scheduler@0.27.0)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@types/react':
         specifier: 19.2.15
         version: 19.2.15
@@ -970,7 +970,7 @@ importers:
         version: 4.1.9
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -991,11 +991,11 @@ importers:
         version: link:../runtime-core
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -1019,11 +1019,11 @@ importers:
         version: link:../effect-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -1050,10 +1050,10 @@ importers:
         version: link:../effect-utils
       '@effect/atom-react':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(react@19.2.6)(scheduler@0.27.0)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(react@19.2.6)(scheduler@0.27.0)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
       scheduler:
         specifier: 'catalog:'
         version: 0.27.0
@@ -1069,7 +1069,7 @@ importers:
         version: link:../server
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@types/react':
         specifier: 19.2.15
         version: 19.2.15
@@ -1135,17 +1135,17 @@ importers:
         version: 2.2.3
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@bufbuild/protobuf':
         specifier: 2.12.0
         version: 2.12.0
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -1178,11 +1178,11 @@ importers:
         version: link:../effect-utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -1212,17 +1212,17 @@ importers:
         version: link:../protocol
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.91
+        version: 4.0.0-beta.100
     devDependencies:
       '@effect-view-server/runtime-core':
         specifier: workspace:*
         version: link:../runtime-core
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)
+        version: 4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -1426,10 +1426,10 @@ packages:
     peerDependencies:
       '@bufbuild/protobuf': ^2.7.0
 
-  '@effect/atom-react@4.0.0-beta.91':
-    resolution: {integrity: sha512-/IzO3pkmHBspYfVTWXtDBy99rW21lCpgU51uIrWbiiKNIVQ0ClpyOZtLfYpN99NMXt7WV+nHVUmndhClG0OgXA==}
+  '@effect/atom-react@4.0.0-beta.100':
+    resolution: {integrity: sha512-NHi/z3iqNbZWrI078+dHB4m2hFWuEjvDwRXFDwTY6Zp8ycQq/EvQI7Bb32g985l3s5fC+QErzdERekDnZZT/oQ==}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.100
       react: ^19.2.4
       scheduler: '*'
 
@@ -1437,47 +1437,38 @@ packages:
     resolution: {integrity: sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg==}
     hasBin: true
 
-  '@effect/platform-browser@4.0.0-beta.91':
-    resolution: {integrity: sha512-6ZUavjlDxhjAlGkmmNYoB9zs3LVLy2SnhJ5ZA6csdqAC7HHQcCIfjFQza1orcQakFQ3QqoYt8XvVlYA8ZFINlg==}
+  '@effect/platform-browser@4.0.0-beta.100':
+    resolution: {integrity: sha512-Ezxkl9nQuPQrHqkxSdJWazQmjaD+ZOYhKoFEiQvfCdiSoEKLN7SWWGkaCKlbO451hLyO4NUO7s2UGTGU3CHVsw==}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.100
 
-  '@effect/platform-node-shared@4.0.0-beta.91':
-    resolution: {integrity: sha512-JX++yhomaOEpQmnTYuhn+pKAgKg5MQvycAf1rXGtyVKi202Nc5nK37xbywDcugfwrc1FrPxrxa3BY3lbSc74cw==}
+  '@effect/platform-node-shared@4.0.0-beta.100':
+    resolution: {integrity: sha512-PMsCXQeK2wnlmnqGCc79oqK9CX8ipZvoHxAy/CRojMF+zHIluxh61L3pzWAYEbMb19Be4Bxgqs7gK2hiV8H8Pg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.100
 
-  '@effect/platform-node@4.0.0-beta.91':
-    resolution: {integrity: sha512-gP7Xlmce/HJxg3WaacmrRMJtRw2j6uJ4UrLEDy596tokdXcMoakz2oAtULSXiLzihLeQnt9nrm9K5nHhqKdBdA==}
+  '@effect/platform-node@4.0.0-beta.100':
+    resolution: {integrity: sha512-nH5xgxOLfPj5Bi0/o4OaDsR98Z59lHKGty+TDqckg7zRz6jry82hGW982NRPduzX0MJloDsGp/3rfeN4Hu7Keg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.100
       ioredis: ^5.7.0
 
-  '@effect/vitest@4.0.0-beta.91':
-    resolution: {integrity: sha512-RTowh92EawJWk+PewFrbqmPSOjbJ9xcq4BcWGV4t0aaYIvZj5g5dubXUvCioh6aq4lkOnTEJmC6seGZjDFO/MQ==}
+  '@effect/vitest@4.0.0-beta.100':
+    resolution: {integrity: sha512-WoxrzPuxc+4QXb+7D1j8PwaBb9zVxHM2yw0sDz7fXij1Sx7X7T6LkYJ7m2xzWbfskIXxIdXVA+NnDSF8qAOGsw==}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.100
       vitest: ^3.0.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
-
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -1673,44 +1664,38 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
     cpu: [x64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
     cpu: [arm64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
     cpu: [arm]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
     cpu: [x64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
-
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@node-rs/crc32-android-arm-eabi@1.10.6':
     resolution: {integrity: sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==}
@@ -2480,9 +2465,6 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
-
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2842,8 +2824,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  effect@4.0.0-beta.91:
-    resolution: {integrity: sha512-FFlkWiy1QK4xuHd/nui9LKD/5qkpSHJdMcbsEY7jl9V27+txye6W+RAIlmWjuA2vvtUyZmzGKarVtdU0l1pdBQ==}
+  effect@4.0.0-beta.100:
+    resolution: {integrity: sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q==}
 
   electron-to-chromium@1.5.361:
     resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
@@ -2893,8 +2875,8 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
-  fast-check@4.8.0:
-    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
     engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
@@ -3228,15 +3210,15 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@2.0.1:
-    resolution: {integrity: sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==}
+  msgpackr@2.0.4:
+    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
 
-  multipasta@0.2.7:
-    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
+  multipasta@0.2.8:
+    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -3580,8 +3562,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toml@4.1.1:
-    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
     engines: {node: '>=20'}
 
   totalist@3.0.1:
@@ -3662,8 +3644,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vite-plus@0.2.1:
@@ -3804,6 +3786,18 @@ packages:
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4154,32 +4148,32 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.12.0
 
-  '@effect/atom-react@4.0.0-beta.91(effect@4.0.0-beta.91)(react@19.2.6)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.100(effect@4.0.0-beta.100)(react@19.2.6)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-beta.91
+      effect: 4.0.0-beta.100
       react: 19.2.6
       scheduler: 0.27.0
 
   '@effect/language-service@0.86.2': {}
 
-  '@effect/platform-browser@4.0.0-beta.91(effect@4.0.0-beta.91)':
+  '@effect/platform-browser@4.0.0-beta.100(effect@4.0.0-beta.100)':
     dependencies:
-      effect: 4.0.0-beta.91
-      multipasta: 0.2.7
+      effect: 4.0.0-beta.100
+      multipasta: 0.2.8
 
-  '@effect/platform-node-shared@4.0.0-beta.91(effect@4.0.0-beta.91)':
+  '@effect/platform-node-shared@4.0.0-beta.100(effect@4.0.0-beta.100)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.91
-      ws: 8.20.1
+      effect: 4.0.0-beta.100
+      ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.100(effect@4.0.0-beta.100)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.91(effect@4.0.0-beta.91)
-      effect: 4.0.0-beta.91
+      '@effect/platform-node-shared': 4.0.0-beta.100(effect@4.0.0-beta.100)
+      effect: 4.0.0-beta.100
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.5.0
@@ -4187,9 +4181,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.91(effect@4.0.0-beta.91)(vitest@4.1.9)':
+  '@effect/vitest@4.0.0-beta.100(effect@4.0.0-beta.100)(vitest@4.1.9)':
     dependencies:
-      effect: 4.0.0-beta.91
+      effect: 4.0.0-beta.100
       vitest: 4.1.9(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/browser-preview@4.1.9)(@vitest/coverage-istanbul@4.1.9)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -4198,28 +4192,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.2.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4348,22 +4326,22 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -4371,13 +4349,6 @@ snapshots:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@node-rs/crc32-android-arm-eabi@1.10.6':
@@ -4672,10 +4643,6 @@ snapshots:
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.3':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.3':
@@ -4996,11 +4963,6 @@ snapshots:
       '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5355,17 +5317,17 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  effect@4.0.0-beta.91:
+  effect@4.0.0-beta.100:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      fast-check: 4.8.0
+      fast-check: 4.9.0
       find-my-way-ts: 0.1.6
       ini: 7.0.0
       kubernetes-types: 1.30.0
-      msgpackr: 2.0.1
-      multipasta: 0.2.7
-      toml: 4.1.1
-      uuid: 14.0.0
+      msgpackr: 2.0.4
+      multipasta: 0.2.8
+      toml: 4.3.0
+      uuid: 14.0.1
       yaml: 2.9.0
 
   electron-to-chromium@1.5.361: {}
@@ -5429,7 +5391,7 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
-  fast-check@4.8.0:
+  fast-check@4.9.0:
     dependencies:
       pure-rand: 8.4.0
 
@@ -5710,23 +5672,23 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.3:
+  msgpackr-extract@3.0.4:
     dependencies:
       node-gyp-build-optional-packages: 5.2.2
     optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@2.0.1:
+  msgpackr@2.0.4:
     optionalDependencies:
-      msgpackr-extract: 3.0.3
+      msgpackr-extract: 3.0.4
 
-  multipasta@0.2.7: {}
+  multipasta@0.2.8: {}
 
   nanoid@3.3.12: {}
 
@@ -6032,7 +5994,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toml@4.1.1: {}
+  toml@4.3.0: {}
 
   totalist@3.0.1: {}
 
@@ -6077,7 +6039,7 @@ snapshots:
     dependencies:
       react: 19.2.6
 
-  uuid@14.0.0: {}
+  uuid@14.0.1: {}
 
   vite-plus@0.2.1(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
@@ -6246,6 +6208,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   ws@8.20.1: {}
+
+  ws@8.21.1: {}
 
   xmlbuilder2@4.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,21 +10,21 @@ onlyBuiltDependencies:
   - msgpackr-extract
 
 catalog:
-  "@effect/platform-browser": 4.0.0-beta.91
-  "@effect/platform-node": 4.0.0-beta.91
+  "@effect/platform-browser": 4.0.0-beta.100
+  "@effect/platform-node": 4.0.0-beta.100
   "@effect/language-service": 0.86.2
-  "@effect/vitest": 4.0.0-beta.91
+  "@effect/vitest": 4.0.0-beta.100
   "@types/node": 25.9.1
   "@vitest/browser": 4.1.9
   "@vitest/browser-playwright": 4.1.9
   "@vitest/coverage-istanbul": 4.1.9
   "@vitest/runner": 4.1.9
-  effect: 4.0.0-beta.91
+  effect: 4.0.0-beta.100
   typescript: 6.0.3
   vite: npm:@voidzero-dev/vite-plus-core@0.2.1
   vitest: 4.1.9
   vite-plus: 0.2.1
-  "@effect/atom-react": 4.0.0-beta.91
+  "@effect/atom-react": 4.0.0-beta.100
   scheduler: 0.27.0
   vitest-browser-react: 2.2.0
   "@platformatic/kafka": 2.2.3
@@ -54,9 +54,9 @@ allowBuilds:
   esbuild: true
   msgpackr-extract: true
 minimumReleaseAgeExclude:
-  - "@effect/atom-react@4.0.0-beta.91"
-  - "@effect/platform-browser@4.0.0-beta.91"
-  - "@effect/platform-node-shared@4.0.0-beta.91"
-  - "@effect/platform-node@4.0.0-beta.91"
-  - "@effect/vitest@4.0.0-beta.91"
-  - effect@4.0.0-beta.91
+  - "@effect/atom-react@4.0.0-beta.100"
+  - "@effect/platform-browser@4.0.0-beta.100"
+  - "@effect/platform-node-shared@4.0.0-beta.100"
+  - "@effect/platform-node@4.0.0-beta.100"
+  - "@effect/vitest@4.0.0-beta.100"
+  - effect@4.0.0-beta.100

--- a/scripts/check-internal-seams.test.ts
+++ b/scripts/check-internal-seams.test.ts
@@ -38,15 +38,30 @@ import {
 const makeDirectory = () => mkdtempSync(join(tmpdir(), "view-server-seams-"));
 
 describe("internal Seam checker", () => {
-  it("keeps the repository aligned with the Package Surface Policy", () => {
+  it("keeps package surfaces aligned with the Package Surface Policy", () => {
     expect(collectPackageSurfaceViolations()).toStrictEqual([]);
+  });
+
+  it("keeps package imports aligned with the Package Surface Policy", () => {
     expect(collectPackageImportViolations()).toStrictEqual([]);
+  });
+
+  it("keeps consumer imports aligned with the Package Surface Policy", () => {
     expect(collectConsumerImportViolations()).toStrictEqual([]);
+  });
+
+  it("keeps Topic Store Module seams intact", () => {
     expect(collectEngineSeamViolations()).toStrictEqual({
       helperViolations: [],
       stateExportViolations: [],
     });
+  });
+
+  it("keeps Runtime Source Module seams intact", () => {
     expect(collectRuntimeSourceSeamViolations()).toStrictEqual([]);
+  });
+
+  it("keeps Runtime Core dependencies acyclic", () => {
     expect(collectRuntimeCoreDependencyCycleViolations()).toStrictEqual([]);
   });
 

--- a/scripts/release-publish-orchestration.test.ts
+++ b/scripts/release-publish-orchestration.test.ts
@@ -91,7 +91,7 @@ const makeReleaseTree = (version = "1.2.3") => {
     },
     dependencies: {
       "@effect-view-server/client": "workspace:*",
-      effect: "4.0.0-beta.91",
+      effect: "4.0.0-beta.100",
     },
     scripts: {
       build: "vp pack",
@@ -248,7 +248,7 @@ describe("release publish orchestration", () => {
           provenance: true,
         },
         dependencies: {
-          effect: "4.0.0-beta.91",
+          effect: "4.0.0-beta.100",
         },
       },
       nestedFile: "ready\n",

--- a/scripts/release-publish-policy.test.ts
+++ b/scripts/release-publish-policy.test.ts
@@ -76,7 +76,7 @@ const publicPackageJson = {
   },
   dependencies: {
     "@effect-view-server/client": "workspace:*",
-    effect: "4.0.0-beta.91",
+    effect: "4.0.0-beta.100",
   },
   devDependencies: {
     "@effect-view-server/runtime": "workspace:*",
@@ -318,7 +318,7 @@ describe("release publish policy", () => {
         provenance: true,
       },
       dependencies: {
-        effect: "4.0.0-beta.91",
+        effect: "4.0.0-beta.100",
       },
       peerDependencies: {
         react: "19.2.6",
@@ -345,7 +345,7 @@ describe("release publish policy", () => {
       peerOptional: packageJson.peerDependenciesMeta.scheduler,
     }).toStrictEqual({
       atomReactDependency: undefined,
-      atomReactPeerDependency: "4.0.0-beta.91",
+      atomReactPeerDependency: "4.0.0-beta.100",
       atomReactPeerOptional: true,
       dependency: undefined,
       peerDependency: undefined,


### PR DESCRIPTION
## What changed

- upgrade the workspace and Effect submodule to Effect 4.0.0-beta.100
- update protocol schema/codecs and package metadata for the beta.100 API
- document the unified Source Adapter architecture for materialized and leased topics
- define the browser-contract/runtime-composition boundary and standard adapter exports
- establish the canonical topic row identity and topic-owned source-module decisions
- keep planned adapter export examples from being interpreted as currently supported package imports

## Why

The runtime needs one strongly typed `source` seam that preserves the existing concise topic configuration while allowing first-party and third-party transports to supply materialized or leased streams. Browser consumers should remain unaware of Kafka, gRPC, or future adapter implementations.

Effect beta.100 is the baseline used to validate the proposed Effect services, Layers, Streams, scoped resource ownership, schemas, and typed-error design.

## Impact

This PR establishes the implementation contract and Effect dependency baseline. It does not implement the adapter runtime yet. Future adapter work can be divided into focused GitHub issues without redesigning the public API during implementation.

## Validation

- `vp install`
- focused package-seam validation
- repository policy tests: 362 passing with 100% coverage
- Effect diagnostics: zero errors, warnings, or messages
- package runtime and type tests, including protocol, client, config, engine, facade, and browser examples
- formatting, linting, and type checking passed during the validation runs

The aggregate `vp run -w ready` command ultimately encountered a `tsgolint` Go parser panic while linting the generated `examples/kafka-react/src/routeTree.gen.ts`. The substantive checks above passed; the remaining failure is a toolchain parser crash on generated TanStack route-tree code rather than a reported source diagnostic or failing assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a canonical optional `source` configuration model for topics, plus a shared frozen View Server Config.
  - Standardized Source Adapter contracts for materialized and leased ingestion.
  - Introduced a canonical `id` for every Topic Row.
- **Bug Fixes**
  - Hardened live-wire JSON encoding/decoding and query/row envelope validation, with improved failures for malformed data and unexpected accessor properties.
  - Increased decoding safety via staged materialization and plan-based encode/decode.
- **Documentation**
  - Expanded ingestion architecture and added multiple ADRs covering adapter packaging/export seams and topic ownership.
- **Tests**
  - Strengthened hostile-input and boundary-condition coverage across wire codecs.
- **Chores**
  - Updated Effect dependencies and refreshed the Effect submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->