### PR TITLE
Fix remote reconnects and malformed registry frames

### DIFF
--- a/.changeset/giant-roses-report.md
+++ b/.changeset/giant-roses-report.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Recover remote subscriptions after WebSocket reconnects and reject malformed Kafka schema-registry frames without exhausting the source.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -99,10 +99,13 @@ Ownership Policy.
 Remote live-query, health-summary, and health-detail subscriptions automatically
 restart after a WebSocket transport interruption. Source-health subscriptions use
 a separate RPC and are not automatically retried. The logical subscription remains
-open while the client retries every 500 milliseconds, and the restarted RPC stream
-begins with a fresh authoritative snapshot. Query, validation, and other
-non-transport errors remain terminal. Calling the subscription's `close` operation
-or closing the client cancels any pending retry and releases the server subscription.
+open while the client retries every 500 milliseconds without an attempt or duration
+limit. Transport interruptions therefore do not produce a terminal status while the
+subscription remains open. The restarted RPC stream begins with a fresh authoritative
+snapshot; consumers maintaining their own accumulated view must replace it with that
+snapshot before applying later deltas. Query, validation, and other non-transport errors
+remain terminal. Calling the subscription's `close` operation or closing the client
+cancels any pending retry and releases the server subscription.
 
 `subscriptionBufferSize` bounds the local queue for each remote subscription.
 It defaults to `1024`; a non-positive or non-integer value is normalized to `1`.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -100,12 +100,13 @@ Remote live-query, health-summary, and health-detail subscriptions automatically
 restart after a WebSocket transport interruption. Source-health subscriptions use
 a separate RPC and are not automatically retried. The logical subscription remains
 open while the client retries every 500 milliseconds without an attempt or duration
-limit. Transport interruptions therefore do not produce a terminal status while the
-subscription remains open. The restarted RPC stream begins with a fresh authoritative
-snapshot; consumers maintaining their own accumulated view must replace it with that
-snapshot before applying later deltas. Query, validation, and other non-transport errors
-remain terminal. Calling the subscription's `close` operation or closing the client
-cancels any pending retry and releases the server subscription.
+limit. The first failed attempt in an outage emits a non-terminal `TransportError`
+status so consumers report the connection as disconnected while retrying. The restarted
+RPC stream begins with a fresh authoritative snapshot, which restores ready status;
+consumers maintaining their own accumulated view must replace it with that snapshot
+before applying later deltas. Query, validation, and other non-transport errors remain
+terminal. Calling the subscription's `close` operation or closing the client cancels any
+pending retry and releases the server subscription.
 
 `subscriptionBufferSize` bounds the local queue for each remote subscription.
 It defaults to `1024`; a non-positive or non-integer value is normalized to `1`.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -94,6 +94,21 @@ Source-free Topics accept Runtime Client and TCP mutations. Source-owned Topics
 reject direct publish, patch, delete, and reset according to the Source
 Ownership Policy.
 
+## Remote client
+
+Remote live-query, health-summary, and health-detail subscriptions automatically
+restart after a WebSocket transport interruption. Source-health subscriptions use
+a separate RPC and are not automatically retried. The logical subscription remains
+open while the client retries every 500 milliseconds, and the restarted RPC stream
+begins with a fresh authoritative snapshot. Query, validation, and other
+non-transport errors remain terminal. Calling the subscription's `close` operation
+or closing the client cancels any pending retry and releases the server subscription.
+
+`subscriptionBufferSize` bounds the local queue for each remote subscription.
+It defaults to `1024`; a non-positive or non-integer value is normalized to `1`.
+If the consumer cannot keep up, the subscription emits its typed backpressure
+status and closes instead of growing without bound.
+
 ## Schema value admission
 
 Use ordinary Effect Schema constructors for JSON-faithful values. The

--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -44,6 +44,7 @@ import { makeViewServerClient } from "./remote";
 import {
   makeViewServerClientWithConstructionOptions,
   mapViewServerRemoteError,
+  subscriptionFailureStatus,
 } from "./remote-client";
 import { makeRemoteHealthState } from "./remote-health";
 
@@ -377,6 +378,8 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
   let healthTopicRows: ReadonlyArray<typeof ViewServerWireRowSchema.Type> = [healthTopicWireRow()];
   let healthSummaryError: ViewServerRpcError | undefined = undefined;
   let healthTopicError: ViewServerRpcError | undefined = undefined;
