### PR TITLE
chore: upgrade Platformatic Kafka

### DIFF
--- a/.changeset/spotty-jobs-ask.md
+++ b/.changeset/spotty-jobs-ask.md
@@ -1,0 +1,5 @@
+---
+"effect-view-server": patch
+---
+
+Upgrade @platformatic/kafka to 2.11.0 while retaining the stricter View Server Schema Registry Protobuf contract and raw-byte decoding boundary.

--- a/packages/effect-view-server/package.json
+++ b/packages/effect-view-server/package.json
@@ -142,7 +142,7 @@
     "@effect/platform-browser": "4.0.0-rc.111",
     "@effect/platform-node": "4.0.0-rc.111",
     "@effect/platform-node-shared": "4.0.0-rc.111",
-    "@platformatic/kafka": "2.9.0"
+    "@platformatic/kafka": "2.11.0"
   },
   "devDependencies": {
     "@effect-view-server/client": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.79.0
       version: 1.79.0
     '@platformatic/kafka':
-      specifier: 2.9.0
-      version: 2.9.0
+      specifier: 2.11.0
+      version: 2.11.0
     '@tailwindcss/vite':
       specifier: 4.3.3
       version: 4.3.3
@@ -284,7 +284,7 @@ importers:
         version: 4.0.0-rc.111(effect@4.0.0-rc.111)(redis@6.2.1)
       '@platformatic/kafka':
         specifier: 'catalog:'
-        version: 2.9.0
+        version: 2.11.0
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.170.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -624,7 +624,7 @@ importers:
         version: 4.0.0-rc.111(effect@4.0.0-rc.111)(redis@6.2.1)
       '@platformatic/kafka':
         specifier: 'catalog:'
-        version: 2.9.0
+        version: 2.11.0
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.170.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -996,8 +996,8 @@ importers:
         specifier: 4.0.0-rc.111
         version: 4.0.0-rc.111(effect@4.0.0-rc.111)
       '@platformatic/kafka':
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 2.11.0
+        version: 2.11.0
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1171,7 +1171,7 @@ importers:
         version: 2.13.0
       '@platformatic/kafka':
         specifier: 'catalog:'
-        version: 2.9.0
+        version: 2.11.0
     devDependencies:
       '@effect-view-server/config':
         specifier: workspace:*
@@ -1776,20 +1776,11 @@ packages:
       effect: ^4.0.0-rc.111
       vitest: '>=4.1.0 <5.0.0'
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -2547,8 +2538,8 @@ packages:
     resolution: {integrity: sha512-xQD5JSkQc4D15suOk7FezGDmh6Vb5e4phDoFZ/ASpa3Ft+3fOVwFOENmHtC1561zm/xHnKwI91NbMF8inpbk0Q==}
     engines: {node: '>= 22.19.0'}
 
-  '@platformatic/kafka@2.9.0':
-    resolution: {integrity: sha512-sVX2aww2RE5fA5AFJ4Bl4DQ3mZAqBnm5kDx2nd54N2hMee+kVNR0KXOmTQ7cmeufp6Kqn1XukZ6XqA7tJoKztg==}
+  '@platformatic/kafka@2.11.0':
+    resolution: {integrity: sha512-mEkmYN+Crx1Tz4BjtRV4RW2L3AcGdxAbuVMGuO9Qv6vZ1iLOfmqyKxWb+CH1SxxvkzPrHE0EyIiuAD2cF1MVIg==}
     engines: {node: '>= 22.22.0 || >= 24.6.0'}
 
   '@platformatic/wasm-utils@0.2.1':
@@ -2940,9 +2931,6 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4662,29 +4650,13 @@ snapshots:
       effect: 4.0.0-rc.111
       vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/browser-preview@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0))
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4832,9 +4804,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -5123,7 +5095,7 @@ snapshots:
 
   '@platformatic/dynamic-buffer@0.3.1': {}
 
-  '@platformatic/kafka@2.9.0':
+  '@platformatic/kafka@2.11.0':
     dependencies:
       '@platformatic/dynamic-buffer': 0.3.1
       '@platformatic/wasm-utils': 0.2.1
@@ -5526,11 +5498,6 @@ snapshots:
   '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
-
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalog:
   "@effect/atom-react": 4.0.0-rc.111
   scheduler: 0.27.0
   vitest-browser-react: 2.2.0
-  "@platformatic/kafka": 2.9.0
+  "@platformatic/kafka": 2.11.0
   "@connectrpc/connect": 2.1.2
   "@connectrpc/connect-node": 2.1.2
   "@tailwindcss/vite": 4.3.3

--- a/scripts/public-value-semantics-consumer.test.ts
+++ b/scripts/public-value-semantics-consumer.test.ts
@@ -354,7 +354,7 @@ describe("published value semantics consumer", () => {
         "@effect/platform-browser": "4.0.0-rc.111",
         "@effect/platform-node": "4.0.0-rc.111",
         "@effect/platform-node-shared": "4.0.0-rc.111",
-        "@platformatic/kafka": "2.9.0",
+        "@platformatic/kafka": "2.11.0",
       });
       for (const path of packedPaths.filter(
         (path) => path.endsWith(".js") || path.endsWith(".d.ts"),


### PR DESCRIPTION
## Summary
- upgrade @platformatic/kafka from 2.9.0 to 2.11.0
- retain our strict Schema Registry Protobuf admission and decoding implementation
- update the published-manifest contract and add a patch changeset

## Validation
- vp check
- vp run @effect-view-server/kafka#test (245 tests, 100% coverage)
- vp test run scripts/public-value-semantics-consumer.test.ts scripts/downstream-viewport-declaration-consumer.test.ts (8 tests)
- vp run -w bench:baseline:kafka-source-adapter
- required Effect, Vitest/type-safety, and architecture reviews: clean

The root readiness run completed 445/447 repository-script assertions; two unrelated checks exceeded their timing limits under the parallel rebuild load, and both passed together on an immediate focused rerun (29 tests).

## Summary by Sourcery

Upgrade Platformatic Kafka and preserve the View Server’s strict Schema Registry Protobuf behavior.

Enhancements:
- Upgrade @platformatic/kafka to 2.11.0 while preserving the stricter Schema Registry Protobuf contract and raw-byte decoding behavior.

Build:
- Update the workspace dependency catalog and lockfile for the Kafka upgrade.

Tests:
- Update the published-manifest contract test to expect the upgraded Kafka version.

Chores:
- Add a patch changeset for the Kafka dependency upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the Kafka integration to version 2.11.0.
  - Preserved strict schema registry Protobuf handling and raw-byte decoding behavior.
- **Release**
  - Prepared a patch release for the View Server package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->