### PR TITLE
fix: defer viewport sink cleanup from insertion effects

### DIFF
--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -416,7 +416,12 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
     const client = useClient();
     // Topic identity owns the public facade. Client changes replace the installed
     // controller below without invalidating viewport references held by the grid.
-    const binding = useMemo(() => makeLiveQueryViewportBinding<Topics, Topic>(), [topic]);
+    // Installation stays in insertion effect so descendant layout effects can connect
+    // immediately; controller deactivation is flushed from layout effects instead.
+    const binding = useMemo(
+      () => makeLiveQueryViewportBinding<Topics, Topic>({ deferDeactivation: true }),
+      [topic],
+    );
     const viewportState = useMemo(() => makeLiveQueryViewportAtom(), [client, topic]);
     const [result, publish] = AtomReact.useAtom(viewportState.atom);
     const entry = useMemo(() => {
@@ -435,6 +440,10 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
       return () => {
         binding.uninstall(entry);
       };
+    }, [binding, entry]);
+    useLayoutEffect(() => {
+      binding.flush();
+      return binding.flush;
     }, [binding, entry]);
     const chrome = viewportState.read(result);
     return {

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -352,8 +352,9 @@ describe("useLiveQueryViewport", () => {
     );
     await expect.element(view.getByRole("meter", { name: "store-updates" })).toBeVisible();
     await expect.poll(() => oldRequests.length).toBe(1);
+    const oldRequest = Option.getOrThrow(Option.fromUndefinedOr(oldRequests[0]));
     await Effect.runPromise(
-      Queue.offer(oldRequests[0]!, {
+      Queue.offer(oldRequest, {
         type: "snapshot",
         topic: "orders",
         queryId: "old-client",
@@ -384,8 +385,9 @@ describe("useLiveQueryViewport", () => {
       sink,
     });
     await expect.poll(() => currentRequests.length).toBe(1);
+    const currentRequest = Option.getOrThrow(Option.fromUndefinedOr(currentRequests[0]));
     await Effect.runPromise(
-      Queue.offer(currentRequests[0]!, {
+      Queue.offer(currentRequest, {
         type: "snapshot",
         topic: "orders",
         queryId: "current-client",
@@ -397,7 +399,7 @@ describe("useLiveQueryViewport", () => {
     );
     await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
     await Effect.runPromise(
-      Queue.offer(oldRequests[0]!, {
+      Queue.offer(oldRequest, {
         type: "snapshot",
         topic: "orders",
         queryId: "old-client",

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -17,7 +17,7 @@ import {
   type ViewServerTransportError,
 } from "@effect-view-server/config";
 import { createInMemoryViewServer } from "@effect-view-server/in-memory";
-import { Deferred, Effect, Queue, Schema, Stream } from "effect";
+import { Deferred, Effect, Option, Queue, Schema, Stream } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
 import {
   StrictMode,
@@ -377,7 +377,8 @@ describe("useLiveQueryViewport", () => {
     expect(observedViewport).toBe(retainedViewport);
     expect(consoleError.mock.calls).toStrictEqual([]);
     expect(callbacksDuringInsertionCleanup).toBe(0);
-    const currentGeneration = retainedViewport!.replace({
+    const currentViewport = Option.getOrThrow(Option.fromUndefinedOr(retainedViewport));
+    const currentGeneration = currentViewport.replace({
       window: { firstRow: 0, lastRow: 9 },
       query: { select: ["id"], where: [], orderBy: [] },
       sink,

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
 import type {
   ViewServerLiveClient,
   ViewServerLiveEvent,
@@ -19,7 +19,14 @@ import {
 import { createInMemoryViewServer } from "@effect-view-server/in-memory";
 import { Deferred, Effect, Queue, Schema, Stream } from "effect";
 import * as BigDecimal from "effect/BigDecimal";
-import { StrictMode, useLayoutEffect } from "react";
+import {
+  StrictMode,
+  useEffect,
+  useInsertionEffect,
+  useLayoutEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { renderToString } from "react-dom/server";
 import { render } from "vitest-browser-react";
 import { createViewServerReact } from "./index";
@@ -127,6 +134,31 @@ const makeGridModel = <Row,>() => {
   };
 };
 
+const makeExternalStore = () => {
+  let snapshot = 0;
+  let onSnapshot: (() => void) | undefined;
+  const listeners = new Set<() => void>();
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    setSnapshot: (next: number) => {
+      snapshot = next;
+      onSnapshot?.();
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    setOnSnapshot: (listener: () => void) => {
+      onSnapshot = listener;
+    },
+  };
+};
+
 describe("useLiveQueryViewport", () => {
   it("renders loading chrome during SSR without starting a subscription", async () => {
     const runtime = createInMemoryViewServer(viewServer);
@@ -205,6 +237,189 @@ describe("useLiveQueryViewport", () => {
     await expect.poll(grid.rows).toStrictEqual({ 0: { id: "connected" } });
     expect(grid.rowKeys()).toStrictEqual({ 0: "connected" });
 
+    await view.unmount();
+    await Effect.runPromise(runtime.close);
+  });
+
+  it("does not notify a useSyncExternalStore sink during insertion cleanup", async ({
+    onTestFinished,
+  }) => {
+    const runtime = createInMemoryViewServer(viewServer);
+    const oldRequests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    const currentRequests: Array<Queue.Queue<ViewServerLiveEvent<object>>> = [];
+    let oldSubscriptionCloseCount = 0;
+    let currentSubscriptionCloseCount = 0;
+    const makeClient = (
+      requests: Array<Queue.Queue<ViewServerLiveEvent<object>>>,
+      onClose: () => void,
+    ): ViewServerLiveClient<typeof viewServer.topics> => ({
+      ...runtime.liveClient,
+      subscribe: adaptQuerySubstrate(() =>
+        Effect.gen(function* () {
+          const events = yield* Queue.unbounded<ViewServerLiveEvent<object>>();
+          requests.push(events);
+          return {
+            events: Stream.fromQueue(events),
+            close: () => Effect.sync(onClose),
+          };
+        }),
+      ),
+    });
+    const oldClient = makeClient(oldRequests, () => {
+      oldSubscriptionCloseCount += 1;
+    });
+    const currentClient = makeClient(currentRequests, () => {
+      currentSubscriptionCloseCount += 1;
+    });
+    const store = makeExternalStore();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    onTestFinished(() => {
+      consoleError.mockRestore();
+    });
+    let insertionCleanupActive = false;
+    let callbacksDuringInsertionCleanup = 0;
+    let retainedViewport: LiveQueryViewport<typeof viewServer.topics, "orders"> | undefined;
+    let observedViewport: LiveQueryViewport<typeof viewServer.topics, "orders"> | undefined;
+    const grid = makeGridModel<{ readonly id: string }>();
+    const sink: LiveQueryViewportSink<{ readonly id: string }> = {
+      setRowCount: (count, keepRenderedRows) => {
+        if (insertionCleanupActive) {
+          callbacksDuringInsertionCleanup += 1;
+        }
+        grid.sink.setRowCount(count, keepRenderedRows);
+        store.setSnapshot(count);
+      },
+      setRowData: (rows, keys) => {
+        grid.sink.setRowData(rows, keys);
+      },
+    };
+
+    function StoreReader() {
+      const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+      return <output role="status">{snapshot}</output>;
+    }
+
+    function ViewportOwner(props: { readonly clientVersion: number }) {
+      useInsertionEffect(() => {
+        return () => {
+          insertionCleanupActive = true;
+        };
+      }, [props.clientVersion]);
+      useLayoutEffect(() => {
+        return () => {
+          insertionCleanupActive = false;
+        };
+      }, [props.clientVersion]);
+      const result = useLiveQueryViewport("orders");
+      observedViewport = result.viewport;
+      if (retainedViewport === undefined) {
+        retainedViewport = result.viewport;
+      }
+      useEffect(() => {
+        const generation = result.viewport.replace({
+          window: { firstRow: 0, lastRow: 9 },
+          query: { select: ["id"], where: [], orderBy: [] },
+          sink,
+        });
+        return generation.release;
+      }, [result.viewport]);
+      return null;
+    }
+
+    function ViewportRoot(props: {
+      readonly clientVersion: number;
+      readonly showViewport: boolean;
+    }) {
+      const [updates, setUpdates] = useState(0);
+      store.setOnSnapshot(() => {
+        setUpdates((current) => current + 1);
+      });
+      return (
+        <>
+          <div aria-label="store-updates" role="meter">
+            {updates}
+          </div>
+          <StoreReader />
+          {props.showViewport ? <ViewportOwner clientVersion={props.clientVersion} /> : null}
+        </>
+      );
+    }
+
+    const view = await render(
+      <ViewServerClientProvider client={oldClient}>
+        <ViewportRoot clientVersion={0} showViewport />
+      </ViewServerClientProvider>,
+    );
+    await expect.element(view.getByRole("meter", { name: "store-updates" })).toBeVisible();
+    await expect.poll(() => oldRequests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(oldRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "old-client",
+        rows: [{ id: "old-client" }],
+        keys: ["old-client"],
+        totalRows: 1,
+        version: 1,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "old-client" } });
+    expect(retainedViewport).toBeDefined();
+    expect(observedViewport).toBe(retainedViewport);
+
+    await view.rerender(
+      <ViewServerClientProvider client={currentClient}>
+        <ViewportRoot clientVersion={1} showViewport />
+      </ViewServerClientProvider>,
+    );
+    await expect.poll(() => oldSubscriptionCloseCount).toBe(1);
+    expect(retainedViewport).toBeDefined();
+    expect(observedViewport).toBe(retainedViewport);
+    expect(consoleError.mock.calls).toStrictEqual([]);
+    expect(callbacksDuringInsertionCleanup).toBe(0);
+    const currentGeneration = retainedViewport!.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink,
+    });
+    await expect.poll(() => currentRequests.length).toBe(1);
+    await Effect.runPromise(
+      Queue.offer(currentRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "current-client",
+        rows: [{ id: "current-client" }],
+        keys: ["current-client"],
+        totalRows: 1,
+        version: 2,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
+    await Effect.runPromise(
+      Queue.offer(oldRequests[0]!, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "old-client",
+        rows: [{ id: "obsolete-client-late" }],
+        keys: ["obsolete-client-late"],
+        totalRows: 1,
+        version: 3,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
+    expect(currentGeneration).toBeDefined();
+    expect(retainedViewport).toBeDefined();
+    expect(consoleError.mock.calls).toStrictEqual([]);
+    expect(callbacksDuringInsertionCleanup).toBe(0);
+
+    await view.rerender(
+      <ViewServerClientProvider client={currentClient}>
+        <ViewportRoot clientVersion={1} showViewport={false} />
+      </ViewServerClientProvider>,
+    );
+    await expect.poll(() => currentSubscriptionCloseCount).toBe(1);
+    expect(consoleError.mock.calls).toStrictEqual([]);
+    expect(callbacksDuringInsertionCleanup).toBe(0);
     await view.unmount();
     await Effect.runPromise(runtime.close);
   });

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -338,6 +338,10 @@ type LiveQueryViewportBindingEntry<
   readonly deactivate: () => void;
 };
 
+type LiveQueryViewportBindingOptions = {
+  readonly deferDeactivation?: boolean;
+};
+
 export type LiveQueryViewportBinding<
   Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
@@ -345,14 +349,26 @@ export type LiveQueryViewportBinding<
   readonly viewport: LiveQueryViewport<Topics, Topic>;
   readonly install: (entry: LiveQueryViewportBindingEntry<Topics, Topic>) => void;
   readonly uninstall: (entry: LiveQueryViewportBindingEntry<Topics, Topic>) => void;
+  readonly flush: () => void;
 };
 
 export const makeLiveQueryViewportBinding = <
   Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
->(): LiveQueryViewportBinding<Topics, Topic> => {
+>(
+  options: LiveQueryViewportBindingOptions = {},
+): LiveQueryViewportBinding<Topics, Topic> => {
   let current: LiveQueryViewportBindingEntry<Topics, Topic> | undefined;
+  let pendingDeactivations = new Set<LiveQueryViewportBindingEntry<Topics, Topic>>();
   let terminal = false;
+  const deactivate = (entry: LiveQueryViewportBindingEntry<Topics, Topic>): void => {
+    // React's insertion effect cannot synchronously notify a consumer sink.
+    if (options.deferDeactivation === true) {
+      pendingDeactivations.add(entry);
+      return;
+    }
+    entry.deactivate();
+  };
   const viewport: LiveQueryViewport<Topics, Topic> = {
     replace: (request) =>
       terminal
@@ -378,22 +394,32 @@ export const makeLiveQueryViewportBinding = <
     viewport,
     install: (entry) => {
       if (terminal) {
-        entry.deactivate();
+        deactivate(entry);
         return;
       }
+      pendingDeactivations.delete(entry);
       if (current === entry) {
         return;
       }
       const previous = current;
       current = entry;
-      previous?.deactivate();
+      if (previous !== undefined) {
+        deactivate(previous);
+      }
     },
     uninstall: (entry) => {
       if (current !== entry) {
         return;
       }
       current = undefined;
-      entry.deactivate();
+      deactivate(entry);
+    },
+    flush: () => {
+      const deactivations = pendingDeactivations;
+      pendingDeactivations = new Set();
+      for (const entry of deactivations) {
+        entry.deactivate();
+      }
     },
   };
 };


### PR DESCRIPTION
## Summary

- defer viewport controller deactivation out of React insertion effects and flush it during layout effects
- preserve stable viewport facades across client replacement while rejecting stale events
- add a browser regression for insertion-effect cleanup, client replacement, subscription cleanup, and late events

## Validation

- `vp check packages/react/src/index.tsx packages/react/src/live-query-viewport.ts packages/react/src/live-query-viewport.test.tsx`
- `vp test run src/live-query-viewport.test.tsx --project chromium --testTimeout 30000`
- `vp test run src/live-query-viewport.test.tsx --project firefox --testTimeout 30000`
- `vp test run src/live-query-viewport.test.tsx --project webkit --testTimeout 30000`

Closes #408

## Summary by Sourcery

Ensure live query viewport deactivation is deferred out of React insertion effects while keeping viewport references stable across client changes and safely dropping obsolete events.

Bug Fixes:
- Prevent live query viewport sinks from being notified during React insertion-effect cleanup by deferring controller deactivation to a later flush.
- Preserve a stable viewport facade when the view server client is replaced and ignore late events from obsolete clients to avoid inconsistent grid state.

Enhancements:
- Add a configurable deferDeactivation option and flush API to live query viewport bindings to control when deactivation runs.

Tests:
- Add a cross-browser regression test verifying insertion-effect cleanup behavior, useSyncExternalStore sinks, client replacement, subscription cleanup, and handling of late events.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `useSyncExternalStore` sinks from being called during React insertion-effect cleanup by deferring viewport deactivation to layout effects. Keeps the viewport facade stable across client swaps and ignores late events from old clients, addressing #408.

- **Bug Fixes**
  - Added `deferDeactivation` option and `flush()` to `makeLiveQueryViewportBinding`; used in React by installing during insertion effects and flushing in `useLayoutEffect`.
  - Preserved a stable viewport instance when the client changes; rejected obsolete-client events.
  - Added cross-browser regression tests for insertion-effect cleanup, client replacement, subscription cleanup, and late events.

<sup>Written for commit 4c5afcd027dfcbcd7b659fb1c55d7fd06bd6daea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bmvantunes/effect-view-server/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