+  let anonymousTransportFailures = 0;
+  let identifiedTransportFailures = 0;
 
   const handlers = ViewServerRpcs.toLayer(
     Effect.succeed(
@@ -487,19 +490,25 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
             });
           }
           if (limit === 997) {
-            return Stream.fail<ViewServerRpcError>({
-              _tag: "ViewServerTransportError",
-              code: "TransportError",
-              message: "transport failure without query",
-            });
+            anonymousTransportFailures += 1;
+            if (anonymousTransportFailures === 1) {
+              return Stream.fail<ViewServerRpcError>({
+                _tag: "ViewServerTransportError",
+                code: "TransportError",
+                message: "transport failure without query",
+              });
+            }
           }
           if (limit === 998) {
-            return Stream.fail<ViewServerRpcError>({
-              _tag: "ViewServerTransportError",
-              code: "TransportError",
-              message: "transport failure",
-              queryId: "query-from-server",
-            });
+            identifiedTransportFailures += 1;
+            if (identifiedTransportFailures === 1) {
+              return Stream.fail<ViewServerRpcError>({
+                _tag: "ViewServerTransportError",
+                code: "TransportError",
+                message: "transport failure",
+                queryId: "query-from-server",
+              });
+            }
           }
           if (limit === 999) {
             return Stream.fail<ViewServerRpcError>({
@@ -669,6 +678,24 @@ describe("remote ViewServer client", () => {
       _tag: "ViewServerTransportError",
       code: "TransportError",
       message: "socket closed",
+    });
+  });
+
+  it("preserves a server query ID when mapping a terminal error status", () => {
+    expect(
+      subscriptionFailureStatus("orders", {
+        _tag: "ViewServerTransportError",
+        code: "TransportError",
+        message: "terminal transport failure",
+        queryId: "query-from-server",
+      }),
+    ).toStrictEqual({
+      type: "status",
+      topic: "orders",
+      queryId: "query-from-server",
+      status: "error",
+      code: "TransportError",
+      message: "terminal transport failure",
     });
   });
 
@@ -1451,9 +1478,10 @@ describe("remote ViewServer client", () => {
     Effect.gen(function* () {
       const summaryServer = yield* makeTestRpcServer();
       summaryServer.failHealthSummary({
-        _tag: "ViewServerTransportError",
-        code: "TransportError",
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
         message: "summary stream failed",
+        topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
       });
       const summaryClient = yield* makeViewServerClient(viewServer, { url: summaryServer.url });
       const summarySubscription = yield* summaryClient.subscribeHealthSummary();
@@ -1466,9 +1494,10 @@ describe("remote ViewServer client", () => {
       const detailServer = yield* makeTestRpcServer();
       detailServer.setHealthSummaryRows([]);
       detailServer.failHealthTopic({
-        _tag: "ViewServerTransportError",
-        code: "TransportError",
+        _tag: "ViewServerRuntimeError",
+        code: "InvalidQuery",
         message: "detail stream failed",
+        topic: VIEW_SERVER_HEALTH_TOPIC,
       });
       const detailClient = yield* makeViewServerClient(viewServer, { url: detailServer.url });
       const emptySummarySubscription = yield* detailClient.subscribeHealthSummary();
@@ -2161,7 +2190,7 @@ describe("remote ViewServer client", () => {
     }),
   );
 
-  it.live("turns remote stream failures into terminal status events", () =>
+  it.live("terminates domain failures and restarts transport failures", () =>
     Effect.gen(function* () {
       const server = yield* makeTestRpcServer();
       const client = yield* makeViewServerClient(viewServer, { url: server.url });
@@ -2226,12 +2255,13 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
       );
       expect(transportStatus[0]).toStrictEqual({
-        type: "status",
+        type: "snapshot",
         topic: "orders",
-        queryId: "remote",
-        status: "error",
-        code: "TransportError",
-        message: "transport failure without query",
+        queryId: "query-remote",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
       });
 
       const identifiedTransportSubscription = yield* client.subscribe("orders", {
@@ -2243,12 +2273,13 @@ describe("remote ViewServer client", () => {
         Stream.runCollect,
       );
       expect(identifiedTransportStatus[0]).toStrictEqual({
-        type: "status",
+        type: "snapshot",
         topic: "orders",
-        queryId: "query-from-server",
-        status: "error",
-        code: "TransportError",
-        message: "transport failure",
+        queryId: "query-remote",
+        version: 0,
+        keys: [],
+        rows: [],
+        totalRows: 0,
       });
 
       const backpressureSubscription = yield* client.subscribe("orders", {

--- a/packages/client/src/remote-client.test.ts
+++ b/packages/client/src/remote-client.test.ts
@@ -662,7 +662,7 @@ const makeTestRpcServer = Effect.fn("ViewServerClient.remote.testServer.make")(f
     setHealthTopicRows: (nextRows: ReadonlyArray<typeof ViewServerWireRowSchema.Type>) => {
       healthTopicRows = nextRows;
     },
-    failHealthSummary: (error: ViewServerRpcError) => {
+    setHealthSummaryError: (error: ViewServerRpcError | undefined) => {
       healthSummaryError = error;
     },
     failHealthTopic: (error: ViewServerRpcError) => {
@@ -1280,6 +1280,64 @@ describe("remote ViewServer client", () => {
     }),
   );
 
+  it.live("reports a health-summary outage and recovers with a fresh snapshot", () =>
+    Effect.gen(function* () {
+      const server = yield* makeTestRpcServer();
+      server.setHealthSummaryError({
+        _tag: "ViewServerTransportError",
+        code: "TransportError",
+        message: "health transport unavailable",
+      });
+      const client = yield* makeViewServerClient(viewServer, { url: server.url });
+      const subscription = yield* client.subscribeHealthSummary();
+      const outageReported = yield* Deferred.make<void>();
+      const eventsFiber = yield* subscription.events.pipe(
+        Stream.tap((event) =>
+          event.type === "status" ? Deferred.succeed(outageReported, undefined) : Effect.void,
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(outageReported).pipe(Effect.timeout("1 second"));
+      server.setHealthSummaryError(undefined);
+      const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("2 seconds"));
+
+      expect(Array.from(events)).toStrictEqual([
+        {
+          type: "status",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "remote",
+          status: "error",
+          code: "TransportError",
+          message: "health transport unavailable",
+        },
+        {
+          type: "snapshot",
+          topic: VIEW_SERVER_HEALTH_SUMMARY_TOPIC,
+          queryId: "query-remote",
+          version: 1,
+          keys: ["summary"],
+          rows: [
+            {
+              id: "summary",
+              status: "ready",
+              runtimeStatus: "ready",
+              connectionStatus: "connected",
+              unhealthyTopics: [],
+              updatedAtNanos: 1n,
+            },
+          ],
+          totalRows: 1,
+        },
+      ]);
+      yield* subscription.close();
+      yield* client.close;
+      yield* server.close;
+    }),
+  );
+
   it.live("subscribes to pushed remote health summary", () =>
     Effect.gen(function* () {
       const server = yield* makeTestRpcServer();
@@ -1477,7 +1535,7 @@ describe("remote ViewServer client", () => {
   it.live("ignores non-snapshot and empty pushed health events for health refs", () =>
     Effect.gen(function* () {
       const summaryServer = yield* makeTestRpcServer();
-      summaryServer.failHealthSummary({
+      summaryServer.setHealthSummaryError({
         _tag: "ViewServerRuntimeError",
         code: "InvalidQuery",
         message: "summary stream failed",
@@ -2251,36 +2309,56 @@ describe("remote ViewServer client", () => {
         limit: 997,
       });
       const transportStatus = yield* transportSubscription.events.pipe(
-        Stream.take(1),
+        Stream.take(2),
         Stream.runCollect,
       );
-      expect(transportStatus[0]).toStrictEqual({
-        type: "snapshot",
-        topic: "orders",
-        queryId: "query-remote",
-        version: 0,
-        keys: [],
-        rows: [],
-        totalRows: 0,
-      });
+      expect(Array.from(transportStatus)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "remote",
+          status: "error",
+          code: "TransportError",
+          message: "transport failure without query",
+        },
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-remote",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+      ]);
 
       const identifiedTransportSubscription = yield* client.subscribe("orders", {
         select: ["id"],
         limit: 998,
       });
       const identifiedTransportStatus = yield* identifiedTransportSubscription.events.pipe(
-        Stream.take(1),
+        Stream.take(2),
         Stream.runCollect,
       );
-      expect(identifiedTransportStatus[0]).toStrictEqual({
-        type: "snapshot",
-        topic: "orders",
-        queryId: "query-remote",
-        version: 0,
-        keys: [],
-        rows: [],
-        totalRows: 0,
-      });
+      expect(Array.from(identifiedTransportStatus)).toStrictEqual([
+        {
+          type: "status",
+          topic: "orders",
+          queryId: "query-from-server",
+          status: "error",
+          code: "TransportError",
+          message: "transport failure",
+        },
+        {
+          type: "snapshot",
+          topic: "orders",
+          queryId: "query-remote",
+          version: 0,
+          keys: [],
+          rows: [],
+          totalRows: 0,
+        },
+      ]);
 
       const backpressureSubscription = yield* client.subscribe("orders", {
         select: ["id"],

--- a/packages/client/src/remote-client.ts
+++ b/packages/client/src/remote-client.ts
@@ -139,7 +139,7 @@ export const mapViewServerRemoteError = (
   return error;
 };
 
-const subscriptionFailureStatus = <Topic extends string>(
+export const subscriptionFailureStatus = <Topic extends string>(
   topic: Topic,
   error: ViewServerRemoteClientError,
 ): ViewServerStatusEvent<Topic> => {
@@ -262,6 +262,7 @@ export const makeViewServerClientWithConstructionOptions: <const Topics extends 
       failureStatus: subscriptionFailureStatus,
       lifecycle,
       overflowStatus: subscriptionOverflowStatus,
+      retryWhile: (error) => error.code === "TransportError",
       source,
       subscriptionBufferSize,
       topic,

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -11,6 +11,7 @@ import {
   Scope,
   Stream,
 } from "effect";
+import { TestClock } from "effect/testing";
 import type { StatusEvent } from "@effect-view-server/config";
 import type { ViewServerLiveEvent } from "./live-client";
 import { makeRemoteSubscription } from "./remote-subscription";
@@ -120,6 +121,108 @@ describe("remote subscription", () => {
       expect(openCount).toBe(1);
       expect(closeCount).toBe(1);
 
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("restarts a failed source when its error is retryable", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const firstAttempt = yield* Deferred.make<void>();
+      let attempts = 0;
+      const source = Stream.unwrap(
+        Effect.gen(function* () {
+          attempts += 1;
+          if (attempts === 1) {
+            yield* Deferred.succeed(firstAttempt, undefined);
+            return Stream.fail("socket closed");
+          }
+          return Stream.make(snapshot);
+        }),
+      );
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        overflowStatus,
+        retryWhile: (error) => error === "socket closed",
+        source,
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+      const eventFiber = yield* subscription.events.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* Deferred.await(firstAttempt);
+      yield* TestClock.adjust("500 millis");
+      const events = yield* Fiber.join(eventFiber);
+
+      expect({ attempts, events: Array.from(events) }).toStrictEqual({
+        attempts: 2,
+        events: [snapshot],
+      });
+      yield* subscription.close();
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("maps a non-retryable source failure to one terminal status", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      let attempts = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        overflowStatus,
+        retryWhile: () => false,
+        source: Stream.unwrap(
+          Effect.sync(() => {
+            attempts += 1;
+            return Stream.fail("invalid query");
+          }),
+        ),
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+
+      const events = yield* subscription.events.pipe(Stream.runCollect);
+
+      expect({ attempts, events: Array.from(events) }).toStrictEqual({
+        attempts: 1,
+        events: [failureStatus("orders", "invalid query")],
+      });
+      yield* Scope.close(clientScope, Exit.void);
+    }),
+  );
+
+  it.effect("stops a pending retry when the subscription closes", () =>
+    Effect.gen(function* () {
+      const clientScope = yield* Scope.make("parallel");
+      const firstAttempt = yield* Deferred.make<void>();
+      let attempts = 0;
+      const subscription = yield* makeRemoteSubscription<Row, string>({
+        clientScope,
+        failureStatus,
+        overflowStatus,
+        retryWhile: () => true,
+        source: Stream.unwrap(
+          Effect.gen(function* () {
+            attempts += 1;
+            yield* Deferred.succeed(firstAttempt, undefined);
+            return Stream.fail("socket closed");
+          }),
+        ),
+        subscriptionBufferSize: 2,
+        topic: "orders",
+      });
+
+      yield* Deferred.await(firstAttempt);
+      yield* subscription.close();
+      yield* TestClock.adjust("1 second");
+
+      expect(attempts).toBe(1);
       yield* Scope.close(clientScope, Exit.void);
     }),
   );

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -129,6 +129,8 @@ describe("remote subscription", () => {
     Effect.gen(function* () {
       const clientScope = yield* Scope.make("parallel");
       const firstAttempt = yield* Deferred.make<void>();
+      const secondAttempt = yield* Deferred.make<void>();
+      const thirdAttempt = yield* Deferred.make<void>();
       let attempts = 0;
       const source = Stream.unwrap(
         Effect.gen(function* () {
@@ -136,6 +138,14 @@ describe("remote subscription", () => {
           if (attempts === 1) {
             yield* Deferred.succeed(firstAttempt, undefined);
             return Stream.fail("socket closed");
+          }
+          if (attempts === 2) {
+            yield* Deferred.succeed(secondAttempt, undefined);
+            return Stream.fail("socket closed");
+          }
+          if (attempts === 3) {
+            yield* Deferred.succeed(thirdAttempt, undefined);
+            return Stream.make(snapshot).pipe(Stream.concat(Stream.fail("socket closed")));
           }
           return Stream.make(snapshot);
         }),
@@ -150,7 +160,7 @@ describe("remote subscription", () => {
         topic: "orders",
       });
       const eventFiber = yield* subscription.events.pipe(
-        Stream.take(1),
+        Stream.take(4),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -159,11 +169,24 @@ describe("remote subscription", () => {
       yield* Effect.yieldNow;
       expect(attempts).toBe(1);
       yield* TestClock.adjust("500 millis");
+      yield* Deferred.await(secondAttempt);
+      yield* Effect.yieldNow;
+      expect(attempts).toBe(2);
+      yield* TestClock.adjust("500 millis");
+      yield* Deferred.await(thirdAttempt);
+      yield* Effect.yieldNow;
+      expect(attempts).toBe(3);
+      yield* TestClock.adjust("500 millis");
       const events = yield* Fiber.join(eventFiber);
 
       expect({ attempts, events: Array.from(events) }).toStrictEqual({
-        attempts: 2,
-        events: [snapshot],
+        attempts: 4,
+        events: [
+          failureStatus("orders", "socket closed"),
+          snapshot,
+          failureStatus("orders", "socket closed"),
+          snapshot,
+        ],
       });
       yield* subscription.close();
       yield* Scope.close(clientScope, Exit.void);

--- a/packages/client/src/remote-subscription.test.ts
+++ b/packages/client/src/remote-subscription.test.ts
@@ -156,6 +156,8 @@ describe("remote subscription", () => {
       );
 
       yield* Deferred.await(firstAttempt);
+      yield* Effect.yieldNow;
+      expect(attempts).toBe(1);
       yield* TestClock.adjust("500 millis");
       const events = yield* Fiber.join(eventFiber);
 

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -124,15 +124,36 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
             );
             yield* Scope.addFinalizer(scope, closeLifecycle);
             yield* lifecycle.onOpen;
+            const retrying = yield* Ref.make(false);
             const runSource = Effect.suspend(() =>
-              Stream.runForEach(source, (event) =>
-                offerRemoteEvent(queue, event, overflowStatus, closeLifecycle, topic),
+              Stream.runForEach(
+                source,
+                Effect.fn("ViewServerClient.remote.subscription.receive")(function* (event) {
+                  yield* Ref.set(retrying, false);
+                  yield* offerRemoteEvent(queue, event, overflowStatus, closeLifecycle, topic);
+                }),
               ),
             );
             const producer =
               retryWhile === undefined
                 ? runSource
                 : runSource.pipe(
+                    Effect.tapError((error) =>
+                      retryWhile(error)
+                        ? Effect.gen(function* () {
+                            const alreadyRetrying = yield* Ref.getAndSet(retrying, true);
+                            if (!alreadyRetrying) {
+                              yield* offerRemoteEvent(
+                                queue,
+                                failureStatus(topic, error),
+                                overflowStatus,
+                                closeLifecycle,
+                                topic,
+                              );
+                            }
+                          })
+                        : Effect.void,
+                    ),
                     Effect.retry({
                       schedule: Schedule.spaced("500 millis"),
                       while: retryWhile,

--- a/packages/client/src/remote-subscription.ts
+++ b/packages/client/src/remote-subscription.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Queue, Ref, Scope, Stream } from "effect";
+import { Cause, Effect, Exit, Queue, Ref, Schedule, Scope, Stream } from "effect";
 import { constant } from "effect/Function";
 import { ignoreLoggedTypedFailuresPreserveNonTypedFailures } from "@effect-view-server/effect-utils";
 import type {
@@ -48,6 +48,7 @@ export type RemoteSubscriptionOptions<
 > = {
   readonly clientScope: Scope.Scope;
   readonly overflowStatus: (topic: Topic, queuedEvents: number) => ViewServerStatusEvent<Topic>;
+  readonly retryWhile?: (error: Error) => boolean;
   readonly failureStatus: (topic: Topic, error: Error) => ViewServerStatusEvent<Topic>;
   readonly lifecycle?: RemoteSubscriptionLifecycle;
   readonly source: Stream.Stream<ViewServerLiveEvent<Row, Topic, Key>, Error>;
@@ -96,6 +97,7 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
       onClose: Effect.void,
     },
     overflowStatus,
+    retryWhile,
     source,
     subscriptionBufferSize,
     topic,
@@ -117,17 +119,35 @@ export const makeRemoteSubscription = Effect.fn("ViewServerClient.remote.subscri
                 }
               }),
             );
-            const stream = source.pipe(
-              Stream.catch((error) => Stream.make(failureStatus(topic, error))),
-            );
             const queue = yield* Queue.dropping<ViewServerLiveEvent<Row, Topic, Key>, Cause.Done>(
               normalizeSubscriptionBufferSize(subscriptionBufferSize),
             );
             yield* Scope.addFinalizer(scope, closeLifecycle);
             yield* lifecycle.onOpen;
-            yield* Stream.runForEach(stream, (event) =>
-              offerRemoteEvent(queue, event, overflowStatus, closeLifecycle, topic),
-            ).pipe(
+            const runSource = Effect.suspend(() =>
+              Stream.runForEach(source, (event) =>
+                offerRemoteEvent(queue, event, overflowStatus, closeLifecycle, topic),
+              ),
+            );
+            const producer =
+              retryWhile === undefined
+                ? runSource
+                : runSource.pipe(
+                    Effect.retry({
+                      schedule: Schedule.spaced("500 millis"),
+                      while: retryWhile,
+                    }),
+                  );
+            yield* producer.pipe(
+              Effect.catch((error) =>
+                offerRemoteEvent(
+                  queue,
+                  failureStatus(topic, error),
+                  overflowStatus,
+                  closeLifecycle,
+                  topic,
+                ),
+              ),
               Effect.onExit((exit) => completeQueueFromProducerExit(queue, exit)),
               Effect.forkIn(scope, { startImmediately: true }),
               ignoreRemoteSubscriptionStreamStartFailure,

--- a/packages/kafka/src/schema-registry-contract.test.ts
+++ b/packages/kafka/src/schema-registry-contract.test.ts
@@ -1431,4 +1431,48 @@ describe("Kafka Schema Registry Protobuf contracts", () => {
       });
     }),
   );
+
+  it.effect("preserves a trusted schema ID when the message-index suffix is malformed", () =>
+    Effect.gen(function* () {
+      const contracts = yield* resolveKafkaSchemaRegistryContracts(
+        [declaration()],
+        reader({
+          compatibility: { "orders-value": "FULL_TRANSITIVE" },
+          active: { "orders-value": [1] },
+          all: { "orders-value": [1] },
+          schemas: { "orders-value:1": schemaVersion(1, 41) },
+        }),
+      );
+      const contract = contracts[0];
+      if (contract === undefined) {
+        throw new Error("resolved contract missing");
+      }
+
+      expect(
+        validateKafkaSchemaRegistryFrame(contract, Uint8Array.from([0, 0, 0, 0, 41, 1])),
+      ).toStrictEqual({
+        _tag: "Mismatch",
+        reason: "frame",
+        schemaId: 41,
+        message:
+          "Confluent Schema Registry Protobuf frame contains a negative message-index count.",
+      });
+      expect(
+        validateKafkaSchemaRegistryFrame(contract, Uint8Array.from([0, 0, 0, 0, 99, 1])),
+      ).toStrictEqual({
+        _tag: "Mismatch",
+        reason: "schema",
+        schemaId: 99,
+        message: 'Schema ID 99 is not an active validated version of subject "orders-value".',
+      });
+      expect(
+        validateKafkaSchemaRegistryFrame(contract, Uint8Array.from([0, 0, 0, 0, 99])),
+      ).toStrictEqual({
+        _tag: "Mismatch",
+        reason: "schema",
+        schemaId: 99,
+        message: 'Schema ID 99 is not an active validated version of subject "orders-value".',
+      });
+    }),
+  );
 });

--- a/packages/kafka/src/schema-registry-contract.test.ts
+++ b/packages/kafka/src/schema-registry-contract.test.ts
@@ -191,11 +191,13 @@ describe("Kafka Schema Registry Protobuf contracts", () => {
       });
       expect(validateKafkaSchemaRegistryFrame(contract, frame(999, 0))).toStrictEqual({
         _tag: "Mismatch",
+        reason: "schema",
         schemaId: 999,
         message: 'Schema ID 999 is not an active validated version of subject "orders-value".',
       });
       expect(validateKafkaSchemaRegistryFrame(contract, frame(41, 1))).toStrictEqual({
         _tag: "Mismatch",
+        reason: "schema",
         schemaId: 41,
         message:
           'Schema ID 41 selected a protobuf message that does not match "viewserver.runtime.test.OrderValue".',
@@ -947,6 +949,7 @@ describe("Kafka Schema Registry Protobuf contracts", () => {
       });
       expect(validateKafkaSchemaRegistryFrame(contract, frame(42, 0))).toStrictEqual({
         _tag: "Mismatch",
+        reason: "schema",
         schemaId: 42,
         message:
           'Schema ID 42 selected a protobuf message that does not match "viewserver.runtime.test.OrderValue".',
@@ -1421,6 +1424,7 @@ describe("Kafka Schema Registry Protobuf contracts", () => {
 
       expect(validateKafkaSchemaRegistryFrame(contract, Uint8Array.from([]))).toStrictEqual({
         _tag: "Mismatch",
+        reason: "frame",
         schemaId: null,
         message:
           "Confluent Schema Registry Protobuf frame is shorter than its six-byte minimum prefix.",

--- a/packages/kafka/src/schema-registry-contract.ts
+++ b/packages/kafka/src/schema-registry-contract.ts
@@ -770,10 +770,18 @@ export const validateKafkaSchemaRegistryFrame = (
 ): KafkaSchemaRegistryFrameMismatch | KafkaSchemaRegistryValidatedFrame => {
   const frame = parseKafkaSchemaRegistryProtobufFrame(bytes);
   if (frame._tag === "KafkaSchemaRegistryFrameParseFailure") {
+    if (frame.schemaId !== null && !contract.schemaIds.has(frame.schemaId)) {
+      return {
+        _tag: "Mismatch",
+        reason: "schema",
+        schemaId: frame.schemaId,
+        message: `Schema ID ${String(frame.schemaId)} is not an active validated version of subject ${JSON.stringify(contract.subject)}.`,
+      };
+    }
     return {
       _tag: "Mismatch",
       reason: "frame",
-      schemaId: null,
+      schemaId: frame.schemaId,
       message: frame.message,
     };
   }

--- a/packages/kafka/src/schema-registry-contract.ts
+++ b/packages/kafka/src/schema-registry-contract.ts
@@ -753,6 +753,7 @@ export const resolveKafkaSchemaRegistryContracts = Effect.fn(
 
 export type KafkaSchemaRegistryFrameMismatch = {
   readonly _tag: "Mismatch";
+  readonly reason: "frame" | "schema";
   readonly schemaId: number | null;
   readonly message: string;
 };
@@ -771,6 +772,7 @@ export const validateKafkaSchemaRegistryFrame = (
   if (frame._tag === "KafkaSchemaRegistryFrameParseFailure") {
     return {
       _tag: "Mismatch",
+      reason: "frame",
       schemaId: null,
       message: frame.message,
     };
@@ -779,6 +781,7 @@ export const validateKafkaSchemaRegistryFrame = (
   if (allowed === undefined) {
     return {
       _tag: "Mismatch",
+      reason: "schema",
       schemaId: frame.schemaId,
       message: `Schema ID ${String(frame.schemaId)} is not an active validated version of subject ${JSON.stringify(contract.subject)}.`,
     };
@@ -786,6 +789,7 @@ export const validateKafkaSchemaRegistryFrame = (
   if (!allowed.some((indexes) => sameIndexes(indexes, frame.messageIndexes))) {
     return {
       _tag: "Mismatch",
+      reason: "schema",
       schemaId: frame.schemaId,
       message: `Schema ID ${String(frame.schemaId)} selected a protobuf message that does not match ${JSON.stringify(contract.descriptor.typeName)}.`,
     };

--- a/packages/kafka/src/schema-registry-frame-rejection.test.ts
+++ b/packages/kafka/src/schema-registry-frame-rejection.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "@effect/vitest";
-import { create, toBinary } from "@bufbuild/protobuf";
 import { ViewServerId, defineViewServerConfig } from "@effect-view-server/config";
 import { makeViewServerRuntimeCore } from "@effect-view-server/runtime-core";
 import { Deferred, Effect, Option, Schedule, Schema, Stream } from "effect";
-import { kafka, type KafkaAdapterFailure, type KafkaMessageMetadata } from "./contract";
+import { kafka, type KafkaAdapterFailure } from "./contract";
 import { parseKafkaSchemaRegistryProtobufFrame } from "./schema-registry-frame";
 import type { KafkaSchemaRegistryRecordDecodeFailure } from "./schema-registry-runtime";
 import { makeKafkaServerLayer, type KafkaServerRecord, type KafkaServerRegion } from "./server";
+import {
+  bytes,
+  foreverBrokerContract,
+  metadata,
+  schemaRegistryRecordPayloads,
+  valueFrame,
+} from "./test-fixtures/schema-registry";
 import { OrderValueSchema } from "./test-fixtures/orders_pb";
 
 const Order = Schema.Struct({
@@ -14,62 +20,6 @@ const Order = Schema.Struct({
   price: Schema.Number,
   region: Schema.String,
 });
-
-const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
-
-const schemaRegistryFrame = (schemaId: number, payload: Uint8Array): Uint8Array =>
-  Uint8Array.from([
-    0,
-    Math.floor(schemaId / 0x1_00_00_00) % 0x100,
-    Math.floor(schemaId / 0x1_00_00) % 0x100,
-    Math.floor(schemaId / 0x1_00) % 0x100,
-    schemaId % 0x100,
-    0,
-    ...payload,
-  ]);
-
-const schemaRegistryPayload = (frame: Uint8Array): Uint8Array => frame.slice(6);
-
-const schemaRegistryRecordPayloads = (input: {
-  readonly key: Uint8Array | null;
-  readonly value: Uint8Array | null;
-}) =>
-  Object.freeze({
-    key: input.key === null ? undefined : schemaRegistryPayload(input.key),
-    value: input.value === null ? undefined : schemaRegistryPayload(input.value),
-  });
-
-const metadata = (region: string, offset: bigint): KafkaMessageMetadata => ({
-  sourceTopic: "source-orders",
-  sourceRegion: region,
-  partition: 0,
-  offset,
-  timestampNanos: offset * 1_000_000n,
-  headers: {},
-});
-
-const foreverBrokerContract = (region: string) => ({
-  viewServerTopic: "orders",
-  sourceTopic: "source-orders",
-  region,
-  cleanupPolicy: "delete" as const,
-  retentionPolicy: { _tag: "Forever" as const },
-  observedCleanupPolicy: "delete" as const,
-  observedRetentionMs: -1n,
-  resolvedRetention: { _tag: "Forever" as const },
-});
-
-const valueFrame = (schemaId: number, price: number): Uint8Array =>
-  schemaRegistryFrame(
-    schemaId,
-    toBinary(
-      OrderValueSchema,
-      create(OrderValueSchema, {
-        customerId: `customer-${String(price)}`,
-        price,
-      }),
-    ),
-  );
 
 describe("schema registry frame rejection", () => {
   it.effect("rejects a malformed frame and still applies the following valid record", () =>
@@ -150,7 +100,7 @@ describe("schema registry frame rejection", () => {
           makeViewServerRuntimeCore(config, {}).pipe(
             Effect.provide(
               makeKafkaServerLayer({
-                brokerContracts: [foreverBrokerContract("eu")],
+                brokerContracts: [foreverBrokerContract("orders", "source-orders", "eu")],
                 retentionSweepIntervalNanos: 900_000_000_000n,
                 consumerGroupPrefix: "frame-rejection",
                 regions: new Map([["eu", region]]),
@@ -217,9 +167,7 @@ describe("schema registry frame rejection", () => {
         );
         const health = Option.getOrThrow(
           yield* diagnostics.events.pipe(
-            Stream.filter(
-              (value) => value.status._tag === "Degraded" || value.status._tag === "Exhausted",
-            ),
+            Stream.filter((value) => value.status._tag === "Degraded"),
             Stream.take(1),
             Stream.runHead,
             Effect.timeout("1 second"),
@@ -337,7 +285,7 @@ describe("schema registry frame rejection", () => {
           makeViewServerRuntimeCore(config, {}).pipe(
             Effect.provide(
               makeKafkaServerLayer({
-                brokerContracts: [foreverBrokerContract("eu")],
+                brokerContracts: [foreverBrokerContract("orders", "source-orders", "eu")],
                 retentionSweepIntervalNanos: 900_000_000_000n,
                 consumerGroupPrefix: "key-frame-rejection",
                 regions: new Map([["eu", region]]),
@@ -474,7 +422,7 @@ describe("schema registry frame rejection", () => {
           makeViewServerRuntimeCore(config, {}).pipe(
             Effect.provide(
               makeKafkaServerLayer({
-                brokerContracts: [foreverBrokerContract("eu")],
+                brokerContracts: [foreverBrokerContract("orders", "source-orders", "eu")],
                 retentionSweepIntervalNanos: 900_000_000_000n,
                 consumerGroupPrefix: "registry-infrastructure-failure",
                 regions: new Map([["eu", region]]),

--- a/packages/kafka/src/schema-registry-frame-rejection.test.ts
+++ b/packages/kafka/src/schema-registry-frame-rejection.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, it } from "@effect/vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { ViewServerId, defineViewServerConfig } from "@effect-view-server/config";
+import { makeViewServerRuntimeCore } from "@effect-view-server/runtime-core";
+import { Deferred, Effect, Option, Schedule, Schema, Stream } from "effect";
+import { kafka, type KafkaAdapterFailure, type KafkaMessageMetadata } from "./contract";
+import { parseKafkaSchemaRegistryProtobufFrame } from "./schema-registry-frame";
+import type { KafkaSchemaRegistryRecordDecodeFailure } from "./schema-registry-runtime";
+import { makeKafkaServerLayer, type KafkaServerRecord, type KafkaServerRegion } from "./server";
+import { OrderValueSchema } from "./test-fixtures/orders_pb";
+
+const Order = Schema.Struct({
+  id: ViewServerId,
+  price: Schema.Number,
+  region: Schema.String,
+});
+
+const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+const schemaRegistryFrame = (schemaId: number, payload: Uint8Array): Uint8Array =>
+  Uint8Array.from([
+    0,
+    Math.floor(schemaId / 0x1_00_00_00) % 0x100,
+    Math.floor(schemaId / 0x1_00_00) % 0x100,
+    Math.floor(schemaId / 0x1_00) % 0x100,
+    schemaId % 0x100,
+    0,
+    ...payload,
+  ]);
+
+const schemaRegistryPayload = (frame: Uint8Array): Uint8Array => frame.slice(6);
+
+const schemaRegistryRecordPayloads = (input: {
+  readonly key: Uint8Array | null;
+  readonly value: Uint8Array | null;
+}) =>
+  Object.freeze({
+    key: input.key === null ? undefined : schemaRegistryPayload(input.key),
+    value: input.value === null ? undefined : schemaRegistryPayload(input.value),
+  });
+
+const metadata = (region: string, offset: bigint): KafkaMessageMetadata => ({
+  sourceTopic: "source-orders",
+  sourceRegion: region,
+  partition: 0,
+  offset,
+  timestampNanos: offset * 1_000_000n,
+  headers: {},
+});
+
+const foreverBrokerContract = (region: string) => ({
+  viewServerTopic: "orders",
+  sourceTopic: "source-orders",
+  region,
+  cleanupPolicy: "delete" as const,
+  retentionPolicy: { _tag: "Forever" as const },
+  observedCleanupPolicy: "delete" as const,
+  observedRetentionMs: -1n,
+  resolvedRetention: { _tag: "Forever" as const },
+});
+
+const valueFrame = (schemaId: number, price: number): Uint8Array =>
+  schemaRegistryFrame(
+    schemaId,
+    toBinary(
+      OrderValueSchema,
+      create(OrderValueSchema, {
+        customerId: `customer-${String(price)}`,
+        price,
+      }),
+    ),
+  );
+
+describe("schema registry frame rejection", () => {
+  it.effect("rejects a malformed frame and still applies the following valid record", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settlements: Array<bigint> = [];
+        let rejections = 0;
+        const records: ReadonlyArray<KafkaServerRecord> = [
+          {
+            key: bytes("poison"),
+            value: bytes("this is not a schema registry frame"),
+            metadata: metadata("eu", 1n),
+            settlement: () =>
+              Effect.sync(() => {
+                settlements.push(1n);
+              }),
+          },
+          {
+            key: bytes("order-2"),
+            value: valueFrame(42, 2),
+            metadata: metadata("eu", 2n),
+            settlement: () =>
+              Effect.sync(() => {
+                settlements.push(2n);
+              }),
+          },
+        ];
+        const region: KafkaServerRegion = {
+          acquire: () =>
+            Effect.succeed({
+              records: Stream.fromIterable(records).pipe(Stream.concat(Stream.never)),
+              recordDecoded: Effect.void,
+              recordDecodeFailure: Effect.void,
+              recordMapped: Effect.void,
+              recordMappingFailure: Effect.void,
+              recordRejection: Effect.sync(() => {
+                rejections += 1;
+              }),
+            }),
+          metrics: () =>
+            Effect.succeed({
+              region: "eu",
+              assignments: [],
+              commits: 0n,
+              commitFailures: 0n,
+              decoded: 0n,
+              decodeFailures: 0n,
+              mapped: 0n,
+              mappingFailures: 0n,
+              rejections: 0n,
+              reconnects: 0n,
+              rebalances: 0n,
+              closes: 0n,
+              closeFailures: 0n,
+            }),
+        };
+        const source = kafka.source(
+          {
+            cleanupPolicy: "delete",
+            retentionPolicy: "Infinity",
+            topic: "source-orders",
+            regions: ["eu"],
+            key: kafka.string(),
+            value: kafka.schemaRegistry.protobuf(OrderValueSchema),
+            localRowKey: ({ key }) => key,
+            map: ({ value, region: sourceRegion }) => ({
+              price: value.price,
+              region: String(sourceRegion),
+            }),
+            startFrom: "earliest",
+          },
+          Schedule.recurs(0),
+        );
+        const config = defineViewServerConfig({
+          topics: { orders: { schema: Order, source } },
+        });
+        const runtime = yield* Effect.acquireRelease(
+          makeViewServerRuntimeCore(config, {}).pipe(
+            Effect.provide(
+              makeKafkaServerLayer({
+                brokerContracts: [foreverBrokerContract("eu")],
+                retentionSweepIntervalNanos: 900_000_000_000n,
+                consumerGroupPrefix: "frame-rejection",
+                regions: new Map([["eu", region]]),
+                schemaRegistries: new Map([
+                  [
+                    "eu",
+                    {
+                      endpoints: ["https://registry.eu.example.com"],
+                      retain: () => Effect.void,
+                      guard: () => Effect.void,
+                      failures: () => Stream.empty,
+                      validateRecord: (input) => {
+                        const value = input.value;
+                        if (value !== null && value !== undefined) {
+                          const frame = parseKafkaSchemaRegistryProtobufFrame(value);
+                          if (frame._tag === "KafkaSchemaRegistryFrameParseFailure") {
+                            return Effect.fail<KafkaSchemaRegistryRecordDecodeFailure>({
+                              _tag: "KafkaSchemaRegistryRecordDecodeFailure",
+                              side: "value",
+                              failure: {
+                                _tag: "KafkaDecodeFailure",
+                                region: "eu",
+                                topic: "source-orders",
+                                message: frame.message,
+                              },
+                            });
+                          }
+                        }
+                        return Effect.succeed(schemaRegistryRecordPayloads(input));
+                      },
+                    },
+                  ],
+                ]),
+              }),
+            ),
+          ),
+          (activeRuntime) => activeRuntime.close,
+        );
+
+        const diagnostics = yield* Effect.acquireRelease(
+          runtime.liveClient.subscribeSourceHealth({ topic: "orders" }),
+          (activeDiagnostics) => activeDiagnostics.close().pipe(Effect.ignore),
+        );
+        const subscription = yield* Effect.acquireRelease(
+          runtime.liveClient.subscribe("orders", {
+            select: ["id", "price"],
+            limit: 10,
+          }),
+          (activeSubscription) => activeSubscription.close().pipe(Effect.ignore),
+        );
+
+        const rowApplied = subscription.events.pipe(
+          Stream.filter(
+            (event) =>
+              (event.type === "snapshot" && event.rows.some((row) => row.id === "eu:0:order-2")) ||
+              (event.type === "delta" &&
+                event.operations.some(
+                  (operation) => operation.type === "insert" && operation.key === "eu:0:order-2",
+                )),
+          ),
+          Stream.take(1),
+          Stream.runHead,
+          Effect.as("row-applied" as const),
+        );
+        const health = Option.getOrThrow(
+          yield* diagnostics.events.pipe(
+            Stream.filter(
+              (value) => value.status._tag === "Degraded" || value.status._tag === "Exhausted",
+            ),
+            Stream.take(1),
+            Stream.runHead,
+            Effect.timeout("1 second"),
+          ),
+        );
+        const degraded = Option.getOrThrow(
+          Option.liftPredicate(health.status, (status) => status._tag === "Degraded"),
+        );
+        const rejection = Option.getOrThrow(
+          Option.liftPredicate(
+            degraded.reasons[0],
+            (reason) => reason._tag === "SourceItemRejection",
+          ),
+        );
+        const outcome = yield* rowApplied.pipe(Effect.timeout("1 second"));
+
+        expect({
+          outcome,
+          rejections,
+          settlements,
+          latestRejection: rejection.latestRejection,
+        }).toStrictEqual({
+          outcome: "row-applied",
+          rejections: 1,
+          settlements: [1n, 2n],
+          latestRejection: {
+            failure: {
+              _tag: "AdapterFailure",
+              failure: {
+                _tag: "KafkaDecodeFailure",
+                region: "eu",
+                topic: "source-orders",
+                message:
+                  "Confluent Schema Registry Protobuf frame uses unsupported payload-prefix version 116.",
+              },
+            },
+            location: {
+              region: "eu",
+              topic: "source-orders",
+              partition: 0,
+              offset: 1n,
+              phase: "valueDecode",
+              message:
+                "Confluent Schema Registry Protobuf frame uses unsupported payload-prefix version 116.",
+            },
+            rejectedAtNanos: 0n,
+          },
+        });
+      }),
+    ),
+  );
+
+  it.effect("reports a malformed registry-backed key as a key decode rejection", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settlements: Array<bigint> = [];
+        const settled = yield* Deferred.make<void>();
+        const malformedRecord: KafkaServerRecord = {
+          key: bytes("malformed registry key"),
+          value: valueFrame(42, 1),
+          metadata: metadata("eu", 1n),
+          settlement: () =>
+            Effect.sync(() => {
+              settlements.push(1n);
+            }).pipe(Effect.andThen(Deferred.succeed(settled, undefined))),
+        };
+        const region: KafkaServerRegion = {
+          acquire: () =>
+            Effect.succeed({
+              records: Stream.make(malformedRecord).pipe(Stream.concat(Stream.never)),
+              recordDecoded: Effect.void,
+              recordDecodeFailure: Effect.void,
+              recordMapped: Effect.void,
+              recordMappingFailure: Effect.void,
+              recordRejection: Effect.void,
+            }),
+          metrics: () =>
+            Effect.succeed({
+              region: "eu",
+              assignments: [],
+              commits: 0n,
+              commitFailures: 0n,
+              decoded: 0n,
+              decodeFailures: 0n,
+              mapped: 0n,
+              mappingFailures: 0n,
+              rejections: 0n,
+              reconnects: 0n,
+              rebalances: 0n,
+              closes: 0n,
+              closeFailures: 0n,
+            }),
+        };
+        const source = kafka.source(
+          {
+            cleanupPolicy: "delete",
+            retentionPolicy: "Infinity",
+            topic: "source-orders",
+            regions: ["eu"],
+            key: kafka.schemaRegistry.protobuf(OrderValueSchema),
+            value: kafka.schemaRegistry.protobuf(OrderValueSchema),
+            localRowKey: ({ key }) => key.customerId,
+            map: ({ value, region: sourceRegion }) => ({
+              price: value.price,
+              region: String(sourceRegion),
+            }),
+            startFrom: "earliest",
+          },
+          Schedule.recurs(0),
+        );
+        const config = defineViewServerConfig({
+          topics: { orders: { schema: Order, source } },
+        });
+        const runtime = yield* Effect.acquireRelease(
+          makeViewServerRuntimeCore(config, {}).pipe(
+            Effect.provide(
+              makeKafkaServerLayer({
+                brokerContracts: [foreverBrokerContract("eu")],
+                retentionSweepIntervalNanos: 900_000_000_000n,
+                consumerGroupPrefix: "key-frame-rejection",
+                regions: new Map([["eu", region]]),
+                schemaRegistries: new Map([
+                  [
+                    "eu",
+                    {
+                      endpoints: ["https://registry.eu.example.com"],
+                      retain: () => Effect.void,
+                      guard: () => Effect.void,
+                      failures: () => Stream.empty,
+                      validateRecord: (input) => {
+                        const key = input.key;
+                        if (key !== null && key !== undefined) {
+                          const frame = parseKafkaSchemaRegistryProtobufFrame(key);
+                          if (frame._tag === "KafkaSchemaRegistryFrameParseFailure") {
+                            return Effect.fail<KafkaSchemaRegistryRecordDecodeFailure>({
+                              _tag: "KafkaSchemaRegistryRecordDecodeFailure",
+                              side: "key",
+                              failure: {
+                                _tag: "KafkaDecodeFailure",
+                                region: "eu",
+                                topic: "source-orders",
+                                message: frame.message,
+                              },
+                            });
+                          }
+                        }
+                        return Effect.succeed(schemaRegistryRecordPayloads(input));
+                      },
+                    },
+                  ],
+                ]),
+              }),
+            ),
+          ),
+          (activeRuntime) => activeRuntime.close,
+        );
+        const diagnostics = yield* Effect.acquireRelease(
+          runtime.liveClient.subscribeSourceHealth({ topic: "orders" }),
+          (activeDiagnostics) => activeDiagnostics.close().pipe(Effect.ignore),
+        );
+        const health = Option.getOrThrow(
+          yield* diagnostics.events.pipe(
+            Stream.filter((value) => value.status._tag === "Degraded"),
+            Stream.take(1),
+            Stream.runHead,
+            Effect.timeout("1 second"),
+          ),
+        );
+        const degraded = Option.getOrThrow(
+          Option.liftPredicate(health.status, (status) => status._tag === "Degraded"),
+        );
+        const rejection = Option.getOrThrow(
+          Option.liftPredicate(
+            degraded.reasons[0],
+            (reason) => reason._tag === "SourceItemRejection",
+          ),
+        );
+        yield* Deferred.await(settled);
+
+        expect({ phase: rejection.latestRejection.location.phase, settlements }).toStrictEqual({
+          phase: "keyDecode",
+          settlements: [1n],
+        });
+      }),
+    ),
+  );
+
+  it.effect("keeps registry infrastructure failures at the Source Attempt level", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settlements: Array<bigint> = [];
+        let rejections = 0;
+        const record: KafkaServerRecord = {
+          key: bytes("order-1"),
+          value: valueFrame(42, 1),
+          metadata: metadata("eu", 1n),
+          settlement: () =>
+            Effect.sync(() => {
+              settlements.push(1n);
+            }),
+        };
+        const region: KafkaServerRegion = {
+          acquire: () =>
+            Effect.succeed({
+              records: Stream.make(record).pipe(Stream.concat(Stream.never)),
+              recordDecoded: Effect.void,
+              recordDecodeFailure: Effect.void,
+              recordMapped: Effect.void,
+              recordMappingFailure: Effect.void,
+              recordRejection: Effect.sync(() => {
+                rejections += 1;
+              }),
+            }),
+          metrics: () =>
+            Effect.succeed({
+              region: "eu",
+              assignments: [],
+              commits: 0n,
+              commitFailures: 0n,
+              decoded: 0n,
+              decodeFailures: 0n,
+              mapped: 0n,
+              mappingFailures: 0n,
+              rejections: 0n,
+              reconnects: 0n,
+              rebalances: 0n,
+              closes: 0n,
+              closeFailures: 0n,
+            }),
+        };
+        const source = kafka.source(
+          {
+            cleanupPolicy: "delete",
+            retentionPolicy: "Infinity",
+            topic: "source-orders",
+            regions: ["eu"],
+            key: kafka.string(),
+            value: kafka.schemaRegistry.protobuf(OrderValueSchema),
+            localRowKey: ({ key }) => key,
+            map: ({ value, region: sourceRegion }) => ({
+              price: value.price,
+              region: String(sourceRegion),
+            }),
+            startFrom: "earliest",
+          },
+          Schedule.recurs(0),
+        );
+        const config = defineViewServerConfig({
+          topics: { orders: { schema: Order, source } },
+        });
+        const runtime = yield* Effect.acquireRelease(
+          makeViewServerRuntimeCore(config, {}).pipe(
+            Effect.provide(
+              makeKafkaServerLayer({
+                brokerContracts: [foreverBrokerContract("eu")],
+                retentionSweepIntervalNanos: 900_000_000_000n,
+                consumerGroupPrefix: "registry-infrastructure-failure",
+                regions: new Map([["eu", region]]),
+                schemaRegistries: new Map([
+                  [
+                    "eu",
+                    {
+                      endpoints: ["https://registry.eu.example.com"],
+                      retain: () => Effect.void,
+                      guard: () => Effect.void,
+                      failures: () => Stream.empty,
+                      validateRecord: () =>
+                        Effect.fail<
+                          Extract<
+                            KafkaAdapterFailure,
+                            { readonly _tag: "KafkaSchemaRegistryUnavailable" }
+                          >
+                        >({
+                          _tag: "KafkaSchemaRegistryUnavailable",
+                          region: "eu",
+                          topic: "source-orders",
+                          subject: "source-orders-value",
+                          side: "value",
+                          schemaId: null,
+                          message: "Schema Registry is unavailable.",
+                        }),
+                    },
+                  ],
+                ]),
+              }),
+            ),
+          ),
+          (activeRuntime) => activeRuntime.close,
+        );
+        const diagnostics = yield* Effect.acquireRelease(
+          runtime.liveClient.subscribeSourceHealth({ topic: "orders" }),
+          (activeDiagnostics) => activeDiagnostics.close().pipe(Effect.ignore),
+        );
+        const health = Option.getOrThrow(
+          yield* diagnostics.events.pipe(
+            Stream.filter((value) => value.status._tag === "Exhausted"),
+            Stream.take(1),
+            Stream.runHead,
+            Effect.timeout("1 second"),
+          ),
+        );
+
+        expect({ status: health.status._tag, rejections, settlements }).toStrictEqual({
+          status: "Exhausted",
+          rejections: 0,
+          settlements: [],
+        });
+      }),
+    ),
+  );
+});

--- a/packages/kafka/src/schema-registry-frame.test.ts
+++ b/packages/kafka/src/schema-registry-frame.test.ts
@@ -16,6 +16,7 @@ describe("Confluent Schema Registry Protobuf framing", () => {
   it("reports every malformed frame shape at the parser boundary", () => {
     const malformedFrames = [
       Uint8Array.from([]),
+      Uint8Array.from([0, 0, 0, 0, 99]),
       Uint8Array.from([1, 0, 0, 0, 42, 0]),
       Uint8Array.from([0, 0, 0, 0, 42, 0x80]),
       Uint8Array.from([0, 0, 0, 0, 42, 2]),
@@ -33,63 +34,82 @@ describe("Confluent Schema Registry Protobuf framing", () => {
     expect(malformedFrames.map(parseKafkaSchemaRegistryProtobufFrame)).toStrictEqual([
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: null,
         message:
           "Confluent Schema Registry Protobuf frame is shorter than its six-byte minimum prefix.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 99,
+        message:
+          "Confluent Schema Registry Protobuf frame is shorter than its six-byte minimum prefix.",
+      },
+      {
+        _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: null,
         message:
           "Confluent Schema Registry Protobuf frame uses unsupported payload-prefix version 1.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame contains a truncated message-index varint.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame declares more message indexes than the payload contains.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message: "Confluent Schema Registry Protobuf frame contains a negative message index.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: null,
         message: "Confluent Schema Registry Protobuf frame contains an invalid schema ID.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: null,
         message: "Confluent Schema Registry Protobuf frame contains an invalid schema ID.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame contains an overflowing message-index varint.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame contains a message-index varint longer than five bytes.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame contains a negative message-index count.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame declares more message indexes than the payload contains.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame contains a truncated message-index varint.",
       },
       {
         _tag: "KafkaSchemaRegistryFrameParseFailure",
+        schemaId: 42,
         message:
           "Confluent Schema Registry Protobuf frame contains an overflowing message-index varint.",
       },

--- a/packages/kafka/src/schema-registry-frame.ts
+++ b/packages/kafka/src/schema-registry-frame.ts
@@ -7,6 +7,7 @@ export type KafkaSchemaRegistryProtobufFrame = {
 
 export type KafkaSchemaRegistryFrameParseFailure = {
   readonly _tag: "KafkaSchemaRegistryFrameParseFailure";
+  readonly schemaId: number | null;
   readonly message: string;
 };
 
@@ -22,14 +23,19 @@ type SignedVarint = {
 
 const defaultMessageIndexes: readonly [number] = Object.freeze([0]);
 
-const frameFailure = (message: string): KafkaSchemaRegistryFrameParseFailure => ({
+const frameFailure = (
+  message: string,
+  schemaId: number | null = null,
+): KafkaSchemaRegistryFrameParseFailure => ({
   _tag: "KafkaSchemaRegistryFrameParseFailure",
+  schemaId,
   message: `Confluent Schema Registry Protobuf frame ${message}`,
 });
 
 const readSignedVarint = (
   bytes: Uint8Array,
   offset: number,
+  schemaId: number,
 ): SignedVarint | KafkaSchemaRegistryFrameParseFailure => {
   let raw = 0;
   let multiplier = 1;
@@ -37,12 +43,12 @@ const readSignedVarint = (
     const nextOffset = offset + index;
     const byte = bytes[nextOffset];
     if (byte === undefined) {
-      return frameFailure("contains a truncated message-index varint.");
+      return frameFailure("contains a truncated message-index varint.", schemaId);
     }
     raw += (byte & 0x7f) * multiplier;
     if ((byte & 0x80) === 0) {
       if (raw > 0xff_ff_ff_ff) {
-        return frameFailure("contains an overflowing message-index varint.");
+        return frameFailure("contains an overflowing message-index varint.", schemaId);
       }
       return {
         _tag: "SignedVarint",
@@ -52,13 +58,13 @@ const readSignedVarint = (
     }
     multiplier *= 128;
   }
-  return frameFailure("contains a message-index varint longer than five bytes.");
+  return frameFailure("contains a message-index varint longer than five bytes.", schemaId);
 };
 
 export const parseKafkaSchemaRegistryProtobufFrame = (
   bytes: Uint8Array,
 ): KafkaSchemaRegistryFrameParseResult => {
-  if (bytes.byteLength < 6) {
+  if (bytes.byteLength < 5) {
     return frameFailure("is shorter than its six-byte minimum prefix.");
   }
   if (bytes[0] !== 0) {
@@ -72,7 +78,10 @@ export const parseKafkaSchemaRegistryProtobufFrame = (
   if (schemaId <= 0 || schemaId > 0x7f_ff_ff_ff) {
     return frameFailure("contains an invalid schema ID.");
   }
-  const size = readSignedVarint(bytes, 5);
+  if (bytes.byteLength < 6) {
+    return frameFailure("is shorter than its six-byte minimum prefix.", schemaId);
+  }
+  const size = readSignedVarint(bytes, 5, schemaId);
   if (size._tag === "KafkaSchemaRegistryFrameParseFailure") {
     return size;
   }
@@ -85,22 +94,22 @@ export const parseKafkaSchemaRegistryProtobufFrame = (
     };
   }
   if (size.value < 0) {
-    return frameFailure("contains a negative message-index count.");
+    return frameFailure("contains a negative message-index count.", schemaId);
   }
   if (size.value > bytes.byteLength - size.nextOffset) {
-    return frameFailure("declares more message indexes than the payload contains.");
+    return frameFailure("declares more message indexes than the payload contains.", schemaId);
   }
 
   let firstMessageIndex = 0;
   const remainingMessageIndexes: Array<number> = [];
   let offset = size.nextOffset;
   for (let index = 0; index < size.value; index += 1) {
-    const messageIndex = readSignedVarint(bytes, offset);
+    const messageIndex = readSignedVarint(bytes, offset, schemaId);
     if (messageIndex._tag === "KafkaSchemaRegistryFrameParseFailure") {
       return messageIndex;
     }
     if (messageIndex.value < 0) {
-      return frameFailure("contains a negative message index.");
+      return frameFailure("contains a negative message index.", schemaId);
     }
     if (index === 0) {
       firstMessageIndex = messageIndex.value;

--- a/packages/kafka/src/schema-registry-runtime.test.ts
+++ b/packages/kafka/src/schema-registry-runtime.test.ts
@@ -258,6 +258,52 @@ describe("Kafka Schema Registry Region runtime", () => {
     ),
   );
 
+  it.effect("prioritizes an attempt-level schema failure over a malformed sibling frame", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const key = mutableSubject("source-orders-key", 40);
+        const value = mutableSubject("source-orders-value", 41);
+        const runtime = yield* makeKafkaSchemaRegistryRuntime({
+          region: "eu",
+          endpoint: "https://registry.eu.example.com",
+          declarations: [
+            declaration("orders", "source-orders", "key"),
+            declaration("orders", "source-orders"),
+          ],
+          reader: mutableReader(
+            new Map([
+              ["source-orders-key", key],
+              ["source-orders-value", value],
+            ]),
+            { compatibility: 0, versions: 0, schemas: 0 },
+          ),
+          monitorInterval: Duration.seconds(1),
+        });
+
+        expect(
+          yield* runtime
+            .validateRecord({
+              viewServerTopic: "orders",
+              sourceTopic: "source-orders",
+              sides: ["key", "value"],
+              key: Uint8Array.from([]),
+              value: frame(99),
+            })
+            .pipe(Effect.flip),
+        ).toStrictEqual({
+          _tag: "KafkaSchemaRegistrySchemaMismatch",
+          region: "eu",
+          topic: "source-orders",
+          subject: "source-orders-value",
+          side: "value",
+          schemaId: 99,
+          message:
+            'Schema ID 99 is not an active validated version of subject "source-orders-value".',
+        });
+      }),
+    ),
+  );
+
   it.effect("groups key and value contracts for one View Server Topic", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/kafka/src/schema-registry-runtime.test.ts
+++ b/packages/kafka/src/schema-registry-runtime.test.ts
@@ -220,6 +220,44 @@ describe("Kafka Schema Registry server lifetime", () => {
 });
 
 describe("Kafka Schema Registry Region runtime", () => {
+  it.effect("classifies a malformed record frame as an item-local decode failure", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const orders = mutableSubject("source-orders-value", 41);
+        const runtime = yield* makeKafkaSchemaRegistryRuntime({
+          region: "eu",
+          endpoint: "https://registry.eu.example.com",
+          declarations: [declaration("orders", "source-orders")],
+          reader: mutableReader(new Map([["source-orders-value", orders]]), {
+            compatibility: 0,
+            versions: 0,
+            schemas: 0,
+          }),
+          monitorInterval: Duration.seconds(1),
+        });
+
+        expect(
+          yield* validateSide(runtime, {
+            viewServerTopic: "orders",
+            sourceTopic: "source-orders",
+            side: "value",
+            bytes: Uint8Array.from([]),
+          }).pipe(Effect.flip),
+        ).toStrictEqual({
+          _tag: "KafkaSchemaRegistryRecordDecodeFailure",
+          side: "value",
+          failure: {
+            _tag: "KafkaDecodeFailure",
+            region: "eu",
+            topic: "source-orders",
+            message:
+              "Confluent Schema Registry Protobuf frame is shorter than its six-byte minimum prefix.",
+          },
+        });
+      }),
+    ),
+  );
+
   it.effect("groups key and value contracts for one View Server Topic", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/kafka/src/schema-registry-runtime.test.ts
+++ b/packages/kafka/src/schema-registry-runtime.test.ts
@@ -241,7 +241,7 @@ describe("Kafka Schema Registry Region runtime", () => {
             viewServerTopic: "orders",
             sourceTopic: "source-orders",
             side: "value",
-            bytes: Uint8Array.from([]),
+            bytes: Uint8Array.from([0, 0, 0, 0, 41, 1]),
           }).pipe(Effect.flip),
         ).toStrictEqual({
           _tag: "KafkaSchemaRegistryRecordDecodeFailure",
@@ -251,8 +251,45 @@ describe("Kafka Schema Registry Region runtime", () => {
             region: "eu",
             topic: "source-orders",
             message:
-              "Confluent Schema Registry Protobuf frame is shorter than its six-byte minimum prefix.",
+              "Confluent Schema Registry Protobuf frame contains a negative message-index count.",
           },
+        });
+      }),
+    ),
+  );
+
+  it.effect("prioritizes an unknown trusted schema ID when the frame suffix is missing", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const orders = mutableSubject("source-orders-value", 41);
+        const runtime = yield* makeKafkaSchemaRegistryRuntime({
+          region: "eu",
+          endpoint: "https://registry.eu.example.com",
+          declarations: [declaration("orders", "source-orders")],
+          reader: mutableReader(new Map([["source-orders-value", orders]]), {
+            compatibility: 0,
+            versions: 0,
+            schemas: 0,
+          }),
+          monitorInterval: Duration.seconds(1),
+        });
+
+        expect(
+          yield* validateSide(runtime, {
+            viewServerTopic: "orders",
+            sourceTopic: "source-orders",
+            side: "value",
+            bytes: Uint8Array.from([0, 0, 0, 0, 99]),
+          }).pipe(Effect.flip),
+        ).toStrictEqual({
+          _tag: "KafkaSchemaRegistrySchemaMismatch",
+          region: "eu",
+          topic: "source-orders",
+          subject: "source-orders-value",
+          side: "value",
+          schemaId: 99,
+          message:
+            'Schema ID 99 is not an active validated version of subject "source-orders-value".',
         });
       }),
     ),

--- a/packages/kafka/src/schema-registry-runtime.ts
+++ b/packages/kafka/src/schema-registry-runtime.ts
@@ -57,10 +57,10 @@ export type KafkaSchemaRegistryRuntime = {
   readonly endpoints: ReadonlyArray<string>;
   readonly guard: (
     input: KafkaSchemaRegistryBindingInput,
-  ) => Effect.Effect<void, KafkaAdapterFailure>;
+  ) => Effect.Effect<void, KafkaSchemaRegistryAttemptFailure>;
   readonly failures: (
     input: KafkaSchemaRegistryBindingInput,
-  ) => Stream.Stream<never, KafkaAdapterFailure>;
+  ) => Stream.Stream<never, KafkaSchemaRegistryAttemptFailure>;
   readonly validateRecord: (
     input: KafkaSchemaRegistryRecordValidationInput,
   ) => Effect.Effect<KafkaSchemaRegistryRecordPayloads, KafkaSchemaRegistryRecordValidationFailure>;
@@ -306,6 +306,7 @@ function validateRecordState(
   let key: Uint8Array | undefined;
   let value: Uint8Array | undefined;
   let requiresRefresh = false;
+  let recordDecodeFailure: KafkaSchemaRegistryRecordDecodeFailure | undefined;
   for (const side of input.sides) {
     const bytes = side === "key" ? input.key : input.value;
     if (bytes === null) {
@@ -324,19 +325,17 @@ function validateRecordState(
     const result = validateKafkaSchemaRegistryFrame(contract, bytes);
     if (result._tag === "Mismatch") {
       if (result.reason === "frame") {
-        return {
-          _tag: "Failure",
+        recordDecodeFailure ??= {
+          _tag: "KafkaSchemaRegistryRecordDecodeFailure",
+          side,
           failure: {
-            _tag: "KafkaSchemaRegistryRecordDecodeFailure",
-            side,
-            failure: {
-              _tag: "KafkaDecodeFailure",
-              region,
-              topic: input.sourceTopic,
-              message: result.message,
-            },
+            _tag: "KafkaDecodeFailure",
+            region,
+            topic: input.sourceTopic,
+            message: result.message,
           },
         };
+        continue;
       }
       if (
         refreshUnknownIds &&
@@ -365,12 +364,16 @@ function validateRecordState(
       value = result.payload;
     }
   }
-  return requiresRefresh
-    ? { _tag: "Refresh" }
-    : {
-        _tag: "Success",
-        payloads: Object.freeze({ key, value }),
-      };
+  if (requiresRefresh) {
+    return { _tag: "Refresh" };
+  }
+  if (recordDecodeFailure !== undefined) {
+    return { _tag: "Failure", failure: recordDecodeFailure };
+  }
+  return {
+    _tag: "Success",
+    payloads: Object.freeze({ key, value }),
+  };
 }
 
 export const makeKafkaSchemaRegistryRuntime = Effect.fn("KafkaSchemaRegistryRuntime.make")(
@@ -459,7 +462,7 @@ export const makeKafkaSchemaRegistryRuntime = Effect.fn("KafkaSchemaRegistryRunt
 
     const guard = (
       binding: KafkaSchemaRegistryBindingInput,
-    ): Effect.Effect<void, KafkaAdapterFailure> =>
+    ): Effect.Effect<void, KafkaSchemaRegistryAttemptFailure> =>
       SubscriptionRef.get(state).pipe(
         Effect.flatMap((current) => {
           const failure = bindingFailure(current, binding);
@@ -468,7 +471,7 @@ export const makeKafkaSchemaRegistryRuntime = Effect.fn("KafkaSchemaRegistryRunt
       );
     const failures = (
       binding: KafkaSchemaRegistryBindingInput,
-    ): Stream.Stream<never, KafkaAdapterFailure> =>
+    ): Stream.Stream<never, KafkaSchemaRegistryAttemptFailure> =>
       SubscriptionRef.changes(state).pipe(
         Stream.mapEffect((current) => {
           const failure = bindingFailure(current, binding);

--- a/packages/kafka/src/schema-registry-runtime.ts
+++ b/packages/kafka/src/schema-registry-runtime.ts
@@ -38,6 +38,21 @@ export type KafkaSchemaRegistryRecordPayloads = {
   readonly value: Uint8Array | undefined;
 };
 
+export type KafkaSchemaRegistryRecordDecodeFailure = {
+  readonly _tag: "KafkaSchemaRegistryRecordDecodeFailure";
+  readonly side: KafkaSchemaRegistrySide;
+  readonly failure: Extract<KafkaAdapterFailure, { readonly _tag: "KafkaDecodeFailure" }>;
+};
+
+type KafkaSchemaRegistryAttemptFailure = Exclude<
+  KafkaAdapterFailure,
+  { readonly _tag: "KafkaDecodeFailure" }
+>;
+
+export type KafkaSchemaRegistryRecordValidationFailure =
+  | KafkaSchemaRegistryAttemptFailure
+  | KafkaSchemaRegistryRecordDecodeFailure;
+
 export type KafkaSchemaRegistryRuntime = {
   readonly endpoints: ReadonlyArray<string>;
   readonly guard: (
@@ -48,7 +63,7 @@ export type KafkaSchemaRegistryRuntime = {
   ) => Stream.Stream<never, KafkaAdapterFailure>;
   readonly validateRecord: (
     input: KafkaSchemaRegistryRecordValidationInput,
-  ) => Effect.Effect<KafkaSchemaRegistryRecordPayloads, KafkaAdapterFailure>;
+  ) => Effect.Effect<KafkaSchemaRegistryRecordPayloads, KafkaSchemaRegistryRecordValidationFailure>;
 };
 
 export type KafkaServerSchemaRegistry = KafkaSchemaRegistryRuntime & {
@@ -140,10 +155,15 @@ type RegistryState = {
     string,
     ReadonlyMap<KafkaSchemaRegistrySide, KafkaResolvedSchemaRegistryContract>
   >;
-  readonly failures: ReadonlyMap<string, ReadonlyMap<KafkaSchemaRegistrySide, KafkaAdapterFailure>>;
+  readonly failures: ReadonlyMap<
+    string,
+    ReadonlyMap<KafkaSchemaRegistrySide, KafkaSchemaRegistryAttemptFailure>
+  >;
 };
 
-const runtimeFailure = (issue: KafkaSchemaRegistryContractIssue): KafkaAdapterFailure => ({
+const runtimeFailure = (
+  issue: KafkaSchemaRegistryContractIssue,
+): KafkaSchemaRegistryAttemptFailure => ({
   _tag:
     issue.code === "RegistryUnavailable"
       ? "KafkaSchemaRegistryUnavailable"
@@ -176,7 +196,10 @@ const contractsByTopic = (
 const failuresByTopic = (
   issues: ReadonlyArray<KafkaSchemaRegistryContractIssue>,
 ): RegistryState["failures"] => {
-  const failures = new Map<string, Map<KafkaSchemaRegistrySide, KafkaAdapterFailure>>();
+  const failures = new Map<
+    string,
+    Map<KafkaSchemaRegistrySide, KafkaSchemaRegistryAttemptFailure>
+  >();
   for (const contractIssue of issues) {
     const sides = failures.get(contractIssue.viewServerTopic) ?? new Map();
     sides.set(contractIssue.side, runtimeFailure(contractIssue));
@@ -188,7 +211,10 @@ const failuresByTopic = (
 const monitorFailures = (
   declarations: ReadonlyArray<KafkaSchemaRegistryDeclaration>,
 ): RegistryState["failures"] => {
-  const failures = new Map<string, Map<KafkaSchemaRegistrySide, KafkaAdapterFailure>>();
+  const failures = new Map<
+    string,
+    Map<KafkaSchemaRegistrySide, KafkaSchemaRegistryAttemptFailure>
+  >();
   for (const declaration of declarations) {
     const sides = failures.get(declaration.viewServerTopic) ?? new Map();
     sides.set(declaration.side, monitorFailure(declaration));
@@ -197,7 +223,9 @@ const monitorFailures = (
   return failures;
 };
 
-const monitorFailure = (declaration: KafkaSchemaRegistryDeclaration): KafkaAdapterFailure => ({
+const monitorFailure = (
+  declaration: KafkaSchemaRegistryDeclaration,
+): KafkaSchemaRegistryAttemptFailure => ({
   _tag: "KafkaSchemaRegistryUnavailable",
   region: declaration.region,
   topic: declaration.sourceTopic,
@@ -210,7 +238,7 @@ const monitorFailure = (declaration: KafkaSchemaRegistryDeclaration): KafkaAdapt
 const bindingFailure = (
   state: RegistryState,
   input: KafkaSchemaRegistryBindingInput,
-): KafkaAdapterFailure | undefined => {
+): KafkaSchemaRegistryAttemptFailure | undefined => {
   const failures = state.failures.get(input.viewServerTopic);
   for (const side of input.sides) {
     const failure = failures?.get(side);
@@ -227,7 +255,7 @@ const missingContractFailure = (
     readonly sourceTopic: string;
     readonly side: KafkaSchemaRegistrySide;
   },
-): KafkaAdapterFailure => ({
+): Extract<KafkaAdapterFailure, { readonly _tag: "KafkaSchemaRegistrySchemaMismatch" }> => ({
   _tag: "KafkaSchemaRegistrySchemaMismatch",
   region,
   topic: input.sourceTopic,
@@ -240,7 +268,7 @@ const missingContractFailure = (
 type SettledRecordStateValidation =
   | {
       readonly _tag: "Failure";
-      readonly failure: KafkaAdapterFailure;
+      readonly failure: KafkaSchemaRegistryRecordValidationFailure;
     }
   | {
       readonly _tag: "Success";
@@ -295,6 +323,21 @@ function validateRecordState(
     }
     const result = validateKafkaSchemaRegistryFrame(contract, bytes);
     if (result._tag === "Mismatch") {
+      if (result.reason === "frame") {
+        return {
+          _tag: "Failure",
+          failure: {
+            _tag: "KafkaSchemaRegistryRecordDecodeFailure",
+            side,
+            failure: {
+              _tag: "KafkaDecodeFailure",
+              region,
+              topic: input.sourceTopic,
+              message: result.message,
+            },
+          },
+        };
+      }
       if (
         refreshUnknownIds &&
         result.schemaId !== null &&
@@ -435,7 +478,10 @@ export const makeKafkaSchemaRegistryRuntime = Effect.fn("KafkaSchemaRegistryRunt
       );
     const validateRecord = (
       validation: KafkaSchemaRegistryRecordValidationInput,
-    ): Effect.Effect<KafkaSchemaRegistryRecordPayloads, KafkaAdapterFailure> =>
+    ): Effect.Effect<
+      KafkaSchemaRegistryRecordPayloads,
+      KafkaSchemaRegistryRecordValidationFailure
+    > =>
       Effect.gen(function* () {
         const current = SubscriptionRef.getUnsafe(state);
         const initialValidation = validateRecordState(input.region, current, validation, true);

--- a/packages/kafka/src/server.test.ts
+++ b/packages/kafka/src/server.test.ts
@@ -49,6 +49,14 @@ import {
 } from "./server";
 import * as kafkaServerInternals from "./server-internal";
 import { OrderKeySchema, OrderValueSchema } from "./test-fixtures/orders_pb";
+import {
+  bytes,
+  foreverBrokerContract,
+  metadata,
+  schemaRegistryFrame,
+  schemaRegistryRecordPayloads,
+  valueFrame,
+} from "./test-fixtures/schema-registry";
 
 const Order = Schema.Struct({
   id: ViewServerId,
@@ -57,45 +65,6 @@ const Order = Schema.Struct({
 });
 
 const kafkaTestLifetimeIdentity = Object.freeze({});
-
-const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
-
-const schemaRegistryFrame = (schemaId: number, payload: Uint8Array): Uint8Array =>
-  Uint8Array.from([
-    0,
-    Math.floor(schemaId / 0x1_00_00_00) % 0x100,
-    Math.floor(schemaId / 0x1_00_00) % 0x100,
-    Math.floor(schemaId / 0x1_00) % 0x100,
-    schemaId % 0x100,
-    0,
-    ...payload,
-  ]);
-
-const schemaRegistryPayload = (frame: Uint8Array): Uint8Array => frame.slice(6);
-
-const schemaRegistryRecordPayloads = (input: {
-  readonly key: Uint8Array | null;
-  readonly value: Uint8Array | null;
-}) =>
-  Object.freeze({
-    key: input.key === null ? undefined : schemaRegistryPayload(input.key),
-    value: input.value === null ? undefined : schemaRegistryPayload(input.value),
-  });
-
-const metadata = (
-  region: string,
-  offset: bigint,
-  headers: KafkaMessageMetadata["headers"] = {},
-  partition = 0,
-  timestampNanos = offset * 1_000_000n,
-): KafkaMessageMetadata => ({
-  sourceTopic: "source-orders",
-  sourceRegion: region,
-  partition,
-  offset,
-  timestampNanos,
-  headers,
-});
 
 const commitFailure = (region: string): KafkaAdapterFailure => ({
   _tag: "KafkaCommitFailure",
@@ -390,22 +359,6 @@ const finiteBrokerContract = () =>
       durationNanos: 5_000_000_000n,
     },
   }) as const;
-
-const foreverBrokerContract = (
-  viewServerTopic: string,
-  sourceTopic: string,
-  region: string,
-  cleanupPolicy: "delete" | "compact" | "compact-and-delete" = "delete",
-) => ({
-  viewServerTopic,
-  sourceTopic,
-  region,
-  cleanupPolicy,
-  retentionPolicy: { _tag: "Forever" as const },
-  observedCleanupPolicy: cleanupPolicy,
-  observedRetentionMs: -1n,
-  resolvedRetention: { _tag: "Forever" as const },
-});
 
 const foreverBrokerContracts = (
   regions: ReadonlyArray<string>,
@@ -1037,7 +990,10 @@ describe("Kafka Source Adapter Server", () => {
       const acquisitionOrder: Array<string> = [];
       const eu = yield* makeFakeRegion("eu", acquisitionOrder);
       const us = yield* makeFakeRegion("us", acquisitionOrder);
-      const registryFailure = yield* Deferred.make<KafkaAdapterFailure>();
+      const registryFailure =
+        yield* Deferred.make<
+          Extract<KafkaAdapterFailure, { readonly _tag: "KafkaSchemaRegistryPolicyMismatch" }>
+        >();
       let euFailureSubscriptions = 0;
       const source = kafka.source(
         {
@@ -1093,7 +1049,10 @@ describe("Kafka Source Adapter Server", () => {
       );
       yield* eu.awaitAcquisitions(1);
       yield* us.awaitAcquisitions(1);
-      const failure: KafkaAdapterFailure = {
+      const failure: Extract<
+        KafkaAdapterFailure,
+        { readonly _tag: "KafkaSchemaRegistryPolicyMismatch" }
+      > = {
         _tag: "KafkaSchemaRegistryPolicyMismatch",
         region: "eu",
         topic: "source-orders",
@@ -1331,17 +1290,6 @@ describe("Kafka Source Adapter Server", () => {
       const releaseFirstSettlement = yield* Deferred.make<void>();
       const settlements: Array<bigint> = [];
       const validations: Array<number> = [];
-      const valueFrame = (schemaId: number, price: number) =>
-        schemaRegistryFrame(
-          schemaId,
-          toBinary(
-            OrderValueSchema,
-            create(OrderValueSchema, {
-              customerId: `customer-${String(price)}`,
-              price,
-            }),
-          ),
-        );
       const records: ReadonlyArray<KafkaServerRecord> = [
         {
           key: bytes("order-1"),

--- a/packages/kafka/src/server.test.ts
+++ b/packages/kafka/src/server.test.ts
@@ -1174,7 +1174,12 @@ describe("Kafka Source Adapter Server", () => {
                         const framedBytes = side === "key" ? input.key : input.value;
                         const schemaId = framedBytes?.[4] ?? -1;
                         if (schemaId === 99) {
-                          return yield* Effect.fail<KafkaAdapterFailure>({
+                          return yield* Effect.fail<
+                            Extract<
+                              KafkaAdapterFailure,
+                              { readonly _tag: "KafkaSchemaRegistrySchemaMismatch" }
+                            >
+                          >({
                             _tag: "KafkaSchemaRegistrySchemaMismatch",
                             region: "eu",
                             topic: "source-orders",

--- a/packages/kafka/src/server.ts
+++ b/packages/kafka/src/server.ts
@@ -516,9 +516,11 @@ const processedRejection = (
   event,
 });
 
-const effectFailure = <Value>(
-  effect: Effect.Effect<Value, unknown>,
-  onFailure: () => Effect.Effect<
+const effectFailure = <Value, Error>(
+  effect: Effect.Effect<Value, Error>,
+  onFailure: (
+    failure: Error,
+  ) => Effect.Effect<
     import("effect-view-server/source-adapter").SourceItemRejection<
       KafkaAdapterFailure,
       KafkaSourceRejectionLocation
@@ -527,7 +529,7 @@ const effectFailure = <Value>(
   >,
 ): Effect.Effect<Processed<Value>, SourceExecutionFailure<KafkaAdapterFailure>> =>
   Effect.matchEffect(effect, {
-    onFailure: () => onFailure().pipe(Effect.map(processedRejection)),
+    onFailure: (failure) => onFailure(failure).pipe(Effect.map(processedRejection)),
     onSuccess: (value) => Effect.succeed(processedValue(value)),
   });
 
@@ -551,7 +553,17 @@ const schemaRegistrySides = (codecs: KafkaSchemaRegistryCodecs): ReadonlyArray<"
 const validateSchemaRegistryRecord = (
   registry: KafkaSchemaRegistryRuntime,
   input: KafkaSchemaRegistryRecordValidationInput,
-) => registry.validateRecord(input).pipe(Effect.mapError(adapterExecutionFailure));
+) =>
+  registry.validateRecord(input).pipe(
+    Effect.mapError((failure) =>
+      failure._tag === "KafkaSchemaRegistryRecordDecodeFailure"
+        ? {
+            ...failure,
+            failure: adapterExecutionFailure(failure.failure),
+          }
+        : adapterExecutionFailure(failure),
+    ),
+  );
 
 const decodeSchemaRegistryProtobufPayload = (
   codec: KafkaSchemaRegistryProtobufCodec,
@@ -585,19 +597,13 @@ const recordEvent = Effect.fn("KafkaSourceAdapter.record.event")(function* <
   const rejectDecode = (
     phase: Extract<KafkaRejectionPhase, "keyDecode" | "valueDecode" | "nullValue">,
     message: string,
+    failure: SourceExecutionFailure<KafkaAdapterFailure> = adapterExecutionFailure(
+      decodeFailure(region, sourceTopic, message),
+    ),
   ) =>
     regionConsumer.recordDecodeFailure.pipe(
       Effect.andThen(regionConsumer.recordRejection),
-      Effect.andThen(
-        rejection(
-          toolkit,
-          metadata,
-          record.settlement,
-          phase,
-          adapterExecutionFailure(decodeFailure(region, sourceTopic, message)),
-          message,
-        ),
-      ),
+      Effect.andThen(rejection(toolkit, metadata, record.settlement, phase, failure, message)),
     );
   const rejectMapping = (
     phase: Exclude<KafkaRejectionPhase, "keyDecode" | "valueDecode">,
@@ -628,19 +634,30 @@ const recordEvent = Effect.fn("KafkaSourceAdapter.record.event")(function* <
   if (record.key === null) {
     return yield* rejectDecode("keyDecode", "Kafka record key is required.");
   }
-  const registryPayloads =
+  const processedRegistryPayloads =
     registryCodecs.key === undefined && registryCodecs.value === undefined
-      ? undefined
-      : yield* validateSchemaRegistryRecord(
-          Option.getOrThrow(Option.fromUndefinedOr(schemaRegistry)),
-          {
+      ? processedValue(undefined)
+      : yield* effectFailure(
+          validateSchemaRegistryRecord(Option.getOrThrow(Option.fromUndefinedOr(schemaRegistry)), {
             viewServerTopic: toolkit.topic,
             sourceTopic,
             sides: registrySides,
             key: registryCodecs.key === undefined ? null : record.key,
             value: registryCodecs.value === undefined ? null : record.value,
-          },
+          }),
+          (failure) =>
+            failure._tag === "KafkaSchemaRegistryRecordDecodeFailure"
+              ? rejectDecode(
+                  failure.side === "key" ? "keyDecode" : "valueDecode",
+                  failure.failure.failure.message,
+                  failure.failure,
+                )
+              : Effect.fail(failure),
         );
+  if (processedRegistryPayloads._tag === "Rejected") {
+    return processedRegistryPayloads.event;
+  }
+  const registryPayloads = processedRegistryPayloads.value;
   const registryKeyPayload = registryPayloads?.key;
   // Compaction identity owns an immutable snapshot that application codecs can never mutate.
   const serializedKeyBytes =

--- a/packages/kafka/src/test-fixtures/schema-registry.ts
+++ b/packages/kafka/src/test-fixtures/schema-registry.ts
@@ -1,0 +1,70 @@
+import { create, toBinary } from "@bufbuild/protobuf";
+import type { KafkaMessageMetadata } from "../contract";
+import { OrderValueSchema } from "./orders_pb";
+
+export const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+export const schemaRegistryFrame = (schemaId: number, payload: Uint8Array): Uint8Array =>
+  Uint8Array.from([
+    0,
+    Math.floor(schemaId / 0x1_00_00_00) % 0x100,
+    Math.floor(schemaId / 0x1_00_00) % 0x100,
+    Math.floor(schemaId / 0x1_00) % 0x100,
+    schemaId % 0x100,
+    0,
+    ...payload,
+  ]);
+
+export const schemaRegistryPayload = (frame: Uint8Array): Uint8Array => frame.slice(6);
+
+export const schemaRegistryRecordPayloads = (input: {
+  readonly key: Uint8Array | null;
+  readonly value: Uint8Array | null;
+}) =>
+  Object.freeze({
+    key: input.key === null ? undefined : schemaRegistryPayload(input.key),
+    value: input.value === null ? undefined : schemaRegistryPayload(input.value),
+  });
+
+export const metadata = (
+  region: string,
+  offset: bigint,
+  headers: KafkaMessageMetadata["headers"] = {},
+  partition = 0,
+  timestampNanos = offset * 1_000_000n,
+): KafkaMessageMetadata => ({
+  sourceTopic: "source-orders",
+  sourceRegion: region,
+  partition,
+  offset,
+  timestampNanos,
+  headers,
+});
+
+export const foreverBrokerContract = (
+  viewServerTopic: string,
+  sourceTopic: string,
+  region: string,
+  cleanupPolicy: "delete" | "compact" | "compact-and-delete" = "delete",
+) => ({
+  viewServerTopic,
+  sourceTopic,
+  region,
+  cleanupPolicy,
+  retentionPolicy: { _tag: "Forever" as const },
+  observedCleanupPolicy: cleanupPolicy,
+  observedRetentionMs: -1n,
+  resolvedRetention: { _tag: "Forever" as const },
+});
+
+export const valueFrame = (schemaId: number, price: number): Uint8Array =>
+  schemaRegistryFrame(
+    schemaId,
+    toBinary(
+      OrderValueSchema,
+      create(OrderValueSchema, {
+        customerId: `customer-${String(price)}`,
+        price,
+      }),
+    ),
+  );

--- a/packages/runtime/src/websocket-reconnect.test.ts
+++ b/packages/runtime/src/websocket-reconnect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { makeViewServerClient } from "@effect-view-server/client/remote";
-import { Effect, Fiber, Schedule, Stream } from "effect";
+import { Deferred, Effect, Fiber, Schedule, Stream } from "effect";
 import { makeViewServerRuntime } from "./index";
 import {
   closeTestTcpServer,
@@ -190,11 +190,18 @@ describe("WebSocket subscription recovery", () => {
           client.subscribe("orders", { select: ["id"], limit: 10 }),
           (activeSubscription) => activeSubscription.close().pipe(Effect.ignore),
         );
-        const eventsFiber = yield* subscription.events.pipe(Stream.runCollect, Effect.forkChild);
+        const outageReported = yield* Deferred.make<void>();
+        const eventsFiber = yield* subscription.events.pipe(
+          Stream.tap((event) =>
+            event.type === "status" ? Deferred.succeed(outageReported, undefined) : Effect.void,
+          ),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
         yield* assertOneRecoveredStream(first.client.health);
 
         yield* first.close;
-        yield* Effect.sleep("100 millis");
+        yield* Deferred.await(outageReported).pipe(Effect.timeout("1 second"));
         yield* client.close;
         const second = yield* acquireRuntime(port);
         yield* Effect.sleep(reconnectSettleDelay);
@@ -214,6 +221,14 @@ describe("WebSocket subscription recovery", () => {
             keys: [],
             rows: [],
             totalRows: 0,
+          },
+          {
+            type: "status",
+            topic: "orders",
+            queryId: "remote",
+            status: "error",
+            code: "TransportError",
+            message: "SocketCloseError: 1001: View Server shutting down",
           },
         ]);
         yield* subscription.close();

--- a/packages/runtime/src/websocket-reconnect.test.ts
+++ b/packages/runtime/src/websocket-reconnect.test.ts
@@ -21,17 +21,20 @@ const acquireRuntime = (port: number) =>
     (runtime) => runtime.close,
   );
 
+const reconnectSettleDelay = "750 millis";
+
 const assertOneRecoveredStream = Effect.fn("WebSocketReconnect.test.assertOneRecoveredStream")(
-  function* (runtime: Effect.Success<ReturnType<typeof makeViewServerRuntime>>) {
-    yield* waitForTransportHealth(runtime.client.health, {
+  function* (health: Effect.Success<ReturnType<typeof makeViewServerRuntime>>["client"]["health"]) {
+    yield* waitForTransportHealth(health, {
       activeClients: 1,
       activeStreams: 1,
     });
-    yield* Effect.sleep("750 millis");
-    const health = yield* runtime.client.health();
+    // Wait beyond one 500 ms retry period to detect duplicate recovered streams.
+    yield* Effect.sleep(reconnectSettleDelay);
+    const current = yield* health();
     expect({
-      activeClients: health.transport.activeClients,
-      activeStreams: health.transport.activeStreams,
+      activeClients: current.transport.activeClients,
+      activeStreams: current.transport.activeStreams,
     }).toStrictEqual({ activeClients: 1, activeStreams: 1 });
   },
 );
@@ -61,7 +64,14 @@ describe("WebSocket subscription recovery", () => {
           Extract<Stream.Success<typeof subscription.events>, { readonly type: "snapshot" }>
         > = [];
         const eventsFiber = yield* subscription.events.pipe(
-          Stream.filter((event) => event.type === "snapshot"),
+          Stream.filter(
+            (
+              event,
+            ): event is Extract<
+              Stream.Success<typeof subscription.events>,
+              { readonly type: "snapshot" }
+            > => event.type === "snapshot",
+          ),
           Stream.runForEach((event) =>
             Effect.sync(() => {
               snapshots.push(event);
@@ -69,11 +79,11 @@ describe("WebSocket subscription recovery", () => {
           ),
           Effect.forkChild,
         );
-        yield* assertOneRecoveredStream(first);
+        yield* assertOneRecoveredStream(first.client.health);
 
         yield* first.close;
         const second = yield* acquireRuntime(port);
-        yield* assertOneRecoveredStream(second);
+        yield* assertOneRecoveredStream(second.client.health);
 
         const controlClient = yield* Effect.acquireRelease(
           makeViewServerClient(viewServer, { url: second.url }),
@@ -115,7 +125,7 @@ describe("WebSocket subscription recovery", () => {
 
         yield* second.close;
         const third = yield* acquireRuntime(port);
-        yield* assertOneRecoveredStream(third);
+        yield* assertOneRecoveredStream(third.client.health);
         yield* Effect.sleep("5 millis").pipe(
           Effect.repeat({
             schedule: Schedule.recurs(50),
@@ -180,19 +190,32 @@ describe("WebSocket subscription recovery", () => {
           client.subscribe("orders", { select: ["id"], limit: 10 }),
           (activeSubscription) => activeSubscription.close().pipe(Effect.ignore),
         );
-        yield* assertOneRecoveredStream(first);
+        const eventsFiber = yield* subscription.events.pipe(Stream.runCollect, Effect.forkChild);
+        yield* assertOneRecoveredStream(first.client.health);
 
         yield* first.close;
         yield* Effect.sleep("100 millis");
         yield* client.close;
         const second = yield* acquireRuntime(port);
-        yield* Effect.sleep("750 millis");
+        yield* Effect.sleep(reconnectSettleDelay);
         const health = yield* second.client.health();
+        const events = yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
 
         expect({
           activeClients: health.transport.activeClients,
           activeStreams: health.transport.activeStreams,
         }).toStrictEqual({ activeClients: 0, activeStreams: 0 });
+        expect(Array.from(events)).toStrictEqual([
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+        ]);
         yield* subscription.close();
       }),
     ),

--- a/packages/runtime/src/websocket-reconnect.test.ts
+++ b/packages/runtime/src/websocket-reconnect.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "@effect/vitest";
+import { makeViewServerClient } from "@effect-view-server/client/remote";
+import { Effect, Fiber, Schedule, Stream } from "effect";
+import { makeViewServerRuntime } from "./index";
+import {
+  closeTestTcpServer,
+  reserveTcpPort,
+  waitForTransportHealth,
+} from "../test-harness/runtime";
+import { order, viewServer } from "../test-harness/runtime-config";
+
+const acquireRuntime = (port: number) =>
+  Effect.acquireRelease(
+    Effect.retry(
+      makeViewServerRuntime(viewServer, {
+        host: "127.0.0.1",
+        websocketPort: port,
+      }),
+      Schedule.addDelay(Schedule.recurs(50), () => Effect.succeed("5 millis")),
+    ),
+    (runtime) => runtime.close,
+  );
+
+const assertOneRecoveredStream = Effect.fn("WebSocketReconnect.test.assertOneRecoveredStream")(
+  function* (runtime: Effect.Success<ReturnType<typeof makeViewServerRuntime>>) {
+    yield* waitForTransportHealth(runtime.client.health, {
+      activeClients: 1,
+      activeStreams: 1,
+    });
+    yield* Effect.sleep("750 millis");
+    const health = yield* runtime.client.health();
+    expect({
+      activeClients: health.transport.activeClients,
+      activeStreams: health.transport.activeStreams,
+    }).toStrictEqual({ activeClients: 1, activeStreams: 1 });
+  },
+);
+
+describe("WebSocket subscription recovery", () => {
+  it.live("delivers one fresh snapshot after every server restart", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const reservation = yield* reserveTcpPort();
+        yield* closeTestTcpServer(reservation.server);
+        const port = reservation.port;
+
+        const first = yield* acquireRuntime(port);
+        yield* first.client.publish("orders", order("a", 10));
+        const client = yield* Effect.acquireRelease(
+          makeViewServerClient(viewServer, { url: first.url }),
+          (remoteClient) => remoteClient.close,
+        );
+        const subscription = yield* Effect.acquireRelease(
+          client.subscribe("orders", {
+            select: ["id", "price"],
+            limit: 10,
+          }),
+          (activeSubscription) => activeSubscription.close().pipe(Effect.ignore),
+        );
+        const snapshots: Array<
+          Extract<Stream.Success<typeof subscription.events>, { readonly type: "snapshot" }>
+        > = [];
+        const eventsFiber = yield* subscription.events.pipe(
+          Stream.filter((event) => event.type === "snapshot"),
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              snapshots.push(event);
+            }),
+          ),
+          Effect.forkChild,
+        );
+        yield* assertOneRecoveredStream(first);
+
+        yield* first.close;
+        const second = yield* acquireRuntime(port);
+        yield* assertOneRecoveredStream(second);
+
+        const controlClient = yield* Effect.acquireRelease(
+          makeViewServerClient(viewServer, { url: second.url }),
+          (remoteClient) => remoteClient.close,
+        );
+        const controlSubscription = yield* Effect.acquireRelease(
+          controlClient.subscribe("orders", {
+            select: ["id", "price"],
+            limit: 10,
+          }),
+          (activeSubscription) => activeSubscription.close().pipe(Effect.ignore),
+        );
+        const controlSnapshot = yield* controlSubscription.events.pipe(
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.timeout("1 second"),
+        );
+        expect(controlSnapshot).toStrictEqual([
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-1",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+        ]);
+        yield* waitForTransportHealth(second.client.health, {
+          activeClients: 2,
+          activeStreams: 2,
+        });
+        yield* controlSubscription.close();
+        yield* controlClient.close;
+        yield* waitForTransportHealth(second.client.health, {
+          activeClients: 1,
+          activeStreams: 1,
+        });
+
+        yield* second.close;
+        const third = yield* acquireRuntime(port);
+        yield* assertOneRecoveredStream(third);
+        yield* Effect.sleep("5 millis").pipe(
+          Effect.repeat({
+            schedule: Schedule.recurs(50),
+            until: () => snapshots.length === 3,
+          }),
+        );
+
+        expect(snapshots).toStrictEqual([
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 1,
+            keys: ["a"],
+            rows: [{ id: "a", price: 10 }],
+            totalRows: 1,
+          },
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+          {
+            type: "snapshot",
+            topic: "orders",
+            queryId: "query-0",
+            version: 0,
+            keys: [],
+            rows: [],
+            totalRows: 0,
+          },
+        ]);
+
+        yield* subscription.close();
+        yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second"));
+        yield* client.close;
+        yield* waitForTransportHealth(third.client.health, {
+          activeClients: 0,
+          activeStreams: 0,
+        });
+      }),
+    ),
+  );
+
+  it.live("does not resubscribe after the client closes during a pending retry", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const reservation = yield* reserveTcpPort();
+        yield* closeTestTcpServer(reservation.server);
+        const port = reservation.port;
+
+        const first = yield* acquireRuntime(port);
+        const client = yield* Effect.acquireRelease(
+          makeViewServerClient(viewServer, { url: first.url }),
+          (remoteClient) => remoteClient.close,
+        );
+        const subscription = yield* Effect.acquireRelease(
+          client.subscribe("orders", { select: ["id"], limit: 10 }),
+          (activeSubscription) => activeSubscription.close().pipe(Effect.ignore),
+        );
+        yield* assertOneRecoveredStream(first);
+
+        yield* first.close;
+        yield* Effect.sleep("100 millis");
+        yield* client.close;
+        const second = yield* acquireRuntime(port);
+        yield* Effect.sleep("750 millis");
+        const health = yield* second.client.health();
+
+        expect({
+          activeClients: health.transport.activeClients,
+          activeStreams: health.transport.activeStreams,
+        }).toStrictEqual({ activeClients: 0, activeStreams: 0 });
+        yield* subscription.close();
+      }),
+    ),
+  );
+});


### PR DESCRIPTION
## Summary

- recover remote live-query and health subscriptions after WebSocket transport interruptions
- preserve fresh snapshot and lifecycle semantics across repeated reconnects
- reject malformed Schema Registry key/value frames as exact item-local Kafka decode failures
- keep registry availability and schema failures attempt-level

## Validation

- `vp check`
- strict Effect diagnostics for client, Kafka, and runtime
- client package: 99 tests, 100% statement/branch/function/line coverage
- Kafka package: 234 tests, 100% coverage, including real Apache Kafka
- runtime package: 82 tests, 100% coverage
- clean Effect, Vitest, and architecture reviews against latest `origin/main`

Closes #458
Closes #459

## Summary by Sourcery

Recover remote subscriptions across WebSocket interruptions and isolate malformed Schema Registry frames to individual Kafka records.

New Features:
- Automatically recover remote live-query and health subscriptions after WebSocket transport interruptions with fresh authoritative snapshots and bounded buffering.
- Classify malformed Schema Registry key and value frames as item-local Kafka decode rejections while preserving source processing.

Bug Fixes:
- Prevent remote subscription retries from continuing after the client or subscription is closed.
- Preserve server-assigned query IDs in terminal remote subscription error statuses.
- Keep Schema Registry availability and schema validation failures at the source-attempt level instead of treating them as individual record rejections.

Enhancements:
- Distinguish malformed frame failures from schema mismatches and retain parsed schema IDs when available.

Documentation:
- Document remote subscription retry behavior, snapshot replacement semantics, transport status reporting, and subscription buffer limits.

Tests:
- Add client, runtime, and Kafka coverage for repeated WebSocket recovery, retry cancellation, malformed key/value frames, subsequent record processing, and attempt-level registry failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Remote live-query and health subscriptions automatically retry temporary connection failures and deliver fresh snapshots after recovery.
  - Added configurable retry handling and clearer terminal failure statuses.
  - Kafka Schema Registry errors now distinguish malformed frames from schema validation failures with structured diagnostics.

- **Bug Fixes**
  - Improved WebSocket recovery after repeated server restarts.
  - Malformed Kafka records are rejected individually without blocking subsequent valid records.
  - Pending retries are cancelled when subscriptions close.

- **Documentation**
  - Documented retry behavior, buffering, backpressure, cancellation, and terminal errors for remote subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->