### PR TITLE
feat: expose viewport base row witness

### DIFF
--- a/.changeset/strong-viewports-witness.md
+++ b/.changeset/strong-viewports-witness.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": minor
+---
+
+Expose a declaration-only invariant base Topic Row witness on Live Query Viewports, plus a safe type helper for structural adapters to extract it across raw, grouped, window, and source replacements.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -708,7 +708,7 @@ _Avoid_: Browser write, send, emit
 - A **Health Payload Codec** protects full runtime health payloads from missing or unknown configured topics.
 - A **View Server Provider** supplies a **Live Client** to React hooks.
 - A **View Server In-Memory Provider** supplies the same hook behavior through an **In-Memory View Server**.
-- A **Live Query Viewport** keeps viewport rows out of React state, derives its query window, and gives every replacement or scroll-only window change switch-latest ownership over row, count, status, and failure delivery.
+- A **Live Query Viewport** keeps viewport rows out of React state, derives its query window, and gives every replacement or scroll-only window change switch-latest ownership over row, count, status, and failure delivery. Its declaration-only **Base Topic Row Witness** invariantly identifies the complete configured Topic Row across raw projections, grouped results, window movement, and source replacement without adding runtime state.
 - An **AG Grid Adapter** accepts AG Grid state without making AG Grid state the canonical View Server query language.
 - An **AG Grid Adapter** validates every **AG Grid Set Key** against the bound Topic Row field schema without attempting to repair a lossy key creator.
 - A **Real View Server** and **In-Memory View Server** differ only by transport and ingress **Adapters**, not by query, storage, health, or subscription logic.

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -92,7 +92,11 @@ authoritative public raw keys or complete canonical grouped keys at the same
 absolute indexes. The returned generation's `setWindow` operation handles
 scroll-only changes. Each replacement is switch-latest: obsolete snapshots,
 deltas, statuses, failures, and sink writes are ignored. See the Public API
-guide for the complete adapter contract.
+guide for the complete adapter contract. Structural adapters can recover the
+complete configured Topic Row with the type-only
+`LiveQueryViewportBaseRow<typeof viewport>` helper. That invariant witness does
+not change when a viewport selects a raw projection, produces grouped rows,
+moves its window, or replaces its source, and it adds no runtime property.
 
 React applications should install the package and compatible peer dependencies:
 

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -3,7 +3,11 @@ import type { DescMessage } from "@bufbuild/protobuf";
 import { EmptySchema, TimestampSchema, type Timestamp } from "@bufbuild/protobuf/wkt";
 import { ViewServerId, defineViewServerConfig, viewSchema } from "effect-view-server/config";
 import type { FalseExpression, LiveQueryResult, RowFromSchema } from "effect-view-server/config";
