### PR TITLE
feat: expose authoritative viewport row keys

### DIFF
--- a/.changeset/lazy-beds-smoke.md
+++ b/.changeset/lazy-beds-smoke.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": minor
+---
+
+Expose authoritative raw and grouped row keys through Live Query Viewport sink deliveries.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -161,8 +161,30 @@ const regional = useLiveQuery("regionalOrders", {
 ```
 
 `useLiveQueryViewport(topic)` is the transport-neutral virtual-grid seam. It
-pushes sparse rows into a caller-owned sink while React retains only chrome
-such as status, version, and total rows.
+pushes sparse rows and their authoritative keys into a caller-owned sink while
+React retains only chrome such as status, version, and total rows.
+
+```tsx
+const generation = useLiveQueryViewport("manualOrders").viewport.replace({
+  window: { firstRow: 100, lastRow: 149 },
+  query: {
+    select: ["id", "price"],
+    where: [],
+    orderBy: [{ field: "price", direction: "desc" }],
+  },
+  sink: {
+    setRowCount: (count, keepRenderedRows) => grid.setRowCount(count, keepRenderedRows),
+    setRowData: (rowsByIndex, rowKeysByIndex) => grid.setRows(rowsByIndex, rowKeysByIndex),
+  },
+});
+```
+
+Every `setRowData` call contains rows and keys at exactly the same absolute
+indexes. Raw queries receive the authoritative public row key; grouped queries
+receive the complete canonical group key. Both maps describe the same
+`ClientStateChange` and are delivered atomically, so keys remain stable when
+rows move or aggregates change. Keys are never derived from viewport position.
+Existing sinks that only accept the first `rowsByIndex` argument remain valid.
 
 ### Source Diagnostics
 

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -73,8 +73,10 @@ Field-keyed `where` objects and shorthand operators are invalid. Leased topics
 also require their exact, independently typed `routeBy` object.
 
 Virtualized grids use `react.useLiveQueryViewport(topic)`. Its `replace`
-operation binds a typed query and sparse row sink to an inclusive absolute
-window, while the returned generation's `setWindow` operation handles
+operation binds a typed query and sparse row/key sink to an inclusive absolute
+window. Each `setRowData(rowsByIndex, rowKeysByIndex)` delivery contains
+authoritative public raw keys or complete canonical grouped keys at the same
+absolute indexes. The returned generation's `setWindow` operation handles
 scroll-only changes. Each replacement is switch-latest: obsolete snapshots,
 deltas, statuses, failures, and sink writes are ignored. See the Public API
 guide for the complete adapter contract.

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -227,10 +227,11 @@ describe("public effect-view-server subpath type contracts", () => {
         setRowCount: (count) => {
           expectTypeOf(count).toBeNumber();
         },
-        setRowData: (rows) => {
+        setRowData: (rows, rowKeys) => {
           expectTypeOf(rows[0]).toEqualTypeOf<
             { readonly id: string; readonly price: number } | undefined
           >();
+          expectTypeOf(rowKeys[0]).toEqualTypeOf<string | undefined>();
         },
       },
     });

--- a/packages/react/src/live-query-viewport.test-d.ts
+++ b/packages/react/src/live-query-viewport.test-d.ts
@@ -70,10 +70,11 @@ describe("Live Query Viewport type contracts", () => {
           expectTypeOf(count).toBeNumber();
           expectTypeOf(keepRenderedRows).toEqualTypeOf<boolean | undefined>();
         },
-        setRowData: (rows) => {
+        setRowData: (rows, rowKeys) => {
           expectTypeOf(rows[20]).toEqualTypeOf<
             { readonly id: string; readonly price: number } | undefined
           >();
+          expectTypeOf(rowKeys[20]).toEqualTypeOf<string | undefined>();
         },
       },
     });
@@ -96,7 +97,7 @@ describe("Live Query Viewport type contracts", () => {
       },
       sink: {
         setRowCount: () => undefined,
-        setRowData: (rows) => {
+        setRowData: (rows, rowKeys) => {
           expectTypeOf(rows[0]).toEqualTypeOf<
             | {
                 readonly status: "open" | "closed";
@@ -105,6 +106,20 @@ describe("Live Query Viewport type contracts", () => {
               }
             | undefined
           >();
+          expectTypeOf(rowKeys[0]).toEqualTypeOf<string | undefined>();
+        },
+      },
+    });
+  });
+
+  it("keeps one-argument row callbacks source-compatible", () => {
+    react.useLiveQueryViewport("orders").viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: {
+        setRowCount: () => undefined,
+        setRowData: (rows) => {
+          expectTypeOf(rows[0]).toEqualTypeOf<{ readonly id: string } | undefined>();
         },
       },
     });
@@ -334,6 +349,15 @@ describe("Live Query Viewport type contracts", () => {
         // @ts-expect-error sink rows cannot require unselected fields.
         setRowData: (_rows: { readonly [index: number]: { readonly id: string; price: number } }) =>
           undefined,
+      },
+    });
+    viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: {
+        setRowCount: () => undefined,
+        // @ts-expect-error viewport row keys are always sparse string maps.
+        setRowData: (_rows, _rowKeys: { readonly [index: number]: number }) => undefined,
       },
     });
     viewport.replace({

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -205,15 +205,17 @@ const deltaMany = (
 const makeSink = <Row>() => {
   const rowCounts: Array<readonly [number, boolean | undefined]> = [];
   const rowData: Array<{ readonly [index: number]: Row }> = [];
+  const rowKeys: Array<{ readonly [index: number]: string }> = [];
   const sink: LiveQueryViewportSink<Row> = {
     setRowCount: (count, keepRenderedRows) => {
       rowCounts.push([count, keepRenderedRows]);
     },
-    setRowData: (rows) => {
+    setRowData: (rows, keys) => {
       rowData.push(rows);
+      rowKeys.push(keys);
     },
   };
-  return { rowCounts, rowData, sink };
+  return { rowCounts, rowData, rowKeys, sink };
 };
 
 const flush = Effect.yieldNow;
@@ -418,6 +420,7 @@ describe("Live Query Viewport Module", () => {
         { 20: { id: "a", price: 1 } },
         { 20: { id: "a", price: 2 } },
       ]);
+      expect(projected.rowKeys).toStrictEqual([{ 20: "a" }, { 20: "a" }]);
       expect(projected.rowCounts).toStrictEqual([
         [0, false],
         [1, true],
@@ -1427,6 +1430,12 @@ describe("Live Query Viewport Module", () => {
           3: { id: "b", price: 2 },
         },
         { 2: { id: "b", price: 2 } },
+      ]);
+      expect(projected.rowKeys).toStrictEqual([
+        { 0: "a", 1: "b", 2: "c" },
+        { 1: "x", 2: "b", 3: "c" },
+        { 0: "c", 1: "a", 2: "x", 3: "b" },
+        { 2: "b" },
       ]);
 
       yield* Fiber.interrupt(fiber);

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -105,21 +105,25 @@ type SelectedOrder = {
 const makeGridModel = <Row,>() => {
   let rowCount = 0;
   let rows: { readonly [index: number]: Row } = {};
+  let rowKeys: { readonly [index: number]: string } = {};
   const sink: LiveQueryViewportSink<Row> = {
     setRowCount: (count, keepRenderedRows) => {
       rowCount = count;
       if (keepRenderedRows !== true) {
         rows = {};
+        rowKeys = {};
       }
     },
-    setRowData: (changedRows) => {
+    setRowData: (changedRows, changedRowKeys) => {
       rows = { ...rows, ...changedRows };
+      rowKeys = { ...rowKeys, ...changedRowKeys };
     },
   };
   return {
     sink,
     rowCount: () => rowCount,
     rows: () => rows,
+    rowKeys: () => rowKeys,
   };
 };
 
@@ -199,6 +203,7 @@ describe("useLiveQueryViewport", () => {
       }),
     );
     await expect.poll(grid.rows).toStrictEqual({ 0: { id: "connected" } });
+    expect(grid.rowKeys()).toStrictEqual({ 0: "connected" });
 
     await view.unmount();
     await Effect.runPromise(runtime.close);
@@ -269,6 +274,13 @@ describe("useLiveQueryViewport", () => {
       13: { id: "order-13", price: 13 },
       14: { id: "order-14", price: 14 },
     });
+    expect(grid.rowKeys()).toStrictEqual({
+      10: "order-10",
+      11: "order-11",
+      12: "order-12",
+      13: "order-13",
+      14: "order-14",
+    });
     expect(grid.rowCount()).toBe(30);
     await expect.element(view.getByText(/^ready:30:\d+$/)).toBeVisible();
 
@@ -279,6 +291,13 @@ describe("useLiveQueryViewport", () => {
       22: { id: "order-22", price: 22 },
       23: { id: "order-23", price: 23 },
       24: { id: "order-24", price: 24 },
+    });
+    expect(grid.rowKeys()).toStrictEqual({
+      20: "order-20",
+      21: "order-21",
+      22: "order-22",
+      23: "order-23",
+      24: "order-24",
     });
     expect(grid.rowCount()).toBe(30);
     await expect
@@ -1134,6 +1153,11 @@ describe("useLiveQueryViewport", () => {
     await expect.poll(() => grid.rows()[0]?.status).toBe("open");
     expect(grid.rows()[0]?.rowCount).toBe(2n);
     expect(BigDecimal.equals(grid.rows()[0]!.totalPrice, BigDecimal.make(30n, 0))).toBe(true);
+    const openKey = grid.rowKeys()[0];
+    const closedKey = grid.rowKeys()[1];
+    expect(openKey).toBeTypeOf("string");
+    expect(closedKey).toBeTypeOf("string");
+    expect(openKey).not.toBe(closedKey);
 
     await Effect.runPromise(
       runtime.client.publish("orders", {
@@ -1144,6 +1168,18 @@ describe("useLiveQueryViewport", () => {
     );
     await expect.poll(() => grid.rows()[0]?.rowCount).toBe(3n);
     expect(BigDecimal.equals(grid.rows()[0]!.totalPrice, BigDecimal.make(40n, 0))).toBe(true);
+    expect(grid.rowKeys()[0]).toBe(openKey);
+
+    await Effect.runPromise(
+      runtime.client.publishMany("orders", [
+        { id: "closed-2", status: "closed", price: 5 },
+        { id: "closed-3", status: "closed", price: 5 },
+        { id: "closed-4", status: "closed", price: 5 },
+      ]),
+    );
+    await expect.poll(() => grid.rows()[0]?.status).toBe("closed");
+    expect(grid.rows()[0]?.rowCount).toBe(4n);
+    expect(grid.rowKeys()).toStrictEqual({ 0: closedKey, 1: openKey });
 
     await view.unmount();
     await Effect.runPromise(runtime.close);

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -36,7 +36,10 @@ export type LiveQueryViewportWindow = {
 
 export type LiveQueryViewportSink<Row> = {
   readonly setRowCount: (count: number, keepRenderedRows?: boolean) => void;
-  readonly setRowData: (rows: { readonly [index: number]: Row }) => void;
+  readonly setRowData: (
+    rowsByIndex: { readonly [index: number]: Row },
+    rowKeysByIndex: { readonly [index: number]: string },
+  ) => void;
 };
 
 type LiveQueryViewportSinkRow<Row, Sink> = Sink extends {
@@ -294,18 +297,27 @@ const chromeFromClientState = <Row>(state: ClientState<Row>): LiveQueryViewportC
   message: state.message,
 });
 
-const rowDataForRange = <Row>(
+type LiveQueryViewportData<Row> = {
+  readonly rowsByIndex: { readonly [index: number]: Row };
+  readonly rowKeysByIndex: { readonly [index: number]: string };
+};
+
+const viewportDataForRange = <Row>(
   firstRow: number,
   rows: ReadonlyArray<Row>,
+  rowKeys: ReadonlyArray<string>,
   range: Exclude<ClientStateChange, { readonly _tag: "None" }>,
-): { readonly [index: number]: Row } => {
-  const rowData: { [index: number]: Row } = {};
+): LiveQueryViewportData<Row> => {
+  const rowsByIndex: { [index: number]: Row } = {};
+  const rowKeysByIndex: { [index: number]: string } = {};
   const start = range._tag === "All" ? 0 : range.start;
   const end = range._tag === "All" ? rows.length - 1 : range.end;
   for (let index = start; index <= end; index += 1) {
-    rowData[firstRow + index] = rows[index]!;
+    const absoluteIndex = firstRow + index;
+    rowsByIndex[absoluteIndex] = rows[index]!;
+    rowKeysByIndex[absoluteIndex] = rowKeys[index]!;
   }
-  return rowData;
+  return { rowsByIndex, rowKeysByIndex };
 };
 
 type LiveQueryViewportControllerInput<
@@ -571,10 +583,15 @@ export const makeLiveQueryViewport = <
             const state = projection.apply(event);
             return {
               current: state.current,
-              rowData:
+              viewportData:
                 state.change._tag === "None"
                   ? undefined
-                  : rowDataForRange(window.firstRow, state.current.rows, state.change),
+                  : viewportDataForRange(
+                      window.firstRow,
+                      state.current.rows,
+                      state.current.keys,
+                      state.change,
+                    ),
             };
           }),
           Stream.tap((state) =>
@@ -589,13 +606,13 @@ export const makeLiveQueryViewport = <
                 return;
               }
               sink.setRowCount(state.current.totalRows, true);
-              if (state.rowData === undefined) {
+              if (state.viewportData === undefined) {
                 return;
               }
               if (!isCurrent(request)) {
                 return;
               }
-              sink.setRowData(state.rowData);
+              sink.setRowData(state.viewportData.rowsByIndex, state.viewportData.rowKeysByIndex);
             }),
           ),
           Stream.filter(() => isCurrent(request)),


### PR DESCRIPTION
## Summary

- deliver authoritative sparse row-key maps atomically with viewport row maps
- preserve raw/grouped row inference and one-argument sink compatibility
- document the key contract and add a minor changeset

Closes #405

## Validation

- `vp run @effect-view-server/react#test` (330 tests, 100% coverage)
- `vp run effect-view-server#test`
- `vp check`
- strict Effect diagnostics for React and the public facade
- package export and internal seam checks
- browser tests in Chromium, Firefox, and WebKit
- required Effect, Vitest/type-test, and architecture reviews all clean

## Summary by Sourcery

Expose authoritative viewport row keys alongside sparse row data in Live Query Viewport deliveries and document the key contract.

New Features:
- Add row key maps to Live Query Viewport sink deliveries so callers receive authoritative raw and grouped keys per viewport index.

Enhancements:
- Preserve compatibility with existing one-argument row sinks while extending the Live Query Viewport sink to accept both rows and row keys.
- Propagate viewport row keys through the React and effect-view-server layers to keep keys stable across window and aggregation changes.

Documentation:
- Describe the Live Query Viewport sink row/key delivery contract in the public API guide and effect-view-server README, including example usage.

Tests:
- Extend React viewport unit, browser, and type-level tests to cover row key delivery, type contracts, and grouped key stability.

Chores:
- Add a minor changeset entry for exposing authoritative raw and grouped row keys from Live Query Viewport.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose authoritative viewport row keys and deliver them with sparse rows in `useLiveQueryViewport` so grids get stable identity for raw and grouped queries. Backward compatible and closes #405.

- **New Features**
  - `setRowData(rowsByIndex, rowKeysByIndex)` now sends rows and aligned keys atomically; keys are public raw IDs or canonical group keys.
  - Stream logic ensures keys stay stable when rows move or aggregates change.
  - Updated docs and tests; minor version bump in `effect-view-server`.

- **Migration**
  - No changes required; one-argument sinks still work.
  - To use keys, accept the second `rowKeysByIndex` argument in `setRowData`.

<sup>Written for commit 8486cf34435253a341c218c51174199e068a5988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bmvantunes/effect-view-server/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

