### PR TITLE
feat(react): add live query viewport

### DIFF
--- a/.changeset/wise-turtles-follow.md
+++ b/.changeset/wise-turtles-follow.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": minor
+---
+
+Add the typed useLiveQueryViewport hook for switch-latest virtualized grid windows.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,6 +264,10 @@ _Avoid_: Runtime provider, in-memory provider when discussing the generic provid
 The React testing provider that owns an In-Memory View Server and supplies its Live Client to the same hooks used in production.
 _Avoid_: Seed provider, mock provider
 
+**Live Query Viewport**:
+The transport-neutral React integration Module for virtualized grids. It binds one typed Live Query, one inclusive absolute row window, and one caller-owned sparse row sink. React observes only query chrome; row payloads flow directly to the sink. Every full replacement and scroll-only window change has switch-latest ownership, so older snapshots, deltas, statuses, failures, and sink writes cannot mutate the current generation.
+_Avoid_: Live grid, grid query language, rows in React state, best-effort cancellation
+
 **AG Grid Adapter**:
 The client integration boundary that translates AG Grid viewport, filter, sort, and grouping state into typed Live Queries while keeping the View Server query language independent of AG Grid.
 _Avoid_: AG Grid where model, AG Grid query language, core FilterModel
@@ -610,6 +614,7 @@ _Avoid_: Browser write, send, emit
 - A **Health Payload Codec** protects full runtime health payloads from missing or unknown configured topics.
 - A **View Server Provider** supplies a **Live Client** to React hooks.
 - A **View Server In-Memory Provider** supplies the same hook behavior through an **In-Memory View Server**.
+- A **Live Query Viewport** keeps viewport rows out of React state, derives its query window, and gives every replacement or scroll-only window change switch-latest ownership over row, count, status, and failure delivery.
 - An **AG Grid Adapter** accepts AG Grid state without making AG Grid state the canonical View Server query language.
 - An **AG Grid Adapter** validates every **AG Grid Set Key** against the bound Topic Row field schema without attempting to repair a lossy key creator.
 - A **Real View Server** and **In-Memory View Server** differ only by transport and ingress **Adapters**, not by query, storage, health, or subscription logic.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,27 @@ function Orders() {
 }
 ```
 
+Virtualized grids use the row-payload-free viewport hook:
+
+```tsx
+const result = react.useLiveQueryViewport("orders");
+const connectGrid = () =>
+  result.viewport.replace({
+    window: { firstRow: 0, lastRow: 99 },
+    query: {
+      select: ["id", "price"],
+      where: [{ field: "status", type: "equals", filter: "open" }],
+      orderBy: [{ field: "price", direction: "asc" }],
+    },
+    sink: gridRows,
+  });
+```
+
+The sink receives sparse rows at absolute indexes. React receives only query
+chrome such as status, version, and `totalRows`. Full replacements and
+scroll-only `setWindow` calls are switch-latest, so an older request can never
+overwrite a newer window, filter, sort, grouping, or route.
+
 `where` is always an implicit-`AND` array of typed Field Conditions or nested
 `AND`, `OR`, and `NOT` expressions. An omitted `where`, `where: []`, and empty
 generated groups all mean no filter. Field-keyed objects and shorthand operators

--- a/README.md
+++ b/README.md
@@ -278,17 +278,21 @@ function Orders() {
 Virtualized grids use the row-payload-free viewport hook:
 
 ```tsx
-const result = react.useLiveQueryViewport("orders");
-const connectGrid = () =>
-  result.viewport.replace({
-    window: { firstRow: 0, lastRow: 99 },
-    query: {
-      select: ["id", "price"],
-      where: [{ field: "status", type: "equals", filter: "open" }],
-      orderBy: [{ field: "price", direction: "asc" }],
-    },
-    sink: gridRows,
-  });
+function OrdersGrid() {
+  const result = react.useLiveQueryViewport("orders");
+  const connectGrid = () =>
+    result.viewport.replace({
+      window: { firstRow: 0, lastRow: 99 },
+      query: {
+        select: ["id", "price"],
+        where: [{ field: "status", type: "equals", filter: "open" }],
+        orderBy: [{ field: "price", direction: "asc" }],
+      },
+      sink: gridRows,
+    });
+
+  return <VirtualizedGrid connect={connectGrid} />;
+}
 ```
 
 The sink receives sparse rows at absolute indexes. React receives only query

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -70,7 +70,12 @@ export const viewServer = defineViewServerConfig({
 });
 
 export const viewServerReact = createViewServerReact(viewServer);
-export const { ViewServerProvider, useLiveQuery, useViewServerHealthSummary } = viewServerReact;
+export const {
+  ViewServerProvider,
+  useLiveQuery,
+  useLiveQueryViewport,
+  useViewServerHealthSummary,
+} = viewServerReact;
 ```
 
 ### Schema value admission