-import { createViewServerReact } from "effect-view-server/react";
+import {
+  createViewServerReact,
+  type LiveQueryViewport,
+  type LiveQueryViewportBaseRow,
+} from "effect-view-server/react";
 import { createInMemoryViewServerReact } from "effect-view-server/react/testing";
 import { runViewServerRuntime } from "effect-view-server/runtime";
 import type {
@@ -489,7 +493,12 @@ describe("public effect-view-server subpath type contracts", () => {
       }>
     >();
     const viewport = react.useLiveQueryViewport("orders");
-    viewport.viewport.replace({
+    expectTypeOf<LiveQueryViewportBaseRow<typeof viewport.viewport>>().toEqualTypeOf<
+      typeof Order.Type
+    >();
+    expectTypeOf<LiveQueryViewportBaseRow<any>>().toBeNever();
+    expectTypeOf<LiveQueryViewportBaseRow<unknown>>().toBeNever();
+    const rawGeneration = viewport.viewport.replace({
       window: { firstRow: 0, lastRow: 19 },
       query: {
         select: ["id", "price"],
@@ -508,6 +517,33 @@ describe("public effect-view-server subpath type contracts", () => {
         },
       },
     });
+    rawGeneration.setWindow({ firstRow: 20, lastRow: 39 });
+    viewport.viewport.replace({
+      window: { firstRow: 0, lastRow: 19 },
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+      },
+      sink: {
+        setRowCount: () => undefined,
+        setRowData: (rows) => {
+          expectTypeOf(rows[0]).toEqualTypeOf<
+            { readonly status: "open" | "closed"; readonly rowCount: bigint } | undefined
+          >();
+        },
+      },
+    });
+    expectTypeOf<LiveQueryViewportBaseRow<typeof viewport.viewport>>().toEqualTypeOf<
+      typeof Order.Type
+    >();
+    const requireOrdersViewport = (
+      _viewport: LiveQueryViewport<typeof viewServer.topics, "orders">,
+    ): void => undefined;
+    requireOrdersViewport(viewport.viewport);
+    // @ts-expect-error the emitted viewport witness rejects a different base Topic row.
+    requireOrdersViewport(publicProfileReact.useLiveQueryViewport("profiles").viewport);
     expectTypeOf(viewport).not.toHaveProperty("rows");
 
     const profileResult = publicProfileReact.useLiveQuery("profiles", {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -65,6 +65,7 @@ import {
 
 export type {
   LiveQueryViewport,
+  LiveQueryViewportBaseRow,
   LiveQueryViewportGeneration,
   LiveQueryViewportGroupedQuery,
   LiveQueryViewportQuery,

--- a/packages/react/src/live-query-viewport.test-d.ts
+++ b/packages/react/src/live-query-viewport.test-d.ts
@@ -5,7 +5,12 @@ import { SourceAdapter } from "@effect-view-server/source-adapter";
 import { Schema } from "effect";
 import type * as BigDecimal from "effect/BigDecimal";
 import { createViewServerReact } from "./index";
-import { makeLiveQueryViewport } from "./live-query-viewport";
+import {
+  makeLiveQueryViewport,
+  makeLiveQueryViewportBinding,
+  type LiveQueryViewport,
+  type LiveQueryViewportBaseRow,
+} from "./live-query-viewport";
 
 const Order = Schema.Struct({
   id: ViewServerId,
@@ -18,6 +23,19 @@ const viewServer = defineViewServerConfig({
   topics: {
     orders: {
       schema: Order,
+    },
+  },
+});
+
+const Position = Schema.Struct({
+  id: ViewServerId,
+  quantity: Schema.Number,
+});
+
+const positionViewServer = defineViewServerConfig({
+  topics: {
+    positions: {
+      schema: Position,
     },
   },
 });
@@ -42,6 +60,7 @@ const leasedViewServer = defineViewServerConfig({
 });
 
 const react = createViewServerReact(viewServer);
+const positionReact = createViewServerReact(positionViewServer);
 const leasedReact = createViewServerReact(leasedViewServer);
 declare const liveClient: ViewServerLiveClient<typeof viewServer.topics>;
 const directViewport = makeLiveQueryViewport({
@@ -52,6 +71,58 @@ const directViewport = makeLiveQueryViewport({
 });
 
 describe("Live Query Viewport type contracts", () => {
+  it("exposes one invariant base Topic row independently of query results", () => {
+    const result = react.useLiveQueryViewport("orders");
+    const binding = makeLiveQueryViewportBinding<typeof viewServer.topics, "orders">();
+    type Viewport = typeof result.viewport;
+
+    expectTypeOf<LiveQueryViewportBaseRow<Viewport>>().toEqualTypeOf<typeof Order.Type>();
+    expectTypeOf<LiveQueryViewportBaseRow<typeof directViewport>>().toEqualTypeOf<
+      typeof Order.Type
+    >();
+    expectTypeOf<LiveQueryViewportBaseRow<typeof binding.viewport>>().toEqualTypeOf<
+      typeof Order.Type
+    >();
+
+    const rawGeneration = result.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: { select: ["id"], where: [], orderBy: [] },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+    rawGeneration.setWindow({ firstRow: 10, lastRow: 19 });
+    result.viewport.replace({
+      window: { firstRow: 0, lastRow: 9 },
+      query: {
+        groupBy: ["status"],
+        aggregates: { rowCount: { aggFunc: "count" } },
+        where: [],
+        orderBy: [{ aggregate: "rowCount", direction: "desc" }],
+      },
+      sink: { setRowCount: () => undefined, setRowData: () => undefined },
+    });
+
+    expectTypeOf<LiveQueryViewportBaseRow<Viewport>>().toEqualTypeOf<typeof Order.Type>();
+  });
+
+  it("rejects mismatched base rows and unsafe extraction inputs", () => {
+    const orderViewport = react.useLiveQueryViewport("orders").viewport;
+    const positionViewport = positionReact.useLiveQueryViewport("positions").viewport;
+    const requireOrderViewport = (
+      _viewport: LiveQueryViewport<typeof viewServer.topics, "orders">,
+    ): void => undefined;
+
+    requireOrderViewport(orderViewport);
+    // @ts-expect-error the viewport base Topic row is invariant.
+    requireOrderViewport(positionViewport);
+
+    expectTypeOf<LiveQueryViewportBaseRow<typeof positionViewport>>().toEqualTypeOf<
+      typeof Position.Type
+    >();
+    expectTypeOf<LiveQueryViewportBaseRow<any>>().toBeNever();
+    expectTypeOf<LiveQueryViewportBaseRow<unknown>>().toBeNever();
+    expectTypeOf<LiveQueryViewportBaseRow<LiveQueryViewport<any, string>>>().toBeNever();
+  });
+
   it("binds the configured topic and exposes chrome without rows", () => {
     const result = react.useLiveQueryViewport("orders");
 

--- a/packages/react/src/live-query-viewport.test.ts
+++ b/packages/react/src/live-query-viewport.test.ts
@@ -250,6 +250,13 @@ const makeSwitchingPublisher = () => {
 };
 
 describe("Live Query Viewport Module", () => {
+  it("keeps the base-row witness declaration-only", () => {
+    const binding = makeLiveQueryViewportBinding<Topics, "orders">();
+
+    expect(Object.getOwnPropertySymbols(binding.viewport)).toStrictEqual([]);
+    expect(Object.keys(binding.viewport)).toStrictEqual(["replace", "destroy"]);
+  });
+
   it("validates inclusive absolute windows", () => {
     expect(validateLiveQueryViewportWindow({ firstRow: 10, lastRow: 19 })).toStrictEqual({
       _tag: "Valid",

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -29,6 +29,53 @@ import type * as Cause from "effect/Cause";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
+declare const LiveQueryViewportBaseRowTypeId: unique symbol;
+
+type IsAny<Value> = 0 extends 1 & Value ? true : false;
+
+type IsUnknown<Value> = IsAny<Value> extends true ? false : unknown extends Value ? true : false;
+
+type ExactSafeRow<Input, Output> =
+  IsAny<Input> extends true
+    ? never
+    : IsUnknown<Input> extends true
+      ? never
+      : IsAny<Output> extends true
+        ? never
+        : IsUnknown<Output> extends true
+          ? never
+          : [Input] extends [Output]
+            ? [Output] extends [Input]
+              ? Input
+              : never
+            : never;
+
+type LiveQueryViewportWitnessRow<Topics, Topic> =
+  IsAny<Topics> extends true
+    ? never
+    : IsUnknown<Topics> extends true
+      ? never
+      : IsAny<Topic> extends true
+        ? never
+        : IsUnknown<Topic> extends true
+          ? never
+          : Topic extends keyof Topics
+            ? TopicRow<Topics, Topic>
+            : never;
+
+export type LiveQueryViewportBaseRow<Viewport> =
+  IsAny<Viewport> extends true
+    ? never
+    : IsUnknown<Viewport> extends true
+      ? never
+      : typeof LiveQueryViewportBaseRowTypeId extends keyof Viewport
+        ? Exclude<Viewport[typeof LiveQueryViewportBaseRowTypeId], undefined> extends (
+            _row: infer Input,
+          ) => infer Output
+          ? ExactSafeRow<Input, Output>
+          : never
+        : never;
+
 export type LiveQueryViewportWindow = {
   readonly firstRow: number;
   readonly lastRow: number;
@@ -133,6 +180,9 @@ export type LiveQueryViewport<
   Topics extends TopicDefinitions,
   Topic extends Extract<keyof Topics, string>,
 > = {
+  readonly [LiveQueryViewportBaseRowTypeId]?: (
+    _row: LiveQueryViewportWitnessRow<Topics, Topic>,
+  ) => LiveQueryViewportWitnessRow<Topics, Topic>;
   readonly replace: <
     const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
     const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,


### PR DESCRIPTION
Closes #465

## Summary
- expose an opaque, invariant, declaration-only base Topic Row witness on LiveQueryViewport
- add a safe LiveQueryViewportBaseRow extractor that rejects erased any/unknown boundaries
- prove raw, grouped, window, semantic/source replacement, runtime, and emitted-package behavior

## Validation
- vp check
- vp run -w ready
- vp run -w bench:baseline:smoke (19/19; comparison passed)
- focused React source and emitted declaration suites
- three frozen-head local review axes: 0 blockers, 0 non-blockers

## Summary by Sourcery

Expose a safe invariant base-row witness for LiveQueryViewport consumers and structural adapters.

New Features:
- Expose a declaration-only invariant base Topic Row witness for LiveQueryViewport.
- Add a safe type helper that extracts the configured base row while rejecting unsafe any/unknown inputs.

Enhancements:
- Preserve base-row identity across raw, grouped, windowed, and source-replaced viewport configurations without adding runtime state.

Documentation:
- Document base-row extraction for structural adapters and its invariance across viewport transformations.

Tests:
- Add type-level and runtime coverage for base-row inference, invariance, unsafe extraction rejection, mismatched viewports, and declaration-only runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `LiveQueryViewportBaseRow` for type-safe extraction and validation of viewport row types.
  * Preserved row-type inference across raw, grouped, windowed, and source-replaced queries.
  * Exported the helper through the React package.
* **Bug Fixes**
  * Improved detection of mismatched, unsafe, or incompatible viewport row types.
* **Tests**
  * Added coverage for direct, bound, and React viewports, including runtime facade behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->