### PR TITLE
fix(react): preserve viewport across client handoff

### DIFF
--- a/.changeset/steady-viewports-switch.md
+++ b/.changeset/steady-viewports-switch.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Keep active live-query viewport generations connected when a React provider swaps clients.

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -433,7 +433,11 @@ export const createViewServerReact = <const Topics extends TopicDefinitions>(
           publish(viewportState.prepare(command));
         },
       });
-      return { viewport, deactivate: viewport.deactivate };
+      return {
+        viewport,
+        replaceCaptured: viewport.replaceCaptured,
+        deactivate: viewport.deactivate,
+      };
     }, [client, publish, topic, viewportState]);
     useInsertionEffect(() => {
       binding.install(entry);

--- a/packages/react/src/live-query-viewport.test-d.ts
+++ b/packages/react/src/live-query-viewport.test-d.ts
@@ -1,9 +1,11 @@
 import { describe, expectTypeOf, it } from "@effect/vitest";
+import type { ViewServerLiveClient } from "@effect-view-server/client";
 import { ViewServerId, defineViewServerConfig } from "@effect-view-server/config";
 import { SourceAdapter } from "@effect-view-server/source-adapter";
 import { Schema } from "effect";
 import type * as BigDecimal from "effect/BigDecimal";
 import { createViewServerReact } from "./index";
+import { makeLiveQueryViewport } from "./live-query-viewport";
 
 const Order = Schema.Struct({
   id: ViewServerId,
@@ -41,6 +43,13 @@ const leasedViewServer = defineViewServerConfig({
 
 const react = createViewServerReact(viewServer);
 const leasedReact = createViewServerReact(leasedViewServer);
+declare const liveClient: ViewServerLiveClient<typeof viewServer.topics>;
+const directViewport = makeLiveQueryViewport({
+  client: liveClient,
+  config: viewServer,
+  topic: "orders",
+  publish: () => undefined,
+});
 
 describe("Live Query Viewport type contracts", () => {
   it("binds the configured topic and exposes chrome without rows", () => {
@@ -122,6 +131,66 @@ describe("Live Query Viewport type contracts", () => {
           expectTypeOf(rows[0]).toEqualTypeOf<{ readonly id: string } | undefined>();
         },
       },
+    });
+  });
+
+  it("types captured viewport replacement inputs end to end", () => {
+    directViewport.replaceCaptured({
+      _tag: "Success",
+      request: {
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id", "price"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => undefined,
+          setRowData: (rows) => {
+            expectTypeOf(rows[0]).toEqualTypeOf<
+              { readonly id: string; readonly price: number } | undefined
+            >();
+          },
+        },
+      },
+    });
+
+    directViewport.replaceCaptured({
+      _tag: "Success",
+      request: {
+        window: { firstRow: 0, lastRow: 9 },
+        // @ts-expect-error captured query selections must name configured fields.
+        query: { select: ["missing"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      },
+    });
+    directViewport.replaceCaptured({
+      _tag: "Success",
+      request: {
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+        // @ts-expect-error captured requests are exact.
+        extra: true,
+      },
+    });
+    directViewport.replaceCaptured({
+      _tag: "Success",
+      request: {
+        window: { firstRow: 0, lastRow: 9 },
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: {
+          setRowCount: () => undefined,
+          // @ts-expect-error captured sinks must accept the selected row shape.
+          setRowData: (_rows: { readonly [index: number]: { readonly id: number } }) => undefined,
+        },
+      },
+    });
+    directViewport.replaceCaptured({
+      _tag: "Failure",
+      request: {
+        window: { firstRow: 0, lastRow: 9 },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+        // @ts-expect-error captured failures cannot carry a query.
+        query: { select: ["id"], where: [], orderBy: [] },
+      },
+      failure: new Error("captured failure"),
     });
   });
 

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -30,7 +30,9 @@ import {
   validateLiveQueryViewportWindow,
   type LiveQueryViewport,
   type LiveQueryViewportChrome,
+  type LiveQueryViewportCapturedReplace,
   type LiveQueryViewportGeneration,
+  type LiveQueryViewportRawQuery,
   type LiveQueryViewportSink,
 } from "./live-query-viewport";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
@@ -50,6 +52,17 @@ const viewServer = defineViewServerConfig({
 });
 
 type Topics = typeof viewServer.topics;
+
+const makeBindingEntry = (
+  viewport: LiveQueryViewport<Topics, "orders">,
+  deactivate: () => void = viewport.destroy,
+) => {
+  const replaceCaptured: LiveQueryViewportCapturedReplace<Topics, "orders"> = (input) =>
+    input._tag === "Success"
+      ? viewport.replace(input.request)
+      : { setWindow: () => undefined, release: () => undefined };
+  return { viewport, replaceCaptured, deactivate };
+};
 
 type ViewportChromeStream = Stream.Stream<
   LiveQueryViewportChrome,
@@ -324,8 +337,8 @@ describe("Live Query Viewport Module", () => {
         });
       },
     } satisfies LiveQueryViewport<Topics, "orders">;
-    const oldEntry = { viewport: oldViewport, deactivate: oldViewport.destroy };
-    const currentEntry = { viewport: currentViewport, deactivate: currentViewport.destroy };
+    const oldEntry = makeBindingEntry(oldViewport);
+    const currentEntry = makeBindingEntry(currentViewport);
     const facade = binding.viewport;
     const uninstalledGeneration = facade.replace({
       window: { firstRow: 0, lastRow: 9 },
@@ -362,6 +375,795 @@ describe("Live Query Viewport Module", () => {
     detachedGeneration.release();
     binding.viewport.destroy();
     expect(currentDestroys).toBe(2);
+  });
+
+  it("replays failed query snapshots on the replacement controller", () => {
+    const replacements: Array<string> = [];
+    const generation = { setWindow: () => undefined, release: () => undefined };
+    const makeEntry = (label: string) => {
+      const viewport = {
+        replace: () => {
+          replacements.push(`${label}:public`);
+          return generation;
+        },
+        destroy: () => undefined,
+      } satisfies LiveQueryViewport<Topics, "orders">;
+      const replaceCaptured: LiveQueryViewportCapturedReplace<Topics, "orders"> = (input) => {
+        replacements.push(label);
+        expect(input._tag).toBe("Failure");
+        return generation;
+      };
+      return {
+        viewport,
+        replaceCaptured,
+        deactivate: viewport.destroy,
+      };
+    };
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    binding.install(makeEntry("old"));
+    const queryTarget = {
+      select: ["id"],
+      where: [],
+      orderBy: [],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [];
+      readonly orderBy: readonly [];
+    };
+    let failSnapshot = true;
+    const query = new Proxy(queryTarget, {
+      ownKeys: (target) => {
+        if (failSnapshot) {
+          failSnapshot = false;
+          throw new Error("query snapshot failed");
+        }
+        return Reflect.ownKeys(target);
+      },
+    });
+
+    binding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query,
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    binding.install(makeEntry("current"));
+    binding.flush();
+    expect(replacements).toStrictEqual(["old", "current"]);
+  });
+
+  it.effect("installs captured query failures without rereading caller input", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      let published: ViewportChromeStream = Stream.never;
+      const viewport = makeLiveQueryViewport({
+        client: base.liveClient,
+        config: viewServer,
+        topic: "orders",
+        publish: (command) => {
+          published = command.stream;
+        },
+      });
+      type CapturedQuery = {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      const sink = { setRowCount: () => undefined, setRowData: () => undefined };
+      viewport.replaceCaptured<CapturedQuery, typeof sink>({
+        _tag: "Failure",
+        request: {
+          window: { firstRow: 0, lastRow: 9 },
+          sink,
+        },
+        failure: new Error("captured query failure"),
+      });
+
+      expect(yield* published.pipe(Stream.runHead)).toStrictEqual(
+        Option.some({
+          totalRows: 0,
+          version: 0,
+          status: "error",
+          statusCode: "InvalidQuery",
+          message: "captured query failure",
+        }),
+      );
+      viewport.destroy();
+      const publishedAfterDestroy = published;
+      let terminalRequestReads = 0;
+      const terminalRequest = {
+        window: { firstRow: 0, lastRow: 9 },
+        get sink() {
+          terminalRequestReads += 1;
+          return sink;
+        },
+      };
+      const terminalGeneration = viewport.replaceCaptured<CapturedQuery, typeof sink>({
+        _tag: "Failure",
+        request: terminalRequest,
+        failure: new Error("terminal captured failure"),
+      });
+      terminalGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+      terminalGeneration.release();
+      expect(terminalRequestReads).toBe(0);
+      expect(published).toBe(publishedAfterDestroy);
+      yield* base.close;
+    }),
+  );
+
+  it.effect("passes captured queries through the production binding seam without rereading", () =>
+    Effect.gen(function* () {
+      const base = createInMemoryViewServer(viewServer);
+      const viewport = makeLiveQueryViewport({
+        client: base.liveClient,
+        config: viewServer,
+        topic: "orders",
+        publish: () => undefined,
+      });
+      const binding = makeLiveQueryViewportBinding<Topics, "orders">();
+      binding.install({
+        viewport,
+        replaceCaptured: viewport.replaceCaptured,
+        deactivate: viewport.deactivate,
+      });
+      let queryReads = 0;
+      const queryTarget = {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      } satisfies {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      const query = new Proxy(queryTarget, {
+        ownKeys: (target) => {
+          queryReads += 1;
+          return Reflect.ownKeys(target);
+        },
+      });
+
+      const generation = binding.viewport.replace({
+        window: { firstRow: 0, lastRow: 9 },
+        query,
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      });
+
+      expect(queryReads).toBe(1);
+      generation.release();
+      binding.viewport.destroy();
+      yield* base.close;
+    }),
+  );
+
+  it("preserves request snapshots across a deferred controller replacement", () => {
+    let replayedRequest: unknown;
+    const generation = { setWindow: () => undefined, release: () => undefined };
+    const oldViewport = {
+      replace: () => generation,
+      destroy: () => undefined,
+    } satisfies LiveQueryViewport<Topics, "orders">;
+    const currentViewport = {
+      replace: (request) => {
+        replayedRequest = request;
+        return generation;
+      },
+      destroy: () => undefined,
+    } satisfies LiveQueryViewport<Topics, "orders">;
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    const where: Array<{
+      readonly field: "status";
+      readonly type: "equals";
+      readonly filter: "closed";
+    }> = [];
+    const select: ["id"] = ["id"];
+    const orderBy: [] = [];
+    const query = {
+      select,
+      where,
+      orderBy,
+    } satisfies LiveQueryViewportRawQuery<TopicRow<Topics, "orders">>;
+    const window = { firstRow: 0, lastRow: 9 };
+    const sink = { setRowCount: () => undefined, setRowData: () => undefined };
+    binding.install(makeBindingEntry(oldViewport));
+    const active = binding.viewport.replace({
+      window,
+      query,
+      sink,
+    });
+    window.firstRow = 90;
+    where.push({ field: "status", type: "equals", filter: "closed" });
+    const latestWindow = { firstRow: 10, lastRow: 19 };
+    active.setWindow(latestWindow);
+    latestWindow.firstRow = 80;
+    binding.install(makeBindingEntry(currentViewport));
+    binding.flush();
+
+    expect(replayedRequest).toStrictEqual({
+      window: { firstRow: 10, lastRow: 19 },
+      query: {
+        select: ["id"],
+        where: [],
+        orderBy: [],
+      },
+      sink,
+    });
+  });
+
+  it("reads the caller query property once before owning its captured outcome", () => {
+    const events: Array<string> = [];
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    const makeEntry = (label: string) => {
+      const viewport: LiveQueryViewport<Topics, "orders"> = {
+        replace: (request) => {
+          events.push(`${label}:${request.window.firstRow}`);
+          return { setWindow: () => undefined, release: () => undefined };
+        },
+        destroy: () => undefined,
+      };
+      return makeBindingEntry(viewport);
+    };
+    const query = {
+      select: ["id"],
+      where: [],
+      orderBy: [],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [];
+      readonly orderBy: readonly [];
+    };
+    let queryReads = 0;
+    const request = {
+      window: { firstRow: 0, lastRow: 9 },
+      query,
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    };
+    Object.defineProperty(request, "query", {
+      enumerable: true,
+      get: () => {
+        queryReads += 1;
+        if (queryReads === 2) {
+          binding.viewport.replace({
+            window: { firstRow: 20, lastRow: 29 },
+            query,
+            sink: request.sink,
+          });
+        }
+        return query;
+      },
+    });
+    binding.install(makeEntry("old"));
+    binding.viewport.replace(request);
+    binding.install(makeEntry("current"));
+    binding.flush();
+
+    expect(queryReads).toBe(1);
+    expect(events).toStrictEqual(["old:0", "current:0"]);
+  });
+
+  it("keeps the active generation owned when caller field capture throws", () => {
+    const events: Array<string> = [];
+    const viewport: LiveQueryViewport<Topics, "orders"> = {
+      replace: () => ({
+        setWindow: (window) => {
+          events.push(`window:${window.firstRow}`);
+        },
+        release: () => {
+          events.push("release");
+        },
+      }),
+      destroy: () => undefined,
+    };
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">();
+    binding.install(makeBindingEntry(viewport));
+    const active = binding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    const sinkRequest = {
+      window: { firstRow: 10, lastRow: 19 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    } satisfies {
+      readonly window: { readonly firstRow: number; readonly lastRow: number };
+      readonly query: {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      };
+      readonly sink: LiveQueryViewportSink<{ readonly id: string }>;
+    };
+    Object.defineProperty(sinkRequest, "sink", {
+      enumerable: true,
+      get: () => {
+        throw new Error("sink capture failed");
+      },
+    });
+    expect(() => binding.viewport.replace(sinkRequest)).toThrowError("sink capture failed");
+    active.setWindow({ firstRow: 20, lastRow: 29 });
+
+    const window = new Proxy(
+      { firstRow: 30, lastRow: 39 },
+      {
+        get: () => {
+          throw new Error("window capture failed");
+        },
+      },
+    );
+    expect(() =>
+      binding.viewport.replace({
+        window,
+        query: { select: ["id"], where: [], orderBy: [] },
+        sink: { setRowCount: () => undefined, setRowData: () => undefined },
+      }),
+    ).toThrowError("window capture failed");
+    active.release();
+    expect(events).toStrictEqual(["window:20", "release"]);
+  });
+
+  it("keeps switch-latest ownership through a reentrant release", () => {
+    const events: Array<string> = [];
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    let reenterRelease = true;
+    const makeEntry = (label: string) => {
+      const viewport: LiveQueryViewport<Topics, "orders"> = {
+        replace: (request) => {
+          events.push(`${label}:replace:${request.window.firstRow}`);
+          return {
+            setWindow: () => undefined,
+            release: () => {
+              if (reenterRelease) {
+                reenterRelease = false;
+                binding.viewport.replace({
+                  window: { firstRow: 20, lastRow: 29 },
+                  query: { select: ["id"], where: [], orderBy: [] },
+                  sink: { setRowCount: () => undefined, setRowData: () => undefined },
+                });
+              }
+            },
+          };
+        },
+        destroy: () => undefined,
+      };
+      return makeBindingEntry(viewport);
+    };
+    const oldEntry = makeEntry("old");
+    const currentEntry = makeEntry("current");
+    binding.install(oldEntry);
+    const released = binding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    released.release();
+    binding.install(currentEntry);
+    binding.flush();
+    expect(events).toStrictEqual(["old:replace:0", "old:replace:20", "current:replace:20"]);
+  });
+
+  it("keeps switch-latest ownership through a reentrant query snapshot", () => {
+    const events: Array<string> = [];
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    const makeEntry = (label: string) => {
+      const viewport: LiveQueryViewport<Topics, "orders"> = {
+        replace: (request) => {
+          events.push(`${label}:replace:${request.window.firstRow}`);
+          return { setWindow: () => undefined, release: () => undefined };
+        },
+        destroy: () => undefined,
+      };
+      return makeBindingEntry(viewport);
+    };
+    binding.install(makeEntry("current"));
+    let reenterSnapshot = true;
+    const queryTarget = {
+      select: ["id"],
+      where: [],
+      orderBy: [],
+    } satisfies {
+      readonly select: readonly ["id"];
+      readonly where: readonly [];
+      readonly orderBy: readonly [];
+    };
+    const query = new Proxy(queryTarget, {
+      ownKeys: (target) => {
+        if (reenterSnapshot) {
+          reenterSnapshot = false;
+          binding.viewport.replace({
+            window: { firstRow: 40, lastRow: 49 },
+            query: { select: ["id"], where: [], orderBy: [] },
+            sink: { setRowCount: () => undefined, setRowData: () => undefined },
+          });
+        }
+        return Reflect.ownKeys(target);
+      },
+    });
+    const superseded = binding.viewport.replace({
+      window: { firstRow: 30, lastRow: 39 },
+      query,
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    superseded.setWindow({ firstRow: 50, lastRow: 59 });
+    superseded.release();
+    const finalEntry = makeEntry("final");
+    binding.install(finalEntry);
+    binding.flush();
+    expect(events).toStrictEqual(["current:replace:40", "final:replace:40"]);
+  });
+
+  it("keeps switch-latest ownership through a reentrant window snapshot", () => {
+    const events: Array<string> = [];
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    const makeEntry = (label: string) => {
+      const viewport: LiveQueryViewport<Topics, "orders"> = {
+        replace: (request) => {
+          events.push(`${label}:replace:${request.window.firstRow}`);
+          return { setWindow: () => undefined, release: () => undefined };
+        },
+        destroy: () => undefined,
+      };
+      return makeBindingEntry(viewport);
+    };
+    binding.install(makeEntry("final"));
+    let reenterWindow = true;
+    const hostileWindow = new Proxy(
+      { firstRow: 50, lastRow: 59 },
+      {
+        get: (target, property, receiver) => {
+          if (property === "firstRow" && reenterWindow) {
+            reenterWindow = false;
+            binding.viewport.replace({
+              window: { firstRow: 60, lastRow: 69 },
+              query: { select: ["id"], where: [], orderBy: [] },
+              sink: { setRowCount: () => undefined, setRowData: () => undefined },
+            });
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    const supersededWindow = binding.viewport.replace({
+      window: hostileWindow,
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    supersededWindow.setWindow({ firstRow: 70, lastRow: 79 });
+    supersededWindow.release();
+    const windowFinalEntry = makeEntry("window-final");
+    binding.install(windowFinalEntry);
+    binding.flush();
+    expect(events).toStrictEqual(["final:replace:60", "window-final:replace:60"]);
+  });
+
+  it("keeps nested replacements authoritative during controller installation", () => {
+    const events: Array<string> = [];
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    let reenterInitialInstall = true;
+    const initialViewport: LiveQueryViewport<Topics, "orders"> = {
+      replace: (request) => {
+        events.push(`initial:replace:${request.window.firstRow}`);
+        if (reenterInitialInstall) {
+          reenterInitialInstall = false;
+          binding.viewport.replace({
+            window: { firstRow: 10, lastRow: 19 },
+            query: { select: ["id"], where: [], orderBy: [] },
+            sink: { setRowCount: () => undefined, setRowData: () => undefined },
+          });
+        }
+        return {
+          setWindow: () => undefined,
+          release: () => {
+            events.push(`initial:release:${request.window.firstRow}`);
+          },
+        };
+      },
+      destroy: () => undefined,
+    };
+    binding.install(makeBindingEntry(initialViewport));
+    const obsolete = binding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    obsolete.setWindow({ firstRow: 90, lastRow: 99 });
+    obsolete.release();
+
+    let reenterReplay = true;
+    const replayViewport: LiveQueryViewport<Topics, "orders"> = {
+      replace: (request) => {
+        events.push(`replay:replace:${request.window.firstRow}`);
+        if (reenterReplay) {
+          reenterReplay = false;
+          binding.viewport.replace({
+            window: { firstRow: 20, lastRow: 29 },
+            query: { select: ["id"], where: [], orderBy: [] },
+            sink: { setRowCount: () => undefined, setRowData: () => undefined },
+          });
+        }
+        return {
+          setWindow: () => undefined,
+          release: () => {
+            events.push(`replay:release:${request.window.firstRow}`);
+          },
+        };
+      },
+      destroy: () => undefined,
+    };
+    binding.install(makeBindingEntry(replayViewport));
+    binding.flush();
+    const finalViewport: LiveQueryViewport<Topics, "orders"> = {
+      replace: (request) => {
+        events.push(`final:replace:${request.window.firstRow}`);
+        return { setWindow: () => undefined, release: () => undefined };
+      },
+      destroy: () => undefined,
+    };
+    binding.install(makeBindingEntry(finalViewport));
+    binding.flush();
+
+    expect(events).toStrictEqual([
+      "initial:replace:0",
+      "initial:replace:10",
+      "replay:replace:10",
+      "replay:replace:20",
+      "replay:release:10",
+      "final:replace:20",
+    ]);
+  });
+
+  it("abandons a query snapshot when reentrant destruction loses ownership", () => {
+    const generation = { setWindow: () => undefined, release: () => undefined };
+    const makeViewport = (replace: LiveQueryViewport<Topics, "orders">["replace"]) => ({
+      replace,
+      destroy: () => undefined,
+    });
+    const select: ["id"] = ["id"];
+    const where: [] = [];
+    const orderBy: [] = [];
+    const request = {
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select, where, orderBy },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    };
+
+    const snapshotDestroyBinding = makeLiveQueryViewportBinding<Topics, "orders">();
+    let snapshotDestroyReplaces = 0;
+    const snapshotDestroyViewport = makeViewport(() => {
+      snapshotDestroyReplaces += 1;
+      return generation;
+    });
+    snapshotDestroyBinding.install(makeBindingEntry(snapshotDestroyViewport));
+    const destroyQuery = new Proxy(request.query, {
+      ownKeys: (target) => {
+        snapshotDestroyBinding.viewport.destroy();
+        return Reflect.ownKeys(target);
+      },
+    });
+    snapshotDestroyBinding.viewport.replace({ ...request, query: destroyQuery });
+    expect(snapshotDestroyReplaces).toBe(0);
+  });
+
+  it("abandons a query snapshot when a reentrant controller switch loses ownership", () => {
+    const generation = { setWindow: () => undefined, release: () => undefined };
+    const makeViewport = (replace: LiveQueryViewport<Topics, "orders">["replace"]) => ({
+      replace,
+      destroy: () => undefined,
+    });
+    const select: ["id"] = ["id"];
+    const where: [] = [];
+    const orderBy: [] = [];
+    const request = {
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select, where, orderBy },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    };
+    const snapshotSwitchBinding = makeLiveQueryViewportBinding<Topics, "orders">();
+    let snapshotSwitchReplaces = 0;
+    const snapshotOldViewport = makeViewport(() => {
+      snapshotSwitchReplaces += 1;
+      return generation;
+    });
+    const snapshotNewViewport = makeViewport(() => generation);
+    const snapshotNewEntry = makeBindingEntry(snapshotNewViewport);
+    snapshotSwitchBinding.install(makeBindingEntry(snapshotOldViewport));
+    const switchQuery = new Proxy(request.query, {
+      ownKeys: (target) => {
+        snapshotSwitchBinding.install(snapshotNewEntry);
+        return Reflect.ownKeys(target);
+      },
+    });
+    snapshotSwitchBinding.viewport.replace({ ...request, query: switchQuery });
+    expect(snapshotSwitchReplaces).toBe(0);
+  });
+
+  it("abandons an installed generation when reentrant destruction loses ownership", () => {
+    const makeViewport = (replace: LiveQueryViewport<Topics, "orders">["replace"]) => ({
+      replace,
+      destroy: () => undefined,
+    });
+    const select: ["id"] = ["id"];
+    const where: [] = [];
+    const orderBy: [] = [];
+    const request = {
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select, where, orderBy },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    };
+    const installDestroyBinding = makeLiveQueryViewportBinding<Topics, "orders">();
+    const installDestroyEvents: Array<string> = [];
+    const installDestroyViewport = makeViewport(() => {
+      installDestroyBinding.viewport.destroy();
+      return {
+        setWindow: () => {
+          installDestroyEvents.push("window");
+        },
+        release: () => {
+          installDestroyEvents.push("release");
+        },
+      };
+    });
+    installDestroyBinding.install(makeBindingEntry(installDestroyViewport));
+    const destroyedGeneration = installDestroyBinding.viewport.replace(request);
+    destroyedGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+    destroyedGeneration.release();
+    expect(installDestroyEvents).toStrictEqual([]);
+  });
+
+  it("abandons an installed generation when a reentrant controller switch loses ownership", () => {
+    const generation = { setWindow: () => undefined, release: () => undefined };
+    const makeViewport = (replace: LiveQueryViewport<Topics, "orders">["replace"]) => ({
+      replace,
+      destroy: () => undefined,
+    });
+    const select: ["id"] = ["id"];
+    const where: [] = [];
+    const orderBy: [] = [];
+    const request = {
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select, where, orderBy },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    };
+    const installSwitchBinding = makeLiveQueryViewportBinding<Topics, "orders">();
+    let installCurrentReplaces = 0;
+    const installCurrentViewport = makeViewport(() => {
+      installCurrentReplaces += 1;
+      return generation;
+    });
+    const installCurrentEntry = makeBindingEntry(installCurrentViewport);
+    const installSwitchEvents: Array<string> = [];
+    const installOldViewport = makeViewport(() => {
+      installSwitchBinding.install(installCurrentEntry);
+      return {
+        setWindow: () => {
+          installSwitchEvents.push("window");
+        },
+        release: () => {
+          installSwitchEvents.push("release");
+        },
+      };
+    });
+    installSwitchBinding.install(makeBindingEntry(installOldViewport));
+    const switchedGeneration = installSwitchBinding.viewport.replace(request);
+    switchedGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+    switchedGeneration.release();
+    installSwitchBinding.viewport.replace(request);
+    expect(installSwitchEvents).toStrictEqual([]);
+    expect(installCurrentReplaces).toBe(1);
+  });
+
+  it("keeps one generation active across deferred controller replacements", () => {
+    const events: Array<string> = [];
+    const makeEntry = (label: string) => {
+      const viewport: LiveQueryViewport<Topics, "orders"> = {
+        replace: (request) => {
+          events.push(`${label}:replace:${request.window.firstRow}-${request.window.lastRow}`);
+          let released = false;
+          return {
+            setWindow: (window) => {
+              if (!released) {
+                events.push(`${label}:window:${window.firstRow}-${window.lastRow}`);
+              }
+            },
+            release: () => {
+              if (!released) {
+                released = true;
+                events.push(`${label}:release`);
+              }
+            },
+          };
+        },
+        destroy: () => {
+          events.push(`${label}:destroy`);
+        },
+      };
+      return makeBindingEntry(viewport, () => {
+        events.push(`${label}:deactivate`);
+      });
+    };
+    const oldEntry = makeEntry("old");
+    const currentEntry = makeEntry("current");
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    binding.install(oldEntry);
+    const generation = binding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    binding.install(currentEntry);
+    expect(events).toStrictEqual(["old:replace:0-9"]);
+    binding.flush();
+    expect(events).toStrictEqual(["old:replace:0-9", "current:replace:0-9", "old:deactivate"]);
+
+    generation.setWindow({ firstRow: 10, lastRow: 19 });
+    expect(events.at(-1)).toBe("current:window:10-19");
+    const replacement = binding.viewport.replace({
+      window: { firstRow: 20, lastRow: 29 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    generation.setWindow({ firstRow: 30, lastRow: 39 });
+    generation.release();
+    expect(events.at(-1)).toBe("current:replace:20-29");
+    replacement.release();
+    replacement.release();
+    replacement.setWindow({ firstRow: 40, lastRow: 49 });
+    expect(events.at(-1)).toBe("current:release");
+
+    const canceledBinding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    const canceledOldEntry = makeEntry("canceled-old");
+    const canceledCurrentEntry = makeEntry("canceled-current");
+    canceledBinding.install(canceledOldEntry);
+    canceledBinding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    canceledBinding.install(canceledCurrentEntry);
+    canceledBinding.uninstall(canceledCurrentEntry);
+    canceledBinding.flush();
+    expect(events).not.toContain("canceled-current:replace:0-9");
+    expect(events.slice(-2)).toStrictEqual([
+      "canceled-old:deactivate",
+      "canceled-current:deactivate",
+    ]);
+
+    const restoredBinding = makeLiveQueryViewportBinding<Topics, "orders">({
+      deferDeactivation: true,
+    });
+    const restoredOldEntry = makeEntry("restored-old");
+    const restoredCurrentEntry = makeEntry("restored-current");
+    const restoredStart = events.length;
+    restoredBinding.install(restoredOldEntry);
+    restoredBinding.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    restoredBinding.install(restoredCurrentEntry);
+    restoredBinding.install(restoredOldEntry);
+    restoredBinding.flush();
+    expect(events.slice(restoredStart)).toStrictEqual([
+      "restored-old:replace:0-9",
+      "restored-current:deactivate",
+    ]);
   });
 
   it.effect("projects snapshots and Deltas at absolute indexes", () =>
@@ -2511,7 +3313,11 @@ describe("Live Query Viewport Module", () => {
             oldStream = command.stream;
           },
         });
-        const oldEntry = { viewport: oldViewport, deactivate: oldViewport.deactivate };
+        const oldEntry = {
+          viewport: oldViewport,
+          replaceCaptured: oldViewport.replaceCaptured,
+          deactivate: oldViewport.deactivate,
+        };
         binding.install(oldEntry);
         binding.viewport.replace({
           window: { firstRow: 0, lastRow: 9 },
@@ -2531,6 +3337,7 @@ describe("Live Query Viewport Module", () => {
         });
         const currentEntry = {
           viewport: currentViewport,
+          replaceCaptured: currentViewport.replaceCaptured,
           deactivate: currentViewport.deactivate,
         };
         binding.install(currentEntry);

--- a/packages/react/src/live-query-viewport.test.tsx
+++ b/packages/react/src/live-query-viewport.test.tsx
@@ -405,6 +405,7 @@ describe("useLiveQueryViewport", () => {
     let insertionCleanupActive = false;
     let callbacksDuringInsertionCleanup = 0;
     let retainedViewport: LiveQueryViewport<typeof viewServer.topics, "orders"> | undefined;
+    let retainedGeneration: LiveQueryViewportGeneration | undefined;
     let observedViewport: LiveQueryViewport<typeof viewServer.topics, "orders"> | undefined;
     const grid = makeGridModel<{ readonly id: string }>();
     const sink: LiveQueryViewportSink<{ readonly id: string }> = {
@@ -447,6 +448,7 @@ describe("useLiveQueryViewport", () => {
           query: { select: ["id"], where: [], orderBy: [] },
           sink,
         });
+        retainedGeneration = generation;
         return generation.release;
       }, [result.viewport]);
       return null;
@@ -504,12 +506,6 @@ describe("useLiveQueryViewport", () => {
     expect(observedViewport).toBe(retainedViewport);
     expect(consoleError.mock.calls).toStrictEqual([]);
     expect(callbacksDuringInsertionCleanup).toBe(0);
-    const currentViewport = Option.getOrThrow(Option.fromUndefinedOr(retainedViewport));
-    const currentGeneration = currentViewport.replace({
-      window: { firstRow: 0, lastRow: 9 },
-      query: { select: ["id"], where: [], orderBy: [] },
-      sink,
-    });
     await expect.poll(() => currentRequests.length).toBe(1);
     const currentRequest = Option.getOrThrow(Option.fromUndefinedOr(currentRequests[0]));
     await Effect.runPromise(
@@ -524,6 +520,23 @@ describe("useLiveQueryViewport", () => {
       }),
     );
     await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
+    const currentGeneration = Option.getOrThrow(Option.fromUndefinedOr(retainedGeneration));
+    currentGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+    await expect.poll(() => currentRequests.length).toBe(2);
+    await expect.poll(() => currentSubscriptionCloseCount).toBe(1);
+    const currentWindowRequest = Option.getOrThrow(Option.fromUndefinedOr(currentRequests[1]));
+    await Effect.runPromise(
+      Queue.offer(currentWindowRequest, {
+        type: "snapshot",
+        topic: "orders",
+        queryId: "current-window",
+        rows: [{ id: "current-window" }],
+        keys: ["current-window"],
+        totalRows: 1,
+        version: 3,
+      }),
+    );
+    await expect.poll(grid.rows).toStrictEqual({ 10: { id: "current-window" } });
     await Effect.runPromise(
       Queue.offer(oldRequest, {
         type: "snapshot",
@@ -532,10 +545,10 @@ describe("useLiveQueryViewport", () => {
         rows: [{ id: "obsolete-client-late" }],
         keys: ["obsolete-client-late"],
         totalRows: 1,
-        version: 3,
+        version: 4,
       }),
     );
-    await expect.poll(grid.rows).toStrictEqual({ 0: { id: "current-client" } });
+    await expect.poll(grid.rows).toStrictEqual({ 10: { id: "current-window" } });
     expect(currentGeneration).toBeDefined();
     expect(retainedViewport).toBeDefined();
     expect(consoleError.mock.calls).toStrictEqual([]);
@@ -546,7 +559,7 @@ describe("useLiveQueryViewport", () => {
         <ViewportRoot clientVersion={1} showViewport={false} />
       </ViewServerClientProvider>,
     );
-    await expect.poll(() => currentSubscriptionCloseCount).toBe(1);
+    await expect.poll(() => currentSubscriptionCloseCount).toBe(2);
     expect(consoleError.mock.calls).toStrictEqual([]);
     expect(callbacksDuringInsertionCleanup).toBe(0);
     await view.unmount();
@@ -1408,11 +1421,6 @@ describe("useLiveQueryViewport", () => {
       </ViewServerClientProvider>,
     );
     expect(retainedViewport).toBeDefined();
-    retainedViewport!.replace({
-      window: { firstRow: 0, lastRow: 9 },
-      query: { select: ["id"], where: [], orderBy: [] },
-      sink: grid.sink,
-    });
     await expect.poll(() => currentRequests.length).toBe(1);
     expect(grid.rows()).toStrictEqual({});
     await Effect.runPromise(

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -81,6 +81,54 @@ export type LiveQueryViewportGeneration = {
   readonly release: () => void;
 };
 
+type LiveQueryViewportRequest<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  Query extends LiveQueryViewportQuery<TopicRow<Topics, Topic>>,
+  Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+> = {
+  readonly window: LiveQueryViewportWindow;
+  readonly query: ExactLiveQueryInputForTopic<Topics, NoInfer<Topic>, Query>;
+  readonly sink: Sink &
+    ExactLiveQueryViewportSink<
+      LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>,
+      NoInfer<Sink>
+    >;
+};
+
+type LiveQueryViewportCapturedInput<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  Query extends LiveQueryViewportQuery<TopicRow<Topics, Topic>>,
+  Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+> =
+  | {
+      readonly _tag: "Success";
+      readonly request: LiveQueryViewportRequest<Topics, Topic, Query, Sink>;
+    }
+  | {
+      readonly _tag: "Failure";
+      readonly request: {
+        readonly window: LiveQueryViewportWindow;
+        readonly sink: Sink &
+          ExactLiveQueryViewportSink<
+            LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>,
+            NoInfer<Sink>
+          >;
+      };
+      readonly failure: unknown;
+    };
+
+export type LiveQueryViewportCapturedReplace<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = <
+  const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
+  const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+>(
+  input: LiveQueryViewportCapturedInput<Topics, Topic, Query, Sink>,
+) => LiveQueryViewportGeneration;
+
 export type LiveQueryViewport<
   Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
@@ -88,15 +136,9 @@ export type LiveQueryViewport<
   readonly replace: <
     const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
     const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
-  >(request: {
-    readonly window: LiveQueryViewportWindow;
-    readonly query: ExactLiveQueryInputForTopic<Topics, NoInfer<Topic>, Query>;
-    readonly sink: Sink &
-      ExactLiveQueryViewportSink<
-        LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>,
-        NoInfer<Sink>
-      >;
-  }) => LiveQueryViewportGeneration;
+  >(
+    request: LiveQueryViewportRequest<Topics, Topic, Query, Sink>,
+  ) => LiveQueryViewportGeneration;
   readonly destroy: () => void;
 };
 
@@ -335,12 +377,47 @@ type LiveQueryViewportBindingEntry<
   Topic extends Extract<keyof Topics, string>,
 > = {
   readonly viewport: LiveQueryViewport<Topics, Topic>;
+  readonly replaceCaptured: LiveQueryViewportCapturedReplace<Topics, Topic>;
   readonly deactivate: () => void;
 };
 
 type LiveQueryViewportBindingOptions = {
   readonly deferDeactivation?: boolean;
 };
+
+type LiveQueryViewportBindingGeneration<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = {
+  readonly generation: LiveQueryViewportGeneration;
+  readonly queueInstall: (entry: LiveQueryViewportBindingEntry<Topics, Topic>) => void;
+  readonly cancelInstall: (entry: LiveQueryViewportBindingEntry<Topics, Topic>) => void;
+  readonly flushInstall: () => void;
+  readonly supersede: () => void;
+};
+
+const inactiveLiveQueryViewportGeneration: LiveQueryViewportGeneration = {
+  setWindow: () => undefined,
+  release: () => undefined,
+};
+
+const capturedInputFrom = <
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+  const Query extends LiveQueryViewportQuery<TopicRow<Topics, Topic>>,
+  const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+>(
+  captured: Result.Result<ExactLiveQueryInputForTopic<Topics, Topic, Query>, unknown>,
+  window: LiveQueryViewportWindow,
+  sink: Sink &
+    ExactLiveQueryViewportSink<
+      LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>,
+      NoInfer<Sink>
+    >,
+): LiveQueryViewportCapturedInput<Topics, Topic, Query, Sink> =>
+  Result.isSuccess(captured)
+    ? { _tag: "Success", request: { window, query: captured.success, sink } }
+    : { _tag: "Failure", request: { window, sink }, failure: captured.failure };
 
 export type LiveQueryViewportBinding<
   Topics extends TopicDefinitions,
@@ -359,6 +436,8 @@ export const makeLiveQueryViewportBinding = <
   options: LiveQueryViewportBindingOptions = {},
 ): LiveQueryViewportBinding<Topics, Topic> => {
   let current: LiveQueryViewportBindingEntry<Topics, Topic> | undefined;
+  let activeGeneration: LiveQueryViewportBindingGeneration<Topics, Topic> | undefined;
+  let replaceInvocation = 0;
   let pendingDeactivations = new Set<LiveQueryViewportBindingEntry<Topics, Topic>>();
   let terminal = false;
   const deactivate = (entry: LiveQueryViewportBindingEntry<Topics, Topic>): void => {
@@ -369,22 +448,99 @@ export const makeLiveQueryViewportBinding = <
     }
     entry.deactivate();
   };
-  const viewport: LiveQueryViewport<Topics, Topic> = {
-    replace: (request) =>
-      terminal
-        ? {
-            setWindow: () => undefined,
-            release: () => undefined,
+  const replace = <
+    const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
+    const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+  >(
+    request: LiveQueryViewportRequest<Topics, Topic, Query, Sink>,
+  ): LiveQueryViewportGeneration => {
+    const invocation = ++replaceInvocation;
+    const entry = current;
+    if (terminal || entry === undefined) {
+      return inactiveLiveQueryViewportGeneration;
+    }
+    const ownsReplacement = (): boolean =>
+      invocation === replaceInvocation && !terminal && current === entry;
+    const capturedQuery = Result.try(() => snapshotViewServerQuery(request.query));
+    if (!ownsReplacement()) {
+      return inactiveLiveQueryViewportGeneration;
+    }
+    const sink = request.sink;
+    let window = { ...request.window };
+    if (!ownsReplacement()) {
+      return inactiveLiveQueryViewportGeneration;
+    }
+    activeGeneration?.supersede();
+    let installedEntry = entry;
+    const install = (nextEntry: LiveQueryViewportBindingEntry<Topics, Topic>) =>
+      nextEntry.replaceCaptured<Query, Sink>(
+        capturedInputFrom<Topics, Topic, Query, Sink>(capturedQuery, window, sink),
+      );
+    let installedGeneration = install(entry);
+    if (!ownsReplacement()) {
+      return inactiveLiveQueryViewportGeneration;
+    }
+    let pendingEntry: LiveQueryViewportBindingEntry<Topics, Topic> | undefined;
+    let active = true;
+    const bindingGeneration: LiveQueryViewportBindingGeneration<Topics, Topic> = {
+      generation: {
+        setWindow: (nextWindow) => {
+          if (!active) {
+            return;
           }
-        : (current?.viewport.replace(request) ?? {
-            setWindow: () => undefined,
-            release: () => undefined,
-          }),
+          window = { ...nextWindow };
+          installedGeneration.setWindow(window);
+        },
+        release: () => {
+          if (!active) {
+            return;
+          }
+          active = false;
+          pendingEntry = undefined;
+          activeGeneration = undefined;
+          installedGeneration.release();
+        },
+      },
+      queueInstall: (nextEntry) => {
+        pendingEntry = installedEntry === nextEntry ? undefined : nextEntry;
+      },
+      cancelInstall: (removedEntry) => {
+        if (pendingEntry === removedEntry) {
+          pendingEntry = undefined;
+        }
+      },
+      flushInstall: () => {
+        if (pendingEntry === undefined) {
+          return;
+        }
+        const nextEntry = pendingEntry;
+        pendingEntry = undefined;
+        const nextGeneration = install(nextEntry);
+        if (!active) {
+          nextGeneration.release();
+          return;
+        }
+        installedEntry = nextEntry;
+        installedGeneration = nextGeneration;
+      },
+      supersede: () => {
+        active = false;
+        pendingEntry = undefined;
+      },
+    };
+    activeGeneration = bindingGeneration;
+    return bindingGeneration.generation;
+  };
+  const viewport: LiveQueryViewport<Topics, Topic> = {
+    replace,
     destroy: () => {
       if (terminal) {
         return;
       }
       terminal = true;
+      replaceInvocation += 1;
+      activeGeneration?.supersede();
+      activeGeneration = undefined;
       const previous = current;
       current = undefined;
       previous?.viewport.destroy();
@@ -403,6 +559,7 @@ export const makeLiveQueryViewportBinding = <
       }
       const previous = current;
       current = entry;
+      activeGeneration?.queueInstall(entry);
       if (previous !== undefined) {
         deactivate(previous);
       }
@@ -412,9 +569,11 @@ export const makeLiveQueryViewportBinding = <
         return;
       }
       current = undefined;
+      activeGeneration?.cancelInstall(entry);
       deactivate(entry);
     },
     flush: () => {
+      activeGeneration?.flushInstall();
       const deactivations = pendingDeactivations;
       pendingDeactivations = new Set();
       for (const entry of deactivations) {
@@ -468,7 +627,10 @@ export const makeLiveQueryViewport = <
   Topic extends Extract<keyof Topics, string>,
 >(
   input: LiveQueryViewportControllerInput<Topics, Topic>,
-): LiveQueryViewport<Topics, Topic> & { readonly deactivate: () => void } => {
+): LiveQueryViewport<Topics, Topic> & {
+  readonly replaceCaptured: LiveQueryViewportCapturedReplace<Topics, Topic>;
+  readonly deactivate: () => void;
+} => {
   type Row = TopicRow<Topics, Topic>;
   let ownerCounter = 0;
   let requestCounter = 0;
@@ -714,23 +876,19 @@ export const makeLiveQueryViewport = <
     });
   };
 
-  const replace: LiveQueryViewport<Topics, Topic>["replace"] = (request) => {
-    if (terminal) {
-      return {
-        setWindow: () => undefined,
-        release: () => undefined,
-      };
-    }
-    const invocation = ++replaceInvocation;
-    const epoch = ++mutationEpoch;
-    const captured = Result.try(() => snapshotViewServerQuery(request.query));
+  const installCaptured = <
+    const Query extends LiveQueryViewportQuery<Row>,
+    const Sink extends LiveQueryViewportSink<LiveQueryRow<Row, NoInfer<Query>>>,
+  >(
+    input_: LiveQueryViewportCapturedInput<Topics, Topic, Query, Sink>,
+    invocation: number,
+    epoch: number,
+  ): LiveQueryViewportGeneration => {
     if (invocation !== replaceInvocation || epoch !== mutationEpoch || terminal) {
-      return {
-        setWindow: () => undefined,
-        release: () => undefined,
-      };
+      return inactiveLiveQueryViewportGeneration;
     }
-    if (Result.isFailure(captured)) {
+    if (input_._tag === "Failure") {
+      const { request } = input_;
       const owner = ++ownerCounter;
       const installed = installActive({
         owner,
@@ -745,7 +903,7 @@ export const makeLiveQueryViewport = <
         stream: Stream.unwrap(
           Effect.sync(() =>
             installed.activate()
-              ? holdChrome(invalidQueryChrome(liveQueryViewportFailureMessage(captured.failure)))
+              ? holdChrome(invalidQueryChrome(liveQueryViewportFailureMessage(input_.failure)))
               : Stream.empty,
           ),
         ),
@@ -767,15 +925,13 @@ export const makeLiveQueryViewport = <
       };
     }
 
-    const query = captured.success;
+    const { request } = input_;
+    const query = request.query;
     const topicDefinition = input.config.topics[input.topic]!;
     const criteriaKey = stableQueryKeyForRowSchema(query, topicDefinition.schema);
     const window = validateLiveQueryViewportWindow(request.window);
     if (epoch !== mutationEpoch || terminal) {
-      return {
-        setWindow: () => undefined,
-        release: () => undefined,
-      };
+      return inactiveLiveQueryViewportGeneration;
     }
     const current = active;
     if (
@@ -803,6 +959,34 @@ export const makeLiveQueryViewport = <
       latestTotalRows,
     });
     return makeGeneration(owner, criteriaKey, query, request.sink, latestTotalRows);
+  };
+
+  const replaceCaptured: LiveQueryViewportCapturedReplace<Topics, Topic> = (capturedInput) => {
+    if (terminal) {
+      return inactiveLiveQueryViewportGeneration;
+    }
+    const invocation = ++replaceInvocation;
+    const epoch = ++mutationEpoch;
+    return installCaptured(capturedInput, invocation, epoch);
+  };
+
+  const replace = <
+    const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
+    const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+  >(
+    request: LiveQueryViewportRequest<Topics, Topic, Query, Sink>,
+  ): LiveQueryViewportGeneration => {
+    if (terminal) {
+      return inactiveLiveQueryViewportGeneration;
+    }
+    const invocation = ++replaceInvocation;
+    const epoch = ++mutationEpoch;
+    const captured = Result.try(() => snapshotViewServerQuery(request.query));
+    return installCaptured<Query, Sink>(
+      capturedInputFrom<Topics, Topic, Query, Sink>(captured, request.window, request.sink),
+      invocation,
+      epoch,
+    );
   };
 
   function makeGeneration<const Query extends LiveQueryViewportQuery<Row>>(
@@ -876,6 +1060,7 @@ export const makeLiveQueryViewport = <
 
   return {
     replace,
+    replaceCaptured,
     destroy: () => {
       if (terminal) {
         return;


### PR DESCRIPTION
## Summary

- replay the active live-query viewport generation when a provider installs a replacement client controller
- preserve the owned query outcome and latest window across handoff without rereading caller input
- guard lifecycle and caller-getter reentrancy while keeping the public viewport facade stable
- remove consumer-side replacement workarounds from the browser regressions

Follow-up to #408 and the post-merge audit of #413.

## Validation

- vp run @effect-view-server/react#test: 366 tests, Chromium/Firefox/WebKit, no type errors, 100% coverage
- vp run -w check:effect:react: 0 errors, warnings, or messages
- vp check: 1061 formatted files; 0 lint or type errors
- local Effect review: clean
- local Vitest review: clean
- local architecture review: clean

## Release

- patch changeset for effect-view-server

## Summary by Sourcery

Ensure live-query viewports keep their active generation and window state when React providers swap underlying clients, including failure scenarios.

New Features:
- Introduce captured replace support on live-query viewports and bindings to replay previously captured query results or failures on replacement controllers.

Enhancements:
- Refine viewport binding lifecycle to track a single authoritative generation across installs, uninstalls, and destroy operations while guarding against reentrant replacements.
- Adjust React hook tests and behavior so components retain and continue using the existing viewport generation through client handoff instead of initiating a fresh query.

Documentation:
- Add a patch changeset documenting that live-query viewport generations stay connected when a React provider swaps clients.

Tests:
- Add extensive viewport binding tests covering deferred controller replacement, captured query failures, reentrant lifecycle and caller field access, and generation ownership across switch-latest scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved active live-query viewport generations when React providers replace clients.
  * Prevented outdated client events from affecting current subscriptions.
  * Improved subscription cleanup when viewports are hidden or destroyed.
  * Ensured viewport changes and replacements are applied reliably, including during concurrent updates.

* **Tests**
  * Expanded coverage for query failures, client replacement, lifecycle changes, cleanup ordering, and late events from obsolete clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->