@@ -224,3 +229,54 @@ const totals = useLiveQuery("orders", {
 The public API is designed so consumers do not need `as const` to keep type
 safety for normal `select`, `where`, `orderBy`, `groupBy`, and aggregate
 queries.
+
+## Live Query Viewports
+
+`useLiveQueryViewport(topic)` is the transport-neutral integration seam for
+virtualized grids. It exposes status, version, and total-row chrome through
+React while delivering row payloads directly into a caller-owned sparse sink.
+The hook never stores or returns viewport rows.
+
+```tsx
+function OrdersGrid() {
+  const result = useLiveQueryViewport("orders");
+
+  return (
+    <VirtualizedGrid
+      status={`${result.status}:${result.totalRows}`}
+      connect={(grid) =>
+        result.viewport.replace({
+          window: { firstRow: 0, lastRow: 99 },
+          query: {
+            select: ["id", "status", "price"],
+            where: [{ field: "status", type: "equals", filter: "open" }],
+            orderBy: [{ field: "price", direction: "desc" }],
+          },
+          sink: {
+            setRowCount: (count, keepRenderedRows) => grid.setRowCount(count, keepRenderedRows),
+            setRowData: (rows) => grid.setRowData(rows),
+          },
+        })
+      }
+    />
+  );
+}
+```
+
+`replace` atomically binds one exact raw or grouped Live Query, one inclusive
+absolute row window, and one sink. Raw viewport queries require explicit
+`select`, `where`, and `orderBy`; grouped viewport queries require
+`aggregates`, `where`, and `orderBy`. The hook derives `offset` and `limit`, so
+callers cannot provide them.
+
+Use the returned generation's `setWindow` operation for scroll-only changes. It
+reuses the captured filter, sort, grouping, route, and sink without requiring a
+grid scroll event or a complete replacement object. The grid adapter keeps the
+returned generation, calls `generation.setWindow(...)` while scrolling, and
+calls `generation.release()` when that data source is retired.
+`viewport.destroy()` releases the controller.
+
+Every `replace` and `setWindow` is switch-latest. Starting a newer request
+immediately clears rendered rows and invalidates every older request. Late
+snapshots, deltas, status changes, failures, and sink callbacks from an older
+request cannot overwrite the current viewport.

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   liveQueryFailureResult,
   liveQueryResult,
   liveQueryResultFromAsyncResult,
+  makeIncrementalClientState,
   stableQueryKey,
   type ClientState,
 } from "./index";
@@ -263,6 +264,78 @@ describe("@effect-view-server/client", () => {
     expect(next.keys).toStrictEqual(["c", "a", "d"]);
     expect(next.totalRows).toBe(3);
     expect(next.version).toBe(2);
+  });
+
+  it("reports changed ranges and rolls every mutation kind back transactionally", () => {
+    const projection = makeIncrementalClientState<{ readonly id: string }>();
+    const snapshot = {
+      type: "snapshot" as const,
+      topic: "orders",
+      queryId: "query-incremental",
+      version: 1,
+      keys: ["a", "b", "c"],
+      rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      totalRows: 3,
+    };
+    expect(projection.apply(snapshot).change).toStrictEqual({ _tag: "All" });
+    expect(
+      projection.apply({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-incremental",
+        fromVersion: 1,
+        toVersion: 2,
+        totalRows: 3,
+        operations: [{ type: "update", key: "b", row: { id: "b-updated" }, index: 1 }],
+      }).change,
+    ).toStrictEqual({ _tag: "Range", start: 1, end: 1 });
+    expect(
+      projection.apply({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-incremental",
+        fromVersion: 2,
+        toVersion: 3,
+        totalRows: 3,
+        operations: [],
+      }).change,
+    ).toStrictEqual({ _tag: "None" });
+
+    const rollbackCases = [
+      [
+        { type: "insert" as const, key: "d", row: { id: "d" }, index: 1 },
+        { type: "insert" as const, key: "a", row: { id: "duplicate" }, index: 0 },
+      ],
+      [
+        { type: "update" as const, key: "b", row: { id: "changed" }, index: 1 },
+        { type: "update" as const, key: "missing", row: { id: "missing" }, index: 1 },
+      ],
+      [
+        { type: "move" as const, key: "c", fromIndex: 2, toIndex: 0 },
+        { type: "move" as const, key: "missing", fromIndex: 2, toIndex: 0 },
+      ],
+      [
+        { type: "remove" as const, key: "b" },
+        { type: "remove" as const, key: "missing" },
+      ],
+    ];
+    for (const operations of rollbackCases) {
+      const transactional = makeIncrementalClientState<{ readonly id: string }>();
+      transactional.apply(snapshot);
+      const result = transactional.apply({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-incremental",
+        fromVersion: 1,
+        toVersion: 2,
+        totalRows: 3,
+        operations,
+      });
+      expect(result.change).toStrictEqual({ _tag: "None" });
+      expect(result.current.rows).toStrictEqual([{ id: "a" }, { id: "b" }, { id: "c" }]);
+      expect(result.current.keys).toStrictEqual(["a", "b", "c"]);
+      expect(result.current.status).toBe("stale");
+    }
   });
 
   it("moves rows by key even when the row value is undefined", () => {

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -338,6 +338,65 @@ describe("@effect-view-server/client", () => {
     }
   });
 
+  it("updates incremental status chrome and clears closed subscriptions in place", () => {
+    const projection = makeIncrementalClientState<{ readonly id: string }>();
+    const ready = projection.apply({
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-status",
+      version: 1,
+      keys: ["a"],
+      rows: [{ id: "a" }],
+      totalRows: 1,
+    }).current;
+    const stale = projection.apply({
+      type: "status",
+      topic: "orders",
+      queryId: "query-status",
+      status: "stale",
+      code: "SnapshotStale",
+      message: "refreshing",
+    });
+    expect(stale).toStrictEqual({
+      current: {
+        rows: [{ id: "a" }],
+        keys: ["a"],
+        totalRows: 1,
+        version: 1,
+        status: "stale",
+        statusCode: "SnapshotStale",
+        message: "refreshing",
+      },
+      change: { _tag: "None" },
+    });
+    expect(stale.current.rows).toBe(ready.rows);
+    expect(stale.current.keys).toBe(ready.keys);
+
+    const closed = projection.apply({
+      type: "status",
+      topic: "orders",
+      queryId: "query-status",
+      status: "closed",
+      code: "SubscriptionClosed",
+    });
+    expect(closed).toStrictEqual({
+      current: {
+        rows: [],
+        keys: [],
+        totalRows: 0,
+        version: 0,
+        status: "closed",
+        statusCode: "SubscriptionClosed",
+        message: undefined,
+      },
+      change: { _tag: "None" },
+    });
+    expect(ready.rows).toStrictEqual([]);
+    expect(ready.keys).toStrictEqual([]);
+    expect(closed.current.rows).toBe(ready.rows);
+    expect(closed.current.keys).toBe(ready.keys);
+  });
+
   it("moves rows by key even when the row value is undefined", () => {
     const previous = applyEvent(initialClientState<undefined>(), {
       type: "snapshot",

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import type { DeltaEvent } from "@effect-view-server/config";
 import { Cause } from "effect";
 import { fromStringUnsafe } from "effect/BigDecimal";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
@@ -11,6 +12,7 @@ import {
   makeIncrementalClientState,
   stableQueryKey,
   type ClientState,
+  type IncrementalClientState,
 } from "./index";
 
 describe("@effect-view-server/client", () => {
@@ -395,6 +397,374 @@ describe("@effect-view-server/client", () => {
     expect(ready.keys).toStrictEqual([]);
     expect(closed.current.rows).toBe(ready.rows);
     expect(closed.current.keys).toBe(ready.keys);
+  });
+
+  it("applies replacement-shaped structural batches transactionally in one commit", () => {
+    const projection = makeIncrementalClientState<{ readonly id: string }>();
+    const ready = projection.apply({
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-replacement",
+      version: 1,
+      keys: ["a", "b", "c", "d"],
+      rows: [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }],
+      totalRows: 4,
+    }).current;
+    const rows = ready.rows;
+    const keys = ready.keys;
+
+    const partial = projection.apply({
+      type: "delta",
+      topic: "orders",
+      queryId: "query-replacement",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 4,
+      operations: [
+        { type: "remove", key: "a" },
+        { type: "remove", key: "c" },
+        { type: "insert", key: "x", row: { id: "x" }, index: 0 },
+        { type: "insert", key: "y", row: { id: "y" }, index: 2 },
+      ],
+    });
+    expect(partial).toStrictEqual({
+      current: {
+        rows: [{ id: "x" }, { id: "b" }, { id: "y" }, { id: "d" }],
+        keys: ["x", "b", "y", "d"],
+        totalRows: 4,
+        version: 2,
+        status: "ready",
+        statusCode: "Ready",
+      },
+      change: { _tag: "Range", start: 0, end: 3 },
+    });
+    expect(partial.current.rows).toBe(rows);
+    expect(partial.current.keys).toBe(keys);
+
+    const disjoint = projection.apply({
+      type: "delta",
+      topic: "orders",
+      queryId: "query-replacement",
+      fromVersion: 2,
+      toVersion: 3,
+      totalRows: 4,
+      operations: [
+        { type: "remove", key: "x" },
+        { type: "remove", key: "b" },
+        { type: "remove", key: "y" },
+        { type: "remove", key: "d" },
+        { type: "insert", key: "p", row: { id: "p" }, index: 0 },
+        { type: "insert", key: "q", row: { id: "q" }, index: 1 },
+        { type: "insert", key: "r", row: { id: "r" }, index: 2 },
+        { type: "insert", key: "s", row: { id: "s" }, index: 3 },
+      ],
+    });
+    expect(disjoint.current.rows).toStrictEqual([
+      { id: "p" },
+      { id: "q" },
+      { id: "r" },
+      { id: "s" },
+    ]);
+    expect(disjoint.current.keys).toStrictEqual(["p", "q", "r", "s"]);
+    expect(disjoint.current.rows).toBe(rows);
+    expect(disjoint.current.keys).toBe(keys);
+  });
+
+  it("stages dense move and mixed structural batches with one stable-array commit", () => {
+    const keys = Array.from({ length: 128 }, (_, index) => `key-${index}`);
+    const rows = keys.map((id) => ({ id }));
+    const projection = makeIncrementalClientState<{ readonly id: string }>();
+    const ready = projection.apply({
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-dense-structural",
+      version: 1,
+      keys,
+      rows,
+      totalRows: rows.length,
+    }).current;
+
+    const expectedKeys = keys.slice();
+    const expectedRows = rows.slice();
+    const moves: Array<DeltaEvent<{ readonly id: string }>["operations"][number]> = [];
+    for (let index = 0; index < 64; index += 1) {
+      const fromIndex = expectedKeys.length - 1;
+      const key = expectedKeys[fromIndex]!;
+      moves.push({ type: "move", key, fromIndex, toIndex: 0 });
+      expectedKeys.unshift(expectedKeys.pop()!);
+      expectedRows.unshift(expectedRows.pop()!);
+    }
+    const moved = projection.apply({
+      type: "delta",
+      topic: "orders",
+      queryId: "query-dense-structural",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: rows.length,
+      operations: moves,
+    });
+    expect(moved).toStrictEqual({
+      current: {
+        rows: expectedRows,
+        keys: expectedKeys,
+        totalRows: 128,
+        version: 2,
+        status: "ready",
+        statusCode: "Ready",
+      },
+      change: { _tag: "Range", start: 0, end: 127 },
+    });
+    expect(moved.current.rows).toBe(ready.rows);
+    expect(moved.current.keys).toBe(ready.keys);
+
+    const structural: Array<DeltaEvent<{ readonly id: string }>["operations"][number]> = [];
+    for (let index = 0; index < 64; index += 1) {
+      const fromIndex = expectedKeys.length - 1;
+      const key = expectedKeys[fromIndex]!;
+      structural.push({ type: "move", key, fromIndex, toIndex: 0 });
+      expectedKeys.unshift(expectedKeys.pop()!);
+      expectedRows.unshift(expectedRows.pop()!);
+    }
+    structural.push({
+      type: "update",
+      key: expectedKeys[10]!,
+      row: { id: "updated" },
+      index: 10,
+    });
+    expectedRows[10] = { id: "updated" };
+    const removedKey = expectedKeys[20]!;
+    structural.push({ type: "remove", key: removedKey });
+    expectedKeys.splice(20, 1);
+    expectedRows.splice(20, 1);
+    structural.push({ type: "insert", key: "inserted", row: { id: "inserted" }, index: 30 });
+    expectedKeys.splice(30, 0, "inserted");
+    expectedRows.splice(30, 0, { id: "inserted" });
+
+    const mixed = projection.apply({
+      type: "delta",
+      topic: "orders",
+      queryId: "query-dense-structural",
+      fromVersion: 2,
+      toVersion: 3,
+      totalRows: expectedRows.length,
+      operations: structural,
+    });
+    expect(mixed.current.rows).toStrictEqual(expectedRows);
+    expect(mixed.current.keys).toStrictEqual(expectedKeys);
+    expect(mixed.current.rows).toBe(ready.rows);
+    expect(mixed.current.keys).toBe(ready.keys);
+    expect(mixed.change).toStrictEqual({ _tag: "Range", start: 0, end: 127 });
+  });
+
+  it("keeps a sparse tail replacement on the narrow in-place path", () => {
+    const keys = Array.from({ length: 10_000 }, (_, index) => `key-${index}`);
+    const projection = makeIncrementalClientState<{ readonly id: string }>();
+    projection.apply({
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-tail-replacement",
+      version: 1,
+      keys,
+      rows: keys.map((id) => ({ id })),
+      totalRows: keys.length,
+    });
+    const changed = projection.apply({
+      type: "delta",
+      topic: "orders",
+      queryId: "query-tail-replacement",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: keys.length,
+      operations: [
+        { type: "remove", key: "key-9999" },
+        { type: "insert", key: "replacement", row: { id: "replacement" }, index: 9_999 },
+      ],
+    });
+    expect(changed.change).toStrictEqual({ _tag: "Range", start: 9_999, end: 9_999 });
+    expect(changed.current.rows[9_999]).toStrictEqual({ id: "replacement" });
+  });
+
+  it("stages dense structural batches for a single-row viewport", () => {
+    const projection = makeIncrementalClientState<{ readonly id: string }>();
+    projection.apply({
+      type: "snapshot",
+      topic: "orders",
+      queryId: "query-single-row-structural",
+      version: 1,
+      keys: ["only"],
+      rows: [{ id: "only" }],
+      totalRows: 1,
+    });
+    const changed = projection.apply({
+      type: "delta",
+      topic: "orders",
+      queryId: "query-single-row-structural",
+      fromVersion: 1,
+      toVersion: 2,
+      totalRows: 1,
+      operations: Array.from(
+        { length: 64 },
+        () =>
+          ({ type: "move", key: "only", fromIndex: 0, toIndex: 0 }) satisfies DeltaEvent<{
+            readonly id: string;
+          }>["operations"][number],
+      ),
+    });
+    expect(changed.current.rows).toStrictEqual([{ id: "only" }]);
+    expect(changed.change).toStrictEqual({ _tag: "Range", start: 0, end: 0 });
+  });
+
+  it("rejects invalid dense structural batches transactionally", () => {
+    const keys = Array.from({ length: 128 }, (_, index) => `key-${index}`);
+    const prefix = Array.from(
+      { length: 64 },
+      () =>
+        ({ type: "move", key: "key-0", fromIndex: 0, toIndex: 0 }) satisfies DeltaEvent<{
+          readonly id: string;
+        }>["operations"][number],
+    );
+    const apply = (
+      operation: DeltaEvent<{ readonly id: string }>["operations"][number],
+      totalRows = 128,
+    ) => {
+      const projection = makeIncrementalClientState<{ readonly id: string }>();
+      const ready = projection.apply({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-invalid-dense",
+        version: 1,
+        keys,
+        rows: keys.map((id) => ({ id })),
+        totalRows: keys.length,
+      }).current;
+      const result = projection.apply({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-invalid-dense",
+        fromVersion: 1,
+        toVersion: 2,
+        totalRows,
+        operations: [...prefix, operation],
+      });
+      expect(result.current.status).toBe("stale");
+      expect(ready.keys).toStrictEqual(keys);
+    };
+
+    apply({ type: "insert", key: "key-1", row: { id: "duplicate" }, index: 1 });
+    apply({ type: "insert", key: "new", row: { id: "new" }, index: 129 });
+    apply({ type: "update", key: "wrong", row: { id: "wrong" }, index: 1 });
+    apply({ type: "update", key: "missing", row: { id: "missing" }, index: 129 });
+    apply({ type: "move", key: "wrong", fromIndex: 1, toIndex: 2 });
+    apply({ type: "move", key: "key-1", fromIndex: 1, toIndex: 128 });
+    apply({ type: "remove", key: "missing" });
+    apply({ type: "remove", key: "key-1" }, 126);
+  });
+
+  it("rejects malformed replacement batches without mutating stable arrays", () => {
+    const makeProjection = () => {
+      const projection = makeIncrementalClientState<{ readonly id: string }>();
+      const ready = projection.apply({
+        type: "snapshot",
+        topic: "orders",
+        queryId: "query-invalid-replacement",
+        version: 1,
+        keys: ["a", "b"],
+        rows: [{ id: "a" }, { id: "b" }],
+        totalRows: 2,
+      }).current;
+      return { projection, ready };
+    };
+    const apply = (
+      projection: IncrementalClientState<{ readonly id: string }>,
+      operations: DeltaEvent<{ readonly id: string }>["operations"],
+      totalRows = 2,
+    ) =>
+      projection.apply({
+        type: "delta",
+        topic: "orders",
+        queryId: "query-invalid-replacement",
+        fromVersion: 1,
+        toVersion: 2,
+        totalRows,
+        operations,
+      }).current;
+
+    const missingRemoval = makeProjection();
+    expect(
+      apply(missingRemoval.projection, [
+        { type: "remove", key: "missing" },
+        { type: "insert", key: "x", row: { id: "x" }, index: 1 },
+      ]).status,
+    ).toBe("stale");
+    expect(missingRemoval.ready.rows).toStrictEqual([{ id: "a" }, { id: "b" }]);
+
+    const duplicateRemoval = makeProjection();
+    expect(
+      apply(duplicateRemoval.projection, [
+        { type: "remove", key: "a" },
+        { type: "remove", key: "a" },
+        { type: "insert", key: "x", row: { id: "x" }, index: 0 },
+      ]).status,
+    ).toBe("stale");
+    expect(duplicateRemoval.ready.keys).toStrictEqual(["a", "b"]);
+
+    const invalidInsertIndex = makeProjection();
+    expect(
+      apply(invalidInsertIndex.projection, [
+        { type: "remove", key: "a" },
+        { type: "insert", key: "x", row: { id: "x" }, index: 2 },
+      ]).status,
+    ).toBe("stale");
+
+    const duplicateInsert = makeProjection();
+    expect(
+      apply(duplicateInsert.projection, [
+        { type: "remove", key: "a" },
+        { type: "insert", key: "x", row: { id: "x" }, index: 0 },
+        { type: "insert", key: "x", row: { id: "x-again" }, index: 1 },
+      ]).status,
+    ).toBe("stale");
+
+    const retainedKeyInsert = makeProjection();
+    expect(
+      apply(retainedKeyInsert.projection, [
+        { type: "remove", key: "a" },
+        { type: "insert", key: "b", row: { id: "b" }, index: 0 },
+      ]).status,
+    ).toBe("stale");
+
+    const excessiveShrink = makeProjection();
+    expect(
+      apply(
+        excessiveShrink.projection,
+        [
+          { type: "remove", key: "a" },
+          { type: "insert", key: "x", row: { id: "x" }, index: 0 },
+        ],
+        1,
+      ).status,
+    ).toBe("stale");
+
+    const reinsertRemovedKey = makeProjection();
+    expect(
+      apply(reinsertRemovedKey.projection, [
+        { type: "remove", key: "a" },
+        { type: "insert", key: "a", row: { id: "a-new" }, index: 0 },
+      ]).rows,
+    ).toStrictEqual([{ id: "a-new" }, { id: "b" }]);
+
+    const nonIncreasingInserts = makeProjection();
+    expect(
+      apply(
+        nonIncreasingInserts.projection,
+        [
+          { type: "remove", key: "a" },
+          { type: "insert", key: "x", row: { id: "x" }, index: 0 },
+          { type: "insert", key: "y", row: { id: "y" }, index: 0 },
+        ],
+        3,
+      ).rows,
+    ).toStrictEqual([{ id: "y" }, { id: "x" }, { id: "b" }]);
   });
 
   it("moves rows by key even when the row value is undefined", () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -15,6 +15,10 @@ export {
   applyEvent,
   initialClientState,
   liveQueryResult,
+  makeIncrementalClientState,
+  type ClientStateChange,
   type ClientState,
+  type IncrementalClientState,
+  type IncrementalClientStateResult,
 } from "./live-query-state";
 export { stableQueryKey, stableQueryKeyForRowSchema } from "./query-key";

--- a/packages/client/src/live-query-state.ts
+++ b/packages/client/src/live-query-state.ts
@@ -1,4 +1,4 @@
-import type { DeltaEvent, LiveQueryResult, StatusEvent } from "@effect-view-server/config";
+import type { DeltaEvent, LiveQueryResult } from "@effect-view-server/config";
 import type { ViewServerLiveEvent } from "./live-client";
 
 export type ClientState<Row> = {
@@ -27,23 +27,6 @@ export const liveQueryResult = <Row>(state: ClientState<Row>): LiveQueryResult<R
   statusCode: state.statusCode,
   message: state.message,
 });
-
-const applySnapshot = <Row>(
-  state: ClientState<Row>,
-  event: Extract<ViewServerLiveEvent<Row>, { readonly type: "snapshot" }>,
-): ClientState<Row> => {
-  if (!isValidSnapshotEvent(event)) {
-    return staleSnapshotState(state);
-  }
-  return {
-    rows: event.rows,
-    keys: event.keys,
-    totalRows: event.totalRows,
-    version: event.version,
-    status: "ready",
-    statusCode: "Ready",
-  };
-};
 
 const reindexKeys = (
   keys: ReadonlyArray<string>,
@@ -84,60 +67,56 @@ const isValidSnapshotEvent = <Row>(
   event.keys.length === event.rows.length &&
   hasUniqueKeys(event.keys);
 
-const applyDeltaOperation = <Row>(
+type ClientStateMutation<Row> =
+  | {
+      readonly _tag: "Insert";
+      readonly index: number;
+      readonly key: string;
+    }
+  | {
+      readonly _tag: "Update";
+      readonly index: number;
+      readonly row: Row;
+    }
+  | {
+      readonly _tag: "Move";
+      readonly fromIndex: number;
+      readonly toIndex: number;
+    }
+  | {
+      readonly _tag: "Remove";
+      readonly index: number;
+      readonly key: string;
+      readonly row: Row;
+    };
+
+const rollbackMutations = <Row>(
   rows: Array<Row>,
   keys: Array<string>,
   keyIndexes: Map<string, number>,
-  operation: DeltaEvent<Row>["operations"][number],
-): boolean => {
-  if (operation.type === "insert") {
-    if (!isInsertIndex(operation.index, keys.length) || keyIndexes.has(operation.key)) {
-      return false;
+  mutations: ReadonlyArray<ClientStateMutation<Row>>,
+): void => {
+  for (let mutationIndex = mutations.length - 1; mutationIndex >= 0; mutationIndex -= 1) {
+    const mutation = mutations[mutationIndex]!;
+    if (mutation._tag === "Insert") {
+      rows.splice(mutation.index, 1);
+      keys.splice(mutation.index, 1);
+      keyIndexes.delete(mutation.key);
+      reindexKeys(keys, keyIndexes, mutation.index);
+    } else if (mutation._tag === "Update") {
+      rows[mutation.index] = mutation.row;
+    } else if (mutation._tag === "Move") {
+      const movedRows = rows.splice(mutation.toIndex, 1);
+      const movedKeys = keys.splice(mutation.toIndex, 1);
+      rows.splice(mutation.fromIndex, 0, ...movedRows);
+      keys.splice(mutation.fromIndex, 0, ...movedKeys);
+      reindexKeys(keys, keyIndexes, Math.min(mutation.fromIndex, mutation.toIndex));
+    } else {
+      rows.splice(mutation.index, 0, mutation.row);
+      keys.splice(mutation.index, 0, mutation.key);
+      reindexKeys(keys, keyIndexes, mutation.index);
     }
-    rows.splice(operation.index, 0, operation.row);
-    keys.splice(operation.index, 0, operation.key);
-    reindexKeys(keys, keyIndexes, operation.index);
-    return true;
   }
-  if (operation.type === "update") {
-    if (!isExistingIndex(operation.index, keys.length)) {
-      return false;
-    }
-    const previousKey = keys[operation.index];
-    if (previousKey !== operation.key) {
-      return false;
-    }
-    rows[operation.index] = operation.row;
-    keyIndexes.set(operation.key, operation.index);
-    return true;
-  }
-  if (operation.type === "move") {
-    if (
-      !isExistingIndex(operation.fromIndex, keys.length) ||
-      !isExistingIndex(operation.toIndex, keys.length)
-    ) {
-      return false;
-    }
-    const key = keys[operation.fromIndex];
-    if (key !== operation.key) {
-      return false;
-    }
-    const movedRows = rows.splice(operation.fromIndex, 1);
-    const movedKeys = keys.splice(operation.fromIndex, 1);
-    rows.splice(operation.toIndex, 0, ...movedRows);
-    keys.splice(operation.toIndex, 0, ...movedKeys);
-    reindexKeys(keys, keyIndexes, Math.min(operation.fromIndex, operation.toIndex));
-    return true;
-  }
-  const index = keyIndexes.get(operation.key);
-  if (index === undefined) {
-    return false;
-  }
-  rows.splice(index, 1);
-  keys.splice(index, 1);
-  keyIndexes.delete(operation.key);
-  reindexKeys(keys, keyIndexes, index);
-  return true;
 };
 
 const staleDeltaState = <Row>(state: ClientState<Row>): ClientState<Row> => ({
@@ -171,50 +150,179 @@ const canApplyDeltaFromVersion = <Row>(
   );
 };
 
-const applyDelta = <Row>(state: ClientState<Row>, event: DeltaEvent<Row>): ClientState<Row> => {
-  if (!canApplyDeltaFromVersion(state, event)) {
-    return staleDeltaState(state);
-  }
-  const rows = state.rows.slice();
-  const keys = state.keys.slice();
-  const keyIndexes = new Map(keys.map((key, index) => [key, index]));
-  for (const operation of event.operations) {
-    if (!applyDeltaOperation(rows, keys, keyIndexes, operation)) {
-      return staleDeltaState(state);
+export type ClientStateChange =
+  | {
+      readonly _tag: "All";
     }
-  }
-  if (event.totalRows < rows.length) {
-    return staleDeltaState(state);
-  }
-  return {
-    rows,
-    keys,
-    totalRows: event.totalRows,
-    version: event.toVersion,
-    status: "ready",
-    statusCode: "Ready",
-  };
+  | {
+      readonly _tag: "Range";
+      readonly start: number;
+      readonly end: number;
+    }
+  | {
+      readonly _tag: "None";
+    };
+
+export type IncrementalClientStateResult<Row> = {
+  readonly current: ClientState<Row>;
+  readonly change: ClientStateChange;
 };
 
-const applyStatus = <Row>(state: ClientState<Row>, event: StatusEvent): ClientState<Row> => {
-  const baseState = event.status === "closed" ? initialClientState<Row>() : state;
-  return {
-    ...baseState,
-    status: event.status,
-    statusCode: event.code,
-    message: event.message,
+export type IncrementalClientState<Row> = {
+  readonly apply: (event: ViewServerLiveEvent<Row>) => IncrementalClientStateResult<Row>;
+};
+
+export const makeIncrementalClientState = <Row>(
+  initial: ClientState<Row> = initialClientState<Row>(),
+): IncrementalClientState<Row> => {
+  const rows = initial.rows.slice();
+  const keys = initial.keys.slice();
+  const keyIndexes = new Map(keys.map((key, index) => [key, index]));
+  let current: ClientState<Row> = { ...initial, rows, keys };
+
+  const staleDelta = (): IncrementalClientStateResult<Row> => {
+    current = staleDeltaState(current);
+    return { current, change: { _tag: "None" } };
   };
+
+  const apply = (event: ViewServerLiveEvent<Row>): IncrementalClientStateResult<Row> => {
+    if (event.type === "snapshot") {
+      if (!isValidSnapshotEvent(event)) {
+        current = staleSnapshotState(current);
+        return { current, change: { _tag: "None" } };
+      }
+      rows.length = 0;
+      keys.length = 0;
+      for (let index = 0; index < event.rows.length; index += 1) {
+        rows.push(event.rows[index]!);
+        keys.push(event.keys[index]!);
+      }
+      keyIndexes.clear();
+      reindexKeys(keys, keyIndexes, 0);
+      current = {
+        rows,
+        keys,
+        totalRows: event.totalRows,
+        version: event.version,
+        status: "ready",
+        statusCode: "Ready",
+      };
+      return { current, change: { _tag: "All" } };
+    }
+    if (event.type !== "delta") {
+      if (event.status === "closed") {
+        rows.length = 0;
+        keys.length = 0;
+        keyIndexes.clear();
+        current = initialClientState<Row>();
+      }
+      current = {
+        ...current,
+        status: event.status,
+        statusCode: event.code,
+        message: event.message,
+      };
+      return { current, change: { _tag: "None" } };
+    }
+    if (!canApplyDeltaFromVersion(current, event)) {
+      return staleDelta();
+    }
+
+    const mutations: Array<ClientStateMutation<Row>> = [];
+    let start = Number.POSITIVE_INFINITY;
+    let end = -1;
+    let throughEnd = false;
+    for (const operation of event.operations) {
+      if (operation.type === "insert") {
+        if (!isInsertIndex(operation.index, keys.length) || keyIndexes.has(operation.key)) {
+          rollbackMutations(rows, keys, keyIndexes, mutations);
+          return staleDelta();
+        }
+        rows.splice(operation.index, 0, operation.row);
+        keys.splice(operation.index, 0, operation.key);
+        reindexKeys(keys, keyIndexes, operation.index);
+        mutations.push({ _tag: "Insert", index: operation.index, key: operation.key });
+        start = Math.min(start, operation.index);
+        throughEnd = true;
+      } else if (operation.type === "update") {
+        if (
+          !isExistingIndex(operation.index, keys.length) ||
+          keys[operation.index] !== operation.key
+        ) {
+          rollbackMutations(rows, keys, keyIndexes, mutations);
+          return staleDelta();
+        }
+        mutations.push({ _tag: "Update", index: operation.index, row: rows[operation.index]! });
+        rows[operation.index] = operation.row;
+        start = Math.min(start, operation.index);
+        end = Math.max(end, operation.index);
+      } else if (operation.type === "move") {
+        if (
+          !isExistingIndex(operation.fromIndex, keys.length) ||
+          !isExistingIndex(operation.toIndex, keys.length) ||
+          keys[operation.fromIndex] !== operation.key
+        ) {
+          rollbackMutations(rows, keys, keyIndexes, mutations);
+          return staleDelta();
+        }
+        const movedRows = rows.splice(operation.fromIndex, 1);
+        const movedKeys = keys.splice(operation.fromIndex, 1);
+        rows.splice(operation.toIndex, 0, ...movedRows);
+        keys.splice(operation.toIndex, 0, ...movedKeys);
+        reindexKeys(keys, keyIndexes, Math.min(operation.fromIndex, operation.toIndex));
+        mutations.push({
+          _tag: "Move",
+          fromIndex: operation.fromIndex,
+          toIndex: operation.toIndex,
+        });
+        start = Math.min(start, operation.fromIndex, operation.toIndex);
+        end = Math.max(end, operation.fromIndex, operation.toIndex);
+      } else {
+        const index = keyIndexes.get(operation.key);
+        if (index === undefined) {
+          rollbackMutations(rows, keys, keyIndexes, mutations);
+          return staleDelta();
+        }
+        const removedRows = rows.splice(index, 1);
+        keys.splice(index, 1);
+        keyIndexes.delete(operation.key);
+        reindexKeys(keys, keyIndexes, index);
+        mutations.push({
+          _tag: "Remove",
+          index,
+          key: operation.key,
+          row: removedRows[0]!,
+        });
+        start = Math.min(start, index);
+        throughEnd = true;
+      }
+    }
+    if (event.totalRows < rows.length) {
+      rollbackMutations(rows, keys, keyIndexes, mutations);
+      return staleDelta();
+    }
+    current = {
+      rows,
+      keys,
+      totalRows: event.totalRows,
+      version: event.toVersion,
+      status: "ready",
+      statusCode: "Ready",
+    };
+    const change: ClientStateChange = Number.isFinite(start)
+      ? {
+          _tag: "Range",
+          start,
+          end: throughEnd ? rows.length - 1 : Math.min(end, rows.length - 1),
+        }
+      : { _tag: "None" };
+    return { current, change };
+  };
+
+  return { apply };
 };
 
 export const applyEvent = <Row>(
   state: ClientState<Row>,
   event: ViewServerLiveEvent<Row>,
-): ClientState<Row> => {
-  if (event.type === "snapshot") {
-    return applySnapshot(state, event);
-  }
-  if (event.type === "delta") {
-    return applyDelta(state, event);
-  }
-  return applyStatus(state, event);
-};
+): ClientState<Row> => makeIncrementalClientState(state).apply(event).current;

--- a/packages/client/src/live-query-state.ts
+++ b/packages/client/src/live-query-state.ts
@@ -169,6 +169,11 @@ export type IncrementalClientStateResult<Row> = {
 };
 
 export type IncrementalClientState<Row> = {
+  /**
+   * Applies an event in place. `current.rows` and `current.keys` are stable,
+   * controller-owned arrays that may be mutated by later calls to `apply`.
+   * Consumers that retain historical states must copy them at that boundary.
+   */
   readonly apply: (event: ViewServerLiveEvent<Row>) => IncrementalClientStateResult<Row>;
 };
 
@@ -214,7 +219,7 @@ export const makeIncrementalClientState = <Row>(
         rows.length = 0;
         keys.length = 0;
         keyIndexes.clear();
-        current = initialClientState<Row>();
+        current = { ...initialClientState<Row>(), rows, keys };
       }
       current = {
         ...current,
@@ -325,4 +330,15 @@ export const makeIncrementalClientState = <Row>(
 export const applyEvent = <Row>(
   state: ClientState<Row>,
   event: ViewServerLiveEvent<Row>,
-): ClientState<Row> => makeIncrementalClientState(state).apply(event).current;
+): ClientState<Row> => {
+  if (event.type !== "snapshot" && event.type !== "delta") {
+    const current = event.status === "closed" ? initialClientState<Row>() : state;
+    return {
+      ...current,
+      status: event.status,
+      statusCode: event.code,
+      message: event.message,
+    };
+  }
+  return makeIncrementalClientState(state).apply(event).current;
+};

--- a/packages/client/src/live-query-state.ts
+++ b/packages/client/src/live-query-state.ts
@@ -67,6 +67,264 @@ const isValidSnapshotEvent = <Row>(
   event.keys.length === event.rows.length &&
   hasUniqueKeys(event.keys);
 
+type StructuralBatch<Row> =
+  | { readonly _tag: "NotStaged" }
+  | { readonly _tag: "Invalid" }
+  | {
+      readonly _tag: "Staged";
+      readonly rows: ReadonlyArray<Row>;
+      readonly keys: ReadonlyArray<string>;
+      readonly start: number;
+      readonly end: number;
+    };
+
+type SequenceNode<Row> = {
+  readonly id: number;
+  readonly priority: bigint;
+  readonly key: string;
+  row: Row;
+  left: SequenceNode<Row> | undefined;
+  right: SequenceNode<Row> | undefined;
+  parent: SequenceNode<Row> | undefined;
+  size: number;
+};
+
+const sequenceSize = <Row>(node: SequenceNode<Row> | undefined): number => node?.size ?? 0;
+
+const updateSequenceNode = <Row>(node: SequenceNode<Row>): void => {
+  node.size = sequenceSize(node.left) + sequenceSize(node.right) + 1;
+  if (node.left !== undefined) {
+    node.left.parent = node;
+  }
+  if (node.right !== undefined) {
+    node.right.parent = node;
+  }
+};
+
+const sequencePrecedes = <Row>(left: SequenceNode<Row>, right: SequenceNode<Row>): boolean =>
+  left.priority < right.priority;
+
+const mergeSequence = <Row>(
+  left: SequenceNode<Row> | undefined,
+  right: SequenceNode<Row> | undefined,
+): SequenceNode<Row> | undefined => {
+  if (left === undefined) {
+    if (right !== undefined) {
+      right.parent = undefined;
+    }
+    return right;
+  }
+  if (right === undefined) {
+    left.parent = undefined;
+    return left;
+  }
+  if (sequencePrecedes(left, right)) {
+    left.right = mergeSequence(left.right, right);
+    updateSequenceNode(left);
+    left.parent = undefined;
+    return left;
+  }
+  right.left = mergeSequence(left, right.left);
+  updateSequenceNode(right);
+  right.parent = undefined;
+  return right;
+};
+
+const splitSequence = <Row>(
+  root: SequenceNode<Row> | undefined,
+  count: number,
+): readonly [SequenceNode<Row> | undefined, SequenceNode<Row> | undefined] => {
+  if (root === undefined) {
+    return [undefined, undefined];
+  }
+  const leftSize = sequenceSize(root.left);
+  if (count <= leftSize) {
+    const [left, right] = splitSequence(root.left, count);
+    root.left = right;
+    updateSequenceNode(root);
+    root.parent = undefined;
+    if (left !== undefined) {
+      left.parent = undefined;
+    }
+    return [left, root];
+  }
+  const [left, right] = splitSequence(root.right, count - leftSize - 1);
+  root.right = left;
+  updateSequenceNode(root);
+  root.parent = undefined;
+  if (right !== undefined) {
+    right.parent = undefined;
+  }
+  return [root, right];
+};
+
+const sequenceNodeAt = <Row>(
+  root: SequenceNode<Row> | undefined,
+  index: number,
+): SequenceNode<Row> | undefined => {
+  let current = root;
+  let remaining = index;
+  while (current !== undefined) {
+    const leftSize = sequenceSize(current.left);
+    if (remaining === leftSize) {
+      return current;
+    }
+    if (remaining < leftSize) {
+      current = current.left;
+    } else {
+      remaining -= leftSize + 1;
+      current = current.right;
+    }
+  }
+  return undefined;
+};
+
+const sequenceNodeIndex = <Row>(node: SequenceNode<Row>): number => {
+  let index = sequenceSize(node.left);
+  let current = node;
+  while (current.parent !== undefined) {
+    if (current.parent.right === current) {
+      index += sequenceSize(current.parent.left) + 1;
+    }
+    current = current.parent;
+  }
+  return index;
+};
+
+const sequencePriority = (id: number): bigint => {
+  let value = id + 0x9e3779b9;
+  value = Math.imul(value ^ (value >>> 16), 0x21f0aaad);
+  value = Math.imul(value ^ (value >>> 15), 0x735a2d97);
+  return (BigInt((value ^ (value >>> 15)) >>> 0) << 53n) | BigInt(id);
+};
+
+const makeSequenceNode = <Row>(id: number, key: string, row: Row): SequenceNode<Row> => ({
+  id,
+  priority: sequencePriority(id),
+  key,
+  row,
+  left: undefined,
+  right: undefined,
+  parent: undefined,
+  size: 1,
+});
+
+const materializeSequence = <Row>(
+  root: SequenceNode<Row> | undefined,
+): { readonly rows: ReadonlyArray<Row>; readonly keys: ReadonlyArray<string> } => {
+  const rows: Array<Row> = [];
+  const keys: Array<string> = [];
+  const stack: Array<SequenceNode<Row>> = [];
+  let current = root;
+  while (current !== undefined || stack.length > 0) {
+    while (current !== undefined) {
+      stack.push(current);
+      current = current.left;
+    }
+    const node = stack.pop()!;
+    rows.push(node.row);
+    keys.push(node.key);
+    current = node.right;
+  }
+  return { rows, keys };
+};
+
+const shouldStageStructuralBatch = <Row>(
+  rowCount: number,
+  operations: DeltaEvent<Row>["operations"],
+): boolean => {
+  let structuralCount = 0;
+  for (const operation of operations) {
+    if (operation.type !== "update") {
+      structuralCount += 1;
+    }
+  }
+  // Below this benchmark-derived density, the in-place path avoids materializing
+  // the whole viewport and preserves cheap, narrow changes such as a tail replace.
+  return structuralCount >= 64 && structuralCount * 4 >= Math.max(rowCount, 1);
+};
+
+const stageStructuralBatch = <Row>(
+  rows: ReadonlyArray<Row>,
+  keys: ReadonlyArray<string>,
+  operations: DeltaEvent<Row>["operations"],
+): StructuralBatch<Row> => {
+  if (!shouldStageStructuralBatch(rows.length, operations)) {
+    return { _tag: "NotStaged" };
+  }
+
+  const nodes = new Map<string, SequenceNode<Row>>();
+  let root: SequenceNode<Row> | undefined;
+  let nextId = 0;
+  for (let index = 0; index < keys.length; index += 1) {
+    const node = makeSequenceNode(++nextId, keys[index]!, rows[index]!);
+    nodes.set(node.key, node);
+    root = mergeSequence(root, node);
+  }
+
+  let start = Number.POSITIVE_INFINITY;
+  let end = -1;
+  let throughEnd = false;
+  for (const operation of operations) {
+    const length = sequenceSize(root);
+    if (operation.type === "insert") {
+      if (!isInsertIndex(operation.index, length) || nodes.has(operation.key)) {
+        return { _tag: "Invalid" };
+      }
+      const [left, right] = splitSequence(root, operation.index);
+      const node = makeSequenceNode(++nextId, operation.key, operation.row);
+      nodes.set(operation.key, node);
+      root = mergeSequence(mergeSequence(left, node), right);
+      start = Math.min(start, operation.index);
+      throughEnd = true;
+    } else if (operation.type === "update") {
+      const node = sequenceNodeAt(root, operation.index);
+      if (node === undefined || node.key !== operation.key) {
+        return { _tag: "Invalid" };
+      }
+      node.row = operation.row;
+      start = Math.min(start, operation.index);
+      end = Math.max(end, operation.index);
+    } else if (operation.type === "move") {
+      const node = sequenceNodeAt(root, operation.fromIndex);
+      if (
+        node === undefined ||
+        node.key !== operation.key ||
+        !isExistingIndex(operation.toIndex, length)
+      ) {
+        return { _tag: "Invalid" };
+      }
+      const [before, from] = splitSequence(root, operation.fromIndex);
+      const [moved, after] = splitSequence(from, 1);
+      root = mergeSequence(before, after);
+      const [left, right] = splitSequence(root, operation.toIndex);
+      root = mergeSequence(mergeSequence(left, moved), right);
+      start = Math.min(start, operation.fromIndex, operation.toIndex);
+      end = Math.max(end, operation.fromIndex, operation.toIndex);
+    } else {
+      const node = nodes.get(operation.key);
+      if (node === undefined) {
+        return { _tag: "Invalid" };
+      }
+      const index = sequenceNodeIndex(node);
+      const [before, from] = splitSequence(root, index);
+      const [, after] = splitSequence(from, 1);
+      root = mergeSequence(before, after);
+      nodes.delete(operation.key);
+      start = Math.min(start, index);
+      throughEnd = true;
+    }
+  }
+  const materialized = materializeSequence(root);
+  return {
+    _tag: "Staged",
+    rows: materialized.rows,
+    keys: materialized.keys,
+    start,
+    end: throughEnd ? materialized.rows.length - 1 : Math.min(end, materialized.rows.length - 1),
+  };
+};
+
 type ClientStateMutation<Row> =
   | {
       readonly _tag: "Insert";
@@ -231,6 +489,40 @@ export const makeIncrementalClientState = <Row>(
     }
     if (!canApplyDeltaFromVersion(current, event)) {
       return staleDelta();
+    }
+
+    const replacement = stageStructuralBatch(rows, keys, event.operations);
+    if (
+      replacement._tag === "Invalid" ||
+      (replacement._tag === "Staged" && event.totalRows < replacement.rows.length)
+    ) {
+      return staleDelta();
+    }
+    if (replacement._tag === "Staged") {
+      rows.length = 0;
+      keys.length = 0;
+      for (let index = 0; index < replacement.rows.length; index += 1) {
+        rows.push(replacement.rows[index]!);
+        keys.push(replacement.keys[index]!);
+      }
+      keyIndexes.clear();
+      reindexKeys(keys, keyIndexes, 0);
+      current = {
+        rows,
+        keys,
+        totalRows: event.totalRows,
+        version: event.toVersion,
+        status: "ready",
+        statusCode: "Ready",
+      };
+      return {
+        current,
+        change: {
+          _tag: "Range",
+          start: replacement.start,
+          end: replacement.end,
+        },
+      };
     }
 
     const mutations: Array<ClientStateMutation<Row>> = [];

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -58,6 +58,13 @@ An omitted `where`, `where: []`, and empty generated groups mean no filter.
 Field-keyed `where` objects and shorthand operators are invalid. Leased topics
 also require their exact, independently typed `routeBy` object.
 
+Virtualized grids use `react.useLiveQueryViewport(topic)`. Its `replace`
+operation binds a typed query and sparse row sink to an inclusive absolute
+window, while the returned generation's `setWindow` operation handles
+scroll-only changes. Each replacement is switch-latest: obsolete snapshots,
+deltas, statuses, failures, and sink writes are ignored. See the Public API
+guide for the complete adapter contract.
+
 React applications should install the package and compatible peer dependencies:
 
 ```sh

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -163,6 +163,9 @@ describe("public effect-view-server subpath type contracts", () => {
   });
 
   it("rejects invalid query and config contracts through public subpaths", () => {
+    // @ts-expect-error viewport topics must exist in the configured topic map.
+    react.useLiveQueryViewport("missing");
+
     // @ts-expect-error raw queries must explicitly select columns.
     react.useLiveQuery("orders", { where: [{ field: "status", type: "equals", filter: "open" }] });
 

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -128,6 +128,26 @@ describe("public effect-view-server subpath type contracts", () => {
         readonly price: number;
       }>
     >();
+    const viewport = react.useLiveQueryViewport("orders");
+    viewport.viewport.replace({
+      window: { firstRow: 0, lastRow: 19 },
+      query: {
+        select: ["id", "price"],
+        where: [],
+        orderBy: [{ field: "price", direction: "desc" }],
+      },
+      sink: {
+        setRowCount: (count) => {
+          expectTypeOf(count).toBeNumber();
+        },
+        setRowData: (rows) => {
+          expectTypeOf(rows[0]).toEqualTypeOf<
+            { readonly id: string; readonly price: number } | undefined
+          >();
+        },
+      },
+    });
+    expectTypeOf(viewport).not.toHaveProperty("rows");
 
     const profileResult = publicProfileReact.useLiveQuery("profiles", {
       select: ["id", "score"],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "bench:in-memory-live-query": "vp run -t @effect-view-server/in-memory#build && sh -c 'rows=${VIEW_SERVER_REACT_BENCH_ROWS:-10000}; browser=${VIEW_SERVER_REACT_BENCH_BROWSER:-chromium}; output=${VIEW_SERVER_REACT_BENCH_OUTPUT_JSON:-.artifacts/in-memory-live-query-${rows}rows-${browser}.json}; mkdir -p .artifacts; VIEW_SERVER_REACT_SKIP_REMOTE_GLOBAL_SETUP=1 VITE_VIEW_SERVER_REACT_BENCH_ROWS=$rows VITE_VIEW_SERVER_REACT_BENCH_BATCH_SIZE=${VIEW_SERVER_REACT_BENCH_BATCH_SIZE:-1000} VITE_VIEW_SERVER_REACT_BENCH_ITERATIONS=${VIEW_SERVER_REACT_BENCH_ITERATIONS:-5} VITE_VIEW_SERVER_REACT_BENCH_TIME_MS=${VIEW_SERVER_REACT_BENCH_TIME_MS:-250} VITE_VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS=${VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS:-0} VITE_VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS=${VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS:-0} VITE_VIEW_SERVER_REACT_BENCH_OUTPUT_JSON=$output vp test bench src/in-memory-live-query.bench.tsx --run --testTimeout 0 --project $browser --outputJson $output'",
-    "bench:live-query-viewport": "vp test bench src/live-query-viewport.bench.tsx --run --project chromium",
+    "bench:live-query-viewport": "vp run -t @effect-view-server/in-memory#build && vp test bench src/live-query-viewport.bench.tsx --run --testTimeout 0 --project chromium",
     "build": "vp run -t @effect-view-server/effect-utils#build && vp run -t @effect-view-server/in-memory#build && vp pack",
     "test": "vp run -t @effect-view-server/effect-utils#build && vp run -t @effect-view-server/in-memory#build && vp run -t @effect-view-server/server#build && vp test run --coverage --typecheck"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "bench:in-memory-live-query": "vp run -t @effect-view-server/in-memory#build && sh -c 'rows=${VIEW_SERVER_REACT_BENCH_ROWS:-10000}; browser=${VIEW_SERVER_REACT_BENCH_BROWSER:-chromium}; output=${VIEW_SERVER_REACT_BENCH_OUTPUT_JSON:-.artifacts/in-memory-live-query-${rows}rows-${browser}.json}; mkdir -p .artifacts; VIEW_SERVER_REACT_SKIP_REMOTE_GLOBAL_SETUP=1 VITE_VIEW_SERVER_REACT_BENCH_ROWS=$rows VITE_VIEW_SERVER_REACT_BENCH_BATCH_SIZE=${VIEW_SERVER_REACT_BENCH_BATCH_SIZE:-1000} VITE_VIEW_SERVER_REACT_BENCH_ITERATIONS=${VIEW_SERVER_REACT_BENCH_ITERATIONS:-5} VITE_VIEW_SERVER_REACT_BENCH_TIME_MS=${VIEW_SERVER_REACT_BENCH_TIME_MS:-250} VITE_VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS=${VIEW_SERVER_REACT_BENCH_WARMUP_ITERATIONS:-0} VITE_VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS=${VIEW_SERVER_REACT_BENCH_WARMUP_TIME_MS:-0} VITE_VIEW_SERVER_REACT_BENCH_OUTPUT_JSON=$output vp test bench src/in-memory-live-query.bench.tsx --run --testTimeout 0 --project $browser --outputJson $output'",
+    "bench:live-query-viewport": "vp test bench src/live-query-viewport.bench.tsx --run --project chromium",
     "build": "vp run -t @effect-view-server/effect-utils#build && vp run -t @effect-view-server/in-memory#build && vp pack",
     "test": "vp run -t @effect-view-server/effect-utils#build && vp run -t @effect-view-server/in-memory#build && vp run -t @effect-view-server/server#build && vp test run --coverage --typecheck"
   },

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -36,8 +36,27 @@ import type {
 import { Effect, Result, Stream } from "effect";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { createContext, useContext, useInsertionEffect, useMemo, type ReactNode } from "react";
 import { ViewServerReactClientProvider, ViewServerReactConfig } from "./internal";
+import {
+  makeLiveQueryViewport,
+  makeLiveQueryViewportAtom,
+  makeLiveQueryViewportBinding,
+  type UseLiveQueryViewportHook,
+  type UseLiveQueryViewportResult,
+} from "./live-query-viewport";
+
+export type {
+  LiveQueryViewport,
+  LiveQueryViewportGeneration,
+  LiveQueryViewportGroupedQuery,
+  LiveQueryViewportQuery,
+  LiveQueryViewportRawQuery,
+  LiveQueryViewportSink,
+  LiveQueryViewportWindow,
+  UseLiveQueryViewportHook,
+  UseLiveQueryViewportResult,
+} from "./live-query-viewport";
 
 export type ViewServerReactBindings<
   Topics extends TopicDefinitions,
@@ -49,6 +68,7 @@ export type ViewServerReactBindings<
     props: ViewServerClientProviderProps<Topics>,
   ) => ReactNode;
   readonly useLiveQuery: UseLiveQueryHook<Topics>;
+  readonly useLiveQueryViewport: UseLiveQueryViewportHook<Topics>;
   readonly useViewServerHealth: () => ViewServerHealthDetails<Extract<keyof Topics, string>>;
   readonly useViewServerHealthSummary: () => ViewServerHealthSummary<Topics>;
   readonly ViewServerProvider: (props: ViewServerProviderProps) => ReactNode;
@@ -144,6 +164,7 @@ export const createViewServerReact = <
 
   const useSubscription = <Row,>(
     subscriptionKey: string,
+    subscriptionOwner: object,
     subscribe: () => Effect.Effect<ViewServerLiveSubscription<Row>, unknown>,
   ): LiveQueryResult<Row> => {
     const liveAtom = useMemo(
@@ -161,7 +182,7 @@ export const createViewServerReact = <
             ),
           ),
         ),
-      [subscriptionKey],
+      [subscriptionKey, subscriptionOwner],
     );
     const result = AtomReact.useAtomValue(liveAtom);
     return liveQueryResultFromAsyncResult<Row>(result);
@@ -190,8 +211,44 @@ export const createViewServerReact = <
     }, [query, topicDefinition]);
     return useSubscription<LiveQueryRow<TopicRow<Topics, Topic>, Query>>(
       `${client.health.key}:query:${topic}:${queryIdentity.key}`,
+      client,
       () => client.subscribe<Topic, Query>(topic, queryIdentity.query),
     );
+  }
+
+  function useLiveQueryViewport<Topic extends Extract<keyof Topics, string>>(
+    topic: Topic,
+  ): UseLiveQueryViewportResult<Topics, Topic> {
+    const client = useClient();
+    const binding = useMemo(() => makeLiveQueryViewportBinding<Topics, Topic>(), [topic]);
+    const viewportState = useMemo(() => makeLiveQueryViewportAtom(), [client, topic]);
+    const [result, publish] = AtomReact.useAtom(viewportState.atom);
+    const entry = useMemo(() => {
+      const viewport = makeLiveQueryViewport({
+        client,
+        config,
+        topic,
+        publish: (command) => {
+          publish(viewportState.prepare(command));
+        },
+      });
+      return { viewport, deactivate: viewport.deactivate };
+    }, [client, publish, topic, viewportState]);
+    useInsertionEffect(() => {
+      binding.install(entry);
+      return () => {
+        binding.uninstall(entry);
+      };
+    }, [binding, entry]);
+    const chrome = viewportState.read(result);
+    return {
+      viewport: binding.viewport,
+      totalRows: chrome.totalRows,
+      version: chrome.version,
+      status: chrome.status,
+      statusCode: chrome.statusCode,
+      message: chrome.message,
+    };
   }
 
   const connectionStatusFromLiveQueryStatus = (
@@ -233,6 +290,7 @@ export const createViewServerReact = <
     const client = useClient();
     const result = useSubscription<ViewServerHealthSummaryRow<Topics>>(
       `${client.health.key}:health-summary`,
+      client,
       client.subscribeHealthSummary,
     );
     const connectionStatus = connectionStatusFromLiveQueryStatus(result.status);
@@ -247,6 +305,7 @@ export const createViewServerReact = <
     const summary = useViewServerHealthSummary();
     const result = useSubscription<ViewServerHealthTopicRow<Extract<keyof Topics, string>>>(
       `${client.health.key}:health`,
+      client,
       client.subscribeHealth,
     );
     const detailConnectionStatus = connectionStatusFromLiveQueryStatus(result.status);
@@ -268,6 +327,7 @@ export const createViewServerReact = <
     [ViewServerReactConfig]: config,
     [ViewServerReactClientProvider]: ViewServerClientProvider,
     useLiveQuery,
+    useLiveQueryViewport,
     useViewServerHealth,
     useViewServerHealthSummary,
     ViewServerProvider,

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -220,6 +220,8 @@ export const createViewServerReact = <
     topic: Topic,
   ): UseLiveQueryViewportResult<Topics, Topic> {
     const client = useClient();
+    // Topic identity owns the public facade. Client changes replace the installed
+    // controller below without invalidating viewport references held by the grid.
     const binding = useMemo(() => makeLiveQueryViewportBinding<Topics, Topic>(), [topic]);
     const viewportState = useMemo(() => makeLiveQueryViewportAtom(), [client, topic]);
     const [result, publish] = AtomReact.useAtom(viewportState.atom);

--- a/packages/react/src/live-query-viewport.bench.tsx
+++ b/packages/react/src/live-query-viewport.bench.tsx
@@ -1,0 +1,183 @@
+// Import Vitest directly so @effect/vitest's eager Effect test runtime does not
+// distort the allocation and latency profile this hot-path benchmark measures.
+// This is a Chromium browser CPU/GC stress microbenchmark over a synthetic
+// in-memory Queue. It is not network-shaped or production-like.
+import { afterAll, bench, describe } from "vitest";
+import type {
+  ViewServerLiveClient,
+  ViewServerLiveEvent,
+  ViewServerLiveSubscription,
+} from "@effect-view-server/client";
+import {
+  defineViewServerConfig,
+  type ExactLiveQueryInputForTopic,
+  type GroupedQuery,
+  type LiveQueryRow,
+  type RawQuery,
+  type TopicDefinitions,
+  type TopicRow,
+  type ViewServerRuntimeError,
+  type ViewServerTransportError,
+} from "@effect-view-server/config";
+import { createInMemoryViewServer } from "@effect-view-server/in-memory";
+import { Effect, Fiber, Queue, Schema, Stream } from "effect";
+import { makeLiveQueryViewport, type LiveQueryViewportChrome } from "./live-query-viewport";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  price: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+
+type QuerySubstrate<Topics_ extends TopicDefinitions> = (
+  topic: Extract<keyof Topics_, string>,
+  query: Readonly<Record<string, unknown>>,
+) => Effect.Effect<
+  ViewServerLiveSubscription<object>,
+  ViewServerRuntimeError | ViewServerTransportError
+>;
+
+const adaptQuerySubstrate = <Topics_ extends TopicDefinitions>(
+  substrate: QuerySubstrate<Topics_>,
+): ViewServerLiveClient<Topics_>["subscribe"] => {
+  function subscribe<
+    Topic extends Extract<keyof Topics_, string>,
+    const Query extends
+      | RawQuery<TopicRow<Topics_, NoInfer<Topic>>>
+      | GroupedQuery<TopicRow<Topics_, NoInfer<Topic>>>,
+  >(
+    topic: Topic,
+    query: ExactLiveQueryInputForTopic<Topics_, NoInfer<Topic>, Query>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics_, Topic>, Query>>,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
+  function subscribe(
+    topic: Extract<keyof Topics_, string>,
+    query: Readonly<Record<string, unknown>>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<object>,
+    ViewServerRuntimeError | ViewServerTransportError
+  > {
+    return substrate(topic, query);
+  }
+  return subscribe;
+};
+
+type ViewportBenchmark = {
+  readonly update: () => Promise<void>;
+  readonly close: () => Promise<void>;
+};
+
+const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmark> => {
+  const runtime = createInMemoryViewServer(viewServer);
+  const events = await Effect.runPromise(Queue.unbounded<ViewServerLiveEvent<object>>());
+  const client = {
+    ...runtime.liveClient,
+    subscribe: adaptQuerySubstrate(() =>
+      Effect.succeed({
+        events: Stream.fromQueue(events),
+        close: () => Effect.void,
+      }),
+    ),
+  } satisfies ViewServerLiveClient<Topics>;
+  let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+  let resolveWrite: (() => void) | undefined;
+  const viewport = makeLiveQueryViewport({
+    client,
+    config: viewServer,
+    topic: "orders",
+    publish: (command) => {
+      currentStream = command.stream;
+    },
+  });
+  viewport.replace({
+    window: { firstRow: 0, lastRow: rowCount - 1 },
+    query: { select: ["id", "price"], where: [], orderBy: [] },
+    sink: {
+      setRowCount: () => undefined,
+      setRowData: () => {
+        resolveWrite?.();
+      },
+    },
+  });
+  const fiber = Effect.runFork(currentStream.pipe(Stream.runDrain));
+  const rows = Array.from({ length: rowCount }, (_, index) => ({
+    id: `row-${index}`,
+    price: index,
+  }));
+  const snapshotWritten = new Promise<void>((resolve) => {
+    resolveWrite = resolve;
+  });
+  await Effect.runPromise(
+    Queue.offer(events, {
+      type: "snapshot",
+      topic: "orders",
+      queryId: "viewport-benchmark",
+      rows,
+      keys: rows.map((row) => row.id),
+      totalRows: rowCount,
+      version: 1,
+    }),
+  );
+  await snapshotWritten;
+
+  const index = Math.floor(rowCount / 2);
+  let version = 1;
+  return {
+    update: async () => {
+      const nextVersion = version + 1;
+      const written = new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+      await Effect.runPromise(
+        Queue.offer(events, {
+          type: "delta",
+          topic: "orders",
+          queryId: "viewport-benchmark",
+          operations: [
+            {
+              type: "update",
+              key: `row-${index}`,
+              row: { id: `row-${index}`, price: nextVersion },
+              index,
+            },
+          ],
+          totalRows: rowCount,
+          fromVersion: version,
+          toVersion: nextVersion,
+        }),
+      );
+      version = nextVersion;
+      await written;
+    },
+    close: async () => {
+      viewport.destroy();
+      await Effect.runPromise(Fiber.interrupt(fiber));
+      await Effect.runPromise(runtime.close);
+    },
+  };
+};
+
+const update100Rows = await makeViewportBenchmark(100);
+const update10000Rows = await makeViewportBenchmark(10_000);
+
+afterAll(async () => {
+  await update100Rows.close();
+  await update10000Rows.close();
+});
+
+describe("Live Query Viewport subscription-to-sink projection", () => {
+  bench("single-row update in a 100-row viewport", () => update100Rows.update());
+  bench("single-row update in a 10000-row viewport", () => update10000Rows.update());
+});

--- a/packages/react/src/live-query-viewport.bench.tsx
+++ b/packages/react/src/live-query-viewport.bench.tsx
@@ -79,6 +79,27 @@ type ViewportBenchmark = {
   readonly close: () => Promise<void>;
 };
 
+const waitForSinkWrite = (
+  write: Promise<void>,
+  label: string,
+  timeoutMilliseconds = 10_000,
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label} after ${timeoutMilliseconds}ms`));
+    }, timeoutMilliseconds);
+    write.then(
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+
 const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmark> => {
   const runtime = createInMemoryViewServer(viewServer);
   const events = await Effect.runPromise(Queue.unbounded<ViewServerLiveEvent<object>>());
@@ -130,7 +151,7 @@ const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmar
       version: 1,
     }),
   );
-  await snapshotWritten;
+  await waitForSinkWrite(snapshotWritten, `${rowCount}-row snapshot`);
 
   const index = Math.floor(rowCount / 2);
   let version = 1;
@@ -159,7 +180,7 @@ const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmar
         }),
       );
       version = nextVersion;
-      await written;
+      await waitForSinkWrite(written, `${rowCount}-row delta`);
     },
     close: async () => {
       viewport.destroy();

--- a/packages/react/src/live-query-viewport.bench.tsx
+++ b/packages/react/src/live-query-viewport.bench.tsx
@@ -76,6 +76,9 @@ const adaptQuerySubstrate = <Topics_ extends TopicDefinitions>(
 
 type ViewportBenchmark = {
   readonly update: () => Promise<void>;
+  readonly replaceAll: () => Promise<void>;
+  readonly moveAll: () => Promise<void>;
+  readonly replaceTail: () => Promise<void>;
   readonly close: () => Promise<void>;
 };
 
@@ -154,6 +157,36 @@ const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmar
   await waitForSinkWrite(snapshotWritten, `${rowCount}-row snapshot`);
 
   const index = Math.floor(rowCount / 2);
+  const replacementRows = Array.from({ length: rowCount }, (_, rowIndex) => ({
+    id: `replacement-${rowIndex}`,
+    price: rowIndex,
+  }));
+  const replaceWithReplacement = [
+    ...rows.map((row) => ({ type: "remove" as const, key: row.id })),
+    ...replacementRows.map((row, rowIndex) => ({
+      type: "insert" as const,
+      key: row.id,
+      row,
+      index: rowIndex,
+    })),
+  ];
+  const replaceWithOriginal = [
+    ...replacementRows.map((row) => ({ type: "remove" as const, key: row.id })),
+    ...rows.map((row, rowIndex) => ({
+      type: "insert" as const,
+      key: row.id,
+      row,
+      index: rowIndex,
+    })),
+  ];
+  const moveAll = Array.from({ length: rowCount }, (_, moveIndex) => ({
+    type: "move" as const,
+    key: `row-${rowCount - moveIndex - 1}`,
+    fromIndex: rowCount - 1,
+    toIndex: 0,
+  }));
+  let replacementIsCurrent = false;
+  let replacementTailIsCurrent = false;
   let version = 1;
   return {
     update: async () => {
@@ -182,6 +215,75 @@ const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmar
       version = nextVersion;
       await waitForSinkWrite(written, `${rowCount}-row delta`);
     },
+    replaceAll: async () => {
+      const nextVersion = version + 1;
+      const written = new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+      await Effect.runPromise(
+        Queue.offer(events, {
+          type: "delta",
+          topic: "orders",
+          queryId: "viewport-benchmark",
+          operations: replacementIsCurrent ? replaceWithOriginal : replaceWithReplacement,
+          totalRows: rowCount,
+          fromVersion: version,
+          toVersion: nextVersion,
+        }),
+      );
+      replacementIsCurrent = !replacementIsCurrent;
+      version = nextVersion;
+      await waitForSinkWrite(written, `${rowCount}-row replacement delta`);
+    },
+    moveAll: async () => {
+      const nextVersion = version + 1;
+      const written = new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+      await Effect.runPromise(
+        Queue.offer(events, {
+          type: "delta",
+          topic: "orders",
+          queryId: "viewport-benchmark",
+          operations: moveAll,
+          totalRows: rowCount,
+          fromVersion: version,
+          toVersion: nextVersion,
+        }),
+      );
+      version = nextVersion;
+      await waitForSinkWrite(written, `${rowCount}-row move delta`);
+    },
+    replaceTail: async () => {
+      const nextVersion = version + 1;
+      const currentKey = replacementTailIsCurrent ? "replacement-tail" : `row-${rowCount - 1}`;
+      const nextKey = replacementTailIsCurrent ? `row-${rowCount - 1}` : "replacement-tail";
+      const written = new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+      await Effect.runPromise(
+        Queue.offer(events, {
+          type: "delta",
+          topic: "orders",
+          queryId: "viewport-benchmark",
+          operations: [
+            { type: "remove", key: currentKey },
+            {
+              type: "insert",
+              key: nextKey,
+              row: { id: nextKey, price: nextVersion },
+              index: rowCount - 1,
+            },
+          ],
+          totalRows: rowCount,
+          fromVersion: version,
+          toVersion: nextVersion,
+        }),
+      );
+      replacementTailIsCurrent = !replacementTailIsCurrent;
+      version = nextVersion;
+      await waitForSinkWrite(written, `${rowCount}-row tail replacement delta`);
+    },
     close: async () => {
       viewport.destroy();
       await Effect.runPromise(Fiber.interrupt(fiber));
@@ -192,13 +294,67 @@ const makeViewportBenchmark = async (rowCount: number): Promise<ViewportBenchmar
 
 const update100Rows = await makeViewportBenchmark(100);
 const update10000Rows = await makeViewportBenchmark(10_000);
+const replace1000Rows = await makeViewportBenchmark(1_000);
+const replace10000Rows = await makeViewportBenchmark(10_000);
+const move1000Rows = await makeViewportBenchmark(1_000);
+const move10000Rows = await makeViewportBenchmark(10_000);
+const replaceTail10000Rows = await makeViewportBenchmark(10_000);
+const scrollSchedulingRuntime = createInMemoryViewServer(viewServer);
+
+const schedulePreActivationScrollBurst = async (): Promise<void> => {
+  let publishCount = 0;
+  let clearCount = 0;
+  const viewport = makeLiveQueryViewport({
+    client: scrollSchedulingRuntime.liveClient,
+    config: viewServer,
+    topic: "orders",
+    publish: () => {
+      publishCount += 1;
+    },
+  });
+  const generation = viewport.replace({
+    window: { firstRow: 0, lastRow: 9 },
+    query: { select: ["id"], where: [], orderBy: [] },
+    sink: {
+      setRowCount: () => {
+        clearCount += 1;
+      },
+      setRowData: () => undefined,
+    },
+  });
+  for (let firstRow = 1; firstRow <= 10_000; firstRow += 1) {
+    generation.setWindow({ firstRow, lastRow: firstRow + 9 });
+  }
+  viewport.destroy();
+  if (publishCount !== 10_002 || clearCount !== 1) {
+    throw new Error("Pre-activation scroll burst did not retain only the latest request.");
+  }
+  await Promise.resolve();
+};
 
 afterAll(async () => {
   await update100Rows.close();
   await update10000Rows.close();
+  await replace1000Rows.close();
+  await replace10000Rows.close();
+  await move1000Rows.close();
+  await move10000Rows.close();
+  await replaceTail10000Rows.close();
+  await Effect.runPromise(scrollSchedulingRuntime.close);
 });
 
 describe("Live Query Viewport subscription-to-sink projection", () => {
   bench("single-row update in a 100-row viewport", () => update100Rows.update());
   bench("single-row update in a 10000-row viewport", () => update10000Rows.update());
+  bench("full replacement in a 1000-row viewport", () => replace1000Rows.replaceAll());
+  bench("full replacement in a 10000-row viewport", () => replace10000Rows.replaceAll());
+  bench("full reorder in a 1000-row viewport", () => move1000Rows.moveAll());
+  bench("full reorder in a 10000-row viewport", () => move10000Rows.moveAll());
+  bench("tail replacement in a 10000-row viewport", () => replaceTail10000Rows.replaceTail());
+  bench("schedule 10000 pre-activation scroll windows", () => schedulePreActivationScrollBurst(), {
+    iterations: 5,
+    time: 0,
+    warmupIterations: 0,
+    warmupTime: 0,
+  });
 });

--- a/packages/react/src/live-query-viewport.test-d.ts
+++ b/packages/react/src/live-query-viewport.test-d.ts
@@ -1,0 +1,377 @@
+import { describe, expectTypeOf, it } from "@effect/vitest";
+import { defineViewServerConfig, grpc, type GrpcRuntimeClients } from "@effect-view-server/config";
+import type { Stream } from "effect";
+import { Schema } from "effect";
+import type * as BigDecimal from "effect/BigDecimal";
+import { createViewServerReact } from "./index";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  status: Schema.Literals(["open", "closed"]),
+  price: Schema.Number,
+  region: Schema.String,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+declare const grpcRuntimeClients: GrpcRuntimeClients;
+declare const grpcRuntimeStream: Stream.Stream<unknown, unknown, never>;
+
+const leasedSources = grpc.topicSources(grpcRuntimeClients);
+const leasedViewServer = defineViewServerConfig({
+  grpc: { clients: grpcRuntimeClients },
+  topics: {
+    orders: leasedSources.leased({
+      schema: Order,
+      key: "id",
+      client: "orders",
+      method: "streamOrders",
+      routeBy: ["region"],
+      request: (route) => route,
+      acquire: () => grpcRuntimeStream,
+      map: ({ route }) => ({
+        id: "order-1",
+        status: "open",
+        price: 1,
+        region: route.region,
+      }),
+    }),
+  },
+});
+
+const react = createViewServerReact(viewServer);
+const leasedReact = createViewServerReact(leasedViewServer);
+
+describe("Live Query Viewport type contracts", () => {
+  it("binds the configured topic and exposes chrome without rows", () => {
+    const result = react.useLiveQueryViewport("orders");
+
+    expectTypeOf(result.totalRows).toBeNumber();
+    expectTypeOf(result.version).toBeNumber();
+    expectTypeOf(result.status).toEqualTypeOf<"loading" | "ready" | "stale" | "closed" | "error">();
+    expectTypeOf(result).not.toHaveProperty("rows");
+
+    // @ts-expect-error viewport topics are bound to configured topic names.
+    react.useLiveQueryViewport("missing");
+    expectTypeOf(react).not.toHaveProperty("useLiveGrid");
+  });
+
+  it("infers raw selected rows into the sink without as const", () => {
+    const result = react.useLiveQueryViewport("orders");
+    const generation = result.viewport.replace({
+      window: { firstRow: 20, lastRow: 39 },
+      query: {
+        select: ["id", "price"],
+        where: [{ field: "status", type: "equals", filter: "open" }],
+        orderBy: [{ field: "price", direction: "desc" }],
+      },
+      sink: {
+        setRowCount: (count, keepRenderedRows) => {
+          expectTypeOf(count).toBeNumber();
+          expectTypeOf(keepRenderedRows).toEqualTypeOf<boolean | undefined>();
+        },
+        setRowData: (rows) => {
+          expectTypeOf(rows[20]).toEqualTypeOf<
+            { readonly id: string; readonly price: number } | undefined
+          >();
+        },
+      },
+    });
+
+    generation.setWindow({ firstRow: 40, lastRow: 59 });
+    generation.release();
+  });
+
+  it("infers grouped result rows into the sink", () => {
+    react.useLiveQueryViewport("orders").viewport.replace({
+      window: { firstRow: 0, lastRow: 19 },
+      query: {
+        groupBy: ["status"],
+        aggregates: {
+          rowCount: { aggFunc: "count" },
+          totalPrice: { aggFunc: "sum", field: "price" },
+        },
+        where: [],
+        orderBy: [{ aggregate: "totalPrice", direction: "desc" }],
+      },
+      sink: {
+        setRowCount: () => undefined,
+        setRowData: (rows) => {
+          expectTypeOf(rows[0]).toEqualTypeOf<
+            | {
+                readonly status: "open" | "closed";
+                readonly rowCount: bigint;
+                readonly totalPrice: BigDecimal.BigDecimal;
+              }
+            | undefined
+          >();
+        },
+      },
+    });
+  });
+
+  it("preserves leased route requirements", () => {
+    leasedReact.useLiveQueryViewport("orders").viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: {
+        routeBy: { region: "usa" },
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      },
+      sink: {
+        setRowCount: () => undefined,
+        setRowData: (rows) => {
+          expectTypeOf(rows[0]).toEqualTypeOf<{ readonly id: string } | undefined>();
+        },
+      },
+    });
+
+    leasedReact.useLiveQueryViewport("orders").viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error leased viewport queries require their exact route.
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    leasedReact.useLiveQueryViewport("orders").viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error leased viewport route values must satisfy the configured route schema.
+      query: { routeBy: { region: 1 }, select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    leasedReact.useLiveQueryViewport("orders").viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error leased viewport routes are exact.
+      query: {
+        routeBy: { region: "usa", missing: "extra" },
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+  });
+
+  it("rejects incomplete, invalid, and mixed query shapes", () => {
+    const viewport = react.useLiveQueryViewport("orders").viewport;
+
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error viewport raw queries require where.
+      query: { select: ["id"], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error viewport raw queries require orderBy.
+      query: { select: ["id"], where: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error callers cannot supply the derived window fields.
+      query: { select: ["id"], where: [], orderBy: [], offset: 0 },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error callers cannot supply a limit because the viewport derives it.
+      query: { select: ["id"], where: [], orderBy: [], limit: 10 },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error raw queries require at least one selected field.
+      query: { select: [], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error selected fields must exist.
+      query: { select: ["missing"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error where operators must be valid for the field.
+      query: {
+        select: ["id"],
+        where: [{ field: "price", type: "contains", filter: "1" }],
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error where fields must exist.
+      query: {
+        select: ["id"],
+        where: [{ field: "missing", type: "equals", filter: "open" }],
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error raw order fields must exist.
+      query: {
+        select: ["id"],
+        where: [],
+        orderBy: [{ field: "missing", direction: "asc" }],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped fields must exist.
+      query: {
+        groupBy: ["missing"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped queries require aggregates.
+      query: { groupBy: ["status"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped viewport queries require where.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped viewport queries require orderBy.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped viewport queries cannot supply the derived offset.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [],
+        offset: 0,
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped viewport queries cannot supply the derived limit.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [],
+        limit: 10,
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped ordering fields must be declared group fields.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [{ field: "price", direction: "asc" }],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error aggregate fields must exist and support the aggregate.
+      query: {
+        groupBy: ["status"],
+        aggregates: { total: { aggFunc: "sum", field: "missing" } },
+        where: [],
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped ordering must reference a declared group or aggregate alias.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [{ aggregate: "missing", direction: "desc" }],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error query inputs reject extra keys.
+      query: { select: ["id"], where: [], orderBy: [], extra: true },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    // @ts-expect-error the sink is required.
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: {
+        setRowCount: () => undefined,
+        // @ts-expect-error sink rows cannot require unselected fields.
+        setRowData: (_rows: { readonly [index: number]: { readonly id: string; price: number } }) =>
+          undefined,
+      },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: {
+        setRowCount: () => undefined,
+        // @ts-expect-error sink rows must preserve the selected field type.
+        setRowData: (_rows: { readonly [index: number]: { readonly id: number } }) => undefined,
+      },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      // @ts-expect-error sink rows cannot omit selected fields.
+      sink: {
+        setRowCount: () => undefined,
+        setRowData: (_rows: { readonly [index: number]: {} }) => undefined,
+      },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      // @ts-expect-error grouped queries cannot contain select.
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+  });
+});

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -21,6 +21,7 @@ import { createInMemoryViewServer } from "@effect-view-server/in-memory";
 import { Deferred, Effect, Fiber, Option, Queue, Schema, Stream } from "effect";
 import {
   liveQueryViewportChromeFromAsyncResult,
+  liveQueryViewportFailureMessage,
   makeLiveQueryViewport,
   makeLiveQueryViewportBinding,
   validateLiveQueryViewportWindow,
@@ -209,7 +210,10 @@ describe("Live Query Viewport Module", () => {
       lastRow: 19,
       limit: 10,
     });
-    expect(validateLiveQueryViewportWindow({ firstRow: -1, lastRow: 1 })._tag).toBe("Invalid");
+    expect(validateLiveQueryViewportWindow({ firstRow: -1, lastRow: 1 })).toStrictEqual({
+      _tag: "Invalid",
+      message: 'Expected a value greater than or equal to 0, got -1\n  at ["firstRow"]',
+    });
     expect(validateLiveQueryViewportWindow({ firstRow: 2, lastRow: 1 })).toStrictEqual({
       _tag: "Invalid",
       message: "Live Query Viewport lastRow must be greater than or equal to firstRow.",
@@ -218,9 +222,15 @@ describe("Live Query Viewport Module", () => {
       validateLiveQueryViewportWindow({
         firstRow: 0,
         lastRow: Number.MAX_SAFE_INTEGER,
-      })._tag,
-    ).toBe("Invalid");
-    expect(validateLiveQueryViewportWindow({ firstRow: 0.5, lastRow: 1 })._tag).toBe("Invalid");
+      }),
+    ).toStrictEqual({
+      _tag: "Invalid",
+      message: "Live Query Viewport limit must be a safe integer.",
+    });
+    expect(validateLiveQueryViewportWindow({ firstRow: 0.5, lastRow: 1 })).toStrictEqual({
+      _tag: "Invalid",
+      message: 'Expected an integer, got 0.5\n  at ["firstRow"]',
+    });
   });
 
   it("maps Atom results to chrome without exposing rows", () => {
@@ -245,6 +255,13 @@ describe("Live Query Viewport Module", () => {
       version: 0,
       status: "loading",
     });
+  });
+
+  it("preserves useful messages for thrown query failures", () => {
+    expect(liveQueryViewportFailureMessage(new Error("query exploded"))).toBe("query exploded");
+    expect(liveQueryViewportFailureMessage("query exploded")).toBe("query exploded");
+    expect(liveQueryViewportFailureMessage({ message: 123 })).toBe("[object Object]");
+    expect(liveQueryViewportFailureMessage(null)).toBe("null");
   });
 
   it("keeps one stable viewport facade across committed controller replacements", () => {
@@ -318,7 +335,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -426,7 +446,10 @@ describe("Live Query Viewport Module", () => {
         health: base.liveClient.health,
         close: Effect.void,
       } satisfies ViewServerLiveClient<LeasedTopics>;
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport<LeasedTopics, "orders">({
         client: leasedClient,
         config: leasedViewServer,
@@ -480,7 +503,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -557,7 +583,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -618,7 +647,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -694,7 +726,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -773,7 +808,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -855,7 +893,10 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       let publishCount = 0;
       const viewport = makeLiveQueryViewport({
         client,
@@ -901,7 +942,10 @@ describe("Live Query Viewport Module", () => {
         subscribe: (topic, query) =>
           base.liveClient.subscribe(topic, query).pipe(Effect.flatMap(() => Effect.fail(failure))),
       } satisfies ViewServerLiveClient<Topics>;
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client: failingClient,
         config: viewServer,
@@ -954,7 +998,10 @@ describe("Live Query Viewport Module", () => {
           }),
         ),
       } satisfies ViewServerLiveClient<Topics>;
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -1023,7 +1070,10 @@ describe("Live Query Viewport Module", () => {
           }),
         ),
       } satisfies ViewServerLiveClient<Topics>;
-      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -1081,7 +1131,10 @@ describe("Live Query Viewport Module", () => {
 
       const sinkReentryRequests: Array<ManualRequest> = [];
       const sinkReentryClient = makeManualClient(base.liveClient, sinkReentryRequests);
-      let sinkReentryStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let sinkReentryStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const sinkReentryViewport = makeLiveQueryViewport({
         client: sinkReentryClient,
         config: viewServer,
@@ -1125,13 +1178,15 @@ describe("Live Query Viewport Module", () => {
     }),
   );
 
-  it.effect("handles hostile query accessors and reentrant sink callbacks", () =>
+  it.effect("reports hostile query access without starting a subscription", () =>
     Effect.gen(function* () {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      const published: Array<Stream.Stream<LiveQueryViewportChrome, unknown>> = [];
-      let viewport = makeLiveQueryViewport({
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
         topic: "orders",
@@ -1174,7 +1229,45 @@ describe("Live Query Viewport Module", () => {
       });
       viewport.destroy();
 
-      viewport = makeLiveQueryViewport({
+      expect(requests).toHaveLength(0);
+      expect(published).toHaveLength(5);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "error",
+          statusCode: "InvalidQuery",
+          message: "Query input fields must be own enumerable data properties.",
+        }),
+      );
+      yield* base.close;
+    }),
+  );
+
+  it.effect("makes destroy during invalid-query sink clearing terminal", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const hostile = {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      } satisfies {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      Object.defineProperty(hostile, "where", {
+        enumerable: true,
+        get: () => {
+          throw new Error("hostile query");
+        },
+      });
+      const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
         topic: "orders",
@@ -1199,7 +1292,28 @@ describe("Live Query Viewport Module", () => {
       invalidReentrantGeneration.setWindow({ firstRow: 10, lastRow: 19 });
       invalidReentrantGeneration.release();
 
-      viewport = makeLiveQueryViewport({
+      expect(requests).toHaveLength(0);
+      expect(published).toHaveLength(1);
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      yield* base.close;
+    }),
+  );
+
+  it.effect("makes destroy during query snapshotting terminal", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
         topic: "orders",
@@ -1230,7 +1344,28 @@ describe("Live Query Viewport Module", () => {
       obsoleteGeneration.setWindow({ firstRow: 10, lastRow: 19 });
       obsoleteGeneration.release();
 
-      viewport = makeLiveQueryViewport({
+      expect(requests).toHaveLength(0);
+      expect(published).toHaveLength(1);
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      yield* base.close;
+    }),
+  );
+
+  it.effect("makes destroy during a valid-query sink clear terminal", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
         topic: "orders",
@@ -1254,7 +1389,14 @@ describe("Live Query Viewport Module", () => {
       });
 
       expect(requests).toHaveLength(0);
-      expect(published.length).toBeGreaterThan(0);
+      expect(published).toHaveLength(1);
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
       yield* base.close;
     }),
   );
@@ -1336,6 +1478,64 @@ describe("Live Query Viewport Module", () => {
     }),
   );
 
+  it.effect("does not write a superseded request after sink cleanup installs its successor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const successor = makeSink<{ readonly id: string }>();
+      let replaceDuringClear = false;
+      let publishCount = 0;
+      const previousRowCounts: Array<readonly [number, boolean | undefined]> = [];
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: () => {
+          publishCount += 1;
+        },
+      });
+      const previous = {
+        sink: {
+          setRowCount: (count: number, keepRenderedRows?: boolean) => {
+            previousRowCounts.push([count, keepRenderedRows]);
+            if (replaceDuringClear) {
+              replaceDuringClear = false;
+              viewport.replace({
+                window: { firstRow: 20, lastRow: 29 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink: successor.sink,
+              });
+            }
+          },
+          setRowData: () => undefined,
+        },
+      };
+
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: previous.sink,
+      });
+      replaceDuringClear = true;
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: successor.sink,
+      });
+
+      expect(previousRowCounts).toStrictEqual([
+        [0, false],
+        [0, false],
+      ]);
+      expect(successor.rowCounts).toStrictEqual([[0, false]]);
+      expect(publishCount).toBe(2);
+      expect(requests).toHaveLength(0);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
   it.effect(
     "commits controller replacements before late events and finalizers can touch the sink",
     () =>
@@ -1345,8 +1545,14 @@ describe("Live Query Viewport Module", () => {
         const currentRequests: Array<ManualRequest> = [];
         const binding = makeLiveQueryViewportBinding<Topics, "orders">();
         const sink = makeSink<{ readonly id: string }>();
-        let oldStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
-        let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+        let oldStream: Stream.Stream<
+          LiveQueryViewportChrome,
+          ViewServerRuntimeError | ViewServerTransportError
+        > = Stream.never;
+        let currentStream: Stream.Stream<
+          LiveQueryViewportChrome,
+          ViewServerRuntimeError | ViewServerTransportError
+        > = Stream.never;
         const oldViewport = makeLiveQueryViewport({
           client: makeManualClient(base.liveClient, oldRequests),
           config: viewServer,

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -202,6 +202,27 @@ const makeSink = <Row>() => {
 
 const flush = Effect.yieldNow;
 
+const makeSwitchingPublisher = () => {
+  let current: Fiber.Fiber<void, ViewServerRuntimeError | ViewServerTransportError> | undefined;
+  let publishCount = 0;
+  return {
+    publish: (command: {
+      readonly stream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      >;
+    }) => {
+      publishCount += 1;
+      if (current !== undefined) {
+        Effect.runFork(Fiber.interrupt(current));
+      }
+      current = Effect.runFork(command.stream.pipe(Stream.runDrain));
+    },
+    current: () => current,
+    publishCount: () => publishCount,
+  };
+};
+
 describe("Live Query Viewport Module", () => {
   it("validates inclusive absolute windows", () => {
     expect(validateLiveQueryViewportWindow({ firstRow: 10, lastRow: 19 })).toStrictEqual({
@@ -642,6 +663,59 @@ describe("Live Query Viewport Module", () => {
     }),
   );
 
+  it.effect("coalesces a large pre-activation scroll burst into the latest acquisition", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      const generation = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: projected.sink,
+      });
+
+      for (let firstRow = 1; firstRow <= 10_000; firstRow += 1) {
+        generation.setWindow({ firstRow, lastRow: firstRow + 9 });
+      }
+      expect(requests).toStrictEqual([]);
+      expect(projected.rowCounts).toStrictEqual([]);
+
+      const fiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.query).toStrictEqual({
+        select: ["id"],
+        where: [],
+        orderBy: [],
+        offset: 10_000,
+        limit: 10,
+      });
+      expect(projected.rowCounts).toStrictEqual([[0, false]]);
+
+      generation.release();
+      expect(projected.rowCounts).toStrictEqual([
+        [0, false],
+        [0, false],
+      ]);
+      yield* Fiber.interrupt(fiber);
+      expect(requests[0]!.closes).toBe(1);
+      yield* base.close;
+    }),
+  );
+
   it.effect("replaces filter, sort, selection, and query mode as distinct identities", () =>
     Effect.gen(function* () {
       const base = createInMemoryViewServer(viewServer);
@@ -803,6 +877,44 @@ describe("Live Query Viewport Module", () => {
     }),
   );
 
+  it.effect("does not publish invalid-window chrome after sink clearing destroys ownership", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
+        client: base.liveClient,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      viewport.replace({
+        window: { firstRow: 2, lastRow: 1 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            viewport.destroy();
+          },
+          setRowData: () => undefined,
+        },
+      });
+
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(Option.none());
+      expect(published).toHaveLength(2);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      yield* base.close;
+    }),
+  );
+
   it.effect("projects every Delta operation shape and ignores non-row events", () =>
     Effect.gen(function* () {
       const base = createInMemoryViewServer(viewServer);
@@ -917,14 +1029,25 @@ describe("Live Query Viewport Module", () => {
       const first = replace();
       const duplicate = replace();
       duplicate.setWindow({ firstRow: 0, lastRow: 9 });
+      first.setWindow({ firstRow: 20, lastRow: 29 });
+      first.release();
       expect(publishCount).toBe(1);
 
       const fiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
       yield* flush;
       expect(requests).toHaveLength(1);
-      first.release();
+      yield* Queue.offer(requests[0]!.events, snapshot("still-current", 1, 1));
+      yield* flush;
+      expect(projected.rowData).toStrictEqual([{ 0: { id: "still-current", price: 1 } }]);
+
+      duplicate.setWindow({ firstRow: 10, lastRow: 19 });
+      expect(publishCount).toBe(2);
+      const replacementFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(2);
       duplicate.release();
       yield* Fiber.interrupt(fiber);
+      yield* Fiber.interrupt(replacementFiber);
       yield* base.close;
     }),
   );
@@ -1219,6 +1342,15 @@ describe("Live Query Viewport Module", () => {
         query: hostile,
         sink: { setRowCount: () => undefined, setRowData: () => undefined },
       });
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "error",
+          statusCode: "InvalidQuery",
+          message: "Query input fields must be own enumerable data properties.",
+        }),
+      );
       hostileGeneration.setWindow({ firstRow: 10, lastRow: 19 });
       hostileGeneration.release();
       hostileGeneration.release();
@@ -1231,15 +1363,6 @@ describe("Live Query Viewport Module", () => {
 
       expect(requests).toHaveLength(0);
       expect(published).toHaveLength(5);
-      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
-        Option.some({
-          totalRows: 0,
-          version: 0,
-          status: "error",
-          statusCode: "InvalidQuery",
-          message: "Query input fields must be own enumerable data properties.",
-        }),
-      );
       yield* base.close;
     }),
   );
@@ -1293,14 +1416,69 @@ describe("Live Query Viewport Module", () => {
       invalidReentrantGeneration.release();
 
       expect(requests).toHaveLength(0);
-      expect(published).toHaveLength(1);
-      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(Option.none());
+      expect(published).toHaveLength(3);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
         Option.some({
           totalRows: 0,
           version: 0,
           status: "loading",
         }),
       );
+      expect(yield* published[2]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      yield* base.close;
+    }),
+  );
+
+  it.effect("preserves a cleanup defect after activation is made obsolete reentrantly", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
+        client: base.liveClient,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const successor = makeSink<{ readonly id: string }>();
+      let clearCount = 0;
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            clearCount += 1;
+            if (clearCount === 1) {
+              viewport.replace({
+                window: { firstRow: 10, lastRow: 19 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink: successor.sink,
+              });
+              return;
+            }
+            throw new Error("cleanup defect");
+          },
+          setRowData: () => undefined,
+        },
+      });
+
+      const obsoleteExit = yield* published[0]!.pipe(Stream.runHead, Effect.exit);
+      expect(obsoleteExit._tag).toBe("Failure");
+      expect(clearCount).toBe(2);
+      expect(published).toHaveLength(2);
+
+      viewport.destroy();
+      expect(successor.rowCounts).toStrictEqual([[0, false]]);
       yield* base.close;
     }),
   );
@@ -1389,8 +1567,9 @@ describe("Live Query Viewport Module", () => {
       });
 
       expect(requests).toHaveLength(0);
-      expect(published).toHaveLength(1);
-      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(Option.none());
+      expect(published).toHaveLength(2);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
         Option.some({
           totalRows: 0,
           version: 0,
@@ -1401,7 +1580,7 @@ describe("Live Query Viewport Module", () => {
     }),
   );
 
-  it.effect("does not publish idle over a replacement started reentrantly during release", () =>
+  it.effect("publishes cancellation before release cleanup installs a replacement", () =>
     Effect.gen(function* () {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
@@ -1423,7 +1602,7 @@ describe("Live Query Viewport Module", () => {
             viewport.replace({
               window: { firstRow: 10, lastRow: 19 },
               query: { select: ["id"], where: [], orderBy: [] },
-              sink: { setRowCount: () => undefined, setRowData: () => undefined },
+              sink,
             });
           }
         },
@@ -1437,7 +1616,191 @@ describe("Live Query Viewport Module", () => {
       replaceDuringRelease = true;
       generation.release();
 
-      expect(publishCount).toBe(2);
+      expect(publishCount).toBe(3);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("cancels the subscription before release cleanup can throw", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const publisher = makeSwitchingPublisher();
+      let throwOnClear = false;
+      const rowData: Array<{ readonly [index: number]: { readonly id: string } }> = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: publisher.publish,
+      });
+      const generation = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            if (throwOnClear) {
+              throw new Error("disposed release sink");
+            }
+          },
+          setRowData: (rows) => {
+            rowData.push(rows);
+          },
+        },
+      });
+      yield* flush;
+      expect(requests).toHaveLength(1);
+
+      throwOnClear = true;
+      expect(() => generation.release()).toThrow("disposed release sink");
+      yield* flush;
+      expect(publisher.publishCount()).toBe(2);
+      expect(requests[0]!.closes).toBe(1);
+      yield* Queue.offer(requests[0]!.events, snapshot("late", 1, 1));
+      yield* flush;
+      expect(rowData).toStrictEqual([]);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("cancels the subscription before terminal destroy cleanup can throw", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const publisher = makeSwitchingPublisher();
+      let throwOnClear = false;
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: publisher.publish,
+      });
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            if (throwOnClear) {
+              throw new Error("disposed destroy sink");
+            }
+          },
+          setRowData: () => undefined,
+        },
+      });
+      yield* flush;
+      expect(requests).toHaveLength(1);
+
+      throwOnClear = true;
+      expect(() => viewport.destroy()).toThrow("disposed destroy sink");
+      yield* flush;
+      expect(publisher.publishCount()).toBe(2);
+      expect(requests[0]!.closes).toBe(1);
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      expect(publisher.publishCount()).toBe(2);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("cancels the old subscription before previous-sink cleanup can throw", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const publisher = makeSwitchingPublisher();
+      let throwOnClear = false;
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: publisher.publish,
+      });
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            if (throwOnClear) {
+              throw new Error("disposed previous sink");
+            }
+          },
+          setRowData: () => undefined,
+        },
+      });
+      yield* flush;
+      expect(requests).toHaveLength(1);
+
+      throwOnClear = true;
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      const failed = publisher.current();
+      expect(failed).toBeDefined();
+      expect((yield* Fiber.await(failed!))._tag).toBe("Failure");
+      expect(requests[0]!.closes).toBe(1);
+      expect(requests).toHaveLength(1);
+
+      throwOnClear = false;
+      viewport.replace({
+        window: { firstRow: 20, lastRow: 29 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      yield* flush;
+      expect(requests).toHaveLength(2);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not acquire after the successor sink initial clear throws", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const publisher = makeSwitchingPublisher();
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: publisher.publish,
+      });
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      yield* flush;
+      expect(requests).toHaveLength(1);
+
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            throw new Error("disposed successor sink");
+          },
+          setRowData: () => undefined,
+        },
+      });
+      const failed = publisher.current();
+      expect(failed).toBeDefined();
+      expect((yield* Fiber.await(failed!))._tag).toBe("Failure");
+      expect(requests[0]!.closes).toBe(1);
+      expect(requests).toHaveLength(1);
+
+      viewport.replace({
+        window: { firstRow: 20, lastRow: 29 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      yield* flush;
+      expect(requests).toHaveLength(2);
       viewport.destroy();
       yield* base.close;
     }),
@@ -1450,11 +1813,17 @@ describe("Live Query Viewport Module", () => {
       const client = makeManualClient(base.liveClient, requests);
       const first = makeSink<{ readonly id: string }>();
       const second = makeSink<{ readonly id: string }>();
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
         topic: "orders",
-        publish: () => undefined,
+        publish: (command) => {
+          currentStream = command.stream;
+        },
       });
 
       viewport.replace({
@@ -1462,11 +1831,16 @@ describe("Live Query Viewport Module", () => {
         query: { select: ["id"], where: [], orderBy: [] },
         sink: first.sink,
       });
+      const firstFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
       viewport.replace({
         window: { firstRow: 10, lastRow: 19 },
         query: { select: ["id"], where: [], orderBy: [] },
         sink: second.sink,
       });
+      yield* Fiber.interrupt(firstFiber);
+      const secondFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
 
       expect(first.rowCounts).toStrictEqual([
         [0, false],
@@ -1474,6 +1848,162 @@ describe("Live Query Viewport Module", () => {
       ]);
       expect(second.rowCounts).toStrictEqual([[0, false]]);
       viewport.destroy();
+      yield* Fiber.interrupt(secondFiber);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("clears both sinks when a replacement is released before activation", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const first = makeSink<{ readonly id: string }>();
+      const second = makeSink<{ readonly id: string }>();
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: first.sink,
+      });
+      const firstFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      yield* Queue.offer(requests[0]!.events, snapshot("rendered", 1, 4));
+      yield* flush;
+
+      const replacement = viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: second.sink,
+      });
+      yield* Fiber.interrupt(firstFiber);
+      replacement.release();
+      yield* Queue.offer(requests[0]!.events, snapshot("late", 2, 5));
+      yield* flush;
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.closes).toBe(1);
+      expect(first.rowCounts).toStrictEqual([
+        [0, false],
+        [1, true],
+        [0, false],
+      ]);
+      expect(first.rowData).toStrictEqual([{ 0: { id: "rendered", price: 1 } }]);
+      expect(second.rowCounts).toStrictEqual([[0, false]]);
+      expect(second.rowData).toStrictEqual([]);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("clears both sinks when destroyed before replacement activation", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const first = makeSink<{ readonly id: string }>();
+      const second = makeSink<{ readonly id: string }>();
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: first.sink,
+      });
+      const firstFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: second.sink,
+      });
+      yield* Fiber.interrupt(firstFiber);
+      viewport.destroy();
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.closes).toBe(1);
+      expect(first.rowCounts).toStrictEqual([
+        [0, false],
+        [0, false],
+      ]);
+      expect(second.rowCounts).toStrictEqual([[0, false]]);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not clear a cleanup-installed successor sharing the pending sink", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const successor = makeSink<{ readonly id: string }>();
+      let installSuccessor = false;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const previousSink: LiveQueryViewportSink<{ readonly id: string }> = {
+        setRowCount: (count) => {
+          if (count === 0 && installSuccessor) {
+            installSuccessor = false;
+            viewport.replace({
+              window: { firstRow: 20, lastRow: 29 },
+              query: { select: ["id"], where: [], orderBy: [] },
+              sink: successor.sink,
+            });
+          }
+        },
+        setRowData: () => undefined,
+      };
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: previousSink,
+      });
+      const firstFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      const pending = viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: successor.sink,
+      });
+      yield* Fiber.interrupt(firstFiber);
+      installSuccessor = true;
+      pending.release();
+      expect(successor.rowCounts).toStrictEqual([]);
+
+      const successorFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(successor.rowCounts).toStrictEqual([[0, false]]);
+      expect(requests).toHaveLength(2);
+      viewport.destroy();
+      yield* Fiber.interrupt(successorFiber);
       yield* base.close;
     }),
   );
@@ -1486,13 +2016,18 @@ describe("Live Query Viewport Module", () => {
       const successor = makeSink<{ readonly id: string }>();
       let replaceDuringClear = false;
       let publishCount = 0;
+      let currentStream: Stream.Stream<
+        LiveQueryViewportChrome,
+        ViewServerRuntimeError | ViewServerTransportError
+      > = Stream.never;
       const previousRowCounts: Array<readonly [number, boolean | undefined]> = [];
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
         topic: "orders",
-        publish: () => {
+        publish: (command) => {
           publishCount += 1;
+          currentStream = command.stream;
         },
       });
       const previous = {
@@ -1517,21 +2052,28 @@ describe("Live Query Viewport Module", () => {
         query: { select: ["id"], where: [], orderBy: [] },
         sink: previous.sink,
       });
+      const previousFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
       replaceDuringClear = true;
       viewport.replace({
         window: { firstRow: 10, lastRow: 19 },
         query: { select: ["id"], where: [], orderBy: [] },
         sink: successor.sink,
       });
+      yield* Fiber.interrupt(previousFiber);
+      expect(yield* currentStream.pipe(Stream.runHead)).toStrictEqual(Option.none());
+      const successorFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
 
       expect(previousRowCounts).toStrictEqual([
         [0, false],
         [0, false],
       ]);
       expect(successor.rowCounts).toStrictEqual([[0, false]]);
-      expect(publishCount).toBe(2);
-      expect(requests).toHaveLength(0);
+      expect(publishCount).toBe(3);
+      expect(requests).toHaveLength(2);
       viewport.destroy();
+      yield* Fiber.interrupt(successorFiber);
       yield* base.close;
     }),
   );

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -27,6 +27,7 @@ import {
   validateLiveQueryViewportWindow,
   type LiveQueryViewport,
   type LiveQueryViewportChrome,
+  type LiveQueryViewportGeneration,
   type LiveQueryViewportSink,
 } from "./live-query-viewport";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
@@ -47,6 +48,11 @@ const viewServer = defineViewServerConfig({
 });
 
 type Topics = typeof viewServer.topics;
+
+type ViewportChromeStream = Stream.Stream<
+  LiveQueryViewportChrome,
+  ViewServerRuntimeError | ViewServerTransportError
+>;
 
 const LeasedOrder = Schema.Struct({
   id: Schema.String,
@@ -206,12 +212,7 @@ const makeSwitchingPublisher = () => {
   let current: Fiber.Fiber<void, ViewServerRuntimeError | ViewServerTransportError> | undefined;
   let publishCount = 0;
   return {
-    publish: (command: {
-      readonly stream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      >;
-    }) => {
+    publish: (command: { readonly stream: ViewportChromeStream }) => {
       publishCount += 1;
       if (current !== undefined) {
         Effect.runFork(Fiber.interrupt(current));
@@ -356,10 +357,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -467,10 +465,7 @@ describe("Live Query Viewport Module", () => {
         health: base.liveClient.health,
         close: Effect.void,
       } satisfies ViewServerLiveClient<LeasedTopics>;
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport<LeasedTopics, "orders">({
         client: leasedClient,
         config: leasedViewServer,
@@ -524,10 +519,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -604,10 +596,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -668,10 +657,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -721,10 +707,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -795,15 +778,12 @@ describe("Live Query Viewport Module", () => {
     }),
   );
 
-  it.effect("rejects invalid windows without subscribing and retries terminal identities", () =>
+  it.effect("rejects invalid windows, retries closed identities, and retains error rows", () =>
     Effect.gen(function* () {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -853,6 +833,8 @@ describe("Live Query Viewport Module", () => {
       const retryFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
       yield* flush;
       expect(requests).toHaveLength(2);
+      yield* Queue.offer(requests[1]!.events, snapshot("retained", 7, 2));
+      yield* flush;
       yield* Queue.offer(requests[1]!.events, {
         type: "status",
         topic: "orders",
@@ -862,17 +844,459 @@ describe("Live Query Viewport Module", () => {
         message: "terminal error",
       });
       yield* flush;
+      expect(projected.rowData.at(-1)).toStrictEqual({ 0: { id: "retained", price: 7 } });
+      expect(projected.rowCounts.at(-1)).toStrictEqual([1, true]);
 
       replaceValid();
-      const errorRetryFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
       yield* flush;
-      expect(requests).toHaveLength(3);
+      expect(requests).toHaveLength(2);
+      yield* Queue.offer(requests[1]!.events, {
+        type: "status",
+        topic: "orders",
+        queryId: "manual",
+        status: "ready",
+        code: "Ready",
+      });
+      yield* flush;
+      expect(projected.rowData.at(-1)).toStrictEqual({ 0: { id: "retained", price: 7 } });
+      expect(projected.rowCounts.at(-1)).toStrictEqual([1, true]);
 
       yield* Fiber.interrupt(firstFiber);
       yield* Fiber.interrupt(retryFiber);
-      yield* Fiber.interrupt(errorRetryFiber);
       viewport.destroy();
       viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not overwrite a replacement started by a window accessor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const sink = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      const initialFiber = yield* published[0]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      const hostileWindow = { firstRow: 0, lastRow: 9 };
+      let replaceOnRead = true;
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          if (replaceOnRead) {
+            replaceOnRead = false;
+            viewport.replace({
+              window: { firstRow: 20, lastRow: 29 },
+              query: {
+                select: ["id"],
+                where: [{ field: "status", type: "equals", filter: "closed" }],
+                orderBy: [],
+              },
+              sink: sink.sink,
+            });
+          }
+          return 0;
+        },
+      });
+
+      const obsolete = viewport.replace({
+        window: hostileWindow,
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      expect(published).toHaveLength(2);
+      const fiber = yield* published[1]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(2);
+      expect(requests[1]!.query).toStrictEqual({
+        select: ["id"],
+        where: [{ field: "status", type: "equals", filter: "closed" }],
+        orderBy: [],
+        offset: 20,
+        limit: 10,
+      });
+
+      obsolete.setWindow({ firstRow: 30, lastRow: 39 });
+      obsolete.release();
+      expect(published).toHaveLength(2);
+      viewport.destroy();
+      yield* Fiber.interrupt(initialFiber);
+      yield* Fiber.interrupt(fiber);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("keeps a replacement installed by a setWindow accessor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const published: Array<ViewportChromeStream> = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const sink = makeSink<{ readonly id: string }>();
+      const generation = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      const initialFiber = yield* published[0]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      const hostileWindow = { firstRow: 10, lastRow: 19 };
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          viewport.replace({
+            window: { firstRow: 20, lastRow: 29 },
+            query: {
+              select: ["id"],
+              where: [{ field: "status", type: "equals", filter: "open" }],
+              orderBy: [],
+            },
+            sink: sink.sink,
+          });
+          return 10;
+        },
+      });
+
+      generation.setWindow(hostileWindow);
+      expect(published).toHaveLength(2);
+      const successorFiber = yield* published[1]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(2);
+      expect(requests[1]!.query).toStrictEqual({
+        select: ["id"],
+        where: [{ field: "status", type: "equals", filter: "open" }],
+        orderBy: [],
+        offset: 20,
+        limit: 10,
+      });
+
+      generation.setWindow({ firstRow: 30, lastRow: 39 });
+      generation.release();
+      expect(published).toHaveLength(2);
+      viewport.destroy();
+      yield* Fiber.interrupt(initialFiber);
+      yield* Fiber.interrupt(successorFiber);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not resurrect a generation released by a setWindow accessor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const published: Array<ViewportChromeStream> = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const generation = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: makeSink<{ readonly id: string }>().sink,
+      });
+      const fiber = yield* published[0]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      const hostileWindow = { firstRow: 10, lastRow: 19 };
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          generation.release();
+          return 10;
+        },
+      });
+
+      generation.setWindow(hostileWindow);
+      expect(requests).toHaveLength(1);
+      expect(published).toHaveLength(2);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      generation.setWindow({ firstRow: 30, lastRow: 39 });
+      generation.release();
+      expect(published).toHaveLength(2);
+      yield* Fiber.interrupt(fiber);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("keeps identical replacement ownership transferred by a window accessor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const published: Array<ViewportChromeStream> = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const sink = makeSink<{ readonly id: string }>();
+      const first = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      const initialFiber = yield* published[0]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      let successor: LiveQueryViewportGeneration | undefined;
+      const hostileWindow = { firstRow: 0, lastRow: 9 };
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          successor = viewport.replace({
+            window: { firstRow: 0, lastRow: 9 },
+            query: { select: ["id"], where: [], orderBy: [] },
+            sink: sink.sink,
+          });
+          return 0;
+        },
+      });
+
+      const obsolete = viewport.replace({
+        window: hostileWindow,
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      expect(published).toHaveLength(1);
+      successor!.setWindow({ firstRow: 20, lastRow: 29 });
+      expect(published).toHaveLength(2);
+      const successorFiber = yield* published[1]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(2);
+      expect(requests[1]!.query).toStrictEqual({
+        select: ["id"],
+        where: [],
+        orderBy: [],
+        offset: 20,
+        limit: 10,
+      });
+
+      first.release();
+      obsolete.setWindow({ firstRow: 30, lastRow: 39 });
+      obsolete.release();
+      expect(published).toHaveLength(2);
+      successor!.release();
+      expect(published).toHaveLength(3);
+      yield* Fiber.interrupt(initialFiber);
+      yield* Fiber.interrupt(successorFiber);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("keeps invalid-query ownership installed by a window accessor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const published: Array<ViewportChromeStream> = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const sink = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      const initialFiber = yield* published[0]!.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      const hostileQuery = {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      } satisfies {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      Object.defineProperty(hostileQuery, "where", {
+        enumerable: true,
+        get: () => {
+          throw new Error("hostile query");
+        },
+      });
+      const hostileWindow = { firstRow: 10, lastRow: 19 };
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          viewport.replace({
+            window: { firstRow: 20, lastRow: 29 },
+            query: hostileQuery,
+            sink: sink.sink,
+          });
+          return 10;
+        },
+      });
+
+      const obsolete = viewport.replace({
+        window: hostileWindow,
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: sink.sink,
+      });
+      expect(requests).toHaveLength(1);
+      expect(published).toHaveLength(2);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "error",
+          statusCode: "InvalidQuery",
+          message: "Query input fields must be own enumerable data properties.",
+        }),
+      );
+      obsolete.setWindow({ firstRow: 30, lastRow: 39 });
+      obsolete.release();
+      expect(published).toHaveLength(2);
+      yield* Fiber.interrupt(initialFiber);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not overwrite invalid-query release from a window accessor", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const published: Array<ViewportChromeStream> = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const hostileQuery = {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      } satisfies {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      Object.defineProperty(hostileQuery, "where", {
+        enumerable: true,
+        get: () => {
+          throw new Error("hostile query");
+        },
+      });
+      const invalidGeneration = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: hostileQuery,
+        sink: makeSink<{ readonly id: string }>().sink,
+      });
+      const hostileWindow = { firstRow: 10, lastRow: 19 };
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          invalidGeneration.release();
+          return 10;
+        },
+      });
+
+      const obsolete = viewport.replace({
+        window: hostileWindow,
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: makeSink<{ readonly id: string }>().sink,
+      });
+      expect(requests).toStrictEqual([]);
+      expect(published).toHaveLength(2);
+      expect(yield* published[1]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      obsolete.setWindow({ firstRow: 30, lastRow: 39 });
+      obsolete.release();
+      invalidGeneration.release();
+      expect(published).toHaveLength(2);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not start a request when a window accessor destroys the viewport", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const published: Array<
+        Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError>
+      > = [];
+      const viewport = makeLiveQueryViewport({
+        client: makeManualClient(base.liveClient, requests),
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const hostileWindow = { firstRow: 0, lastRow: 9 };
+      Object.defineProperty(hostileWindow, "firstRow", {
+        enumerable: true,
+        get: () => {
+          viewport.destroy();
+          return 0;
+        },
+      });
+
+      const obsolete = viewport.replace({
+        window: hostileWindow,
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: makeSink<{ readonly id: string }>().sink,
+      });
+      expect(requests).toStrictEqual([]);
+      expect(published).toHaveLength(1);
+      expect(yield* published[0]!.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "loading",
+        }),
+      );
+      obsolete.setWindow({ firstRow: 30, lastRow: 39 });
+      obsolete.release();
+      expect(published).toHaveLength(1);
       yield* base.close;
     }),
   );
