### PR TITLE
Expose dependency-free viewport query authority

### DIFF
--- a/.changeset/quiet-viewport-authority.md
+++ b/.changeset/quiet-viewport-authority.md
@@ -1,0 +1,6 @@
+---
+"effect-view-server": patch
+---
+
+Expose dependency-free source-owned Live Query Viewport query authority through
+`effect-view-server/react/viewport-base-row`.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -268,12 +268,14 @@ declaration-only extractor from the pure subpath:
 import type {
   LiveQueryViewportBaseRow,
   LiveQueryViewportCompleteRawSelect,
+  LiveQueryViewportQueryAuthority,
   LiveQueryViewportRouteBy,
   LiveQueryViewportWhere,
 } from "effect-view-server/react/viewport-base-row";
 
 type BaseRow = LiveQueryViewportBaseRow<typeof viewport>;
 type CompleteSelect = LiveQueryViewportCompleteRawSelect<typeof viewport>;
+type QueryAuthority = LiveQueryViewportQueryAuthority<typeof viewport>;
 type RouteBy = LiveQueryViewportRouteBy<typeof viewport>;
 type ExternalWhere = LiveQueryViewportWhere<typeof viewport>;
 ```
@@ -284,6 +286,10 @@ collection for the complete Topic Row, including schema-admitted Filterable
 Scalar domains such as exact number, bigint, and BigDecimal numeric kinds. These witnesses let a
 structural adapter preserve source-owned query domains without importing or
 reconstructing View Server schemas.
+
+`QueryAuthority` is the exact source-owned `{ semanticKey, replace }` pair for
+raw and grouped queries. It resolves to `never` if either operation is narrowed,
+widened, or detached from the Viewport contract.
 
 The subpath owns its helper declarations directly, imports neither React nor
 Effect, and has an empty runtime module. `effect-view-server/react` re-exports

--- a/packages/effect-view-server/README.md
+++ b/packages/effect-view-server/README.md
@@ -102,6 +102,9 @@ The same subpath exposes `LiveQueryViewportRouteBy<typeof viewport>` and
 `LiveQueryViewportWhere<typeof viewport>` for the exact source-owned Feed Route
 and Filter Expression domains; materialized viewports extract `never` for the
 Route.
+It also exposes `LiveQueryViewportQueryAuthority<typeof viewport>`, which yields
+the exact source-owned `{ semanticKey, replace }` pair for raw and grouped
+queries or `never` after either operation is narrowed, widened, or detached.
 The invariant witness does not change when a viewport selects a raw projection,
 produces grouped rows, moves its window, or replaces its source, and it adds no
 runtime property.

--- a/packages/effect-view-server/src/index.test-d.ts
+++ b/packages/effect-view-server/src/index.test-d.ts
@@ -16,6 +16,7 @@ import {
 import type {
   LiveQueryViewportBaseRow as PureLiveQueryViewportBaseRow,
   LiveQueryViewportCompleteRawSelect,
+  LiveQueryViewportQueryAuthority,
   LiveQueryViewportRouteBy,
   LiveQueryViewportWhere,
 } from "effect-view-server/react/viewport-base-row";
@@ -603,6 +604,12 @@ describe("public effect-view-server subpath type contracts", () => {
     expectTypeOf<PureLiveQueryViewportBaseRow<typeof viewport.viewport>>().toEqualTypeOf<
       LiveQueryViewportBaseRow<typeof viewport.viewport>
     >();
+    expectTypeOf<LiveQueryViewportQueryAuthority<typeof viewport.viewport>>().toEqualTypeOf<
+      Readonly<{
+        semanticKey: (typeof viewport.viewport)["semanticKey"];
+        replace: (typeof viewport.viewport)["replace"];
+      }>
+    >();
     expectTypeOf<LiveQueryViewportRouteBy<typeof viewport.viewport>>().toBeNever();
     const materializedWhere: LiveQueryViewportWhere<typeof viewport.viewport> = [
       { field: "price", type: "inRange", filter: 1, filterTo: 3 },
@@ -670,6 +677,59 @@ describe("public effect-view-server subpath type contracts", () => {
     expectTypeOf<LiveQueryViewportRouteBy<{ readonly destroy: () => void }>>().toBeNever();
     expectTypeOf<LiveQueryViewportWhere<{ readonly destroy: () => void }>>().toBeNever();
     expectTypeOf<LiveQueryViewportWhere<LiveQueryViewport<any, string>>>().toBeNever();
+    expectTypeOf<LiveQueryViewportQueryAuthority<any>>().toBeNever();
+    expectTypeOf<LiveQueryViewportQueryAuthority<unknown>>().toBeNever();
+    type RawOnlySemanticKeyViewport = Omit<MaterializedOrderViewport, "semanticKey"> & {
+      readonly semanticKey: (query: {
+        readonly select: readonly ["id"];
+        readonly where: readonly [];
+        readonly orderBy: readonly [];
+      }) => LiveQueryViewportSemanticKey;
+    };
+    type RawOnlyReplaceViewport = Omit<MaterializedOrderViewport, "replace"> & {
+      readonly replace: (
+        request: Readonly<{
+          window: Readonly<{ firstRow: number; lastRow: number }>;
+          query: Readonly<{
+            select: readonly ["id"];
+            where: readonly [];
+            orderBy: readonly [];
+          }>;
+          sink: Readonly<{
+            setRowCount: (count: number, keepRenderedRows?: boolean) => void;
+            setRowData: (
+              rowsByIndex: Readonly<{ [index: number]: Readonly<{ id: string }> }>,
+              rowKeysByIndex: Readonly<{ [index: number]: string }>,
+            ) => void;
+          }>;
+        }>,
+      ) => Readonly<{
+        setWindow: (window: Readonly<{ firstRow: number; lastRow: number }>) => void;
+        release: () => void;
+      }>;
+    };
+    type SameAuthorityTaggedUnion =
+      | (MaterializedOrderViewport & Readonly<{ source: "left" }>)
+      | (MaterializedOrderViewport & Readonly<{ source: "right" }>);
+    expectTypeOf<LiveQueryViewportQueryAuthority<SameAuthorityTaggedUnion>>().toEqualTypeOf<
+      Readonly<{
+        semanticKey: MaterializedOrderViewport["semanticKey"];
+        replace: MaterializedOrderViewport["replace"];
+      }>
+    >();
+    expectTypeOf<LiveQueryViewportQueryAuthority<RawOnlySemanticKeyViewport>>().toBeNever();
+    expectTypeOf<LiveQueryViewportQueryAuthority<RawOnlyReplaceViewport>>().toBeNever();
+    expectTypeOf<
+      LiveQueryViewportQueryAuthority<MaterializedOrderViewport | RawOnlySemanticKeyViewport>
+    >().toBeNever();
+    expectTypeOf<
+      LiveQueryViewportQueryAuthority<MaterializedOrderViewport | RawOnlyReplaceViewport>
+    >().toBeNever();
+    expectTypeOf<
+      LiveQueryViewportQueryAuthority<
+        MaterializedOrderViewport | Readonly<{ semanticKey: () => unknown; replace: () => unknown }>
+      >
+    >().toBeNever();
     type MaterializedOrderViewport = typeof viewport.viewport;
     type LeasedOrderViewport = typeof leasedWitnessViewport;
     type CrossRowRouteWitness = Pick<

--- a/packages/effect-view-server/src/react-viewport-base-row.ts
+++ b/packages/effect-view-server/src/react-viewport-base-row.ts
@@ -202,3 +202,52 @@ export type LiveQueryViewportWhere<Viewport> = LiveQueryViewportCorrelatedWitnes
   Viewport,
   "__effect-view-server/LiveQueryViewportWhere@v1"
 >;
+
+type LiveQueryViewportQueryAuthorityValue<Viewport> = LiveQueryViewportCorrelatedWitnessValue<
+  Viewport,
+  "__effect-view-server/LiveQueryViewportQueryAuthority@v1"
+>;
+
+type LiveQueryViewportActualQueryAuthority<Viewport> =
+  Viewport extends Readonly<{
+    semanticKey: infer SemanticKey;
+    replace: infer Replace;
+  }>
+    ? Readonly<{ semanticKey: SemanticKey; replace: Replace }>
+    : never;
+
+type ExactLiveQueryViewportQueryAuthority<Viewport, Authority> =
+  Authority extends Readonly<{ semanticKey: infer SemanticKey; replace: infer Replace }>
+    ? IsAny<SemanticKey> extends true
+      ? never
+      : IsUnknown<SemanticKey> extends true
+        ? never
+        : IsAny<Replace> extends true
+          ? never
+          : IsUnknown<Replace> extends true
+            ? never
+            : IsExact<
+                  Authority,
+                  Readonly<{ semanticKey: SemanticKey; replace: Replace }>
+                > extends true
+              ? IsExact<Authority, LiveQueryViewportActualQueryAuthority<Viewport>> extends true
+                ? Authority
+                : never
+              : never
+    : never;
+
+/**
+ * Exact source-owned raw and grouped query authority for a Live Query Viewport.
+ *
+ * Resolves to `never` when either `semanticKey` or `replace` has been narrowed, widened, or
+ * detached from the source-owned Viewport contract.
+ */
+export type LiveQueryViewportQueryAuthority<Viewport> =
+  IsAny<Viewport> extends true
+    ? never
+    : IsUnknown<Viewport> extends true
+      ? never
+      : ExactLiveQueryViewportQueryAuthority<
+          Viewport,
+          LiveQueryViewportQueryAuthorityValue<Viewport>
+        >;

--- a/packages/react/src/live-query-viewport.ts
+++ b/packages/react/src/live-query-viewport.ts
@@ -155,6 +155,13 @@ export type LiveQueryViewportQuery<Row> =
   | LiveQueryViewportRawQuery<Row>
   | LiveQueryViewportGroupedQuery<Row>;
 
+type LiveQueryViewportSemanticKeyOperation<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = <const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>>(
+  query: ExactLiveQueryInputForTopic<Topics, NoInfer<Topic>, Query>,
+) => LiveQueryViewportSemanticKey;
+
 export type LiveQueryViewportGeneration = {
   readonly setWindow: (window: LiveQueryViewportWindow) => void;
   readonly release: () => void;
@@ -174,6 +181,24 @@ type LiveQueryViewportRequest<
       NoInfer<Sink>
     >;
 };
+
+type LiveQueryViewportReplaceOperation<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = <
+  const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
+  const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
+>(
+  request: LiveQueryViewportRequest<Topics, Topic, Query, Sink>,
+) => LiveQueryViewportGeneration;
+
+type LiveQueryViewportQueryAuthority<
+  Topics extends TopicDefinitions,
+  Topic extends Extract<keyof Topics, string>,
+> = Readonly<{
+  semanticKey: LiveQueryViewportSemanticKeyOperation<Topics, Topic>;
+  replace: LiveQueryViewportReplaceOperation<Topics, Topic>;
+}>;
 
 type LiveQueryViewportCapturedInput<
   Topics extends TopicDefinitions,
@@ -237,17 +262,17 @@ export type LiveQueryViewport<
     LiveQueryViewportWitnessRow<Topics, Topic>,
     LiveQueryViewportWitnessWhere<Topics, Topic>
   >;
-  readonly semanticKey: <
-    const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
-  >(
-    query: ExactLiveQueryInputForTopic<Topics, NoInfer<Topic>, Query>,
-  ) => LiveQueryViewportSemanticKey;
-  readonly replace: <
-    const Query extends LiveQueryViewportQuery<TopicRow<Topics, NoInfer<Topic>>>,
-    const Sink extends LiveQueryViewportSink<LiveQueryRow<TopicRow<Topics, Topic>, NoInfer<Query>>>,
-  >(
-    request: LiveQueryViewportRequest<Topics, Topic, Query, Sink>,
-  ) => LiveQueryViewportGeneration;
+  readonly "__effect-view-server/LiveQueryViewportQueryAuthority@v1"?: (
+    _witness: LiveQueryViewportCorrelatedWitness<
+      LiveQueryViewportWitnessRow<Topics, Topic>,
+      LiveQueryViewportQueryAuthority<Topics, Topic>
+    >,
+  ) => LiveQueryViewportCorrelatedWitness<
+    LiveQueryViewportWitnessRow<Topics, Topic>,
+    LiveQueryViewportQueryAuthority<Topics, Topic>
+  >;
+  readonly semanticKey: LiveQueryViewportSemanticKeyOperation<Topics, Topic>;
+  readonly replace: LiveQueryViewportReplaceOperation<Topics, Topic>;
   readonly destroy: () => void;
 };
 

--- a/scripts/downstream-viewport-declaration-consumer.test.ts
+++ b/scripts/downstream-viewport-declaration-consumer.test.ts
@@ -231,10 +231,11 @@ describe("downstream viewport declaration bundle", () => {
     writeFileSync(
       join(downstreamDirectory, "src", "index.ts"),
       [
-        'import type { LiveQueryViewportBaseRow, LiveQueryViewportCompleteRawSelect, LiveQueryViewportRouteBy, LiveQueryViewportWhere } from "effect-view-server/react/viewport-base-row";',
+        'import type { LiveQueryViewportBaseRow, LiveQueryViewportCompleteRawSelect, LiveQueryViewportQueryAuthority, LiveQueryViewportRouteBy, LiveQueryViewportWhere } from "effect-view-server/react/viewport-base-row";',
         "",
         "export type BundledViewportBaseRow<Viewport> = LiveQueryViewportBaseRow<Viewport>;",
         "export type BundledViewportCompleteRawSelect<Viewport> = LiveQueryViewportCompleteRawSelect<Viewport>;",
+        "export type BundledViewportQueryAuthority<Viewport> = LiveQueryViewportQueryAuthority<Viewport>;",
         "export type BundledViewportRouteBy<Viewport> = LiveQueryViewportRouteBy<Viewport>;",
         "export type BundledViewportWhere<Viewport> = LiveQueryViewportWhere<Viewport>;",
         "export const clientReady = true;",
@@ -342,6 +343,7 @@ describe("downstream viewport declaration bundle", () => {
     );
     expect(downstreamDeclaration).toContain("BundledViewportBaseRow");
     expect(downstreamDeclaration).toContain("BundledViewportCompleteRawSelect");
+    expect(downstreamDeclaration).toContain("BundledViewportQueryAuthority");
     expect(
       declarationClosure.flatMap(({ path, source }) =>
         inspectTypeScriptModule({ fileName: path, source }).moduleSpecifiers.filter(
@@ -371,6 +373,7 @@ describe("downstream viewport declaration bundle", () => {
     expect(declaration).toContain("type LiveQueryViewportCompleteRawSelect<Viewport>");
     expect(declaration).toContain("type LiveQueryViewportRouteBy<Viewport>");
     expect(declaration).toContain("type LiveQueryViewportWhere<Viewport>");
+    expect(declaration).toContain("type LiveQueryViewportQueryAuthority<Viewport>");
     expect(inspection.moduleSpecifiers).toStrictEqual([]);
     expect(declaration).not.toMatch(
       /\bdeclare\s+(?:global|module)\b|stackTraceLimit|\bReact(?:Node|Element|Portal|HTML)?\b|\bEffect\b/,
@@ -439,7 +442,7 @@ describe("downstream viewport declaration bundle", () => {
       writeFileSync(
         join(integrationDirectory, "consumer.ts"),
         [
-          'import type { BundledViewportBaseRow, BundledViewportCompleteRawSelect, BundledViewportRouteBy, BundledViewportWhere } from "downstream-viewport-adapter";',
+          'import type { BundledViewportBaseRow, BundledViewportCompleteRawSelect, BundledViewportQueryAuthority, BundledViewportRouteBy, BundledViewportWhere } from "downstream-viewport-adapter";',
           'import { ViewServerId, defineViewServerConfig } from "effect-view-server/config";',
           'import type { ExactRawQuery, LiveQueryRow } from "effect-view-server/config";',
           'import type * as PublicConfig from "effect-view-server/config";',
@@ -508,6 +511,8 @@ describe("downstream viewport declaration bundle", () => {
           'declare const leasedOrMaterializedOrders: LiveQueryViewport<typeof leasedOrMaterializedConfig.topics, "orders">;',
           'declare const leasedOrderSource: UseLiveQueryViewportResult<typeof leasedOrderConfig.topics, "orders">;',
           "type Order = typeof orderConfig.topics.orders.schema.Type;",
+          "type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends (<Value>() => Value extends Right ? 1 : 2) ? (<Value>() => Value extends Right ? 1 : 2) extends (<Value>() => Value extends Left ? 1 : 2) ? true : false : false;",
+          "type RequireTrue<Value extends true> = Value;",
           "type RequireNever<Value extends never> = Value;",
           "// @ts-expect-error row-only complete-projection authority is not public.",
           "type _NoPublicCompleteSelect = PublicConfig.LiveQueryViewportCompleteRawSelectForRow;",
@@ -530,6 +535,16 @@ describe("downstream viewport declaration bundle", () => {
           "const exactForward: Order = extractedOrder;",
           "const exactBackward: BundledViewportBaseRow<typeof orders> = expectedOrder;",
           "const matching: ExactSource<Order, typeof orders> = orders;",
+          "type ExactQueryAuthority = RequireTrue<Equal<BundledViewportQueryAuthority<typeof orders>, Readonly<{ semanticKey: (typeof orders)[\"semanticKey\"]; replace: (typeof orders)[\"replace\"] }>>>;",
+          "type SameQueryAuthorityUnion = (typeof orders & Readonly<{ source: \"left\" }>) | (typeof orders & Readonly<{ source: \"right\" }>);",
+          "type ExactUnionQueryAuthority = RequireTrue<Equal<BundledViewportQueryAuthority<SameQueryAuthorityUnion>, Readonly<{ semanticKey: (typeof orders)[\"semanticKey\"]; replace: (typeof orders)[\"replace\"] }>>>;",
+          "type RawOnlySemanticKeyViewport = Omit<typeof orders, \"semanticKey\"> & { readonly semanticKey: (query: { readonly select: readonly [\"id\"]; readonly where: readonly []; readonly orderBy: readonly [] }) => LiveQueryViewportSemanticKey };",
+          "type RawOnlyReplaceViewport = Omit<typeof orders, \"replace\"> & { readonly replace: (request: Readonly<{ window: Readonly<{ firstRow: number; lastRow: number }>; query: Readonly<{ select: readonly [\"id\"]; where: readonly []; orderBy: readonly [] }>; sink: Readonly<{ setRowCount: (count: number, keepRenderedRows?: boolean) => void; setRowData: (rowsByIndex: Readonly<{ [index: number]: Readonly<{ id: string }> }>, rowKeysByIndex: Readonly<{ [index: number]: string }>) => void }> }>) => Readonly<{ setWindow: (window: Readonly<{ firstRow: number; lastRow: number }>) => void; release: () => void }> };",
+          "type RejectRawOnlySemanticKeyAuthority = RequireNever<BundledViewportQueryAuthority<RawOnlySemanticKeyViewport>>;",
+          "type RejectRawOnlyReplaceAuthority = RequireNever<BundledViewportQueryAuthority<RawOnlyReplaceViewport>>;",
+          "type RejectMixedSemanticKeyAuthority = RequireNever<BundledViewportQueryAuthority<typeof orders | RawOnlySemanticKeyViewport>>;",
+          "type RejectMixedReplaceAuthority = RequireNever<BundledViewportQueryAuthority<typeof orders | RawOnlyReplaceViewport>>;",
+          "type RejectUnwitnessedQueryAuthority = RequireNever<BundledViewportQueryAuthority<typeof orders | Readonly<{ semanticKey: () => unknown; replace: () => unknown }>>>;",
           'const semanticKey: LiveQueryViewportSemanticKey = orders.semanticKey({ select: ["id"], where: [], orderBy: [] });',
           'const equivalentSemanticKey = orders.semanticKey({ select: ["id"], where: [], orderBy: [] });',
           "const semanticallyEqual = Object.is(semanticKey, equivalentSemanticKey);",


### PR DESCRIPTION
## Summary
- expose a source-owned query authority witness for the exact semanticKey and replace pair
- keep the extractor on the dependency-free react/viewport-base-row subpath
- reject narrowed raw-only operations and unsafe mixed unions
- document the public helper and add a patch changeset

## Validation
- effect-view-server package build and emitted type tests: 9/9
- repository script/export/consumer tests: 449/449 with 100% coverage
- vp check: clean
- strict Effect diagnostics: 0 errors, 0 warnings
- three-axis local review: 0/0/0 blockers and 0/0/0 non-blockers

Required by downstream BrunoTable issue #21; avoids reconstructing source-owned grouped query semantics or importing Effect through the root consumer declaration.

## Summary by Sourcery

Expose an exact dependency-free query authority witness for Live Query Viewports through the pure viewport base-row subpath.

New Features:
- Expose a dependency-free type helper for extracting the exact source-owned semantic-key and replace authority from Live Query Viewports.

Bug Fixes:
- Reject narrowed, widened, detached, and unsafe mixed-union viewport contracts instead of exposing invalid query authority.

Enhancements:
- Preserve the viewport query authority as a correlated source-owned witness across raw and grouped queries.

Documentation:
- Document the new query authority helper in the public API and package README.

Tests:
- Add type-level and downstream consumer coverage for valid authorities and rejected narrowed or mixed contracts.

Chores:
- Add a patch changeset for the new public helper.