@@ -920,10 +1344,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -1005,10 +1426,7 @@ describe("Live Query Viewport Module", () => {
       const base = createInMemoryViewServer(viewServer);
       const requests: Array<ManualRequest> = [];
       const client = makeManualClient(base.liveClient, requests);
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       let publishCount = 0;
       const viewport = makeLiveQueryViewport({
         client,
@@ -1065,10 +1483,7 @@ describe("Live Query Viewport Module", () => {
         subscribe: (topic, query) =>
           base.liveClient.subscribe(topic, query).pipe(Effect.flatMap(() => Effect.fail(failure))),
       } satisfies ViewServerLiveClient<Topics>;
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client: failingClient,
         config: viewServer,
@@ -1121,10 +1536,7 @@ describe("Live Query Viewport Module", () => {
           }),
         ),
       } satisfies ViewServerLiveClient<Topics>;
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -1193,10 +1605,7 @@ describe("Live Query Viewport Module", () => {
           }),
         ),
       } satisfies ViewServerLiveClient<Topics>;
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -1254,10 +1663,7 @@ describe("Live Query Viewport Module", () => {
 
       const sinkReentryRequests: Array<ManualRequest> = [];
       const sinkReentryClient = makeManualClient(base.liveClient, sinkReentryRequests);
-      let sinkReentryStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let sinkReentryStream: ViewportChromeStream = Stream.never;
       const sinkReentryViewport = makeLiveQueryViewport({
         client: sinkReentryClient,
         config: viewServer,
@@ -1813,10 +2219,7 @@ describe("Live Query Viewport Module", () => {
       const client = makeManualClient(base.liveClient, requests);
       const first = makeSink<{ readonly id: string }>();
       const second = makeSink<{ readonly id: string }>();
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client,
         config: viewServer,
@@ -1859,10 +2262,7 @@ describe("Live Query Viewport Module", () => {
       const requests: Array<ManualRequest> = [];
       const first = makeSink<{ readonly id: string }>();
       const second = makeSink<{ readonly id: string }>();
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client: makeManualClient(base.liveClient, requests),
         config: viewServer,
@@ -1912,10 +2312,7 @@ describe("Live Query Viewport Module", () => {
       const requests: Array<ManualRequest> = [];
       const first = makeSink<{ readonly id: string }>();
       const second = makeSink<{ readonly id: string }>();
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client: makeManualClient(base.liveClient, requests),
         config: viewServer,
@@ -1956,10 +2353,7 @@ describe("Live Query Viewport Module", () => {
       const requests: Array<ManualRequest> = [];
       const successor = makeSink<{ readonly id: string }>();
       let installSuccessor = false;
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const viewport = makeLiveQueryViewport({
         client: makeManualClient(base.liveClient, requests),
         config: viewServer,
@@ -2016,10 +2410,7 @@ describe("Live Query Viewport Module", () => {
       const successor = makeSink<{ readonly id: string }>();
       let replaceDuringClear = false;
       let publishCount = 0;
-      let currentStream: Stream.Stream<
-        LiveQueryViewportChrome,
-        ViewServerRuntimeError | ViewServerTransportError
-      > = Stream.never;
+      let currentStream: ViewportChromeStream = Stream.never;
       const previousRowCounts: Array<readonly [number, boolean | undefined]> = [];
       const viewport = makeLiveQueryViewport({
         client,
@@ -2087,14 +2478,8 @@ describe("Live Query Viewport Module", () => {
         const currentRequests: Array<ManualRequest> = [];
         const binding = makeLiveQueryViewportBinding<Topics, "orders">();
         const sink = makeSink<{ readonly id: string }>();
-        let oldStream: Stream.Stream<
-          LiveQueryViewportChrome,
-          ViewServerRuntimeError | ViewServerTransportError
-        > = Stream.never;
-        let currentStream: Stream.Stream<
-          LiveQueryViewportChrome,
-          ViewServerRuntimeError | ViewServerTransportError
-        > = Stream.never;
+        let oldStream: ViewportChromeStream = Stream.never;
+        let currentStream: ViewportChromeStream = Stream.never;
         const oldViewport = makeLiveQueryViewport({
           client: makeManualClient(base.liveClient, oldRequests),
           config: viewServer,

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -1,0 +1,1471 @@
+import { describe, expect, it } from "@effect/vitest";
+import type {
+  ViewServerLiveClient,
+  ViewServerLiveEvent,
+  ViewServerLiveSubscription,
+} from "@effect-view-server/client";
+import {
+  defineViewServerConfig,
+  type ExactLiveQueryInputForTopic,
+  type DeltaOperation,
+  type GroupedQuery,
+  type LiveQueryRow,
+  type RawQuery,
+  type TopicDefinitions,
+  type TopicRow,
+  type ViewServerRuntimeError,
+  type ViewServerTransportError,
+} from "@effect-view-server/config";
+import { grpcSourceMarkers } from "@effect-view-server/config/internal";
+import { createInMemoryViewServer } from "@effect-view-server/in-memory";
+import { Deferred, Effect, Fiber, Option, Queue, Schema, Stream } from "effect";
+import {
+  liveQueryViewportChromeFromAsyncResult,
+  makeLiveQueryViewport,
+  makeLiveQueryViewportBinding,
+  validateLiveQueryViewportWindow,
+  type LiveQueryViewport,
+  type LiveQueryViewportChrome,
+  type LiveQueryViewportSink,
+} from "./live-query-viewport";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  status: Schema.Literals(["open", "closed"]),
+  price: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+type Topics = typeof viewServer.topics;
+
+const LeasedOrder = Schema.Struct({
+  id: Schema.String,
+  region: Schema.String,
+});
+
+const leasedViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: LeasedOrder,
+      key: "id",
+      grpcSource: grpcSourceMarkers.leased({
+        routeBy: ["region"],
+      }),
+    },
+  },
+});
+
+type LeasedTopics = typeof leasedViewServer.topics;
+
+type ManualRequest = {
+  readonly query: Readonly<Record<string, unknown>>;
+  readonly events: Queue.Queue<ViewServerLiveEvent<object>>;
+  closes: number;
+};
+
+type QuerySubstrate<Topics_ extends TopicDefinitions> = (
+  topic: Extract<keyof Topics_, string>,
+  query: Readonly<Record<string, unknown>>,
+) => Effect.Effect<
+  ViewServerLiveSubscription<object>,
+  ViewServerRuntimeError | ViewServerTransportError
+>;
+
+const adaptQuerySubstrate = <Topics_ extends TopicDefinitions>(
+  substrate: QuerySubstrate<Topics_>,
+): ViewServerLiveClient<Topics_>["subscribe"] => {
+  function subscribe<
+    Topic extends Extract<keyof Topics_, string>,
+    const Query extends
+      | RawQuery<TopicRow<Topics_, NoInfer<Topic>>>
+      | GroupedQuery<TopicRow<Topics_, NoInfer<Topic>>>,
+  >(
+    topic: Topic,
+    query: ExactLiveQueryInputForTopic<Topics_, NoInfer<Topic>, Query>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics_, Topic>, Query>>,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
+  function subscribe(
+    topic: Extract<keyof Topics_, string>,
+    query: Readonly<Record<string, unknown>>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<object>,
+    ViewServerRuntimeError | ViewServerTransportError
+  > {
+    return substrate(topic, query);
+  }
+  return subscribe;
+};
+
+const makeManualClient = (
+  base: ViewServerLiveClient<Topics>,
+  requests: Array<ManualRequest>,
+): ViewServerLiveClient<Topics> => ({
+  ...base,
+  subscribe: adaptQuerySubstrate((_, query) =>
+    Effect.gen(function* () {
+      const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+      const request: ManualRequest = {
+        query,
+        events,
+        closes: 0,
+      };
+      requests.push(request);
+      return {
+        events: Stream.fromQueue(events),
+        close: () =>
+          Effect.sync(() => {
+            request.closes += 1;
+          }),
+      };
+    }),
+  ),
+});
+
+const snapshot = (id: string, price: number, version: number): ViewServerLiveEvent<object> => ({
+  type: "snapshot",
+  topic: "orders",
+  queryId: "manual",
+  rows: [{ id, price }],
+  keys: [id],
+  totalRows: 1,
+  version,
+});
+
+const delta = (
+  id: string,
+  price: number,
+  fromVersion: number,
+  toVersion: number,
+): ViewServerLiveEvent<object> => ({
+  type: "delta",
+  topic: "orders",
+  queryId: "manual",
+  operations: [{ type: "update", key: id, row: { id, price }, index: 0 }],
+  totalRows: 1,
+  fromVersion,
+  toVersion,
+});
+
+const snapshotMany = (
+  rows: ReadonlyArray<{ readonly id: string; readonly price: number }>,
+  version: number,
+): ViewServerLiveEvent<object> => ({
+  type: "snapshot",
+  topic: "orders",
+  queryId: "manual",
+  rows,
+  keys: rows.map((row) => row.id),
+  totalRows: rows.length,
+  version,
+});
+
+const deltaMany = (
+  operations: ReadonlyArray<DeltaOperation<object>>,
+  totalRows: number,
+  fromVersion: number,
+  toVersion: number,
+): ViewServerLiveEvent<object> => ({
+  type: "delta",
+  topic: "orders",
+  queryId: "manual",
+  operations,
+  totalRows,
+  fromVersion,
+  toVersion,
+});
+
+const makeSink = <Row>() => {
+  const rowCounts: Array<readonly [number, boolean | undefined]> = [];
+  const rowData: Array<{ readonly [index: number]: Row }> = [];
+  const sink: LiveQueryViewportSink<Row> = {
+    setRowCount: (count, keepRenderedRows) => {
+      rowCounts.push([count, keepRenderedRows]);
+    },
+    setRowData: (rows) => {
+      rowData.push(rows);
+    },
+  };
+  return { rowCounts, rowData, sink };
+};
+
+const flush = Effect.yieldNow;
+
+describe("Live Query Viewport Module", () => {
+  it("validates inclusive absolute windows", () => {
+    expect(validateLiveQueryViewportWindow({ firstRow: 10, lastRow: 19 })).toStrictEqual({
+      _tag: "Valid",
+      firstRow: 10,
+      lastRow: 19,
+      limit: 10,
+    });
+    expect(validateLiveQueryViewportWindow({ firstRow: -1, lastRow: 1 })._tag).toBe("Invalid");
+    expect(validateLiveQueryViewportWindow({ firstRow: 2, lastRow: 1 })).toStrictEqual({
+      _tag: "Invalid",
+      message: "Live Query Viewport lastRow must be greater than or equal to firstRow.",
+    });
+    expect(
+      validateLiveQueryViewportWindow({
+        firstRow: 0,
+        lastRow: Number.MAX_SAFE_INTEGER,
+      })._tag,
+    ).toBe("Invalid");
+    expect(validateLiveQueryViewportWindow({ firstRow: 0.5, lastRow: 1 })._tag).toBe("Invalid");
+  });
+
+  it("maps Atom results to chrome without exposing rows", () => {
+    const ready: LiveQueryViewportChrome = {
+      totalRows: 3,
+      version: 2,
+      status: "ready",
+      statusCode: "Ready",
+    };
+    expect(
+      liveQueryViewportChromeFromAsyncResult(AsyncResult.success({ owner: 1, chrome: ready }), 1),
+    ).toStrictEqual(ready);
+    expect(liveQueryViewportChromeFromAsyncResult(AsyncResult.initial(), 1)).toStrictEqual({
+      totalRows: 0,
+      version: 0,
+      status: "loading",
+    });
+    expect(
+      liveQueryViewportChromeFromAsyncResult(AsyncResult.success({ owner: 1, chrome: ready }), 2),
+    ).toStrictEqual({
+      totalRows: 0,
+      version: 0,
+      status: "loading",
+    });
+  });
+
+  it("keeps one stable viewport facade across committed controller replacements", () => {
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">();
+    const generation = { setWindow: () => undefined, release: () => undefined };
+    let oldDestroys = 0;
+    let currentDestroys = 0;
+    let currentReplaces = 0;
+    const oldViewport = {
+      replace: () => generation,
+      destroy: () => {
+        oldDestroys += 1;
+      },
+    } satisfies LiveQueryViewport<Topics, "orders">;
+    const currentViewport = {
+      replace: () => {
+        currentReplaces += 1;
+        return generation;
+      },
+      destroy: () => {
+        currentDestroys += 1;
+        binding.viewport.replace({
+          window: { firstRow: 20, lastRow: 29 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: { setRowCount: () => undefined, setRowData: () => undefined },
+        });
+      },
+    } satisfies LiveQueryViewport<Topics, "orders">;
+    const oldEntry = { viewport: oldViewport, deactivate: oldViewport.destroy };
+    const currentEntry = { viewport: currentViewport, deactivate: currentViewport.destroy };
+    const facade = binding.viewport;
+    const uninstalledGeneration = facade.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    uninstalledGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+    uninstalledGeneration.release();
+
+    binding.install(oldEntry);
+    binding.install(oldEntry);
+    binding.install(currentEntry);
+    binding.uninstall(oldEntry);
+    facade.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+
+    expect(binding.viewport).toBe(facade);
+    expect(oldDestroys).toBe(1);
+    expect(currentReplaces).toBe(1);
+    binding.viewport.destroy();
+    expect(currentReplaces).toBe(1);
+    binding.install(currentEntry);
+    binding.uninstall(currentEntry);
+    binding.uninstall(currentEntry);
+    const detachedGeneration = binding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    detachedGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+    detachedGeneration.release();
+    binding.viewport.destroy();
+    expect(currentDestroys).toBe(2);
+  });
+
+  it.effect("projects snapshots and Deltas at absolute indexes", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string; readonly price: number }>();
+
+      const generation = viewport.replace({
+        window: { firstRow: 20, lastRow: 29 },
+        query: {
+          select: ["id", "price"],
+          where: [],
+          orderBy: [{ field: "price", direction: "asc" }],
+        },
+        sink: projected.sink,
+      });
+      const chrome: Array<LiveQueryViewportChrome> = [];
+      const fiber = yield* currentStream.pipe(
+        Stream.tap((value) =>
+          Effect.sync(() => {
+            chrome.push(value);
+          }),
+        ),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
+      yield* flush;
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.query).toStrictEqual({
+        select: ["id", "price"],
+        where: [],
+        orderBy: [{ field: "price", direction: "asc" }],
+        offset: 20,
+        limit: 10,
+      });
+
+      yield* Queue.offer(requests[0]!.events, snapshot("a", 1, 1));
+      yield* flush;
+      yield* Queue.offer(requests[0]!.events, delta("a", 2, 1, 2));
+      yield* flush;
+      yield* Queue.offer(requests[0]!.events, deltaMany([], 2, 2, 3));
+      yield* flush;
+
+      expect(projected.rowData).toStrictEqual([
+        { 20: { id: "a", price: 1 } },
+        { 20: { id: "a", price: 2 } },
+      ]);
+      expect(projected.rowCounts).toStrictEqual([
+        [0, false],
+        [1, true],
+        [1, true],
+        [2, true],
+      ]);
+      expect(chrome).toStrictEqual([
+        {
+          totalRows: 1,
+          version: 1,
+          status: "ready",
+          statusCode: "Ready",
+          message: undefined,
+        },
+        {
+          totalRows: 1,
+          version: 2,
+          status: "ready",
+          statusCode: "Ready",
+          message: undefined,
+        },
+        {
+          totalRows: 2,
+          version: 3,
+          status: "ready",
+          statusCode: "Ready",
+          message: undefined,
+        },
+      ]);
+
+      generation.release();
+      yield* Fiber.interrupt(fiber);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("preserves leased routing in the runtime subscription", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const leasedClient = {
+        subscribe: adaptQuerySubstrate<LeasedTopics>((_, query) =>
+          Effect.gen(function* () {
+            const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+            requests.push({ query, events, closes: 0 });
+            return {
+              events: Stream.fromQueue(events),
+              close: () => Effect.void,
+            };
+          }),
+        ),
+        subscribeHealthSummary: base.liveClient.subscribeHealthSummary,
+        subscribeHealth: base.liveClient.subscribeHealth,
+        subscribeSourceHealth: () => Effect.die("unused source health"),
+        health: base.liveClient.health,
+        close: Effect.void,
+      } satisfies ViewServerLiveClient<LeasedTopics>;
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport<LeasedTopics, "orders">({
+        client: leasedClient,
+        config: leasedViewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: {
+          routeBy: { region: "emea" },
+          select: ["id"],
+          where: [],
+          orderBy: [],
+        },
+        sink: projected.sink,
+      });
+      const fiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+
+      expect(requests[0]!.query).toStrictEqual({
+        routeBy: { region: "emea" },
+        select: ["id"],
+        where: [],
+        orderBy: [],
+        offset: 10,
+        limit: 10,
+      });
+      yield* Queue.offer(requests[0]!.events, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "leased",
+        rows: [{ id: "leased-order" }],
+        keys: ["leased-order"],
+        totalRows: 1,
+        version: 1,
+      });
+      yield* flush;
+      expect(projected.rowData).toStrictEqual([{ 10: { id: "leased-order" } }]);
+
+      yield* Fiber.interrupt(fiber);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("enforces switch-latest when an older request emits after its replacement", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string; readonly price: number }>();
+
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: {
+          select: ["id", "price"],
+          where: [{ field: "status", type: "equals", filter: "open" }],
+          orderBy: [],
+        },
+        sink: projected.sink,
+      });
+      const oldChrome: Array<LiveQueryViewportChrome> = [];
+      const oldFiber = yield* currentStream.pipe(
+        Stream.tap((chrome) =>
+          Effect.sync(() => {
+            oldChrome.push(chrome);
+          }),
+        ),
+        Stream.runDrain,
+        Effect.forkChild,
+      );
+      yield* flush;
+
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: {
+          select: ["id", "price"],
+          where: [{ field: "status", type: "equals", filter: "closed" }],
+          orderBy: [],
+        },
+        sink: projected.sink,
+      });
+      const newFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(2);
+
+      yield* Queue.offer(requests[1]!.events, snapshot("new", 2, 2));
+      yield* flush;
+      yield* Queue.offer(requests[0]!.events, snapshot("old-late", 1, 1));
+      yield* Queue.offer(requests[0]!.events, delta("old-late", 3, 1, 2));
+      yield* Queue.offer(requests[0]!.events, {
+        type: "status",
+        topic: "orders",
+        queryId: "manual",
+        status: "error",
+        code: "InvalidQuery",
+        message: "obsolete status",
+      });
+      yield* flush;
+
+      expect(projected.rowData).toStrictEqual([{ 0: { id: "new", price: 2 } }]);
+      expect(oldChrome).toStrictEqual([]);
+
+      yield* Fiber.interrupt(oldFiber);
+      expect(requests[0]!.closes).toBe(1);
+      expect(requests[1]!.closes).toBe(0);
+      yield* Fiber.interrupt(newFiber);
+      expect(requests[1]!.closes).toBe(1);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("uses setWindow as a generation-owned switch-latest hot path", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      const first = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: projected.sink,
+      });
+      const oldFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+
+      first.setWindow({ firstRow: 50, lastRow: 59 });
+      const newFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests[1]!.query).toStrictEqual({
+        select: ["id"],
+        where: [],
+        orderBy: [],
+        offset: 50,
+        limit: 10,
+      });
+
+      yield* Queue.offer(requests[1]!.events, snapshot("new-window", 0, 2));
+      yield* flush;
+      yield* Queue.offer(requests[0]!.events, snapshot("old-window", 0, 1));
+      yield* flush;
+      expect(projected.rowData).toStrictEqual([{ 50: { id: "new-window", price: 0 } }]);
+
+      const replacement = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: {
+          select: ["id"],
+          where: [{ field: "status", type: "equals", filter: "open" }],
+          orderBy: [],
+        },
+        sink: projected.sink,
+      });
+      first.setWindow({ firstRow: 100, lastRow: 109 });
+      expect(requests).toHaveLength(2);
+      replacement.release();
+      replacement.release();
+      first.release();
+
+      yield* Fiber.interrupt(oldFiber);
+      yield* Fiber.interrupt(newFiber);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("replaces filter, sort, selection, and query mode as distinct identities", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const fibers: Array<Fiber.Fiber<void, unknown>> = [];
+      const startCurrent = Effect.gen(function* () {
+        const fiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+        fibers.push(fiber);
+        yield* flush;
+      });
+
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: makeSink<{ readonly id: string }>().sink,
+      });
+      yield* startCurrent;
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: {
+          select: ["id", "price"],
+          where: [{ field: "status", type: "equals", filter: "open" }],
+          orderBy: [{ field: "price", direction: "desc" }],
+        },
+        sink: makeSink<{ readonly id: string; readonly price: number }>().sink,
+      });
+      yield* startCurrent;
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: {
+          groupBy: ["status"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          where: [],
+          orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+        },
+        sink: makeSink<{ readonly status: "open" | "closed"; readonly rowCount: bigint }>().sink,
+      });
+      yield* startCurrent;
+
+      expect(requests.map(({ query }) => query)).toStrictEqual([
+        { select: ["id"], where: [], orderBy: [], offset: 0, limit: 10 },
+        {
+          select: ["id", "price"],
+          where: [{ field: "status", type: "equals", filter: "open" }],
+          orderBy: [{ field: "price", direction: "desc" }],
+          offset: 0,
+          limit: 10,
+        },
+        {
+          groupBy: ["status"],
+          aggregates: { rowCount: { aggFunc: "count" } },
+          where: [],
+          orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+          offset: 0,
+          limit: 10,
+        },
+      ]);
+
+      for (const fiber of fibers) {
+        yield* Fiber.interrupt(fiber);
+      }
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("rejects invalid windows without subscribing and retries terminal identities", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 2, lastRow: 1 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: projected.sink,
+      });
+      const invalidChrome = yield* currentStream.pipe(Stream.runHead);
+      expect(invalidChrome).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "error",
+          statusCode: "InvalidQuery",
+          message: "Live Query Viewport lastRow must be greater than or equal to firstRow.",
+        }),
+      );
+      expect(requests).toHaveLength(0);
+
+      const replaceValid = () =>
+        viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: projected.sink,
+        });
+      replaceValid();
+      const firstFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      yield* Queue.offer(requests[0]!.events, {
+        type: "status",
+        topic: "orders",
+        queryId: "manual",
+        status: "closed",
+        code: "SubscriptionClosed",
+        message: "closed",
+      });
+      yield* flush;
+
+      replaceValid();
+      const retryFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(2);
+      yield* Queue.offer(requests[1]!.events, {
+        type: "status",
+        topic: "orders",
+        queryId: "manual",
+        status: "error",
+        code: "InvalidQuery",
+        message: "terminal error",
+      });
+      yield* flush;
+
+      replaceValid();
+      const errorRetryFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(3);
+
+      yield* Fiber.interrupt(firstFiber);
+      yield* Fiber.interrupt(retryFiber);
+      yield* Fiber.interrupt(errorRetryFiber);
+      viewport.destroy();
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("projects every Delta operation shape and ignores non-row events", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string; readonly price: number }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id", "price"], where: [], orderBy: [] },
+        sink: projected.sink,
+      });
+      const fiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      yield* Queue.offer(
+        requests[0]!.events,
+        snapshotMany(
+          [
+            { id: "a", price: 1 },
+            { id: "b", price: 2 },
+            { id: "c", price: 3 },
+          ],
+          1,
+        ),
+      );
+      yield* Queue.offer(
+        requests[0]!.events,
+        deltaMany([{ type: "insert", key: "x", row: { id: "x", price: 4 }, index: 1 }], 4, 1, 2),
+      );
+      yield* Queue.offer(
+        requests[0]!.events,
+        deltaMany([{ type: "move", key: "c", fromIndex: 3, toIndex: 0 }], 4, 2, 3),
+      );
+      yield* Queue.offer(requests[0]!.events, deltaMany([{ type: "remove", key: "x" }], 3, 3, 4));
+      yield* Queue.offer(requests[0]!.events, deltaMany([], 3, 4, 5));
+      yield* Queue.offer(
+        requests[0]!.events,
+        deltaMany([{ type: "remove", key: "missing" }], 3, 5, 6),
+      );
+      yield* Queue.offer(requests[0]!.events, {
+        type: "status",
+        topic: "orders",
+        queryId: "manual",
+        status: "ready",
+        code: "Ready",
+      });
+      yield* flush;
+
+      expect(projected.rowData).toStrictEqual([
+        {
+          0: { id: "a", price: 1 },
+          1: { id: "b", price: 2 },
+          2: { id: "c", price: 3 },
+        },
+        {
+          1: { id: "x", price: 4 },
+          2: { id: "b", price: 2 },
+          3: { id: "c", price: 3 },
+        },
+        {
+          0: { id: "c", price: 3 },
+          1: { id: "a", price: 1 },
+          2: { id: "x", price: 4 },
+          3: { id: "b", price: 2 },
+        },
+        { 2: { id: "b", price: 2 } },
+      ]);
+
+      yield* Fiber.interrupt(fiber);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("deduplicates a live identity and treats an unchanged window as a no-op", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      let publishCount = 0;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          publishCount += 1;
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      const replace = () =>
+        viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: projected.sink,
+        });
+      const first = replace();
+      const duplicate = replace();
+      duplicate.setWindow({ firstRow: 0, lastRow: 9 });
+      expect(publishCount).toBe(1);
+
+      const fiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(requests).toHaveLength(1);
+      first.release();
+      duplicate.release();
+      yield* Fiber.interrupt(fiber);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("surfaces current subscription failures while suppressing obsolete failures", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const failure = {
+        _tag: "ViewServerRuntimeError" as const,
+        code: "InvalidQuery" as const,
+        message: "subscription failed",
+      };
+      const failingClient = {
+        ...base.liveClient,
+        subscribe: (topic, query) =>
+          base.liveClient.subscribe(topic, query).pipe(Effect.flatMap(() => Effect.fail(failure))),
+      } satisfies ViewServerLiveClient<Topics>;
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client: failingClient,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: projected.sink,
+      });
+
+      const actualFailure = yield* currentStream.pipe(Stream.runDrain, Effect.flip);
+      expect(actualFailure).toStrictEqual(failure);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("clears ready rows after a current stream defect and permits an identical retry", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      let subscribeCount = 0;
+      let closeCount = 0;
+      const defectSignals: Array<Deferred.Deferred<void>> = [];
+      const client = {
+        ...base.liveClient,
+        subscribe: adaptQuerySubstrate(() =>
+          Effect.gen(function* () {
+            subscribeCount += 1;
+            const defectSignal = yield* Deferred.make<void>();
+            defectSignals.push(defectSignal);
+            return {
+              events: Stream.concat(
+                Stream.make(snapshot("ready-before-error", 1, 1)),
+                Stream.fromEffect(
+                  Deferred.await(defectSignal).pipe(
+                    Effect.flatMap(() => Effect.die("stream defect")),
+                  ),
+                ),
+              ),
+              close: () =>
+                Effect.sync(() => {
+                  closeCount += 1;
+                }),
+            };
+          }),
+        ),
+      } satisfies ViewServerLiveClient<Topics>;
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const projected = makeSink<{ readonly id: string }>();
+      const replace = () =>
+        viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: projected.sink,
+        });
+
+      replace();
+      const firstFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      expect(projected.rowData).toStrictEqual([{ 0: { id: "ready-before-error", price: 1 } }]);
+      yield* Deferred.succeed(defectSignals[0]!, undefined);
+      const actualExit = yield* Fiber.await(firstFiber);
+      expect(actualExit._tag).toBe("Failure");
+      expect(projected.rowCounts.at(-1)).toStrictEqual([0, false]);
+      expect(closeCount).toBe(1);
+
+      replace();
+      const retryFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      yield* Deferred.succeed(defectSignals[1]!, undefined);
+      const retryExit = yield* Fiber.await(retryFiber);
+      expect(retryExit._tag).toBe("Failure");
+      expect(subscribeCount).toBe(2);
+      expect(closeCount).toBe(2);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("drops obsolete acquisition failures and reentrant event or sink writes", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const oldFailure = yield* Deferred.make<void>();
+      const requests: Array<ManualRequest> = [];
+      let subscriptionAttempt = 0;
+      const client = {
+        ...base.liveClient,
+        subscribe: adaptQuerySubstrate((_, query) =>
+          Effect.gen(function* () {
+            subscriptionAttempt += 1;
+            if (subscriptionAttempt === 1) {
+              yield* Deferred.await(oldFailure);
+              return yield* Effect.fail({
+                _tag: "ViewServerRuntimeError" as const,
+                code: "InvalidQuery" as const,
+                message: "obsolete failure",
+              });
+            }
+            const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+            const request: ManualRequest = { query, events, closes: 0 };
+            requests.push(request);
+            return {
+              events: Stream.fromQueue(events),
+              close: () => Effect.void,
+            };
+          }),
+        ),
+      } satisfies ViewServerLiveClient<Topics>;
+      let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          currentStream = command.stream;
+        },
+      });
+      const firstSink = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: firstSink.sink,
+      });
+      const oldFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+
+      const secondSink = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: {
+          select: ["id"],
+          where: [{ field: "status", type: "equals", filter: "open" }],
+          orderBy: [],
+        },
+        sink: secondSink.sink,
+      });
+      const currentFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      yield* Deferred.succeed(oldFailure, undefined);
+      yield* flush;
+      expect(requests).toHaveLength(1);
+      const oldExit = yield* Fiber.await(oldFiber);
+      expect(oldExit._tag).toBe("Success");
+
+      const reentrantEvent = snapshot("reentrant-event", 1, 1);
+      Object.defineProperty(reentrantEvent, "type", {
+        enumerable: true,
+        get: () => {
+          viewport.replace({
+            window: { firstRow: 10, lastRow: 19 },
+            query: {
+              select: ["id"],
+              where: [{ field: "status", type: "equals", filter: "closed" }],
+              orderBy: [],
+            },
+            sink: secondSink.sink,
+          });
+          return "snapshot";
+        },
+      });
+      yield* Queue.offer(requests[0]!.events, reentrantEvent);
+      yield* flush;
+      expect(secondSink.rowData).toStrictEqual([]);
+
+      const sinkReentryRequests: Array<ManualRequest> = [];
+      const sinkReentryClient = makeManualClient(base.liveClient, sinkReentryRequests);
+      let sinkReentryStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+      const sinkReentryViewport = makeLiveQueryViewport({
+        client: sinkReentryClient,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          sinkReentryStream = command.stream;
+        },
+      });
+      const reentrantSink: LiveQueryViewportSink<{ readonly id: string }> = {
+        setRowCount: (_, keepRenderedRows) => {
+          if (keepRenderedRows === true) {
+            sinkReentryViewport.replace({
+              window: { firstRow: 10, lastRow: 19 },
+              query: {
+                select: ["id"],
+                where: [{ field: "status", type: "equals", filter: "closed" }],
+                orderBy: [],
+              },
+              sink: reentrantSink,
+            });
+          }
+        },
+        setRowData: () => undefined,
+      };
+      sinkReentryViewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: reentrantSink,
+      });
+      const sinkFiber = yield* sinkReentryStream.pipe(Stream.runDrain, Effect.forkChild);
+      yield* flush;
+      yield* Queue.offer(sinkReentryRequests[0]!.events, snapshot("sink-reentry", 1, 1));
+      yield* flush;
+
+      yield* Fiber.interrupt(oldFiber);
+      yield* Fiber.interrupt(currentFiber);
+      yield* Fiber.interrupt(sinkFiber);
+      viewport.destroy();
+      sinkReentryViewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("handles hostile query accessors and reentrant sink callbacks", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const published: Array<Stream.Stream<LiveQueryViewportChrome, unknown>> = [];
+      let viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const hostile = {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      } satisfies {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      Object.defineProperty(hostile, "where", {
+        enumerable: true,
+        get: () => {
+          throw new Error("hostile query");
+        },
+      });
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      const hostileGeneration = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: hostile,
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      hostileGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+      hostileGeneration.release();
+      hostileGeneration.release();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: hostile,
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      viewport.destroy();
+
+      viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      let destroyInvalidOnClear = true;
+      const invalidReentrantGeneration = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: hostile,
+        sink: {
+          setRowCount: () => {
+            if (destroyInvalidOnClear) {
+              destroyInvalidOnClear = false;
+              viewport.destroy();
+            }
+          },
+          setRowData: () => undefined,
+        },
+      });
+      invalidReentrantGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+      invalidReentrantGeneration.release();
+
+      viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      const reentrantQueryTarget = {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      } satisfies {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      const reentrantQuery = new Proxy(reentrantQueryTarget, {
+        ownKeys: (target) => {
+          viewport.destroy();
+          return Reflect.ownKeys(target);
+        },
+      });
+      const obsoleteGeneration = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: reentrantQuery,
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+      obsoleteGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+      obsoleteGeneration.release();
+
+      viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published.push(command.stream);
+        },
+      });
+      let destroyOnClear = true;
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            if (destroyOnClear) {
+              destroyOnClear = false;
+              viewport.destroy();
+            }
+          },
+          setRowData: () => undefined,
+        },
+      });
+
+      expect(requests).toHaveLength(0);
+      expect(published.length).toBeGreaterThan(0);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("does not publish idle over a replacement started reentrantly during release", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      let publishCount = 0;
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: () => {
+          publishCount += 1;
+        },
+      });
+      let replaceDuringRelease = false;
+      const sink = {
+        setRowCount: () => {
+          if (replaceDuringRelease) {
+            replaceDuringRelease = false;
+            viewport.replace({
+              window: { firstRow: 10, lastRow: 19 },
+              query: { select: ["id"], where: [], orderBy: [] },
+              sink: { setRowCount: () => undefined, setRowData: () => undefined },
+            });
+          }
+        },
+        setRowData: () => undefined,
+      };
+      const generation = viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink,
+      });
+      replaceDuringRelease = true;
+      generation.release();
+
+      expect(publishCount).toBe(2);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect("clears a superseded sink and gives its replacement exclusive ownership", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const requests: Array<ManualRequest> = [];
+      const client = makeManualClient(base.liveClient, requests);
+      const first = makeSink<{ readonly id: string }>();
+      const second = makeSink<{ readonly id: string }>();
+      const viewport = makeLiveQueryViewport({
+        client,
+        config: viewServer,
+        topic: "orders",
+        publish: () => undefined,
+      });
+
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: first.sink,
+      });
+      viewport.replace({
+        window: { firstRow: 10, lastRow: 19 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: second.sink,
+      });
+
+      expect(first.rowCounts).toStrictEqual([
+        [0, false],
+        [0, false],
+      ]);
+      expect(second.rowCounts).toStrictEqual([[0, false]]);
+      viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it.effect(
+    "commits controller replacements before late events and finalizers can touch the sink",
+    () =>
+      Effect.gen(function* () {
+        const base = createInMemoryViewServer(viewServer);
+        const oldRequests: Array<ManualRequest> = [];
+        const currentRequests: Array<ManualRequest> = [];
+        const binding = makeLiveQueryViewportBinding<Topics, "orders">();
+        const sink = makeSink<{ readonly id: string }>();
+        let oldStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+        let currentStream: Stream.Stream<LiveQueryViewportChrome, unknown> = Stream.never;
+        const oldViewport = makeLiveQueryViewport({
+          client: makeManualClient(base.liveClient, oldRequests),
+          config: viewServer,
+          topic: "orders",
+          publish: (command) => {
+            oldStream = command.stream;
+          },
+        });
+        const oldEntry = { viewport: oldViewport, deactivate: oldViewport.deactivate };
+        binding.install(oldEntry);
+        binding.viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: sink.sink,
+        });
+        const oldFiber = yield* oldStream.pipe(Stream.runDrain, Effect.forkChild);
+        yield* flush;
+
+        const currentViewport = makeLiveQueryViewport({
+          client: makeManualClient(base.liveClient, currentRequests),
+          config: viewServer,
+          topic: "orders",
+          publish: (command) => {
+            currentStream = command.stream;
+          },
+        });
+        const currentEntry = {
+          viewport: currentViewport,
+          deactivate: currentViewport.deactivate,
+        };
+        binding.install(currentEntry);
+        const obsoleteGeneration = oldViewport.replace({
+          window: { firstRow: 20, lastRow: 29 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: sink.sink,
+        });
+        obsoleteGeneration.setWindow({ firstRow: 30, lastRow: 39 });
+        obsoleteGeneration.release();
+        binding.viewport.replace({
+          window: { firstRow: 10, lastRow: 19 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: sink.sink,
+        });
+        const currentFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+        yield* flush;
+        yield* Queue.offer(currentRequests[0]!.events, snapshot("current", 2, 1));
+        yield* flush;
+        expect(sink.rowData.at(-1)).toStrictEqual({ 10: { id: "current", price: 2 } });
+
+        yield* Queue.offer(oldRequests[0]!.events, snapshot("obsolete", 1, 1));
+        binding.uninstall(oldEntry);
+        const currentGeneration = binding.viewport.replace({
+          window: { firstRow: 20, lastRow: 29 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: sink.sink,
+        });
+        currentGeneration.setWindow({ firstRow: 30, lastRow: 39 });
+        const latestFiber = yield* currentStream.pipe(Stream.runDrain, Effect.forkChild);
+        yield* flush;
+        expect(currentRequests).toHaveLength(2);
+        expect(oldRequests).toHaveLength(1);
+        yield* Queue.offer(currentRequests[1]!.events, snapshot("latest", 3, 2));
+        yield* flush;
+        expect(sink.rowData.at(-1)).toStrictEqual({ 30: { id: "latest", price: 3 } });
+
+        yield* Fiber.interrupt(oldFiber);
+        yield* Fiber.interrupt(currentFiber);
+        yield* Fiber.interrupt(latestFiber);
+        binding.uninstall(currentEntry);
+        yield* base.close;
+      }),
+  );
+
+  it.effect("makes destroy terminal even when sink cleanup attempts to replace", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      let publishCount = 0;
+      const viewport = makeLiveQueryViewport({
+        client: base.liveClient,
+        config: viewServer,
+        topic: "orders",
+        publish: () => {
+          publishCount += 1;
+        },
+      });
+      let replaceDuringDestroy = false;
+      const replacementSink = makeSink<{ readonly id: string }>();
+      viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => {
+            if (replaceDuringDestroy) {
+              replaceDuringDestroy = false;
+              viewport.replace({
+                window: { firstRow: 10, lastRow: 19 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink: replacementSink.sink,
+              });
+            }
+          },
+          setRowData: () => undefined,
+        },
+      });
+      replaceDuringDestroy = true;
+      viewport.destroy();
+      const destroyedGeneration = viewport.replace({
+        window: { firstRow: 20, lastRow: 29 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: replacementSink.sink,
+      });
+      destroyedGeneration.setWindow({ firstRow: 30, lastRow: 39 });
+      destroyedGeneration.release();
+
+      expect(publishCount).toBe(2);
+      expect(replacementSink.rowCounts).toStrictEqual([]);
+      viewport.destroy();
+      expect(publishCount).toBe(2);
+      yield* base.close;
+    }),
+  );
+});

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -1,0 +1,1149 @@
+import { describe, expect, it } from "@effect/vitest";
+import type {
+  ViewServerLiveClient,
+  ViewServerLiveEvent,
+  ViewServerLiveSubscription,
+} from "@effect-view-server/client";
+import {
+  defineViewServerConfig,
+  type ExactLiveQueryInputForTopic,
+  type GroupedQuery,
+  type LiveQueryRow,
+  type RawQuery,
+  type TopicDefinitions,
+  type TopicRow,
+  type ViewServerRuntimeError,
+  type ViewServerTransportError,
+} from "@effect-view-server/config";
+import { createInMemoryViewServer } from "@effect-view-server/in-memory";
+import { Deferred, Effect, Queue, Schema, Stream } from "effect";
+import type * as BigDecimal from "effect/BigDecimal";
+import { StrictMode, useLayoutEffect } from "react";
+import { renderToString } from "react-dom/server";
+import { render } from "vitest-browser-react";
+import { createViewServerReact } from "./index";
+import { ViewServerReactClientProvider } from "./internal";
+import type {
+  LiveQueryViewport,
+  LiveQueryViewportGeneration,
+  LiveQueryViewportSink,
+} from "./live-query-viewport";
+
+const Order = Schema.Struct({
+  id: Schema.String,
+  status: Schema.Literals(["open", "closed"]),
+  price: Schema.Number,
+});
+
+const viewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+const react = createViewServerReact(viewServer);
+const { useLiveQuery, useLiveQueryViewport } = react;
+const ViewServerClientProvider = react[ViewServerReactClientProvider];
+
+const multiTopicViewServer = defineViewServerConfig({
+  topics: {
+    orders: {
+      schema: Order,
+      key: "id",
+    },
+    archivedOrders: {
+      schema: Order,
+      key: "id",
+    },
+  },
+});
+
+const multiTopicReact = createViewServerReact(multiTopicViewServer);
+const MultiTopicClientProvider = multiTopicReact[ViewServerReactClientProvider];
+
+type QuerySubstrate<Topics_ extends TopicDefinitions> = (
+  topic: Extract<keyof Topics_, string>,
+  query: Readonly<Record<string, unknown>>,
+) => Effect.Effect<
+  ViewServerLiveSubscription<object>,
+  ViewServerRuntimeError | ViewServerTransportError
+>;
+
+const adaptQuerySubstrate = <Topics_ extends TopicDefinitions>(
+  substrate: QuerySubstrate<Topics_>,
+): ViewServerLiveClient<Topics_>["subscribe"] => {
+  function subscribe<
+    Topic extends Extract<keyof Topics_, string>,
+    const Query extends
+      | RawQuery<TopicRow<Topics_, NoInfer<Topic>>>
+      | GroupedQuery<TopicRow<Topics_, NoInfer<Topic>>>,
+  >(
+    topic: Topic,
+    query: ExactLiveQueryInputForTopic<Topics_, NoInfer<Topic>, Query>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<LiveQueryRow<TopicRow<Topics_, Topic>, Query>>,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
+  function subscribe(
+    topic: Extract<keyof Topics_, string>,
+    query: Readonly<Record<string, unknown>>,
+  ): Effect.Effect<
+    ViewServerLiveSubscription<object>,
+    ViewServerRuntimeError | ViewServerTransportError
+  > {
+    return substrate(topic, query);
+  }
+  return subscribe;
+};
+
+type SelectedOrder = {
+  readonly id: string;
+  readonly price: number;
+};
+
+const makeGridModel = <Row,>() => {
+  let rowCount = 0;
+  let rows: { readonly [index: number]: Row } = {};
+  const sink: LiveQueryViewportSink<Row> = {
+    setRowCount: (count, keepRenderedRows) => {
+      rowCount = count;
+      if (keepRenderedRows !== true) {
+        rows = {};
+      }
+    },
+    setRowData: (changedRows) => {
+      rows = { ...rows, ...changedRows };
+    },
+  };
+  return {
+    sink,
+    rowCount: () => rowCount,
+    rows: () => rows,
+  };
+};
+
+describe("useLiveQueryViewport", () => {
+  it("renders loading chrome during SSR without starting a subscription", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+
+    function ViewportChrome() {
+      const result = useLiveQueryViewport("orders");
+      return <output role="status">{`${result.status}:${result.totalRows}`}</output>;
+    }
+
+    expect(
+      renderToString(
+        <ViewServerClientProvider client={runtime.liveClient}>
+          <ViewportChrome />
+        </ViewServerClientProvider>,
+      ),
+    ).toBe('<output role="status">loading:0</output>');
+    const health = await Effect.runPromise(runtime.client.health());
+    expect(health.engine.topics.orders.activeSubscriptions).toBe(0);
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("accepts a descendant grid connection from its first layout effect", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const requests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const client = {
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.gen(function* () {
+          const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+          requests.push(events);
+          return {
+            events: Stream.fromQueue(events),
+            close: () => Effect.void,
+          };
+        }),
+      ),
+    } satisfies ViewServerLiveClient<typeof viewServer.topics>;
+    const grid = makeGridModel<{ readonly id: string }>();
+
+    function GridAdapter(props: {
+      readonly viewport: LiveQueryViewport<typeof viewServer.topics, "orders">;
+    }) {
+      useLayoutEffect(() => {
+        const generation = props.viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink: grid.sink,
+        });
+        return generation.release;
+      }, [props.viewport]);
+      return null;
+    }
+
+    function ViewportOwner() {
+      const result = useLiveQueryViewport("orders");
+      return <GridAdapter viewport={result.viewport} />;
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={client}>
+        <ViewportOwner />
+      </ViewServerClientProvider>,
+    );
+    await expect.poll(() => requests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "layout-grid",
+        rows: [{ id: "connected" }],
+        keys: ["connected"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "connected" } });
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("loads absolute rows, scrolls through setWindow, and releases on unmount", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    await Effect.runPromise(
+      runtime.client.publishMany(
+        "orders",
+        Array.from({ length: 30 }, (_, index) => ({
+          id: `order-${index}`,
+          status: index % 2 === 0 ? ("open" as const) : ("closed" as const),
+          price: index,
+        })),
+      ),
+    );
+    const grid = makeGridModel<SelectedOrder>();
+    let generation: LiveQueryViewportGeneration | undefined;
+
+    function ViewportView() {
+      const result = useLiveQueryViewport("orders");
+      return (
+        <>
+          <output role="status">
+            {result.status}:{result.totalRows}:{result.version}
+          </output>
+          <button
+            type="button"
+            onClick={() => {
+              generation = result.viewport.replace({
+                window: { firstRow: 10, lastRow: 14 },
+                query: {
+                  select: ["id", "price"],
+                  where: [],
+                  orderBy: [{ field: "price", direction: "asc" }],
+                },
+                sink: grid.sink,
+              });
+            }}
+          >
+            load viewport
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              generation?.setWindow({ firstRow: 20, lastRow: 24 });
+            }}
+          >
+            scroll viewport
+          </button>
+        </>
+      );
+    }
+
+    const view = await render(
+      <StrictMode>
+        <ViewServerClientProvider client={runtime.liveClient}>
+          <ViewportView />
+        </ViewServerClientProvider>
+      </StrictMode>,
+    );
+    await view.getByRole("button", { name: "load viewport" }).click();
+    await expect.poll(grid.rows).toStrictEqual({
+      10: { id: "order-10", price: 10 },
+      11: { id: "order-11", price: 11 },
+      12: { id: "order-12", price: 12 },
+      13: { id: "order-13", price: 13 },
+      14: { id: "order-14", price: 14 },
+    });
+    expect(grid.rowCount()).toBe(30);
+    await expect.element(view.getByText(/^ready:30:\d+$/)).toBeVisible();
+
+    await view.getByRole("button", { name: "scroll viewport" }).click();
+    await expect.poll(grid.rows).toStrictEqual({
+      20: { id: "order-20", price: 20 },
+      21: { id: "order-21", price: 21 },
+      22: { id: "order-22", price: 22 },
+      23: { id: "order-23", price: 23 },
+      24: { id: "order-24", price: 24 },
+    });
+    expect(grid.rowCount()).toBe(30);
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(1);
+
+    await view.unmount();
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(0);
+    generation?.setWindow({ firstRow: 0, lastRow: 4 });
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(0);
+    expect(grid.rowCount()).toBe(0);
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("makes public destroy terminal, resets chrome, and closes the subscription", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    await Effect.runPromise(
+      runtime.client.publish("orders", {
+        id: "destroyed-order",
+        status: "open",
+        price: 1,
+      }),
+    );
+    const grid = makeGridModel<{ readonly id: string }>();
+    const replacementGrid = makeGridModel<{ readonly id: string }>();
+    let replaceDuringClear = false;
+
+    function DestroyableViewport() {
+      const result = useLiveQueryViewport("orders");
+      const sink: LiveQueryViewportSink<{ readonly id: string }> = {
+        setRowCount: (count, keepRenderedRows) => {
+          grid.sink.setRowCount(count, keepRenderedRows);
+          if (replaceDuringClear) {
+            replaceDuringClear = false;
+            result.viewport.replace({
+              window: { firstRow: 10, lastRow: 19 },
+              query: { select: ["id"], where: [], orderBy: [] },
+              sink: replacementGrid.sink,
+            });
+          }
+        },
+        setRowData: grid.sink.setRowData,
+      };
+      return (
+        <>
+          <output role="status">
+            {result.status}:{result.totalRows}:{result.version}
+          </output>
+          <button
+            type="button"
+            onClick={() => {
+              result.viewport.replace({
+                window: { firstRow: 0, lastRow: 9 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink,
+              });
+            }}
+          >
+            load destroyable viewport
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              replaceDuringClear = true;
+              result.viewport.destroy();
+              result.viewport.destroy();
+              result.viewport.replace({
+                window: { firstRow: 20, lastRow: 29 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink: replacementGrid.sink,
+              });
+            }}
+          >
+            destroy viewport
+          </button>
+        </>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={runtime.liveClient}>
+        <DestroyableViewport />
+      </ViewServerClientProvider>,
+    );
+    await view.getByRole("button", { name: "load destroyable viewport" }).click();
+    await expect.element(view.getByText(/^ready:1:\d+$/)).toBeVisible();
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(1);
+
+    await view.getByRole("button", { name: "destroy viewport" }).click();
+    await expect.element(view.getByText("loading:0:0", { exact: true })).toBeVisible();
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(0);
+    expect(grid.rowCount()).toBe(0);
+    expect(grid.rows()).toStrictEqual({});
+    expect(replacementGrid.rowCount()).toBe(0);
+    expect(replacementGrid.rows()).toStrictEqual({});
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("never lets an older useLiveQuery identity replace newer filter data", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const requests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const client = {
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.gen(function* () {
+          const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+          requests.push(events);
+          return {
+            events: Stream.fromQueue(events),
+            close: () => Effect.void,
+          };
+        }),
+      ),
+    } satisfies ViewServerLiveClient<typeof viewServer.topics>;
+    const openQuery = {
+      select: ["id"],
+      where: [{ field: "status", type: "equals", filter: "open" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [
+        {
+          readonly field: "status";
+          readonly type: "equals";
+          readonly filter: "open";
+        },
+      ];
+    };
+    const closedQuery = {
+      select: ["id"],
+      where: [{ field: "status", type: "equals", filter: "closed" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [
+        {
+          readonly field: "status";
+          readonly type: "equals";
+          readonly filter: "closed";
+        },
+      ];
+    };
+
+    function QueryView(props: {
+      readonly query:
+        | {
+            readonly select: readonly ["id"];
+            readonly where: typeof openQuery.where;
+          }
+        | {
+            readonly select: readonly ["id"];
+            readonly where: typeof closedQuery.where;
+          };
+    }) {
+      const result = useLiveQuery("orders", props.query);
+      return (
+        <output role="status">
+          {result.status}:{result.rows.map((row) => row.id).join("|")}
+        </output>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={client}>
+        <QueryView query={openQuery} />
+      </ViewServerClientProvider>,
+    );
+    await expect.poll(() => requests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "open",
+        rows: [{ id: "open-1" }],
+        keys: ["open-1"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.element(view.getByText("ready:open-1", { exact: true })).toBeVisible();
+
+    await view.rerender(
+      <ViewServerClientProvider client={client}>
+        <QueryView query={closedQuery} />
+      </ViewServerClientProvider>,
+    );
+    await expect.element(view.getByText("loading:", { exact: true })).toBeVisible();
+    await expect.poll(() => requests.length).toBe(2);
+    await Effect.runPromise(
+      Queue.offer(requests[1]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "closed",
+        rows: [{ id: "closed-1" }],
+        keys: ["closed-1"],
+        totalRows: 1,
+        version: 2,
+      }),
+    );
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "delta",
+        topic: "orders",
+        queryId: "open",
+        fromVersion: 1,
+        toVersion: 2,
+        operations: [
+          {
+            type: "update",
+            key: "open-1",
+            row: { id: "open-delta-late" },
+            index: 0,
+          },
+        ],
+        totalRows: 1,
+      }),
+    );
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "status",
+        topic: "orders",
+        queryId: "open",
+        status: "error",
+        code: "InvalidQuery",
+        message: "obsolete status",
+      }),
+    );
+    await expect.element(view.getByText("ready:closed-1", { exact: true })).toBeVisible();
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "open",
+        rows: [{ id: "open-late" }],
+        keys: ["open-late"],
+        totalRows: 1,
+        version: 3,
+      }),
+    );
+    await expect.element(view.getByText("ready:closed-1", { exact: true })).toBeVisible();
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("ignores an obsolete useLiveQuery acquisition failure after its replacement is ready", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const oldFailure = await Effect.runPromise(Deferred.make<void>());
+    const currentEvents = await Effect.runPromise(Queue.unbounded<ViewServerLiveEvent<object>>());
+    let subscriptionAttempt = 0;
+    const client = {
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() => {
+        subscriptionAttempt += 1;
+        if (subscriptionAttempt === 1) {
+          return Deferred.await(oldFailure).pipe(
+            Effect.andThen(
+              Effect.fail({
+                _tag: "ViewServerRuntimeError" as const,
+                code: "InvalidQuery" as const,
+                message: "obsolete acquisition failure",
+              }),
+            ),
+          );
+        }
+        return Effect.succeed({
+          events: Stream.fromQueue(currentEvents),
+          close: () => Effect.void,
+        });
+      }),
+    } satisfies ViewServerLiveClient<typeof viewServer.topics>;
+    const openQuery = {
+      select: ["id"],
+      where: [{ field: "status", type: "equals", filter: "open" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [
+        {
+          readonly field: "status";
+          readonly type: "equals";
+          readonly filter: "open";
+        },
+      ];
+    };
+    const closedQuery = {
+      select: ["id"],
+      where: [{ field: "status", type: "equals", filter: "closed" }],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [
+        {
+          readonly field: "status";
+          readonly type: "equals";
+          readonly filter: "closed";
+        },
+      ];
+    };
+
+    function QueryView(props: { readonly query: typeof openQuery | typeof closedQuery }) {
+      const result = useLiveQuery("orders", props.query);
+      return (
+        <output role="status">
+          {result.status}:{result.rows.map((row) => row.id).join("|")}
+        </output>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={client}>
+        <QueryView query={openQuery} />
+      </ViewServerClientProvider>,
+    );
+    await expect.poll(() => subscriptionAttempt).toBe(1);
+    await view.rerender(
+      <ViewServerClientProvider client={client}>
+        <QueryView query={closedQuery} />
+      </ViewServerClientProvider>,
+    );
+    await expect.element(view.getByText("loading:", { exact: true })).toBeVisible();
+    await expect.poll(() => subscriptionAttempt).toBe(2);
+    await Effect.runPromise(
+      Queue.offer(currentEvents, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "closed",
+        rows: [{ id: "closed-current" }],
+        keys: ["closed-current"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.element(view.getByText("ready:closed-current", { exact: true })).toBeVisible();
+    await Effect.runPromise(Deferred.succeed(oldFailure, undefined));
+    await expect.element(view.getByText("ready:closed-current", { exact: true })).toBeVisible();
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("resets viewport chrome and rows while the newest request is pending", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const requests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const client = {
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.gen(function* () {
+          const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+          requests.push(events);
+          return {
+            events: Stream.fromQueue(events),
+            close: () => Effect.void,
+          };
+        }),
+      ),
+    } satisfies ViewServerLiveClient<typeof viewServer.topics>;
+    const grid = makeGridModel<SelectedOrder>();
+
+    function ViewportSwitchView() {
+      const result = useLiveQueryViewport("orders");
+      const replace = (status: "open" | "closed") => {
+        result.viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: {
+            select: ["id", "price"],
+            where: [{ field: "status", type: "equals", filter: status }],
+            orderBy: [],
+          },
+          sink: grid.sink,
+        });
+      };
+      return (
+        <>
+          <output role="status">
+            {result.status}:{result.totalRows}:{result.version}
+          </output>
+          <button type="button" onClick={() => replace("open")}>
+            request open
+          </button>
+          <button type="button" onClick={() => replace("closed")}>
+            request closed
+          </button>
+        </>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={client}>
+        <ViewportSwitchView />
+      </ViewServerClientProvider>,
+    );
+    await view.getByRole("button", { name: "request open" }).click();
+    await expect.poll(() => requests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "open",
+        rows: [{ id: "open-1", price: 1 }],
+        keys: ["open-1"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.element(view.getByText("ready:1:1", { exact: true })).toBeVisible();
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "open-1", price: 1 } });
+
+    await view.getByRole("button", { name: "request closed" }).click();
+    await expect.poll(() => requests.length).toBe(2);
+    await expect.element(view.getByText("loading:0:0", { exact: true })).toBeVisible();
+    expect(grid.rows()).toStrictEqual({});
+
+    await Effect.runPromise(
+      Queue.offer(requests[0]!, {
+        type: "status",
+        topic: "orders",
+        queryId: "open",
+        status: "error",
+        code: "InvalidQuery",
+        message: "late old error",
+      }),
+    );
+    await expect.element(view.getByText("loading:0:0", { exact: true })).toBeVisible();
+    await Effect.runPromise(
+      Queue.offer(requests[1]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "closed",
+        rows: [{ id: "closed-1", price: 2 }],
+        keys: ["closed-1"],
+        totalRows: 1,
+        version: 2,
+      }),
+    );
+    await expect.element(view.getByText("ready:1:2", { exact: true })).toBeVisible();
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "closed-1", price: 2 } });
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("maps the current acquisition failure into owned error chrome", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const client = {
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.fail({
+          _tag: "ViewServerRuntimeError" as const,
+          code: "InvalidQuery" as const,
+          message: "rejected viewport",
+        }),
+      ),
+    } satisfies ViewServerLiveClient<typeof viewServer.topics>;
+
+    function FailingViewport() {
+      const result = useLiveQueryViewport("orders");
+      return (
+        <>
+          <output role="status">
+            {result.status}:{result.statusCode ?? "none"}:{result.totalRows}
+          </output>
+          <button
+            type="button"
+            onClick={() => {
+              result.viewport.replace({
+                window: { firstRow: 0, lastRow: 9 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink: { setRowCount: () => undefined, setRowData: () => undefined },
+              });
+            }}
+          >
+            load failing viewport
+          </button>
+        </>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={client}>
+        <FailingViewport />
+      </ViewServerClientProvider>,
+    );
+    await view.getByRole("button", { name: "load failing viewport" }).click();
+    await expect.element(view.getByText("error:InvalidQuery:0", { exact: true })).toBeVisible();
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("finalizes topic ownership before a retained generation can restart it", async () => {
+    const runtime = createInMemoryViewServer(multiTopicViewServer);
+    const grid = makeGridModel<{ readonly id: string }>();
+    let retainedGeneration: LiveQueryViewportGeneration | undefined;
+    let retainedViewport:
+      | LiveQueryViewport<typeof multiTopicViewServer.topics, "orders" | "archivedOrders">
+      | undefined;
+
+    function TopicViewport(props: { readonly topic: "orders" | "archivedOrders" }) {
+      const result = multiTopicReact.useLiveQueryViewport(props.topic);
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            retainedViewport = result.viewport;
+            retainedGeneration = result.viewport.replace({
+              window: { firstRow: 0, lastRow: 9 },
+              query: {
+                select: ["id"],
+                where: [],
+                orderBy: [],
+              },
+              sink: grid.sink,
+            });
+          }}
+        >
+          load {props.topic}
+        </button>
+      );
+    }
+
+    const view = await render(
+      <MultiTopicClientProvider client={runtime.liveClient}>
+        <TopicViewport topic="orders" />
+      </MultiTopicClientProvider>,
+    );
+    await view.getByRole("button", { name: "load orders" }).click();
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(1);
+
+    await view.rerender(
+      <MultiTopicClientProvider client={runtime.liveClient}>
+        <TopicViewport topic="archivedOrders" />
+      </MultiTopicClientProvider>,
+    );
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(0);
+    retainedViewport?.replace({
+      window: { firstRow: 20, lastRow: 29 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: grid.sink,
+    });
+    retainedGeneration?.setWindow({ firstRow: 10, lastRow: 19 });
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.orders.activeSubscriptions;
+      })
+      .toBe(0);
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.archivedOrders.activeSubscriptions;
+      })
+      .toBe(0);
+
+    await view.getByRole("button", { name: "load archivedOrders" }).click();
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.archivedOrders.activeSubscriptions;
+      })
+      .toBe(1);
+    await Effect.runPromise(runtime.liveClient.close);
+    await expect
+      .poll(async () => {
+        const health = await Effect.runPromise(runtime.client.health());
+        return health.engine.topics.archivedOrders.activeSubscriptions;
+      })
+      .toBe(0);
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("switches useLiveQuery ownership when the provider client identity changes", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const oldRequests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const currentRequests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const makeClient = (
+      requests: Array<Queue.Queue<ViewServerLiveEvent<object>>>,
+    ): ViewServerLiveClient<typeof viewServer.topics> => ({
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.gen(function* () {
+          const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+          requests.push(events);
+          return {
+            events: Stream.fromQueue(events),
+            close: () => Effect.void,
+          };
+        }),
+      ),
+    });
+    const oldClient = makeClient(oldRequests);
+    const currentClient = makeClient(currentRequests);
+
+    function ClientQuery() {
+      const result = useLiveQuery("orders", { select: ["id"] });
+      return (
+        <output role="status">
+          {result.status}:{result.rows.map((row) => row.id).join("|")}
+        </output>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={oldClient}>
+        <ClientQuery />
+      </ViewServerClientProvider>,
+    );
+    await expect.poll(() => oldRequests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(oldRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "old-client",
+        rows: [{ id: "old-client" }],
+        keys: ["old-client"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.element(view.getByText("ready:old-client", { exact: true })).toBeVisible();
+
+    await view.rerender(
+      <ViewServerClientProvider client={currentClient}>
+        <ClientQuery />
+      </ViewServerClientProvider>,
+    );
+    await expect.element(view.getByText("loading:", { exact: true })).toBeVisible();
+    await expect.poll(() => currentRequests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(currentRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "current-client",
+        rows: [{ id: "current-client" }],
+        keys: ["current-client"],
+        totalRows: 1,
+        version: 2,
+      }),
+    );
+    await Effect.runPromise(
+      Queue.offer(oldRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "old-client",
+        rows: [{ id: "obsolete-client-late" }],
+        keys: ["obsolete-client-late"],
+        totalRows: 1,
+        version: 3,
+      }),
+    );
+    await expect.element(view.getByText("ready:current-client", { exact: true })).toBeVisible();
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("switches viewport ownership immediately when the provider client identity changes", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const oldRequests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const currentRequests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const makeClient = (
+      requests: Array<Queue.Queue<ViewServerLiveEvent<object>>>,
+    ): ViewServerLiveClient<typeof viewServer.topics> => ({
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.gen(function* () {
+          const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+          requests.push(events);
+          return {
+            events: Stream.fromQueue(events),
+            close: () => Effect.void,
+          };
+        }),
+      ),
+    });
+    const oldClient = makeClient(oldRequests);
+    const currentClient = makeClient(currentRequests);
+    const grid = makeGridModel<{ readonly id: string }>();
+    let retainedViewport: LiveQueryViewport<typeof viewServer.topics, "orders"> | undefined;
+
+    function ClientViewport() {
+      const result = useLiveQueryViewport("orders");
+      return (
+        <>
+          <output role="status">
+            {result.status}:{result.totalRows}:{result.version}
+          </output>
+          <button
+            type="button"
+            onClick={() => {
+              retainedViewport = result.viewport;
+              result.viewport.replace({
+                window: { firstRow: 0, lastRow: 9 },
+                query: { select: ["id"], where: [], orderBy: [] },
+                sink: grid.sink,
+              });
+            }}
+          >
+            load client viewport
+          </button>
+        </>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={oldClient}>
+        <ClientViewport />
+      </ViewServerClientProvider>,
+    );
+    await view.getByRole("button", { name: "load client viewport" }).click();
+    await expect.poll(() => oldRequests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(oldRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "old-client",
+        rows: [{ id: "old-client" }],
+        keys: ["old-client"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "old-client" } });
+
+    await view.rerender(
+      <ViewServerClientProvider client={currentClient}>
+        <ClientViewport />
+      </ViewServerClientProvider>,
+    );
+    retainedViewport?.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: grid.sink,
+    });
+    await expect.poll(() => currentRequests.length).toBe(1);
+    expect(grid.rows()).toStrictEqual({});
+    await Effect.runPromise(
+      Queue.offer(currentRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "current-client",
+        rows: [{ id: "current-client" }],
+        keys: ["current-client"],
+        totalRows: 1,
+        version: 2,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
+
+    await Effect.runPromise(
+      Queue.offer(oldRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "old-client",
+        rows: [{ id: "obsolete-client-late" }],
+        keys: ["obsolete-client-late"],
+        totalRows: 1,
+        version: 3,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("streams grouped rows through the same viewport sink", async () => {
+    const runtime = createInMemoryViewServer(viewServer);
+    await Effect.runPromise(
+      runtime.client.publishMany("orders", [
+        { id: "open-1", status: "open", price: 10 },
+        { id: "open-2", status: "open", price: 20 },
+        { id: "closed-1", status: "closed", price: 5 },
+      ]),
+    );
+    type GroupedRow = {
+      readonly status: "open" | "closed";
+      readonly rowCount: bigint;
+      readonly totalPrice: BigDecimal.BigDecimal;
+    };
+    const grid = makeGridModel<GroupedRow>();
+
+    function GroupedViewportView() {
+      const result = useLiveQueryViewport("orders");
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            result.viewport.replace({
+              window: { firstRow: 0, lastRow: 9 },
+              query: {
+                groupBy: ["status"],
+                aggregates: {
+                  rowCount: { aggFunc: "count" },
+                  totalPrice: { aggFunc: "sum", field: "price" },
+                },
+                where: [],
+                orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+              },
+              sink: grid.sink,
+            });
+          }}
+        >
+          load grouped viewport
+        </button>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={runtime.liveClient}>
+        <GroupedViewportView />
+      </ViewServerClientProvider>,
+    );
+    await view.getByRole("button", { name: "load grouped viewport" }).click();
+    await expect.poll(grid.rowCount).toBe(2);
+    await expect.poll(() => grid.rows()[0]?.status).toBe("open");
+    expect(grid.rows()[0]?.rowCount).toBe(2n);
+    expect(String(grid.rows()[0]?.totalPrice)).toBe("BigDecimal(30)");
+
+    await Effect.runPromise(
+      runtime.client.publish("orders", {
+        id: "open-3",
+        status: "open",
+        price: 10,
+      }),
+    );
+    await expect.poll(() => grid.rows()[0]?.rowCount).toBe(3n);
+    expect(String(grid.rows()[0]?.totalPrice)).toBe("BigDecimal(40)");
+
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+});

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "@effect-view-server/config";
 import { createInMemoryViewServer } from "@effect-view-server/in-memory";
 import { Deferred, Effect, Queue, Schema, Stream } from "effect";
-import type * as BigDecimal from "effect/BigDecimal";
+import * as BigDecimal from "effect/BigDecimal";
 import { StrictMode, useLayoutEffect } from "react";
 import { renderToString } from "react-dom/server";
 import { render } from "vitest-browser-react";
@@ -297,7 +297,8 @@ describe("useLiveQueryViewport", () => {
         return health.engine.topics.orders.activeSubscriptions;
       })
       .toBe(0);
-    generation?.setWindow({ firstRow: 0, lastRow: 4 });
+    expect(generation).toBeDefined();
+    generation!.setWindow({ firstRow: 0, lastRow: 4 });
     await expect
       .poll(async () => {
         const health = await Effect.runPromise(runtime.client.health());
@@ -847,12 +848,14 @@ describe("useLiveQueryViewport", () => {
         return health.engine.topics.orders.activeSubscriptions;
       })
       .toBe(0);
-    retainedViewport?.replace({
+    expect(retainedViewport).toBeDefined();
+    expect(retainedGeneration).toBeDefined();
+    retainedViewport!.replace({
       window: { firstRow: 20, lastRow: 29 },
       query: { select: ["id"], where: [], orderBy: [] },
       sink: grid.sink,
     });
-    retainedGeneration?.setWindow({ firstRow: 10, lastRow: 19 });
+    retainedGeneration!.setWindow({ firstRow: 10, lastRow: 19 });
     await expect
       .poll(async () => {
         const health = await Effect.runPromise(runtime.client.health());
@@ -1043,7 +1046,8 @@ describe("useLiveQueryViewport", () => {
         <ClientViewport />
       </ViewServerClientProvider>,
     );
-    retainedViewport?.replace({
+    expect(retainedViewport).toBeDefined();
+    retainedViewport!.replace({
       window: { firstRow: 0, lastRow: 9 },
       query: { select: ["id"], where: [], orderBy: [] },
       sink: grid.sink,
@@ -1131,7 +1135,7 @@ describe("useLiveQueryViewport", () => {
     await expect.poll(grid.rowCount).toBe(2);
     await expect.poll(() => grid.rows()[0]?.status).toBe("open");
     expect(grid.rows()[0]?.rowCount).toBe(2n);
-    expect(String(grid.rows()[0]?.totalPrice)).toBe("BigDecimal(30)");
+    expect(BigDecimal.equals(grid.rows()[0]!.totalPrice, BigDecimal.make(30n, 0))).toBe(true);
 
     await Effect.runPromise(
       runtime.client.publish("orders", {
@@ -1141,7 +1145,7 @@ describe("useLiveQueryViewport", () => {
       }),
     );
     await expect.poll(() => grid.rows()[0]?.rowCount).toBe(3n);
-    expect(String(grid.rows()[0]?.totalPrice)).toBe("BigDecimal(40)");
+    expect(BigDecimal.equals(grid.rows()[0]!.totalPrice, BigDecimal.make(40n, 0))).toBe(true);
 
     await view.unmount();
     await Effect.runPromise(runtime.close);

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -372,8 +372,9 @@ export const makeLiveQueryViewportBinding = <
       if (current === entry) {
         return;
       }
-      current?.deactivate();
+      const previous = current;
       current = entry;
+      previous?.deactivate();
     },
     uninstall: (entry) => {
       if (current !== entry) {
@@ -386,15 +387,38 @@ export const makeLiveQueryViewportBinding = <
 };
 
 type ActiveRequest = {
-  readonly generation: number;
+  owner: number;
   readonly request: number;
   readonly criteriaKey: string;
   readonly firstRow: number;
   readonly lastRow: number;
   readonly latestTotalRows: { value: number };
   readonly sink: unknown;
-  readonly clearSink: () => void;
+  readonly cleanup: SinkCleanup;
   live: boolean;
+};
+
+type SinkCleanup = {
+  readonly sink: unknown;
+  readonly discard: () => void;
+  readonly run: () => void;
+};
+
+const makeSinkCleanup = (sink: unknown, clear: () => void): SinkCleanup => {
+  let pending = true;
+  return {
+    sink,
+    discard: () => {
+      pending = false;
+    },
+    run: () => {
+      if (!pending) {
+        return;
+      }
+      pending = false;
+      clear();
+    },
+  };
 };
 
 const ignoreSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
@@ -408,14 +432,45 @@ export const makeLiveQueryViewport = <
   input: LiveQueryViewportControllerInput<Topics, Topic>,
 ): LiveQueryViewport<Topics, Topic> & { readonly deactivate: () => void } => {
   type Row = TopicRow<Topics, Topic>;
-  let generationCounter = 0;
+  let ownerCounter = 0;
   let requestCounter = 0;
   let replaceInvocation = 0;
   let active: ActiveRequest | undefined;
+  let pendingCleanups: Array<SinkCleanup> = [];
+  let latestPendingCleanupBySink = new Map<unknown, SinkCleanup>();
   let terminal = false;
 
-  const isCurrent = (generation: number, request: number): boolean =>
-    active?.generation === generation && active.request === request;
+  const isCurrent = (request: number): boolean => active?.request === request;
+
+  const runSinkCleanups = (cleanups: ReadonlyArray<SinkCleanup>): void => {
+    let firstFailure: unknown;
+    let failed = false;
+    for (const cleanup of cleanups) {
+      const result = Result.try(() => {
+        if (active !== undefined && Object.is(active.sink, cleanup.sink)) {
+          cleanup.discard();
+        } else {
+          cleanup.run();
+        }
+      });
+      if (!failed && Result.isFailure(result)) {
+        failed = true;
+        firstFailure = result.failure;
+      }
+    }
+    if (failed) {
+      throw firstFailure;
+    }
+  };
+
+  const cleanupRequest = (request: ActiveRequest): void => {
+    const cleanups = pendingCleanups;
+    pendingCleanups = [];
+    latestPendingCleanupBySink.get(request.sink)?.discard();
+    latestPendingCleanupBySink = new Map();
+    cleanups.push(request.cleanup);
+    runSinkCleanups(cleanups);
+  };
 
   const publishIdle = (owner: number): void => {
     input.publish({ owner, stream: Stream.succeed(idleChrome()) });
@@ -424,43 +479,72 @@ export const makeLiveQueryViewport = <
   const clearSink = <SinkRow>(
     sink: LiveQueryViewportSink<SinkRow>,
     totalRows: number,
-    generation: number,
     request: number,
   ): boolean => {
-    if (!isCurrent(generation, request)) {
+    if (!isCurrent(request)) {
       return false;
     }
     sink.setRowCount(totalRows, false);
-    return isCurrent(generation, request);
+    return isCurrent(request);
   };
 
   const installActive = <SinkRow>(input_: {
-    readonly generation: number;
+    readonly owner: number;
     readonly criteriaKey: string;
     readonly window: LiveQueryViewportWindow;
     readonly latestTotalRows: { value: number };
     readonly sink: LiveQueryViewportSink<SinkRow>;
     readonly live: boolean;
-  }): { readonly request: number; readonly isCurrent: boolean } => {
+  }): { readonly request: number; readonly activate: () => boolean } => {
     const request = ++requestCounter;
     const previous = active;
-    active = {
-      generation: input_.generation,
+    if (previous !== undefined) {
+      latestPendingCleanupBySink.get(previous.sink)?.discard();
+      pendingCleanups.push(previous.cleanup);
+      latestPendingCleanupBySink.set(previous.sink, previous.cleanup);
+    }
+    const current: ActiveRequest = {
+      owner: input_.owner,
       request,
       criteriaKey: input_.criteriaKey,
       firstRow: input_.window.firstRow,
       lastRow: input_.window.lastRow,
       latestTotalRows: input_.latestTotalRows,
       sink: input_.sink,
-      clearSink: () => input_.sink.setRowCount(0, false),
+      cleanup: makeSinkCleanup(input_.sink, () => input_.sink.setRowCount(0, false)),
       live: input_.live,
     };
-    if (previous !== undefined && !Object.is(previous.sink, input_.sink)) {
-      previous.clearSink();
-    }
+    active = current;
     return {
       request,
-      isCurrent: clearSink(input_.sink, input_.latestTotalRows.value, input_.generation, request),
+      activate: () => {
+        let activated = false;
+        const predecessors = pendingCleanups;
+        pendingCleanups = [];
+        latestPendingCleanupBySink = new Map();
+        const activation = Result.try(() => {
+          runSinkCleanups(predecessors);
+          if (!clearSink(input_.sink, input_.latestTotalRows.value, request)) {
+            return false;
+          }
+          activated = true;
+          return true;
+        });
+        if (activated) {
+          return true;
+        }
+        if (isCurrent(request)) {
+          active = undefined;
+        }
+        const cleanup = Result.try(() => runSinkCleanups([current.cleanup]));
+        if (Result.isFailure(activation)) {
+          throw activation.failure;
+        }
+        if (Result.isFailure(cleanup)) {
+          throw cleanup.failure;
+        }
+        return false;
+      },
     };
   };
 
@@ -468,7 +552,6 @@ export const makeLiveQueryViewport = <
     query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
     sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>,
     window: Extract<LiveQueryViewportWindowValidation, { readonly _tag: "Valid" }>,
-    generation: number,
     request: number,
     updateTotalRows: (totalRows: number) => void,
   ): Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError> => {
@@ -481,7 +564,7 @@ export const makeLiveQueryViewport = <
           windowedQuery,
         );
         return subscription.events.pipe(
-          Stream.filter(() => isCurrent(generation, request)),
+          Stream.filter(() => isCurrent(request)),
           Stream.map((event) => {
             const state = projection.apply(event);
             return {
@@ -494,7 +577,7 @@ export const makeLiveQueryViewport = <
           }),
           Stream.tap((state) =>
             Effect.sync(() => {
-              if (!isCurrent(generation, request)) {
+              if (!isCurrent(request)) {
                 return;
               }
               updateTotalRows(state.current.totalRows);
@@ -507,32 +590,26 @@ export const makeLiveQueryViewport = <
               if (state.rowData === undefined) {
                 return;
               }
-              if (!isCurrent(generation, request)) {
+              if (!isCurrent(request)) {
                 return;
               }
               sink.setRowData(state.rowData);
             }),
           ),
-          Stream.filter(() => isCurrent(generation, request)),
+          Stream.filter(() => isCurrent(request)),
           Stream.map((state) => chromeFromClientState(state.current)),
           Stream.ensuring(subscription.close().pipe(ignoreSubscriptionCloseFailure)),
         );
       },
     );
     return Stream.scoped(Stream.unwrap(acquireSubscription())).pipe(
-      Stream.catchCause((cause) =>
-        isCurrent(generation, request) ? Stream.failCause(cause) : Stream.empty,
-      ),
+      Stream.catchCause((cause) => (isCurrent(request) ? Stream.failCause(cause) : Stream.empty)),
       Stream.ensuring(
         Effect.sync(() => {
           const current = active;
-          if (
-            current !== undefined &&
-            current.generation === generation &&
-            current.request === request
-          ) {
+          if (current !== undefined && current.request === request) {
             active = undefined;
-            current.clearSink();
+            cleanupRequest(current);
           }
         }),
       ),
@@ -540,7 +617,7 @@ export const makeLiveQueryViewport = <
   };
 
   const start = <const Query extends LiveQueryViewportQuery<Row>>(input_: {
-    readonly generation: number;
+    readonly owner: number;
     readonly criteriaKey: string;
     readonly query: ExactLiveQueryInputForTopic<Topics, Topic, Query>;
     readonly sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>;
@@ -549,34 +626,40 @@ export const makeLiveQueryViewport = <
   }): void => {
     const window = validateLiveQueryViewportWindow(input_.window);
     const installed = installActive({
-      generation: input_.generation,
+      owner: input_.owner,
       criteriaKey: input_.criteriaKey,
       window: input_.window,
       latestTotalRows: input_.latestTotalRows,
       sink: input_.sink,
       live: window._tag === "Valid",
     });
-    if (!installed.isCurrent) {
-      return;
-    }
     if (window._tag === "Invalid") {
       input.publish({
         owner: installed.request,
-        stream: holdChrome(invalidWindowChrome(window.message)),
+        stream: Stream.unwrap(
+          Effect.sync(() =>
+            installed.activate() ? holdChrome(invalidWindowChrome(window.message)) : Stream.empty,
+          ),
+        ),
       });
       return;
     }
     input.publish({
       owner: installed.request,
-      stream: makeSubscriptionStream(
-        input_.query,
-        input_.sink,
-        window,
-        input_.generation,
-        installed.request,
-        (totalRows) => {
-          input_.latestTotalRows.value = totalRows;
-        },
+      stream: Stream.unwrap(
+        Effect.sync(() =>
+          installed.activate()
+            ? makeSubscriptionStream(
+                input_.query,
+                input_.sink,
+                window,
+                installed.request,
+                (totalRows) => {
+                  input_.latestTotalRows.value = totalRows;
+                },
+              )
+            : Stream.empty,
+        ),
       ),
     });
   };
@@ -597,31 +680,36 @@ export const makeLiveQueryViewport = <
       };
     }
     if (Result.isFailure(captured)) {
-      const generation = ++generationCounter;
+      const owner = ++ownerCounter;
       const installed = installActive({
-        generation,
+        owner,
         criteriaKey: "",
         window: request.window,
         latestTotalRows: { value: 0 },
         sink: request.sink,
         live: false,
       });
-      if (!installed.isCurrent) {
-        return {
-          setWindow: () => undefined,
-          release: () => undefined,
-        };
-      }
       input.publish({
         owner: installed.request,
-        stream: holdChrome(invalidQueryChrome(liveQueryViewportFailureMessage(captured.failure))),
+        stream: Stream.unwrap(
+          Effect.sync(() =>
+            installed.activate()
+              ? holdChrome(invalidQueryChrome(liveQueryViewportFailureMessage(captured.failure)))
+              : Stream.empty,
+          ),
+        ),
       });
       return {
         setWindow: () => undefined,
         release: () => {
-          if (active?.generation === generation) {
+          if (active?.owner === owner) {
+            const current = active;
             active = undefined;
-            publishIdle(++requestCounter);
+            try {
+              publishIdle(++requestCounter);
+            } finally {
+              cleanupRequest(current);
+            }
           }
         },
       };
@@ -639,30 +727,26 @@ export const makeLiveQueryViewport = <
       current.lastRow === request.window.lastRow &&
       Object.is(current.sink, request.sink)
     ) {
-      return makeGeneration(
-        current.generation,
-        criteriaKey,
-        query,
-        request.sink,
-        current.latestTotalRows,
-      );
+      const owner = ++ownerCounter;
+      current.owner = owner;
+      return makeGeneration(owner, criteriaKey, query, request.sink, current.latestTotalRows);
     }
 
-    const generation = ++generationCounter;
+    const owner = ++ownerCounter;
     const latestTotalRows = { value: 0 };
     start({
-      generation,
+      owner,
       criteriaKey,
       query,
       sink: request.sink,
       window: request.window,
       latestTotalRows,
     });
-    return makeGeneration(generation, criteriaKey, query, request.sink, latestTotalRows);
+    return makeGeneration(owner, criteriaKey, query, request.sink, latestTotalRows);
   };
 
   function makeGeneration<const Query extends LiveQueryViewportQuery<Row>>(
-    generation: number,
+    owner: number,
     criteriaKey: string,
     query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
     sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>,
@@ -670,7 +754,7 @@ export const makeLiveQueryViewport = <
   ): LiveQueryViewportGeneration {
     return {
       setWindow: (window) => {
-        if (active?.generation !== generation) {
+        if (active?.owner !== owner) {
           return;
         }
         if (
@@ -681,7 +765,7 @@ export const makeLiveQueryViewport = <
           return;
         }
         start({
-          generation,
+          owner,
           criteriaKey,
           query,
           sink,
@@ -690,14 +774,16 @@ export const makeLiveQueryViewport = <
         });
       },
       release: () => {
-        if (active?.generation !== generation) {
+        if (active?.owner !== owner) {
           return;
         }
         const request = ++requestCounter;
+        const current = active;
         active = undefined;
-        sink.setRowCount(0, false);
-        if (active === undefined && request === requestCounter) {
+        try {
           publishIdle(request);
+        } finally {
+          cleanupRequest(current);
         }
       },
     };
@@ -709,7 +795,9 @@ export const makeLiveQueryViewport = <
     requestCounter += 1;
     const current = active;
     active = undefined;
-    current?.clearSink();
+    if (current !== undefined) {
+      cleanupRequest(current);
+    }
   };
 
   return {
@@ -723,10 +811,13 @@ export const makeLiveQueryViewport = <
       const request = ++requestCounter;
       const current = active;
       active = undefined;
-      if (current !== undefined) {
-        current.clearSink();
+      try {
+        publishIdle(request);
+      } finally {
+        if (current !== undefined) {
+          cleanupRequest(current);
+        }
       }
-      publishIdle(request);
     },
     deactivate,
   };

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -1,0 +1,693 @@
+import type {
+  ExactLiveQueryInputForTopic,
+  GroupedOrderBy,
+  GroupedQuery,
+  LiveQueryResult,
+  LiveQueryRow,
+  OrderBy,
+  RawQuery,
+  TopicDefinitions,
+  TopicRow,
+  Where,
+} from "@effect-view-server/config";
+import {
+  liveQueryFailureResult,
+  makeIncrementalClientState,
+  stableQueryKeyForRowSchema,
+  type ClientState,
+  type ClientStateChange,
+  type ViewServerLiveClient,
+} from "@effect-view-server/client";
+import {
+  ignoreLoggedTypedFailuresPreserveNonTypedFailures,
+  snapshotViewServerQuery,
+} from "@effect-view-server/effect-utils";
+import { Effect, Result, Schema, Stream } from "effect";
+import type * as Cause from "effect/Cause";
+import * as Atom from "effect/unstable/reactivity/Atom";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+
+export type LiveQueryViewportWindow = {
+  readonly firstRow: number;
+  readonly lastRow: number;
+};
+
+export type LiveQueryViewportSink<Row> = {
+  readonly setRowCount: (count: number, keepRenderedRows?: boolean) => void;
+  readonly setRowData: (rows: { readonly [index: number]: Row }) => void;
+};
+
+type LiveQueryViewportSinkRow<Row, Sink> = Sink extends {
+  readonly setRowData: (...args: infer Args) => void;
+}
+  ? Args extends readonly []
+    ? Row
+    : Args[0] extends { readonly [index: number]: infer SinkRow }
+      ? SinkRow
+      : never
+  : never;
+
+type ExactLiveQueryViewportSink<Row, Sink> = [Row] extends [LiveQueryViewportSinkRow<Row, Sink>]
+  ? [LiveQueryViewportSinkRow<Row, Sink>] extends [Row]
+    ? unknown
+    : never
+  : never;
+
+export type LiveQueryViewportRawQuery<Row> = RawQuery<Row> & {
+  readonly where: Where<Row>;
+  readonly orderBy: ReadonlyArray<OrderBy<Row>>;
+  readonly offset?: never;
+  readonly limit?: never;
+};
+
+export type LiveQueryViewportGroupedQuery<Row> = GroupedQuery<Row> & {
+  readonly where: Where<Row>;
+  readonly orderBy: ReadonlyArray<GroupedOrderBy<Row>>;
+  readonly offset?: never;
+  readonly limit?: never;
+};
+
+export type LiveQueryViewportQuery<Row> =
+  | LiveQueryViewportRawQuery<Row>
+  | LiveQueryViewportGroupedQuery<Row>;
+
+export type LiveQueryViewportGeneration = {
+  readonly setWindow: (window: LiveQueryViewportWindow) => void;
+  readonly release: () => void;
+};
+
+export type LiveQueryViewport<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = {
+  readonly replace: <
+    const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
+    const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+  >(request: {
+    readonly window: LiveQueryViewportWindow;
+    readonly query: ExactLiveQueryInputForTopic<Topics, NoInfer<Topic>, Query>;
+    readonly sink: Sink &
+      ExactLiveQueryViewportSink<
+        LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>,
+        NoInfer<Sink>
+      >;
+  }) => LiveQueryViewportGeneration;
+  readonly destroy: () => void;
+};
+
+export type UseLiveQueryViewportResult<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = {
+  readonly viewport: LiveQueryViewport<Topics, Topic>;
+  readonly totalRows: number;
+  readonly version: number;
+  readonly status: LiveQueryResult<never>["status"];
+  readonly statusCode?: LiveQueryResult<never>["statusCode"];
+  readonly message?: string | undefined;
+};
+
+export type UseLiveQueryViewportHook<Topics extends TopicDefinitions> = <
+  Topic extends Extract<keyof Topics, string>,
+>(
+  topic: Topic,
+) => UseLiveQueryViewportResult<Topics, Topic>;
+
+export type LiveQueryViewportChrome = Omit<LiveQueryResult<never>, "rows">;
+
+type LiveQueryViewportCommand = {
+  readonly owner: number;
+  readonly stream: Stream.Stream<LiveQueryViewportChrome, unknown>;
+};
+
+type OwnedLiveQueryViewportChrome = {
+  readonly owner: number;
+  readonly chrome: LiveQueryViewportChrome;
+};
+
+const idleChrome = (): LiveQueryViewportChrome => ({
+  totalRows: 0,
+  version: 0,
+  status: "loading",
+});
+
+const invalidWindowChrome = (message: string): LiveQueryViewportChrome => ({
+  totalRows: 0,
+  version: 0,
+  status: "error",
+  statusCode: "InvalidQuery",
+  message,
+});
+
+const holdChrome = (chrome: LiveQueryViewportChrome): Stream.Stream<LiveQueryViewportChrome> =>
+  Stream.concat(Stream.succeed(chrome), Stream.never);
+
+export const liveQueryViewportChromeFromAsyncResult = (
+  result: AsyncResult.AsyncResult<OwnedLiveQueryViewportChrome, unknown>,
+  expectedOwner: number,
+): LiveQueryViewportChrome => {
+  if (AsyncResult.isSuccess(result) && result.value.owner === expectedOwner) {
+    return result.value.chrome;
+  }
+  return idleChrome();
+};
+
+const failureChrome = (cause: Cause.Cause<unknown>) => {
+  const failure = liveQueryFailureResult<never>(cause);
+  return {
+    totalRows: failure.totalRows,
+    version: failure.version,
+    status: failure.status,
+    statusCode: failure.statusCode,
+    message: failure.message,
+  } satisfies LiveQueryViewportChrome;
+};
+
+export const makeLiveQueryViewportAtom = () => {
+  let expectedOwner = 0;
+  const atom = Atom.fn(
+    (command: LiveQueryViewportCommand): Stream.Stream<OwnedLiveQueryViewportChrome> =>
+      Stream.concat(
+        Stream.succeed({
+          owner: command.owner,
+          chrome: idleChrome(),
+        }),
+        command.stream.pipe(
+          Stream.map((chrome) => ({ owner: command.owner, chrome })),
+          Stream.catchCause((cause) =>
+            Stream.succeed({ owner: command.owner, chrome: failureChrome(cause) }),
+          ),
+        ),
+      ),
+    {
+      initialValue: {
+        owner: expectedOwner,
+        chrome: idleChrome(),
+      },
+    },
+  );
+  return {
+    atom,
+    prepare: (command: LiveQueryViewportCommand): LiveQueryViewportCommand => {
+      expectedOwner = command.owner;
+      return command;
+    },
+    read: (
+      result: AsyncResult.AsyncResult<OwnedLiveQueryViewportChrome, unknown>,
+    ): LiveQueryViewportChrome => liveQueryViewportChromeFromAsyncResult(result, expectedOwner),
+  };
+};
+
+export type LiveQueryViewportWindowValidation =
+  | {
+      readonly _tag: "Valid";
+      readonly firstRow: number;
+      readonly lastRow: number;
+      readonly limit: number;
+    }
+  | {
+      readonly _tag: "Invalid";
+      readonly message: string;
+    };
+
+const LiveQueryViewportIndex = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0));
+
+const LiveQueryViewportWindowSchema = Schema.Struct({
+  firstRow: LiveQueryViewportIndex,
+  lastRow: LiveQueryViewportIndex,
+}).check(
+  Schema.makeFilter((window) => {
+    if (window.lastRow < window.firstRow) {
+      return "Live Query Viewport lastRow must be greater than or equal to firstRow.";
+    }
+    if (window.lastRow - window.firstRow >= Number.MAX_SAFE_INTEGER) {
+      return "Live Query Viewport limit must be a safe integer.";
+    }
+    return undefined;
+  }),
+);
+
+const decodeLiveQueryViewportWindow = Schema.decodeUnknownResult(LiveQueryViewportWindowSchema);
+
+export const validateLiveQueryViewportWindow = (
+  window: LiveQueryViewportWindow,
+): LiveQueryViewportWindowValidation => {
+  const decoded = decodeLiveQueryViewportWindow(window);
+  if (Result.isFailure(decoded)) {
+    return {
+      _tag: "Invalid",
+      message: decoded.failure.message,
+    };
+  }
+  return {
+    _tag: "Valid",
+    firstRow: decoded.success.firstRow,
+    lastRow: decoded.success.lastRow,
+    limit: decoded.success.lastRow - decoded.success.firstRow + 1,
+  };
+};
+
+type WindowedQuery<Query> = Query & {
+  readonly offset: number;
+  readonly limit: number;
+};
+
+const queryWithWindow = <Row, Query extends LiveQueryViewportQuery<Row>>(
+  query: Query,
+  window: Extract<LiveQueryViewportWindowValidation, { readonly _tag: "Valid" }>,
+): WindowedQuery<Query> => ({
+  ...query,
+  offset: window.firstRow,
+  limit: window.limit,
+});
+
+const chromeFromClientState = <Row>(state: ClientState<Row>): LiveQueryViewportChrome => ({
+  totalRows: state.totalRows,
+  version: state.version,
+  status: state.status,
+  statusCode: state.statusCode,
+  message: state.message,
+});
+
+const rowDataForRange = <Row>(
+  firstRow: number,
+  rows: ReadonlyArray<Row>,
+  range: Exclude<ClientStateChange, { readonly _tag: "None" }>,
+): { readonly [index: number]: Row } => {
+  const rowData: { [index: number]: Row } = {};
+  const start = range._tag === "All" ? 0 : range.start;
+  const end = range._tag === "All" ? rows.length - 1 : range.end;
+  for (let index = start; index <= end; index += 1) {
+    rowData[firstRow + index] = rows[index]!;
+  }
+  return rowData;
+};
+
+type LiveQueryViewportControllerInput<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = {
+  readonly client: ViewServerLiveClient<Topics>;
+  readonly config: { readonly topics: Topics };
+  readonly topic: Topic;
+  readonly publish: (command: LiveQueryViewportCommand) => void;
+};
+
+type LiveQueryViewportBindingEntry<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = {
+  readonly viewport: LiveQueryViewport<Topics, Topic>;
+  readonly deactivate: () => void;
+};
+
+export type LiveQueryViewportBinding<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = {
+  readonly viewport: LiveQueryViewport<Topics, Topic>;
+  readonly install: (entry: LiveQueryViewportBindingEntry<Topics, Topic>) => void;
+  readonly uninstall: (entry: LiveQueryViewportBindingEntry<Topics, Topic>) => void;
+};
+
+export const makeLiveQueryViewportBinding = <
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(): LiveQueryViewportBinding<Topics, Topic> => {
+  let current: LiveQueryViewportBindingEntry<Topics, Topic> | undefined;
+  let terminal = false;
+  const viewport: LiveQueryViewport<Topics, Topic> = {
+    replace: (request) =>
+      terminal
+        ? {
+            setWindow: () => undefined,
+            release: () => undefined,
+          }
+        : (current?.viewport.replace(request) ?? {
+            setWindow: () => undefined,
+            release: () => undefined,
+          }),
+    destroy: () => {
+      if (terminal) {
+        return;
+      }
+      terminal = true;
+      const previous = current;
+      current = undefined;
+      previous?.viewport.destroy();
+    },
+  };
+  return {
+    viewport,
+    install: (entry) => {
+      if (terminal) {
+        entry.deactivate();
+        return;
+      }
+      if (current === entry) {
+        return;
+      }
+      current?.deactivate();
+      current = entry;
+    },
+    uninstall: (entry) => {
+      if (current !== entry) {
+        return;
+      }
+      current = undefined;
+      entry.deactivate();
+    },
+  };
+};
+
+type ActiveRequest = {
+  readonly generation: number;
+  readonly request: number;
+  readonly criteriaKey: string;
+  readonly firstRow: number;
+  readonly lastRow: number;
+  readonly latestTotalRows: { value: number };
+  readonly sink: unknown;
+  readonly clearSink: () => void;
+  live: boolean;
+};
+
+const ignoreSubscriptionCloseFailure = ignoreLoggedTypedFailuresPreserveNonTypedFailures(
+  "Ignoring React Live Query Viewport subscription close failure.",
+);
+
+export const makeLiveQueryViewport = <
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+>(
+  input: LiveQueryViewportControllerInput<Topics, Topic>,
+): LiveQueryViewport<Topics, Topic> & { readonly deactivate: () => void } => {
+  type Row = TopicRow<Topics, Topic>;
+  let generationCounter = 0;
+  let requestCounter = 0;
+  let replaceInvocation = 0;
+  let active: ActiveRequest | undefined;
+  let terminal = false;
+
+  const isCurrent = (generation: number, request: number): boolean =>
+    active?.generation === generation && active.request === request;
+
+  const publishIdle = (owner: number): void => {
+    input.publish({ owner, stream: Stream.succeed(idleChrome()) });
+  };
+
+  const clearSink = <SinkRow>(
+    sink: LiveQueryViewportSink<SinkRow>,
+    totalRows: number,
+    generation: number,
+    request: number,
+  ): boolean => {
+    sink.setRowCount(totalRows, false);
+    return isCurrent(generation, request);
+  };
+
+  const makeSubscriptionStream = <const Query extends LiveQueryViewportQuery<Row>>(
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+    sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>,
+    window: Extract<LiveQueryViewportWindowValidation, { readonly _tag: "Valid" }>,
+    generation: number,
+    request: number,
+    updateTotalRows: (totalRows: number) => void,
+  ): Stream.Stream<LiveQueryViewportChrome, unknown> => {
+    const windowedQuery = queryWithWindow<Row, Query>(query, window);
+    const projection = makeIncrementalClientState<LiveQueryRow<Row, Query>>();
+    const acquireSubscription = Effect.fn("ViewServerReact.LiveQueryViewport.acquireSubscription")(
+      function* () {
+        const subscription = yield* input.client.subscribe<Topic, WindowedQuery<Query>>(
+          input.topic,
+          windowedQuery,
+        );
+        return subscription.events.pipe(
+          Stream.filter(() => isCurrent(generation, request)),
+          Stream.map((event) => {
+            const state = projection.apply(event);
+            return {
+              current: state.current,
+              rowData:
+                state.change._tag === "None"
+                  ? undefined
+                  : rowDataForRange(window.firstRow, state.current.rows, state.change),
+            };
+          }),
+          Stream.tap((state) =>
+            Effect.sync(() => {
+              if (!isCurrent(generation, request)) {
+                return;
+              }
+              updateTotalRows(state.current.totalRows);
+              if (state.current.status === "closed" || state.current.status === "error") {
+                active!.live = false;
+                sink.setRowCount(0, false);
+                return;
+              }
+              sink.setRowCount(state.current.totalRows, true);
+              if (state.rowData === undefined) {
+                return;
+              }
+              if (!isCurrent(generation, request)) {
+                return;
+              }
+              sink.setRowData(state.rowData);
+            }),
+          ),
+          Stream.filter(() => isCurrent(generation, request)),
+          Stream.map((state) => chromeFromClientState(state.current)),
+          Stream.ensuring(subscription.close().pipe(ignoreSubscriptionCloseFailure)),
+        );
+      },
+    );
+    return Stream.scoped(Stream.unwrap(acquireSubscription())).pipe(
+      Stream.catchCause((cause) =>
+        isCurrent(generation, request) ? Stream.failCause(cause) : Stream.empty,
+      ),
+      Stream.ensuring(
+        Effect.sync(() => {
+          const current = active;
+          if (
+            current !== undefined &&
+            current.generation === generation &&
+            current.request === request
+          ) {
+            active = undefined;
+            current.clearSink();
+          }
+        }),
+      ),
+    );
+  };
+
+  const start = <const Query extends LiveQueryViewportQuery<Row>>(input_: {
+    readonly generation: number;
+    readonly criteriaKey: string;
+    readonly query: ExactLiveQueryInputForTopic<Topics, Topic, Query>;
+    readonly sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>;
+    readonly window: LiveQueryViewportWindow;
+    readonly latestTotalRows: { value: number };
+  }): void => {
+    const request = ++requestCounter;
+    const window = validateLiveQueryViewportWindow(input_.window);
+    const previous = active;
+    const nextActive: ActiveRequest = {
+      generation: input_.generation,
+      request,
+      criteriaKey: input_.criteriaKey,
+      firstRow: input_.window.firstRow,
+      lastRow: input_.window.lastRow,
+      latestTotalRows: input_.latestTotalRows,
+      sink: input_.sink,
+      clearSink: () => input_.sink.setRowCount(0, false),
+      live: window._tag === "Valid",
+    };
+    active = nextActive;
+    if (previous !== undefined && !Object.is(previous.sink, input_.sink)) {
+      previous.clearSink();
+    }
+    if (!clearSink(input_.sink, input_.latestTotalRows.value, input_.generation, request)) {
+      return;
+    }
+    if (window._tag === "Invalid") {
+      input.publish({
+        owner: request,
+        stream: holdChrome(invalidWindowChrome(window.message)),
+      });
+      return;
+    }
+    input.publish({
+      owner: request,
+      stream: makeSubscriptionStream(
+        input_.query,
+        input_.sink,
+        window,
+        input_.generation,
+        request,
+        (totalRows) => {
+          input_.latestTotalRows.value = totalRows;
+        },
+      ),
+    });
+  };
+
+  const replace: LiveQueryViewport<Topics, Topic>["replace"] = (request) => {
+    if (terminal) {
+      return {
+        setWindow: () => undefined,
+        release: () => undefined,
+      };
+    }
+    const invocation = ++replaceInvocation;
+    const captured = Result.try(() => snapshotViewServerQuery(request.query));
+    if (invocation !== replaceInvocation) {
+      return {
+        setWindow: () => undefined,
+        release: () => undefined,
+      };
+    }
+    if (Result.isFailure(captured)) {
+      const generation = ++generationCounter;
+      const requestId = ++requestCounter;
+      const previous = active;
+      const nextActive: ActiveRequest = {
+        generation,
+        request: requestId,
+        criteriaKey: "",
+        firstRow: request.window.firstRow,
+        lastRow: request.window.lastRow,
+        latestTotalRows: { value: 0 },
+        sink: request.sink,
+        clearSink: () => request.sink.setRowCount(0, false),
+        live: false,
+      };
+      active = nextActive;
+      if (previous !== undefined && !Object.is(previous.sink, request.sink)) {
+        previous.clearSink();
+      }
+      if (!clearSink(request.sink, 0, generation, requestId)) {
+        return {
+          setWindow: () => undefined,
+          release: () => undefined,
+        };
+      }
+      input.publish({
+        owner: requestId,
+        stream: holdChrome(invalidWindowChrome(String(captured.failure))),
+      });
+      return {
+        setWindow: () => undefined,
+        release: () => {
+          if (active?.generation === generation) {
+            active = undefined;
+            publishIdle(++requestCounter);
+          }
+        },
+      };
+    }
+
+    const query = captured.success;
+    const topicDefinition = input.config.topics[input.topic]!;
+    const criteriaKey = stableQueryKeyForRowSchema(query, topicDefinition.schema);
+    const current = active;
+    if (
+      current !== undefined &&
+      current.live &&
+      current.criteriaKey === criteriaKey &&
+      current.firstRow === request.window.firstRow &&
+      current.lastRow === request.window.lastRow &&
+      Object.is(current.sink, request.sink)
+    ) {
+      return makeGeneration(
+        current.generation,
+        criteriaKey,
+        query,
+        request.sink,
+        current.latestTotalRows,
+      );
+    }
+
+    const generation = ++generationCounter;
+    const latestTotalRows = { value: 0 };
+    start({
+      generation,
+      criteriaKey,
+      query,
+      sink: request.sink,
+      window: request.window,
+      latestTotalRows,
+    });
+    return makeGeneration(generation, criteriaKey, query, request.sink, latestTotalRows);
+  };
+
+  function makeGeneration<const Query extends LiveQueryViewportQuery<Row>>(
+    generation: number,
+    criteriaKey: string,
+    query: ExactLiveQueryInputForTopic<Topics, Topic, Query>,
+    sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>,
+    latestTotalRows: { value: number },
+  ): LiveQueryViewportGeneration {
+    return {
+      setWindow: (window) => {
+        if (active?.generation !== generation) {
+          return;
+        }
+        if (
+          active.live &&
+          active.firstRow === window.firstRow &&
+          active.lastRow === window.lastRow
+        ) {
+          return;
+        }
+        start({
+          generation,
+          criteriaKey,
+          query,
+          sink,
+          window,
+          latestTotalRows,
+        });
+      },
+      release: () => {
+        if (active?.generation !== generation) {
+          return;
+        }
+        const request = ++requestCounter;
+        active = undefined;
+        sink.setRowCount(0, false);
+        if (active === undefined && request === requestCounter) {
+          publishIdle(request);
+        }
+      },
+    };
+  }
+
+  const deactivate = (): void => {
+    terminal = true;
+    replaceInvocation += 1;
+    requestCounter += 1;
+    const current = active;
+    active = undefined;
+    current?.clearSink();
+  };
+
+  return {
+    replace,
+    destroy: () => {
+      if (terminal) {
+        return;
+      }
+      terminal = true;
+      replaceInvocation += 1;
+      const request = ++requestCounter;
+      const current = active;
+      active = undefined;
+      if (current !== undefined) {
+        current.clearSink();
+      }
+      publishIdle(request);
+    },
+    deactivate,
+  };
+};

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -435,6 +435,7 @@ export const makeLiveQueryViewport = <
   let ownerCounter = 0;
   let requestCounter = 0;
   let replaceInvocation = 0;
+  let mutationEpoch = 0;
   let active: ActiveRequest | undefined;
   let pendingCleanups: Array<SinkCleanup> = [];
   let latestPendingCleanupBySink = new Map<unknown, SinkCleanup>();
@@ -535,6 +536,7 @@ export const makeLiveQueryViewport = <
         }
         if (isCurrent(request)) {
           active = undefined;
+          mutationEpoch += 1;
         }
         const cleanup = Result.try(() => runSinkCleanups([current.cleanup]));
         if (Result.isFailure(activation)) {
@@ -581,7 +583,7 @@ export const makeLiveQueryViewport = <
                 return;
               }
               updateTotalRows(state.current.totalRows);
-              if (state.current.status === "closed" || state.current.status === "error") {
+              if (state.current.status === "closed") {
                 active!.live = false;
                 sink.setRowCount(0, false);
                 return;
@@ -609,6 +611,7 @@ export const makeLiveQueryViewport = <
           const current = active;
           if (current !== undefined && current.request === request) {
             active = undefined;
+            mutationEpoch += 1;
             cleanupRequest(current);
           }
         }),
@@ -621,14 +624,18 @@ export const makeLiveQueryViewport = <
     readonly criteriaKey: string;
     readonly query: ExactLiveQueryInputForTopic<Topics, Topic, Query>;
     readonly sink: LiveQueryViewportSink<LiveQueryRow<Row, Query>>;
-    readonly window: LiveQueryViewportWindow;
+    readonly window: LiveQueryViewportWindowValidation;
     readonly latestTotalRows: { value: number };
   }): void => {
-    const window = validateLiveQueryViewportWindow(input_.window);
+    const window = input_.window;
+    const installedWindow =
+      window._tag === "Valid"
+        ? { firstRow: window.firstRow, lastRow: window.lastRow }
+        : { firstRow: 0, lastRow: 0 };
     const installed = installActive({
       owner: input_.owner,
       criteriaKey: input_.criteriaKey,
-      window: input_.window,
+      window: installedWindow,
       latestTotalRows: input_.latestTotalRows,
       sink: input_.sink,
       live: window._tag === "Valid",
@@ -672,8 +679,9 @@ export const makeLiveQueryViewport = <
       };
     }
     const invocation = ++replaceInvocation;
+    const epoch = ++mutationEpoch;
     const captured = Result.try(() => snapshotViewServerQuery(request.query));
-    if (invocation !== replaceInvocation) {
+    if (invocation !== replaceInvocation || epoch !== mutationEpoch || terminal) {
       return {
         setWindow: () => undefined,
         release: () => undefined,
@@ -684,7 +692,7 @@ export const makeLiveQueryViewport = <
       const installed = installActive({
         owner,
         criteriaKey: "",
-        window: request.window,
+        window: { firstRow: 0, lastRow: 0 },
         latestTotalRows: { value: 0 },
         sink: request.sink,
         live: false,
@@ -703,6 +711,7 @@ export const makeLiveQueryViewport = <
         setWindow: () => undefined,
         release: () => {
           if (active?.owner === owner) {
+            mutationEpoch += 1;
             const current = active;
             active = undefined;
             try {
@@ -718,13 +727,21 @@ export const makeLiveQueryViewport = <
     const query = captured.success;
     const topicDefinition = input.config.topics[input.topic]!;
     const criteriaKey = stableQueryKeyForRowSchema(query, topicDefinition.schema);
+    const window = validateLiveQueryViewportWindow(request.window);
+    if (epoch !== mutationEpoch || terminal) {
+      return {
+        setWindow: () => undefined,
+        release: () => undefined,
+      };
+    }
     const current = active;
     if (
       current !== undefined &&
       current.live &&
+      window._tag === "Valid" &&
       current.criteriaKey === criteriaKey &&
-      current.firstRow === request.window.firstRow &&
-      current.lastRow === request.window.lastRow &&
+      current.firstRow === window.firstRow &&
+      current.lastRow === window.lastRow &&
       Object.is(current.sink, request.sink)
     ) {
       const owner = ++ownerCounter;
@@ -739,7 +756,7 @@ export const makeLiveQueryViewport = <
       criteriaKey,
       query,
       sink: request.sink,
-      window: request.window,
+      window,
       latestTotalRows,
     });
     return makeGeneration(owner, criteriaKey, query, request.sink, latestTotalRows);
@@ -757,10 +774,22 @@ export const makeLiveQueryViewport = <
         if (active?.owner !== owner) {
           return;
         }
+        const epoch = ++mutationEpoch;
+        const request = active.request;
+        const validatedWindow = validateLiveQueryViewportWindow(window);
+        if (
+          epoch !== mutationEpoch ||
+          active?.owner !== owner ||
+          active.request !== request ||
+          terminal
+        ) {
+          return;
+        }
         if (
           active.live &&
-          active.firstRow === window.firstRow &&
-          active.lastRow === window.lastRow
+          validatedWindow._tag === "Valid" &&
+          active.firstRow === validatedWindow.firstRow &&
+          active.lastRow === validatedWindow.lastRow
         ) {
           return;
         }
@@ -769,7 +798,7 @@ export const makeLiveQueryViewport = <
           criteriaKey,
           query,
           sink,
-          window,
+          window: validatedWindow,
           latestTotalRows,
         });
       },
@@ -777,6 +806,7 @@ export const makeLiveQueryViewport = <
         if (active?.owner !== owner) {
           return;
         }
+        mutationEpoch += 1;
         const request = ++requestCounter;
         const current = active;
         active = undefined;
@@ -792,6 +822,7 @@ export const makeLiveQueryViewport = <
   const deactivate = (): void => {
     terminal = true;
     replaceInvocation += 1;
+    mutationEpoch += 1;
     requestCounter += 1;
     const current = active;
     active = undefined;
@@ -808,6 +839,7 @@ export const makeLiveQueryViewport = <
       }
       terminal = true;
       replaceInvocation += 1;
+      mutationEpoch += 1;
       const request = ++requestCounter;
       const current = active;
       active = undefined;

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -8,6 +8,8 @@ import type {
   RawQuery,
   TopicDefinitions,
   TopicRow,
+  ViewServerRuntimeError,
+  ViewServerTransportError,
   Where,
 } from "@effect-view-server/config";
 import {
@@ -117,7 +119,10 @@ export type LiveQueryViewportChrome = Omit<LiveQueryResult<never>, "rows">;
 
 type LiveQueryViewportCommand = {
   readonly owner: number;
-  readonly stream: Stream.Stream<LiveQueryViewportChrome, unknown>;
+  readonly stream: Stream.Stream<
+    LiveQueryViewportChrome,
+    ViewServerRuntimeError | ViewServerTransportError
+  >;
 };
 
 type OwnedLiveQueryViewportChrome = {
@@ -138,6 +143,26 @@ const invalidWindowChrome = (message: string): LiveQueryViewportChrome => ({
   statusCode: "InvalidQuery",
   message,
 });
+
+const invalidQueryChrome = (message: string): LiveQueryViewportChrome => ({
+  totalRows: 0,
+  version: 0,
+  status: "error",
+  statusCode: "InvalidQuery",
+  message,
+});
+
+export const liveQueryViewportFailureMessage = (failure: unknown): string => {
+  if (
+    typeof failure === "object" &&
+    failure !== null &&
+    "message" in failure &&
+    typeof failure.message === "string"
+  ) {
+    return failure.message;
+  }
+  return String(failure);
+};
 
 const holdChrome = (chrome: LiveQueryViewportChrome): Stream.Stream<LiveQueryViewportChrome> =>
   Stream.concat(Stream.succeed(chrome), Stream.never);
@@ -402,8 +427,41 @@ export const makeLiveQueryViewport = <
     generation: number,
     request: number,
   ): boolean => {
+    if (!isCurrent(generation, request)) {
+      return false;
+    }
     sink.setRowCount(totalRows, false);
     return isCurrent(generation, request);
+  };
+
+  const installActive = <SinkRow>(input_: {
+    readonly generation: number;
+    readonly criteriaKey: string;
+    readonly window: LiveQueryViewportWindow;
+    readonly latestTotalRows: { value: number };
+    readonly sink: LiveQueryViewportSink<SinkRow>;
+    readonly live: boolean;
+  }): { readonly request: number; readonly isCurrent: boolean } => {
+    const request = ++requestCounter;
+    const previous = active;
+    active = {
+      generation: input_.generation,
+      request,
+      criteriaKey: input_.criteriaKey,
+      firstRow: input_.window.firstRow,
+      lastRow: input_.window.lastRow,
+      latestTotalRows: input_.latestTotalRows,
+      sink: input_.sink,
+      clearSink: () => input_.sink.setRowCount(0, false),
+      live: input_.live,
+    };
+    if (previous !== undefined && !Object.is(previous.sink, input_.sink)) {
+      previous.clearSink();
+    }
+    return {
+      request,
+      isCurrent: clearSink(input_.sink, input_.latestTotalRows.value, input_.generation, request),
+    };
   };
 
   const makeSubscriptionStream = <const Query extends LiveQueryViewportQuery<Row>>(
@@ -413,7 +471,7 @@ export const makeLiveQueryViewport = <
     generation: number,
     request: number,
     updateTotalRows: (totalRows: number) => void,
-  ): Stream.Stream<LiveQueryViewportChrome, unknown> => {
+  ): Stream.Stream<LiveQueryViewportChrome, ViewServerRuntimeError | ViewServerTransportError> => {
     const windowedQuery = queryWithWindow<Row, Query>(query, window);
     const projection = makeIncrementalClientState<LiveQueryRow<Row, Query>>();
     const acquireSubscription = Effect.fn("ViewServerReact.LiveQueryViewport.acquireSubscription")(
@@ -489,42 +547,33 @@ export const makeLiveQueryViewport = <
     readonly window: LiveQueryViewportWindow;
     readonly latestTotalRows: { value: number };
   }): void => {
-    const request = ++requestCounter;
     const window = validateLiveQueryViewportWindow(input_.window);
-    const previous = active;
-    const nextActive: ActiveRequest = {
+    const installed = installActive({
       generation: input_.generation,
-      request,
       criteriaKey: input_.criteriaKey,
-      firstRow: input_.window.firstRow,
-      lastRow: input_.window.lastRow,
+      window: input_.window,
       latestTotalRows: input_.latestTotalRows,
       sink: input_.sink,
-      clearSink: () => input_.sink.setRowCount(0, false),
       live: window._tag === "Valid",
-    };
-    active = nextActive;
-    if (previous !== undefined && !Object.is(previous.sink, input_.sink)) {
-      previous.clearSink();
-    }
-    if (!clearSink(input_.sink, input_.latestTotalRows.value, input_.generation, request)) {
+    });
+    if (!installed.isCurrent) {
       return;
     }
     if (window._tag === "Invalid") {
       input.publish({
-        owner: request,
+        owner: installed.request,
         stream: holdChrome(invalidWindowChrome(window.message)),
       });
       return;
     }
     input.publish({
-      owner: request,
+      owner: installed.request,
       stream: makeSubscriptionStream(
         input_.query,
         input_.sink,
         window,
         input_.generation,
-        request,
+        installed.request,
         (totalRows) => {
           input_.latestTotalRows.value = totalRows;
         },
@@ -549,32 +598,23 @@ export const makeLiveQueryViewport = <
     }
     if (Result.isFailure(captured)) {
       const generation = ++generationCounter;
-      const requestId = ++requestCounter;
-      const previous = active;
-      const nextActive: ActiveRequest = {
+      const installed = installActive({
         generation,
-        request: requestId,
         criteriaKey: "",
-        firstRow: request.window.firstRow,
-        lastRow: request.window.lastRow,
+        window: request.window,
         latestTotalRows: { value: 0 },
         sink: request.sink,
-        clearSink: () => request.sink.setRowCount(0, false),
         live: false,
-      };
-      active = nextActive;
-      if (previous !== undefined && !Object.is(previous.sink, request.sink)) {
-        previous.clearSink();
-      }
-      if (!clearSink(request.sink, 0, generation, requestId)) {
+      });
+      if (!installed.isCurrent) {
         return {
           setWindow: () => undefined,
           release: () => undefined,
         };
       }
       input.publish({
-        owner: requestId,
-        stream: holdChrome(invalidWindowChrome(String(captured.failure))),
+        owner: installed.request,
+        stream: holdChrome(invalidQueryChrome(liveQueryViewportFailureMessage(captured.failure))),
       });
       return {
         setWindow: () => undefined,


### PR DESCRIPTION
Closes #394

## Summary

- add the typed `useLiveQueryViewport(topic)` sibling to `useLiveQuery` with atomic query/window/sink correlation
- add generation-scoped `setWindow` and `release`, terminal `destroy`, absolute sparse-index projection, and shared incremental live-query state
- enforce switch-latest ownership for viewport criteria/window changes and existing `useLiveQuery`, rejecting every late snapshot, delta, status, error, chrome, sink, acquisition, and finalizer write
- preserve exact raw/grouped/leased query inference, transport-neutral React boundaries, SSR/Strict Mode behavior, and scoped subscription cleanup
- add public docs, facade/type/export coverage, browser/runtime regressions, a changeset, and a classified viewport hot-path benchmark

## Validation

- `vp check`
- `vp test` (375 tests)
- `vp run @effect-view-server/client#test` (85 tests, 100% coverage)
- `vp run @effect-view-server/react#test` (228 tests across Chromium, Firefox, and WebKit; type tests; 100% coverage)
- `vp run --concurrency-limit 1 -w check:effect`
- `vp run -w check:package-exports`
- `vp run -w check:internal-seams`
- `vp run @effect-view-server/react#bench:live-query-viewport`
- `vp run -w bench:baseline:smoke`
- independent Effect, Vitest, architecture, standards, and issue-spec reviews: clean

## Summary by Sourcery

Add a typed React live query viewport hook and supporting client-side incremental state projection for virtualized grids, ensuring switch-latest ownership and documenting the new API and behavior.

New Features:
- Introduce makeIncrementalClientState with range-change tracking for client live query state projection.
- Expose a useLiveQueryViewport hook and associated viewport types in the React bindings for virtualized, sink-driven live queries.

Enhancements:
- Refine client live-query state handling to support incremental projections and transactional rollback of invalid deltas.
- Ensure React subscriptions and health queries are keyed by both subscription identity and client ownership to support viewport isolation and client switching.

Build:
- Add a dedicated live-query-viewport benchmark script to the React package build tooling.

Documentation:
- Document the new useLiveQueryViewport hook, viewport semantics, and virtualized grid integration in public API guides and READMEs.
- Extend architectural context to define Live Query Viewport as the transport-neutral React integration module for virtualized grids.

Tests:
- Add extensive unit, React integration, type-level, and browser-based tests plus a microbenchmark covering live query viewport behavior, switch-latest semantics, window validation, and delta projection.

Chores:
- Add a changeset declaring a minor version bump for the effect-view-server package due to the new React viewport capability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `useLiveQueryViewport(topic)` to `@effect-view-server/react` for virtualized grids. It streams rows into a caller-owned sink, keeps React free of row payloads, and strictly enforces switch-latest ownership for replacements and scroll-only window changes (implements #394).

- **New Features**
  - Export `useLiveQueryViewport` from `createViewServerReact(...)` with `viewport.replace({ window, query, sink })`, per-generation `setWindow`, and `release`/`destroy`.
  - React observes only chrome (status, version, `totalRows`); rows flow to a sparse sink. Publicly export viewport types and `UseLiveQueryViewport*` from `@effect-view-server/react`.
  - Add `makeIncrementalClientState` to `@effect-view-server/client` with changed-range reporting and transactional rollback; update docs/examples, add a hot-path benchmark, and comprehensive tests (SSR/Strict Mode safe).

- **Bug Fixes**
  - Harden viewport request ownership to ignore late snapshots, deltas, statuses, failures, and sink writes across replacements and window-only updates, and preserve ownership under reentrancy.

<sup>Written for commit 51b7ab4bfc5bcb8f7a2503990a756b24c67b9113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bmvantunes/effect-view-server/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the typed `useLiveQueryViewport` React hook for virtualized grids, supporting raw vs grouped queries, inclusive absolute row windows, sparse row sinks, and live “chrome” metadata.
  * Introduced incremental client-state projection via `makeIncrementalClientState`, enabling structured change tracking with stronger stale/rollback behavior.
* **Documentation**
  * Updated React and public API guides with a “Live Query Viewports” section and `replace`/`setWindow` examples, including `switch-latest` semantics.
* **Tests**
  * Added runtime, end-to-end React, type-contract, and benchmark coverage for viewport behavior and incremental projection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->